### PR TITLE
Ratvarian grammar/punctuation rules in proc form!

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -421,51 +421,20 @@ var/list/binary = list("0","1")
 
 	return t
 
-/proc/char_split(t)
-	. = list()
-	for(var/x in 1 to length(t))
-		. += copytext(t,x,x+1)
+#define string2charlist(string) (splittext(string, regex("(.)")) - splittext(string, ""))
 
-var/list/rot13_lookup = list()
-
-/proc/generate_rot13_lookup()
-	var/letters = alphabet.Copy()
-	for(var/c in alphabet)
-		letters += uppertext(c)
-
-	for(var/char in letters)
-		var/ascii_char = text2ascii(char, 1)
-
-		var/index
-
-		switch(ascii_char)
-			// A - Z
-			if(65 to 90)
-				index = 65
-			// a - z
-			if(97 to 122)
-				index = 97
-
-		var/d = ascii_char - index
-		d += 13
-		if(d >= 26)
-			d -= 26
-		ascii_char = index + d
-		var/translated_char = ascii2text(ascii_char)
-
-		rot13_lookup[char] = translated_char
-
-/proc/rot13(t_in)
-	if(!rot13_lookup.len)
-		generate_rot13_lookup()
-
-	var/t_out = ""
-
-	for(var/i in 1 to length(t_in))
-		var/char = copytext(t_in, i, i + 1)
-		if(char in rot13_lookup)
-			t_out += rot13_lookup[char]
-		else
-			t_out += char
-
-	return t_out
+/proc/rot13(text = "")
+	var/list/textlist = string2charlist(text)
+	var/list/result = list()
+	for(var/c in textlist)
+		var/ca = text2ascii(c)
+		if(ca >= text2ascii("a") && ca <= text2ascii("m"))
+			ca += 13
+		else if(ca >= text2ascii("n") && ca <= text2ascii("z"))
+			ca -= 13
+		else if(ca >= text2ascii("A") && ca <= text2ascii("M"))
+			ca += 13
+		else if(ca >= text2ascii("N") && ca <= text2ascii("Z"))
+			ca -= 13
+		result += ascii2text(ca)
+	return jointext(result, "")

--- a/code/game/gamemodes/clock_cult/clock_unsorted.dm
+++ b/code/game/gamemodes/clock_cult/clock_unsorted.dm
@@ -216,9 +216,7 @@
 		M.clear_alert("nocache")
 
 /*
-
 The Ratvarian Language
-
 	In the lore of the Servants of Ratvar, the Ratvarian tongue is a timeless language and full of power. It sounds like gibberish, much like Nar-Sie's language, but is in fact derived from
 aforementioned language, and may induce miracles when spoken in the correct way with an amplifying tool (similar to runes used by the Nar-Sian cult).
 
@@ -227,23 +225,77 @@ actually very simple. To translate a plain English sentence to Ratvar's tongue, 
 This cipher is known as "rot13" for "rotate 13 places" and there are many sites online that allow instant translation between English and rot13 - one of the benefits is that moving the translated
 sentence thirteen places ahead changes it right back to plain English.
 
-	There are, however, a few parts of the Ratvarian tongue that aren't typical and are implemented for fluff reasons. Some words may have apostrophes, hyphens, and spaces, making the plain
+	There are, however, a few parts of the Ratvarian tongue that aren't typical and are implemented for fluff reasons. Some words may have graves, or hyphens (prefix and postfix), making the plain
 English translation apparent but disjoined (for instance, "Orubyq zl-cbjre!" translates directly to "Behold my-power!") although this can be ignored without impacting overall quality. When
 translating from Ratvar's tongue to plain English, simply remove the disjointments and use the finished sentence. This would make "Orubyq zl-cbjre!" into "Behold my power!" after removing the
 abnormal spacing, hyphens, and grave accents.
 
 List of nuances:
-
-- Any time the word "of" occurs, it is linked to the previous word by a hyphen. (i.e. "V nz-bs Ratvar." directly translates to "I am-of Ratvar.")
-- Any time "th", followed by any two letters occurs, you add an apostrophe between those two letters, i.e; "Thi's"
-- In the same vein, any time "ti", followed by one letter occurs, you add an apostrophe between "i" and the letter, i.e; "Ti'me"
+- Any time the WORD "of" occurs, it is linked to the previous word by a hyphen. (i.e. "V nz-bs Ratvar." directly translates to "I am-of Ratvar.")
+- Any time "th", followed by any two letters occurs, you add a grave (`) between those two letters, i.e; "Thi`s"
+- In the same vein, any time "ti", followed by one letter occurs, you add a grave (`) between "i" and the letter, i.e; "Ti`me"
 - Whereever "te" or "et" appear and there is another letter next to the e(i.e; "m"etal, greate"r"), add a hyphen between "e" and the letter, i.e; "M-etal", "Greate-r"
-- Where the word "and" appears, it is linked to the previous and following words by hyphens, i.e; "Sword-and-shield"
-- Where the word "to" appears, it is linked to the following word by a hyphen, i.e; "to-use"
-- Where the word "my" appears, it is linked to the following word by a hyphen, i.e; "my-light"
-
+- Where the WORD "and" appears it is linked to all surrounding words by hyphens, i.e; "Sword-and-shield"
+- Where the WORD "to" appears, it is linked to the following word by a hyphen, i.e; "to-use"
+- Where the WORD "my" appears, it is linked to the following word by a hyphen, i.e; "my-light"
 - Although "Ratvar" translates to "Engine" in English, the word "Ratvar" is used regardless of language as it is a proper noun.
  - The same rule applies to Ratvar's four generals: Nezbere (Armorer), Sevtug (Fright), Nzcrentr (Amperage), and Inath-Neq (Vangu-Ard), although these words can be used in proper context if one is
    not referring to the four generals and simply using the words themselves.
-
 */
+
+//Regexes used to alter english to ratvarian style
+#define RATVAR_OF_MATCH				regex("(\\w)\\s(\[oO]\[fF])","g")
+#define RATVAR_OF_REPLACEMENT 		"$1-$2"
+#define RATVAR_TH_MATCH				regex("(\[tT]\[hH]\\w)(\\w)","g")
+#define RATVAR_TH_REPLACEMENT		"$1`$2"
+#define RATVAR_TI_MATCH				regex("(\[tT]\[iI])(\\w{2})","g")
+#define RATVAR_TI_REPLACEMENT		"$1`$2"
+#define RATVAR_ET_MATCH				regex("(\\w)(\[eE]\[tT])","g")
+#define RATVAR_ET_REPLACEMENT		"$1-$2"
+#define RATVAR_TE_MATCH				regex("(\[tT]\[eE])(\\w)","g")
+#define RATVAR_TE_REPLACEMENT		"$1-$2"
+#define RATVAR_PRE_AND_MATCH		regex("(\\w)\\s(\[aA]\[nN]\[dD])","g")
+#define RATVAR_PRE_AND_REPLACEMENT	"$1-$2"
+#define RATVAR_POST_AND_MATCH		regex("(\[aA]\[nN]\[dD])\\s(\\w)","g")
+#define RATVAR_POST_AND_REPLACEMENT	"$1-$2"
+#define RATVAR_TO_MATCH				regex("(\\s)(\[tT]\[oO])\\s(\\w)","g")
+#define RATVAR_TO_REPLACEMENT		"$1$2-$3"
+#define RATVAR_MY_MATCH 			regex("(\\s)(\[mM]\[yY])\\s(\\w)","g")
+#define RATVAR_MY_REPLACEMENT		"$1$2-$3"
+
+//Regexes used to remove ratvarian styling from english
+#define REVERSE_RATVAR_HYPHEN_PRE_AND_MATCH			regex("(\\w)-(\[aA]\[nN]\[dD])","g") //specifically structured to support -emphasis-, including with -and-
+#define REVERSE_RATVAR_HYPHEN_PRE_AND_REPLACEMENT	"$1 $2"
+#define REVERSE_RATVAR_HYPHEN_POST_AND_MATCH		regex("(\[aA]\[nN]\[dD])-(\\w)","g")
+#define REVERSE_RATVAR_HYPHEN_POST_AND_REPLACEMENT	"$1 $2"
+#define REVERSE_RATVAR_HYPHEN_TO_MY_MATCH			regex("(\[tTmM]\[oOyY])-","g")
+#define REVERSE_RATVAR_HYPHEN_TO_MY_REPLACEMENT		"$1 "
+#define REVERSE_RATVAR_HYPHEN_TE_MATCH				regex("(\[tT]\[eE])-","g")
+#define REVERSE_RATVAR_HYPHEN_TE_REPLACEMENT		"$1"
+#define REVERSE_RATVAR_HYPHEN_ET_MATCH				regex("-(\[eE]\[tT])","g")
+#define REVERSE_RATVAR_HYPHEN_ET_REPLACEMENT		"$1"
+#define REVERSE_RATVAR_HYPHEN_OF_MATCH				regex("-(\[oO]\[fF])","g")
+#define REVERSE_RATVAR_HYPHEN_OF_REPLACEMENT		" $1"
+
+
+/proc/text2ratvar(text) //Takes english and applies ratvarian styling rules (and rot13) to it
+	var/ratvarian 	= replacetext(text, 		RATVAR_OF_MATCH, 		RATVAR_OF_REPLACEMENT)
+	ratvarian 		= replacetext(ratvarian,	RATVAR_TH_MATCH, 		RATVAR_TH_REPLACEMENT)
+	ratvarian 		= replacetext(ratvarian,	RATVAR_TI_MATCH, 		RATVAR_TI_REPLACEMENT)
+	ratvarian 		= replacetext(ratvarian, 	RATVAR_ET_MATCH, 		RATVAR_ET_REPLACEMENT)
+	ratvarian 		= replacetext(ratvarian, 	RATVAR_TE_MATCH, 		RATVAR_TE_REPLACEMENT)
+	ratvarian 		= replacetext(ratvarian, 	RATVAR_PRE_AND_MATCH,	RATVAR_PRE_AND_REPLACEMENT)
+	ratvarian 		= replacetext(ratvarian, 	RATVAR_POST_AND_MATCH,	RATVAR_POST_AND_REPLACEMENT)
+	ratvarian 		= replacetext(ratvarian, 	RATVAR_TO_MATCH, 		RATVAR_TO_REPLACEMENT)
+	ratvarian 		= replacetext(ratvarian, 	RATVAR_MY_MATCH, 		RATVAR_MY_REPLACEMENT)
+	return rot13(ratvarian)
+
+/proc/ratvar2text(ratvarian) //Reverts ravarian styling and rot13 in text.
+	var/text 	= replacetext(rot13(ratvarian), "`",								 		"")
+	text 		= replacetext(text, 			REVERSE_RATVAR_HYPHEN_PRE_AND_MATCH,	 	REVERSE_RATVAR_HYPHEN_PRE_AND_REPLACEMENT)
+	text 		= replacetext(text, 			REVERSE_RATVAR_HYPHEN_POST_AND_MATCH,	 	REVERSE_RATVAR_HYPHEN_POST_AND_REPLACEMENT)
+	text 		= replacetext(text, 			REVERSE_RATVAR_HYPHEN_TO_MY_MATCH,			REVERSE_RATVAR_HYPHEN_TO_MY_REPLACEMENT)
+	text 		= replacetext(text, 			REVERSE_RATVAR_HYPHEN_TE_MATCH,				REVERSE_RATVAR_HYPHEN_TE_REPLACEMENT)
+	text 		= replacetext(text, 			REVERSE_RATVAR_HYPHEN_ET_MATCH,				REVERSE_RATVAR_HYPHEN_ET_REPLACEMENT)
+	text 		= replacetext(text, 			REVERSE_RATVAR_HYPHEN_OF_MATCH,				REVERSE_RATVAR_HYPHEN_OF_REPLACEMENT)
+	return text

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -241,7 +241,7 @@
 	update_icon()
 
 /obj/item/toy/crayon/proc/crayon_text_strip(text)
-	var/list/base = char_split(lowertext(text))
+	var/list/base = string2charlist(lowertext(text))
 	var/list/out = list()
 	for(var/a in base)
 		if(a in (letters|numerals))

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -91,7 +91,7 @@ var/list/freqtospan = list(
 		if(message_langs & HUMAN)
 			raw_message = stars(raw_message)
 		if(message_langs & RATVAR)
-			raw_message = rot13(raw_message)
+			raw_message = text2ratvar(raw_message)
 		if(AM)
 			return AM.say_quote(raw_message, spans)
 		else


### PR DESCRIPTION
:cl: 
tweak: Auto-generated ratvarian now follows all the rules of hand-written ratvarian, but you probably won't notice.
/:cl:
- Adds a proc `text2ratvar()` which applies all ratvarian grammar/punctuation rules and then applies rot13, returning the final text
- Adds a proc `ratvar2text()` which (lazily) removes ratvarian grammar/punctuation rules and rot13, returning about 95% readable english
- Ratvarian now uses graves ``` instead of apostrophes `'`, as suggested by Joan, so that converting back to english is easier (English doesn't use graves but it does use apostrophes)
- Replaces `rot13()` with a superior version
- Replaces `char_split()` proc with MSO's `string2charlist` define

<B>Example:</B>
http://pastebin.com/x4Lffrtu
