### PR TITLE
Map fixes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -541,7 +541,7 @@
 "bC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
-	on = 1;
+	on = 1
 	},
 /turf/open/floor/plating/asteroid,
 /area/ruin/powered)
@@ -676,7 +676,7 @@
 "bU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
-	on = 1;
+	on = 1
 	},
 /turf/open/floor/plasteel/bar,
 /area/ruin/powered{
@@ -704,7 +704,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
-	on = 1;
+	on = 1
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered{
@@ -751,8 +751,12 @@
 /turf/open/floor/plating/asteroid,
 /area/ruin/powered)
 "cf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/mineral,
+/obj/machinery/button/door{
+	id = "spacebardock";
+	name = "Podbay Airlock";
+	pixel_y = -24
+	},
+/turf/open/floor/plating/asteroid,
 /area/ruin/powered)
 "cg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -794,7 +798,7 @@
 "cn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
-	on = 1;
+	on = 1
 	},
 /turf/open/floor/plating/asteroid,
 /area/ruin/powered)
@@ -1312,7 +1316,7 @@ af
 af
 af
 af
-bl
+aP
 bm
 aP
 aP
@@ -1354,7 +1358,7 @@ af
 af
 af
 af
-bl
+aP
 bm
 aP
 aP
@@ -1396,7 +1400,7 @@ af
 af
 af
 af
-bl
+aP
 bm
 aP
 aP
@@ -1438,7 +1442,7 @@ af
 af
 af
 af
-bl
+aP
 bm
 aP
 aP
@@ -1480,7 +1484,7 @@ az
 af
 af
 af
-bl
+aP
 bm
 aP
 aP
@@ -1522,7 +1526,7 @@ aA
 af
 af
 af
-bl
+aP
 bm
 aP
 aP
@@ -1563,7 +1567,7 @@ am
 aB
 af
 af
-af
+cf
 al
 al
 al
@@ -1730,8 +1734,8 @@ bI
 bI
 br
 cc
-cd
-cd
+cc
+cc
 cc
 cg
 aM
@@ -1940,7 +1944,7 @@ ca
 bV
 bh
 bV
-cf
+cj
 cj
 cl
 cj

--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -1209,7 +1209,7 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "cW" = (
@@ -1472,19 +1472,8 @@
 	},
 /area/hallway/primary/central)
 "dv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 2;
-	name = "_South APC";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/warnplate{
-	dir = 2
-	},
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "dw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1497,9 +1486,6 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "dy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/status_display{
 	density = 0;
 	pixel_y = 2;
@@ -2571,11 +2557,12 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "fN" = (
-/obj/machinery/photocopier,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 2;
 	on = 1
 	},
+/obj/structure/table,
+/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/caution/corner{
 	dir = 4
 	},
@@ -15055,6 +15042,83 @@
 /obj/item/clothing/under/burial,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"IR" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	color = "#0000ff";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"IQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"IP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"IO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"IN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"IM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 2;
+	name = "_South APC";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating/warnplate{
+	dir = 2
+	},
+/area/quartermaster/storage)
 
 (1,1,1) = {"
 aa
@@ -44729,8 +44793,8 @@ bv
 bq
 ce
 bq
-bq
 ds
+bq
 bq
 bJ
 bq
@@ -44984,12 +45048,12 @@ aa
 aa
 aa
 aa
-am
 bx
-bN
+cx
 bN
 bq
 eD
+cS
 ff
 fD
 fa
@@ -45241,12 +45305,12 @@ aa
 aa
 aa
 bL
-am
 bx
 bN
 dt
 bq
 eE
+cS
 cS
 fA
 cS
@@ -45499,11 +45563,11 @@ aa
 bx
 bM
 bx
-bx
 bN
 iE
 dR
 eF
+fb
 fb
 fE
 cS
@@ -45756,11 +45820,11 @@ am
 by
 bN
 bx
-cx
-cT
-dv
+bN
+IM
 bq
 eG
+dv
 fg
 fF
 fN
@@ -46014,8 +46078,8 @@ bx
 bM
 bx
 bN
-cU
-dw
+IN
+bq
 bq
 bQ
 bQ
@@ -46272,7 +46336,7 @@ bO
 bO
 bO
 cV
-dx
+bx
 eI
 eI
 eI
@@ -46528,7 +46592,7 @@ bA
 bN
 cf
 bN
-cU
+IO
 dy
 dV
 el
@@ -46785,8 +46849,8 @@ bB
 ah
 ah
 bx
-cW
-dw
+IP
+bx
 dW
 eK
 eK
@@ -47042,8 +47106,8 @@ bD
 bR
 bo
 cy
-cX
-dz
+IQ
+IR
 eL
 eL
 eL

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -8526,7 +8526,7 @@
 	scrub_N2O = 0;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/vacantoffice2)
 "aso" = (
 /obj/machinery/door/airlock/maintenance{

--- a/_maps/map_files/generic/lavaland.dmm
+++ b/_maps/map_files/generic/lavaland.dmm
@@ -45,7 +45,9 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/lavaland/surface/outdoors)
+/area/ruin/unpowered{
+	name = "Necropolis Bridge"
+	})
 "aj" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -54,7 +56,9 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/lavaland/surface/outdoors)
+/area/ruin/unpowered{
+	name = "Necropolis Bridge"
+	})
 "ak" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2080,16 +2084,10 @@
 	},
 /area/mine/living_quarters)
 "en" = (
-/obj/structure/rack,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/mine/living_quarters)
+/turf/closed/indestructible/riveted,
+/area/ruin/unpowered{
+	name = "Necropolis Bridge"
+	})
 "eo" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -2706,7 +2704,9 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/lavaland/surface/outdoors)
+/area/ruin/unpowered{
+	name = "Necropolis Bridge"
+	})
 "fy" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /turf/closed/mineral/random/volcanic,
@@ -34666,8 +34666,8 @@ ab
 ab
 ab
 ab
-aa
-aa
+en
+en
 ah
 ah
 ah
@@ -34679,8 +34679,8 @@ ah
 ah
 ah
 ah
-aa
-aa
+en
+en
 ab
 ab
 ab
@@ -34923,7 +34923,7 @@ ab
 ab
 ab
 ab
-aa
+en
 ai
 ai
 ai
@@ -34937,7 +34937,7 @@ ai
 ai
 ai
 ai
-aa
+en
 ab
 ab
 ab
@@ -35437,7 +35437,7 @@ ab
 ab
 ab
 ab
-aa
+en
 aj
 aj
 aj
@@ -35451,7 +35451,7 @@ aj
 aj
 aj
 aj
-aa
+en
 ab
 ab
 ab
@@ -35694,8 +35694,8 @@ ab
 ab
 ab
 ab
-aa
-aa
+en
+en
 ak
 ak
 ak
@@ -35707,8 +35707,8 @@ ak
 ak
 ak
 ak
-aa
-aa
+en
+en
 ab
 ab
 ab

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -37,7 +37,7 @@
 "ah" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "ai" = (
 /obj/machinery/door/airlock/shuttle{
@@ -679,7 +679,7 @@ aB
 aJ
 at
 aZ
-bh
+ah
 aK
 at
 aL
@@ -694,7 +694,7 @@ at
 at
 at
 aZ
-bh
+ah
 aK
 at
 aS
@@ -709,7 +709,7 @@ aC
 aK
 at
 aZ
-bh
+ah
 aK
 at
 bw
@@ -720,22 +720,22 @@ aa
 (14,1,1) = {"
 ag
 ag
-aD
+ad
 aK
 at
 aZ
-bh
+ah
 aK
 at
 aZ
-aD
+ad
 aa
 aa
 "}
 (15,1,1) = {"
 ag
 ag
-aD
+ad
 aK
 at
 at
@@ -743,22 +743,22 @@ at
 at
 at
 aZ
-aD
+ad
 aa
 aa
 "}
 (16,1,1) = {"
 ag
 ag
-aD
+ad
 aK
 at
 aZ
-bh
+ah
 aK
 at
 aZ
-aD
+ad
 aa
 aa
 "}
@@ -769,7 +769,7 @@ aB
 aK
 at
 aZ
-bh
+ah
 aK
 at
 bx
@@ -784,7 +784,7 @@ at
 at
 at
 aZ
-bh
+ah
 aK
 at
 aS
@@ -799,7 +799,7 @@ aC
 aL
 at
 aZ
-bh
+ah
 aK
 at
 by
@@ -906,7 +906,7 @@ ad
 aP
 ak
 bq
-aD
+ad
 as
 as
 au


### PR DESCRIPTION
Fixes #18972
Piping fixed.

Fixes #16246
Lavaland bridge now has an area to prevent ruins overlapping it.

Fixes #17488
Ministation now has a stock computer, cargo was slightly remapped to properly fit it in.
![ministation](https://cloud.githubusercontent.com/assets/9276171/16428539/5a6badc2-3d40-11e6-829a-2d9e62311d4f.png)

Resolves #18506
Couldn't exactly find an issue with shuttle windows causing leakage but replacing the airless turfs fixed the air issue (as far as I could tell).

Closes #18781
Atmos for spacebar was already fixed but didn't close the issue. Removed some rock turf because pipes going through rock turf triggers me. Podbay airlocks now actually have a button to toggle the blastdoors.

cashing in those ez-tokens
