### PR TITLE
Unused Traitor Items: Microbombs

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -999,7 +999,6 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			This will permanently destroy your body, however."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_microbomb
 	cost = 2
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/implants/macrobomb
 	name = "Macrobomb Implant"


### PR DESCRIPTION
nobody buys them since they became nuke ops only since you start with them, this should be a good buff since traitors can buy them now
