### PR TITLE
Shuttle SS keeps track of hostile environments

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -263,9 +263,9 @@ var/datum/subsystem/shuttle/SSshuttle
 	checkHostileEnvironment()
 
 /datum/subsystem/shuttle/proc/checkHostileEnvironment()
-	for(var/atom/a in hostileEnvironments)
-		if(!istype(a) || qdeleted(a))
-			hostileEnvironments -= a
+	for(var/datum/d in hostileEnvironments)
+		if(!istype(d) || qdeleted(d))
+			hostileEnvironments -= d
 	emergencyNoEscape = hostileEnvironments.len
 
 	if(emergencyNoEscape && (emergency.mode == SHUTTLE_IGNITING))

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -24,6 +24,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	var/emergencyEscapeTime = 1200	//time taken for emergency shuttle to reach a safe distance after leaving station (in deciseconds)
 	var/area/emergencyLastCallLoc
 	var/emergencyNoEscape
+	var/list/hostileEnvironments = list()
 
 		//supply shuttle stuff
 	var/obj/docking_port/mobile/supply/supply
@@ -252,6 +253,34 @@ var/datum/subsystem/shuttle/SSshuttle
 			emergency.request(null, 2.5)
 			log_game("There is no means of calling the shuttle anymore. Shuttle automatically called.")
 			message_admins("All the communications consoles were destroyed and all AIs are inactive. Shuttle called.")
+
+/datum/subsystem/shuttle/proc/registerHostileEnvironment(datum/bad)
+	hostileEnvironments[bad] = TRUE
+	checkHostileEnvironment()
+
+/datum/subsystem/shuttle/proc/clearHostileEnvironment(datum/bad)
+	hostileEnvironments -= bad
+	checkHostileEnvironment()
+
+/datum/subsystem/shuttle/proc/checkHostileEnvironment()
+	for(var/atom/a in hostileEnvironments)
+		if(!istype(a) || qdeleted(a))
+			hostileEnvironments -= a
+	emergencyNoEscape = hostileEnvironments.len
+
+	if(emergencyNoEscape && (emergency.mode == SHUTTLE_IGNITING))
+		emergency.mode = SHUTTLE_STRANDED
+		emergency.timer = null
+		emergency.sound_played = FALSE
+		priority_announce("Hostile environment detected. \
+			Departure has been postponed indefinitely pending \
+			conflict resolution.", null, 'sound/misc/notice1.ogg', "Priority")
+	if(!emergencyNoEscape && (emergency.mode == SHUTTLE_STRANDED))
+		emergency.mode = SHUTTLE_DOCKED
+		emergency.setTimer(emergencyDockTime)
+		priority_announce("Hostile environment resolved. \
+			You have 3 minutes to board the Emergency Shuttle.",
+			null, 'sound/AI/shuttledock.ogg', "Priority")
 
 //try to move/request to dockHome if possible, otherwise dockAway. Mainly used for admin buttons
 /datum/subsystem/shuttle/proc/toggleShuttle(shuttleId, dockHome, dockAway, timed)

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -78,7 +78,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 		B.loc = T
 		B.base_point_rate = blob_point_rate
 
-	SSshuttle.emergencyNoEscape = 1
+	SSshuttle.registerHostileEnvironment(src)
 
 	// Disable the blob event for this round.
 	var/datum/round_event_control/blob/B = locate() in SSevent.control

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -6,11 +6,7 @@
 	if(!blob_cores.len) //blob is dead
 		if(config.continuous["blob"])
 			continuous_sanity_checked = 1 //Nonstandard definition of "alive" gets past the check otherwise
-			SSshuttle.emergencyNoEscape = 0
-			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
-				SSshuttle.emergency.mode = SHUTTLE_DOCKED
-				SSshuttle.emergency.timer = world.time
-				priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
+			SSshuttle.clearHostileEnvironment(src)
 			return ..()
 		return 1
 	return ..()

--- a/code/game/gamemodes/clock_cult/clock_ratvar.dm
+++ b/code/game/gamemodes/clock_cult/clock_ratvar.dm
@@ -37,28 +37,25 @@
 	glow = new(get_turf(src))
 	countdown = new(src)
 	countdown.start()
-	SSshuttle.emergencyNoEscape = TRUE
+	SSshuttle.registerHostileEnvironment(src)
 	START_PROCESSING(SSobj, src)
 	var/area/gate_area = get_area(src)
 	hierophant_message("<span class='large_brass'><b>A gateway to the Celestial Derelict has been created in [gate_area.map_name]!</b></span>")
 
 /obj/structure/clockwork/massive/celestial_gateway/Destroy()
-	SSshuttle.emergencyNoEscape = FALSE
-	if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
-		SSshuttle.emergency.mode = SHUTTLE_DOCKED
-		SSshuttle.emergency.timer = world.time
-		if(!purpose_fulfilled)
-			priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
+	SSshuttle.clearHostileEnvironment(src)
 	STOP_PROCESSING(SSobj, src)
 	if(!purpose_fulfilled)
 		var/area/gate_area = get_area(src)
 		hierophant_message("<span class='large_brass'><b>A gateway to the Celestial Derelict has fallen at [gate_area.map_name]!</b></span>")
 		world << sound(null, 0, channel = 8)
-	qdel(glow)
-	glow = null
-	qdel(countdown)
-	countdown = null
-	return ..()
+	if(glow)
+		qdel(glow)
+		glow = null
+	if(countdown)
+		qdel(countdown)
+		countdown = null
+	. = ..()
 
 /obj/structure/clockwork/massive/celestial_gateway/destroyed()
 	countdown.stop()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -187,7 +187,7 @@
 				message_admins("The roundtype ([config_tag]) has no antagonists, continuous round has been defaulted to on and midround_antag has been defaulted to off.")
 				config.continuous[config_tag] = 1
 				config.midround_antag[config_tag] = 0
-				SSshuttle.emergencyNoEscape = 0
+				SSshuttle.clearHostileEnvironment(src)
 				return 0
 
 

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -100,12 +100,9 @@
 				takeover_in_progress = 1
 				break
 		if(!takeover_in_progress)
-			SSshuttle.emergencyNoEscape = 0
-			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
-				SSshuttle.emergency.mode = SHUTTLE_DOCKED
-				SSshuttle.emergency.timer = world.time
-				priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
-			else
+			var/was_stranded = SSshuttle.emergency.mode == SHUTTLE_STRANDED
+			SSshuttle.clearHostileEnvironment(src)
+			if(!was_stranded)
 				priority_announce("All hostile activity within station systems has ceased.","Network Alert")
 
 			if(get_security_level() == "delta")
@@ -194,6 +191,7 @@
 		gang.dom_attempts --
 		priority_announce("Network breach detected in [locname]. The [gang.name] Gang is attempting to seize control of the station!","Network Alert")
 		gang.domination()
+		SSshuttle.registerHostileEnvironment(src)
 		src.name = "[gang.name] Gang [src.name]"
 		operating = 1
 		icon_state = "dominator-[gang.color]"

--- a/code/game/gamemodes/gang/gang_datum.dm
+++ b/code/game/gamemodes/gang/gang_datum.dm
@@ -60,7 +60,6 @@
 	set_domination_time(determine_domination_time(src) * modifier)
 	is_dominating = TRUE
 	set_security_level("delta")
-	SSshuttle.emergencyNoEscape = 1
 
 /datum/gang/proc/set_domination_time(d)
 	domination_timer = world.time + (10 * d)

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -35,10 +35,10 @@
 	src << "<span class='notice'>Nuclear device armed.</span>"
 	priority_announce("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", "Anomaly Alert", 'sound/AI/aimalf.ogg')
 	set_security_level("delta")
-	SSshuttle.emergencyNoEscape = 1
 	nuking = 1
 	var/obj/machinery/doomsday_device/DOOM = new /obj/machinery/doomsday_device(src)
 	doomsday_device = DOOM
+	doomsday_device.start()
 	verbs -= /mob/living/silicon/ai/proc/nuke_station
 	for(var/obj/item/weapon/pinpointer/point in pinpointer_list)
 		for(var/mob/living/silicon/ai/A in ai_list)
@@ -53,29 +53,52 @@
 	anchored = 1
 	density = 1
 	verb_exclaim = "blares"
-	var/timing = 1
-	var/timer = 450
+	var/timing = FALSE
+	var/default_timer = 4500
+	var/obj/effect/countdown/doomsday/countdown
+	var/detonation_timer
+	var/list/milestones = list()
+
+/obj/machinery/doomsday_device/New()
+	..()
+	countdown = new(src)
+
+/obj/machinery/doomsday_device/Destroy()
+	if(countdown)
+		qdel(countdown)
+		countdown = null
+	STOP_PROCESSING(SSfastprocess, src)
+	SSshuttle.clearHostileEnvironment(src)
+	. = ..()
+
+/obj/machinery/doomsday_device/proc/start()
+	detonation_timer = world.time + default_timer
+	timing = TRUE
+	countdown.start()
+	START_PROCESSING(SSfastprocess, src)
+	SSshuttle.registerHostileEnvironment(src)
+
+/obj/machinery/doomsday_device/proc/seconds_remaining()
+	. = max(0, (round(detonation_timer - world.time) / 10))
 
 /obj/machinery/doomsday_device/process()
 	var/turf/T = get_turf(src)
 	if(!T || T.z != ZLEVEL_STATION)
 		minor_announce("DOOMSDAY DEVICE OUT OF STATION RANGE, ABORTING", "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4", 1)
-		SSshuttle.emergencyNoEscape = 0
-		if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
-			SSshuttle.emergency.mode = SHUTTLE_DOCKED
-			SSshuttle.emergency.timer = world.time
-			priority_announce("Hostile environment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
+		SSshuttle.clearHostileEnvironment(src)
 		qdel(src)
 	if(!timing)
+		STOP_PROCESSING(SSfastprocess, src)
 		return
-	if(timer <= 0)
-		timing = 0
+	var/sec_left = seconds_remaining()
+	if(sec_left <= 0)
+		timing = FALSE
 		detonate(T.z)
 		qdel(src)
 	else
-		timer--
-		if(!(timer%60))
-			var/message = "[timer] SECONDS UNTIL DOOMSDAY DEVICE ACTIVATION!"
+		if(!(sec_left % 60) && (!milestones[sec_left]))
+			milestones[sec_left] = TRUE
+			var/message = "[sec_left] SECONDS UNTIL DOOMSDAY DEVICE ACTIVATION!"
 			minor_announce(message, "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4", 1)
 
 /obj/machinery/doomsday_device/proc/detonate(z_level = 1)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -82,7 +82,7 @@
 	for(var/datum/mind/rev_mind in head_revolutionaries)
 		greet_revolutionary(rev_mind)
 	modePlayer += head_revolutionaries
-	SSshuttle.emergencyNoEscape = 1
+	SSshuttle.registerHostileEnvironment(src)
 	..()
 
 
@@ -216,12 +216,8 @@
 ///////////////////////////////
 /datum/game_mode/revolution/check_finished()
 	if(config.continuous["revolution"])
-		if(finished != 0)
-			SSshuttle.emergencyNoEscape = 0
-			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
-				SSshuttle.emergency.mode = SHUTTLE_DOCKED
-				SSshuttle.emergency.timer = world.time
-				priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
+		if(finished)
+			SSshuttle.clearHostileEnvironment(src)
 		return ..()
 	if(finished != 0)
 		return 1

--- a/code/game/gamemodes/sandbox/sandbox.dm
+++ b/code/game/gamemodes/sandbox/sandbox.dm
@@ -14,4 +14,4 @@
 
 /datum/game_mode/sandbox/post_setup()
 	..()
-	SSshuttle.emergencyNoEscape = 1
+	SSshuttle.registerHostileEnvironment(src)

--- a/code/modules/countdown/countdown.dm
+++ b/code/modules/countdown/countdown.dm
@@ -135,3 +135,13 @@
 	else if(T.cooldown)
 		var/seconds_left = max(0, (T.cooldown_timer - world.time) / 10)
 		return "[round(seconds_left)]"
+
+/obj/effect/countdown/doomsday
+	name = "doomsday countdown"
+
+/obj/effect/countdown/doomsday/get_value()
+	var/obj/machinery/doomsday_device/DD = attached_to
+	if(!istype(DD))
+		return
+	else if(DD.timing)
+		. = DD.seconds_remaining()

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -23,17 +23,13 @@
 
 	if(nuking)
 		set_security_level("red")
-		nuking = 0
-		SSshuttle.emergencyNoEscape = 0
-		if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
-			SSshuttle.emergency.mode = SHUTTLE_DOCKED
-			SSshuttle.emergency.timer = world.time
-			priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
+		nuking = FALSE
 		for(var/obj/item/weapon/pinpointer/point in pinpointer_list)
 			point.the_disk = null //Point back to the disk.
 
 	if(doomsday_device)
-		doomsday_device.timing = 0
+		doomsday_device.timing = FALSE
+		SSshuttle.clearHostileEnvironment(doomsday_device)
 		qdel(doomsday_device)
 	if(explosive)
 		spawn(10)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -274,19 +274,20 @@
 
 		if(SHUTTLE_DOCKED)
 			if(time_left <= ENGINES_START_TIME)
-				if(SSshuttle.emergencyNoEscape)
-					priority_announce("Hostile environment detected. Departure has been postponed indefinitely pending conflict resolution.", null, 'sound/misc/notice1.ogg', "Priority")
-					sound_played = 0 //Since we didn't launch, we will need to rev up the engines again next pass.
-					mode = SHUTTLE_STRANDED
-				else
-					mode = SHUTTLE_IGNITING
-					for(var/A in SSshuttle.mobile)
-						var/obj/docking_port/mobile/M = A
-						if(M.launch_status == UNLAUNCHED) //Pods will not launch from the mine/planet, and other ships won't launch unless we tell them to.
-							M.check_transit_zone()
+				mode = SHUTTLE_IGNITING
+				SSshuttle.checkHostileEnvironment()
+				if(mode == SHUTTLE_STRANDED)
+					return
+				for(var/A in SSshuttle.mobile)
+					var/obj/docking_port/mobile/M = A
+					if(M.launch_status == UNLAUNCHED) //Pods will not launch from the mine/planet, and other ships won't launch unless we tell them to.
+						M.check_transit_zone()
 
 		if(SHUTTLE_IGNITING)
 			var/success = TRUE
+			SSshuttle.checkHostileEnvironment()
+			if(mode == SHUTTLE_STRANDED)
+				return
 
 			success &= (check_transit_zone() == TRANSIT_READY)
 			for(var/A in SSshuttle.mobile)
@@ -317,6 +318,8 @@
 				launch_status = ENDGAME_LAUNCHED
 				setTimer(SSshuttle.emergencyEscapeTime)
 				priority_announce("The Emergency Shuttle has left the station. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, "Priority")
+		if(SHUTTLE_STRANDED)
+			SSshuttle.checkHostileEnvironment()
 		if(SHUTTLE_ESCAPE)
 			if(time_left <= 0)
 				//move each escape pod to its corresponding escape dock
@@ -433,7 +436,11 @@
 		usr << "The storage unit will only unlock during a Red or Delta security alert."
 
 /obj/item/weapon/storage/pod/attack_hand(mob/user)
-	return
+	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA)
+		return ..()
+	else
+		user << "The storage unit will only unlock during a Red or Delta security alert."
+
 
 /obj/docking_port/mobile/emergency/backup
 	name = "backup shuttle"

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -431,15 +431,12 @@
 
 /obj/item/weapon/storage/pod/MouseDrop(over_object, src_location, over_location)
 	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA)
-		return ..()
+		. = ..()
 	else
 		usr << "The storage unit will only unlock during a Red or Delta security alert."
 
 /obj/item/weapon/storage/pod/attack_hand(mob/user)
-	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA)
-		return ..()
-	else
-		user << "The storage unit will only unlock during a Red or Delta security alert."
+	return
 
 
 /obj/docking_port/mobile/emergency/backup


### PR DESCRIPTION
Instead of changing SSshuttle.emergencyNoEscape manually, datums now
register and clear themselves with the SS, and a hostile environment is
if any datums are registered.

Note that it's datums that can be registered, as rev and blob gamemodes
register themselves.

Overhauling this means that you can have multiple sources of no-recall,
which although can't happen at present, may do so in the future whenever
multi-antag rounds happen.

:cl: coiax
tweak: The AI doomsday device timer is more accurate.
fix: Fixes a bug where the doomsday device would take twice as long as
it should.
/:cl:

AI doomsday timer uses world.time, uses fastprocess to make sure the
announcements go out on time, added observer countdown for
the AI doomsday device.
