### PR TITLE
Increases shuttle delay to 5.5+10 seconds

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -194,8 +194,8 @@
 	var/last_timer_length
 
 	var/mode = SHUTTLE_IDLE			//current shuttle mode
-	var/callTime = 50				//time spent in transit (deciseconds)
-	var/ignitionTime = 10			// time spent "starting the engines"
+	var/callTime = 100				//time spent in transit (deciseconds). Should not be lower then 10 seconds without editing the animation of the hyperspace ripples.
+	var/ignitionTime = 55			// time spent "starting the engines". Also rate limits how often we try to reserve transit space if its ever full of transiting shuttles.
 	var/roundstart_move				//id of port to send shuttle to at roundstart
 
 	// The direction the shuttle prefers to travel in


### PR DESCRIPTION
1+5 seconds was super lame.

The delays had code related reasons, call time at the least shouldn't ever be below 10 seconds without editing the animation for the hyperspace ripples.

The ignition time is designed to make reserving transit space easier, and if it is ever full, ignition time rate limits how often it attempts to reserve transit space.

There isn't actually enough transit space for all of our shuttles (because there doesn't need to be 99% of the time) but with a call time only 1 second, the syndicates, the miners, security/gulag, people using the white ship, and admins could all spam call their related shuttles and then now you have a case where 1 or 2 shuttles are calling the proc to check for transit space every second. add on the escape shuttle docking and cargo shuttle docking at that moment, and that number could jump to 4 shuttles trying to reserve transit space every second, all needlessly.

Also, https://tgstation13.org/phpBB/viewtopic.php?f=10&t=7286&view=unread#p195824 points out that having ignition time too short causes issues. I'd want there to be enough time that when we make ignition more apparent, there is actually time to react.

@KorPhaeron never fall into the trap of over-nerfing or over-buffing or over-reacting to unbalance in general.
