### PR TITLE
Pockets

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -475,3 +475,8 @@ var/global/list/ghost_others_options = list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 
 #define COORD(A) "([A.x],[A.y],[A.z])"
 #define INCREMENT_TALLY(L, stat) if(L[stat]){L[stat]++}else{L[stat] = 1}
+
+// Inventory depth: limits how many nested storage items you can access directly.
+// 1: stuff in mob, 2: stuff in backpack, 3: stuff in box in backpack, etc
+#define INVENTORY_DEPTH		3
+#define STORAGE_VIEW_DEPTH	2

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -110,7 +110,7 @@
 		return
 
 	// operate three levels deep here (item in backpack in src; item in box in backpack in src, not any deeper)
-	if(A.ClickAccesible(src, depth=INVENTORY_DEPTH))
+	if(A.ClickAccessible(src, depth=INVENTORY_DEPTH))
 		// No adjacency needed
 		if(W)
 			var/resolved = A.attackby(W,src)
@@ -278,14 +278,14 @@
 	Helper to check can the mob click/access an item.
 	Used by mob inventory and storage items.
 */
-/atom/proc/ClickAccesible(mob/user, depth=1)
+/atom/proc/ClickAccessible(mob/user, depth=1)
 	if(src == user.loc || (src in user.contents))
 		return TRUE
 
 	if(loc && depth > 1)
-		return loc.ClickAccesible(user, depth-1)
+		return loc.ClickAccessible(user, depth-1)
 
-/turf/ClickAccesible(mob/user, depth=1)
+/turf/ClickAccessible(mob/user, depth=1)
 	return
 
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -110,7 +110,7 @@
 		return
 
 	// operate three levels deep here (item in backpack in src; item in box in backpack in src, not any deeper)
-	if(!isturf(A) && A == loc || (A in contents) || (A.loc in contents) || (A.loc && (A.loc.loc in contents)))
+	if(A.ClickAccesible(src, depth=INVENTORY_DEPTH))
 		// No adjacency needed
 		if(W)
 			var/resolved = A.attackby(W,src)
@@ -273,6 +273,21 @@
 
 /atom/proc/CtrlShiftClick(mob/user)
 	return
+
+/*
+	Helper to check can the mob click/access an item.
+	Used by mob inventory and storage items.
+*/
+/atom/proc/ClickAccesible(mob/user, depth=1)
+	if(src == user.loc || (src in user.contents))
+		return TRUE
+
+	if(loc && depth > 1)
+		return loc.ClickAccesible(user, depth-1)
+
+/turf/ClickAccesible(mob/user, depth=1)
+	return
+
 
 /*
 	Misc helpers

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -430,11 +430,11 @@ var/global/list/multiverse = list()
 			M.equip_to_slot_or_del(sword, slot_r_hand)
 
 		if("soviet")
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/hgpiratecap(M), slot_head)
+			M.equip_to_slot_or_del(new /obj/item/clothing/head/pirate/captain(M), slot_head)
 			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(M), slot_shoes)
 			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat(M), slot_gloves)
 			M.equip_to_slot_or_del(new /obj/item/device/radio/headset(M), slot_ears)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/hgpirate(M), slot_wear_suit)
+			M.equip_to_slot_or_del(new /obj/item/clothing/suit/pirate/captain(M), slot_wear_suit)
 			M.equip_to_slot_or_del(new /obj/item/clothing/under/soviet(M), slot_w_uniform)
 			M.equip_to_slot_or_del(sword, slot_r_hand)
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -900,7 +900,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 					/obj/item/clothing/suit/snowman = 1,
 					/obj/item/clothing/head/snowman = 1)
 	contraband = list(/obj/item/clothing/suit/judgerobe = 1,/obj/item/clothing/head/powdered_wig = 1,/obj/item/weapon/gun/magic/wand = 2,/obj/item/clothing/glasses/sunglasses/garb = 2)
-	premium = list(/obj/item/clothing/suit/hgpirate = 2, /obj/item/clothing/head/hgpiratecap = 2, /obj/item/clothing/head/helmet/roman = 1, /obj/item/clothing/head/helmet/roman/legionaire = 1, /obj/item/clothing/under/roman = 1, /obj/item/clothing/shoes/roman = 1, /obj/item/weapon/shield/riot/roman = 1, /obj/item/weapon/skub = 1)
+	premium = list(/obj/item/clothing/suit/pirate/captain = 2, /obj/item/clothing/head/pirate/captain = 2, /obj/item/clothing/head/helmet/roman = 1, /obj/item/clothing/head/helmet/roman/legionaire = 1, /obj/item/clothing/under/roman = 1, /obj/item/clothing/shoes/roman = 1, /obj/item/weapon/shield/riot/roman = 1, /obj/item/weapon/skub = 1)
 	refill_canister = /obj/item/weapon/vending_refill/autodrobe
 
 /obj/machinery/vending/dinnerware

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -4,9 +4,9 @@
 	max_combined_w_class = 50 // Limited by slots, not combined weight class
 	w_class = 4
 
-/obj/item/weapon/storage/internal/ClickAccesible(mob/user, depth=1)
+/obj/item/weapon/storage/internal/ClickAccessible(mob/user, depth=1)
 	if(loc)
-		return loc.ClickAccesible(user, depth)
+		return loc.ClickAccessible(user, depth)
 
 /obj/item/weapon/storage/internal/Adjacent(A)
 	if(loc)

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -3,15 +3,21 @@
 	max_w_class = 2
 	max_combined_w_class = 4
 	w_class = 4
-	var/priority = 1
+
 
 /obj/item/weapon/storage/internal/ClickAccesible(mob/user, depth=1)
 	if(loc)
 		return loc.ClickAccesible(user, depth)
 
+/obj/item/weapon/storage/internal/pocket
+	var/priority = TRUE
+	// TRUE if opens when clicked, like a backpack.
+	// FALSE if opens only when dragged on mob's icon (hidden pocket)
+
 /obj/item/weapon/storage/internal/pocket/New()
 	..()
-	if(loc) name = loc.name
+	if(loc)
+		name = loc.name
 
 /obj/item/weapon/storage/internal/pocket/big
 	max_w_class = 3
@@ -20,17 +26,17 @@
 /obj/item/weapon/storage/internal/pocket/small
 	storage_slots = 1
 	max_combined_w_class = 2
-	priority = 0
+	priority = FALSE
 
 /obj/item/weapon/storage/internal/pocket/tiny
 	storage_slots = 1
 	max_w_class = 1
 	max_combined_w_class = 1
-	priority = 0
+	priority = FALSE
 
 
 /obj/item/weapon/storage/internal/pocket/small/detective
-	priority = 1
+	priority = TRUE // so the detectives would discover pockets in their hats
 
 /obj/item/weapon/storage/internal/pocket/small/detective/New()
 	..()

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -4,10 +4,13 @@
 	max_combined_w_class = 50 // Limited by slots, not combined weight class
 	w_class = 4
 
-
 /obj/item/weapon/storage/internal/ClickAccesible(mob/user, depth=1)
 	if(loc)
 		return loc.ClickAccesible(user, depth)
+
+/obj/item/weapon/storage/internal/Adjacent(A)
+	if(loc)
+		return loc.Adjacent(A)
 
 /obj/item/weapon/storage/internal/pocket
 	var/priority = TRUE

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -5,7 +5,11 @@
 	w_class = 4
 	var/priority = 1
 
-/*obj/item/weapon/storage/internal/pocket/New()
+/obj/item/weapon/storage/internal/ClickAccesible(mob/user, depth=1)
+	if(loc)
+		return loc.ClickAccesible(user, depth)
+
+/obj/item/weapon/storage/internal/pocket/New()
 	..()
 	if(loc) name = loc.name
 
@@ -32,8 +36,8 @@
 	..()
 	new /obj/item/weapon/reagent_containers/food/drinks/flask/det(src)
 
-
-proc/isstorage(var/atom/A)
+/*
+/proc/isstorage(var/atom/A)
 	if(istype(A, /obj/item/weapon/storage))
 		return 1
 

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -24,6 +24,14 @@
 	if(loc)
 		name = loc.name
 
+/obj/item/weapon/storage/internal/pocket/handle_item_insertion(obj/item/W, prevent_warning = 0, mob/user)
+	. = ..()
+	if(. && silent && !prevent_warning)
+		if(quickdraw)
+			user << "<span class='notice'>You discreetly slip [W] into [src]. Alt-click [src] to remove it.</span>"
+		else
+			user << "<span class='notice'>You discreetly slip [W] into [src]."
+
 /obj/item/weapon/storage/internal/pocket/big
 	max_w_class = 3
 

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -16,6 +16,8 @@
 	var/priority = TRUE
 	// TRUE if opens when clicked, like a backpack.
 	// FALSE if opens only when dragged on mob's icon (hidden pocket)
+	var/quickdraw = FALSE
+	// TRUE if you can quickdraw items from it with alt-click.
 
 /obj/item/weapon/storage/internal/pocket/New()
 	..()
@@ -34,6 +36,26 @@
 	max_w_class = 1
 	priority = FALSE
 
+/obj/item/weapon/storage/internal/pocket/shoes
+	can_hold = list(
+		/obj/item/weapon/kitchen/knife, /obj/item/weapon/switchblade, /obj/item/weapon/pen,
+		/obj/item/weapon/scalpel, /obj/item/weapon/reagent_containers/syringe, /obj/item/weapon/dnainjector,
+		/obj/item/weapon/reagent_containers/hypospray/medipen, /obj/item/weapon/reagent_containers/dropper,
+		/obj/item/weapon/implanter, /obj/item/weapon/screwdriver, /obj/item/weapon/weldingtool/mini,
+		/obj/item/device/firing_pin
+		)
+	//can hold both regular pens and energy daggers. made for your every-day tactical librarians/murderers.
+	priority = FALSE
+	quickdraw = TRUE
+	silent = TRUE
+
+/obj/item/weapon/storage/internal/pocket/shoes/clown
+	can_hold = list(
+		/obj/item/weapon/kitchen/knife, /obj/item/weapon/switchblade, /obj/item/weapon/pen,
+		/obj/item/weapon/scalpel, /obj/item/weapon/reagent_containers/syringe, /obj/item/weapon/dnainjector,
+		/obj/item/weapon/reagent_containers/hypospray/medipen, /obj/item/weapon/reagent_containers/dropper,
+		/obj/item/weapon/implanter, /obj/item/weapon/screwdriver, /obj/item/weapon/weldingtool/mini,
+		/obj/item/device/firing_pin, /obj/item/weapon/bikehorn)
 
 /obj/item/weapon/storage/internal/pocket/small/detective
 	priority = TRUE // so the detectives would discover pockets in their hats

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/storage/internal
 	storage_slots = 2
 	max_w_class = 2
-	max_combined_w_class = 4
+	max_combined_w_class = 50 // Limited by slots, not combined weight class
 	w_class = 4
 
 
@@ -21,17 +21,14 @@
 
 /obj/item/weapon/storage/internal/pocket/big
 	max_w_class = 3
-	max_combined_w_class = 6
 
 /obj/item/weapon/storage/internal/pocket/small
 	storage_slots = 1
-	max_combined_w_class = 2
 	priority = FALSE
 
 /obj/item/weapon/storage/internal/pocket/tiny
 	storage_slots = 1
 	max_w_class = 1
-	max_combined_w_class = 1
 	priority = FALSE
 
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -37,7 +37,7 @@
 			return
 
 		// this must come before the screen objects only block, dunno why it wasn't before
-		if(over_object == M && (src.ClickAccesible(M, depth=STORAGE_VIEW_DEPTH) || Adjacent(M)))
+		if(over_object == M && (src.ClickAccessible(M, depth=STORAGE_VIEW_DEPTH) || Adjacent(M)))
 			orient2hud(M)
 			if(M.s_active)
 				M.s_active.close(M)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -36,8 +36,9 @@
 		if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
 			return
 
-		if(over_object == M && Adjacent(M)) // this must come before the screen objects only block
-			orient2hud(M)					// dunno why it wasn't before
+		// this must come before the screen objects only block, dunno why it wasn't before
+		if(over_object == M && (src.ClickAccesible(M, depth=STORAGE_VIEW_DEPTH) || Adjacent(M)))
+			orient2hud(M)
 			if(M.s_active)
 				M.s_active.close(M)
 			show_to(M)
@@ -205,7 +206,7 @@
 	number = 1
 
 
-//This proc determins the size of the inventory to be displayed. Please touch it only if you know what you're doing.
+//This proc determines the size of the inventory to be displayed. Please touch it only if you know what you're doing.
 /obj/item/weapon/storage/proc/orient2hud(mob/user)
 	var/adjusted_contents = contents.len
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -303,7 +303,7 @@
 	flags = NOSLIP
 	origin_tech = "syndicate=2"
 	burn_state = FIRE_PROOF
-	can_hold_items = 1
+	pockets = /obj/item/weapon/storage/internal/pocket/shoes
 	armor = list(melee = 10, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/shoes/chameleon/New()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -69,6 +69,19 @@
 	else
 		return ..()
 
+/obj/item/clothing/AltClick(mob/user)
+	if(pockets && pockets.quickdraw && pockets.contents.len && !user.incapacitated())
+		var/obj/item/I = pockets.contents[1]
+		if(!I)
+			return
+		pockets.remove_from_storage(I, get_turf(src))
+
+		if(!user.put_in_hands(I))
+			user << "<span class='notice'>You fumble for [I] and it falls on the floor.</span>"
+			return
+		user.visible_message("<span class='warning'>[user] draws [I] from [src]!</span>", "<span class='notice'>You draw [I] from [src].</span>")
+	else
+		return ..()
 
 
 /obj/item/clothing/Destroy()
@@ -258,10 +271,6 @@ BLIND     // can't see anything
 	slowdown = SHOES_SLOWDOWN
 	var/blood_state = BLOOD_STATE_NOT_BLOODY
 	var/list/bloody_shoes = list(BLOOD_STATE_HUMAN = 0,BLOOD_STATE_XENO = 0, BLOOD_STATE_OIL = 0, BLOOD_STATE_NOT_BLOODY = 0)
-	var/can_hold_items = 0//if set to 1, the shoe can hold knives and edaggers
-	var/obj/held_item
-	var/list/valid_held_items = list(/obj/item/weapon/kitchen/knife, /obj/item/weapon/pen, /obj/item/weapon/switchblade, /obj/item/weapon/scalpel, /obj/item/weapon/reagent_containers/syringe, /obj/item/weapon/dnainjector)//can hold both regular pens and energy daggers. made for your every-day tactical librarians/murderers.
-
 
 /obj/item/clothing/shoes/worn_overlays(var/isinhands = FALSE)
 	. = list()
@@ -283,33 +292,6 @@ BLIND     // can't see anything
 	if(ismob(loc))
 		var/mob/M = loc
 		M.update_inv_shoes()
-
-/obj/item/clothing/shoes/attackby(obj/item/I, mob/user, params)
-	..()
-	if(!can_hold_items)
-		return
-	if(held_item)
-		user << "<span class='notice'>There's already something in [src].</span>"
-		return
-	if(is_type_in_list(I, valid_held_items))//can hold both regular pens and energy daggers. made for your every-day tactical librarians/murderers.
-		if(I.w_class > 2)//if the object is too big (like if it's a cleaver or an extended edagger) it wont fit
-			user << "<span class='notice'>[I] is currently too big to fit into [src]. </span>"
-			return
-		if(!user.drop_item())
-			return
-		I.loc = src
-		held_item = I
-		user << "<span class='notice'>You discreetly slip [I] into [src]. Alt-click [src] to remove it.</span>"
-
-/obj/item/clothing/shoes/AltClick(mob/user)
-	if(user.incapacitated() || !held_item || !can_hold_items)
-		return
-	if(!user.put_in_hands(held_item))
-		user << "<span class='notice'>You fumble for [held_item] and it falls on the floor.</span>"
-		held_item = null
-		return
-	user.visible_message("<span class='warning'>[user] draws [held_item] from their shoes!</span>", "<span class='notice'>You draw [held_item] from [src].</span>")
-	held_item = null
 
 /obj/item/proc/negates_gravity()
 	return 0

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -65,7 +65,7 @@
 
 /obj/item/clothing/attackby(obj/item/W, mob/user, params)
 	if(pockets)
-		pockets.attackby(W, user, params)
+		return pockets.attackby(W, user, params)
 	else
 		return ..()
 

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -8,7 +8,7 @@
 	desc = "The commander in chef's head wear."
 	strip_delay = 10
 	put_on_delay = 10
-
+	pockets = /obj/item/weapon/storage/internal/pocket/small
 	dog_fashion = /datum/dog_fashion/head/chef
 
 /obj/item/clothing/head/chefhat/suicide_act(mob/user)
@@ -64,7 +64,7 @@
 	icon_state = "detective"
 	armor = list(melee = 25, bullet = 5, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
 	var/candy_cooldown = 0
-
+	pockets = /obj/item/weapon/storage/internal/pocket/small/detective
 	dog_fashion = /datum/dog_fashion/head/detective
 
 /obj/item/clothing/head/det_hat/AltClick()

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -116,12 +116,9 @@
 	desc = "Yarr."
 	icon_state = "pirate"
 	item_state = "pirate"
-
 	dog_fashion = /datum/dog_fashion/head/pirate
 
-/obj/item/clothing/head/hgpiratecap
-	name = "pirate hat"
-	desc = "Yarr."
+/obj/item/clothing/head/pirate/captain
 	icon_state = "hgpiratecap"
 	item_state = "hgpiratecap"
 
@@ -136,6 +133,7 @@
 	desc = "Gentleman, elite aboard!"
 	icon_state = "bowler"
 	item_state = "bowler"
+	pockets = /obj/item/weapon/storage/internal/pocket/small
 
 /obj/item/clothing/head/witchwig
 	name = "witch costume wig"
@@ -176,6 +174,7 @@
 	icon_state = "fedora"
 	item_state = "fedora"
 	desc = "A really cool hat if you're a mobster. A really lame hat if you're not."
+	pockets = /obj/item/weapon/storage/internal/pocket/small
 
 /obj/item/clothing/head/fedora/suicide_act(mob/user)
 	if(user.gender == FEMALE)

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -64,6 +64,7 @@
 	burn_state = FLAMMABLE
 	actions_types = list(/datum/action/item_action/adjust)
 	dog_fashion = /datum/dog_fashion/head/clown
+	pockets = /obj/item/weapon/storage/internal/pocket/tiny // Honk!
 
 /obj/item/clothing/mask/gas/clown_hat/attack_self(mob/user)
 	AltClick(user)

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -272,12 +272,12 @@
 	name = "Soviet Admiral"
 
 	uniform = /obj/item/clothing/under/soviet
-	head = /obj/item/clothing/head/hgpiratecap
+	head = /obj/item/clothing/head/pirate/captain
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	ears = /obj/item/device/radio/headset/headset_cent
 	glasses = /obj/item/clothing/glasses/thermal/eyepatch
-	suit = /obj/item/clothing/suit/hgpirate
+	suit = /obj/item/clothing/suit/pirate/captain
 	back = /obj/item/weapon/storage/backpack/satchel
 	belt = /obj/item/weapon/gun/projectile/revolver/mateba
 

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -20,7 +20,7 @@
 	armor = list(melee = 25, bullet = 25, laser = 25, energy = 25, bomb = 50, bio = 10, rad = 0)
 	strip_delay = 70
 	burn_state = FIRE_PROOF
-	can_hold_items = 1
+	pockets = /obj/item/weapon/storage/internal/pocket/shoes
 
 /obj/item/clothing/shoes/combat/swat //overpowered boots for death squads
 	name = "\improper SWAT boots"
@@ -72,8 +72,7 @@
 	slowdown = SHOES_SLOWDOWN+1
 	item_color = "clown"
 	var/footstep = 1	//used for squeeks whilst walking
-	can_hold_items = 1
-	valid_held_items = list(/obj/item/weapon/bikehorn)
+	pockets = /obj/item/weapon/storage/internal/pocket/shoes/clown
 
 /obj/item/clothing/shoes/clown_shoes/step_action()
 	if(footstep > 1)
@@ -91,7 +90,7 @@
 	strip_delay = 50
 	put_on_delay = 50
 	burn_state = FIRE_PROOF
-	can_hold_items = 1
+	pockets = /obj/item/weapon/storage/internal/pocket/shoes
 
 /obj/item/clothing/shoes/jackboots/fast
 	slowdown = -1
@@ -105,7 +104,7 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET|LEGS
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
-	can_hold_items = 1
+	pockets = /obj/item/weapon/storage/internal/pocket/shoes
 
 /obj/item/clothing/shoes/workboots
 	name = "work boots"
@@ -114,7 +113,7 @@
 	item_state = "jackboots"
 	strip_delay = 40
 	put_on_delay = 40
-	can_hold_items = 1
+	pockets = /obj/item/weapon/storage/internal/pocket/shoes
 
 /obj/item/clothing/shoes/workboots/mining
 	name = "mining boots"
@@ -161,4 +160,4 @@
 	desc = "A pair of costume boots fashioned after bird talons."
 	icon_state = "griffinboots"
 	item_state = "griffinboots"
-	can_hold_items = 1
+	pockets = /obj/item/weapon/storage/internal/pocket/shoes

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -151,6 +151,7 @@
 	item_state = "eng_hardsuit"
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 	//Atmospherics
 /obj/item/clothing/head/helmet/space/hardsuit/engine/atmos
@@ -196,6 +197,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/elite
 	jetpack = /obj/item/weapon/tank/jetpack/suit
+	pockets = /obj/item/weapon/storage/internal/pocket/big
 
 
 	//Mining hardsuit
@@ -221,7 +223,7 @@
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 50, bio = 100, rad = 50)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/pickaxe)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/mining
-
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 
 	//Syndicate hardsuit

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -151,7 +151,7 @@
 	item_state = "eng_hardsuit"
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 	//Atmospherics
 /obj/item/clothing/head/helmet/space/hardsuit/engine/atmos
@@ -197,7 +197,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/elite
 	jetpack = /obj/item/weapon/tank/jetpack/suit
-	pockets = /obj/item/weapon/storage/internal/pocket/big
+//	pockets = /obj/item/weapon/storage/internal/pocket/big
 
 
 	//Mining hardsuit
@@ -223,7 +223,7 @@
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 50, bio = 100, rad = 50)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/pickaxe)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/mining
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 
 	//Syndicate hardsuit

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -36,7 +36,7 @@
 	armor = list(melee = 30, bullet = 30, laser = 30, energy = 10, bomb = 25, bio = 0, rad = 0)
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 	strip_delay = 80
 
 /obj/item/clothing/suit/armor/hos/trenchcoat
@@ -73,7 +73,7 @@
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	dog_fashion = null
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/suit/armor/vest/capcarapace
 	name = "captain's carapace"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -36,6 +36,7 @@
 	armor = list(melee = 30, bullet = 30, laser = 30, energy = 10, bomb = 25, bio = 0, rad = 0)
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
+	pockets = /obj/item/weapon/storage/internal/pocket
 	strip_delay = 80
 
 /obj/item/clothing/suit/armor/hos/trenchcoat
@@ -72,6 +73,7 @@
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	dog_fashion = null
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/suit/armor/vest/capcarapace
 	name = "captain's carapace"

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -18,7 +18,7 @@
 	flags = NODROP
 	flags_inv = HIDEHAIR|HIDEEARS
 
-/obj/item/clothing/cloak/suicide_act(mob/user)
+/obj/item/clothing/suit/cloak/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is strangling themself with [src]! It looks like they're trying to commit suicide.</span>")
 	return(OXYLOSS)
 

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -11,7 +11,7 @@
 	blood_overlay_type = "armor"
 	body_parts_covered = CHEST|GROIN
 	allowed = list(/obj/item/weapon/reagent_containers/spray/plantbgone,/obj/item/device/plant_analyzer,/obj/item/seeds,/obj/item/weapon/reagent_containers/glass/bottle, /obj/item/weapon/reagent_containers/glass/beaker, /obj/item/weapon/cultivator,/obj/item/weapon/reagent_containers/spray/pestspray,/obj/item/weapon/hatchet,/obj/item/weapon/storage/bag/plants)
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 //Captain
 /obj/item/clothing/suit/captunic
@@ -33,7 +33,7 @@
 	allowed = list(/obj/item/weapon/storage/book/bible, /obj/item/weapon/nullrod, /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater, /obj/item/weapon/storage/fancy/candle_box, /obj/item/candle, /obj/item/weapon/tank/internals/emergency_oxygen)
 	hooded = 1
 	hoodtype = /obj/item/clothing/head/chaplain_hood
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/head/chaplain_hood
 	name = "chaplain hood"
@@ -52,7 +52,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS|HANDS
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 	allowed = list(/obj/item/weapon/storage/book/bible, /obj/item/weapon/nullrod, /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater, /obj/item/weapon/storage/fancy/candle_box, /obj/item/candle, /obj/item/weapon/tank/internals/emergency_oxygen)
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 //Chef
 /obj/item/clothing/suit/toggle/chef
@@ -65,7 +65,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	allowed = list(/obj/item/weapon/kitchen)
 	togglename = "sleeves"
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 
 //Cook
@@ -90,7 +90,7 @@
 	armor = list(melee = 25, bullet = 10, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/suit/det_suit/grey
 	name = "noir trenchcoat"
@@ -107,7 +107,7 @@
 	blood_overlay_type = "armor"
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/device/t_scanner,/obj/item/device/radio)
 	burn_state = FIRE_PROOF
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 //Lawyer
 /obj/item/clothing/suit/toggle/lawyer

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -33,6 +33,7 @@
 	allowed = list(/obj/item/weapon/storage/book/bible, /obj/item/weapon/nullrod, /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater, /obj/item/weapon/storage/fancy/candle_box, /obj/item/candle, /obj/item/weapon/tank/internals/emergency_oxygen)
 	hooded = 1
 	hoodtype = /obj/item/clothing/head/chaplain_hood
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/head/chaplain_hood
 	name = "chaplain hood"
@@ -51,6 +52,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS|HANDS
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 	allowed = list(/obj/item/weapon/storage/book/bible, /obj/item/weapon/nullrod, /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater, /obj/item/weapon/storage/fancy/candle_box, /obj/item/candle, /obj/item/weapon/tank/internals/emergency_oxygen)
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 //Chef
 /obj/item/clothing/suit/toggle/chef

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -11,6 +11,7 @@
 	blood_overlay_type = "armor"
 	body_parts_covered = CHEST|GROIN
 	allowed = list(/obj/item/weapon/reagent_containers/spray/plantbgone,/obj/item/device/plant_analyzer,/obj/item/seeds,/obj/item/weapon/reagent_containers/glass/bottle, /obj/item/weapon/reagent_containers/glass/beaker, /obj/item/weapon/cultivator,/obj/item/weapon/reagent_containers/spray/pestspray,/obj/item/weapon/hatchet,/obj/item/weapon/storage/bag/plants)
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 //Captain
 /obj/item/clothing/suit/captunic
@@ -62,6 +63,8 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	allowed = list(/obj/item/weapon/kitchen)
 	togglename = "sleeves"
+	pockets = /obj/item/weapon/storage/internal/pocket
+
 
 //Cook
 /obj/item/clothing/suit/apron/chef
@@ -85,6 +88,7 @@
 	armor = list(melee = 25, bullet = 10, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/suit/det_suit/grey
 	name = "noir trenchcoat"
@@ -101,6 +105,7 @@
 	blood_overlay_type = "armor"
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/device/t_scanner,/obj/item/device/radio)
 	burn_state = FIRE_PROOF
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 //Lawyer
 /obj/item/clothing/suit/toggle/lawyer

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -8,6 +8,7 @@
 	allowed = list(/obj/item/device/analyzer,/obj/item/stack/medical,/obj/item/weapon/dnainjector,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/obj/item/weapon/reagent_containers/hypospray,/obj/item/device/healthanalyzer,/obj/item/device/flashlight/pen,/obj/item/weapon/reagent_containers/glass/bottle,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/pill,/obj/item/weapon/storage/pill_bottle,/obj/item/weapon/paper,/obj/item/weapon/melee/classic_baton/telescopic,/obj/item/weapon/soap,/obj/item/device/sensor_device,/obj/item/weapon/tank/internals/emergency_oxygen)
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 50, rad = 0)
 	togglename = "buttons"
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/suit/toggle/labcoat/cmo
 	name = "chief medical officer's labcoat"

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -8,7 +8,7 @@
 	allowed = list(/obj/item/device/analyzer,/obj/item/stack/medical,/obj/item/weapon/dnainjector,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/obj/item/weapon/reagent_containers/hypospray,/obj/item/device/healthanalyzer,/obj/item/device/flashlight/pen,/obj/item/weapon/reagent_containers/glass/bottle,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/pill,/obj/item/weapon/storage/pill_bottle,/obj/item/weapon/paper,/obj/item/weapon/melee/classic_baton/telescopic,/obj/item/weapon/soap,/obj/item/device/sensor_device,/obj/item/weapon/tank/internals/emergency_oxygen)
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 50, rad = 0)
 	togglename = "buttons"
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/suit/toggle/labcoat/cmo
 	name = "chief medical officer's labcoat"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -37,13 +37,13 @@
 	icon_state = "pirate"
 	item_state = "pirate"
 	allowed = list(/obj/item/weapon/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/weapon/reagent_containers/food/drinks/bottle/rum)
+	pockets = /obj/item/weapon/storage/internal/pocket
 
-/obj/item/clothing/suit/hgpirate
+/obj/item/clothing/suit/pirate/captain
 	name = "pirate captain coat"
 	desc = "Yarr."
 	icon_state = "hgpirate"
 	item_state = "hgpirate"
-	allowed = list(/obj/item/weapon/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/weapon/reagent_containers/food/drinks/bottle/rum)
 
 
 /obj/item/clothing/suit/cyborg_suit
@@ -91,6 +91,7 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/toy)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	burn_state = FIRE_PROOF
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/suit/hastur
 	name = "\improper Hastur's robe"
@@ -332,6 +333,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/suit/jacket/leather
 	name = "leather jacket"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -154,6 +154,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 	allowed = list(/obj/item/weapon/storage/book/bible, /obj/item/weapon/nullrod, /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater, /obj/item/weapon/storage/fancy/candle_box, /obj/item/candle, /obj/item/weapon/tank/internals/emergency_oxygen)
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 
 /obj/item/clothing/suit/cardborg
@@ -421,6 +422,7 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 0)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/toy,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/weapon/lighter)
 	hooded = 1
+	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/head/winterhood
 	name = "winter hood"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -37,7 +37,7 @@
 	icon_state = "pirate"
 	item_state = "pirate"
 	allowed = list(/obj/item/weapon/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/weapon/reagent_containers/food/drinks/bottle/rum)
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/suit/pirate/captain
 	name = "pirate captain coat"
@@ -91,7 +91,7 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/toy)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	burn_state = FIRE_PROOF
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/suit/hastur
 	name = "\improper Hastur's robe"
@@ -154,7 +154,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 	allowed = list(/obj/item/weapon/storage/book/bible, /obj/item/weapon/nullrod, /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater, /obj/item/weapon/storage/fancy/candle_box, /obj/item/candle, /obj/item/weapon/tank/internals/emergency_oxygen)
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 
 /obj/item/clothing/suit/cardborg
@@ -334,7 +334,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/suit/jacket/leather
 	name = "leather jacket"
@@ -422,7 +422,7 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 0)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/toy,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/weapon/lighter)
 	hooded = 1
-	pockets = /obj/item/weapon/storage/internal/pocket
+//	pockets = /obj/item/weapon/storage/internal/pocket
 
 /obj/item/clothing/head/winterhood
 	name = "winter hood"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -588,8 +588,7 @@ Sorry Giacom. Please don't be mad :(
 	if(pulledby && moving_diagonally != FIRST_DIAG_STEP && get_dist(src, pulledby) > 1)//separated from our puller and not in the middle of a diagonal move.
 		pulledby.stop_pulling()
 
-	if (s_active && !(s_active in contents) && !(s_active.loc in contents))
-		// It's ugly. But everything related to inventory/storage is. -- c0
+	if (s_active && !(s_active.ClickAccesible(src, depth=STORAGE_VIEW_DEPTH) || s_active.Adjacent(src)))
 		s_active.close(src)
 
 /mob/living/movement_delay()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -588,7 +588,7 @@ Sorry Giacom. Please don't be mad :(
 	if(pulledby && moving_diagonally != FIRST_DIAG_STEP && get_dist(src, pulledby) > 1)//separated from our puller and not in the middle of a diagonal move.
 		pulledby.stop_pulling()
 
-	if (s_active && !(s_active.ClickAccesible(src, depth=STORAGE_VIEW_DEPTH) || s_active.Adjacent(src)))
+	if (s_active && !(s_active.ClickAccessible(src, depth=STORAGE_VIEW_DEPTH) || s_active.Adjacent(src)))
 		s_active.close(src)
 
 /mob/living/movement_delay()


### PR DESCRIPTION
This PR ports pockets (from Animus Green) and adds them to some clothing.
![scrnshot1](https://cloud.githubusercontent.com/assets/13571765/16721816/f3bf212a-474a-11e6-80a8-7b61d0e29ecc.png)
_Hazard vest with 2 items in pockets._
- Coats and jackets generally have 2 small pockets.
- Engineering and mining hardsuits have 2 small pockets.
- CE's hardsuit has 2 medium pockets.
- Shoes that support storing items now use pockets system.
- Some hats have 1 small pocket. 
- Detective's hat spawns with a flask in it. 
- Clown's mask has a single tiny top-secret pocket. Honk!

This PR also includes two or three path fixes. It also fixes internal storages (pockets, storage implant) having less "max depth" than external ones.

:cl: CoreOverload
add: Some clothing has pockets now.
/:cl:

Token: #18534
