### PR TITLE
Immovable rods now notify ghosts when created

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -39,24 +39,22 @@
 	var/obj/effect/meteor/M = new Me(pickedstart)
 	M.dest = pickedgoal
 	M.z_original = 1
-	spawn(0)
-		walk_towards(M, M.dest, 1)
-	return
+	addtimer(GLOBAL_PROC, "walk_towards", 0, FALSE, M, M.dest, 1)
 
 /proc/spaceDebrisStartLoc(startSide, Z)
 	var/starty
 	var/startx
 	switch(startSide)
-		if(1) //NORTH
+		if(NORTH)
 			starty = world.maxy-(TRANSITIONEDGE+1)
 			startx = rand((TRANSITIONEDGE+1), world.maxx-(TRANSITIONEDGE+1))
-		if(2) //EAST
+		if(EAST)
 			starty = rand((TRANSITIONEDGE+1),world.maxy-(TRANSITIONEDGE+1))
 			startx = world.maxx-(TRANSITIONEDGE+1)
-		if(3) //SOUTH
+		if(SOUTH)
 			starty = (TRANSITIONEDGE+1)
 			startx = rand((TRANSITIONEDGE+1), world.maxx-(TRANSITIONEDGE+1))
-		if(4) //WEST
+		if(WEST)
 			starty = rand((TRANSITIONEDGE+1), world.maxy-(TRANSITIONEDGE+1))
 			startx = (TRANSITIONEDGE+1)
 	var/turf/T = locate(startx, starty, Z)
@@ -66,16 +64,16 @@
 	var/endy
 	var/endx
 	switch(startSide)
-		if(1) //NORTH
+		if(NORTH)
 			endy = TRANSITIONEDGE
 			endx = rand(TRANSITIONEDGE, world.maxx-TRANSITIONEDGE)
-		if(2) //EAST
+		if(EAST)
 			endy = rand(TRANSITIONEDGE, world.maxy-TRANSITIONEDGE)
 			endx = TRANSITIONEDGE
-		if(3) //SOUTH
+		if(SOUTH)
 			endy = world.maxy-TRANSITIONEDGE
 			endx = rand(TRANSITIONEDGE, world.maxx-TRANSITIONEDGE)
-		if(4) //WEST
+		if(WEST)
 			endy = rand(TRANSITIONEDGE,world.maxy-TRANSITIONEDGE)
 			endx = world.maxx-TRANSITIONEDGE
 	var/turf/T = locate(endx, endy, Z)
@@ -116,8 +114,6 @@
 
 		if(prob(10) && !istype(T, /turf/open/space))//randomly takes a 'hit' from ramming
 			get_hit()
-
-	return .
 
 /obj/effect/meteor/Destroy()
 	walk(src,0) //this cancels the walk_towards() proc
@@ -163,7 +159,6 @@
 	if(istype(W, /obj/item/weapon/pickaxe))
 		make_debris()
 		qdel(src)
-		return
 	else
 		return ..()
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -26,7 +26,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	new /obj/effect/immovablerod(startT, endT)
 
 /obj/effect/immovablerod
-	name = "Immovable Rod"
+	name = "immovable rod"
 	desc = "What the fuck is that?"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "immrod"
@@ -37,14 +37,28 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/destination
 
 /obj/effect/immovablerod/New(atom/start, atom/end)
-	loc = start
+	..()
 	z_original = z
 	destination = end
+	notify_ghosts("\A [src] is inbound!",
+		enter_link="<a href=?src=\ref[src];orbit=1>(Click to orbit)</a>",
+		source=src, action=NOTIFY_ORBIT)
+	poi_list += src
 	if(end && end.z==z_original)
 		walk_towards(src, destination, 1)
 
+/obj/effect/immovablerod/Topic(href, href_list)
+	if(href_list["orbit"])
+		var/mob/dead/observer/ghost = usr
+		if(istype(ghost))
+			ghost.ManualFollow(src)
+
+/obj/effect/immovablerod/Destroy()
+	poi_list -= src
+	. = ..()
+
 /obj/effect/immovablerod/Move()
-	if(z != z_original || loc == destination)
+	if((z != z_original) || (loc == destination))
 		qdel(src)
 	return ..()
 
@@ -54,7 +68,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/Bump(atom/clong)
 	if(prob(10))
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
-		audible_message("CLANG")
+		audible_message("<span class='danger'>You hear a CLANG!</span>")
 
 	if(clong && prob(25))
 		x = clong.x
@@ -71,4 +85,12 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 			H.adjustBruteLoss(160)
 		if(clong.density || prob(10))
 			clong.ex_act(2)
-	return
+	else if(istype(clong, type))
+		var/obj/effect/immovablerod/other = clong
+		visible_message("<span class='danger'>[src] collides with [other]!\
+			</span>")
+		var/datum/effect_system/smoke_spread/smoke = new
+		smoke.set_up(2, get_turf(src))
+		smoke.start()
+		qdel(src)
+		qdel(other)


### PR DESCRIPTION
:cl: coiax
rscadd: Immovable rods now notify ghosts when created, allowing them to
orbit it and follow their path of destruction through the station.
fix: Fixed bugs where no meteors would come or go from the south.
Seriously, that was a real bug. Meteor showers are now about 33%
stronger as a result.
/:cl:
- Immovable rods also cancel out if they collide (and decay into a
  number of high energy particles, such as smoke, and more smoke).
- Replaces spawn(0) in meteor code with an addtimer.
