### PR TITLE
Fixes an AI with a deleted camera being stuck

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -322,7 +322,7 @@ var/list/ai_list = list()
 			C.post_status("shuttle")
 
 /mob/living/silicon/ai/cancel_camera()
-	src.view_core()
+	view_core()
 
 /mob/living/silicon/ai/verb/toggle_anchor()
 	set category = "AI Commands"
@@ -896,15 +896,16 @@ var/list/ai_list = list()
 
 /mob/living/silicon/ai/proc/malfhacked(obj/machinery/power/apc/apc)
 	malfhack = null
-	malfhacking = FALSE
+	malfhacking = 0
+	clear_alert("hackingapc")
 
 	if(!istype(apc) || qdeleted(apc) || apc.stat & BROKEN)
-		src << "Hack aborted. The designated APC no longer exists on the \
-			power network."
+		src << "<span class='danger'>Hack aborted. The designated APC no \
+			longer exists on the power network.</span>"
 		playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
 	else if(apc.aidisabled)
-		src << "Hack aborted. \The [apc] is no longer responding \
-			to our systems."
+		src << "<span class='danger'>Hack aborted. \The [apc] is no \
+			longer responding to our systems.</span>"
 		playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 1)
 	else
 		malf_picker.processing_time += 10

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -76,7 +76,7 @@
 
 	//user.unset_machine() //Uncomment this if it causes problems.
 	//user.lightNearbyCamera()
-	if (user.camera_light_on)
+	if(user.camera_light_on)
 		user.light_cameras()
 
 // Return to the Core.
@@ -86,13 +86,11 @@
 	cameraFollow = null
 	unset_machine()
 
-	if(src.eyeobj && src.loc)
-		src.eyeobj.loc = src.loc
-	else
+	if(!eyeobj || !eyeobj.loc || qdeleted(eyeobj))
 		src << "ERROR: Eyeobj not found. Creating new eye..."
-		src.eyeobj = new(src.loc)
-		src.eyeobj.ai = src
-		src.eyeobj.name = "[src.name] (AI Eye)" // Give it a name
+		eyeobj = new(loc)
+		eyeobj.ai = src
+		eyeobj.name = "[src.name] (AI Eye)" // Give it a name
 
 	eyeobj.setLoc(loc)
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -11,11 +11,14 @@
 
 		update_gravity(mob_has_gravity())
 
-		if(malfhack)
-			if(malfhack.aidisabled)
-				src << "<span class='danger'>ERROR: APC access disabled, hack attempt canceled.</span>"
-				malfhacking = 0
-				malfhack = null
+		if(malfhack && malfhack.aidisabled)
+			deltimer(malfhacking)
+			// This proc handles cleanup of screen notifications and
+			// messenging the client
+			malfhacked(malfhack)
+
+		if(!eyeobj || qdeleted(eyeobj) || !eyeobj.loc)
+			view_core()
 
 		if(machine)
 			machine.check_eye(src)
@@ -156,8 +159,7 @@
 	blind_eyes(1)
 	update_sight()
 	src << "You've lost power!"
-	spawn(20)
-		start_RestorePowerRoutine()
+	addtimer(src, "start_RestorePowerRoutine", 20)
 
 #undef POWER_RESTORATION_OFF
 #undef POWER_RESTORATION_START

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -414,7 +414,6 @@
 			playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
 			visible_message("<span class='danger'>[M] took a swipe at [src]!</span>", \
 							"<span class='userdanger'>[M] took a swipe at [src]!</span>")
-	return
 
 /mob/living/silicon/attack_animal(mob/living/simple_animal/M)
 	if(..())
@@ -440,7 +439,6 @@
 /mob/living/silicon/attack_larva(mob/living/carbon/alien/larva/L)
 	if(L.a_intent == "help")
 		visible_message("[L.name] rubs its head against [src].")
-	return
 
 /mob/living/silicon/attack_hulk(mob/living/carbon/human/user)
 	if(user.a_intent == "harm")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -796,8 +796,7 @@
 		return
 	malf << "Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process."
 	malf.malfhack = src
-	malf.malfhacking = TRUE
-	addtimer(malf, "malfhacked", 600, FALSE, src)
+	malf.malfhacking = addtimer(malf, "malfhacked", 600, FALSE, src)
 
 	var/obj/screen/alert/hackingapc/A
 	A = malf.throw_alert("hackingapc", /obj/screen/alert/hackingapc)


### PR DESCRIPTION
For example #19279 will cause the roadkill to (incorrectly) kill the
AI's camera mob. Now the AI Life() tick will correctly recognise a dead
camera, and recreate it.
- Also fixes a bug where a hacking-in-progress APC getting its AI
  control wire cut would make a message, and then another message when the
  timer finished.
- Removed trailing returns, addtimer'd a thing
