### PR TITLE
Reworks how the mob inventory code applies the equipped callback

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -57,6 +57,8 @@
 /mob/living/carbon/human/equip_to_slot(obj/item/I, slot)
 	if(!..()) //a check failed or the item has already found its slot
 		return
+
+	var/not_handled = FALSE //Added in case we make this type path deeper one day
 	switch(slot)
 		if(slot_belt)
 			belt = I
@@ -107,6 +109,12 @@
 			update_inv_s_store()
 		else
 			src << "<span class='danger'>You are trying to equip this item to an unsupported inventory slot. Report this to a coder!</span>"
+
+	//Item is handled and in slot, valid to call callback, for this proc should always be true
+	if(!not_handled)
+		I.equipped(src, slot)
+	
+	return not_handled //For future deeper overrides
 
 /mob/living/carbon/human/unEquip(obj/item/I)
 	. = ..() //See mob.dm for an explanation on this and some rage about people copypasting instead of calling ..() like they should.

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -34,9 +34,8 @@
 
 	I.screen_loc = null // will get moved if inventory is visible
 	I.loc = src
-	I.equipped(src, slot)
 	I.layer = ABOVE_HUD_LAYER
-
+	var/not_handled = FALSE
 	switch(slot)
 		if(slot_back)
 			back = I
@@ -64,8 +63,15 @@
 				unEquip(I)
 			I.loc = back
 		else
-			return 1
-
+			not_handled = TRUE
+	
+	//Item has been handled at this point and equipped callback can be safely called
+	//We cannot call it for items that have not been handled as they are not yet correctly
+	//in a slot (handled further down inheritance chain, probably living/carbon/human/equip_to_slot
+	if(!not_handled)
+		I.equipped(src, slot)
+	
+	return not_handled
 
 /mob/living/carbon/unEquip(obj/item/I)
 	. = ..() //Sets the default return value to what the parent returns.

--- a/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
@@ -96,7 +96,6 @@
 
 	I.screen_loc = null // will get moved if inventory is visible
 	I.loc = src
-	I.equipped(src, slot)
 	I.layer = ABOVE_HUD_LAYER
 
 	switch(slot)
@@ -110,6 +109,8 @@
 			src << "<span class='danger'>You are trying to equip this item to an unsupported inventory slot. Report this to a coder!</span>"
 			return
 
+	//Call back for item being equipped to drone
+	I.equipped(src, slot)
 
 /mob/living/simple_animal/drone/stripPanelUnequip(obj/item/what, mob/who, where)
 	..(what, who, where, 1)


### PR DESCRIPTION
It's now correctly called after the item is placed in the actual slot
and then update hooks are called.

This now matches how the hand updates are applied
