### PR TITLE
Fixes borgs adding their analyzers to security cameras.

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -162,6 +162,8 @@
 
 		else if(istype(W, /obj/item/device/analyzer))
 			if(!isXRay())
+				if(!user.drop_item(W))
+					return
 				upgradeXRay()
 				qdel(W)
 				user << "[msg]"

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -103,11 +103,11 @@
 
 	// Upgrades!
 	if(is_type_in_list(W, possible_upgrades) && !is_type_in_list(W, upgrades)) // Is a possible upgrade and isn't in the camera already.
-		if(!user.unEquip(W))
+		if(!user.drop_item(W))
 			return
 		user << "<span class='notice'>You attach \the [W] into the assembly inner circuits.</span>"
 		upgrades += W
-		W.loc = src
+		W.forceMove(src)
 		return
 
 	// Taking out upgrades


### PR DESCRIPTION
Basically what the title says. Borgs can no longer add their analyzers to security cameras. Fixes #18501 .

Decided to remake this PR since its been 28 days since @bgobandit's PR was closed and it seemed like they weren't gonna remake it.
