### PR TITLE
Fixed SSU disinfect not working on most items.

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -358,7 +358,8 @@
 			else if(!helmet && !mask && !suit && !storage && !occupant)
 				return
 			else
-				occupant << "<span class='userdanger'>[src]'s confines grow warm, then hot, then scorching. You're being burned [!occupant.stat ? "alive" : "away"]!</span>"
+				if(occupant)
+					occupant << "<span class='userdanger'>[src]'s confines grow warm, then hot, then scorching. You're being burned [!occupant.stat ? "alive" : "away"]!</span>"
 				cook()
 				. = TRUE
 		if("dispense")


### PR DESCRIPTION
Fixed Suit Storage Units runtiming if you tried to disinfect them without a mob inside them.
:cl: optional name here
bugfix: Suit Storage Units can now disinfect items other than living and dead creatures.
/:cl:
