### PR TITLE
[Ready]Makes space wind great again!

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -209,7 +209,7 @@
 	verb_exclaim = "roars"
 	verb_yell = "bellows"
 	force_threshold = 10
-	pressure_resistance = 40
+	pressure_resistance = 50
 	mob_size = MOB_SIZE_LARGE
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	see_in_dark = 8

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -98,7 +98,7 @@ Class Procs:
 	icon = 'icons/obj/stationobjs.dmi'
 	verb_say = "beeps"
 	verb_yell = "blares"
-	pressure_resistance = 10
+	pressure_resistance = 15
 	var/stat = 0
 	var/emagged = 0
 	var/use_power = 1

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -25,7 +25,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	var/w_class = 3
 	var/slot_flags = 0		//This is used to determine on which slots an item can fit.
 	pass_flags = PASSTABLE
-	pressure_resistance = 3
+	pressure_resistance = 4
 	var/obj/item/master = null
 
 	var/heat_protection = 0 //flags which determine which body parts are protected from heat. Use the HEAD, CHEST, GROIN, etc. flags. See setup.dm

--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -9,7 +9,7 @@
 	throw_range = 1
 	throw_speed = 1
 	layer = MOB_LAYER
-	pressure_resistance = 1
+	pressure_resistance = 2
 
 /obj/item/documents/nanotrasen
 	desc = "\"Top Secret\" Nanotrasen documents, filled with complex diagrams and lists of names, dates and coordinates."

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -246,16 +246,22 @@
 	for(var/atom/movable/M in src)
 		M.experience_pressure_difference(pressure_difference, pressure_direction)
 
-/atom/movable/var/pressure_resistance = 5
+/atom/movable/var/pressure_resistance = 10
 /atom/movable/var/last_high_pressure_movement_air_cycle = 0
-/atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
+
+/atom/movable/proc/experience_pressure_difference(pressure_difference, direction, pressure_resistance_prob_delta = 0)
 	set waitfor = 0
 	. = 0
-	if(!anchored && !pulledby)
+	if (!anchored && !pulledby)
 		. = 1
-		if(pressure_difference > pressure_resistance && last_high_pressure_movement_air_cycle < SSair.times_fired)
-			last_high_pressure_movement_air_cycle = SSair.times_fired
-			step(src, direction)
+		if (last_high_pressure_movement_air_cycle < SSair.times_fired)
+			var/move_prob = 100
+			if (pressure_resistance > 0)
+				move_prob = pressure_difference/pressure_resistance*50
+			move_prob += pressure_resistance_prob_delta
+			if (prob(move_prob))
+				step(src, direction)
+				last_high_pressure_movement_air_cycle = SSair.times_fired
 
 ///////////////////////////EXCITED GROUPS/////////////////////////////
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -1,5 +1,6 @@
 /mob/living/carbon
 	gender = MALE
+	pressure_resistance = 15
 	var/list/stomach_contents		= list()
 	var/list/internal_organs		= list()	//List of /obj/item/organ in the mob. They don't go in the contents for some reason I don't want to know.
 	var/list/internal_organs_slot	= list()	//Same as above, but stores "slot ID" - "organ" pairs for easy access.

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -3,6 +3,7 @@ var/global/default_martial_art = new/datum/martial_art
 	languages_spoken = HUMAN
 	languages_understood = HUMAN
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD,ANTAG_HUD)
+	pressure_resistance = 25
 	//Hair colour and style
 	var/hair_color = "000"
 	var/hair_style = "Bald"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -645,6 +645,33 @@ Sorry Giacom. Please don't be mad :(
 	else
 		return pick("trails_1", "trails_2")
 
+/mob/living/experience_pressure_difference(pressure_difference, direction, pressure_resistance_prob_delta = 0)
+	if (client && client.move_delay >= world.time + world.tick_lag*2)
+		pressure_resistance_prob_delta -= 30
+
+	var/list/turfs_to_check = list()
+
+	if (has_limbs)
+		var/turf/T = get_step(src, angle2dir(dir2angle(direction)+90))
+		if (T)
+			turfs_to_check += T
+
+		T = get_step(src, angle2dir(dir2angle(direction)-90))
+		if (T)
+			turfs_to_check += T
+
+		for (var/t in turfs_to_check)
+			T = t
+			if (T.density)
+				pressure_resistance_prob_delta -= 20
+				continue
+			for (var/atom/movable/AM in T)
+				if (AM.density && AM.anchored)
+					pressure_resistance_prob_delta -= 20
+					break
+
+	..(pressure_difference, direction, pressure_resistance_prob_delta)
+
 /mob/living/verb/resist()
 	set name = "Resist"
 	set category = "IC"

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -5,6 +5,7 @@
 	sight = 0
 	see_in_dark = 2
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ANTAG_HUD)
+	pressure_resistance = 10
 
 	//Health and life related vars
 	var/maxHealth = 100 //Maximum health that should be possible.

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -21,7 +21,7 @@
 	healable = 0
 	faction = list("cult")
 	flying = 1
-	pressure_resistance = 200
+	pressure_resistance = 100
 	unique_name = 1
 	AIStatus = AI_OFF //normal constructs don't have AI
 	loot = list(/obj/item/weapon/ectoplasm)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/ghost.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/ghost.dm
@@ -28,7 +28,7 @@
 	minbodytemp = 0
 	maxbodytemp = 1500
 	flying = 1
-	pressure_resistance = 200
+	pressure_resistance = 300
 	gold_core_spawnable = 0 //too spooky for science
 	var/ghost_hair_style
 	var/ghost_hair_color

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -348,6 +348,11 @@
 	..()
 	update_icon()
 
+/obj/item/weapon/paper/experience_pressure_difference(pressure_difference, direction)
+	if(last_high_pressure_movement_air_cycle < SSair.times_fired)
+		last_high_pressure_movement_air_cycle = SSair.times_fired
+		step(src, direction)
+
 /*
  * Premade paper
  */

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -348,11 +348,6 @@
 	..()
 	update_icon()
 
-/obj/item/weapon/paper/experience_pressure_difference(pressure_difference, direction)
-	if(last_high_pressure_movement_air_cycle < SSair.times_fired)
-		last_high_pressure_movement_air_cycle = SSair.times_fired
-		step(src, direction)
-
 /*
  * Premade paper
  */

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -10,7 +10,7 @@
 	mouse_opacity = 0
 	hitsound = 'sound/weapons/pierce.ogg'
 	var/hitsound_wall = ""
-	pressure_resistance = INFINITY
+
 	burn_state = LAVA_PROOF
 	var/def_zone = ""	//Aiming at
 	var/mob/firer = null//Who shot it
@@ -227,3 +227,7 @@
 /obj/item/projectile/proc/dumbfire(var/dir)
 	current = get_ranged_target_turf(src, dir, world.maxx)
 	fire()
+
+
+/obj/item/projectile/experience_pressure_difference()
+	return


### PR DESCRIPTION
Space wind is now a scaling percent to move on pressure differences.
Space wind percent to move scales with pressure amount, and other modifers:
Actively moving (as in holding down a move key) reduces chance of getting moved by space wind by 30%
Having a wall or dense anchored object to your left or right (in terms of direction to be moved) will lower your chance to be moved in space wind by 20% in each direction. (so a wall on both sides is 40%) (Only applies to mob's with limbs)

:cl:
tweak: Space wind (movement from pressure differentials (like a hole to space)) has been improved.
tweak: Space wind's rate of movement now scales with pressure differential amount.
experiment: Actively moving (as in holding down a move key) reduces chance/rate of getting moved by space wind.
add: Having a wall or dense anchored object to your left or right will lower the chance/rate of getting moved by space wind for each direction (IE: a wall on both sides of you will be a double reduction)
/:cl:
