### PR TITLE
Makes toolboxes great again

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -4,11 +4,11 @@
 	icon_state = "red"
 	item_state = "toolbox_red"
 	flags = CONDUCT
-	force = 10
+	force = 15
 	throwforce = 10
 	throw_speed = 2
 	throw_range = 7
-	w_class = 4
+	w_class = 3
 	materials = list(MAT_METAL = 500)
 	origin_tech = "combat=1;engineering=1"
 	attack_verb = list("robusted")


### PR DESCRIPTION
Forum suggested: https://tgstation13.org/phpBB/viewtopic.php?f=9&t=7376

:cl: 
tweak: Toolboxes have been restored to their former glory. They now fit in backpacks and do 15 force.
/:cl:

Toolboxes now fit in your backpack, and do 15 brute.
Fire extinguishers do 15 brute and they also fit in your backpack, and are more common.
You can already hold all your tools in a cardboard box in your backpack anyways.
