### PR TITLE
Prevents the maploader from resetting when another map is read

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -41,8 +41,11 @@ var/global/dmm_suite/preloader/_preloader = new
 	var/list/grid_models = list()
 	var/key_len = 0
 
-	dmmRegex.next = 1
-	while(dmmRegex.Find(tfile, dmmRegex.next))
+	var/dmm_suite/loaded_map/LM = new
+
+	LM.index = 1
+	while(dmmRegex.Find(tfile, LM.index))
+		LM.index = dmmRegex.next
 
 		// "aa" = (/type{vars=blah})
 		if(dmmRegex.group[1]) // Model
@@ -130,6 +133,8 @@ var/global/dmm_suite/preloader/_preloader = new
 			bounds[MAP_MAXX] = max(bounds[MAP_MAXX], cropMap ? min(maxx, world.maxx) : maxx)
 
 		CHECK_TICK
+
+	qdel(LM)
 
 	if(bounds[1] == 1.#INF) // Shouldn't need to check every item
 		return null
@@ -394,6 +399,10 @@ var/global/dmm_suite/preloader/_preloader = new
 			value = deepCopyList(value)
 		what.vars[attribute] = value
 	use_preloader = FALSE
+
+/dmm_suite/loaded_map
+	parent_type = /datum
+	var/index = 1 // To store the state of the regex
 
 /area/template_noop
 	name = "Area Passthrough"

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -41,11 +41,9 @@ var/global/dmm_suite/preloader/_preloader = new
 	var/list/grid_models = list()
 	var/key_len = 0
 
-	var/dmm_suite/loaded_map/LM = new
-
-	LM.index = 1
-	while(dmmRegex.Find(tfile, LM.index))
-		LM.index = dmmRegex.next
+	var/stored_index = 1
+	while(dmmRegex.Find(tfile, stored_index))
+		stored_index = dmmRegex.next
 
 		// "aa" = (/type{vars=blah})
 		if(dmmRegex.group[1]) // Model
@@ -133,8 +131,6 @@ var/global/dmm_suite/preloader/_preloader = new
 			bounds[MAP_MAXX] = max(bounds[MAP_MAXX], cropMap ? min(maxx, world.maxx) : maxx)
 
 		CHECK_TICK
-
-	qdel(LM)
 
 	if(bounds[1] == 1.#INF) // Shouldn't need to check every item
 		return null
@@ -399,10 +395,6 @@ var/global/dmm_suite/preloader/_preloader = new
 			value = deepCopyList(value)
 		what.vars[attribute] = value
 	use_preloader = FALSE
-
-/dmm_suite/loaded_map
-	parent_type = /datum
-	var/index = 1 // To store the state of the regex
 
 /area/template_noop
 	name = "Area Passthrough"


### PR DESCRIPTION
After having worked on ParadiseSS13/Paradise#4780, I've found a bug where when the map loader hits a template loader and activates it, its state is reset, as the `dmmregex` is used by the template loader and has its state reset. When I tried to load an away mission that had these templates in place, to add variety, the loader would reset infinitely and do mean things to the server. This should fix that.

:cl: Crazylemon
fix: The map loader no longer resets when reading another map mid-load
/:cl:
