### PR TITLE
Toggling alert level toggles security/peacekeeper borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -162,7 +162,7 @@
 	return ..()
 
 
-/mob/living/silicon/robot/proc/pick_module()
+/mob/living/silicon/robot/proc/pick_module(override = null)
 	if(module)
 		return
 
@@ -172,7 +172,10 @@
 	if(!config.forbid_secborg)
 		modulelist += "Security"
 
-	designation = input("Please, select a module!", "Robot", null, null) in modulelist
+	if(override)
+		designation = override
+	else
+		designation = input("Please, select a module!", "Robot", null, null) in modulelist
 	var/animation_length = 0
 
 	if(module)
@@ -1311,3 +1314,16 @@
 			locked = 1
 		notify_ai(1)
 		. = 1
+
+
+/mob/living/silicon/robot/proc/security_level(security_level = SEC_LEVEL_GREEN)
+	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA)
+		if(designation == "Peacekeeper")
+			var/obj/item/borg/upgrade/reset/re = new
+			re.action(src)
+			pick_module("Security")
+	else
+		if(designation == "Security")
+			var/obj/item/borg/upgrade/reset/re = new
+			re.action(src)
+			pick_module("Peacekeeper")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -160,7 +160,7 @@
 /proc/CheckMedal(medal,client/player)
 
 	if(!player || !medal)
-		return
+		return 0
 	if(global.medal_hub && global.medal_pass && global.medals_enabled)
 
 		var/result = world.GetMedal(medal, player, global.medal_hub, global.medal_pass)
@@ -171,6 +171,8 @@
 			message_admins("Error! Failed to contact hub to get [medal] medal for [player.ckey]!")
 		else if (result)
 			player << "[medal] is unlocked"
+			return 1
+	return 0
 
 /proc/LockMedal(medal,client/player)
 

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -42,11 +42,6 @@
 					minor_announce(config.alert_desc_red_downto, "Attention! Code red!")
 				security_level = SEC_LEVEL_RED
 
-				/*	- At the time of commit, setting status displays didn't work properly
-				var/obj/machinery/computer/communications/CC = locate(/obj/machinery/computer/communications,world)
-				if(CC)
-					CC.post_status("alert", "redalert")*/
-
 				for(var/obj/machinery/firealarm/FA in machines)
 					if(FA.z == ZLEVEL_STATION)
 						FA.update_icon()
@@ -60,6 +55,8 @@
 						FA.update_icon()
 				for(var/obj/machinery/computer/shuttle/pod/pod in machines)
 					pod.admin_controlled = 0
+		for(var/mob/living/silicon/robot/R in living_mob_list)
+			R.security_level(level)
 	else
 		return
 


### PR DESCRIPTION
As in, peacekeeper borgs transform into sec borgs at red/delta, and secborgs change back at blue/green.

This is probably a bad idea that won't get past the test merge stage but that guy who added catgirls suggested something similar and I thought it'd be fun to code if nothing else.

Also the idea of security cyborgs turning into useless eggs mid chase amuses me.

Red alert probably needs some sort of downside so it isn't a no brainer to declare FNR though
