### PR TITLE
Alternative solution to ghost whisper problem

### DIFF
--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -61,7 +61,7 @@
 
 	var/rendered
 
-	rendered = "<span class='game say'><span class='name'>[src.name]</span> whispers something in their final breath.</span>"
+	rendered = "<span class='game say'><span class='name'>[src.name]</span> whispers something...</span>"
 	for(var/mob/M in watching)
 		M.show_message(rendered, 2)
 

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -61,7 +61,7 @@
 
 	var/rendered
 
-	rendered = "<span class='game say'><span class='name'>[src.name]</span> whispers something...</span>"
+	rendered = "<span class='game say'><span class='name'>[src.name]</span> whispers something.</span>"
 	for(var/mob/M in watching)
 		M.show_message(rendered, 2)
 

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -42,7 +42,6 @@
 		var/message_len = length(message)
 		message = copytext(message, 1, health_diff) + "[message_len > health_diff ? "-.." : "..."]"
 		message = Ellipsis(message, 10, 1)
-		whispers = "whispers in their final breath"
 
 	message = treat_message(message)
 
@@ -60,12 +59,13 @@
 	watching  -= eavesdropping
 
 	var/rendered
-
-	rendered = "<span class='game say'><span class='name'>[src.name]</span> whispers something.</span>"
+	whispers = critical ? "whispers something in their final breath." : "whispers something."
+	rendered = "<span class='game say'><span class='name'>[src.name]</span> [whispers]</span>"
 	for(var/mob/M in watching)
 		M.show_message(rendered, 2)
 
 	var/spans = list(SPAN_ITALICS)
+	whispers = critical ? "whispers in their final breath" : "whispers"
 	rendered = "<span class='game say'><span class='name'>[GetVoice()]</span>[alt_name] [whispers], <span class='message'>\"[attach_spans(message, spans)]\"</span></span>"
 
 	for(var/atom/movable/AM in listening)


### PR DESCRIPTION
I """fixed"""" this in a previous PR but I really caused another bug because this code is quality stuff.

What was happening was that the variable [whispers] was set to the value "whispers in their final breath" and then this string is used in the various distances when a mob hears someone death whisper.  However, the original problem arose when one of the distances had bad grammar of "Greytide mcasshole whispers in their final breath something..." instead of "Greytide mcasshole whispers something in their final breath" which is what I changed the string to and cut out the variable.  Well it turns out, that if you aren't death whispering, the variable is ignored and for a certain distance away, you'll get the same string but without the variable converting itself to a string. 

UPDATE: Antur coded a check in or something and now this works perfectly and fixes all the whisper grammar forever. YAYYY
