### PR TITLE
Reverts accidental botany buff

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -34,7 +34,7 @@
 	// Stronger reagents must always come first to avoid being displaced by weaker ones.
 	// Total amount of any reagent in plant is calculated by formula: 1 + round(potency * multiplier)
 
-	var/innate_yieldmod = 1 //modifier for yield, seperate to the one in Hydro trays, as that one is SPECIFICALLY for nutriment/chems (which means it's constantly reset)
+	var/innate_yieldmod = 0 //modifier for yield, seperate to the one in Hydro trays, as that one is SPECIFICALLY for nutriment/chems (which means it's constantly reset)
 	//This is added onto the yield mod of the hydro tray, yield *= (parent.yieldmod+innate_yieldmod)
 
 	var/weed_rate = 1 //If the chance below passes, then this many weeds sprout during growth


### PR DESCRIPTION
:cl:
tweak: Fixes accidental buff to botany, all modifiers should now be at the point they were at pre-bees (this does not remove, nerf or alter bees)
/:cl:

This was accidentally introduced along with Bees back in March, this value should always have been 0 by default but I made it 1 on accident, leading to all multipliers being 1 stronger than they should be (Eg: Robust Harvest went from 2x -> 3x)

@bobdobbington + @Firecage noticed this (rather, they noticed the issue, not the actual code problem itself)
