### PR TITLE
Sad Trombone implant is now buildable!

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -287,7 +287,7 @@
 	build_path = /obj/item/weapon/implantcase
 	category = list("Medical Designs")
 
-/datum/design/implantcase
+/datum/design/implant_sadtrombone
 	name = "Sad Trombone Implant Case"
 	desc = "Makes death amusing."
 	id = "implant_trombone"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -287,6 +287,16 @@
 	build_path = /obj/item/weapon/implantcase
 	category = list("Medical Designs")
 
+/datum/design/implantcase
+	name = "Sad Trombone Implant Case"
+	desc = "Makes death amusing."
+	id = "implant_trombone"
+	req_tech = list("materials" = 2, "biotech" = 3, "programming" = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_GLASS = 500, MAT_BANANIUM = 500)
+	build_path = /obj/item/weapon/implantcase/sad_trombone
+	category = list("Medical Designs")
+
 /datum/design/implant_freedom
 	name = "Freedom Implant Case"
 	desc = "A glass case containing an implant."


### PR DESCRIPTION
:cl: Gun Hog
add: In an effort to reduce the demoralizing effects that accompany the death of a crew member, Nanotrasen has provided the prototype designs for the Sad Trombone implant. It can be fabricated at your station's protolathe, if you manage to secure the ever elusive Bananium ore.
/:cl:

You may now construct the Sad Trombone implant in Science. Easy tech requirements, but requires Bananium (because it is a clown item).
