### PR TITLE
Most ratvarian text is now passed through text2ratvar()

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -263,7 +263,7 @@
 	user << "<i>Nezbere: </i>[clockwork_generals_invoked["nezbere"] <= world.time ? "<font color='green'><b>Ready</b></font>" : "<span class='boldannounce'>Invoked</span>"]"
 	user << "<i>Sevtug: </i>[clockwork_generals_invoked["sevtug"] <= world.time ? "<font color='green'><b>Ready</b></font>" : "<span class='boldannounce'>Invoked</span>"]"
 	user << "<i>Nzcrentr: </i>[clockwork_generals_invoked["nzcrentr"] <= world.time ? "<font color='green'><b>Ready</b></font>" : "<span class='boldannounce'>Invoked</span>"]"
-	user << "<i>Inath-Neq: </i>[clockwork_generals_invoked["inath-neq"] <= world.time ? "<font color='green'><b>Ready</b></font>" : "<span class='boldannounce'>Invoked</span>"]"
+	user << "<i>Inath-neq: </i>[clockwork_generals_invoked["inath-neq"] <= world.time ? "<font color='green'><b>Ready</b></font>" : "<span class='boldannounce'>Invoked</span>"]"
 
 /obj/item/clockwork/slab/proc/show_guide(mob/living/user)
 	var/text = "<font color=#BE8700 size=3><b><center>Chetr nyy hagehguf-naq-ubabe Ratvar.</center></b></font><br><br>\
@@ -427,7 +427,7 @@
 	var/message = stripped_input(user, "Enter a message to send to your fellow servants.", "Hierophant")
 	if(!message || !user || !user.canUseTopic(src))
 		return 0
-	user.whisper("Freinagf, urne zl-jbeqf. [message]")
+	clockwork_say(user, text2ratvar("Servants, hear my words. [message]"), TRUE)
 	titled_hierophant_message(user, message)
 	return 1
 
@@ -618,7 +618,7 @@
 			V.recharging = TRUE //To prevent exploiting multiple visors to bypass the cooldown
 			V.update_status()
 			addtimer(V, "recharge_visor", (ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown) * 2, FALSE, user)
-		clockwork_say(user, "Xarry, urngur'af!")
+		clockwork_say(user, text2ratvar("Kneel, heathens!"))
 		user.visible_message("<span class='warning'>The flame in [user]'s hand rushes to [target]!</span>", "<span class='heavy_brass'>You direct [visor]'s power to [target]. You must wait for some time before doing this again.</span>")
 		var/turf/T = get_turf(target)
 		new/obj/effect/clockwork/judicial_marker(T, user)

--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -974,7 +974,7 @@
 	burn_state = LAVA_PROOF
 	var/component_id //What the component is identified as
 	var/cultist_message = "You are not worthy of this meme." //Showed to Nar-Sian cultists if they pick up the component in addition to chaplains
-	var/list/servant_of_ratvar_messages = list("ayy", "lmao") //Fluff, shown to servants of Ratvar on a low chance
+	var/list/servant_of_ratvar_messages = list("ayy" = FALSE, "lmao" = TRUE) //Fluff, shown to servants of Ratvar on a low chance, if associated value is TRUE, will automatically apply ratvarian
 	var/message_span = "heavy_brass"
 
 /obj/item/clockwork/component/pickup(mob/living/user)
@@ -982,7 +982,8 @@
 	if(iscultist(user) || (user.mind && user.mind.assigned_role == "Chaplain"))
 		user << "<span class='[message_span]'>[cultist_message]</span>"
 	if(is_servant_of_ratvar(user) && prob(20))
-		user << "<span class='[message_span]'>[pick(servant_of_ratvar_messages)]</span>"
+		var/pickedmessage = pick(servant_of_ratvar_messages)
+		user << "<span class='[message_span]'>[servant_of_ratvar_messages[pickedmessage] ? "[text2ratvar("pickedmessage")]" : "pickedmessage"]</span>"
 
 /obj/item/clockwork/component/examine(mob/user)
 	..()
@@ -995,7 +996,7 @@
 	icon_state = "belligerent_eye"
 	component_id = "belligerent_eye"
 	cultist_message = "The eye gives you an intensely hateful glare."
-	servant_of_ratvar_messages = list("\"...\"", "For a moment, your mind is flooded with extremely violent thoughts.", "\"...Qvr.\"")
+	servant_of_ratvar_messages = list("\"...\"" = FALSE, "For a moment, your mind is flooded with extremely violent thoughts." = FALSE, "\"...Die.\"" = 1)
 	message_span = "neovgre"
 
 /obj/item/clockwork/component/belligerent_eye/blind_eye
@@ -1004,7 +1005,7 @@
 	clockwork_desc = "A smashed ocular warden covered in dents. Might still be serviceable as a substitute for a belligerent eye."
 	icon_state = "blind_eye"
 	cultist_message = "The eye flickers at you with intense hate before falling dark."
-	servant_of_ratvar_messages = list("The eye flickers before falling dark.", "You feel watched.", "\"...\"")
+	servant_of_ratvar_messages = list("The eye flickers before falling dark." = FALSE, "You feel watched." = FALSE, "\"...\"" = FALSE)
 	w_class = 3
 
 /obj/item/clockwork/component/vanguard_cogwheel
@@ -1013,7 +1014,7 @@
 	icon_state = "vanguard_cogwheel"
 	component_id = "vanguard_cogwheel"
 	cultist_message = "\"Pray to your god that we never meet.\""
-	servant_of_ratvar_messages = list("\"Be safe, child.\"", "You feel unexplainably comforted.", "\"Never forget: pain is temporary. The Justiciar's glory is eternal.\"")
+	servant_of_ratvar_messages = list("\"Be safe, child.\"" = FALSE, "You feel unexplainably comforted." = FALSE, "\"Never forget: pain is temporary. The Justiciar's glory is eternal.\"" = FALSE)
 	message_span = "inathneq"
 
 /obj/item/clockwork/component/vanguard_cogwheel/pinion_lock
@@ -1022,7 +1023,8 @@
 	clockwork_desc = "A broken gear lock for pinion airlocks. Might still be serviceable as a substitute for a vanguard cogwheel."
 	icon_state = "pinion_lock"
 	cultist_message = "The gear grows warm in your hands."
-	servant_of_ratvar_messages = list("The lock isn't getting any lighter.", "\"Qnzntrq trnef ner orggr-e gun'a oebxra obqvrf.\"", "\"Vg pbhyq fgv'yy or hfrq, vs gur'er jnf n qbbe gb-cynpr vg ba.\"")
+	servant_of_ratvar_messages = list("The lock isn't getting any lighter." = FALSE, "\"Damaged gears are better than broken bodies.\"" = TRUE, \
+	"\"It could still be used, if there was a door to place it on.\"" = TRUE)
 	w_class = 3
 
 /obj/item/clockwork/component/guvax_capacitor
@@ -1031,8 +1033,8 @@
 	icon_state = "guvax_capacitor"
 	component_id = "guvax_capacitor"
 	cultist_message = "\"Try not to lose your mind - I'll need it. Heh heh...\""
-	servant_of_ratvar_messages = list("\"Disgusting.\"", "\"Well, aren't you an inquisitive fellow?\"", "A foul presence pervades your mind, then vanishes.", \
-	"\"The fact that Ratvar has to depend on simpletons like you is appalling.\"")
+	servant_of_ratvar_messages = list("\"Disgusting.\"" = FALSE, "\"Well, aren't you an inquisitive fellow?\"" = FALSE, "A foul presence pervades your mind, then vanishes." = FALSE, \
+	"\"The fact that Ratvar has to depend on simpletons like you is appalling.\"" = FALSE)
 	message_span = "sevtug"
 
 /obj/item/clockwork/component/guvax_capacitor/antennae
@@ -1041,8 +1043,8 @@
 	clockwork_desc = "The antennae from a mania motor. May be usable as a substitute for a guvax capacitor."
 	icon_state = "mania_motor_antennae"
 	cultist_message = "Your head is filled with a burst of static."
-	servant_of_ratvar_messages = list("\"Jub oebxr guv'f.\"", "\"Qvq lbh oernx gur'fr bss LBHEFRYS?\"", "\"Jul qvq jr tvir guv'f gb-fhpu fvzcy-rgbaf, naljnl?\"", \
-	"\"Ng yrnfg jr pna hfr gur'fr sbe fbzrguv'at - hayvxr lbh.\"")
+	servant_of_ratvar_messages = list("\"Who broke this.\"" = TRUE, "\"Did you break these off YOURSELF?\"" = TRUE, "\"Why did we give this to such simpletons, anyway?\"" = TRUE, \
+	"\"At least we can use these for something - unlike you.\"" = TRUE)
 
 /obj/item/clockwork/component/replicant_alloy
 	name = "replicant alloy"
@@ -1050,8 +1052,8 @@
 	icon_state = "replicant_alloy"
 	component_id = "replicant_alloy"
 	cultist_message = "The alloy takes on the appearance of a screaming face for a moment."
-	servant_of_ratvar_messages = list("\"There's always something to be done. Get to it.\"", "\"Idle hands are worse than broken ones. Get to work.\"", \
-	"A detailed image of Ratvar appears in the alloy for a moment.")
+	servant_of_ratvar_messages = list("\"There's always something to be done. Get to it.\"" = FALSE, "\"Idle hands are worse than broken ones. Get to work.\"" = FALSE, \
+	"A detailed image of Ratvar appears in the alloy for a moment." = FALSE)
 	message_span = "nezbere"
 
 /obj/item/clockwork/component/replicant_alloy/examine(mob/user)
@@ -1065,7 +1067,7 @@
 	clockwork_desc = "The sad remains of an anima fragment. Might still be serviceable as a substitute for replicant alloy."
 	icon_state = "smashed_anime_fragment"
 	cultist_message = "The shards vibrate in your hands for a moment."
-	servant_of_ratvar_messages = list("\"...still fight...\"", "\"...where am I...?\"", "\"...put me... slab...\"")
+	servant_of_ratvar_messages = list("\"...still fight...\"" = FALSE, "\"...where am I...?\"" = FALSE, "\"...put me... slab...\"" = FALSE)
 	message_span = "heavy_brass"
 	w_class = 3
 
@@ -1075,7 +1077,7 @@
 	clockwork_desc = "The armor from a former clockwork marauder. Might still be serviceable as a substitute for replicant alloy."
 	icon_state = "fallen_armor"
 	cultist_message = "Red flame sputters from the mask's eye before winking out."
-	servant_of_ratvar_messages = list("A piece of armor hovers away from the others for a moment.", "Red flame appears in the cuirass before sputtering out.")
+	servant_of_ratvar_messages = list("A piece of armor hovers away from the others for a moment." = FALSE, "Red flame appears in the cuirass before sputtering out." = FALSE)
 	message_span = "heavy_brass"
 	w_class = 3
 
@@ -1085,8 +1087,8 @@
 	icon_state = "hierophant_ansible"
 	component_id = "hierophant_ansible"
 	cultist_message = "\"Gur obff fnlf vg'f abg ntnvafg gur ehyrf gb-xvyy lbh.\""
-	servant_of_ratvar_messages = list("\"Rkvyr vf fhpu n ober. Gur'er'f abguvat V pna uhag va urer.\"", "\"Jung'f xrrcvat lbh? V jnag gb-tb xvyy fbzrguv'at.\"", "\"HEHEHEHEHEHEH!\"", \
-	"\"Vs V xvyyrq lbh snfg rabhtu, qb lbh guv'ax gur obff jbhyq abgv'pr?\"")
+	servant_of_ratvar_messages = list("\"Exile is such a bore. There's nothing I can hunt in here.\"" = TRUE, "\"What's keeping you? I want to go kill something.\"" = TRUE, \
+	"\"HEHEHEHEHEHEH!\"" = FALSE, "\"If I killed you fast enough, do you think the boss would notice?\"" = TRUE)
 	message_span = "nzcrentr"
 
 /obj/item/clockwork/component/hierophant_ansible/obelisk
@@ -1094,8 +1096,8 @@
 	desc = "A prism that occasionally glows brightly. It seems not-quite there."
 	clockwork_desc = "The prism from a clockwork obelisk. Likely suitable as a substitute for a hierophant ansible."
 	cultist_message = "The prism flickers wildly in your hands before resuming its normal glow."
-	servant_of_ratvar_messages = list("You hear the distinctive sound of the Hierophant Network for a moment.","\"Uvrebcu'nag Oe'b'nqpnf'g snvy'her.\"",\
-	"The obelisk flickers wildly, as if trying to open a gateway.", "\"Fcng'v'ny Tn'gr-jn'l snv'yher.\"")
+	servant_of_ratvar_messages = list("You hear the distinctive sound of the Hierophant Network for a moment." = FALSE, "\"Hieroph'ant Br'o'adcas't fail'ure.\"" = TRUE, \
+	"The obelisk flickers wildly, as if trying to open a gateway." = FALSE, "\"Spa'tial Ga'tewa'y fai'lure.\"" = TRUE)
 	icon_state = "obelisk_prism"
 	w_class = 3
 

--- a/code/game/gamemodes/clock_cult/clock_machines.dm
+++ b/code/game/gamemodes/clock_cult/clock_machines.dm
@@ -223,7 +223,7 @@
 		if(stored_alloy + 2500 > max_alloy)
 			user << "<span class='warning'>[src] is too full to accept any more alloy!</span>"
 			return 0
-		user.whisper("Genafzhgr vagb jngr-e.")
+		clockwork_say(user, text2ratvar("Transmute into water."), TRUE)
 		user.visible_message("<span class='notice'>[user] liquifies [I] and pours it onto [src].</span>", \
 		"<span class='notice'>You liquify [src] and pour it onto [src], transferring the alloy into its reserves.</span>")
 		stored_alloy = stored_alloy + 2500
@@ -253,16 +253,16 @@
 	var/convert_attempt_cost = 150
 	var/convert_cost = 300
 
-	var/mania_messages = list("\"Tb ahgf.\"", "\"Gnxr n penpx ng penml.\"", "\"Znxr n ovq sbe vafnavgl.\"", "\"T-rg xbbxl.\"", "\"Zbir gbjneqf znavn.\"", "\"Orpbzr orjvyqrerq.\"", "\"Jnk jvyq.\"", \
-	"\"Tb ebhaq gur oraq.\"", "\"Ynaq va yhanpl.\"", "\"Gel qrzragv'n.\"", "\"Fgevir gb-t-rg n fperj ybbfr.\"")
-	var/compel_messages = list("\"Pbzr pybfre.\"", "\"Nccebnpu gur genafzvggr-e.\"", "\"Gbhpu gur nagr-aanr.\"", "\"V nyjnlf unir gb-qrny jvgu vqvbgf. Zbir gbjneqf gur znavn zbgbe.\"", \
-	"\"Nqinapr sbejneq-naq-cynpr lbhe urnq o-rgjrra gur nagr-aanr - gun'g'f nyy vg'f tbbq sbe.\"", "\"Vs lbh jrer fznegr-e, lbh'q or bire urer nyernql.\"", "\"Zbir SBEJNEQ, lbh sbby.\"")
-	var/convert_messages = list("\"Lbh jba'g qb. Tb gb-fyrrc juvyr V gr-yy gur'fr avgjvgf ubj gb-pbaireg lbh.\"", "\"Lbh ner vafhssvpvrag. V zhfg vafgehpg gur'fr vqvbgf va gur neg-bs pbairefvba.\"", \
-	"\"Bu-bs pbhefr, fbzrbar jr pna'g pbaireg. Gur'fr freinagf ner sbbyf.\"", "\"Ubj uneq vf vg gb-hfr n Fvtvy, naljnl? Nyy vg gnxrf vf qenttvat fbzrbar bagb vg.\"", \
-	"\"Ubj qb gur'l snvy gb hfr n Fvtvy-bs Npprffvba, naljnl?\"", "\"Jul vf vg gun'g nyy freinagf ner guv'f varcg?\"", "\"Vg'f dhvgr yvxryl lbh'yy or fghpx urer sbe n juvyr.\"")
-	var/close_messages = list("\"Jryy, lbh pna'g ernpu gur zbgbe sebz GUR'ER, lbh zbeba.\"", "\"Vagr-erfgvat ybpngv'ba. V'q cersre vs lbh jrag fbzrjurer lbh pbhyq NPGHNYYL GBHPU GUR NAGR-AANR!\"", \
-	"\"Nznmvat. Lbh fbzrubj znantrq gb-jrqtr lbhefrys fbzrjurer lbh pna'g npghnyyl ernpu gur zbgbe sebz.\"", "\"Fhpu n fubj-bs vqvbpl vf hacnenyyryrq. Creuncf V fubhyq chg lbh ba qvfcynl?\"", \
-	"\"Qvq lbh qb guv'f ba checbfr? V pna'g vzntvar lbh qbvat fb nppvqragnyyl. Bu, jnvg, V pna.\"", "\"Ubj vf vg gun'g fhpu fzneg perngherf pna fgv'yy qb fbz-rguv'at NF FGHCVQ NF GUV'F!\"")
+	var/mania_messages = list("\"Go nuts.\"", "\"Take a crack at crazy.\"", "\"Make a bid for insanity.\"", "\"Get kooky.\"", "\"Move towards mania.\"", "\"Become bewildered.\"", "\"Wax wild.\"", \
+	"\"Go round the bend.\"", "\"Land in lunacy.\"", "\"Try dementia.\"", "\"Strive to get a screw loose.\"")
+	var/compel_messages = list("\"Come closer.\"", "\"Approach the transmitter.\"", "\"Touch the ante-nnae.\"", "\"I always have to deal with idiots. Move towards the mania motor.\"", \
+	"\"Advance forward and place your head between the antennae - that's all it's good for.\"", "\"If you were smarter, you'd be over here already.\"", "\"Move FORWARD, you fool.\"")
+	var/convert_messages = list("\"You won't do. Go to sleep while I tell these nitwits how to convert you.\"", "\"You are insufficient. I must instruct these idiots in the art of conversion.\"", \
+	"\"Oh of course, someone we can't convert. These servants are fools.\"", "\"How hard is it to use a Sigil, anyway? All it takes is dragging someone onto it.\"", \
+	"\"How do they fail to use a Sigil of Accession, anyway?\"", "\"Why is it that all servants are this inept?\"", "\"It's quite likely you'll be stuck here for a while.\"")
+	var/close_messages = list("\"Well, you can't reach the motor from THERE, you moron.\"", "\"Interesting location. I'd prefer if you went somewhere you could ACTUALLY TOUCH THE ANTENNAE!\"", \
+	"\"Amazing. You somehow managed to wedge yourself somewhere you can't actually reach the motor from.\"", "\"Such a show of idiocy is unparalleled. Perhaps I should put you on display?\"", \
+	"\"Did you do this on purpose? I can't imagine you doing so accidentally. Oh, wait, I can.\"", "\"How is it that such smart creatures can still do something AS STUPID AS THIS!\"")
 
 
 /obj/structure/clockwork/powered/mania_motor/examine(mob/user)
@@ -282,13 +282,13 @@
 		for(var/mob/living/carbon/human/H in view(1, src))
 			if(H.Adjacent(src) && try_use_power(convert_attempt_cost))
 				if(is_eligible_servant(H) && try_use_power(convert_cost))
-					H << "<span class='sevtug'>\"Lbh ner zvar-naq-uvf, abj.\"</span>"
+					H << "<span class='sevtug'>\"[text2ratvar("You are mine and his, now.")]\"</span>"
 					H.playsound_local(T, hum, 80, 1)
 					add_servant_of_ratvar(H)
 				else if(!H.stat)
 					if(H.getBrainLoss() >= 100)
 						H.Paralyse(5)
-						H << "<span class='sevtug'>[pick(convert_messages)]</span>"
+						H << "<span class='sevtug'>[text2ratvar(pick(convert_messages))]</span>"
 					else
 						H.adjustBrainLoss(100)
 						H.visible_message("<span class='warning'>[H] reaches out and touches [src].</span>", "<span class='sevtug'>You touch [src] involuntarily.</span>")
@@ -304,15 +304,15 @@
 				var/targethallu = H.hallucination
 				var/targetdruggy = H.druggy
 				if(distance >= 4 && prob(falloff_distance))
-					H << "<span class='sevtug_small'>[pick(mania_messages)]</span>"
+					H << "<span class='sevtug_small'>[text2ratvar(pick(mania_messages))]</span>"
 				H.playsound_local(T, hum, sound_distance, 1)
 				switch(distance)
 					if(2 to 3)
 						if(prob(falloff_distance))
 							if(prob(falloff_distance))
-								H << "<span class='sevtug_small'>[pick(mania_messages)]</span>"
+								H << "<span class='sevtug_small'>[text2ratvar(pick(mania_messages))]</span>"
 							else
-								H << "<span class='sevtug'>[pick(compel_messages)]</span>"
+								H << "<span class='sevtug'>[text2ratvar(pick(compel_messages))]</span>"
 						if(targetbrainloss <= 50)
 							H.adjustBrainLoss(50 - targetbrainloss) //got too close had brain eaten
 						if(targetdruggy <= 100)
@@ -349,11 +349,11 @@
 						if(targetbrainloss <= 99)
 							if(prob(falloff_distance))
 								if(prob(falloff_distance))
-									H << "<span class='sevtug'>[pick(compel_messages)]</span>"
+									H << "<span class='sevtug'>[text2ratvar(pick(compel_messages))]</span>"
 								else if(prob(falloff_distance))
-									H << "<span class='sevtug'>[pick(close_messages)]</span>"
+									H << "<span class='sevtug'>[text2ratvar(pick(close_messages))]</span>"
 								else
-									H << "<span class='sevtug_small'>[pick(mania_messages)]</span>"
+									H << "<span class='sevtug_small'>[text2ratvar(pick(mania_messages))]</span>"
 							H.adjustBrainLoss(99 - targetbrainloss)
 						if(targetdruggy <= 150)
 							H.adjust_drugginess(15)
@@ -584,7 +584,7 @@
 			if(!try_use_power(hierophant_cost))
 				user << "<span class='warning'>The obelisk lacks the power to broadcast!</span>"
 				return
-			clockwork_say(user, "Uvrebcunag Oebnqpnfg, npgv'ingr!")
+			clockwork_say(user, text2ratvar("Hierophant Broadcast, activate!"))
 			titled_hierophant_message(user, input, "big_brass", "large_brass")
 		if("Spatial Gateway")
 			if(gateway_active)
@@ -594,7 +594,7 @@
 				user << "<span class='warning'>The obelisk lacks the power to open a gateway!</span>"
 				return
 			if(procure_gateway(user, 100, 5, 1) && !gateway_active)
-				clockwork_say(user, "Fcngv'ny Tngrjnl, npgv'ingr!")
+				clockwork_say(user, text2ratvar("Spatial Gateway, activate!"))
 			else
 				return_power(gateway_cost)
 		if("Cancel")

--- a/code/game/gamemodes/clock_cult/clock_ratvar.dm
+++ b/code/game/gamemodes/clock_cult/clock_ratvar.dm
@@ -39,7 +39,7 @@
 	countdown.start()
 	START_PROCESSING(SSobj, src)
 	var/area/gate_area = get_area(src)
-	hierophant_message("<span class='large_brass'><b>A gateway to the Celestial Derelict has been created in [gate_area.map_name]!</b></span>")
+	hierophant_message("<span class='large_brass'><b>A gateway to the Celestial Derelict has been created in [gate_area.map_name]!</b></span>", FALSE, src)
 
 /obj/structure/clockwork/massive/celestial_gateway/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -169,7 +169,7 @@
 	for(var/obj/item/clockwork/ratvarian_spear/R in all_clockwork_objects)
 		R.update_force()
 	START_PROCESSING(SSobj, src)
-	world << "<span class='heavy_brass'><font size=6>\"BAPR NTNVA ZL-YVTUG FUNYY FUVAR NPEBFF GUV'F CNGU-RGV'P ERNYZ!!\"</font></span>"
+	world << "<span class='heavy_brass'><font size=6>\"[text2ratvar("ONCE AGAIN MY LIGHT SHALL SHINE ACROSS THIS PATHETIC REALM")]!!\"</font></span>"
 	world << 'sound/effects/ratvar_reveal.ogg'
 	var/image/alert_overlay = image('icons/effects/clockwork_effects.dmi', "ratvar_alert")
 	var/area/A = get_area(src)
@@ -288,7 +288,7 @@
 		base_victory_chance++ //The clash has a higher chance of resolving each time both gods attack one another
 	switch(winner)
 		if("Ratvar")
-			world << "<span class='heavy_brass'><font size=5>\"[pick("DIE! DIE! DIE!", "REEEEEEEEE!", "FILTH!!!", "SUFFER!!!", "EBG SBE PRAGHEVRF NF V UNIR!!")]\"</font></span>" //nar-sie get out
+			world << "<span class='heavy_brass'><font size=5>\"[pick("DIE! DIE! DIE!", "REEEEEEEEE!", "FILTH!!!", "SUFFER!!!", text2ratvar("ROT FOR CENTURIES AS I HAVE!!"))]\"</font></span>" //nar-sie get out
 			world << "<span class='cult'><font size=5>\"<b>[pick("Nooooo...", "Not die. To y-", "Die. Ratv-", "Sas tyen re-")]\"</b></font></span>"
 			world << 'sound/magic/clockwork/anima_fragment_attack.ogg'
 			world << 'sound/magic/demon_dies.ogg'

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -1001,7 +1001,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 
 /datum/clockwork_scripture/invoke_nezbere/scripture_effects()
 	new/obj/effect/clockwork/general_marker/nezbere(get_turf(invoker))
-	hierophant_message("<span class='nezbere'>Nezbere: \"[text2ratvar("I heed your call, champions. May your artifacts bring ruin upon the heathens that oppose our master!")]\"</span>", FALSE, invoker)
+	hierophant_message("<span class='nezbere'>[text2ratvar("Armorer: \"I heed your call, champions. May your artifacts bring ruin upon the heathens that oppose our master!")]\"</span>", FALSE, invoker)
 	clockwork_generals_invoked["nezbere"] = world.time + CLOCKWORK_GENERAL_COOLDOWN
 	for(var/obj/structure/clockwork/ocular_warden/W in all_clockwork_objects) //Ocular wardens have increased damage and radius
 		W.damage_per_tick *= 1.5
@@ -1056,7 +1056,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 
 /datum/clockwork_scripture/invoke_sevtug/scripture_effects()
 	new/obj/effect/clockwork/general_marker/sevtug(get_turf(invoker))
-	hierophant_message("<span class='sevtug'>Sevtug: \"[text2ratvar("I heed your call, idiots. Get going and use this chance while it lasts!")]\"</span>", FALSE, invoker)
+	hierophant_message("<span class='sevtug'>[text2ratvar("Fright: \"I heed your call, idiots. Get going and use this chance while it lasts!")]\"</span>", FALSE, invoker)
 	clockwork_generals_invoked["sevtug"] = world.time + CLOCKWORK_GENERAL_COOLDOWN
 	var/hum = get_sfx('sound/effects/screech.ogg') //like playsound, same sound for everyone affected
 	var/turf/T = get_turf(invoker)

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -112,9 +112,9 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 		if(multiple_invokers_used)
 			for(var/mob/living/L in range(1, invoker))
 				if(is_servant_of_ratvar(L) && L.stat == CONSCIOUS && L.can_speak_vocal())
-					clockwork_say(L, invocation, whispered)
+					clockwork_say(L, text2ratvar(invocation), whispered)
 		else
-			clockwork_say(invoker, invocation, whispered)
+			clockwork_say(invoker, text2ratvar(invocation), whispered)
 	return 1
 
 /datum/clockwork_scripture/proc/scripture_effects() //The actual effects of the recital after its conclusion
@@ -122,7 +122,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 
 
 /datum/clockwork_scripture/channeled //Channeled scripture begins instantly but runs constantly
-	var/list/chant_invocations = list("NLL YZNB") //"AYY LMAO"
+	var/list/chant_invocations = list("AYY LMAO")
 	var/chant_amount = 5 //Times the chant is spoken
 	var/chant_interval = 10 //Amount of deciseconds between times the chant is actually spoken aloud
 
@@ -132,7 +132,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 			break
 		if(!do_after(invoker, chant_interval, target = invoker))
 			break
-		clockwork_say(invoker, pick(chant_invocations), whispered)
+		clockwork_say(invoker, text2ratvar(pick(chant_invocations)), whispered)
 		chant_effects(i)
 	if(invoker && slab)
 		invoker << "<span class='brass'>You cease your chant.</span>"
@@ -178,7 +178,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Channeled, Area Slowdown"
 	name = "Belligerent"
 	desc = "Forces all nearby non-servants to walk rather than run. Chanted every two seconds for up to thirty seconds."
-	chant_invocations = list("Chavfu gur've oyvaqarff!", "Gnxr gv'zr, znxr fybj!") //"Punish their blindness!", "Take time, make slow!"
+	chant_invocations = list("Punish their blindness!", "Take time, make slow!")
 	chant_amount = 15
 	chant_interval = 20
 	required_components = list("belligerent_eye" = 1)
@@ -203,7 +203,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Judicial Visor"
 	desc = "Forms a visor that, when worn, will grant the ability to form a flame in your hand that can be activated at an area to smite it, stunning, muting, and damaging the nonfaithful. \
 	Cultists of Nar-Sie will be set on fire, though they will be stunned for half the time."
-	invocations = list("Tenag-zr gur synzrf-bs Ratvar!")
+	invocations = list("Grant me the flames of Engine!")
 	channel_time = 10
 	required_components = list("belligerent_eye" = 2)
 	consumed_components = list("belligerent_eye" = 1)
@@ -220,7 +220,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Vanguard"
 	desc = "Provides twenty seconds of stun immunity. At the end of the twenty seconds, the invoker is stunned for the equivalent of 50% of all stuns they absorbed. \
 	Excessive absorption will cause unconsciousness."
-	invocations = list("Fuvryq zr...", "...sebz qnexarff!") //"Shield me from darkness!"
+	invocations = list("Shield me...", "...from darkness!")
 	channel_time = 30
 	required_components = list("vanguard_cogwheel" = 1)
 	usage_tip = "You cannot reactivate Vanguard while still shielded by it."
@@ -267,7 +267,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Convert Brute/Burn to Half Toxin"
 	name = "Sentinel's Compromise"
 	desc = "Heals all brute and burn damage on a nearby living, friendly servant, but deals 50% of that amount as toxin damage."
-	invocations = list("Zraq gur jbhaqf-bs...", "...zl vasrevbe syrfu.") //"Mend the wounds of my inferior flesh."
+	invocations = list("Mend the wounds of...", "...my inferior flesh.")
 	channel_time = 30
 	required_components = list("vanguard_cogwheel" = 2)
 	consumed_components = list("vanguard_cogwheel" = 1)
@@ -298,9 +298,9 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	var/targetturf = get_turf(L)
 	for(var/i in 1 to healseverity)
 		PoolOrNew(/obj/effect/overlay/temp/heal, list(targetturf, "#1E8CE1"))
-	invoker << "<span class='brass'>You bathe [L] in Inath-Neq's power!</span>"
+	invoker << "<span class='brass'>You bathe [L] in Inath-neq's power!</span>"
 	L.visible_message("<span class='warning'>A blue light washes over [L], mending their bruises and burns!</span>", \
-	"<span class='heavy_brass'>You feel Inath-Neq's power healing your wounds, but a deep nausea overcomes you!</span>")
+	"<span class='heavy_brass'>You feel Inath-neq's power healing your wounds, but a deep nausea overcomes you!</span>")
 	playsound(targetturf, 'sound/magic/Staff_Healing.ogg', 50, 1)
 	return 1
 
@@ -310,7 +310,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Melee Area Convert"
 	name = "Guvax"
 	desc = "Enlists all nearby living unshielded creatures into servitude to Ratvar. Also purges holy water from nearby Servants."
-	invocations = list("Rayvtugr-a guv'f urngura!", "Nyy ner vafrpgf orsber Ratvar!", "Chetr nyy hagehguf-naq-ubabe Ratvar.")
+	invocations = list("Enlighten this heathen!", "All are insects before Engine!", "Purge all untruths and honor Engine.")
 	channel_time = 50
 	required_components = list("guvax_capacitor" = 1)
 	usage_tip = "Only works on those in melee range and does not penetrate mindshield implants. Much more efficient than a Sigil of Submission at low Servant amounts."
@@ -335,9 +335,6 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 			if(L.reagents && L.reagents.has_reagent("holywater"))
 				L.reagents.remove_reagent("holywater", 1000)
 				L << "<span class='heavy_brass'>Ratvar's light flares, banishing the darkness. Your devotion remains intact!</span>"
-	for(var/mob/living/silicon/ai/A in range(1, get_turf(invoker))) //Seems necessary because AIs don't count as hearers for some reason
-		if(A.stat != DEAD)
-			add_servant_of_ratvar(A)
 	return 1
 
 
@@ -346,7 +343,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Channeled, Mobile Area Confusion"
 	name = "Taunting Tirade"
 	desc = "Weakens, confuses and dizzies all nearby non-servants with a short invocation, then allows movement for five seconds. Chanted every second for up to thirty seconds."
-	chant_invocations = list("Ubfgv'yrf ba zl-onpx!", "Rarzvrf ba zl-genvy!", "Tbaan gel-naq-funxr zl-gnvy.", "Obtrlf ba zl-fvk!")
+	chant_invocations = list("Hostiles on my back!", "Enemies on my trail!", "Gonna try and shake my tail.", "Bogeys on my six!")
 	chant_amount = 5
 	chant_interval = 10
 	required_components = list("guvax_capacitor" = 2)
@@ -387,7 +384,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "New Clockwork Slab"
 	name = "Replicant"
 	desc = "Creates a new clockwork slab."
-	invocations = list("Z-rgny, orpbzr terngr-e!")
+	invocations = list("Metal, become greater!")
 	channel_time = 0
 	required_components = list("replicant_alloy" = 1)
 	whispered = TRUE
@@ -406,7 +403,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Necessary, Shares Components"
 	name = "Tinkerer's Cache"
 	desc = "Forms a cache that can store an infinite amount of components. All caches are linked and will provide components to slabs."
-	invocations = list("Pbafgehpgv'at...", "...n pnpur!")
+	invocations = list("Constructing...", "...a cache!")
 	channel_time = 50
 	required_components = list("replicant_alloy" = 2)
 	consumed_components = list("replicant_alloy" = 1)
@@ -423,7 +420,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Xray Vision Glasses"
 	name = "Wraith Spectacles"
 	desc = "Fabricates a pair of glasses that provides true sight but quickly damage vision, eventually causing blindness if worn for too long."
-	invocations = list("Fubj gur gehgu-bs guv'f jbeyq gb-zr!")
+	invocations = list("Show the truth of this world to me!")
 	channel_time = 10
 	required_components = list("hierophant_ansible" = 1)
 	whispered = TRUE
@@ -438,7 +435,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Stun Trap"
 	name = "Sigil of Transgression"
 	desc = "Wards a tile with a sigil. The next person to cross the sigil will be smitten and unable to move. Nar-Sian cultists are stunned altogether."
-	invocations = list("Qvivavgl, qnmmyr...", "...gub'fr jub gerffcnff urer!") //"Divinity, dazzle those who trespass here!"
+	invocations = list("Divinity, dazzle...", "...those who tresspass here!")
 	channel_time = 50
 	required_components = list("hierophant_ansible" = 2)
 	consumed_components = list("hierophant_ansible" = 1)
@@ -457,7 +454,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Turret"
 	name = "Ocular Warden"
 	desc = "Forms an automatic short-range turret that deals low sustained damage to the unenlightened in its range."
-	invocations = list("Thneqvnaf...", "...bs gur Ratvar...", "...qrsraq hf!")
+	invocations = list("Guardians...", "...of the Engine...", "...defend us!")
 	channel_time = 120
 	required_components = list("belligerent_eye" = 2, "replicant_alloy" = 1)
 	consumed_components = list("belligerent_eye" = 1, "replicant_alloy" = 1)
@@ -479,7 +476,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Channeled, Area Power Drain"
 	name = "Volt Void" //Alternative name: "On all levels but physical, I am a power sink"
 	desc = "Drains energy from nearby power sources, dealing burn damage if the total power consumed is above a threshhold. Channeled every second for a maximum of thirty seconds."
-	chant_invocations = list("Qenj punetr gb-guv'f furyy!")
+	chant_invocations = list("Draw charge to this shell!")
 	chant_amount = 30
 	chant_interval = 10
 	required_components = list("guvax_capacitor" = 1, "hierophant_ansible" = 2)
@@ -566,7 +563,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Necessary, Converts Objects"
 	name = "Clockwork Proselytizer"
 	desc = "Forms a device that, when used on certain objects, converts them into their Ratvarian equivalents. It requires replicant alloys to function."
-	invocations = list("Jvgu guv'f qrivpr...", "...uvf cerfrapr funyy or-znqr xabja.")
+	invocations = list("With this device...", "...his presence shall be made known.")
 	channel_time = 20
 	required_components = list("guvax_capacitor" = 1, "replicant_alloy" = 2)
 	consumed_components = list("guvax_capacitor" = 1, "replicant_alloy" = 1)
@@ -583,7 +580,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Fellowship Armory"
 	desc = "Equips the invoker and any nearby servants with Ratvarian armor. This armor provides high melee resistance but a weakness to lasers. \
 	It grows faster to invoke with more nearby servants."
-	invocations = list("Fuvryq zr...", "...jvgu gur...", "... sentzragf-bs Ratvar!")
+	invocations = list("Shield me...", "...with the...", "... fragments of Engine!")
 	channel_time = 110 //effectively 100 because it counts the invoker
 	required_components = list("vanguard_cogwheel" = 2, "replicant_alloy" = 1)
 	consumed_components = list("vanguard_cogwheel" = 1, "replicant_alloy" = 1)
@@ -617,7 +614,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Function Call"
 	desc = "Grants the invoker the ability to call forth a powerful Ratvarian spear every five minutes. The spear will deal significant damage to Nar-Sie's dogs and silicon lifeforms, but will \
 	vanish five minutes after being summoned."
-	invocations = list("Tenag zr...", "...gur zvtug-bs oenff!")
+	invocations = list("Grant me...", "...the might of brass!")
 	channel_time = 20
 	required_components = list("replicant_alloy" = 2, "hierophant_ansible" = 1)
 	consumed_components = list("replicant_alloy" = 1, "hierophant_ansible" = 1)
@@ -644,7 +641,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Spatial Gateway"
 	desc = "Tears open a miniaturized gateway in spacetime to any conscious servant that can transport objects or creatures to its destination. \
 	Each servant assisting in the invocation adds one additional use and four additional seconds to the gateway's uses and duration."
-	invocations = list("Fcngv'ny Tngr-jnl...", "...npgv'ingr!")
+	invocations = list("Spatial Gateway...", "...activate!")
 	channel_time = 80
 	required_components = list("vanguard_cogwheel" = 1, "hierophant_ansible" = 2)
 	consumed_components = list("vanguard_cogwheel" = 1, "hierophant_ansible" = 1)
@@ -686,7 +683,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Clockwork Posibrain"
 	name = "Soul Vessel"
 	desc = "Forms an ancient positronic brain with an overriding directive to serve Ratvar."
-	invocations = list("Ureq gur fbhyf-bs...", "...gur oynfcurzbhf qnzarq!")
+	invocations = list("Herd the souls of...", "...the blasphemous damned!")
 	channel_time = 20
 	required_components = list("vanguard_cogwheel" = 1, "guvax_capacitor" = 2)
 	consumed_components = list("vanguard_cogwheel" = 1, "guvax_capacitor" = 1)
@@ -702,7 +699,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Constructor Soul Vessel Shell"
 	name = "Cogscarab"
 	desc = "Creates a small shell fitted for soul vessels. Adding an active soul vessel to it results in a small construct with tools and an inbuilt proselytizer."
-	invocations = list("Pnyy sbegu...", "...gur jbexref-bs Nezbere.")
+	invocations = list("Call forth...", "...the workers of Armorer.")
 	channel_time = 50
 	required_components = list("belligerent_eye" = 2, "hierophant_ansible" = 1)
 	consumed_components = list("belligerent_eye" = 1, "hierophant_ansible" = 1)
@@ -718,7 +715,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Conversion Trap"
 	name = "Sigil of Submission"
 	desc = "Places a luminous sigil that will enslave any valid beings standing on it after a time."
-	invocations = list("Qvivavgl, rayvtugr-a...", "...gub'fr-jub gerfcnff urer!")
+	invocations = list("Divinity, enlighten...", "...those who trespass here!")
 	channel_time = 60
 	required_components = list("belligerent_eye" = 1, "guvax_capacitor" = 2)
 	consumed_components = list("belligerent_eye" = 1, "guvax_capacitor" = 1)
@@ -739,7 +736,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Anima Fragment"
 	desc = "Creates a large shell fitted for soul vessels. Adding an active soul vessel to it results in a powerful construct with decent health, notable melee power, \
 	and exceptional speed, though taking damage will temporarily slow it down."
-	invocations = list("Pnyy sbegu...", "...gur fbyqvref-bs Nezbere.")
+	invocations = list("Call forth...", "...the soldiers of Armorer.")
 	channel_time = 70
 	required_components = list("belligerent_eye" = 1, "vanguard_cogwheel" = 1, "replicant_alloy" = 3)
 	consumed_components = list("belligerent_eye" = 1, "vanguard_cogwheel" = 1, "replicant_alloy" = 2)
@@ -756,7 +753,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Sigil of Accession"
 	desc = "Places a luminous sigil much like a Sigil of Submission, but it will remain even after successfully converting a non-implanted target. \
 	It will penetrate mindshield implants once before disappearing."
-	invocations = list("Qvivavgl, rafynir...", "...nyy jub gerfcnff urer!")
+	invocations = list("Divinity, enslave...", "...all who trespass here!")
 	channel_time = 70
 	required_components = list("belligerent_eye" = 3, "guvax_capacitor" = 1, "hierophant_ansible" = 1)
 	consumed_components = list("belligerent_eye" = 2, "guvax_capacitor" = 1, "hierophant_ansible" = 1)
@@ -774,7 +771,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Structure Battery"
 	name = "Sigil of Transmission"
 	desc = "Scribes a sigil beneath the invoker which stores power to power clockwork structures."
-	invocations = list("Qvivavgl...", "...cbjre bhe perngv'baf!")
+	invocations = list("Divinity...", "...power our creations!")
 	channel_time = 70
 	required_components = list("vanguard_cogwheel" = 1, "guvax_capacitor" = 1, "hierophant_ansible" = 3)
 	consumed_components = list("vanguard_cogwheel" = 1, "guvax_capacitor" = 1, "hierophant_ansible" = 2)
@@ -792,7 +789,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Vitality Matrix"
 	desc = "Scribes a sigil beneath the invoker which drains life from any living non-servants that cross it. Servants that cross it, however, will be healed based on how much it drained from non-servants. \
 	Dead servants can be revived by this sigil if it has enough stored vitality."
-	invocations = list("Qvivavgl...", "...fgr-ny gur've yvsr...", "...sbe gur'fr furyyf!")
+	invocations = list("Divinity...", "...steal their life...", "...for these shells!")
 	channel_time = 70
 	required_components = list("belligerent_eye" = 1, "vanguard_cogwheel" = 3, "hierophant_ansible" = 1)
 	consumed_components = list("belligerent_eye" = 1, "vanguard_cogwheel" = 2, "hierophant_ansible" = 1)
@@ -811,7 +808,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	called forth by Speaking its True Name or if you become exceptionally low on health.<br> \
 	Unlike holoparasites, however, it does not transfer the damage it takes to you, instead simply gaining Fatigue as it is attacked. Marauders cannot move too far from their hosts, \
 	and will gain Fatigue at an increasing rate as they grow farther away. At maximum Fatigue, the marauder is forced to return to you and will be unable to manifest until its Fatigue is at zero."
-	invocations = list("Sevtug'f jvyy...", "...pnyy sbegu...")
+	invocations = list("Fright's will...", "...call forth...")
 	channel_time = 100
 	required_components = list("belligerent_eye" = 1, "vanguard_cogwheel" = 1, "guvax_capacitor" = 3)
 	consumed_components = list("belligerent_eye" = 1, "vanguard_cogwheel" = 1, "guvax_capacitor" = 2)
@@ -842,7 +839,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 		invoker.apply_damage(10, BRUTE, "head")
 		slab.busy = null
 		return 0
-	clockwork_say(invoker, "...gur zvaq znqr...")
+	clockwork_say(invoker, text2ratvar("...the mind made..."))
 	invoker.notransform = FALSE
 	slab.busy = null
 	if(!check_special_requirements())
@@ -855,7 +852,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 		invoker.visible_message("<span class='warning'>The tendril retracts from [invoker]'s head, sealing the entry wound as it does so!</span>", \
 		"<span class='warning'>The tendril was unsuccessful! Perhaps you should try again another time.</span>")
 		return 0
-	clockwork_say(invoker, "...fjbeq-naq-fuvryq!")
+	clockwork_say(invoker, text2ratvar("...sword and shield!"))
 	var/mob/dead/observer/theghost = pick(marauder_candidates)
 	var/mob/living/simple_animal/hostile/clockwork/marauder/M = new(invoker)
 	M.key = theghost.key
@@ -875,7 +872,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Structure, Disables Machinery"
 	name = "Interdiction Lens"
 	desc = "Creates a clockwork totem that sabotages nearby machinery and funnels drained power into nearby Sigils of Transmission."
-	invocations = list("Znl guv'f gbgr-z...", "...fuebhq gur snyfr fhaf!")
+	invocations = list("May this totem...", "...shroud the false suns!")
 	channel_time = 80
 	required_components = list("belligerent_eye" = 1, "replicant_alloy" = 4, "hierophant_ansible" = 1)
 	consumed_components = list("belligerent_eye" = 1, "replicant_alloy" = 3, "hierophant_ansible" = 1)
@@ -894,7 +891,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Structure, Repairs Other Structures"
 	name = "Mending Motor"
 	desc = "Creates a mechanized prism that will rapidly repair damage to clockwork creatures, converted cyborgs, and clockwork structures. Requires replicant alloy or power to function."
-	invocations = list("Znl guv'f cevfz...", "...zraq bhe qragf-naq-fpengpurf!")
+	invocations = list("May this prism...", "...mend our dents and scratches!")
 	channel_time = 80
 	required_components = list("vanguard_cogwheel" = 4, "guvax_capacitor" = 1, "replicant_alloy" = 1)
 	consumed_components = list("vanguard_cogwheel" = 3, "guvax_capacitor" = 1, "replicant_alloy" = 1)
@@ -913,7 +910,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Structure, Teleportation Hub"
 	name = "Clockwork Obelisk"
 	desc = "Creates a clockwork obelisk that can broadcast messages over the Hierophant Network or open a Spatial Gateway to any living servant or clockwork obelisk."
-	invocations = list("Znl guv'f boryvfx...", "...gnxr hf gb-nyy cynprf!")
+	invocations = list("May this obelisk...", "...take us to all places!")
 	channel_time = 80
 	required_components = list("vanguard_cogwheel" = 1, "replicant_alloy" = 1, "hierophant_ansible" = 4)
 	consumed_components = list("vanguard_cogwheel" = 1, "replicant_alloy" = 1, "hierophant_ansible" = 3)
@@ -932,7 +929,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Structure, Area Denial"
 	name = "Mania Motor"
 	desc = "Creates a mania motor which will cause brain damage and hallucinations in nearby non-servant humans. It will also try to convert humans directly adjecent to the motor."
-	invocations = list("Znl guv'f genafzvggr-e...", "...oernx gur jvyy-bs nyy jub bccbfr hf!")
+	invocations = list("May this transmitter...", "...break the will of all who oppose us!")
 	channel_time = 80
 	required_components = list("guvax_capacitor" = 4, "replicant_alloy" = 1, "hierophant_ansible" = 1)
 	consumed_components = list("guvax_capacitor" = 3, "replicant_alloy" = 1, "hierophant_ansible" = 1)
@@ -941,7 +938,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	observer_message = "<span class='warning'>A two-pronged machine rises from the ground!</span>"
 	invokers_required = 2
 	multiple_invokers_used = TRUE
-	usage_tip = "Eligible human servants next to the motor will be converted at an additonal power cost. It will also cure hallucinations and brain damage in nearby servants."
+	usage_tip = "Eligible human servants next to the motor will be converted at an additional power cost. It will also cure hallucinations and brain damage in nearby servants."
 	tier = SCRIPTURE_APPLICATION
 	one_per_tile = TRUE
 
@@ -951,7 +948,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	descname = "Component Generator"
 	name = "Tinkerer's Daemon"
 	desc = "Forms a daemon shell that can be attached to a tinkerer's cache to add new components at a healthy rate. It will only function if it is outnumbered by servants in a ratio of 5:1."
-	invocations = list("Pbyyrpg Ratvar cnegf...", "...gun'g l-rg ubyq terngarff!")
+	invocations = list("Collect Engine parts...", "...that yet hold greatness!")
 	channel_time = 80
 	required_components = list("belligerent_eye" = 3, "vanguard_cogwheel" = 3, "guvax_capacitor" = 3, "replicant_alloy" = 3, "hierophant_ansible" = 3)
 	consumed_components = list("belligerent_eye" = 1, "vanguard_cogwheel" = 1, "guvax_capacitor" = 1, "replicant_alloy" = 1, "hierophant_ansible" = 1)
@@ -983,7 +980,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Invoke Nezbere, the Brass Eidolon"
 	desc = "Taps the limitless power of Nezbere, one of Ratvar's four generals. The restless toil of the Eidolon will empower a wide variety of clockwork apparatus for a full minute - notably, \
 	clockwork proselytizers will cost no replicant alloy to use."
-	invocations = list("V pnyy hcba lbh, Nezbere!!", "Y-rg lbhe znpuvangv'baf ervta ba guv'f zvfrenoyr fgngv'ba!!", "Y-rg lbhe cbjre sybj gue'bhtu gur gbbyf bs lbhe znfgr-e!!")
+	invocations = list("I call upon you, Armorer!!", "Let your machinations reign on this miserable station!!", "Let your power flow through the tools of your master!!")
 	channel_time = 150
 	required_components = list("belligerent_eye" = 3, "vanguard_cogwheel" = 3, "guvax_capacitor" = 3, "replicant_alloy" = 6)
 	consumed_components = list("belligerent_eye" = 3, "vanguard_cogwheel" = 3, "guvax_capacitor" = 3, "replicant_alloy" = 6)
@@ -993,18 +990,18 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 
 /datum/clockwork_scripture/invoke_nezbere/check_special_requirements()
 	if(!slab.no_cost && clockwork_generals_invoked["nezbere"] > world.time)
-		invoker << "<span class='nezbere'>\"Abg whfg l-rg, sevraq. Cngv'rapr vf n iveghr.\"</span>\n\
+		invoker << "<span class='nezbere'>\"[text2ratvar("Not just yet, friend. Patience is a virtue.")]\"</span>\n\
 		<span class='warning'>Nezbere has already been invoked recently! You must wait several minutes before calling upon the Brass Eidolon.</span>"
 		return 0
 	if(!slab.no_cost && ratvar_awakens)
-		invoker << "<span class='nezbere'>\"Bhe znfgr-e vf urer nyernql. Lbh qb abg erdhver zl-uryc, sevraq.\"</span>\n\
+		invoker << "<span class='nezbere'>\"[text2ratvar("Our master is here already. You do not require my help, friend.")]\"</span>\n\
 		<span class='warning'>Nezbere will not grant his power while Ratvar's dwarfs his own!</span>"
 		return 0
 	return 1
 
 /datum/clockwork_scripture/invoke_nezbere/scripture_effects()
-	var/obj/effect/clockwork/general_marker/nezbere/N = new(get_turf(invoker))
-	N.visible_message("<span class='nezbere'>\"V urrq lbhe pnyy, punzcvbaf. Znl lbhe negv'snpgf oevat ehva hcba gur urngur'af gun'g bccbfr bhe znfgr-e!\"</span>")
+	new/obj/effect/clockwork/general_marker/nezbere(get_turf(invoker))
+	hierophant_message("<span class='nezbere'>Nezbere: \"[text2ratvar("I heed your call, champions. May your artifacts bring ruin upon the heathens that oppose our master!")]\"</span>", FALSE, invoker)
 	clockwork_generals_invoked["nezbere"] = world.time + CLOCKWORK_GENERAL_COOLDOWN
 	for(var/obj/structure/clockwork/ocular_warden/W in all_clockwork_objects) //Ocular wardens have increased damage and radius
 		W.damage_per_tick *= 1.5
@@ -1034,7 +1031,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Invoke Sevtug, the Formless Pariah"
 	desc = "Taps the limitless power of Sevtug, one of Ratvar's four generals. The mental manipulation ability of the Pariah allows its wielder to cause mass hallucinations and confusion \
 	for all non-servant humans on the same z-level as them. The power of this scripture falls off somewhat with distance, and certain things may reduce its effects."
-	invocations = list("V pnyy hcba lbh, Sevtug!!", "Y-rg lbhe cbjre funggr-e gur fnavgl-bs gur jrnx-zvaqrq!!", "Y-rg lbhe graqevyf ubyq fjnl bire nyy!!")
+	invocations = list("I call upon you, Fright!!", "Let your power shatter the sanity of the weak minded!!", "Let your tendrils hold sway over all!!")
 	channel_time = 150
 	required_components = list("belligerent_eye" = 3, "vanguard_cogwheel" = 3, "guvax_capacitor" = 6, "hierophant_ansible" = 3)
 	consumed_components = list("belligerent_eye" = 3, "vanguard_cogwheel" = 3, "guvax_capacitor" = 6, "hierophant_ansible" = 3)
@@ -1042,23 +1039,24 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	tier = SCRIPTURE_REVENANT
 	invokers_required = 3
 	multiple_invokers_used = TRUE
-	var/list/mindbreaksayings = list("\"Bu, terng. V t-rg gb funggr-e fbzr zvaqf.\"", "\"Zber zvaqf gb-pehfu.\"", \
-	"\"Ernyyl, guv'f vf nyzbfg obevat.\"", "\"Abar-bs gur'fr zvaqf unir nalguv'at vagr-erfgvat va gur'z.\"", "\"Znlor V pna vafgv'yy n yvggyr ovg-bs gr-eebe va guv'f bar.\"", \
-	"\"Jung n jnfgr-bs zl-cbjre.\"", "\"V'z fher V pbhyq whfg pbageby gur'fr zvaqf vafgr-nq, ohg gur'l arire nfx.\"")
+	var/list/mindbreaksayings = list("\"Oh, great. I get to shatter some minds.\"", "\"More minds to crush.\"", \
+	"\"Really, this is almost boring.\"", "\"None of these minds have anything interesting in them.\"", "\"Maybe I can instill a little bit of terror in this one.\"", \
+	"\"What a waste of my power.\"", "\"I'm sure I could just control these minds instead, but they never ask.\"")
 
 /datum/clockwork_scripture/invoke_sevtug/check_special_requirements()
 	if(!slab.no_cost && clockwork_generals_invoked["sevtug"] > world.time)
-		invoker << "<span class='sevtug'>\"Vf vg ernyyl fb uneq - rira sbe n fvzcy-rgba yvxr lbh - gb-tenfc gur pbaprcg-bs jnvgv'at?\"</span>\n\
+		invoker << "<span class='sevtug'>\"[text2ratvar("Is it really so hard - even for a simpleton like you - to grasp the concept-of waiting?")]\"</span>\n\
 		<span class='warning'>Sevtug has already been invoked recently! You must wait several minutes before calling upon the Formless Pariah.</span>"
 		return 0
 	if(!slab.no_cost && ratvar_awakens)
-		invoker << "<span class='sevtug'>\"Qb lbh ernyyl guv'ax nalguv'at V pna qb evtug abj jvyy pbzcner gb-Ratvar's cbjre?.\"</span>\n\
+		invoker << "<span class='sevtug'>\"[text2ratvar("Do you really think anything I can do right now will compare to Engine's power?")]\"</span>\n\
 		<span class='warning'>Sevtug will not grant his power while Ratvar's dwarfs his own!</span>"
 		return 0
 	return ..()
 
 /datum/clockwork_scripture/invoke_sevtug/scripture_effects()
 	new/obj/effect/clockwork/general_marker/sevtug(get_turf(invoker))
+	hierophant_message("<span class='sevtug'>Sevtug: \"[text2ratvar("I heed your call, idiots. Get going and use this chance while it lasts!")]\"</span>", FALSE, invoker)
 	clockwork_generals_invoked["sevtug"] = world.time + CLOCKWORK_GENERAL_COOLDOWN
 	var/hum = get_sfx('sound/effects/screech.ogg') //like playsound, same sound for everyone affected
 	var/turf/T = get_turf(invoker)
@@ -1074,7 +1072,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 				visualsdistance = round(visualsdistance * 0.25)
 				minordistance = round(minordistance * 0.25)
 				majordistance = round(majordistance * 0.25)
-				H << "<span class='sevtug'>Bu, n ibvq jrncba. Ubj naablvat, V znl nf jryy abg obgur'e.</span>\n\
+				H << "<span class='sevtug'>[text2ratvar("Oh, a void weapon. How annoying, I may as well not bother.")]</span>\n\
 				<span class='warning'>Your holy weapon glows a faint orange in an attempt to defend your mind!</span>"
 				messaged = TRUE
 			if(isloyal(H))
@@ -1082,10 +1080,10 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 				minordistance = round(minordistance * 0.5)
 				majordistance = round(majordistance * 0.5)
 				if(!messaged)
-					H << "<span class='sevtug'>Bu, ybbx, n zvaqfuvryq. Phgr, V fhccbfr V'yy uhzbe vg.</span>"
+					H << "<span class='sevtug'>[text2ratvar("Oh, look, a mindshield. Cute, I suppose I'll humor it.")]</span>"
 					messaged = TRUE
 			if(!messaged && prob(visualsdistance))
-				H << "<span class='sevtug'>[pick(mindbreaksayings)]</span>"
+				H << "<span class='sevtug'>[text2ratvar(pick(mindbreaksayings))]</span>"
 			H.playsound_local(T, hum, visualsdistance, 1)
 			flash_color(H, flash_color="#AF0AAF", flash_time=visualsdistance*10)
 			H.set_drugginess(visualsdistance + H.druggy)
@@ -1102,7 +1100,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Invoke Nzcrentr, the Forgotten Arbiter"
 	desc = "Taps the limitless power of Nzcrentr, one of Ratvar's four generals. The immense energy Nzcrentr wields will allow you to imbue a tiny fraction of it into your body. After several \
 	seconds, anyone nearby will be struck by a devastating lightning bolt."
-	invocations = list("V pnyy hcba lbh, Nzcrentr!!", "Y-rg lbhe raretl sybj gue'bhtu zr!!", "Y-rg lbhe obhaqyrff-cbjre funggr-e fgnef!!")
+	invocations = list("I call upon you, Amperage!!", "Let your energy flow through me!!", "Let your boundless power shatter stars!!")
 	channel_time = 150
 	required_components = list("belligerent_eye" = 3, "guvax_capacitor" = 3, "replicant_alloy" = 3, "hierophant_ansible" = 6)
 	consumed_components = list("belligerent_eye" = 3, "guvax_capacitor" = 3, "replicant_alloy" = 3, "hierophant_ansible" = 6)
@@ -1111,7 +1109,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 
 /datum/clockwork_scripture/invoke_nzcrentr/check_special_requirements()
 	if(!slab.no_cost && clockwork_generals_invoked["nzcrentr"] > world.time)
-		invoker << "<span class='nzcrentr'>\"Gur obff fnlf lbh unir gb-jnvg. Url, qb lbh guv'ax ur jbhyq zvaq vs V xvyyrq lbh? ...Ur jbhyq? Bx.\"</span>\n\
+		invoker << "<span class='nzcrentr'>\"[text2ratvar("The boss says you have to wait. Hey, do you think he would mind if I killed you? ...He would? Ok.")]\"</span>\n\
 		<span class='warning'>Nzcrentr has already been invoked recently! You must wait several minutes before calling upon the Forgotten Arbiter.</span>"
 		return 0
 	return 1
@@ -1119,15 +1117,16 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 /datum/clockwork_scripture/invoke_nzcrentr/scripture_effects()
 	new/obj/effect/clockwork/general_marker/nzcrentr(get_turf(invoker))
 	clockwork_generals_invoked["nzcrentr"] = world.time + CLOCKWORK_GENERAL_COOLDOWN
+	hierophant_message("<span class='nzcrentr'>[text2ratvar("Amperage: \"[invoker.name] has called forth my power. Hope they do not shatter under it!")]\"</span>", FALSE, invoker)
 	invoker.visible_message("<span class='warning'>[invoker] begins to radiate a blinding light!</span>", \
-	"<span class='nzcrentr'>\"Gur obff fnlf vg'f bxnl gb-qb guv'f. Qba'g oynzr zr vs lbh qvr sebz vg.\"</span>\n \
+	"<span class='nzcrentr'>\"[text2ratvar("The boss says it's okay to do this. Don't blame me if you die from it.")]\"</span>\n \
 	<span class='userdanger'>You feel limitless power surging through you!</span>")
 	playsound(invoker, 'sound/magic/lightning_chargeup.ogg', 100, 0)
 	animate(invoker, color = list(rgb(255, 255, 255), rgb(255, 255, 255), rgb(255, 255, 255), rgb(0,0,0)), time = 88) //Gradual advancement to extreme brightness
 	sleep(88)
 	if(invoker)
 		invoker.visible_message("<span class='warning'>Massive bolts of energy emerge from across [invoker]'s body!</span>", \
-		"<span class='nzcrentr'>\"V gbyq lbh lbh jbhyqa'g or noyr gb-unaqyr vg.\"</span>\n \
+		"<span class='nzcrentr'>\"[text2ratvar("I told you you wouldn't be able to handle it.")]\"</span>\n \
 		<span class='userdanger'>TOO... MUCH! CAN'T... TAKE IT!</span>")
 		playsound(invoker, 'sound/magic/lightningbolt.ogg', 100, 0)
 		animate(invoker, color = initial(invoker.color), time = 10)
@@ -1153,11 +1152,11 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 
 
 
-/datum/clockwork_scripture/invoke_inathneq //Invoke Inath-Neq, the Resonant Cogwheel: Grants invulnerability and stun immunity for 15 seconds
+/datum/clockwork_scripture/invoke_inathneq //Invoke Inath-neq, the Resonant Cogwheel: Grants invulnerability and stun immunity for 15 seconds
 	descname = "Area Invuln"
-	name = "Invoke Inath-Neq, the Resonant Cogwheel"
-	desc = "Taps the limitless power of Inath-Neq, one of Ratvar's four generals. The benevolence of Inath-Neq will grant complete invulnerability to all servants in range for fifteen seconds."
-	invocations = list("V pnyy hcba lbh, Inath-Neq!!", "Y-rg gur Erfbanag Pbtf ghea bapr zber!!", "Tenag zr-naq-zl-nyyvrf gur fgeratgu gb-inadhvfu bhe sbrf!!")
+	name = "Invoke Inath-neq, the Resonant Cogwheel"
+	desc = "Taps the limitless power of Inath-neq, one of Ratvar's four generals. The benevolence of Inath-Neq will grant complete invulnerability to all servants in range for fifteen seconds."
+	invocations = list("I call upon you, Vanguard!!", "Let the Resonant Cogs turn once more!!", "Grant me and my allies the strength to vanquish our foes!!")
 	channel_time = 150
 	required_components = list("vanguard_cogwheel" = 6, "guvax_capacitor" = 3, "replicant_alloy" = 3, "hierophant_ansible" = 3)
 	consumed_components = list("vanguard_cogwheel" = 6, "guvax_capacitor" = 3, "replicant_alloy" = 3, "hierophant_ansible" = 3)
@@ -1167,31 +1166,31 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 
 /datum/clockwork_scripture/invoke_inathneq/check_special_requirements()
 	if(!slab.no_cost && clockwork_generals_invoked["inath-neq"] > world.time)
-		invoker << "<span class='inathneq'>\"V pnaabg yraq lbh zl-nvq l-rg, punzcvba. Cyrnfr or pnershy.\"</span>\n\
-		<span class='warning'>Inath-Neq has already been invoked recently! You must wait several minutes before calling upon the Resonant Cogwheel.</span>"
+		invoker << "<span class='inathneq'>\"[text2ratvar("I cannot lend you my aid yet, champion. Please be careful.")]\"</span>\n\
+		<span class='warning'>Inath-neq has already been invoked recently! You must wait several minutes before calling upon the Resonant Cogwheel.</span>"
 		return 0
 	return 1
 
 /datum/clockwork_scripture/invoke_inathneq/scripture_effects()
 	new/obj/effect/clockwork/general_marker/inathneq(get_turf(invoker))
+	hierophant_message("<span class='inathneq'>[text2ratvar("Vanguard: \"I lend you my aid, champions! Let glory guide your blows!")]\"</span>", FALSE, invoker)
 	clockwork_generals_invoked["inath-neq"] = world.time + CLOCKWORK_GENERAL_COOLDOWN
 	if(invoker.real_name == "Lucio")
-		clockwork_say(invoker, rot13("Aww, let's break it DOWN!!"))
+		clockwork_say(invoker, text2ratvar("Aww, let's break it DOWN!!"))
 	var/list/affected_servants = list()
 	for(var/mob/living/L in range(7, invoker))
 		if(!is_servant_of_ratvar(L) || L.stat == DEAD)
 			continue
-		L << "<span class='inathneq'>\"V yraq lbh zl-nvq, punzcvba! Y-rg tybel thvqr lbhe oybjf!\"</span>\n\
-		<span class='notice'>Inath-Neq's power flows through you!</span>"
+		L << "<span class='notice'>Inath-neq's power flows through you!</span>"
 		L.color = "#1E8CE1"
 		L.fully_heal()
-		L.add_stun_absorption("inathneq", total_duration, 2, "'s flickering blue aura momentarily intensifies!", "Inath-Neq's ward absorbs the stun!", " is glowing with a flickering blue light!")
+		L.add_stun_absorption("inathneq", total_duration, 2, "'s flickering blue aura momentarily intensifies!", "Inath-neq's ward absorbs the stun!", " is glowing with a flickering blue light!")
 		L.status_flags |= GODMODE
 		animate(L, color = initial(L.color), time = total_duration, easing = EASE_IN)
 		affected_servants += L
 	spawn(total_duration)
 		for(var/mob/living/L in affected_servants)
-			L << "<span class='notice'>You feel Inath-Neq's power fade from your body.</span>"
+			L << "<span class='notice'>You feel Inath-neq's power fade from your body.</span>"
 			L.status_flags &= ~GODMODE
 	return 1
 
@@ -1202,9 +1201,9 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	name = "Ark of the Clockwork Justiciar"
 	desc = "Pulls from the power of all of Ratvar's servants and generals to construct a massive machine used to tear apart a rift in spacetime to the Celestial Derelict. This gateway will \
 	call forth Ratvar from his exile after some time."
-	invocations = list("NEZBERE! SEVTUG! NZCRENTR! INATH-NEQ! V PNYY HCBA LBH!!", \
-	"GUR GV'ZR UNF PBZR SBE BHE ZNFGR-E GB-OERNX GUR PUNVAF-BS RKVYR!!", \
-	"YRAQ HF LBHE NVQ! RATVAR PBZRF!!")
+	invocations = list("ARMORER! FRIGHT! AMPERAGE! VANGUARD! I CALL UPON YOU!!", \
+	"THE TIME HAS COME FOR OUR MASTER TO BREAK THE CHAINS OF EXILE!!", \
+	"LEND US YOUR AID! ENGINE COMES!!")
 	channel_time = 150
 	required_components = list("belligerent_eye" = 10, "vanguard_cogwheel" = 10, "guvax_capacitor" = 10, "replicant_alloy" = 10, "hierophant_ansible" = 10)
 	consumed_components = list("belligerent_eye" = 10, "vanguard_cogwheel" = 10, "guvax_capacitor" = 10, "replicant_alloy" = 10, "hierophant_ansible" = 10)
@@ -1234,19 +1233,25 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 /datum/clockwork_scripture/ark_of_the_clockwork_justiciar/scripture_effects()
 	var/turf/T = get_turf(invoker)
 	new/obj/effect/clockwork/general_marker/inathneq(T)
-	T.visible_message("<span class='inathneq'>\"Ratvar, pbzr sbegu-naq-fubj lbhe freinagf lbhe zrepl!\"</span>")
+	T.visible_message("<span class='inathneq'>\"[text2ratvar("Engine, come forth and show your servants your mercy!")]\"</span>")
 	playsound(T, 'sound/magic/clockwork/invoke_general.ogg', 30, 0)
 	sleep(10)
+	if(!check_special_requirements())
+		return 0
 	new/obj/effect/clockwork/general_marker/sevtug(T)
-	T.visible_message("<span class='sevtug'>\"Ratvar, pbzr sbegu-naq-fubj guv'f fgngv'ba lbhe qrpbengv'at fxvyyf!\"</span>")
+	T.visible_message("<span class='sevtug'>\"[text2ratvar("Engine, come forth and show this station your decorating skills!")]\"</span>")
 	playsound(T, 'sound/magic/clockwork/invoke_general.ogg', 45, 0)
 	sleep(10)
+	if(!check_special_requirements())
+		return 0
 	new/obj/effect/clockwork/general_marker/nezbere(T)
-	T.visible_message("<span class='nezbere'>\"Ratvar, pbzr sbegu-naq-fuvar lbhe yvtug npebff guv'f ernyz!\"</span>")
+	T.visible_message("<span class='nezbere'>\"[text2ratvar("Engine, come forth and shine your light across this realm!")]\"</span>")
 	playsound(T, 'sound/magic/clockwork/invoke_general.ogg', 60, 0)
 	sleep(10)
+	if(!check_special_requirements())
+		return 0
 	new/obj/effect/clockwork/general_marker/nzcrentr(T)
-	T.visible_message("<span class='nzcrentr'>\"Ratvar, pbzr sbegu.\"</span>")
+	T.visible_message("<span class='nzcrentr'>\"[text2ratvar("Engine, come forth.")]\"</span>")
 	playsound(T, 'sound/magic/clockwork/invoke_general.ogg', 75, 0)
 	sleep(10)
 	if(check_special_requirements())

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -277,7 +277,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 /datum/clockwork_scripture/sentinels_compromise/scripture_effects()
 	var/list/nearby_cultists = list()
 	for(var/mob/living/C in range(7, invoker))
-		if(C.stat != DEAD && is_servant_of_ratvar(C) && (C.getBruteLoss() || C.getBruteLoss()))
+		if(C.stat != DEAD && is_servant_of_ratvar(C) && (C.getBruteLoss() || C.getFireLoss()))
 			nearby_cultists += C
 	if(!nearby_cultists.len)
 		invoker << "<span class='warning'>There are no eligible servants nearby!</span>"

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -98,10 +98,10 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 			for(var/mob/living/L in range(1, invoker))
 				if(is_servant_of_ratvar(L) && L.stat == CONSCIOUS && L.can_speak_vocal())
 					for(var/invocation in invocations)
-						clockwork_say(L, invocation, whispered)
+						clockwork_say(L, text2ratvar(invocation), whispered)
 		else
 			for(var/invocation in invocations)
-				clockwork_say(invoker, invocation, whispered)
+				clockwork_say(invoker, text2ratvar(invocation), whispered)
 	invoker << "<span class='brass'>You [channel_time <= 0 ? "recite" : "begin reciting"] a piece of scripture entitled \"[name]\".</span>"
 	if(!channel_time)
 		return 1

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -734,19 +734,20 @@
 /obj/effect/clockwork/general_marker/nzcrentr
 	name = "Nzcrentr, the Forgotten Arbiter"
 	desc = "A terrifying war machine crackling with limitless energy."
-	clockwork_desc = "One of Ratvar's four generals. Nzcrentr is the result of Neovgre - Nezbere's finest war machine, commandeerable only be a mortal - fusing with its pilot and driving her \
-	insane. Nzcrentr seeks out any and all sentient life to slaughter it for sport."
+	clockwork_desc = "One of Ratvar's four generals. Before becoming one of Ratvar's generals, Nzcrentr sook out any and all sentient life to slaughter it for sport.\
+	Nzcrentr was coerced by Ratvar into entering a shell constructed by Nezbere, ostensibly made to grant Nzcrentr more power. In reality, the shell was made to trap and control it.\
+	Nzcrentr now serves loyally, though even one of Nezbere's finest creations was not enough to totally eliminate its will."
 	icon = 'icons/effects/254x361.dmi'
 	icon_state = "nzcrentr"
 	pixel_x = -111
 	pixel_y = -164
 
 /obj/effect/clockwork/general_marker/inathneq
-	name = "Inath-Neq, the Resonant Cogwheel"
+	name = "Inath-neq, the Resonant Cogwheel"
 	desc = "A humanoid form blazing with blue fire. It radiates an aura of kindness and caring."
-	clockwork_desc = "One of Ratvar's four generals. Before her current form, Inath-Neq was a powerful warrior priestess commanding the Resonant Cogs, a sect of Ratvarian warriors renowned for \
-	their prowess. After a lost battle with Nar-Sian cultists, Inath-Neq was struck down and stated in her dying breath, \
-	\"The Resonant Cogs shall not fall silent this day, but will come together to form a wheel that shall never stop turning.\" Ratvar, touched by this, granted Inath-Neq an eternal body and \
+	clockwork_desc = "One of Ratvar's four generals. Before her current form, Inath-neq was a powerful warrior priestess commanding the Resonant Cogs, a sect of Ratvarian warriors renowned for \
+	their prowess. After a lost battle with Nar-Sian cultists, Inath-neq was struck down and stated in her dying breath, \
+	\"The Resonant Cogs shall not fall silent this day, but will come together to form a wheel that shall never stop turning.\" Ratvar, touched by this, granted Inath-neq an eternal body and \
 	merged her soul with those of the Cogs slain with her on the battlefield."
 	icon = 'icons/effects/187x381.dmi'
 	icon_state = "inath-neq"
@@ -894,7 +895,7 @@
 	if(isloyal(L))
 		delete_on_finish = TRUE
 		L.visible_message("<span class='warning'>[L] visibly trembles!</span>", \
-		"<span class='sevtug'>Lbh jvyy or zvar-naq-uvf. Guv'f chal gevax-rg jvyy abg fgbc zr.</span>")
+		"<span class='sevtug'>[text2ratvar("You will be mine and his. This puny trinket will not stop me.")]</span>")
 		for(var/obj/item/weapon/implant/mindshield/M in L)
 			if(M.implanted)
 				qdel(M)
@@ -985,7 +986,8 @@
 						ghost.reenter_corpse()
 						L.revive(1, 1)
 						playsound(L, 'sound/magic/Staff_Healing.ogg', 50, 1)
-						L.visible_message("<span class='warning'>[L] suddenly gets back up, their mouth dripping blue ichor!</span>", "<span class='inathneq'>\"Lbh jvyy or bxnl, puvyq.\"</span>")
+						L.visible_message("<span class='warning'>[L] suddenly gets back up, their mouth dripping blue ichor!</span>", \
+						"<span class='inathneq'>\"[text2ratvar("You will be okay, child.")]\"</span>")
 						vitality -= revival_cost
 						break
 				else

--- a/code/game/gamemodes/clock_cult/clock_unsorted.dm
+++ b/code/game/gamemodes/clock_cult/clock_unsorted.dm
@@ -239,16 +239,18 @@ List of nuances:
 - Where the WORD "to" appears, it is linked to the following word by a hyphen, i.e; "to-use"
 - Where the WORD "my" appears, it is linked to the following word by a hyphen, i.e; "my-light"
 - Although "Ratvar" translates to "Engine" in English, the word "Ratvar" is used regardless of language as it is a proper noun.
- - The same rule applies to Ratvar's four generals: Nezbere (Armorer), Sevtug (Fright), Nzcrentr (Amperage), and Inath-Neq (Vangu-Ard), although these words can be used in proper context if one is
+ - The same rule applies to Ratvar's four generals: Nezbere (Armorer), Sevtug (Fright), Nzcrentr (Amperage), and Inath-neq (Vangu-Ard), although these words can be used in proper context if one is
    not referring to the four generals and simply using the words themselves.
 */
 
 //Regexes used to alter english to ratvarian style
 #define RATVAR_OF_MATCH				regex("(\\w)\\s(\[oO]\[fF])","g")
 #define RATVAR_OF_REPLACEMENT 		"$1-$2"
+#define RATVAR_GUA_MATCH			regex("(\[gG]\[uU])(\[aA])","g")
+#define RATVAR_GUA_REPLACEMENT		"$1-$2"
 #define RATVAR_TH_MATCH				regex("(\[tT]\[hH]\\w)(\\w)","g")
 #define RATVAR_TH_REPLACEMENT		"$1`$2"
-#define RATVAR_TI_MATCH				regex("(\[tT]\[iI])(\\w{2})","g")
+#define RATVAR_TI_MATCH				regex("(\[tT]\[iI])(\\w)","g")
 #define RATVAR_TI_REPLACEMENT		"$1`$2"
 #define RATVAR_ET_MATCH				regex("(\\w)(\[eE]\[tT])","g")
 #define RATVAR_ET_REPLACEMENT		"$1-$2"
@@ -274,12 +276,15 @@ List of nuances:
 #define REVERSE_RATVAR_HYPHEN_TE_REPLACEMENT		"$1"
 #define REVERSE_RATVAR_HYPHEN_ET_MATCH				regex("-(\[eE]\[tT])","g")
 #define REVERSE_RATVAR_HYPHEN_ET_REPLACEMENT		"$1"
+#define REVERSE_RATVAR_HYPHEN_GUA_MATCH				regex("(\[gG]\[uU])-(\[aA])","g")
+#define REVERSE_RATVAR_HYPHEN_GUA_REPLACEMENT		"$1$2"
 #define REVERSE_RATVAR_HYPHEN_OF_MATCH				regex("-(\[oO]\[fF])","g")
 #define REVERSE_RATVAR_HYPHEN_OF_REPLACEMENT		" $1"
 
 
 /proc/text2ratvar(text) //Takes english and applies ratvarian styling rules (and rot13) to it
 	var/ratvarian 	= replacetext(text, 		RATVAR_OF_MATCH, 		RATVAR_OF_REPLACEMENT)
+	ratvarian 		= replacetext(ratvarian,	RATVAR_GUA_MATCH, 		RATVAR_GUA_REPLACEMENT)
 	ratvarian 		= replacetext(ratvarian,	RATVAR_TH_MATCH, 		RATVAR_TH_REPLACEMENT)
 	ratvarian 		= replacetext(ratvarian,	RATVAR_TI_MATCH, 		RATVAR_TI_REPLACEMENT)
 	ratvarian 		= replacetext(ratvarian, 	RATVAR_ET_MATCH, 		RATVAR_ET_REPLACEMENT)
@@ -292,6 +297,7 @@ List of nuances:
 
 /proc/ratvar2text(ratvarian) //Reverts ravarian styling and rot13 in text.
 	var/text 	= replacetext(rot13(ratvarian), "`",								 		"")
+	text 		= replacetext(text, 			REVERSE_RATVAR_HYPHEN_GUA_MATCH,	 		REVERSE_RATVAR_HYPHEN_GUA_REPLACEMENT)
 	text 		= replacetext(text, 			REVERSE_RATVAR_HYPHEN_PRE_AND_MATCH,	 	REVERSE_RATVAR_HYPHEN_PRE_AND_REPLACEMENT)
 	text 		= replacetext(text, 			REVERSE_RATVAR_HYPHEN_POST_AND_MATCH,	 	REVERSE_RATVAR_HYPHEN_POST_AND_REPLACEMENT)
 	text 		= replacetext(text, 			REVERSE_RATVAR_HYPHEN_TO_MY_MATCH,			REVERSE_RATVAR_HYPHEN_TO_MY_REPLACEMENT)

--- a/code/game/gamemodes/clock_cult/clock_unsorted.dm
+++ b/code/game/gamemodes/clock_cult/clock_unsorted.dm
@@ -235,6 +235,7 @@ List of nuances:
 - Any time "th", followed by any two letters occurs, you add a grave (`) between those two letters, i.e; "Thi`s"
 - In the same vein, any time "ti", followed by one letter occurs, you add a grave (`) between "i" and the letter, i.e; "Ti`me"
 - Whereever "te" or "et" appear and there is another letter next to the e(i.e; "m"etal, greate"r"), add a hyphen between "e" and the letter, i.e; "M-etal", "Greate-r"
+- Where "gua" appears, add a hyphen between "gu" and "a", i.e "Gu-ard"
 - Where the WORD "and" appears it is linked to all surrounding words by hyphens, i.e; "Sword-and-shield"
 - Where the WORD "to" appears, it is linked to the following word by a hyphen, i.e; "to-use"
 - Where the WORD "my" appears, it is linked to the following word by a hyphen, i.e; "my-light"

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -196,7 +196,7 @@
 		operating = 1
 		icon_state = "dominator-[gang.color]"
 
-		countdown.text_color = gang.color_hex
+		countdown.color = gang.color_hex
 		countdown.start()
 
 		SetLuminosity(3)

--- a/code/modules/countdown/countdown.dm
+++ b/code/modules/countdown/countdown.dm
@@ -7,7 +7,7 @@
 
 	var/displayed_text
 	var/atom/attached_to
-	var/text_color = "#ff0000"
+	color = "#ff0000"
 	var/text_size = 4
 	var/started = FALSE
 	invisibility = INVISIBILITY_OBSERVER
@@ -29,7 +29,7 @@
 
 /obj/effect/countdown/proc/stop()
 	if(started)
-		overlays.Cut()
+		maptext = null
 		STOP_PROCESSING(SSfastprocess, src)
 		started = FALSE
 
@@ -47,15 +47,9 @@
 	displayed_text = new_val
 
 	if(displayed_text)
-		var/image/text_image = new(loc = src)
-		//text_image.maptext = "<font size=[text_size]>[new_val]</font>"
-		text_image.maptext = "<font size = [text_size]>[displayed_text]</font>"
-		text_image.color = text_color
-
-		overlays.Cut()
-		overlays += text_image
+		maptext = "<font size = [text_size]>[displayed_text]</font>"
 	else
-		overlays.Cut()
+		maptext = null
 
 /obj/effect/countdown/Destroy()
 	attached_to = null
@@ -74,7 +68,7 @@
 
 /obj/effect/countdown/nuclearbomb
 	name = "nuclear bomb countdown"
-	text_color = "#81FF14"
+	color = "#81FF14"
 
 /obj/effect/countdown/nuclearbomb/get_value()
 	var/obj/machinery/nuclearbomb/N = attached_to
@@ -85,7 +79,7 @@
 
 /obj/effect/countdown/clonepod
 	name = "cloning pod countdown"
-	text_color = "#0C479D"
+	color = "#0C479D"
 	text_size = 1
 
 /obj/effect/countdown/clonepod/get_value()
@@ -99,7 +93,7 @@
 /obj/effect/countdown/dominator
 	name = "dominator countdown"
 	text_size = 1
-	text_color = "#ff00ff" // Overwritten when the dominator starts
+	color = "#ff00ff" // Overwritten when the dominator starts
 
 /obj/effect/countdown/dominator/get_value()
 	var/obj/machinery/dominator/D = attached_to
@@ -114,7 +108,7 @@
 /obj/effect/countdown/clockworkgate
 	name = "gateway countdown"
 	text_size = 1
-	text_color = "#BE8700"
+	color = "#BE8700"
 	layer = POINT_LAYER
 
 /obj/effect/countdown/clockworkgate/get_value()
@@ -126,7 +120,7 @@
 
 /obj/effect/countdown/transformer
 	name = "transformer countdown"
-	text_color = "#4C5866"
+	color = "#4C5866"
 
 /obj/effect/countdown/transformer/get_value()
 	var/obj/machinery/transformer/T = attached_to

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -181,7 +181,7 @@
 		else if(is_servant_of_ratvar(M) && prob(5))
 			switch(pick("speech", "message", "emote"))
 				if("speech")
-					clockwork_say(M, "...[pick("Ratvar... lbhe yvtug tebjf qnex...", "Jurer ner lbh, znfgr-e?", "Ur yvrf ehfgv'at va Reebe...", "Chetr nyy hagehguf-naq... naq... fbzrguv'at...")]")
+					clockwork_say(M, "...[text2ratvar(pick("Engine... your light grows dark...", "Where are you, master?", "He lies rusting in Error...", "Purge all untruths and... and... something..."))]")
 				if("message")
 					M << "<span class='boldwarning'>[pick("Ratvar's illumination of your mind has begun to flicker", "He lies rusting in Reebe, derelict and forgotten. And there he shall stay", \
 					"You can't save him. Nothing can save him now", "It seems that Nar-Sie will triumph after all")].</span>"


### PR DESCRIPTION
:cl: Joan
rscadd: Revenant scriptures now announce to all servants and ghosts when used instead of having a visible message.
/:cl:

Accidentally fixes some countdown code to be more simple(coiax what the fuck why was that using an overlay)
Retcons Inath-neq's name to have a lower-case N, so that the regex for it doesn't need to capitalize it.
Redoes the tiny bit of Nzcrentr lore.
I might have fixed a bug or two? It's kind of hazy.
