### PR TITLE
Guvax is slower if above 5 servants

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -308,7 +308,8 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 		if(is_servant_of_ratvar(M) && (ishuman(M) || issilicon(M)))
 			servants++
 	if(servants > 5)
-		channel_time = min(servants*10, 150) //if above 5 servants, is slower
+		servants -= 5
+		channel_time = min(channel_time + servants*7.5, 150) //if above 5 servants, is slower
 	return ..()
 
 /datum/clockwork_scripture/guvax/scripture_effects()

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -297,10 +297,19 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Guvax"
 	desc = "Enlists all nearby living unshielded creatures into servitude to Ratvar. Also purges holy water from nearby servants."
 	invocations = list("Rayvtugra guvf urngura!", "Nyy ner vafrpgf orsber Ratvar!", "Chetr nyy hageh'guf naq ubabe Ratvar.")
-	channel_time = 60
+	channel_time = 50
 	required_components = list("guvax_capacitor" = 1)
 	usage_tip = "Only works on those in melee range and does not penetrate mindshield implants. Much more efficient than a Sigil of Submission."
 	tier = SCRIPTURE_DRIVER
+
+/datum/clockwork_scripture/guvax/run_scripture()
+	var/servants = 0
+	for(var/mob/living/M in living_mob_list)
+		if(is_servant_of_ratvar(M) && (ishuman(M) || issilicon(M)))
+			servants++
+	if(servants > 5)
+		channel_time = min(servants*10, 150) //if above 5 servants, is slower
+	return ..()
 
 /datum/clockwork_scripture/guvax/scripture_effects()
 	for(var/mob/living/L in hearers(1, get_turf(invoker))) //Affects silicons


### PR DESCRIPTION
:cl: Joan
experiment: Guvax now invokes 1 second faster(5 seconds), but is 0.75 seconds slower for each scripture-valid servant above 5, up to a maximum of 15 seconds.
/:cl:

Basically, if you have a lot of servants guvax becomes painfully slow. Where's your base, why aren't you summoning ratvar already.
