### PR TITLE
Morgue Light Fix

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -128,7 +128,7 @@
 				icon_state = "morgue3"
 				return
 			for(var/mob/living/M in compiled)
-				if(M.client)
+				if(M.client && !M.suiciding)
 					icon_state = "morgue4" // Cloneable
 					break
 


### PR DESCRIPTION
Fixes an edge case in which a suicide where the person doesn't ghost would cause the morgue tray to light up green, despite not being revivable.
