### PR TITLE
Canned Laughter Improvements

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -117,7 +117,9 @@
 	metabolization_rate = INFINITY
 	color = "#FF4DD2"
 
-/datum/reagent/consumable/laughter/on_mob_life(mob/living/M)
+/datum/reagent/consumable/laughter/on_mob_life(mob/living/carbon/M)
+	if(!iscarbon(M))
+		return
 	if(!M.silent)//cant laugh if you're mute
 		M.emote("laugh")
 		var/laughnum = rand(1,2)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -118,17 +118,18 @@
 	color = "#FF4DD2"
 
 /datum/reagent/consumable/laughter/on_mob_life(mob/living/M)
-	M.emote("laugh")
-	var/laughnum = rand(1,2)
-	if(M.gender == MALE)
-		if(laughnum == 1)
+	if(!M.silent)//cant laugh if you're mute
+		M.emote("laugh")
+		var/laughnum = rand(1,2)
+		if(M.gender == MALE)
+			if(laughnum == 1)
+				playsound(get_turf(M), 'sound/voice/human/manlaugh1.ogg', 50, 1)
+			if(laughnum == 2)
+				playsound(get_turf(M), 'sound/voice/human/manlaugh2.ogg', 50, 1)
+		else if(M.gender == FEMALE)
+			playsound(get_turf(M), 'sound/voice/human/womanlaugh.ogg', 65, 1)
+		else//non-binary gender just sounds like a man
 			playsound(get_turf(M), 'sound/voice/human/manlaugh1.ogg', 50, 1)
-		if(laughnum == 2)
-			playsound(get_turf(M), 'sound/voice/human/manlaugh2.ogg', 50, 1)
-	else if(M.gender == FEMALE)
-		playsound(get_turf(M), 'sound/voice/human/womanlaugh.ogg', 65, 1)
-	else//non-binary gender just sounds like a man
-		playsound(get_turf(M), 'sound/voice/human/manlaugh1.ogg', 50, 1)
 	..()
 
 /datum/reagent/consumable/potato_juice

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -517,3 +517,10 @@
 	result = "royal_bee_jelly"
 	required_reagents = list("mutagen" = 10, "honey" = 40)
 	result_amount = 5
+
+/datum/chemical_reaction/laughter
+	name = "laughter"
+	id = "laughter"
+	result = "laughter"
+	required_reagents = list("sugar" = 1, "banana" = 1)
+	result_amount = 10


### PR DESCRIPTION
Ports being unable to laugh while muted from https://github.com/HippieStationCode/HippieStation13/pull/2657

Todo:
- [ ] Add an adminspawnable grenade/clustergrenade that fires Laughter gas

:cl: PKPenguin321
bugfix: Laughter no longer makes you laugh if you're muted.
rscadd: Laughter can now be brewed with banana juice and sugar.
/:cl:
