### PR TITLE
[ready]Adds lazy airlock cycle pair system

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -5279,6 +5279,7 @@
 /area/security/brig)
 "akW" = (
 /obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 2;
 	id_tag = "innerbrig";
 	name = "Brig";
 	req_access_txt = "63"
@@ -5294,6 +5295,7 @@
 /area/security/brig)
 "akX" = (
 /obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 2;
 	id_tag = "innerbrig";
 	name = "Brig";
 	req_access_txt = "63"
@@ -5440,8 +5442,10 @@
 /area/shuttle/labor)
 "aln" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
+	req_access_txt = "2";
+	shuttledocked = 1
 	},
 /turf/open/floor/plating,
 /area/security/processing)
@@ -5964,6 +5968,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
 	name = "Solar Maintenance";
 	req_access = null;
 	req_access_txt = "10; 13"
@@ -6236,6 +6241,7 @@
 "amW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 1;
 	id_tag = "outerbrig";
 	name = "Brig";
 	req_access_txt = "63"
@@ -6247,6 +6253,7 @@
 "amX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 1;
 	id_tag = "outerbrig";
 	name = "Brig";
 	req_access_txt = "63"
@@ -6524,6 +6531,7 @@
 /area/maintenance/fsmaint)
 "anE" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -6587,7 +6595,9 @@
 /area/shuttle/labor)
 "anN" = (
 /obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock"
+	cyclelinkeddir = 4;
+	name = "Labor Camp Shuttle Airlock";
+	shuttledocked = 1
 	},
 /turf/open/floor/plating,
 /area/security/processing)
@@ -7823,6 +7833,7 @@
 /area/space)
 "aqJ" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
 	name = "External Access";
 	req_access = null;
 	req_access_txt = "13"
@@ -9050,7 +9061,9 @@
 /area/maintenance/electrical)
 "atI" = (
 /obj/machinery/door/airlock/external{
-	name = "Escape Pod One"
+	cyclelinkeddir = 2;
+	name = "Escape Pod One";
+	shuttledocked = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -9651,6 +9664,7 @@
 /area/maintenance/fpmaint2)
 "avd" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -19153,6 +19167,7 @@
 /area/hallway/secondary/exit)
 "aQF" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Security Escape Airlock";
 	req_access_txt = "2"
 	},
@@ -20150,6 +20165,7 @@
 /area/hallway/secondary/exit)
 "aTn" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Escape Airlock"
 	},
 /obj/structure/sign/securearea{
@@ -20164,6 +20180,7 @@
 /area/hallway/secondary/exit)
 "aTo" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
 	name = "Escape Airlock"
 	},
 /turf/open/floor/plating,
@@ -21632,6 +21649,7 @@
 	d2 = 4
 	},
 /obj/machinery/door/airlock/glass_command{
+	crit_fail = 4;
 	name = "Bridge";
 	req_access_txt = "19"
 	},
@@ -21654,6 +21672,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_command{
+	cyclelinkeddir = 8;
 	name = "Bridge";
 	req_access_txt = "19"
 	},
@@ -21868,6 +21887,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_command{
+	cyclelinkeddir = 4;
 	name = "Bridge";
 	req_access_txt = "19"
 	},
@@ -21905,6 +21925,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/door/airlock/glass_command{
+	cyclelinkeddir = 8;
 	name = "Bridge";
 	req_access_txt = "19"
 	},
@@ -22122,6 +22143,7 @@
 /area/shuttle/syndicate)
 "aXI" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	id_tag = null;
 	name = "Port Docking Bay 2";
 	req_access_txt = "0"
@@ -24507,6 +24529,7 @@
 /area/hallway/secondary/exit)
 "bdA" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Cargo Escape Airlock"
 	},
 /turf/open/floor/plating,
@@ -25060,6 +25083,7 @@
 /area/hallway/secondary/exit)
 "beK" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
 	name = "Port Docking Bay 4";
 	req_access_txt = "0"
 	},
@@ -25067,6 +25091,7 @@
 /area/hallway/secondary/entry)
 "beL" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
 	name = "Port Docking Bay 3";
 	req_access_txt = "0"
 	},
@@ -28273,6 +28298,7 @@
 /area/maintenance/asmaint2)
 "blP" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
@@ -31162,6 +31188,7 @@
 /area/maintenance/asmaint2)
 "brJ" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Supply Dock Airlock";
 	req_access_txt = "31"
 	},
@@ -39616,9 +39643,11 @@
 /area/toxins/test_area)
 "bJb" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Mining Dock Airlock";
 	req_access = null;
-	req_access_txt = "48"
+	req_access_txt = "48";
+	shuttledocked = 1
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
@@ -39648,6 +39677,7 @@
 /area/shuttle/labor)
 "bJd" = (
 /obj/machinery/door/airlock/glass_mining{
+	cyclelinkeddir = 8;
 	name = "Mining Dock";
 	req_access_txt = "48"
 	},
@@ -46283,6 +46313,7 @@
 /area/maintenance/asmaint2)
 "bXv" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "External Access";
 	req_access = null;
 	req_access_txt = "13"
@@ -47487,6 +47518,7 @@
 /area/tcommsat/server)
 "cal" = (
 /obj/machinery/door/airlock/glass_engineering{
+	cyclelinkeddir = 4;
 	name = "Server Room";
 	req_access_txt = "61"
 	},
@@ -47517,6 +47549,7 @@
 /area/tcommsat/server)
 "can" = (
 /obj/machinery/door/airlock/glass_engineering{
+	cyclelinkeddir = 8;
 	name = "Server Room";
 	req_access_txt = "61"
 	},
@@ -50160,6 +50193,7 @@
 /area/engine/engineering)
 "cfM" = (
 /obj/machinery/door/airlock/engineering{
+	cyclelinkeddir = 2;
 	name = "Engine Room";
 	req_access_txt = "10"
 	},
@@ -50701,6 +50735,7 @@
 /area/engine/chiefs_office)
 "cgT" = (
 /obj/machinery/door/airlock/engineering{
+	cyclelinkeddir = 8;
 	name = "SMES Room";
 	req_access_txt = "32"
 	},
@@ -50797,6 +50832,7 @@
 /area/atmos)
 "che" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Atmospherics External Airlock";
 	req_access_txt = "24"
 	},
@@ -51157,6 +51193,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Solar Maintenance";
 	req_access = null;
 	req_access_txt = "10; 13"
@@ -52078,6 +52115,7 @@
 /area/engine/engineering)
 "cjR" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
 	name = "Engineering External Access";
 	req_access = null;
 	req_access_txt = "10;13"
@@ -52163,6 +52201,7 @@
 	name = "test chamber blast door"
 	},
 /obj/machinery/door/airlock/glass_research{
+	cyclelinkeddir = 4;
 	name = "Test Chamber";
 	req_access_txt = "47"
 	},
@@ -52464,6 +52503,7 @@
 /area/toxins/misc_lab)
 "ckN" = (
 /obj/machinery/door/airlock/glass_research{
+	cyclelinkeddir = 8;
 	name = "Test Chamber";
 	req_access_txt = "47"
 	},
@@ -53535,6 +53575,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
 	name = "Solar Maintenance";
 	req_access = null;
 	req_access_txt = "10; 13"
@@ -54284,6 +54325,7 @@
 /area/engine/engine_smes)
 "coB" = (
 /obj/machinery/door/airlock/engineering{
+	cyclelinkeddir = 4;
 	name = "SMES Room";
 	req_access_txt = "32"
 	},
@@ -54840,6 +54882,7 @@
 /area/shuttle/syndicate)
 "cpI" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Escape Pod Four";
 	req_access = null;
 	req_access_txt = "0"
@@ -55261,6 +55304,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
 	name = "Engineering External Access";
 	req_access = null;
 	req_access_txt = "10;13"
@@ -55954,6 +55998,7 @@
 /area/engine/engineering)
 "csg" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
 	name = "Engineering External Access";
 	req_access = null;
 	req_access_txt = "10;13"
@@ -56292,6 +56337,7 @@
 /area/solar/starboard)
 "cta" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "MiniSat External Access";
 	req_access = null;
 	req_access_txt = "65;13"
@@ -58660,11 +58706,13 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "cxJ" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s9";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
+	name = "Escape Pod Three";
+	req_access_txt = "0"
 	},
-/area/shuttle/transport)
+/turf/open/floor/plating,
+/area/security/main)
 "cxK" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock"
@@ -58685,12 +58733,13 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "cxN" = (
-/obj/machinery/status_display,
-/turf/closed/wall/shuttle{
-	icon_state = "swall14";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2"
 	},
-/area/shuttle/escape)
+/turf/open/floor/plating,
+/area/security/processing)
 "cxO" = (
 /obj/machinery/door/airlock/glass{
 	name = "Emergency Shuttle Infirmary"
@@ -58698,11 +58747,19 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "cxP" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall11";
-	dir = 2
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/shuttle/escape)
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "Solar Maintenance";
+	req_access = null;
+	req_access_txt = "10; 13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/auxsolarstarboard)
 "cxQ" = (
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
@@ -58743,11 +58800,12 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "cxW" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s5";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "Labor Camp Shuttle Airlock"
 	},
-/area/shuttle/escape)
+/turf/open/floor/plating,
+/area/security/processing)
 "cxX" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -58756,24 +58814,34 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "cxY" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s9";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
+	name = "External Access";
+	req_access = null;
+	req_access_txt = "13"
 	},
-/area/shuttle/escape)
+/turf/open/floor/plating,
+/area/maintenance/fsmaint2)
 "cxZ" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "cya" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/shuttle/abandoned)
-"cyb" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s10";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "External Access";
+	req_access = null;
+	req_access_txt = "13"
 	},
-/area/shuttle/abandoned)
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2)
+"cyb" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fpmaint)
 "cyc" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
@@ -58816,17 +58884,20 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 "cyg" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall13";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "Escape Pod One"
 	},
-/area/shuttle/abandoned)
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "cyh" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall11";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "Security Escape Airlock";
+	req_access_txt = "2"
 	},
-/area/shuttle/abandoned)
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "cyi" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
@@ -58841,11 +58912,14 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "cyl" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall3";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	id_tag = null;
+	name = "Port Docking Bay 2";
+	req_access_txt = "0"
 	},
-/area/shuttle/abandoned)
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "cym" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion";
@@ -58868,11 +58942,12 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 "cyp" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall15";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
+	name = "Escape Airlock"
 	},
-/area/shuttle/abandoned)
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "cyq" = (
 /obj/machinery/computer/pod{
 	id = "oldship_gun"
@@ -58880,23 +58955,31 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "cyr" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall7";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "Cargo Escape Airlock"
 	},
-/area/shuttle/abandoned)
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "cys" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/supply)
 "cyt" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/shuttle/supply)
-"cyu" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s10";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "Port Docking Bay 4";
+	req_access_txt = "0"
 	},
-/area/shuttle/supply)
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"cyu" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "Port Docking Bay 3";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "cyv" = (
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
@@ -58933,22 +59016,29 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "cyC" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall3";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	req_access_txt = "13"
 	},
-/area/shuttle/supply)
+/turf/open/floor/plating,
+/area/maintenance/asmaint2)
 "cyD" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f12"
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "Supply Dock Airlock";
+	req_access_txt = "31"
 	},
-/area/shuttle/abandoned)
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "cyE" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall14";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Access";
+	req_access = null;
+	req_access_txt = "13"
 	},
-/area/shuttle/abandoned)
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "cyF" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion_r";
@@ -58957,10 +59047,13 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 "cyG" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f17"
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "Atmospherics External Airlock";
+	req_access_txt = "24"
 	},
-/area/shuttle/abandoned)
+/turf/open/floor/plating,
+/area/atmos)
 "cyH" = (
 /obj/machinery/door/airlock/shuttle,
 /turf/open/floor/plating,
@@ -58982,10 +59075,19 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "cyK" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f14"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/shuttle/abandoned)
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "Solar Maintenance";
+	req_access = null;
+	req_access_txt = "10; 13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/portsolar)
 "cyL" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -58999,10 +59101,14 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cyM" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f11"
+/obj/machinery/door/airlock/engineering{
+	cyclelinkeddir = 1;
+	name = "Engine Room";
+	req_access_txt = "10"
 	},
-/area/shuttle/abandoned)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cyN" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -59074,10 +59180,20 @@
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "cyU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "Solar Maintenance";
+	req_access = null;
+	req_access_txt = "10; 13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboardsolar)
 "cyV" = (
 /obj/machinery/door/window,
 /turf/open/floor/mineral/titanium/purple,
@@ -59140,17 +59256,29 @@
 /turf/closed/wall/mineral/titanium/interior,
 /area/shuttle/supply)
 "czg" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall7";
-	dir = 2
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "Escape Pod Four";
+	req_access = null;
+	req_access_txt = "0";
+	shuttledocked = 1
 	},
-/area/shuttle/supply)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "czh" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall12";
-	dir = 2
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/shuttle/abandoned)
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "czi" = (
 /obj/machinery/door/airlock/shuttle,
 /turf/open/floor/plasteel/shuttle/white,
@@ -59160,10 +59288,14 @@
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/abandoned)
 "czk" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f13"
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "MiniSat External Access";
+	req_access = null;
+	req_access_txt = "65;13"
 	},
-/area/shuttle/abandoned)
+/turf/open/floor/plating,
+/area/turret_protected/aisat_interior)
 "czl" = (
 /obj/machinery/door/window/northright,
 /obj/effect/decal/remains/human,
@@ -70195,7 +70327,7 @@ cpL
 asG
 atI
 auP
-atI
+cyg
 awV
 ayl
 azy
@@ -70224,7 +70356,7 @@ awZ
 ayl
 beK
 auP
-beK
+cyt
 cyd
 cyi
 cyi
@@ -71223,7 +71355,7 @@ czK
 asJ
 atI
 auP
-avQ
+cyg
 awV
 ayl
 ayl
@@ -72023,7 +72155,7 @@ awZ
 ayl
 beL
 auP
-beL
+cyu
 cye
 cyi
 cyq
@@ -72505,7 +72637,7 @@ aaa
 aag
 aqJ
 amC
-aqJ
+cya
 aAY
 aub
 auV
@@ -72786,7 +72918,7 @@ aRZ
 asE
 aAF
 awW
-aXI
+cyl
 awW
 baF
 asE
@@ -78712,9 +78844,9 @@ blW
 blW
 blW
 bqi
-brJ
+cyD
 blW
-brJ
+cyD
 bvS
 blW
 aaa
@@ -79520,7 +79652,7 @@ bCq
 bCq
 cfx
 cfx
-chO
+cyK
 cfx
 cfx
 aaa
@@ -80280,7 +80412,7 @@ bTs
 bCq
 bVy
 bLv
-bXv
+cyE
 bLv
 bLv
 bCq
@@ -80552,7 +80684,7 @@ chS
 cfw
 cfw
 bCq
-clB
+bXv
 bCq
 aaa
 aaa
@@ -81066,7 +81198,7 @@ chU
 bHE
 bLu
 bCq
-clB
+cyE
 bCq
 aaa
 aaa
@@ -83301,7 +83433,7 @@ aaa
 arP
 arP
 arP
-avd
+cyb
 avZ
 axt
 ayG
@@ -84317,11 +84449,11 @@ aiT
 aiT
 aiV
 akG
-aln
+cxN
 aiU
 amK
 aiU
-anN
+cxW
 aoq
 aiV
 aiT
@@ -87243,7 +87375,7 @@ ckH
 ckH
 cqA
 cqT
-cqA
+czh
 crJ
 crU
 csb
@@ -91858,7 +91990,7 @@ cfM
 cco
 cdp
 cel
-cfM
+cyM
 ckT
 cgU
 cfC
@@ -91869,7 +92001,7 @@ ciV
 ckH
 cqA
 cre
-cqA
+czh
 crM
 crV
 csf
@@ -93921,7 +94053,7 @@ clW
 bOh
 cig
 cig
-cpI
+czg
 cig
 cig
 crh
@@ -94843,7 +94975,7 @@ abp
 abp
 adR
 abp
-afo
+cxJ
 abp
 adR
 ahl
@@ -96224,7 +96356,7 @@ bPj
 bOh
 apQ
 bLK
-che
+cyG
 bLK
 aoV
 aoV
@@ -98557,7 +98689,7 @@ aaf
 csD
 csO
 csD
-cta
+czk
 cti
 cua
 cua
@@ -100258,7 +100390,7 @@ aaa
 aaa
 aaa
 aag
-aqv
+cxY
 anf
 aqv
 anf
@@ -101796,7 +101928,7 @@ alg
 alN
 amv
 ane
-amv
+cxP
 aog
 aoM
 apz
@@ -110310,7 +110442,7 @@ aNa
 aNa
 aNa
 aNa
-aTo
+cyp
 aNa
 bdA
 aNa
@@ -110575,7 +110707,7 @@ aaf
 aaf
 aaf
 bky
-blP
+cyC
 bns
 boF
 bqe
@@ -110624,7 +110756,7 @@ clx
 cmv
 cnk
 cnK
-cnk
+cyU
 cpi
 cpi
 cpi
@@ -111587,7 +111719,7 @@ aaa
 aaa
 aaa
 aNa
-aQF
+cyh
 aRW
 aTo
 aNa
@@ -111597,7 +111729,7 @@ aaa
 aNa
 aTo
 aRW
-bdA
+cyr
 aNa
 aaa
 aaa
@@ -112669,7 +112801,7 @@ aaa
 aaa
 aaf
 bky
-blP
+cyC
 bky
 aaf
 aaf

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -2723,6 +2723,7 @@
 /area/ai_monitored/storage/eva)
 "afP" = (
 /obj/machinery/door/airlock/command{
+	cyclelinkeddir = 2;
 	name = "Command Tool Storage";
 	req_access = null;
 	req_access_txt = "19"
@@ -26224,6 +26225,7 @@
 	})
 "bhB" = (
 /obj/machinery/door/airlock/research{
+	cyclelinkeddir = 2;
 	name = "Research Division Access";
 	req_access_txt = "47"
 	},
@@ -28356,6 +28358,7 @@
 /area/quartermaster/storage)
 "blX" = (
 /obj/machinery/door/airlock/research{
+	cyclelinkeddir = 1;
 	name = "Research Division Access";
 	req_access_txt = "47"
 	},
@@ -58686,15 +58689,13 @@
 	},
 /area/shuttle/transport)
 "cxG" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 4
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
+	name = "Escape Pod Three";
+	req_access_txt = "0"
 	},
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s5";
-	dir = 2
-	},
-/area/shuttle/transport)
+/turf/open/floor/plating,
+/area/security/main)
 "cxH" = (
 /obj/structure/closet/crate,
 /turf/open/floor/mineral/titanium/blue,
@@ -58707,12 +58708,12 @@
 /area/shuttle/transport)
 "cxJ" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
-	name = "Escape Pod Three";
-	req_access_txt = "0"
+	cyclelinkeddir = 8;
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2"
 	},
 /turf/open/floor/plating,
-/area/security/main)
+/area/security/processing)
 "cxK" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock"
@@ -58733,20 +58734,6 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "cxN" = (
-/obj/machinery/door/airlock/external{
-	cyclelinkeddir = 8;
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/security/processing)
-"cxO" = (
-/obj/machinery/door/airlock/glass{
-	name = "Emergency Shuttle Infirmary"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"cxP" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -58760,6 +58747,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/auxsolarstarboard)
+"cxO" = (
+/obj/machinery/door/airlock/glass{
+	name = "Emergency Shuttle Infirmary"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"cxP" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "Labor Camp Shuttle Airlock"
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "cxQ" = (
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
@@ -58801,11 +58801,13 @@
 /area/shuttle/escape)
 "cxW" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 8;
-	name = "Labor Camp Shuttle Airlock"
+	cyclelinkeddir = 2;
+	name = "External Access";
+	req_access = null;
+	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
-/area/security/processing)
+/area/maintenance/fsmaint2)
 "cxX" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -58815,19 +58817,6 @@
 /area/shuttle/escape)
 "cxY" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 2;
-	name = "External Access";
-	req_access = null;
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fsmaint2)
-"cxZ" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/open/floor/plating/airless,
-/area/shuttle/escape)
-"cya" = (
-/obj/machinery/door/airlock/external{
 	cyclelinkeddir = 1;
 	name = "External Access";
 	req_access = null;
@@ -58835,13 +58824,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fpmaint2)
-"cyb" = (
+"cxZ" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"cya" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 8;
 	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fpmaint)
+"cyb" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "Escape Pod One"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "cyc" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
@@ -58884,12 +58884,14 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 "cyg" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/command{
 	cyclelinkeddir = 1;
-	name = "Escape Pod One"
+	name = "Command Tool Storage";
+	req_access = null;
+	req_access_txt = "19"
 	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/turf/open/floor/plasteel/black,
+/area/ai_monitored/storage/eva)
 "cyh" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 8;
@@ -70327,7 +70329,7 @@ cpL
 asG
 atI
 auP
-cyg
+cyb
 awV
 ayl
 azy
@@ -71355,7 +71357,7 @@ czK
 asJ
 atI
 auP
-cyg
+cyb
 awV
 ayl
 ayl
@@ -72637,7 +72639,7 @@ aaa
 aag
 aqJ
 amC
-cya
+cxY
 aAY
 aub
 auV
@@ -83433,7 +83435,7 @@ aaa
 arP
 arP
 arP
-cyb
+cya
 avZ
 axt
 ayG
@@ -84449,11 +84451,11 @@ aiT
 aiT
 aiV
 akG
-cxN
+cxJ
 aiU
 amK
 aiU
-cxW
+cxP
 aoq
 aiV
 aiT
@@ -88840,7 +88842,7 @@ azW
 afP
 aFb
 aEZ
-afP
+cyg
 aJp
 aKE
 aMa
@@ -94975,7 +94977,7 @@ abp
 abp
 adR
 abp
-cxJ
+cxG
 abp
 adR
 ahl
@@ -100390,7 +100392,7 @@ aaa
 aaa
 aaa
 aag
-cxY
+cxW
 anf
 aqv
 anf
@@ -101928,7 +101930,7 @@ alg
 alN
 amv
 ane
-cxP
+cxN
 aog
 aoM
 apz

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -67,6 +67,9 @@ var/list/airlock_overlays = list()
 	var/image/old_weld_overlay
 	var/image/old_sparks_overlay
 
+	var/cyclelinkeddir = 0
+	var/obj/machinery/door/airlock/cyclelinkedairlock
+
 	explosion_block = 1
 
 /obj/machinery/door/airlock/New()
@@ -81,6 +84,32 @@ var/list/airlock_overlays = list()
 	if(glass)
 		airlock_material = "glass"
 	update_icon()
+	if(map_ready)
+		initialize()
+
+/obj/machinery/door/airlock/initialize()
+	. = ..()
+	if (cyclelinkeddir)
+		cyclelinkairlock()
+
+/obj/machinery/door/airlock/proc/cyclelinkairlock()
+	if (!cyclelinkeddir)
+		return
+	var/limit = world.view
+	var/turf/T = get_turf(src)
+	var/obj/machinery/door/airlock/FoundDoor
+	do
+		T = get_step(T, cyclelinkeddir)
+		FoundDoor = locate() in T
+		if (FoundDoor && FoundDoor.cyclelinkeddir != get_dir(FoundDoor, src))
+			FoundDoor = null
+		limit--
+	while(!FoundDoor && limit)
+	if (!FoundDoor)
+		return
+	FoundDoor.cyclelinkedairlock = src
+	cyclelinkedairlock = FoundDoor
+
 
 /obj/machinery/door/airlock/lock()
 	bolt()
@@ -129,6 +158,10 @@ var/list/airlock_overlays = list()
 /obj/machinery/door/airlock/Destroy()
 	qdel(wires)
 	wires = null
+	if (cyclelinkedairlock)
+		if (cyclelinkedairlock.cyclelinkedairlock == src)
+			cyclelinkedairlock.cyclelinkedairlock = null
+		cyclelinkedairlock = null
 	if(id_tag)
 		for(var/obj/machinery/doorButtons/D in machines)
 			D.removeMe(src)
@@ -150,7 +183,11 @@ var/list/airlock_overlays = list()
 			user.staminaloss += 50
 			user.stunned += 5
 			return
+	if (cyclelinkedairlock)
+		if (!emergency && allowed(user))
+			addtimer(cyclelinkedairlock, "close", 0)
 	..()
+
 
 /obj/machinery/door/airlock/proc/isElectrified()
 	if(src.secondsElectrified != 0)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -193,7 +193,7 @@ var/list/airlock_overlays = list()
 			return
 	if (cyclelinkedairlock)
 		if (!shuttledocked && !emergency && !cyclelinkedairlock.shuttledocked && !cyclelinkedairlock.emergency && allowed(user))
-			addtimer(cyclelinkedairlock, "close", 0)
+			addtimer(cyclelinkedairlock, "close", ( cyclelinkedairlock.operating ? 2 : 0 ))
 	..()
 
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -69,6 +69,7 @@ var/list/airlock_overlays = list()
 
 	var/cyclelinkeddir = 0
 	var/obj/machinery/door/airlock/cyclelinkedairlock
+	var/shuttledocked = 0
 
 	explosion_block = 1
 
@@ -84,8 +85,6 @@ var/list/airlock_overlays = list()
 	if(glass)
 		airlock_material = "glass"
 	update_icon()
-	if(map_ready)
-		initialize()
 
 /obj/machinery/door/airlock/initialize()
 	. = ..()
@@ -93,6 +92,9 @@ var/list/airlock_overlays = list()
 		cyclelinkairlock()
 
 /obj/machinery/door/airlock/proc/cyclelinkairlock()
+	if (cyclelinkedairlock)
+		cyclelinkedairlock.cyclelinkedairlock = null
+		cyclelinkedairlock = null
 	if (!cyclelinkeddir)
 		return
 	var/limit = world.view
@@ -109,6 +111,12 @@ var/list/airlock_overlays = list()
 		return
 	FoundDoor.cyclelinkedairlock = src
 	cyclelinkedairlock = FoundDoor
+
+/obj/machinery/door/airlock/on_varedit(varname)
+	. = ..()
+	switch (varname)
+		if ("cyclelinkeddir")
+			cyclelinkairlock()
 
 
 /obj/machinery/door/airlock/lock()
@@ -184,7 +192,7 @@ var/list/airlock_overlays = list()
 			user.stunned += 5
 			return
 	if (cyclelinkedairlock)
-		if (!emergency && allowed(user))
+		if (!shuttledocked && !emergency && !cyclelinkedairlock.shuttledocked && !cyclelinkedairlock.emergency && allowed(user))
 			addtimer(cyclelinkedairlock, "close", 0)
 	..()
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -21,6 +21,14 @@
 	for(var/obj/machinery/door/D in orange(1, src))
 		addtimer(src, "close", 0, TRUE)
 
+/obj/machinery/door/airlock/onShuttleMove()
+	shuttledocked = 0
+	for(var/obj/machinery/door/airlock/A in orange(1, src))
+		A.shuttledocked = 0
+	. = ..()
+	shuttledocked =  1
+	for(var/obj/machinery/door/airlock/A in orange(1, src))
+		A.shuttledocked = 1
 /mob/onShuttleMove()
 	if(!move_on_shuttle)
 		return 0


### PR DESCRIPTION
When bump opening one of the pair, the other will attempt to close. Opening will not wait on the close or require a successful close.

This system is disabled when emergency access is enabled on the door (~~todo, make it check both doors~~)

~~No map example because map merger is broke for me. (YAY PYTHON, fucking idiots)~~

Added to every paired up airlock set on box station (including the one going to brig, bridge, engine room)

todo:

Add a way to set the direction via airlock electronics.
~~Add a system to detect when shuttles are docked to bypass.~~ done.

https://tgstation13.org/msoshit/2016-07-26-0834-14.webm

:cl:
add: Added Lazy airlock cycling. Bump opening an airlock with this system will close its partner. This system has been added to most airlocks that go to space on boxstation, as well as airlocks to secure areas like brig, bridge, engine.
tweak: This can be overridden by click opening, having a shuttle docked, or setting emergency mode on one of the doors.
/:cl:
