### PR TITLE
Refactors out num2roman because byond has inbuilt support (yes, really!)

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -100,7 +100,7 @@ var/religion_name = null
 		if(2)
 			new_station_name += pick(greek_letters)
 		if(3)
-			new_station_name += pick(roman_numerals)
+			new_station_name += "\Roman[rand(1,99)]"
 		if(4)
 			new_station_name += pick(phonetic_alphabet)
 		if(5)

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -573,16 +573,3 @@ for(var/t in test_times)
 	var/G = hex2num(copytext(A,4,6))
 	var/B = hex2num(copytext(A,6,0))
 	return R+G+B
-
-//Converts a positive interger to its roman numeral equivilent. Ignores any decimals.
-//Numbers over 3999 will display with extra "M"s (don't tell the Romans) and can get comically long, so be careful.
-/proc/num2roman(A)
-	var/list/values = list("M" = 1000, "CM" = 900, "D" = 500, "CD" = 400, "C" = 100, "XC" = 90, "L" = 50, "XL" = 40, "X" = 10, "IX" = 9, "V" = 5, "IV" = 4, "I" = 1)
-	if(!A || !isnum(A))
-		return 0
-	while(A >= 1)
-		for(var/i in values)
-			if(A >= values[i])
-				. += i
-				A -= values[i]
-				break

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -132,10 +132,6 @@ var/global/list/greek_letters = list("Alpha", "Beta", "Gamma", "Delta",
 	"Nu", "Xi", "Omicron", "Pi", "Rho", "Sigma", "Tau", "Upsilon", "Phi",
 	"Chi", "Psi", "Omega")
 
-var/global/list/roman_numerals = list("I", "II", "III", "IV", "V", "VI",
-	"VII", "VIII", "IX", "X", "XI", "XII", "XIII", "XIV", "XV", "XVI",
-	"XVII", "XVIII", "XIX", "XX")
-
 var/global/list/phonetic_alphabet = list("Alpha", "Bravo", "Charlie",
 	"Delta", "Echo", "Foxtrot", "Golf", "Hotel", "India", "Juliet",
 	"Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec",
@@ -151,6 +147,7 @@ var/global/list/numbers_as_words = list("One", "Two", "Three", "Four",
 	var/list/L
 	for(var/i in 1 to 99)
 		L += "[i]"
+		L += "\Roman[i]"
 	return L
 
-var/global/list/station_numerals = greek_letters + roman_numerals + phonetic_alphabet + numbers_as_words + generate_number_strings()
+var/global/list/station_numerals = greek_letters + phonetic_alphabet + numbers_as_words + generate_number_strings()

--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -18,7 +18,7 @@
 	if(ancestor_name)
 		name = ancestor_name
 		if(ancestor_chain > 1)
-			name += " [num2roman(ancestor_chain)]"
+			name += " \Roman[ancestor_chain]"
 	else
 		if(prob(5))
 			name = pick(rare_pet_monkey_names)


### PR DESCRIPTION
Hello I was bored.

Note: Byond's inbuilt text macro for roman numerals doesn't strictly render correct past 4000 either. The bigger symbols the romans used simply don't have have support in byond.
