### PR TITLE
Fixes lighting hanging up with changed turfs

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -57,7 +57,7 @@ var/datum/subsystem/lighting/SSlighting
 		if(T.lighting_changed)
 			T.redraw_lighting()
 		if (MC_TICK_CHECK)
-			return
+			break
 	if (i > 1)
 		changed_turfs.Cut(1,i)
 


### PR DESCRIPTION
Someone put a return where it should of been a break, thus preventing the changed turfs from being cut from the list on the lighting sub system

:cl: Flavo
fix: fixed a bug where lights would not update.
/:cl:
