### PR TITLE
Adds conveyor belts to autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -711,3 +711,20 @@
 	materials = list(MAT_METAL = 12000)
 	build_path = /obj/item/wallframe/turret_control
 	category = list("initial", "Construction")
+
+/datum/design/conveyor_belt
+	name = "Conveyor belt"
+	id = "conveyor_belt"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 5000)
+	build_path = /obj/item/conveyor_construct
+	category = list("initial", "Construction")
+
+/datum/design/conveyor_switch
+	name = "Conveyor belt switch"
+	id = "conveyor_switch"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 450, MAT_GLASS = 190)
+	build_path = /obj/item/conveyor_switch_construct
+	category = list("initial", "Construction")
+


### PR DESCRIPTION
:cl: Gun Hog
add: Nanotrasen is proud to announce that conveyor belts can now be fabricated at your station's autolathes!
/:cl:

A few members of #coderbus requested conveyor belt construction for the autolathe. Enjoy!
- Added Conveyor belt to autolathe designs.
- Added Conveyor switches to autolathe designs.
