### PR TITLE
Minor projectile refactor

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -140,58 +140,65 @@
 		Angle = setAngle
 	if(!legacy) //new projectiles
 		set waitfor = 0
+		var/next_run = world.time
 		while(loc)
-			if(!paused)
-				if((!( current ) || loc == current))
-					current = locate(Clamp(x+xo,1,world.maxx),Clamp(y+yo,1,world.maxy),z)
+			if(paused)
+				sleep(1)
+				continue
+			
+			if((!( current ) || loc == current))
+				current = locate(Clamp(x+xo,1,world.maxx),Clamp(y+yo,1,world.maxy),z)
 
-				if(!Angle)
-					Angle=round(Get_Angle(src,current))
-				if(spread)
-					Angle += (rand() - 0.5) * spread
-				var/matrix/M = new
-				M.Turn(Angle)
-				transform = M
+			if(!Angle)
+				Angle=round(Get_Angle(src,current))
+			if(spread)
+				Angle += (rand() - 0.5) * spread
+			var/matrix/M = new
+			M.Turn(Angle)
+			transform = M
 
-				var/Pixel_x=round(sin(Angle)+16*sin(Angle)*2)
-				var/Pixel_y=round(cos(Angle)+16*cos(Angle)*2)
-				var/pixel_x_offset = pixel_x + Pixel_x
-				var/pixel_y_offset = pixel_y + Pixel_y
-				var/new_x = x
-				var/new_y = y
+			var/Pixel_x=round(sin(Angle)+16*sin(Angle)*2)
+			var/Pixel_y=round(cos(Angle)+16*cos(Angle)*2)
+			var/pixel_x_offset = pixel_x + Pixel_x
+			var/pixel_y_offset = pixel_y + Pixel_y
+			var/new_x = x
+			var/new_y = y
 
-				while(pixel_x_offset > 16)
-					pixel_x_offset -= 32
-					pixel_x -= 32
-					new_x++// x++
-				while(pixel_x_offset < -16)
-					pixel_x_offset += 32
-					pixel_x += 32
-					new_x--
+			while(pixel_x_offset > 16)
+				pixel_x_offset -= 32
+				pixel_x -= 32
+				new_x++// x++
+			while(pixel_x_offset < -16)
+				pixel_x_offset += 32
+				pixel_x += 32
+				new_x--
 
-				while(pixel_y_offset > 16)
-					pixel_y_offset -= 32
-					pixel_y -= 32
-					new_y++
-				while(pixel_y_offset < -16)
-					pixel_y_offset += 32
-					pixel_y += 32
-					new_y--
+			while(pixel_y_offset > 16)
+				pixel_y_offset -= 32
+				pixel_y -= 32
+				new_y++
+			while(pixel_y_offset < -16)
+				pixel_y_offset += 32
+				pixel_y += 32
+				new_y--
 
-				speed = round(speed)
-				step_towards(src, locate(new_x, new_y, z))
-				if(speed <= 1)
-					pixel_x = pixel_x_offset
-					pixel_y = pixel_y_offset
-				else
-					animate(src, pixel_x = pixel_x_offset, pixel_y = pixel_y_offset, time = max(1, (speed <= 3 ? speed - 1 : speed)))
+			step_towards(src, locate(new_x, new_y, z))
+			next_run += max(world.tick_lag, speed)
+			var/delay = next_run - world.time
+			if(delay <= world.tick_lag*2)
+				pixel_x = pixel_x_offset
+				pixel_y = pixel_y_offset
+			else
+				animate(src, pixel_x = pixel_x_offset, pixel_y = pixel_y_offset, time = max(1, (delay <= 3 ? delay - 1 : delay)))
 
-				if(original && (original.layer>=2.75) || ismob(original))
-					if(loc == get_turf(original))
-						if(!(original in permutated))
-							Bump(original, 1)
-				Range()
-			sleep(max(1, speed))
+			if(original && (original.layer>=2.75) || ismob(original))
+				if(loc == get_turf(original))
+					if(!(original in permutated))
+						Bump(original, 1)
+			Range()
+			if (delay > 0)
+				sleep(delay)
+			
 	else //old projectile system
 		set waitfor = 0
 		while(loc)
@@ -204,7 +211,7 @@
 						if(!(original in permutated))
 							Bump(original, 1)
 				Range()
-			sleep(1)
+			sleep(config.run_speed * 0.9)
 
 
 /obj/item/projectile/Crossed(atom/movable/AM) //A mob moving on a tile with a projectile is hit by it.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -143,6 +143,7 @@
 		var/next_run = world.time
 		while(loc)
 			if(paused)
+				next_run = world.time
 				sleep(1)
 				continue
 			


### PR DESCRIPTION
Haven't tested shit, I'll download the zip and try this out in a bit.

Basically we account for tick drifts or byond not firing this proc on time such that we run it quicker if it falls behind.

This also allows for any speed, even when it doesn't round to world.tick_lag, causing it to just alternate rounding such that it avgs to the requested speed.

Something better would be to move all of this to a subsystem, to reduce the amount of sleeps and wakeups, but i don't think there will ever be enough projectiles to justify the effort of doing so.

(Also, made it early return to reduce unneeded indentation)

This should fix projectiles being slower than they needed to be
