### PR TITLE
Removes toxin damage from diphen-synaptizine

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -102,8 +102,6 @@
 	if(holder.has_reagent("histamine"))
 		holder.remove_reagent("histamine", 5)
 	M.hallucination = max(0, M.hallucination - 10)
-	if(prob(30))
-		M.adjustToxLoss(1, 0)
 		. = 1
 	..()
 


### PR DESCRIPTION
:cl: XDTM
rscdel:The Sensory Restoration symptom will no longer deal toxin damage over time.
/:cl:

Diphen-synaptizine is one of the chems used by Sensory Restoration to make it work; since it was based on normal synaptizine, it has a 30% chance per tick to deal 1 tox damage, which does not make sense on this symptom, and was responsible for those constant tiny amounts of damage i observed when doing virology.
