### PR TITLE
Bees are rendered docile for 30 seconds by smoke

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -723,7 +723,7 @@
 		recoil(user)
 	else
 		user.mind.AddSpell(S)
-		user <<"<span class='notice'>you rapidly read through the arcane book. Suddenly you realize you understand [spellname]!</span>"
+		user <<"<span class='notice'>You rapidly read through the arcane book. Suddenly you realize you understand [spellname]!</span>"
 		user.attack_log += text("\[[time_stamp()]\] <font color='orange'>[user.real_name] ([user.ckey]) learned the spell [spellname] ([S]).</font>")
 		onlearned(user)
 

--- a/code/game/objects/items/weapons/grenades/smokebomb.dm
+++ b/code/game/objects/items/weapons/grenades/smokebomb.dm
@@ -10,8 +10,8 @@
 
 /obj/item/weapon/grenade/smokebomb/New()
 	..()
-	src.smoke = new /datum/effect_system/smoke_spread/bad
-	src.smoke.attach(src)
+	smoke = new /datum/effect_system/smoke_spread/bad
+	smoke.attach(src)
 
 /obj/item/weapon/grenade/smokebomb/Destroy()
 	qdel(smoke)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -914,6 +914,9 @@
 	var/mob/living/simple_animal/hostile/C = new chosen
 	C.faction = list("plants")
 
+/obj/machinery/hydroponics/proc/reset_bee_visit()
+	recent_bee_visit = FALSE
+
 
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -790,3 +790,16 @@
 			blood_volume -= amount
 	return ..()
 
+/mob/living/carbon/smoke_act(var/obj/effect/particle_effect/smoke/smoke)
+	if(internal != null || has_smoke_protection())
+		. = FALSE
+	else if(smoke_delay && (!smoke.ignores_smoke_delay))
+		. = FALSE
+	else
+		if(!smoke.ignores_smoke_delay)
+			smoke_delay = TRUE
+			addtimer(src, "remove_smoke_delay", 10)
+		. = TRUE
+
+/mob/living/carbon/proc/remove_smoke_delay()
+	smoke_delay = FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1045,3 +1045,6 @@ Sorry Giacom. Please don't be mad :(
 		G.Recall()
 		G << "<span class='holoparasite'>Your summoner has changed \
 			form!</span>"
+
+/mob/living/proc/smoke_act(var/obj/effect/particle_effect/smoke/smoke)
+	return FALSE


### PR DESCRIPTION
:cl: coiax
add: Bees are now made docile by smoke of any sort, including smoke
grenades, chemical reactions, nanofrost and harvester smoke.
/:cl:
- Smoke now affects mob/living, but doesn't do anything unless
  mob/living/carbon, so we can have a smoke_act() proc that bees can react
  to.
- Smoke uses timers
- Admin defined some things
- Spelling error in spellbooks
