### PR TITLE
Fixes some Alternate Appearance issues

### DIFF
--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -30,7 +30,11 @@
 		if(!M.viewing_alternate_appearances)
 			M.viewing_alternate_appearances = list()
 		viewers |= M
-		M.viewing_alternate_appearances[key] = src
+		var/list/AAsiblings = M.viewing_alternate_appearances[key]
+		if(!AAsiblings)
+			AAsiblings = list()
+			M.viewing_alternate_appearances[key] = AAsiblings
+		AAsiblings |= src
 		if(M.client)
 			M.client.images |= img
 
@@ -48,9 +52,13 @@
 		if(M.client)
 			M.client.images -= img
 		if(M.viewing_alternate_appearances && M.viewing_alternate_appearances.len)
-			M.viewing_alternate_appearances -= key
-			if(!M.viewing_alternate_appearances.len)
-				M.viewing_alternate_appearances = null
+			var/list/AAsiblings = M.viewing_alternate_appearances[key]
+			if(AAsiblings)
+				AAsiblings -= src
+				if(!AAsiblings.len)
+					M.viewing_alternate_appearances -= key
+					if(!M.viewing_alternate_appearances.len)
+						M.viewing_alternate_appearances = null
 		viewers -= M
 
 
@@ -73,8 +81,9 @@
 
 /atom
 	var/list/alternate_appearances //the alternate appearances we own
-	var/list/viewing_alternate_appearances //the alternate appearances we're viewing, stored here to reestablish them after Logout()s
-	//these lists are built/destroyed as necessary, so atoms aren't all lugging around lists full of datums
+	var/list/viewing_alternate_appearances //this is an assoc list of lists, the keys being the AA's key
+	//inside these lists are the AAs themselves, this is to allow the atom to see multiple of the same type of AA
+	//eg: two (or more) people disguised as cardborgs, or two (or more) people disguised as plants
 
 /*
 	Builds an alternate_appearance datum for the supplied args, optionally displaying it straight away

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -30,7 +30,8 @@
 	if(viewing_alternate_appearances)
 		for(var/aakey in viewing_alternate_appearances)
 			for(var/aa in viewing_alternate_appearances[aakey])
-				qdel(aa)
+				var/datum/alternate_appearance/AA = aa
+				AA.hide(list(src))
 	return ..()
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -27,7 +27,10 @@
 			var/datum/alternate_appearance/AA = alternate_appearances[aakey]
 			qdel(AA)
 		alternate_appearances = null
-
+	if(viewing_alternate_appearances)
+		for(var/aakey in viewing_alternate_appearances)
+			for(var/aa in viewing_alternate_appearances[aakey])
+				qdel(aa)
 	return ..()
 
 

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -236,7 +236,7 @@
 	throw_speed = 2
 	throw_range = 4
 
-/obj/item/weapon/twohanded/flora/kirbyplants/equipped(mob/living/user)
+/obj/item/weapon/twohanded/required/kirbyplants/equipped(mob/living/user)
 	var/image/I = image(icon = 'icons/obj/flora/plants.dmi' , icon_state = src.icon_state, loc = user)
 	I.override = 1
 	user.add_alt_appearance("sneaking_mission", I, player_list)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -64,8 +64,8 @@
 
 	if(viewing_alternate_appearances && viewing_alternate_appearances.len)
 		for(var/aakey in viewing_alternate_appearances)
-			var/datum/alternate_appearance/AA = viewing_alternate_appearances[aakey]
-			if(AA)
+			for(var/aa in viewing_alternate_appearances[aakey])
+				var/datum/alternate_appearance/AA = aa
 				AA.display_to(list(src))
 
 	update_client_colour()


### PR DESCRIPTION
:cl:
fix: fixed Kor's plant disguises
fix: fixed some issues with Alternate Appearances not being added/removed
/:cl:
- Fixes Viewed Alternate Appearances not being cleared out during an atom's Destroy()
- Fixes @KorPhaeron's AA plants
- Fixes #18941 
- Fixes #16860

![miss master of disguise](http://i.imgur.com/zIj0I28.gif)

Thanks to our friends at paradise for helping me discover some of these issues.
