### PR TITLE
"Return to lobby if preferences unavailable" Revengence

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -50,3 +50,8 @@ var/global/list/special_roles = list(
 	ROLE_DEVIL = /datum/game_mode/devil,
 	ROLE_SERVANT_OF_RATVAR = /datum/game_mode/clockwork_cult,
 )
+
+//Job defines for what happens when you fail to qualify for any job during job selection
+#define BEASSISTANT 	1
+#define BERANDOMJOB 	2
+#define RETURNTOLOBBY 	3

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -328,7 +328,7 @@ var/datum/subsystem/job/SSjob
 	for(var/mob/new_player/player in unassigned)
 		if(PopcapReached())
 			RejectPlayer(player)
-		else if(player.client.prefs.userandomjob)
+		else if(player.client.prefs.joblessrole == BERANDOMJOB)
 			GiveRandomJob(player)
 
 	Debug("DO, Standard Check end")
@@ -339,8 +339,15 @@ var/datum/subsystem/job/SSjob
 	for(var/mob/new_player/player in unassigned)
 		if(PopcapReached())
 			RejectPlayer(player)
-		Debug("AC2 Assistant located, Player: [player]")
-		AssignRole(player, "Assistant")
+		if(player.client.prefs.joblessrole == BEASSISTANT)
+			Debug("AC2 Assistant located, Player: [player]")
+			AssignRole(player, "Assistant")
+		else // For those who don't want to play if their preference were filled, back you go.
+			RejectPlayer(player)
+
+	for(var/mob/new_player/player in unassigned) //Players that wanted to back out but couldn't because they're antags (can you feel the edge case?)
+		GiveRandomJob(player)
+
 	return 1
 
 //Gives the player the stuff he should have with his rank
@@ -470,7 +477,8 @@ var/datum/subsystem/job/SSjob
 /datum/subsystem/job/proc/RejectPlayer(mob/new_player/player)
 	if(player.mind && player.mind.special_role)
 		return
-	Debug("Popcap overflow Check observer located, Player: [player]")
+	if(PopcapReached())
+		Debug("Popcap overflow Check observer located, Player: [player]")
 	player << "<b>You have failed to qualify for any job you desired.</b>"
 	unassigned -= player
 	player.ready = 0

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -78,7 +78,7 @@ var/list/preferences_datums = list()
 	var/job_engsec_low = 0
 
 		// Want randomjob if preferences already filled - Donkie
-	var/userandomjob = 1 //defaults to 1 for fewer assistants
+	var/joblessrole = BERANDOMJOB  //defaults to 1 for fewer assistants
 
 	// 0 = character settings, 1 = game preferences
 	var/current_tab = 0
@@ -551,7 +551,12 @@ var/list/preferences_datums = list()
 
 	HTML += "</center></table>"
 
-	HTML += "<center><br><a href='?_src_=prefs;preference=job;task=random'>[userandomjob ? "Get random job if preferences unavailable" : "Be an Assistant if preference unavailable"]</a></center>"
+	var/message = "Be an Assistant if preferences unavailable"
+	if(joblessrole == BERANDOMJOB)
+		message = "Get random job if preferences unavailable"
+	else if(joblessrole == RETURNTOLOBBY)
+		message = "Return to lobby if preferences unavailable"
+	HTML += "<center><br><a href='?_src_=prefs;preference=job;task=random'>[message]</a></center>"
 	HTML += "<center><a href='?_src_=prefs;preference=job;task=reset'>Reset Preferences</a></center>"
 
 	user << browse(null, "window=preferences")
@@ -726,10 +731,16 @@ var/list/preferences_datums = list()
 				ResetJobs()
 				SetChoices(user)
 			if("random")
-				if(jobban_isbanned(user, "Assistant"))
-					userandomjob = 1
-				else
-					userandomjob = !userandomjob
+				switch(joblessrole)
+					if(RETURNTOLOBBY)
+						if(jobban_isbanned(user, "Assistant"))
+							joblessrole = BERANDOMJOB
+						else
+							joblessrole = BEASSISTANT
+					if(BEASSISTANT)
+						joblessrole = BERANDOMJOB
+					if(BERANDOMJOB)
+						joblessrole = RETURNTOLOBBY
 				SetChoices(user)
 			if("setJobLevel")
 				UpdateJobPreference(user, href_list["text"], text2num(href_list["level"]))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -346,7 +346,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["deity_name"]			>> custom_names["deity"]
 
 	//Jobs
-	S["userandomjob"]		>> userandomjob
+	S["joblessrole"]		>> joblessrole
 	S["job_civilian_high"]	>> job_civilian_high
 	S["job_civilian_med"]	>> job_civilian_med
 	S["job_civilian_low"]	>> job_civilian_low
@@ -398,7 +398,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	features["spines"] 	= sanitize_inlist(features["spines"], spines_list)
 	features["body_markings"] 	= sanitize_inlist(features["body_markings"], body_markings_list)
 
-	userandomjob	= sanitize_integer(userandomjob, 0, 1, initial(userandomjob))
+	joblessrole	= sanitize_integer(joblessrole, 1, 3, initial(joblessrole))
 	job_civilian_high = sanitize_integer(job_civilian_high, 0, 65535, initial(job_civilian_high))
 	job_civilian_med = sanitize_integer(job_civilian_med, 0, 65535, initial(job_civilian_med))
 	job_civilian_low = sanitize_integer(job_civilian_low, 0, 65535, initial(job_civilian_low))
@@ -456,7 +456,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["deity_name"]			<< custom_names["deity"]
 
 	//Jobs
-	S["userandomjob"]		<< userandomjob
+	S["joblessrole"]		<< joblessrole
 	S["job_civilian_high"]	<< job_civilian_high
 	S["job_civilian_med"]	<< job_civilian_med
 	S["job_civilian_low"]	<< job_civilian_low

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,8 +1,8 @@
 //This is the lowest supported version, anything below this is completely obsolete and the entire savefile will be wiped.
-#define SAVEFILE_VERSION_MIN	8
+#define SAVEFILE_VERSION_MIN	10
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
-#define SAVEFILE_VERSION_MAX	15
+#define SAVEFILE_VERSION_MAX	16
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
 	This proc checks if the current directory of the savefile S needs updating
@@ -31,7 +31,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	return -1
 
 
-/datum/preferences/proc/update_antagchoices(current_version)
+/datum/preferences/proc/update_antagchoices(current_version, savefile/S)
 	if((!islist(be_special) || old_be_special ) && current_version < 12)
 		//Archived values of when antag pref defines were a bitfield+fitflags
 		var/B_traitor = 1
@@ -87,7 +87,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 						be_special += ROLE_ABDUCTOR
 
 
-/datum/preferences/proc/update_preferences(current_version)
+/datum/preferences/proc/update_preferences(current_version, savefile/S)
 	if(current_version < 10)
 		toggles |= MEMBER_PUBLIC
 	if(current_version < 11)
@@ -97,6 +97,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		ignoring = list()
 	if(current_version < 15)
 		toggles |= SOUND_ANNOUNCEMENTS
+	
 
 //should this proc get fairly long (say 3 versions long),
 //just increase SAVEFILE_VERSION_MIN so it's not as far behind
@@ -104,65 +105,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 //from this proc.
 //It's only really meant to avoid annoying frequent players
 //if your savefile is 3 months out of date, then 'tough shit'.
-/datum/preferences/proc/update_character(current_version)
-	if(current_version < 9)		//an example, underwear were an index for a hardcoded list, converting to a string
-		if(gender == MALE)
-			switch(underwear)
-				if(1)
-					underwear = "Mens White"
-				if(2)
-					underwear = "Mens Grey"
-				if(3)
-					underwear = "Mens Green"
-				if(4)
-					underwear = "Mens Blue"
-				if(5)
-					underwear = "Mens Black"
-				if(6)
-					underwear = "Mankini"
-				if(7)
-					underwear = "Mens Hearts Boxer"
-				if(8)
-					underwear = "Mens Black Boxer"
-				if(9)
-					underwear = "Mens Grey Boxer"
-				if(10)
-					underwear = "Mens Striped Boxer"
-				if(11)
-					underwear = "Mens Kinky"
-				if(12)
-					underwear = "Mens Red"
-				if(13)
-					underwear = "Nude"
-		else
-			switch(underwear)
-				if(1)
-					underwear = "Ladies Red"
-				if(2)
-					underwear = "Ladies White"
-				if(3)
-					underwear = "Ladies Yellow"
-				if(4)
-					underwear = "Ladies Blue"
-				if(5)
-					underwear = "Ladies Black"
-				if(6)
-					underwear = "Ladies Thong"
-				if(7)
-					underwear = "Babydoll"
-				if(8)
-					underwear = "Ladies Baby-Blue"
-				if(9)
-					underwear = "Ladies Green"
-				if(10)
-					underwear = "Ladies Pink"
-				if(11)
-					underwear = "Ladies Kinky"
-				if(12)
-					underwear = "Tankini"
-				if(13)
-					underwear = "Nude"
-
+/datum/preferences/proc/update_character(current_version, savefile/S)
 	if(pref_species && !(pref_species.id in roundstart_species))
 		var/rando_race = pick(config.roundstart_races)
 		pref_species = new rando_race()
@@ -173,6 +116,14 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 				backbag = DSATCHEL
 			else
 				backbag = DBACKPACK
+	if(current_version < 16)
+		var/berandom
+		S["userandomjob"] >> berandom
+		if (berandom)
+			joblessrole = BERANDOMJOB
+		else
+			joblessrole = BEASSISTANT
+		
 
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
@@ -223,8 +174,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
-		update_preferences(needs_update)		//needs_update = savefile_version if we need an update (positive integer)
-		update_antagchoices(needs_update)
+		update_preferences(needs_update, S)		//needs_update = savefile_version if we need an update (positive integer)
+		update_antagchoices(needs_update, S)
 
 	//Sanitize
 	ooccolor		= sanitize_ooccolor(sanitize_hexcolor(ooccolor, 6, 1, initial(ooccolor)))
@@ -359,7 +310,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
-		update_character(needs_update)		//needs_update == savefile_version if we need an update (positive integer)
+		update_character(needs_update, S)		//needs_update == savefile_version if we need an update (positive integer)
 
 	//Sanitize
 	metadata		= sanitize_text(metadata, initial(metadata))


### PR DESCRIPTION
A remake of #4308

:cl:
add: You now have the ability to automatically "back out" of a round if you miss your chance at all the jobs you have set to low or higher. This is found on the toggle at the bottom of the jobs window
add: Due to a quirk of game mode code this option will fail to work if you've been selected as an antag (what a tragedy!) In this situation, you'll be assigned a random job.
/:cl:
