### PR TITLE
Cogscarabs can use clockwork slabs to check cult status

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -160,7 +160,7 @@
 		user << "<span class='warning'>[src] refuses to work, displaying the message: \"[busy]!\"</span>"
 		return 0
 	if(!nonhuman_usable && !ishuman(user))
-		user << "<span class='warning'>[src] hums quietly in your hands, but you can't seem to get it to do anything.</span>"
+		show_stats(user) //if it's not human, show it stats
 		return 0
 	access_display(user)
 


### PR DESCRIPTION
:cl: Joan
rscadd: Cogscarabs(and other nonhuman mobs able to hold clockwork slabs) can now check the stats of the clockwork cult by using a clockwork slab. They remain unable to use slabs under normal conditions.
/:cl:
