### PR TITLE
Removes zombie shuttle ripples

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -26,9 +26,11 @@
 	mouse_opacity = 0
 	var/duration = 10 //in deciseconds
 	var/randomdir = TRUE
+	var/timerid
 
 /obj/effect/overlay/temp/Destroy()
 	..()
+	deltimer(timerid)
 	return QDEL_HINT_PUTINPOOL
 
 /obj/effect/overlay/temp/New()
@@ -37,7 +39,7 @@
 		setDir(pick(cardinal))
 	flick("[icon_state]", src) //Because we might be pulling it from a pool, flick whatever icon it uses so it starts at the start of the icon's animation.
 
-	QDEL_IN(src, duration)
+	timerid = QDEL_IN(src, duration)
 
 /obj/effect/overlay/temp/bloodsplatter
 	icon = 'icons/effects/blood.dmi'

--- a/code/game/pooling/pool.dm
+++ b/code/game/pooling/pool.dm
@@ -62,6 +62,8 @@ var/global/list/GlobalPool = list()
 
 	var/datum/pooled = pop(GlobalPool[get_type])
 	if(pooled)
+		pooled.gc_destroyed = null
+
 		var/atom/movable/AM
 		if(istype(pooled, /atom/movable))
 			AM = pooled
@@ -91,12 +93,14 @@ var/global/list/GlobalPool = list()
 
 	GlobalPool[diver.type] |= diver
 
-	if (destroy)
+	if(destroy)
 		diver.Destroy()
+
+	diver.gc_destroyed = 1
 
 	diver.ResetVars()
 
-var/list/exclude = list("animate_movement", "contents", "loc", "locs", "parent_type", "vars", "verbs", "type")
+var/list/exclude = list("animate_movement", "contents", "loc", "locs", "parent_type", "vars", "verbs", "type", "gc_destroyed")
 var/list/pooledvariables = list()
 //thanks to clusterfack @ /vg/station for these two procs
 /datum/proc/createVariables()

--- a/code/modules/shuttle/ripple.dm
+++ b/code/modules/shuttle/ripple.dm
@@ -8,6 +8,7 @@
 	anchored = TRUE
 	density = FALSE
 	layer = RIPPLE_LAYER
+	mouse_opacity = 1
 	alpha = 0
 
 	duration = 3 * SHUTTLE_RIPPLE_TIME

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -298,10 +298,8 @@
 /obj/docking_port/mobile/proc/cancel()
 	if(mode != SHUTTLE_CALL)
 		return
-	if(ripples.len)
-		for(var/i in ripples)
-			qdel(i)
-		ripples.Cut()
+
+	remove_ripples()
 
 	timer = world.time - timeLeft(1)
 	mode = SHUTTLE_RECALL
@@ -376,6 +374,11 @@
 	for(var/t in turfs)
 		ripples += PoolOrNew(/obj/effect/overlay/temp/ripple, t)
 
+/obj/docking_port/mobile/proc/remove_ripples()
+	for(var/R in ripples)
+		qdel(R)
+	ripples.Cut()
+
 /obj/docking_port/mobile/proc/ripple_area(obj/docking_port/stationary/S1)
 	var/list/L0 = return_ordered_turfs(x, y, z, dir, areaInstance)
 	var/list/L1 = return_ordered_turfs(S1.x, S1.y, S1.z, S1.dir)
@@ -441,13 +444,11 @@
 		for(var/turf/T0 in L0)
 			A0.contents += T0
 
+
+	remove_ripples()
+
 	//move or squish anything in the way ship at destination
 	roadkill(L0, L1, S1.dir)
-
-	// Removes ripples
-	for(var/i in ripples)
-		qdel(i)
-	ripples.Cut()
 
 	for(var/i in 1 to L0.len)
 		var/turf/T0 = L0[i]


### PR DESCRIPTION
The qdel timer was interacting weirdly with the pool. This makes it
stop.

Fixes #19021
