### PR TITLE
Clockwork slabs produce components significantly slower

### DIFF
--- a/code/game/gamemodes/clock_cult/__clock_defines.dm
+++ b/code/game/gamemodes/clock_cult/__clock_defines.dm
@@ -14,11 +14,11 @@ var/global/ratvar_awakens = FALSE //If Ratvar has been summoned
 #define SCRIPTURE_REVENANT 4
 #define SCRIPTURE_JUDGEMENT 5
 
-#define SLAB_PRODUCTION_TIME 600 //how long(deciseconds) slabs require to produce a single component; defaults to 1 minute
+#define SLAB_PRODUCTION_TIME 900 //how long(deciseconds) slabs require to produce a single component; defaults to 1 minute 30 seconds
 
-#define SLAB_SERVANT_SLOWDOWN 200 //how much each servant above 5 slows down slab-based generation; defaults to 20 seconds per sevant
+#define SLAB_SERVANT_SLOWDOWN 300 //how much each servant above 5 slows down slab-based generation; defaults to 30 seconds per sevant
 
-#define SLAB_SLOWDOWN_MAXIMUM 2400 //maximum slowdown from additional servants; defaults to 4 minutes
+#define SLAB_SLOWDOWN_MAXIMUM 2700 //maximum slowdown from additional servants; defaults to 4 minutes 30 seconds
 
 #define CACHE_PRODUCTION_TIME 900 //how long(deciseconds) caches require to produce a component; defaults to 1 minute 30 seconds
 

--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -230,8 +230,8 @@
 	\
 	This is done through <b>Components</b> - pieces of the Justiciar's body that have since fallen off in the countless years since his imprisonment. Ratvar's unfortunate condition results \
 	in the fragmentation of his body. These components still house great power on their own, and can slowly be drawn from Reebe by links capable of doing so. The most basic of these links lies \
-	in the clockwork slab, which will slowly generate components over time - around one component of a random type is produced every minute, which is obviously inefficient. There are other ways \
-	to create these components through scripture and certain structures.<br><br>\
+	in the clockwork slab, which will slowly generate components over time - one component of a random type is produced every 1 minute and 30 seconds, plus 30 seconds per each servant above 5, \
+	which is obviously inefficient. There are other ways to create these components through scripture and certain structures.<br><br>\
 	\
 	In addition to their ability to pull components, slabs also possess other functionalities...<br><br>\
 	\


### PR DESCRIPTION
:cl: Joan
tweak: Clockwork Slabs now produce a component every 1 minute, 30 seconds, from every 1 minute.
experiment: The slab production time gain from each servant above 5 has been increased from 20 seconds to 30 seconds, and the maximum production time has been increased from 5 minutes to 6 minutes.
/:cl:
