### PR TITLE
Tinkerer's Caches link to clockwork walls

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -153,7 +153,7 @@
 	max_health = 80
 	health = 80
 	var/wall_generation_cooldown
-	var/wall_found = FALSE //if we've found a wall and finished our windup delay
+	var/turf/closed/wall/clockwork/linkedwall //if we've got a linked wall and are producing
 
 /obj/structure/clockwork/cache/New()
 	..()
@@ -170,6 +170,9 @@
 	clockwork_caches--
 	scripture_unlock_alert(scripture_states)
 	STOP_PROCESSING(SSobj, src)
+	if(linkedwall)
+		linkedwall.linkedcache = null
+		linkedwall = null
 	for(var/i in all_clockwork_mobs)
 		cache_check(i)
 	return ..()
@@ -182,13 +185,14 @@
 	return ..()
 
 /obj/structure/clockwork/cache/process()
-	for(var/turf/closed/wall/clockwork/C in orange(1, src))
-		if(!wall_found)
-			wall_found = TRUE
+	for(var/turf/closed/wall/clockwork/C in view(5, src))
+		if(!C.linkedcache && !linkedwall)
+			C.linkedcache = src
+			linkedwall = C
 			wall_generation_cooldown = world.time + CACHE_PRODUCTION_TIME
 			visible_message("<span class='warning'>[src] starts to whirr in the presence of [C]...</span>")
 			break
-		if(wall_generation_cooldown <= world.time)
+		if(linkedwall && wall_generation_cooldown <= world.time)
 			wall_generation_cooldown = world.time + CACHE_PRODUCTION_TIME
 			generate_cache_component()
 			playsound(C, 'sound/magic/clockwork/fellowship_armory.ogg', rand(15, 20), 1, -3, 1, 1)
@@ -290,6 +294,8 @@
 /obj/structure/clockwork/cache/examine(mob/user)
 	..()
 	if(is_servant_of_ratvar(user) || isobserver(user))
+		if(linkedwall)
+			user << "<span class='brass'>It is linked and will generate components!</span>"
 		user << "<b>Stored components:</b>"
 		user << "<span class='neovgre_small'><i>Belligerent Eyes:</i> [clockwork_component_cache["belligerent_eye"]]</span>"
 		user << "<span class='inathneq_small'><i>Vanguard Cogwheels:</i> [clockwork_component_cache["vanguard_cogwheel"]]</span>"

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -185,7 +185,7 @@
 	return ..()
 
 /obj/structure/clockwork/cache/process()
-	for(var/turf/closed/wall/clockwork/C in view(5, src))
+	for(var/turf/closed/wall/clockwork/C in view(4, src))
 		if(!C.linkedcache && !linkedwall)
 			C.linkedcache = src
 			linkedwall = C

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -45,6 +45,7 @@
 	desc = "A huge chunk of warm metal. The clanging of machinery emanates from within."
 	explosion_block = 2
 	var/obj/effect/clockwork/overlay/wall/realappearence
+	var/obj/structure/clockwork/cache/linkedcache
 
 /turf/closed/wall/clockwork/New()
 	..()
@@ -53,6 +54,11 @@
 	realappearence = PoolOrNew(/obj/effect/clockwork/overlay/wall, src)
 	realappearence.linked = src
 	change_construction_value(5)
+
+/turf/closed/wall/clockwork/examine(mob/user)
+	..()
+	if((is_servant_of_ratvar(user) || isobserver(user)) && linkedcache)
+		user << "<span class='brass'>It is linked, generating components in a cache!</span>"
 
 /turf/closed/wall/clockwork/Destroy()
 	be_removed()
@@ -64,6 +70,9 @@
 	return ..()
 
 /turf/closed/wall/clockwork/proc/be_removed()
+	if(linkedcache)
+		linkedcache.linkedwall = null
+		linkedcache = null
 	change_construction_value(-5)
 	qdel(realappearence)
 	realappearence = null


### PR DESCRIPTION
:cl: Joan
experiment: Tinkerer's Caches now link to a nearby unlinked clockwork wall, and will not generate components unless linked. As compensation, they will link to nearby walls(and can generate components) in a larger area.
/:cl:
