### PR TITLE
Fixes borgs losing ash storm protection when reset.

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -49,7 +49,6 @@
 	R.speed = 0 // Remove upgrades.
 	R.ionpulse = FALSE
 	R.magpulse = FALSE
-	R.weather_immunities = initial(R.weather_immunities)
 
 	R.status_flags |= CANPUSH
 


### PR DESCRIPTION
Fixes #19525 
So what does initial actually work for? I swear it breaks on everything.
