### PR TITLE
Slab component generation is slower if above 5 servants

### DIFF
--- a/code/game/gamemodes/clock_cult/__clock_defines.dm
+++ b/code/game/gamemodes/clock_cult/__clock_defines.dm
@@ -16,7 +16,9 @@ var/global/ratvar_awakens = FALSE //If Ratvar has been summoned
 
 #define SLAB_PRODUCTION_TIME 600 //how long(deciseconds) slabs require to produce a single component; defaults to 1 minute
 
-#define SLAB_SERVANT_SLOWDOWN 300 //how much each servant above 5 slows down slab-based generation; defaults to 30 seconds per sevant
+#define SLAB_SERVANT_SLOWDOWN 200 //how much each servant above 5 slows down slab-based generation; defaults to 20 seconds per sevant
+
+#define SLAB_SLOWDOWN_MAXIMUM 2400 //maximum slowdown from additional servants; defaults to 4 minutes
 
 #define CACHE_PRODUCTION_TIME 900 //how long(deciseconds) caches require to produce a component; defaults to 1 minute 30 seconds
 

--- a/code/game/gamemodes/clock_cult/__clock_defines.dm
+++ b/code/game/gamemodes/clock_cult/__clock_defines.dm
@@ -16,7 +16,7 @@ var/global/ratvar_awakens = FALSE //If Ratvar has been summoned
 
 #define SLAB_PRODUCTION_TIME 600 //how long(deciseconds) slabs require to produce a single component; defaults to 1 minute
 
-#define SLAB_SERVANT_SLOWDOWN 150 //how much each servant above 5 slows down slab-based generation; defaults to 15 seconds per sevant
+#define SLAB_SERVANT_SLOWDOWN 300 //how much each servant above 5 slows down slab-based generation; defaults to 30 seconds per sevant
 
 #define CACHE_PRODUCTION_TIME 900 //how long(deciseconds) caches require to produce a component; defaults to 1 minute 30 seconds
 

--- a/code/game/gamemodes/clock_cult/__clock_defines.dm
+++ b/code/game/gamemodes/clock_cult/__clock_defines.dm
@@ -16,6 +16,8 @@ var/global/ratvar_awakens = FALSE //If Ratvar has been summoned
 
 #define SLAB_PRODUCTION_TIME 600 //how long(deciseconds) slabs require to produce a single component; defaults to 1 minute
 
+#define SLAB_SERVANT_SLOWDOWN 150 //how much each servant above 5 slows down slab-based generation; defaults to 15 seconds per sevant
+
 #define CACHE_PRODUCTION_TIME 900 //how long(deciseconds) caches require to produce a component; defaults to 1 minute 30 seconds
 
 #define LOWER_PROB_PER_COMPONENT 10 //how much each component in the cache reduces the weight of getting another of that component type

--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -77,7 +77,7 @@
 			servants++
 	if(servants > 5)
 		servants -= 5
-		production_slowdown = SLAB_SERVANT_SLOWDOWN * servants //SLAB_SERVANT_SLOWDOWN additional seconds for each servant above 5
+		production_slowdown = min(SLAB_SERVANT_SLOWDOWN * servants, SLAB_SLOWDOWN_MAXIMUM) //SLAB_SERVANT_SLOWDOWN additional seconds for each servant above 5, up to SLAB_SLOWDOWN_MAXIMUM
 	production_time = world.time + SLAB_PRODUCTION_TIME + production_slowdown
 	var/mob/living/L
 	if(isliving(loc))

--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -70,7 +70,15 @@
 		return
 	if(production_time > world.time)
 		return
-	production_time = world.time + SLAB_PRODUCTION_TIME
+	var/servants = 0
+	var/production_slowdown = 0
+	for(var/mob/living/M in living_mob_list)
+		if(is_servant_of_ratvar(M) && (ishuman(M) || issilicon(M)))
+			servants++
+	if(servants > 5)
+		servants -= 5
+		production_slowdown = SLAB_SERVANT_SLOWDOWN * servants //15 seconds for each servant above 5
+	production_time = world.time + SLAB_PRODUCTION_TIME + production_slowdown
 	var/mob/living/L
 	if(isliving(loc))
 		L = loc

--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -77,7 +77,7 @@
 			servants++
 	if(servants > 5)
 		servants -= 5
-		production_slowdown = SLAB_SERVANT_SLOWDOWN * servants //15 seconds for each servant above 5
+		production_slowdown = SLAB_SERVANT_SLOWDOWN * servants //SLAB_SERVANT_SLOWDOWN additional seconds for each servant above 5
 	production_time = world.time + SLAB_PRODUCTION_TIME + production_slowdown
 	var/mob/living/L
 	if(isliving(loc))


### PR DESCRIPTION
:cl: Joan
experiment: Clockwork Slabs generate components 20 seconds slower for each scripture-valid servant above 5, up to a maximum of 1 component every 5 minutes.
/:cl:

Basically, if you have lots of servants you need to build a base for component generation, you absolutely can't rely on slabs alone.
