### PR TITLE
Nuke disk relocation is more random

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -462,18 +462,21 @@ This is here to make the tiles around the station mininuke change when it's arme
 		log_game("[src] has been moved out of bounds in ([diskturf ? "[diskturf.x], [diskturf.y] ,[diskturf.z]":"nonexistent location"]). Moving it to ([targetturf.x], [targetturf.y], [targetturf.z]).")
 
 /obj/item/weapon/disk/nuclear/proc/relocate()
-	if(blobstart.len > 0)
-		var/turf/targetturf = get_turf(pick(blobstart))
-		if(ismob(loc))
-			var/mob/M = loc
-			M.remove_from_mob(src)
-		if(istype(loc, /obj/item/weapon/storage))
-			var/obj/item/weapon/storage/S = loc
-			S.remove_from_storage(src, targetturf)
-		forceMove(targetturf) //move the disc, so ghosts remain orbitting it even if it's "destroyed"
-		return targetturf
+	var/targetturf = find_safe_turf(ZLEVEL_STATION)
+	if(!targetturf && (blobstart.len > 0))
+		targetturf = get_turf(pick(blobstart))
 	else
 		throw EXCEPTION("Unable to find a blobstart landmark")
+
+	if(ismob(loc))
+		var/mob/M = loc
+		M.remove_from_mob(src)
+	if(istype(loc, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/S = loc
+		S.remove_from_storage(src, targetturf)
+	// move the disc, so ghosts remain orbiting it even if it's "destroyed"
+	forceMove(targetturf)
+	return targetturf
 
 /obj/item/weapon/disk/nuclear/Destroy(force)
 	var/turf/diskturf = get_turf(src)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -463,10 +463,11 @@ This is here to make the tiles around the station mininuke change when it's arme
 
 /obj/item/weapon/disk/nuclear/proc/relocate()
 	var/targetturf = find_safe_turf(ZLEVEL_STATION)
-	if(!targetturf && (blobstart.len > 0))
-		targetturf = get_turf(pick(blobstart))
-	else
-		throw EXCEPTION("Unable to find a blobstart landmark")
+	if(!targetturf)
+		if(blobstart.len > 0)
+			targetturf = get_turf(pick(blobstart))
+		else
+			throw EXCEPTION("Unable to find a blobstart landmark")
 
 	if(ismob(loc))
 		var/mob/M = loc


### PR DESCRIPTION
:cl: coiax
add: The nuke disk reappears on the station in far more random locations, but tends to re-materialise in safe pressurised areas that aren't on fire.
/:cl:
- Nuke disk now uses find_safe_turf(), same proc as swarmers and
  laughter demons. Fallback is blobstart turfs in case it can't find
  anything (find_safe_turf() gives up after 1000 tries)
