### PR TITLE
Fixes dextrous not working on hostile mobs

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -60,10 +60,6 @@
 /mob/living/UnarmedAttack(atom/A)
 	A.attack_animal(src)
 
-/mob/living/simple_animal/hostile/UnarmedAttack(atom/A)
-	target = A
-	AttackingTarget()
-
 /atom/proc/attack_animal(mob/user)
 	return
 /mob/living/RestrainedClickOn(atom/A)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -232,6 +232,13 @@
 		else if(target != null && prob(40))//No more pulling a mob forever and having a second player attack it, it can switch targets now if it finds a more suitable one
 			FindTarget()
 
+/mob/living/simple_animal/hostile/UnarmedAttack(atom/A)
+	target = A
+	if(dextrous)
+		..()
+	else
+		AttackingTarget()
+
 /mob/living/simple_animal/hostile/proc/AttackingTarget()
 	target.attack_animal(src)
 


### PR DESCRIPTION
Hostile mobs with `dextrous = TRUE` now can actually use their hands. It may interact weirdly with environment smash, but no current hostile mobs actually have `dextrous`, so it isn't a problem for now.
