### PR TITLE
increase emergency tank w_class

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -158,7 +158,7 @@
 	icon_state = "emergency"
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
-	w_class = 2
+	w_class = 3
 	force = 4
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 	volume = 3 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)


### PR DESCRIPTION
in 2011 this was accidentally-on-purpose changed during the DANGERCON meme to allow e-tanks to fit in pockets, which is the opposite of danger and makes hull breaches not really a problem

:cl: 
tweak: Emergency tanks no longer fit in pockets
/:cl: