### PR TITLE
Mending Motors, Sigils of Transmission, and Clockwork Proselytizers contain less free power/alloy

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_machines.dm
+++ b/code/game/gamemodes/clock_cult/clock_machines.dm
@@ -142,14 +142,14 @@
 	health = 150
 	break_message = "<span class='warning'>The prism collapses with a heavy thud!</span>"
 	debris = list(/obj/item/clockwork/alloy_shards, /obj/item/clockwork/component/vanguard_cogwheel)
-	var/stored_alloy = 0 //250W = 1 alloy
-	var/max_alloy = 50000
+	var/stored_alloy = 0 //2500W = 1 alloy = 100 liquified alloy
+	var/max_alloy = 25000
 	var/mob_cost = 200
 	var/structure_cost = 250
 	var/cyborg_cost = 300
 
 /obj/structure/clockwork/powered/mending_motor/prefilled
-	stored_alloy = 5000 //starts with 20 alloy
+	stored_alloy = 2500 //starts with 1 replicant alloy/100 liquified alloy
 
 /obj/structure/clockwork/powered/mending_motor/total_accessable_power()
 	. = ..()
@@ -170,11 +170,11 @@
 /obj/structure/clockwork/powered/mending_motor/examine(mob/user)
 	..()
 	if(is_servant_of_ratvar(user) || isobserver(user))
-		user << "<span class='alloy'>It has [stored_alloy*0.004]/[max_alloy*0.004] units of replicant alloy, which is equivalent to [stored_alloy]W/[max_alloy]W of power.</span>"
+		user << "<span class='alloy'>It contains [stored_alloy*0.04]/[max_alloy*0.04] units of liquified alloy, which is equivalent to [stored_alloy]W/[max_alloy]W of power.</span>"
 		user << "<span class='inathneq_small'>It requires [mob_cost]W to heal clockwork mobs, [structure_cost]W for clockwork structures, and [cyborg_cost]W for cyborgs.</span>"
 
 /obj/structure/clockwork/powered/mending_motor/process()
-	if(!..())
+	if(..() < mob_cost)
 		visible_message("<span class='warning'>[src] emits an airy chuckling sound and falls dark!</span>")
 		toggle()
 		return
@@ -210,7 +210,7 @@
 
 /obj/structure/clockwork/powered/mending_motor/attack_hand(mob/living/user)
 	if(user.canUseTopic(src, BE_CLOSE))
-		if(!total_accessable_power() >= 300)
+		if(total_accessable_power() < mob_cost)
 			user << "<span class='warning'>[src] needs more power or replicant alloy to function!</span>"
 			return 0
 		toggle(0, user)

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -832,7 +832,7 @@
 	icon_state = "sigiltransmission"
 	color = "#EC8A2D"
 	alpha = 50
-	var/power_charge = 4000 //starts with 4000W by default
+	var/power_charge = 2500 //starts with 2500W by default
 
 /obj/effect/clockwork/sigil/transmission/examine(mob/user)
 	..()

--- a/code/game/gamemodes/clock_cult/clockwork_proselytizer.dm
+++ b/code/game/gamemodes/clock_cult/clockwork_proselytizer.dm
@@ -14,7 +14,7 @@
 	var/repairing = null //what we're currently repairing, if anything
 
 /obj/item/clockwork/clockwork_proselytizer/preloaded
-	stored_alloy = REPLICANT_ALLOY_UNIT
+	stored_alloy = REPLICANT_WALL_MINUS_FLOOR+REPLICANT_WALL_TOTAL
 
 /obj/item/clockwork/clockwork_proselytizer/scarab
 	name = "scarab proselytizer"


### PR DESCRIPTION
:cl: Joan
rscdel: Mending motors start with 2500W of power in alloy, from 5000. Sigils of Transmission start with 2500W of power, from 4000. Clockwork Proselytizers start with 90 alloy, from 100.
/:cl:

Mending motor alloy amounts are now accurate to proselytizer amounts.
