### PR TITLE
Fixes the slowdown on bluespace(and all other) floors.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -594,7 +594,7 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/movement_delay()
 	. = ..()
-	if(isturf(loc, /turf/open))
+	if(istype(loc, /turf/open))
 		var/turf/open/T = loc
 		. += T.slowdown
 	switch(m_intent)


### PR DESCRIPTION
Basically what is says on the title. This fixes the issue of the -1 slowdown on bluespace floors not working previously, and ironically it didn't work on any floors, no matter how high or low their slowdown was into the positive or negative.

Who woulda thought that turning istype into isturf would have broken this, but turning it back to istype instantly fixed this.

Fixes #16996 
