### PR TITLE
Grammar Fix for death whisper

### DIFF
--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -61,7 +61,7 @@
 
 	var/rendered
 
-	rendered = "<span class='game say'><span class='name'>[src.name]</span> [whispers] something.</span>"
+	rendered = "<span class='game say'><span class='name'>[src.name]</span> whispers something in their final breath.</span>"
 	for(var/mob/M in watching)
 		M.show_message(rendered, 2)
 


### PR DESCRIPTION
Fixes #19301

Because [whispers] = Whispers in their final breath
and that was just applied to all the death whisper messages, it broke grammar in the one that displayed for people 4-5 tiles away.  You could change the variable message but it'd mess up the other whisper messages and it's simplest to just remove it from the offending grammar sentence and just fill it in with a span.  
