### PR TITLE
Halves the Interdiction Lens' disrupt cost

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_machines.dm
+++ b/code/game/gamemodes/clock_cult/clock_machines.dm
@@ -392,7 +392,7 @@
 	var/recharge_time = 1200 //if it drains no power and affects no objects, it turns off for two minutes
 	var/disabled = FALSE //if it's actually usable
 	var/interdiction_range = 14 //how large an area it drains and disables in
-	var/disrupt_cost = 100 //how much power to use when disabling an object
+	var/disrupt_cost = 50 //how much power to use when disabling an object
 
 /obj/structure/clockwork/powered/interdiction_lens/examine(mob/user)
 	..()


### PR DESCRIPTION
:cl: Joan
tweak: Halves the Interdiction Lens' disrupt cost from 100 per disrupted object to 50 per disrupted object.
/:cl:
