### PR TITLE
Fixes Photos more cheaply

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -692,7 +692,11 @@ The _flatIcons list is a cache for generated icon files.
 	var/image/copy
 	// Add the atom's icon itself, without pixel_x/y offsets.
 	if(!noIcon)
-		copy = image(icon=curicon, icon_state=curstate, layer=A.layer, dir=curdir)
+		var/icon/copyicon = icon(curicon, curstate, dir=curdir)
+		if(IsBlankIcon(copyicon))
+			curdir = SOUTH
+		copy = image(icon=curicon, icon_state=curstate, layer=A.layer)
+		copy.dir = curdir
 		copy.color = A.color
 		copy.alpha = A.alpha
 		copy.blend_mode = curblend
@@ -915,6 +919,12 @@ var/global/list/friendly_animal_types = list()
 		final_average = BlendRGB(final_average, colour, 1)
 	return final_average
 
+/proc/IsBlankIcon(icon/I)
+	for(var/y_pixel = 1 to I.Height())
+		for(var/x_pixel = 1 to I.Width())
+			if(I.GetPixel(x_pixel, y_pixel))
+				return 0
+	return 1
 
 //Interface for using DrawBox() to draw 1 pixel on a coordinate.
 //Returns the same icon specifed in the argument, but with the pixel drawn

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -258,9 +258,9 @@
 						holding = "They are holding \a [L.r_hand]"
 
 			if(!mob_detail)
-				mob_detail = "You can see [L] on the photo[L.health < 75 ? " - [L] looks hurt":""].[holding ? " [holding]":"."]. "
+				mob_detail = "You can see [L] on the photo[L.health < (0.75 * L.maxHealth) ? " - [L] looks hurt":""].[holding ? " [holding]":"."]. "
 			else
-				mob_detail += "You can also see [L] on the photo[L.health < 75 ? " - [L] looks hurt":""].[holding ? " [holding]":"."]."
+				mob_detail += "You can also see [L] on the photo[L.health < (0.75 * L.maxHealth) ? " - [L] looks hurt":""].[holding ? " [holding]":"."]."
 
 
 	return mob_detail


### PR DESCRIPTION
Cheaper alternative to #19427. Still has an extra icon operation per getflaticon, but no more expensive blend procs.

I'm thinking about caching whether an icon-icon_state combo is missing cardinal or diagonal icon state, but that is going to take me some more time to put together.

Unmergeable until #19499 is merged.
