### PR TITLE
Autoevac time no longer always 25 minutes; war ops autocall

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -233,7 +233,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	return TRUE
 
 /datum/subsystem/shuttle/proc/autoEvac(force=FALSE)
-	var/callShuttle = 1
+	var/callShuttle = TRUE
 
 	for(var/thing in shuttle_caller_list)
 		if(istype(thing, /mob/living/silicon/ai))
@@ -247,26 +247,23 @@ var/datum/subsystem/shuttle/SSshuttle
 
 		var/turf/T = get_turf(thing)
 		if(T && T.z == ZLEVEL_STATION)
-			callShuttle = 0
+			callShuttle = FALSE
 			break
 
 	var/delay = config.shuttle_refuel_delay - (world.time - round_start_time)
 	var/delay_fraction = max(delay, 0) / emergencyCallTime
 	var/call_multiplier = 1 + delay_fraction
 	if(callShuttle || force)
-		emergencyNoRecall = TRUE
 		if(EMERGENCY_IDLE_OR_RECALLED)
 			emergency.request(null, call_multiplier)
 		if(callShuttle)
 			log_game("There is no means of calling the shuttle anymore. \
-				Shuttle automatically called and no longer recallable.")
+				Shuttle automatically called.")
 			message_admins("All the communications consoles were destroyed \
-				and all AIs are inactive. Shuttle called and no longer \
-				recallable.")
+				and all AIs are inactive. Shuttle called.")
 		if(force)
-			log_game("Unrecallable mandatory shuttle evacuation forced.")
-			message_admins("The emergency shuttle has been force called, \
-				and cannot be recalled.")
+			log_game("An auto-evacuation shuttle has been forced.")
+			message_admins("The emergency shuttle has been force called.")
 
 //try to move/request to dockHome if possible, otherwise dockAway. Mainly used for admin buttons
 /datum/subsystem/shuttle/proc/toggleShuttle(shuttleId, dockHome, dockAway, timed)

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -11,6 +11,7 @@
 			Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
 			Must be used within five minutes, or your benefactors will lose interest."
 	var/declaring_war = 0
+	var/always_allowed = FALSE // for debug purposes.
 
 /obj/item/device/nuclear_challenge/attack_self(mob/living/user)
 	if(!check_allowed(user))
@@ -39,26 +40,31 @@
 	U.hidden_uplink.telecrystals = CHALLENGE_TELECRYSTALS
 	U.hidden_uplink.gamemode = /datum/game_mode/nuclear
 	config.shuttle_refuel_delay = max(config.shuttle_refuel_delay, CHALLENGE_SHUTTLE_DELAY)
+	// After the sound effect finishes playing, call the shuttle
+	// and make it unrecallable.
+	addtimer(SSshuttle, "autoEvac", 150, TRUE, TRUE)
 	qdel(src)
 
 /obj/item/device/nuclear_challenge/proc/check_allowed(mob/living/user)
+	if(always_allowed)
+		return TRUE
 	if(declaring_war)
-		return 0
+		return FALSE
 	if(player_list.len < CHALLENGE_MIN_PLAYERS)
 		user << "The enemy crew is too small to be worth declaring war on."
-		return 0
+		return FALSE
 	if(user.z != ZLEVEL_CENTCOM)
 		user << "You have to be at your base to use this."
-		return 0
+		return FALSE
 	if(world.time-round_start_time > CHALLENGE_TIME_LIMIT)
 		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
-		return 0
+		return FALSE
 	for(var/V in syndicate_shuttle_boards)
 		var/obj/item/weapon/circuitboard/computer/syndicate_shuttle/board = V
 		if(board.moved)
 			user << "The shuttle has already been moved! You have forfeit the right to declare war."
-			return 0
-	return 1
+			return FALSE
+	return TRUE
 
 #undef CHALLENGE_TELECRYSTALS
 #undef CHALLENGE_MIN_PLAYERS

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -29,7 +29,7 @@
 	declaring_war = 1
 	var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
 	priority_announce(war_declaration, title = "Declaration of War", sound = 'sound/machines/Alarm.ogg')
-	user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
+	user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission. Mostly bragging rights."
 
 	for(var/V in syndicate_shuttle_boards)
 		var/obj/item/weapon/circuitboard/computer/syndicate_shuttle/board = V
@@ -43,6 +43,7 @@
 	// After the sound effect finishes playing, call the shuttle
 	// and make it unrecallable.
 	addtimer(SSshuttle, "autoEvac", 150, TRUE, TRUE)
+	SSshuttle.emergencyNoRecall = TRUE
 	qdel(src)
 
 /obj/item/device/nuclear_challenge/proc/check_allowed(mob/living/user)

--- a/code/modules/mob/living/silicon/ai/logout.dm
+++ b/code/modules/mob/living/silicon/ai/logout.dm
@@ -3,3 +3,4 @@
 	for(var/obj/machinery/ai_status_display/O in world) //change status
 		O.mode = 0
 	view_core()
+	SSshuttle.autoEvac()


### PR DESCRIPTION
:cl: coiax
add: The automatic evacuation triggered by the destruction of all communication consoles and AIs is now ten minutes (reduced from twenty five minutes) plus any round start shuttle delay (so you can't get around the shuttle's refueling time).
add: A declaration of war by Nuclear Operatives will automatically call the shuttle (delay to refuel time included), providing both sides with a timer. The operatives will (with normal config options) be able to arrive on the station at the ETA 15:00 mark. The shuttle is not recallable when a declaration of war has been made.
/:cl:
### Balance implications
- Station crew on war ops can no longer get a red alert shuttle, in exchange for reliably having a timer for victory and the window when the ops will be arriving. (Regular war ops timings will be evacuation shuttle docks at 35 minutes after roundstart, op window opens at 20 minutes after roundstart.)
