### PR TITLE
Resolves a runtime with X4

### DIFF
--- a/code/game/objects/items/weapons/grenades/plastic.dm
+++ b/code/game/objects/items/weapons/grenades/plastic.dm
@@ -164,7 +164,7 @@
 	if(location)
 		if(istype(loc, /obj/item/weapon/twohanded/spear))
 			explosion(location, 0, 2, 3)
-		else if(target.density)
+		else if(target && target.density)
 			var/turf/T = get_step(location, aim_dir)
 			explosion(get_step(T, aim_dir),0,0,3)
 			explosion(T,0,2,0)


### PR DESCRIPTION
X4 would runtime if an assembly holder detonated it without it being planted first, because it never checks to make sure target exists. Now we _actually_ check to make sure we've got a target before we look at the density of it.

You can reproduce this by slapping an igniter/mousetrap assembly on X4 and stepping on it.
(Theoretically any assembly would cause this runtime if the X4 wasn't given a target first by planting it on a wall or some shit, but that's the assembly that I found the bug with)

Found this bug while porting your plastic explosives refactor ParadiseSS13/Paradise#5041
