### PR TITLE
Makes spray bottles apply touch

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -278,7 +278,7 @@
 
 /datum/reagent/spraytan/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(istype(M, /mob/living/carbon/human))
-		if(method == PATCH || method == VAPOR)
+		if(method == PATCH || method == TOUCH || method == VAPOR)
 			var/mob/living/carbon/human/N = M
 			if(N.dna.species.id == "human")
 				switch(N.skin_tone)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -88,17 +88,17 @@
 					if(ismob(T))
 						var/mob/M = T
 						if(!M.lying || !range_left)
-							D.reagents.reaction(M, VAPOR)
+							D.reagents.reaction(M, TOUCH)
 							puff_reagent_left -= 1
 					else if(!range_left)
-						D.reagents.reaction(T, VAPOR)
+						D.reagents.reaction(T, TOUCH)
 				else
-					D.reagents.reaction(T, VAPOR)
+					D.reagents.reaction(T, TOUCH)
 					if(ismob(T))
 						puff_reagent_left -= 1
 
 			if(puff_reagent_left > 0 && (!stream_mode || !range_left))
-				D.reagents.reaction(get_turf(D), VAPOR)
+				D.reagents.reaction(get_turf(D), TOUCH)
 				puff_reagent_left -= 1
 
 			if(puff_reagent_left <= 0) // we used all the puff so we delete it.


### PR DESCRIPTION
Spray bottles apply touch instead of vapor like they're supposed to.
:cl:
tweak: Spray bottle apply touch instead of vapor
rscadd: Spray tan can now be applied by touch as proper.
/:cl:
/MAY CAUSE BALANCE ISSUES SUCH AS FACID SPRAY/
