### PR TITLE
Changling power: regenerate; regrow limbs, organs

### DIFF
--- a/code/game/gamemodes/changeling/changeling_power.dm
+++ b/code/game/gamemodes/changeling/changeling_power.dm
@@ -15,7 +15,8 @@
 	var/req_stat = CONSCIOUS // CONSCIOUS, UNCONSCIOUS or DEAD
 	var/genetic_damage = 0 // genetic damage caused by using the sting. Nothing to do with cloneloss.
 	var/max_genetic_damage = 100 // hard counter for spamming abilities. Not used/balanced much yet.
-	var/always_keep = 0 // important for abilities like regenerate that screw you if you lose them.
+	var/always_keep = 0 // important for abilities like revive that screw you if you lose them.
+	var/ignores_fakedeath = FALSE // usable with the FAKEDEATH flag
 
 
 /obj/effect/proc_holder/changeling/proc/on_purchase(mob/user)
@@ -56,16 +57,16 @@
 		user << "<span class='warning'>We cannot do that in this form!</span>"
 		return 0
 	var/datum/changeling/c = user.mind.changeling
-	if(c.chem_charges<chemical_cost)
+	if(c.chem_charges < chemical_cost)
 		user << "<span class='warning'>We require at least [chemical_cost] unit\s of chemicals to do that!</span>"
 		return 0
-	if(c.absorbedcount<req_dna)
+	if(c.absorbedcount < req_dna)
 		user << "<span class='warning'>We require at least [req_dna] sample\s of compatible DNA.</span>"
 		return 0
 	if(req_stat < user.stat)
 		user << "<span class='warning'>We are incapacitated.</span>"
 		return 0
-	if((user.status_flags & FAKEDEATH) && name != "Regenerate")
+	if((user.status_flags & FAKEDEATH) && (!ignores_fakedeath))
 		user << "<span class='warning'>We are incapacitated.</span>"
 		return 0
 	if(c.geneticdamage > max_genetic_damage)

--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -1,5 +1,5 @@
 /obj/effect/proc_holder/changeling/fakedeath
-	name = "Regenerative Stasis"
+	name = "Reviving Stasis"
 	desc = "We fall into a stasis, allowing us to regenerate and trick our enemies."
 	chemical_cost = 15
 	dna_cost = 0
@@ -25,12 +25,12 @@
 
 /obj/effect/proc_holder/changeling/fakedeath/proc/ready_to_regenerate(mob/user)
 	if(user && user.mind && user.mind.changeling && user.mind.changeling.purchasedpowers)
-		user << "<span class='notice'>We are ready to regenerate.</span>"
+		user << "<span class='notice'>We are ready to revive.</span>"
 		user.mind.changeling.purchasedpowers += new /obj/effect/proc_holder/changeling/revive(null)
 
 /obj/effect/proc_holder/changeling/fakedeath/can_sting(mob/user)
 	if(user.status_flags & FAKEDEATH)
-		user << "<span class='warning'>We are already regenerating.</span>"
+		user << "<span class='warning'>We are already reviving.</span>"
 		return
 	if(!user.stat) //Confirmation for living changelings if they want to fake their death
 		switch(alert("Are we sure we wish to fake our own death?",,"Yes", "No"))

--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -1,11 +1,12 @@
 /obj/effect/proc_holder/changeling/fleshmend
 	name = "Fleshmend"
-	desc = "Our flesh rapidly regenerates, healing our wounds, and growing \
-		back missing limbs. Effectiveness decreases with quick, repeated use."
+	desc = "Our flesh rapidly regenerates, healing our burns, bruises and \
+		shortness of breath. Effectiveness decreases with quick, \
+		repeated use."
 	helptext = "Heals a moderate amount of damage over a short period of \
-		time. Can be used while unconscious. Will alert nearby crew if \
-		any limbs are regenerated."
-	chemical_cost = 25
+		time. Can be used while unconscious. Does not regrow limbs or \
+		restore lost blood."
+	chemical_cost = 20
 	dna_cost = 2
 	req_stat = UNCONSCIOUS
 	var/recent_uses = 1 //The factor of which the healing should be divided by
@@ -33,30 +34,25 @@
 	if(recent_uses > 1)
 		user << "<span class='warning'>Our healing's effectiveness is reduced \
 			by quick repeated use!</span>"
-	spawn(0)
-		recent_uses++
-		if(ishuman(user))
-			var/mob/living/carbon/human/H = user
-			H.restore_blood()
-			H.remove_all_embedded_objects()
-			var/list/missing = H.get_missing_limbs()
-			if(missing.len)
-				playsound(user, 'sound/magic/Demon_consume.ogg', 50, 1)
-				H.visible_message("<span class='warning'>[user]'s missing limbs reform, making a loud, grotesque sound!</span>", "<span class='userdanger'>Your limbs regrow, making a loud, crunchy sound and giving you great pain!</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
-				H.emote("scream")
-				H.regenerate_limbs(1)
 
-		// The healing itself - doesn't heal toxin damage
-		// (that's anatomic panacea) and the effectiveness decreases with
-		// each use in a short timespan
-		for(var/i in 1 to healing_ticks)
-			if(user)
-				var/healpertick = -(total_healing / healing_ticks)
-				user.adjustBruteLoss(healpertick / recent_uses, 0)
-				user.adjustOxyLoss(healpertick / recent_uses, 0)
-				user.adjustFireLoss(healpertick / recent_uses, 0)
-				user.updatehealth()
-			sleep(10)
+	recent_uses++
+	addtimer(src, "fleshmend", 0, FALSE, user)
 
 	feedback_add_details("changeling_powers","RR")
 	return 1
+
+/obj/effect/proc_holder/changeling/fleshmend/proc/fleshmend(mob/living/user)
+
+	// The healing itself - doesn't heal toxin damage
+	// (that's anatomic panacea) and the effectiveness decreases with
+	// each use in a short timespan
+	for(var/i in 1 to healing_ticks)
+		if(user)
+			var/healpertick = -(total_healing / healing_ticks)
+			user.adjustBruteLoss(healpertick / recent_uses, 0)
+			user.adjustOxyLoss(healpertick / recent_uses, 0)
+			user.adjustFireLoss(healpertick / recent_uses, 0)
+			user.updatehealth()
+		else
+			break
+		sleep(10)

--- a/code/game/gamemodes/changeling/powers/regenerate.dm
+++ b/code/game/gamemodes/changeling/powers/regenerate.dm
@@ -5,8 +5,8 @@
 		blood volume."
 	helptext = "Will alert nearby crew if any external limbs are \
 		regenerated. Can be used while unconscious."
-	chemical_cost = 20
-	dna_cost = 1
+	chemical_cost = 10
+	dna_cost = 0
 	req_stat = UNCONSCIOUS
 
 /obj/effect/proc_holder/changeling/regenerate/sting_action(mob/living/user)

--- a/code/game/gamemodes/changeling/powers/regenerate.dm
+++ b/code/game/gamemodes/changeling/powers/regenerate.dm
@@ -8,6 +8,7 @@
 	chemical_cost = 10
 	dna_cost = 0
 	req_stat = UNCONSCIOUS
+	always_keep = TRUE
 
 /obj/effect/proc_holder/changeling/regenerate/sting_action(mob/living/user)
 	user << "<span class='notice'>You feel an itching, both inside and \

--- a/code/game/gamemodes/changeling/powers/regenerate.dm
+++ b/code/game/gamemodes/changeling/powers/regenerate.dm
@@ -1,0 +1,32 @@
+/obj/effect/proc_holder/changeling/regenerate
+	name = "Regenerate"
+	desc = "Allows us to regrow and restore missing external limbs, and \
+		vital internal organs, as well as removing shrapnel and restoring \
+		blood volume."
+	helptext = "Will alert nearby crew if any external limbs are \
+		regenerated. Can be used while unconscious."
+	chemical_cost = 20
+	dna_cost = 1
+	req_stat = UNCONSCIOUS
+
+/obj/effect/proc_holder/changeling/regenerate/sting_action(mob/living/user)
+	user << "<span class='notice'>You feel an itching, both inside and \
+		outside as your tissues knit and reknit.</span>"
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.restore_blood()
+		H.remove_all_embedded_objects()
+		var/list/missing = H.get_missing_limbs()
+		if(missing.len)
+			playsound(user, 'sound/magic/Demon_consume.ogg', 50, 1)
+			H.visible_message("<span class='warning'>[user]'s missing limbs \
+				reform, making a loud, grotesque sound!</span>",
+				"<span class='userdanger'>Your limbs regrow, making a \
+				loud, crunchy sound and giving you great pain!</span>",
+				"<span class='italics'>You hear organic matter ripping \
+				and tearing!</span>")
+			H.emote("scream")
+			H.regenerate_limbs(1)
+
+		CHECK_DNA_AND_SPECIES(H)
+		H.dna.species.on_species_gain(H, H.dna.species)

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -1,6 +1,7 @@
 /obj/effect/proc_holder/changeling/revive
-	name = "Regenerate"
+	name = "Revive"
 	desc = "We regenerate, healing all damage from our form."
+	helptext = "Does not regrow lost organs or limbs."
 	req_stat = DEAD
 	always_keep = 1
 
@@ -9,8 +10,8 @@
 	user.status_flags &= ~(FAKEDEATH)
 	user.tod = null
 	user.revive(full_heal = 1)
-	user.regenerate_limbs(0, list("head")) //regenerate all limbs except the head
-	user << "<span class='notice'>We have regenerated.</span>"
+	// Does not restore limbs, 
+	user << "<span class='notice'>We have revived ourselves.</span>"
 	user.mind.changeling.purchasedpowers -= src
 	feedback_add_details("changeling_powers","CR")
 	return 1

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -1,16 +1,28 @@
 /obj/effect/proc_holder/changeling/revive
 	name = "Revive"
 	desc = "We regenerate, healing all damage from our form."
-	helptext = "Does not regrow lost organs or limbs."
+	helptext = "Does not regrow lost organs or a missing head."
 	req_stat = DEAD
-	always_keep = 1
+	always_keep = TRUE
+	ignores_fakedeath = TRUE
 
 //Revive from revival stasis
 /obj/effect/proc_holder/changeling/revive/sting_action(mob/living/carbon/user)
 	user.status_flags &= ~(FAKEDEATH)
 	user.tod = null
 	user.revive(full_heal = 1)
-	// Does not restore limbs, 
+	var/list/missing = user.get_missing_limbs()
+	missing -= "head" // headless changelings are funny
+	if(missing.len)
+		playsound(user, 'sound/magic/Demon_consume.ogg', 50, 1)
+		user.visible_message("<span class='warning'>[user]'s missing limbs \
+			reform, making a loud, grotesque sound!</span>",
+			"<span class='userdanger'>Your limbs regrow, making a \
+			loud, crunchy sound and giving you great pain!</span>",
+			"<span class='italics'>You hear organic matter ripping \
+			and tearing!</span>")
+		user.emote("scream")
+		user.regenerate_limbs(0, list("head"))
 	user << "<span class='notice'>We have revived ourselves.</span>"
 	user.mind.changeling.purchasedpowers -= src
 	feedback_add_details("changeling_powers","CR")

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -78,6 +78,8 @@
 /obj/item/bodypart/throw_impact(atom/hit_atom)
 	..()
 	playsound(get_turf(src), 'sound/misc/splort.ogg', 50, 1, -1)
+	pixel_x = rand(-3, 3)
+	pixel_y = rand(-3, 3)
 
 /obj/item/bodypart/proc/drop_organs(mob/user)
 	var/turf/T = get_turf(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -312,6 +312,7 @@
 #include "code\game\gamemodes\changeling\powers\mutations.dm"
 #include "code\game\gamemodes\changeling\powers\panacea.dm"
 #include "code\game\gamemodes\changeling\powers\revive.dm"
+#include "code\game\gamemodes\changeling\powers\regenerate.dm"
 #include "code\game\gamemodes\changeling\powers\shriek.dm"
 #include "code\game\gamemodes\changeling\powers\spiders.dm"
 #include "code\game\gamemodes\changeling\powers\strained_muscles.dm"


### PR DESCRIPTION
:cl: coiax
del: Fleshmend no longer regrows lost limbs. 
add: Added free Regenerate power to changelings, which regrows all
external limbs and internal organs
(including the tongue if you lost your head). It costs 10 chemicals to
use.
add: Fleshmend now costs 20 chemicals, down from 25.
tweak: Changeling revive power name changed from Regenerate to Revive.
/:cl:
- Also makes fleshmend use a 0'd addtimer rather than a spawn.
- Thrown limbs now don't always land in the centre of the tile.
