### PR TITLE
tgui modifications for custom browser id

### DIFF
--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -33,6 +33,8 @@
 	var/datum/ui_state/state = null // Topic state used to determine status/interactability.
 	var/datum/tgui/master_ui // The parent UI.
 	var/list/datum/tgui/children = list() // Children of this UI.
+	var/titlebar = TRUE
+	var/custom_browser_id = FALSE
 
  /**
   * public
@@ -51,11 +53,12 @@
   *
   * return datum/tgui The requested UI.
  **/
-/datum/tgui/New(mob/user, datum/src_object, ui_key, interface, title, width = 0, height = 0, datum/tgui/master_ui = null, datum/ui_state/state = default_state)
+/datum/tgui/New(mob/user, datum/src_object, ui_key, interface, title, width = 0, height = 0, datum/tgui/master_ui = null, datum/ui_state/state = default_state, browser_id)
 	src.user = user
 	src.src_object = src_object
 	src.ui_key = ui_key
-	src.window_id = "\ref[src_object]-[ui_key]"
+	src.window_id = browser_id ? browser_id : "\ref[src_object]-[ui_key]"
+	src.custom_browser_id = browser_id ? TRUE : FALSE
 
 	set_interface(interface)
 
@@ -96,7 +99,7 @@
 
 	var/debugable = check_rights_for(user.client, R_DEBUG)
 	user << browse(get_html(debugable), "window=[window_id];[window_size][list2params(window_options)]") // Open the window.
-	winset(user, window_id, "on-close=\"uiclose \ref[src]\"") // Instruct the client to signal UI when the window is closed.
+	if (custom_browser_id) winset(user, window_id, "on-close=\"uiclose \ref[src]\"") // Instruct the client to signal UI when the window is closed.
 	SStgui.on_open(src)
 
  /**
@@ -216,7 +219,7 @@
 			"style"     = style,
 			"interface" = interface,
 			"fancy"     = user.client.prefs.tgui_fancy,
-			"locked"    = user.client.prefs.tgui_lock,
+			"locked"    = user.client.prefs.tgui_lock && !custom_browser_id,
 			"window"    = window_id,
 			"ref"       = "\ref[src]",
 			"user"      = list(
@@ -226,7 +229,8 @@
 			"srcObject" = list(
 				"name" = "[src_object]",
 				"ref"  = "\ref[src_object]"
-			)
+			),
+			"titlebar" = titlebar
 		)
 	return config_data
 
@@ -268,7 +272,7 @@
 
 	switch(action)
 		if("tgui:initialize")
-			user << output(url_encode(get_json(initial_data)), "[window_id].browser:initialize")
+			user << output(url_encode(get_json(initial_data)), "[custom_browser_id ? window_id : "[window_id].browser"]:initialize")
 			initialized = TRUE
 		if("tgui:view")
 			if(params["screen"])
@@ -320,7 +324,7 @@
 		return // Cannot update UI, we have no visibility.
 
 	// Send the new JSON to the update() Javascript function.
-	user << output(url_encode(get_json(data)), "[window_id].browser:update")
+	user << output(url_encode(get_json(data)), "[custom_browser_id ? window_id : "[window_id].browser"]:update")
 
  /**
   * private
@@ -367,3 +371,6 @@
 			src.status = status
 			if(status == UI_DISABLED || push) // Update if the UI just because disabled, or a push is requested.
 				push_data(null, force = 1)
+
+/datum/tgui/proc/set_titlebar(value)
+	titlebar = value

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -99,7 +99,8 @@
 
 	var/debugable = check_rights_for(user.client, R_DEBUG)
 	user << browse(get_html(debugable), "window=[window_id];[window_size][list2params(window_options)]") // Open the window.
-	if (custom_browser_id) winset(user, window_id, "on-close=\"uiclose \ref[src]\"") // Instruct the client to signal UI when the window is closed.
+	if (custom_browser_id)
+		winset(user, window_id, "on-close=\"uiclose \ref[src]\"") // Instruct the client to signal UI when the window is closed.
 	SStgui.on_open(src)
 
  /**

--- a/tgui/src/components/button.ract
+++ b/tgui/src/components/button.ract
@@ -18,6 +18,8 @@
       },
       styles () {
         let extra = ''
+        if (this.get('class'))
+          extra += ' ' + this.get('class');
         if (this.get('tooltip-side'))
           extra = ` tooltip-${this.get('tooltip-side')}`
         if (this.get('grid'))

--- a/tgui/src/components/titlebar.ract
+++ b/tgui/src/components/titlebar.ract
@@ -19,7 +19,7 @@ component.exports = {
     const onrelease = (event) => this.set({ drag: false, x: null, y: null })
 
     this.observe('config.fancy', (newkey, oldkey, keypath) => {
-      winset(this.get('config.window'), 'titlebar', !newkey)
+      winset(this.get('config.window'), 'titlebar', !newkey && this.get('config.titlebar'))
 
       if (newkey) {
         document.addEventListener('mousemove', ondrag)
@@ -46,11 +46,13 @@ component.exports = {
 }
 </script>
 
-<header class='titlebar' on-mousedown='drag'>
-  <i class='statusicon fa fa-eye fa-2x {{visualStatus}}'></i>
-  <span class='title'>{{yield}}</span>
-  {{#if config.fancy}}
-    <i class='minimize fa fa-minus fa-2x' on-click='minimize'></i>
-    <i class='close fa fa-close fa-2x' on-click='close'></i>
-  {{/if}}
-</header>
+{{#if config.titlebar}}
+  <header class='titlebar' on-mousedown='drag'>
+    <i class='statusicon fa fa-eye fa-2x {{visualStatus}}'></i>
+    <span class='title'>{{yield}}</span>
+    {{#if config.fancy}}
+      <i class='minimize fa fa-minus fa-2x' on-click='minimize'></i>
+      <i class='close fa fa-close fa-2x' on-click='close'></i>
+    {{/if}}
+  </header>
+{{/if}}

--- a/tgui/src/tgui.ract
+++ b/tgui/src/tgui.ract
@@ -58,4 +58,6 @@ component.exports = {
   <warnings/>
   <interface/>
 </main>
-<resize/>
+{{#if config.titlebar}}
+  <resize/>
+{{/if}}


### PR DESCRIPTION
Resolves #19103. AFAIK no changelog is needed because this change does not directly affect players.
- Ability to pass a custom browser_id to the "/datum/tgui" constructor.
- Ability to remove the titlebar and resize grip on tgui elements.
- Ability to provide custom classes to an "ui-button" element.
