### PR TITLE
Changes the message for bluespace artillery fired by admins

### DIFF
--- a/code/modules/admin/verbs/bluespacearty.dm
+++ b/code/modules/admin/verbs/bluespacearty.dm
@@ -24,8 +24,8 @@
 			T.break_tile()
 
 	target << "<span class='userdanger'>You're hit by bluespace artillery!</span>"
-	log_admin("[target.name] has been hit by Bluespace Artillery fired by [usr]")
-	message_admins("[target.name] has been hit by Bluespace Artillery fired by [usr]")
+	log_admin("[key_name(target)] has been hit by Bluespace Artillery fired by [key_name(usr)]")
+	message_admins("[ADMIN_LOOKUPFLW(target)] has been hit by Bluespace Artillery fired by [ADMIN_LOOKUPFLW(usr)]")
 
 	if(target.health <= 1)
 		target.gib(1, 1)


### PR DESCRIPTION
Now it appears the ckey and not just the admin's IC name(same for the target)
