### PR TITLE
[s]Removes lag from character setup window.

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -61,21 +61,26 @@
 	if(previewJob)
 		mannequin.job = previewJob.title
 		previewJob.equip(mannequin, TRUE)
-
+	CHECK_TICK
 	preview_icon = icon('icons/effects/effects.dmi', "nothing")
 	preview_icon.Scale(48+32, 16+32)
-
+	CHECK_TICK
 	mannequin.setDir(NORTH)
+	
 	var/icon/stamp = getFlatIcon(mannequin)
+	CHECK_TICK
 	preview_icon.Blend(stamp, ICON_OVERLAY, 25, 17)
-
+	CHECK_TICK
 	mannequin.setDir(WEST)
 	stamp = getFlatIcon(mannequin)
+	CHECK_TICK
 	preview_icon.Blend(stamp, ICON_OVERLAY, 1, 9)
-
+	CHECK_TICK
 	mannequin.setDir(SOUTH)
 	stamp = getFlatIcon(mannequin)
+	CHECK_TICK
 	preview_icon.Blend(stamp, ICON_OVERLAY, 49, 1)
-
+	CHECK_TICK
 	preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
+	CHECK_TICK
 	qdel(mannequin)


### PR DESCRIPTION
Ok, this doesn't remove it fully, but it does reduce it decently

Security tag because of how easily spammable this is to basically halt the server.

basically getFlatIcon and Blend are slow as balls. so we sleep for a tick between them unless they weren't being slow as balls.
