### PR TITLE
Clockwork Walls and Floors are no longer visible to mesons

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_ratvar.dm
+++ b/code/game/gamemodes/clock_cult/clock_ratvar.dm
@@ -29,7 +29,7 @@
 	var/first_sound_played = FALSE
 	var/second_sound_played = FALSE
 	var/third_sound_played = FALSE
-	var/obj/effect/clockwork/gateway_glow/glow
+	var/obj/effect/clockwork/overlay/gateway_glow/glow
 	var/obj/effect/countdown/clockworkgate/countdown
 
 /obj/structure/clockwork/massive/celestial_gateway/New()
@@ -74,8 +74,8 @@
 
 /obj/structure/clockwork/massive/celestial_gateway/proc/make_glow()
 	if(!glow)
-		glow = new(get_turf(src))
-		glow.linked_gate = src
+		glow = PoolOrNew(/obj/effect/clockwork/overlay/gateway_glow, get_turf(src))
+		glow.linked = src
 
 /obj/structure/clockwork/massive/celestial_gateway/ex_act(severity)
 	return 0 //Nice try, Toxins!
@@ -146,27 +146,12 @@
 			if(GATEWAY_RATVAR_COMING to INFINITY)
 				user << "<span class='warning'><b>Something is coming through!</b></span>"
 
-/obj/effect/clockwork/gateway_glow //the actual appearance of the Gateway to the Celestial Derelict; an object so the edges of the gate can be clicked through.
+/obj/effect/clockwork/overlay/gateway_glow //the actual appearance of the Gateway to the Celestial Derelict; an object so the edges of the gate can be clicked through.
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "clockwork_gateway_charging"
 	pixel_x = -32
 	pixel_y = -32
-	mouse_opacity = 0
 	layer = MASSIVE_OBJ_LAYER
-	var/obj/structure/clockwork/massive/celestial_gateway/linked_gate
-
-/obj/effect/clockwork/gateway_glow/Destroy()
-	if(linked_gate)
-		linked_gate.glow = null
-		linked_gate = null
-	return ..()
-
-/obj/effect/clockwork/gateway_glow/examine(mob/user)
-	if(linked_gate)
-		linked_gate.examine(user)
-
-/obj/effect/clockwork/gateway_glow/ex_act(severity, target)
-	return FALSE
 
 
 /obj/structure/clockwork/massive/ratvar

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -662,6 +662,40 @@
 	animate(src, alpha = 0, time = 10)
 	QDEL_IN(src, 10)
 
+/obj/effect/clockwork/overlay
+	mouse_opacity = 0
+	var/atom/linked
+
+/obj/effect/clockwork/overlay/examine(mob/user)
+	if(linked)
+		linked.examine(user)
+
+/obj/effect/clockwork/overlay/ex_act()
+	return FALSE
+
+/obj/effect/clockwork/overlay/Destroy()
+	if(linked)
+		linked = null
+	..()
+	return QDEL_HINT_PUTINPOOL
+
+/obj/effect/clockwork/overlay/wall
+	name = "clockwork wall"
+	icon = 'icons/turf/walls/clockwork_wall.dmi'
+	icon_state = "clockwork_wall"
+	canSmoothWith = list(/obj/effect/clockwork/overlay/wall)
+	smooth = SMOOTH_TRUE
+	layer = CLOSED_TURF_LAYER
+
+/obj/effect/clockwork/overlay/wall/Destroy()
+	..()
+	return QDEL_HINT_QUEUE
+
+/obj/effect/clockwork/overlay/floor
+	icon = 'icons/turf/floors.dmi'
+	icon_state = "clockwork_floor"
+	layer = TURF_LAYER
+
 /obj/effect/clockwork/general_marker/nezbere
 	name = "Nezbere, the Brass Eidolon"
 	desc = "A towering colossus clad in nigh-impenetrable brass armor. Its gaze is stern yet benevolent, even upon you."

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -116,25 +116,31 @@
 /turf/open/floor/clockwork
 	name = "clockwork floor"
 	desc = "Tightly-pressed brass tiles. They emit minute vibration."
-	icon = 'icons/turf/floors.dmi'
-	icon_state = "clockwork_floor"
+	icon_state = "plating"
+	var/obj/effect/clockwork/overlay/floor/realappearence
 
 /turf/open/floor/clockwork/New()
 	..()
 	PoolOrNew(/obj/effect/overlay/temp/ratvar/floor, src)
 	PoolOrNew(/obj/effect/overlay/temp/ratvar/beam, src)
+	realappearence = PoolOrNew(/obj/effect/clockwork/overlay/floor, src)
+	realappearence.linked = src
 	change_construction_value(1)
 
 /turf/open/floor/clockwork/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	change_construction_value(-1)
+	be_removed()
 	return ..()
 
 /turf/open/floor/clockwork/ChangeTurf(path, defer_change = FALSE)
 	if(path != type)
-		STOP_PROCESSING(SSobj, src)
-		change_construction_value(-1)
+		be_removed()
 	return ..()
+
+/turf/open/floor/clockwork/proc/be_removed()
+	STOP_PROCESSING(SSobj, src)
+	change_construction_value(-1)
+	qdel(realappearence)
+	realappearence = null
 
 /turf/open/floor/clockwork/Entered(atom/movable/AM)
 	..()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -21,7 +21,8 @@
 	/obj/structure/falsewall,
 	/obj/structure/falsewall/reinforced,
 	/turf/closed/wall/rust,
-	/turf/closed/wall/r_wall/rust)
+	/turf/closed/wall/r_wall/rust,
+	/turf/closed/wall/clockwork)
 	smooth = SMOOTH_TRUE
 
 /turf/closed/wall/New()

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -43,26 +43,30 @@
 /turf/closed/wall/clockwork
 	name = "clockwork wall"
 	desc = "A huge chunk of warm metal. The clanging of machinery emanates from within."
-	icon = 'icons/turf/walls/clockwork_wall.dmi'
-	icon_state = "clockwork_wall"
-	canSmoothWith = list(/turf/closed/wall/clockwork)
-	smooth = SMOOTH_MORE
 	explosion_block = 2
+	var/obj/effect/clockwork/overlay/wall/realappearence
 
 /turf/closed/wall/clockwork/New()
 	..()
 	PoolOrNew(/obj/effect/overlay/temp/ratvar/wall, src)
 	PoolOrNew(/obj/effect/overlay/temp/ratvar/beam, src)
+	realappearence = PoolOrNew(/obj/effect/clockwork/overlay/wall, src)
+	realappearence.linked = src
 	change_construction_value(5)
 
 /turf/closed/wall/clockwork/Destroy()
-	change_construction_value(-5)
+	be_removed()
 	return ..()
 
 /turf/closed/wall/clockwork/ChangeTurf(path, defer_change = FALSE)
 	if(path != type)
-		change_construction_value(-5)
+		be_removed()
 	return ..()
+
+/turf/closed/wall/clockwork/proc/be_removed()
+	change_construction_value(-5)
+	qdel(realappearence)
+	realappearence = null
 
 /turf/closed/wall/clockwork/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/weapon/weldingtool))


### PR DESCRIPTION
:cl: Joan
experiment: Clockwork Walls and Floors will appear as normal walls and plating to mesons, respectively.
/:cl:

Pooling fucks up smoothing for `/obj/effect/clockwork/overlay/wall` (and so is currently disabled) and I'm not sure how to fix it; adjacencies smooth with it fine, but if you got it from the pool it, but not its adjacencies, will fail to smooth.
