### PR TITLE
Can use staff of storms on station

### DIFF
--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -27,7 +27,7 @@ var/datum/subsystem/weather/SSweather
 			if(WE.target_z == Z && WE.probability) //Another check so that it doesn't run extra weather
 				possible_weather_for_this_z[WE] = WE.probability
 		var/datum/weather/W = pickweight(possible_weather_for_this_z)
-		run_weather(W.name)
+		run_weather(W.name, Z)
 		eligible_zlevels -= Z
 		addtimer(src, "make_z_eligible", rand(3000, 6000) + W.weather_duration_upper, TRUE, Z) //Around 5-10 minutes between weathers
 
@@ -37,12 +37,12 @@ var/datum/subsystem/weather/SSweather
 		var/datum/weather/W = V
 		existing_weather |= new W
 
-/datum/subsystem/weather/proc/run_weather(weather_name)
+/datum/subsystem/weather/proc/run_weather(weather_name, Z)
 	if(!weather_name)
 		return
 	for(var/V in existing_weather)
 		var/datum/weather/W = V
-		if(W.name == weather_name)
+		if(W.name == weather_name && W.target_z == Z)
 			W.telegraph()
 
 /datum/subsystem/weather/proc/make_z_eligible(zlevel)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -166,14 +166,18 @@ Difficulty: Medium
 			"<span class='notice'>You hold [src] skyward, dispelling the storm!</span>")
 			playsound(user, 'sound/magic/Staff_Change.ogg', 200, 0)
 			A.wind_down()
+			return
 	else
 		A = new storm_type
+		A.name = "staff storm"
 		A.area_type = user_area.type
 		A.target_z = user.z
+		A.telegraph_duration = 100
+		A.end_duration = 100
 		A.telegraph()
 	user.visible_message("<span class='warning'>[user] holds [src] skywards as red lightning crackles into the sky!</span>", \
 	"<span class='notice'>You hold [src] skyward, calling down a terrible storm!</span>")
-	playsound(user, 'sound/magic/Staff_Chaos.ogg', 200, 0)
+	playsound(user, 'sound/magic/Staff_Change.ogg', 200, 0)
 	A.telegraph()
 	storm_cooldown = world.time + 200
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -174,7 +174,7 @@ Difficulty: Medium
 		A.target_z = user.z
 		A.telegraph_duration = 100
 		A.end_duration = 100
-		A.telegraph()
+
 	user.visible_message("<span class='warning'>[user] holds [src] skywards as red lightning crackles into the sky!</span>", \
 	"<span class='notice'>You hold [src] skyward, calling down a terrible storm!</span>")
 	playsound(user, 'sound/magic/Staff_Change.ogg', 200, 0)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -151,10 +151,12 @@ Difficulty: Medium
 		user << "<span class='warning'>You can't seem to control the weather here!</span>"
 		return
 
+	var/area/user_area = get_area(user)
+
 	var/datum/weather/ash_storm/A
 	for(var/V in SSweather.existing_weather)
 		var/datum/weather/W = V
-		if(W.name == "ash storm")
+		if(W.area_type == user_area.type)
 			A = W
 			break
 	if(!A)
@@ -166,15 +168,18 @@ Difficulty: Medium
 			user << "<span class='warning'>The storm is already ending! It would be a waste to use the staff now.</span>"
 			return
 		user.visible_message("<span class='warning'>[user] holds [src] skywards as an orange beam travels into the sky!</span>", \
-		"<span class='notice'>You hold [src] skyward, dispelling the ash storm!</span>")
+		"<span class='notice'>You hold [src] skyward, dispelling the storm!</span>")
 		playsound(user, 'sound/magic/Staff_Change.ogg', 200, 0)
 		A.wind_down()
 	else
 		user.visible_message("<span class='warning'>[user] holds [src] skywards as red lightning crackles into the sky!</span>", \
 		"<span class='notice'>You hold [src] skyward, calling down a terrible storm!</span>")
 		playsound(user, 'sound/magic/Staff_Chaos.ogg', 200, 0)
+		if(user.z != ZLEVEL_LAVALAND)
+			A.target_z = user.z
+			A.area_type = user_area.type
 		A.telegraph()
 
-	storm_cooldown = world.time + 600
+	storm_cooldown = world.time + 200
 
 #undef MEDAL_PREFIX

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -141,45 +141,40 @@ Difficulty: Medium
 	force = 25
 	damtype = BURN
 	hitsound = 'sound/weapons/sear.ogg'
+	var/storm_type = /datum/weather/ash_storm
 	var/storm_cooldown = 0
 
 /obj/item/weapon/staff/storm/attack_self(mob/user)
 	if(storm_cooldown > world.time)
 		user << "<span class='warning'>The staff is still recharging!</span>"
 		return
-	if(user.z != ZLEVEL_LAVALAND)
-		user << "<span class='warning'>You can't seem to control the weather here!</span>"
-		return
 
 	var/area/user_area = get_area(user)
-
-	var/datum/weather/ash_storm/A
+	var/datum/weather/A
 	for(var/V in SSweather.existing_weather)
 		var/datum/weather/W = V
-		if(W.area_type == user_area.type)
+		if(W.target_z == user.z && W.area_type == user_area.type)
 			A = W
 			break
-	if(!A)
-		user << "<span class='warning'>How odd! The planet seems to have lost its atmosphere!</span>"
-		return
+	if(A)
 
-	if(A.stage != END_STAGE)
-		if(A.stage == WIND_DOWN_STAGE)
-			user << "<span class='warning'>The storm is already ending! It would be a waste to use the staff now.</span>"
-			return
-		user.visible_message("<span class='warning'>[user] holds [src] skywards as an orange beam travels into the sky!</span>", \
-		"<span class='notice'>You hold [src] skyward, dispelling the storm!</span>")
-		playsound(user, 'sound/magic/Staff_Change.ogg', 200, 0)
-		A.wind_down()
+		if(A.stage != END_STAGE)
+			if(A.stage == WIND_DOWN_STAGE)
+				user << "<span class='warning'>The storm is already ending! It would be a waste to use the staff now.</span>"
+				return
+			user.visible_message("<span class='warning'>[user] holds [src] skywards as an orange beam travels into the sky!</span>", \
+			"<span class='notice'>You hold [src] skyward, dispelling the storm!</span>")
+			playsound(user, 'sound/magic/Staff_Change.ogg', 200, 0)
+			A.wind_down()
 	else
-		user.visible_message("<span class='warning'>[user] holds [src] skywards as red lightning crackles into the sky!</span>", \
-		"<span class='notice'>You hold [src] skyward, calling down a terrible storm!</span>")
-		playsound(user, 'sound/magic/Staff_Chaos.ogg', 200, 0)
-		if(user.z != ZLEVEL_LAVALAND)
-			A.target_z = user.z
-			A.area_type = user_area.type
+		A = new storm_type
+		A.area_type = user_area.type
+		A.target_z = user.z
 		A.telegraph()
-
+	user.visible_message("<span class='warning'>[user] holds [src] skywards as red lightning crackles into the sky!</span>", \
+	"<span class='notice'>You hold [src] skyward, calling down a terrible storm!</span>")
+	playsound(user, 'sound/magic/Staff_Chaos.ogg', 200, 0)
+	A.telegraph()
 	storm_cooldown = world.time + 200
 
 #undef MEDAL_PREFIX


### PR DESCRIPTION
If you're not on lavaland, you can instead summon localized ash storms by room/area

The staff can now be edited to summon any kind of storm, just in case we ever have a distant future in which more of them are sprited/coded

:cl: Kor
add: The Staff of Storms, dropped by Legion, can now be used on station.
/:cl:
