### PR TITLE
Makes spec ops crate not hidden anymore, removes sleepy pen and adds in tear gas grenade

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -132,13 +132,12 @@
 
 /datum/supply_pack/emergency/specialops
 	name = "Special Ops Supplies"
-	hidden = TRUE
 	cost = 2000
 	contains = list(/obj/item/weapon/storage/box/emps,
 					/obj/item/weapon/grenade/smokebomb,
 					/obj/item/weapon/grenade/smokebomb,
 					/obj/item/weapon/grenade/smokebomb,
-					/obj/item/weapon/pen/sleepy,
+					/obj/item/weapon/grenade/chem_grenade/teargas,
 					/obj/item/weapon/grenade/chem_grenade/incendiary)
 	crate_name = "emergency crate"
 	crate_type = /obj/structure/closet/crate/internals


### PR DESCRIPTION
Does what it says in title

This is meant to make it seem more like spec ops, as before only people with emags could get this. This crate also requires (possibly HoS/Warden) a normal security officer. The sleeping pen didn't make much sense, so it was instead replaced with a tear gas grenade. 

Feel free to discuss
