### PR TITLE
Makes saltpetre more cost efficient 

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -619,7 +619,7 @@
 		adjustHealth(round(salt * 0.25))
 		if (myseed)
 			myseed.adjust_production(-round(salt/100)-prob(salt%100))
-			myseed.adjust_potency(round(salt*0.15))
+			myseed.adjust_potency(round(salt*0.30))
 	// Ash is also used IRL in gardening, as a fertilizer enhancer and weed killer
 	if(S.has_reagent("ash", 1))
 		adjustHealth(round(S.get_reagent_amount("ash") * 0.25))


### PR DESCRIPTION
Saltpetre is meant to be an alternative of mutagen. Whereas with mutagen, dropping 1-2u of of it onto a plant can easily get it to 100 potency but very high production speed. Saltpetre is a more expensive but it can increase potency to 100 and lower production speed at the same time. This will make it so it requires nearly 180 units for 50-100 and around 320 for 0 - 100
