### PR TITLE
Indentation fix for #19477 (Saltpetre rounding bug fix + tweak)

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -615,10 +615,11 @@
 
 	// Saltpetre is used for gardening IRL, to simplify highly, it speeds up growth and strengthens plants
 	if(S.has_reagent("saltpetre", 1))
-		adjustHealth(round(S.get_reagent_amount("saltpetre") * 0.25))
-		if(myseed)
-			myseed.adjust_production(-round(S.get_reagent_amount("saltpetre") * 0.01))
-			myseed.adjust_potency(round(S.get_reagent_amount("saltpetre") * 0.05))
+         	var/salt = S.get_reagent_amount("saltpetre")
+        	adjustHealth(round(salt * 0.25))
+        	if(myseed)
+            		myseed.adjust_production(-round(salt/100)-prob(salt%100))
+             		myseed.adjust_potency(round(salt*0.15))
 
 	// Ash is also used IRL in gardening, as a fertilizer enhancer and weed killer
 	if(S.has_reagent("ash", 1))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -618,7 +618,7 @@
 		var/salt = S.get_reagent_amount("saltpetre")
 		adjustHealth(round(salt * 0.25))
 		if (myseed)
-			myseed.adjust_product(-round(salt/100)-prob(salt%100))
+			myseed.adjust_production(-round(salt/100)-prob(salt%100))
 			myseed.adjust_potency(round(salt*0.15))
 	// Ash is also used IRL in gardening, as a fertilizer enhancer and weed killer
 	if(S.has_reagent("ash", 1))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -615,12 +615,11 @@
 
 	// Saltpetre is used for gardening IRL, to simplify highly, it speeds up growth and strengthens plants
 	if(S.has_reagent("saltpetre", 1))
-         	var/salt = S.get_reagent_amount("saltpetre")
-        	adjustHealth(round(salt * 0.25))
-        	if(myseed)
-            		myseed.adjust_production(-round(salt/100)-prob(salt%100))
-             		myseed.adjust_potency(round(salt*0.15))
-
+		var/salt = S.get_reagent_amount("saltpetre")
+		adjustHealth(round(salt * 0.25))
+		if (myseed)
+			myseed.adjust_product(-round(salt/100)-prob(salt%100))
+			myseed.adjust_potency(round(salt*0.15))
 	// Ash is also used IRL in gardening, as a fertilizer enhancer and weed killer
 	if(S.has_reagent("ash", 1))
 		adjustHealth(round(S.get_reagent_amount("ash") * 0.25))


### PR DESCRIPTION
Before, adding a small amount of saltpetre would round it back to 0, making it not increase potency.

With the help of Lordpidey, now the decreasing off production speed via Saltpetre will operate out of a percentage system. For every u of saltpetre, there will be a greater chance of production speed decreasing.
