### PR TITLE
Fixes Nicotine's stun reduction

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -40,7 +40,9 @@
 	if(prob(1))
 		var/smoke_message = pick("You feel relaxed.", "You feel calmed.","You feel alert.","You feel rugged.")
 		M << "<span class='notice'>[smoke_message]</span>"
+	M.AdjustParalysis(-1, 0)
 	M.AdjustStunned(-1, 0)
+	M.AdjustWeakened(-1, 0)
 	M.adjustStaminaLoss(-0.5*REM, 0)
 	..()
 	. = 1


### PR DESCRIPTION
:cl: Iamgoofball
fix: Fixes Nicotine's stun reduction
/:cl:

~~GFD phil, this is a fix because nicotine is supposed to reduce all stuns by a little. he made it literally only reduce Stun(), which is never ever used, he probably thought it meant all stuns or some shit~~

neverminnd it was idiot me from 2 years ago not realizing how stun code worked at the time, this is still a fix because it was supposed to reduce all stuns
