### PR TITLE
Patched a mapmerger bug where it would incorrectly recycle keys.

### DIFF
--- a/tools/mapmerge/map_helpers.py
+++ b/tools/mapmerge/map_helpers.py
@@ -1,5 +1,7 @@
 import collections
 
+error = {0:"OK", 1:"WARNING: Key lengths are different, all the lines change."}
+
 maxx = 0
 maxy = 0
 key_length = 1
@@ -16,11 +18,21 @@ def merge_map(newfile, backupfile, tgm):
     reset_globals()
 
     shitmap = parse_map(newfile)
+    originalmap = parse_map(backupfile)
+
+    global key_length
+    if shitmap["key_length"] != originalmap["key_length"]:
+        if tgm:
+            write_dictionary_tgm(newfile, shitmap["dictionary"])
+            write_grid_coord_small(newfile, shitmap["grid"])
+        return 1
+    else:
+        key_length = originalmap["key_length"]
+
     shitDict = shitmap["dictionary"] #key to tile data dictionary
     shitGrid = shitmap["grid"] #x,y coords to tiles (keys) dictionary (the map's layout)
-        
-    originalmap = parse_map(backupfile)
-    originalDict = originalmap["dictionary"]
+    
+    originalDict = sort_dictionary(originalmap["dictionary"])
     originalGrid = originalmap["grid"]
 
     mergeGrid = dict() #final map layout
@@ -60,7 +72,7 @@ def merge_map(newfile, backupfile, tgm):
                     try:
                         unused_keys.remove(newKey)
                     except ValueError: #caused by a duplicate entry
-                        print("WARNING: Correcting duplicate dictionary entry. ({})".format(shitKey))
+                        print("NOTICE: Correcting duplicate dictionary entry. ({})".format(shitKey))
                     mergeGrid[x,y] = newKey
                     known_keys[shitKey] = newKey    
                 #if data at original x,y no longer exists we reuse the key immediately
@@ -74,9 +86,6 @@ def merge_map(newfile, backupfile, tgm):
                         newKey = generate_new_key(originalDict)
                     else:
                         newKey = generate_new_key(tempDict)
-                    if newKey == "OVERFLOW": #if this happens, merging is impossible
-                        print("ERROR: Key overflow detected.")
-                        return 0
                     tempGrid[x,y] = newKey
                     temp_keys[shitKey] = newKey
                     tempDict[newKey] = shitData
@@ -101,7 +110,6 @@ def merge_map(newfile, backupfile, tgm):
                 i += 1
             sort = 1
 
-
     #Recycle outdated keys with any new tile data, starting from the bottom of the dictionary
     i = 0
     for key, value in reversed(tempDict.items()):
@@ -120,15 +128,7 @@ def merge_map(newfile, backupfile, tgm):
 
     #if gaps in the key sequence were found, sort the dictionary for cleanliness
     if sort == 1:
-        sorted_dict = collections.OrderedDict()
-        next_key = get_next_key("")
-        while len(sorted_dict) < len(originalDict):
-            try:
-                sorted_dict[next_key] = originalDict[next_key]
-            except KeyError:
-                pass
-            next_key = get_next_key(next_key)
-        originalDict = sorted_dict
+        originalDict = sort_dictionary(originalDict)
 
     if tgm:
         write_dictionary_tgm(newfile, originalDict)
@@ -136,7 +136,7 @@ def merge_map(newfile, backupfile, tgm):
     else:
         write_dictionary(newfile, originalDict)
         write_grid(newfile, mergeGrid)
-    return 1
+    return 0
 
 #write dictionary in tgm format
 def write_dictionary_tgm(filename, dictionary): 
@@ -229,6 +229,17 @@ def get_next_key(key):
             carry -= 1
     return new_key[::-1]
 
+def sort_dictionary(dictionary):
+    sorted_dict = collections.OrderedDict()
+    next_key = get_next_key("")
+    while len(sorted_dict) < len(dictionary):
+        try:
+            sorted_dict[next_key] = dictionary[next_key]
+        except KeyError:
+            pass
+        next_key = get_next_key(next_key)
+    return sorted_dict
+
 #still does not support more than one z level per file, but should parse any format
 def parse_map(map_file):
     with open(map_file, "r") as map_input:
@@ -256,9 +267,10 @@ def parse_map(map_file):
         curr_num = ""
         reading_coord = "x"
 
-        global key_length
+        
         global maxx
         global maxy
+        key_length_local = 0
         curr_x = 0
         curr_y = 0
         curr_z = 1
@@ -343,7 +355,7 @@ def parse_map(map_file):
                 if in_key_block:
                     if char == "\"":
                         in_key_block = False
-                        key_length = len(curr_key)
+                        key_length_local = len(curr_key)
                     else:
                         curr_key = curr_key + char
                     continue    
@@ -419,7 +431,7 @@ def parse_map(map_file):
 
                     
                     curr_key = curr_key + char
-                    if len(curr_key) == key_length:
+                    if len(curr_key) == key_length_local:
                         iter_x += 1
                         if iter_x > 1:
                             curr_x += 1
@@ -444,6 +456,7 @@ def parse_map(map_file):
         data = dict()
         data["dictionary"] = dictionary
         data["grid"] = grid
+        data["key_length"] = key_length_local
         return data
 
 #subtract keyB from keyA

--- a/tools/mapmerge/mapmerger.py
+++ b/tools/mapmerge/mapmerger.py
@@ -47,7 +47,7 @@ def main(map_folder, tgm=0):
     print("\nMerging these maps:")
     for i in valid_indices:
         print(str(list_of_files[i])[len(map_folder):])
-    merge = input("\nPress Enter to merge...")
+    merge = input("\nPress Enter to merge...\n")
     if merge == "abort":
         print("\nAborted map merge.")
         sys.exit()
@@ -57,14 +57,19 @@ def main(map_folder, tgm=0):
             shutil.copyfile(path_str, path_str + ".before")
             path_str_pretty = path_str[len(map_folder):]
             try:
-                if map_helpers.merge_map(path_str, path_str + ".backup", tgm) != 1:
-                    print("ERROR MERGING: {}".format(path_str_pretty))
+                error = map_helpers.merge_map(path_str, path_str + ".backup", tgm)
+                if error > 1:
+                    print(map_helpers.error[error])
                     os.remove(path_str + ".before")
                     continue
+                if error == 1:
+                    print(map_helpers.error[1])
                 print("MERGED: {}".format(path_str_pretty))
+                print("  -  ")
             except FileNotFoundError:
-                print("\nERROR: File not found! Make sure you run 'Prepare Maps.bat' before merging.")
-                print(path_str_pretty + " || " + path_str_pretty + ".backup")
+                print("ERROR: File not found! Make sure you run 'Prepare Maps.bat' before merging.")
+                print("MISSING BACKUP FILE: " + path_str_pretty + ".backup")
+                print("  -  ")
 
     print("\nFinished merging.")
     print("\nNOTICE: A version of the map files from before merging have been created for debug purposes.\nDo not delete these files until it is sure your map edits have no undesirable changes.")


### PR DESCRIPTION
It was recycling keys that were still in use, when the model list wasn't ordered (likely happening because of git reverts). Solution: Sort it before doing anything.

Also added a method to print errors, added a preemptive check for key length difference, made it so the map is still converted to TGM when a key length difference is detected.

Fixes https://github.com/tgstation/tgstation/issues/17349
Fixes https://github.com/tgstation/tgstation/issues/19089

Merge this before any z2 edits as z2 merging is broken with the current version of the merging script.