### PR TITLE
Fixes 2 bugs with mirrors.

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -10,7 +10,7 @@
 
 
 /obj/structure/mirror/attack_hand(mob/user)
-	if(shattered)
+	if(shattered || !Adjacent(user))
 		return
 
 	if(ishuman(user))
@@ -45,6 +45,7 @@
 	icon_state = "mirror_broke"
 	playsound(src, "shatter", 70, 1)
 	desc = "Oh no, seven years of bad luck!"
+	shattered = 1
 
 
 /obj/structure/mirror/bullet_act(obj/item/projectile/P)


### PR DESCRIPTION
Fixes 2 small bugs(well, one is more of an issue), with mirrors.
1. You can no longer use TK on a mirror to change your appearance while far away from the mirror. You have to be adjacent to it. Fixes #18823 
2. You can no longer normally use shattered mirrors, they now properly become shattered. Yes, you could shatter a mirror and still use it, stealthily. Honk.
