### PR TITLE
Reduces the odds of the hilarious (but tragic) 3 minute rev rounds

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -57,6 +57,14 @@
 	shuttleId = "mining"
 	possible_destinations = "mining_home;mining_away"
 	no_destination_swap = 1
+	var/global/list/dumb_rev_heads = list()
+
+/obj/machinery/computer/shuttle/mining/attack_hand(mob/user)
+	if(user.z == ZLEVEL_STATION && user.mind && (user.mind in ticker.mode.head_revolutionaries) && !(user.mind in dumb_rev_heads))
+		user << "<span class='warning'>You get a feeling that leaving the station might be a REALLY dumb idea...</span>"
+		dumb_rev_heads += user.mind
+		return
+	..()
 
 /*********************Pickaxe & Drills**************************/
 


### PR DESCRIPTION
Head Revs that attempt to move the mining shuttle around will get a one time reminder that leaving on it might cause them to lose the round and end the game. They can then choose to disregard the warning and lose the round anyway.

This warning happens regardless of whether or not the head rev is the only (living) rev head, as to do otherwise would allow a rev head to gain knowledge on these things in a painless way.
