### PR TITLE
Doubles the amount of viscerators in the viscerator grenade

### DIFF
--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -32,7 +32,7 @@
 /obj/item/weapon/grenade/spawnergrenade/manhacks
 	name = "viscerator delivery grenade"
 	spawner_type = /mob/living/simple_animal/hostile/viscerator
-	deliveryamt = 5
+	deliveryamt = 10
 	origin_tech = "materials=3;magnets=4;syndicate=3"
 
 /obj/item/weapon/grenade/spawnergrenade/spesscarp


### PR DESCRIPTION
As per request in #19451 

:cl: incoming5643
tweak: viscerator grenades are now more generous with viscerators spawned
/:cl:
