### PR TITLE
Reduces Weight chance on Meteor/Dust events

### DIFF
--- a/code/modules/events/major_dust.dm
+++ b/code/modules/events/major_dust.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/meteor_wave/major_dust
 	name = "Major Space Dust"
 	typepath = /datum/round_event/meteor_wave/major_dust
-	weight = 30
+	weight = 8
 
 /datum/round_event/meteor_wave/major_dust
 	wave_name = "space dust"

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -3,7 +3,7 @@
 /datum/round_event_control/meteor_wave
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
-	weight = 5
+	weight = 4
 	min_players = 5
 	max_occurrences = 3
 
@@ -50,7 +50,7 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 4
+	weight = 2
 	min_players = 5
 	max_occurrences = 3
 


### PR DESCRIPTION
Major Space Dust triggers every single round, and the damage is not minor.  Meteors trigger every single round and with atmospherics being super mega turbo cunt fast for some reason, it makes the game literally super awful to play.  This reduces the meteor weight chances by a lot and makes major space dust trigger substantially less.  I barely know what the weights are though so give feedback.
