### PR TITLE
Add dropdel flag to royal parasite injector

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -99,7 +99,7 @@
 	name = "\improper royal parasite"
 	desc = "Inject this into one of your grown children to promote her to a Praetorian!"
 	icon_state = "alien_medal"
-	flags = ABSTRACT|NODROP
+	flags = ABSTRACT|NODROP|DROPDEL
 	icon = 'icons/mob/alien.dmi'
 
 /obj/item/queenpromote/attack(mob/living/M, mob/living/carbon/alien/humanoid/user)


### PR DESCRIPTION
This item should definitely be deleted when dropped due to queen death
