### PR TITLE
Adds double holocarp bundle for 20 TC

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -530,7 +530,6 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	..()
 	new /obj/item/weapon/guardiancreator/tech/choose/traitor(src)
 	new /obj/item/weapon/paper/guardian(src)
-	return
 
 /obj/item/weapon/guardiancreator/carp
 	name = "holocarp fishsticks"
@@ -549,3 +548,11 @@ var/global/list/parasites = list() //all currently existing/living guardians
 
 /obj/item/weapon/guardiancreator/carp/choose
 	random = FALSE
+
+/obj/item/weapon/storage/box/syndie_kit/holofish
+	name = "holocarp fishfinger carton"
+
+/obj/item/weapon/storage/box/syndie_kit/holofish/New()
+	..()
+	new /obj/item/weapon/guardiancreator/carp(src)
+	new /obj/item/weapon/guardiancreator/carp(src)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -312,6 +312,18 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 	player_minimum = 25
 
+/datum/uplink_item/dangerous/holocarp
+	name = "Holocarp Bundle"
+	desc = "At the edges of space exist a mad cult, obsessed with worshiping \
+		space carp, and a whole host of associated deities. They claim \
+		that these \"magical fishsticks\" summon fishy spirits from byond \
+		the veil. It seems likely that it's some sort of hologram projection \
+		but the fishy guardians are useful, none the less."
+	item = /obj/item/weapon/storage/box/syndie_kit/holofish
+	cost = 20
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
+	player_minimum = 25
+
 // Ammunition
 /datum/uplink_item/ammo
 	category = "Ammunition"


### PR DESCRIPTION
:cl: coiax
rscadd: A double holocarp bundle can be purchased by Syndicate agents
for 20 TC. Although a human body can host more than one holocarp, it's
not possible to pick which type you get. Also, not all carp are
competent. Because they're fish.
/:cl:
