### PR TITLE
RIP meteor looping

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -364,3 +364,19 @@
 //called when a mob resists while inside a container that is itself inside something.
 /atom/movable/proc/relay_container_resist(mob/living/user, obj/O)
 	return
+
+/atom/movable/proc/SpaceTransit(var/turf/destination)
+	forceMove(destination)
+	stoplag()
+	newtonian_move(inertia_dir)
+
+/mob/living/SpaceTransit(var/turf/destination)
+	var/old_pulling
+	if(pulling)
+		old_pulling = pulling
+		var/turf/T = get_step(destination, turn(dir, 180))
+		pulling.forceMove(T)
+	forceMove(destination)
+	pulling = old_pulling
+	stoplag()
+	newtonian_move(inertia_dir)

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -102,6 +102,7 @@
 
 	var/list/meteordrop = list(/obj/item/weapon/ore/iron)
 	var/dropamt = 2
+	var/no_transit = TRUE
 
 /obj/effect/meteor/Move()
 	if(z != z_original || loc == dest)
@@ -116,6 +117,12 @@
 
 		if(prob(10) && !istype(T, /turf/open/space))//randomly takes a 'hit' from ramming
 			get_hit()
+
+/obj/effect/meteor/SpaceTransit(turf/destination)
+	if(no_transit)
+		qdel(src)
+	else
+		. = ..()
 
 /obj/effect/meteor/Destroy()
 	walk(src,0) //this cancels the walk_towards() proc

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -26,15 +26,10 @@
 		return QDEL_HINT_LETMELIVE
 
 /turf/open/space/attack_ghost(mob/dead/observer/user)
-	if(destination_z)
-		var/turf/T = locate(destination_x, destination_y, destination_z)
-		user.forceMove(T)
+	Entered(user)
 
 /turf/open/space/Initalize_Atmos(times_fired)
 	return
-
-/turf/open/space/ChangeTurf(path)
-	. = ..()
 
 /turf/open/space/TakeTemperature(temp)
 
@@ -99,23 +94,13 @@
 
 /turf/open/space/Entered(atom/movable/A)
 	..()
-	if ((!(A) || src != A.loc))
+	if(!istype(A))
 		return
 
 	if(destination_z)
-		A.x = destination_x
-		A.y = destination_y
-		A.z = destination_z
-
-		if(isliving(A))
-			var/mob/living/L = A
-			if(L.pulling)
-				var/turf/T = get_step(L.loc,turn(A.dir, 180))
-				L.pulling.loc = T
-
-		//now we're on the new z_level, proceed the space drifting
-		stoplag()//Let a diagonal move finish, if necessary
-		A.newtonian_move(A.inertia_dir)
+		var/turf/T = locate(destination_x, destination_y, destination_z)
+		if(T)
+			A.SpaceTransit(T)
 
 /turf/open/space/proc/Sandbox_Spacemove(atom/movable/A)
 	var/cur_x

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -50,11 +50,8 @@
 			_y = min
 
 	var/turf/T = locate(_x, _y, _z)
-	AM.loc = T
-	AM.newtonian_move(dir)
-
-
-
+	if(T)
+		AM.SpaceTransit(T)
 
 //Overwrite because we dont want people building rods in space.
 /turf/open/space/transit/attackby()


### PR DESCRIPTION
:cl: coiax
tweak: Meteors now delete themselves when they would be moved by a z-level transition. Immovable rods are unaffected.
/:cl:
- Adds SpaceTransit proc. The way that it works for /mob/living requires it to be rewritten because of how the pulling stuff happens in the middle.
- This means you can now drag a thing into a transit turf and it'll fall through as well, although during testing, my ninja ended up in one z level, and the sword in another. So, eh?
