### PR TITLE
Adds option to only spawn if antag.

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -6,6 +6,7 @@
 
 //These are synced with the Database, if you change the values of the defines
 //then you MUST update the database!
+#define ROLE_ONLY_ANTAG			"only an antag"
 #define ROLE_TRAITOR			"traitor"
 #define ROLE_OPERATIVE			"operative"
 #define ROLE_CHANGELING			"changeling"
@@ -30,6 +31,7 @@
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough
 //(in game days played) to play that role
 var/global/list/special_roles = list(
+	ROLE_ONLY_ANTAG,
 	ROLE_TRAITOR = /datum/game_mode/traitor,
 	ROLE_OPERATIVE = /datum/game_mode/nuclear,
 	ROLE_CHANGELING = /datum/game_mode/changeling,

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -301,7 +301,7 @@
 		for(var/mob/dead/observer/G in player_list)
 			if(G.client != null)
 				if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
-					if(!G.client.is_afk(afk_bracket) && (be_special_type in G.client.prefs.be_special))
+					if(!G.client.is_afk(afk_bracket) && (G.client.prefs.be_special[be_special_type]))
 						if (jobbanType)
 							if(!(jobban_isbanned(G, jobbanType) || jobban_isbanned(G, "Syndicate")))
 								candidates += G.client
@@ -407,7 +407,7 @@
 		if(!G.key || !G.client)
 			continue
 		if(be_special_flag)
-			if(!(G.client.prefs) || !(be_special_flag in G.client.prefs.be_special))
+			if(!(G.client.prefs) || !(G.client.prefs.be_special[be_special_flag]))
 				continue
 		if (gametypeCheck)
 			if(!gametypeCheck.age_check(G.client))

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -90,7 +90,7 @@ var/datum/subsystem/job/SSjob
 		if(!job.player_old_enough(player.client))
 			Debug("FOC player not old enough, Player: [player]")
 			continue
-		if(flag && (!(flag in player.client.prefs.be_special)))
+		if(flag && (!player.client.prefs.be_special[flag]))
 			Debug("FOC flag failed, Player: [player], Flag: [flag], ")
 			continue
 		if(player.mind && job.title in player.mind.restricted_roles)
@@ -221,7 +221,10 @@ var/datum/subsystem/job/SSjob
 
 	//Get the players who are ready
 	for(var/mob/new_player/player in player_list)
-		if(player.ready && player.mind && !player.mind.assigned_role)
+		if(player.ready && player.client && player.mind && !player.mind.assigned_role)
+			if (player.client.prefs.be_special[ROLE_ONLY_ANTAG] && !player.mind.special_role)
+				RejectPlayer(player)
+				continue
 			unassigned += player
 
 	initial_players_to_assign = unassigned.len

--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -194,7 +194,7 @@ var/datum/subsystem/pai/SSpai
 			for(var/datum/paiCandidate/c in SSpai.candidates)
 				if(c.key == O.key)
 					hasSubmitted = 1
-			if(!hasSubmitted && (ROLE_PAI in O.client.prefs.be_special))
+			if(!hasSubmitted && (O.client.prefs.be_special[ROLE_PAI]))
 				question(O.client)
 
 /datum/subsystem/pai/proc/question(client/C)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -283,7 +283,7 @@
 		else
 			text += "head|loyal|<b>EMPLOYEE</b>|<a href='?src=\ref[src];revolution=headrev'>headrev</a>|<a href='?src=\ref[src];revolution=rev'>rev</a>"
 
-		if(current && current.client && (ROLE_REV in current.client.prefs.be_special))
+		if(current && current.client && current.client.prefs.be_special[ROLE_REV])
 			text += "|Enabled in Prefs"
 		else
 			text += "|Disabled in Prefs"
@@ -301,7 +301,7 @@
 		else
 			text += "<B>NONE</B>"
 
-		if(current && current.client && (ROLE_GANG in current.client.prefs.be_special))
+		if(current && current.client && current.client.prefs.be_special[ROLE_GANG])
 			text += "|Enabled in Prefs<BR>"
 		else
 			text += "|Disabled in Prefs<BR>"
@@ -348,7 +348,7 @@
 		else
 			text += "loyal|<b>EMPLOYEE</b>|<a href='?src=\ref[src];cult=cultist'>cultist</a>"
 
-		if(current && current.client && (ROLE_CULTIST in current.client.prefs.be_special))
+		if(current && current.client && current.client.prefs.be_special[ROLE_CULTIST])
 			text += "|Enabled in Prefs"
 		else
 			text += "|Disabled in Prefs"
@@ -368,7 +368,7 @@
 		else
 			text += "loyal|<b>EMPLOYEE</b>|<a href='?src=\ref[src];clockcult=servant'>servant</a>"
 
-		if(current && current.client && (ROLE_SERVANT_OF_RATVAR in current.client.prefs.be_special))
+		if(current && current.client && current.client.prefs.be_special[ROLE_SERVANT_OF_RATVAR])
 			text += "|Enabled in Prefs"
 		else
 			text += "|Disabled in Prefs"
@@ -388,7 +388,7 @@
 		else
 			text += "<a href='?src=\ref[src];wizard=wizard'>yes</a>|<b>NO</b>"
 
-		if(current && current.client && (ROLE_WIZARD in current.client.prefs.be_special))
+		if(current && current.client && current.client.prefs.be_special[ROLE_WIZARD])
 			text += "|Enabled in Prefs"
 		else
 			text += "|Disabled in Prefs"
@@ -418,7 +418,7 @@
 //			if (istype(changeling) && changeling.changelingdeath)
 //				text += "<br>All the changelings are dead! Restart in [round((changeling.TIME_TO_GET_REVIVED-(world.time-changeling.changelingdeathtime))/10)] seconds."
 
-		if(current && current.client && (ROLE_CHANGELING in current.client.prefs.be_special))
+		if(current && current.client && current.client.prefs.be_special[ROLE_CHANGELING])
 			text += "|Enabled in Prefs"
 		else
 			text += "|Disabled in Prefs"
@@ -443,7 +443,7 @@
 		else
 			text += "<a href='?src=\ref[src];nuclear=nuclear'>operative</a>|<b>NANOTRASEN</b>"
 
-		if(current && current.client && (ROLE_OPERATIVE in current.client.prefs.be_special))
+		if(current && current.client && current.client.prefs.be_special[ROLE_OPERATIVE])
 			text += "|Enabled in Prefs"
 		else
 			text += "|Disabled in Prefs"
@@ -462,7 +462,7 @@
 	else
 		text += "<a href='?src=\ref[src];traitor=traitor'>traitor</a>|<b>LOYAL</b>"
 
-	if(current && current.client && (ROLE_TRAITOR in current.client.prefs.be_special))
+	if(current && current.client && current.client.prefs.be_special[ROLE_TRAITOR])
 		text += "|Enabled in Prefs"
 	else
 		text += "|Disabled in Prefs"
@@ -481,7 +481,7 @@
 	else
 		text += "<a href='?src=\ref[src];abductor=abductor'>Abductor</a>|<b>human</b>"
 
-	if(current && current.client && (ROLE_ABDUCTOR in current.client.prefs.be_special))
+	if(current && current.client && current.client.prefs.be_special[ROLE_ABDUCTOR])
 		text += "|Enabled in Prefs"
 	else
 		text += "|Disabled in Prefs"
@@ -508,12 +508,12 @@
 	else
 		text += "<a href='?src=\ref[src];handofgod=red_god'>red god</a>|<a href='?src=\ref[src];handofgod=red prophet'>red prophet</a>|<a href='?src=\ref[src];handofgod=red follower'>red follower</a>|<B>EMPLOYEE</b>|<a href='?src=\ref[src];handofgod=blue god'>blue god</a>|<a href='?src=\ref[src];handofgod=blue prophet'>blue prophet</a>|<a href='?src=\ref[src];handofgod=blue follower'>blue follower</a>"
 
-	if(current && current.client && (ROLE_HOG_GOD in current.client.prefs.be_special))
+	if(current && current.client && current.client.prefs.be_special[ROLE_HOG_GOD])
 		text += "|HOG God Enabled in Prefs"
 	else
 		text += "|HOG God Disabled in Prefs"
 
-	if(current && current.client && (ROLE_HOG_CULTIST in current.client.prefs.be_special))
+	if(current && current.client && current.client.prefs.be_special[ROLE_HOG_CULTIST])
 		text += "|HOG Cultist Enabled in Prefs"
 	else
 		text += "|HOG Disabled in Prefs"
@@ -541,7 +541,7 @@
 		else
 			text += "healthy|infected|human|<b>OTHER</b>"
 
-		if(current && current.client && (ROLE_MONKEY in current.client.prefs.be_special))
+		if(current && current.client && current.client.prefs.be_special[ROLE_MONKEY])
 			text += "|Enabled in Prefs"
 		else
 			text += "|Disabled in Prefs"
@@ -560,7 +560,7 @@
 	else
 		text += "<a href='?src=\ref[src];devil=devil'>devil</a>|<a href='?src=\ref[src];devil=sintouched'>sintouched</a>|<b>HUMAN</b>"
 
-	if(current && current.client && (ROLE_DEVIL in current.client.prefs.be_special))
+	if(current && current.client && current.client.prefs.be_special[ROLE_DEVIL])
 		text += "|Enabled in Prefs"
 	else
 		text += "|Disabled in Prefs"

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -61,7 +61,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 /datum/game_mode/blob/proc/get_blob_candidates()
 	var/list/candidates = list()
 	for(var/mob/living/carbon/human/player in player_list)
-		if(!player.stat && player.mind && !player.mind.special_role && !jobban_isbanned(player, "Syndicate") && (ROLE_BLOB in player.client.prefs.be_special))
+		if(!player.stat && player.mind && !player.mind.special_role && !jobban_isbanned(player, "Syndicate") && (player.client.prefs.be_special[ROLE_BLOB]))
 			if(age_check(player.client))
 				candidates += player
 	return candidates

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -105,7 +105,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	if(ticker.mode.changelings.len >= changelingcap) //Caps number of latejoin antagonists
 		return
 	if(ticker.mode.changelings.len <= (changelingcap - 2) || prob(100 - (config.changeling_scaling_coeff*2)))
-		if(ROLE_CHANGELING in character.client.prefs.be_special)
+		if(character.client.prefs.be_special[ROLE_CHANGELING])
 			if(!jobban_isbanned(character, ROLE_CHANGELING) && !jobban_isbanned(character, "Syndicate"))
 				if(age_check(character.client))
 					if(!(character.job in restricted_jobs))

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -68,7 +68,7 @@
 		..()
 		return
 	if(ticker.mode.changelings.len <= (changelingcap - 2) || prob(100 / (config.changeling_scaling_coeff * 4)))
-		if(ROLE_CHANGELING in character.client.prefs.be_special)
+		if(character.client.prefs.be_special[ROLE_CHANGELING])
 			if(!jobban_isbanned(character.client, ROLE_CHANGELING) && !jobban_isbanned(character.client, "Syndicate"))
 				if(age_check(character.client))
 					if(!(character.job in restricted_jobs))

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -302,7 +302,7 @@
 
 	for(var/mob/new_player/player in players)
 		if(player.client && player.ready)
-			if(role in player.client.prefs.be_special)
+			if(player.client.prefs.be_special[role])
 				if(!jobban_isbanned(player, "Syndicate") && !jobban_isbanned(player, role)) //Nodrak/Carn: Antag Job-bans
 					if(age_check(player.client)) //Must be older than the minimum age
 						candidates += player.mind				// Get a list of all the people who want to be the antagonist for this round
@@ -316,7 +316,7 @@
 	if(candidates.len < recommended_enemies)
 		for(var/mob/new_player/player in players)
 			if(player.client && player.ready)
-				if(!(role in player.client.prefs.be_special)) // We don't have enough people who want to be antagonist, make a seperate list of people who don't want to be one
+				if(!player.client.prefs.be_special[role]) // We don't have enough people who want to be antagonist, make a seperate list of people who don't want to be one
 					if(!jobban_isbanned(player, "Syndicate") && !jobban_isbanned(player, role)) //Nodrak/Carn: Antag Job-bans
 						drafted += player.mind
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -192,7 +192,7 @@
 		var/list/promotable_revs = list()
 		for(var/datum/mind/khrushchev in revolutionaries)
 			if(khrushchev.current && khrushchev.current.client && khrushchev.current.stat != DEAD)
-				if(ROLE_REV in khrushchev.current.client.prefs.be_special)
+				if(khrushchev.current.client.prefs.be_special[ROLE_REV])
 					promotable_revs += khrushchev
 		if(promotable_revs.len)
 			var/datum/mind/stalin = pick(promotable_revs)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -74,7 +74,7 @@
 	if(ticker.mode.traitors.len >= traitorcap) //Upper cap for number of latejoin antagonists
 		return
 	if(ticker.mode.traitors.len <= (traitorcap - 2) || prob(100 / (config.traitor_scaling_coeff * 2)))
-		if(ROLE_TRAITOR in character.client.prefs.be_special)
+		if(character.client.prefs.be_special[ROLE_TRAITOR])
 			if(!jobban_isbanned(character, ROLE_TRAITOR) && !jobban_isbanned(character, "Syndicate"))
 				if(age_check(character.client))
 					if(!(character.job in restricted_jobs))

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -91,7 +91,7 @@
 	spawn(rand(spawn_delay_min, spawn_delay_max))
 		message_admins("SWF is still pissed, sending another wizard - [max_mages - mages_made] left.")
 		for(var/mob/dead/observer/G in player_list)
-			if(G.client && !G.client.holder && !G.client.is_afk() && (ROLE_WIZARD in G.client.prefs.be_special))
+			if(G.client && !G.client.holder && !G.client.is_afk() && G.client.prefs.be_special[ROLE_WIZARD])
 				if(!jobban_isbanned(G, ROLE_WIZARD) && !jobban_isbanned(G, "Syndicate"))
 					if(age_check(G.client))
 						candidates += G

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -42,7 +42,7 @@
 	var/mob/living/carbon/human/H = null
 
 	for(var/mob/living/carbon/human/applicant in player_list)
-		if(ROLE_TRAITOR in applicant.client.prefs.be_special)
+		if(applicant.client.prefs.be_special[ROLE_TRAITOR])
 			if(!applicant.stat)
 				if(applicant.mind)
 					if (!applicant.mind.special_role)
@@ -78,7 +78,7 @@
 	var/mob/living/carbon/human/H = null
 
 	for(var/mob/living/carbon/human/applicant in player_list)
-		if(ROLE_CHANGELING in applicant.client.prefs.be_special)
+		if(applicant.client.prefs.be_special[ROLE_CHANGELING])
 			var/turf/T = get_turf(applicant)
 			if(applicant.stat == CONSCIOUS && applicant.mind && !applicant.mind.special_role && T.z == ZLEVEL_STATION)
 				if(!jobban_isbanned(applicant, ROLE_CHANGELING) && !jobban_isbanned(applicant, "Syndicate"))
@@ -111,7 +111,7 @@
 	var/mob/living/carbon/human/H = null
 
 	for(var/mob/living/carbon/human/applicant in player_list)
-		if(ROLE_REV in applicant.client.prefs.be_special)
+		if(applicant.client.prefs.be_special[ROLE_REV])
 			var/turf/T = get_turf(applicant)
 			if(applicant.stat == CONSCIOUS && applicant.mind && !applicant.mind.special_role && T.z == ZLEVEL_STATION)
 				if(!jobban_isbanned(applicant, ROLE_REV) && !jobban_isbanned(applicant, "Syndicate"))
@@ -153,7 +153,7 @@
 	var/mob/living/carbon/human/H = null
 
 	for(var/mob/living/carbon/human/applicant in player_list)
-		if(ROLE_CULTIST in applicant.client.prefs.be_special)
+		if(applicant.client.prefs.be_special[ROLE_CULTIST])
 			var/turf/T = get_turf(applicant)
 			if(applicant.stat == CONSCIOUS && applicant.mind && !applicant.mind.special_role && T.z == ZLEVEL_STATION)
 				if(!jobban_isbanned(applicant, ROLE_CULTIST) && !jobban_isbanned(applicant, "Syndicate"))
@@ -186,7 +186,7 @@
 	var/mob/living/carbon/human/H = null
 
 	for(var/mob/living/carbon/human/applicant in player_list)
-		if(ROLE_SERVANT_OF_RATVAR in applicant.client.prefs.be_special)
+		if(applicant.client.prefs.be_special[ROLE_SERVANT_OF_RATVAR])
 			var/turf/T = get_turf(applicant)
 			if(applicant.stat == CONSCIOUS && applicant.mind && !applicant.mind.special_role && T.z == ZLEVEL_STATION)
 				if(!jobban_isbanned(applicant, ROLE_SERVANT_OF_RATVAR) && !jobban_isbanned(applicant, "Syndicate"))
@@ -371,7 +371,7 @@
 	var/mob/living/carbon/human/H = null
 
 	for(var/mob/living/carbon/human/applicant in player_list)
-		if(ROLE_GANG in applicant.client.prefs.be_special)
+		if(applicant.client.prefs.be_special[ROLE_GANG])
 			var/turf/T = get_turf(applicant)
 			if(applicant.stat == CONSCIOUS && applicant.mind && !applicant.mind.special_role && T.z == ZLEVEL_STATION)
 				if(!jobban_isbanned(applicant, ROLE_GANG) && !jobban_isbanned(applicant, "Syndicate"))

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -216,7 +216,7 @@
 		for(var/mob/M in player_list)
 			if(M.stat != DEAD)
 				continue	//we are not dead!
-			if(!(ROLE_ALIEN in M.client.prefs.be_special))
+			if(!M.client.prefs.be_special[ROLE_ALIEN])
 				continue	//we don't want to be an alium
 			if(M.client.is_afk())
 				continue	//we are afk
@@ -441,7 +441,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/datum/round_event/ion_storm/ion = new(0, announce_ion_laws, input)
 	ion.start()
-	
+
 	feedback_add_details("admin_verb","IONC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_rejuvenate(mob/living/M in mob_list)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1103,10 +1103,10 @@ var/list/preferences_datums = list()
 
 				if("be_special")
 					var/be_special_type = href_list["be_special_type"]
-					if(be_special_type in be_special)
+					if(be_special[be_special_type])
 						be_special -= be_special_type
 					else
-						be_special += be_special_type
+						be_special[be_special_type] = 1
 
 				if("name")
 					be_random_name = !be_random_name

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -2,7 +2,7 @@
 #define SAVEFILE_VERSION_MIN	10
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
-#define SAVEFILE_VERSION_MAX	16
+#define SAVEFILE_VERSION_MAX	17
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
 	This proc checks if the current directory of the savefile S needs updating
@@ -88,8 +88,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 
 /datum/preferences/proc/update_preferences(current_version, savefile/S)
-	if(current_version < 10)
-		toggles |= MEMBER_PUBLIC
 	if(current_version < 11)
 		chat_toggles = TOGGLES_DEFAULT_CHAT
 		toggles = TOGGLES_DEFAULT
@@ -97,7 +95,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		ignoring = list()
 	if(current_version < 15)
 		toggles |= SOUND_ANNOUNCEMENTS
-	
+
 
 //should this proc get fairly long (say 3 versions long),
 //just increase SAVEFILE_VERSION_MIN so it's not as far behind
@@ -123,7 +121,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			joblessrole = BERANDOMJOB
 		else
 			joblessrole = BEASSISTANT
-		
+	if(current_version < 17)
+		if (be_special)
+			for (var/role in be_special)
+				be_special[role] = 1
+
 
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")


### PR DESCRIPTION
# The idea is to keep antag rollers from taking up job slots

They can late join in the remaining job slots if they want, or ghost, or whatever.

It will just send you to lobby other wise.

The fact of the matter is, this issue isn't gonna get solved administratively, and the only reason it is even an administrative issue is people stealing job slots. Antag Rollers are always going to exist, and with even the assistant slot being limited, we can't have them taking up job slots.

:cl:
add: You may now choose to only join at round start if you roll antag. See the game preferences screen for the option.
/:cl:

This PR brought to you by a smoking session between myself and @bobdobbington. The idea was partially his.
