### PR TITLE
Planetary atmos

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -187,6 +187,7 @@
 	if (planetary_atmos) //share our air with the "atmosphere" "above" the turf
 		var/datum/gas_mixture/G = new
 		G.copy_from_turf(src)
+		G.archive()
 		if(air.compare(G))
 			if(!our_excited_group)
 				var/datum/excited_group/EG = new

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -30,6 +30,8 @@
 	var/datum/gas_mixture/air
 
 	var/obj/effect/hotspot/active_hotspot
+	var/atmos_cooldown  = 0
+	var/planetary_atmos = FALSE //air will revert to initial_gas_mix over time
 
 	var/list/atmos_overlay_types = list() //gas IDs of current active gas overlays
 
@@ -129,6 +131,9 @@
 	var/list/adjacent_turfs = atmos_adjacent_turfs
 	var/datum/excited_group/our_excited_group = excited_group
 	var/adjacent_turfs_length = adjacent_turfs.len
+	atmos_cooldown++
+	if (planetary_atmos)
+		adjacent_turfs_length++
 
 	for(var/t in adjacent_turfs)
 		var/turf/open/enemy_tile = t
@@ -179,6 +184,17 @@
 
 		/******************* GROUP HANDLING FINISH *********************************************************************/
 
+	if (planetary_atmos) //share our air with the "atmosphere" "above" the turf
+		var/datum/gas_mixture/G = new
+		G.copy_from_turf(src)
+		if(air.compare(G))
+			if(!our_excited_group)
+				var/datum/excited_group/EG = new
+				EG.add_turf(src)
+				our_excited_group = excited_group
+			air.share(G, adjacent_turfs_length)
+			last_share_check()
+
 	air.react()
 
 	update_visuals()
@@ -193,8 +209,11 @@
 			if(consider_superconductivity(starting = 1))
 				remove = 0
 
+	if (atmos_cooldown > EXCITED_GROUP_DISMANTLE_CYCLES*2)
+		SSair.remove_from_active(src)
 	if(!our_excited_group && remove == 1)
 		SSair.remove_from_active(src)
+
 
 /turf/open/proc/share_air(turf/open/T, fire_count, adjacent_turfs_length)
 	if(T.current_cycle < fire_count)
@@ -217,8 +236,10 @@
 /turf/open/proc/last_share_check()
 	if(air.last_share > MINIMUM_AIR_TO_SUSPEND)
 		excited_group.reset_cooldowns()
+		atmos_cooldown = 0
 	else if(air.last_share > MINIMUM_MOLES_DELTA_TO_MOVE)
 		excited_group.dismantle_cooldown = 0
+		atmos_cooldown = 0
 
 /turf/open/proc/high_pressure_movements()
 	for(var/atom/movable/M in src)
@@ -295,6 +316,7 @@
 	for(var/t in turf_list)
 		var/turf/open/T = t
 		T.air.copy_from(A)
+		T.atmos_cooldown = 0
 		T.update_visuals()
 
 	breakdown_cooldown = 0

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -619,10 +619,12 @@
 
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	planetary_atmos = TRUE
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 
 /turf/open/chasm/straight_down/lava_land_surface
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	planetary_atmos = TRUE
 	baseturf = /turf/open/chasm/straight_down/lava_land_surface
 
 /turf/open/chasm/straight_down/lava_land_surface/drop(atom/movable/AM)
@@ -674,6 +676,7 @@
 
 /turf/open/floor/plating/lava/smooth/lava_land_surface
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	planetary_atmos = TRUE
 	baseturf = /turf/open/chasm/straight_down/lava_land_surface
 
 /turf/closed/mineral/gibtonite/volcanic
@@ -759,6 +762,7 @@
 	baseturf = /turf/open/floor/plating/ash //I assume this will be a chasm eventually, once this becomes an actual surface
 	slowdown = 1
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	planetary_atmos = TRUE
 
 /turf/open/floor/plating/ash/New()
 	pixel_y = -4


### PR DESCRIPTION
:cl:
experiment: Atmos on planets is now more realistic. There is an unseen upper atmosphere that gas changes get carried away into, causing planet turfs to revert back to their original gas mixture.
tweak: This should massively improve atmos run speed as all of lavaland won't be processing the moment somebody opens a door anymore
/:cl:

Turfs marked as planetary_atmos will revert back to their default state as if the upper atmosphere mixes with it reverting it.
