### PR TITLE
Fixed auto-set nuke code on blob being a number instead of a string.

### DIFF
--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -16,7 +16,7 @@
 			print_command_report(intercepttext,"Level 5-6 Biohazard Response Procedures")
 			priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
 		if(2)
-			var/nukecode = rand(10000, 99999)
+			var/nukecode = "[rand(10000, 99999)]"
 			for(var/obj/machinery/nuclearbomb/bomb in machines)
 				if(bomb && bomb.r_code)
 					if(bomb.z == ZLEVEL_STATION)


### PR DESCRIPTION
This bug has existed since September of 2014, how has it not been fixed yet?
