### PR TITLE
Saltpetre rounding bug fix + tweaked numbers (credit to Lordpidey for fix)

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -614,11 +614,12 @@
 			myseed.adjust_yield(round(S.get_reagent_amount("ammonia") * 0.01))
 
 	// Saltpetre is used for gardening IRL, to simplify highly, it speeds up growth and strengthens plants
-	if(S.has_reagent("saltpetre", 1))
-		adjustHealth(round(S.get_reagent_amount("saltpetre") * 0.25))
-		if(myseed)
-			myseed.adjust_production(-round(S.get_reagent_amount("saltpetre") * 0.01))
-			myseed.adjust_potency(round(S.get_reagent_amount("saltpetre") * 0.05))
+    if(S.has_reagent("saltpetre", 1))
+        var/salt = S.get_reagent_amount("saltpetre")
+        adjustHealth(round(salt * 0.25))
+        if(myseed)
+            myseed.adjust_production(-round(salt/100)-prob(salt%100))
+            myseed.adjust_potency(round(salt*0.15))
 
 	// Ash is also used IRL in gardening, as a fertilizer enhancer and weed killer
 	if(S.has_reagent("ash", 1))


### PR DESCRIPTION
Before, adding a small amount of saltpetre would round it back to 0, making it not increase potency.

With the help of Lordpidey, now the decreasing off production speed via Saltpetre will operate out of a percentage system. For every u of saltpetre, there will be a greater chance of production speed decreasing. 
