### PR TITLE
Dark Seed "fix"

### DIFF
--- a/code/game/gamemodes/miniantags/hades/hades.dm
+++ b/code/game/gamemodes/miniantags/hades/hades.dm
@@ -746,7 +746,7 @@
 				user << "<span class='warning'><font size=3>Such power.. Slay this [M] so that I may partake of its being.</font></span>"
 				return
 			if(!M.stat)
-				user << "<span class='warning'><font size=3>[M] is still too tightly bound to the mortal world! You must either kill or knock them unconscious to sacrafice them.</font></span>"
+				user << "<span class='warning'><font size=3>[M] is still too tightly bound to the mortal world! You must either kill or knock them unconscious to sacrifice them.</font></span>"
 				return
 			user << "<span class='warning'><font size=3>I accept your offering.</font></span>"
 			absorbedHP += M.maxHealth

--- a/code/game/gamemodes/miniantags/hades/hades.dm
+++ b/code/game/gamemodes/miniantags/hades/hades.dm
@@ -745,7 +745,7 @@
 				// no absorbing super strong creatures unless they're dead
 				user << "<span class='warning'><font size=3>Such power.. Slay this [M] so that I may partake of its being.</font></span>"
 				return
-			if(M.stat)
+			if(!M.stat)
 				user << "<span class='warning'><font size=3>[M] is still too tightly bound to the mortal world! You must either kill or knock them unconscious to sacrafice them.</font></span>"
 				return
 			user << "<span class='warning'><font size=3>I accept your offering.</font></span>"

--- a/code/game/gamemodes/miniantags/hades/hades.dm
+++ b/code/game/gamemodes/miniantags/hades/hades.dm
@@ -745,6 +745,9 @@
 				// no absorbing super strong creatures unless they're dead
 				user << "<span class='warning'><font size=3>Such power.. Slay this [M] so that I may partake of its being.</font></span>"
 				return
+			if(M.stat)
+				user << "<span class='warning'><font size=3>[M] is still too tightly bound to the mortal world! You must either kill or knock them unconscious to sacrafice them.</font></span>"
+				return
 			user << "<span class='warning'><font size=3>I accept your offering.</font></span>"
 			absorbedHP += M.maxHealth
 			if(!M.ckey)


### PR DESCRIPTION
Instead of being able to use it on anyone to instantly thrall them regardless of whether they're living or dead you must now kill or crit someone before being able to thrall them with a dark seed.
