### PR TITLE
Fixed camera bugs and Voice Changers

### DIFF
--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -60,13 +60,14 @@
 /obj/item/device/camera_bug/check_eye(mob/user)
 	if ( loc != user || user.incapacitated() || user.eye_blind || !current )
 		user.unset_machine()
-		return
+		return 0
 	var/turf/T = get_turf(user.loc)
 	if(T.z != current.z || !current.can_use())
 		user << "<span class='danger'>[src] has lost the signal.</span>"
 		current = null
 		user.unset_machine()
-
+		return 0
+	return 1
 /obj/item/device/camera_bug/on_unset_machine(mob/user)
 	user.reset_perspective(null)
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -291,7 +291,7 @@
 	var/datum/action/item_action/chameleon/drone/randomise/randomise_action = new(src)
 	randomise_action.UpdateButtonIcon()
 
-/obj/item/clothing/mask/chameleon/attack_self(mob/user)
+/obj/item/clothing/mask/chameleon/drone/attack_self(mob/user)
 	user << "<span class='notice'>The [src] does not have a voice changer.</span>"
 
 /obj/item/clothing/shoes/chameleon


### PR DESCRIPTION
Fixes #19075

Voice changers in the chameleon kit do not work because of #16935, but that PR does not mention removing the voice changer, so I assumed that this was unintended.

:cl:
bugfix: Camera bugs can now show camera views.
bugfix: The chameleon masks in the chameleon kit can once again have their voice changers toggled.
/:cl:

EDIT: it turns out that the voice changers worked, they just could not be toggled off, and when you tried to toggle them it would tell you that the mask was not a voice changer when it actually was.
