### PR TITLE
Removed Amber ERT's thermals

### DIFF
--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -28,7 +28,7 @@
 
 	id = /obj/item/weapon/card/id/ert
 	suit = /obj/item/clothing/suit/space/hardsuit/ert
-	glasses = /obj/item/clothing/glasses/thermal/eyepatch
+	
 	back = /obj/item/weapon/storage/backpack/captain
 	belt = /obj/item/weapon/storage/belt/security/full
 	backpack_contents = list(/obj/item/weapon/storage/box/engineer=1,\
@@ -42,7 +42,7 @@
 
 	if(visualsOnly)
 		return
-
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	var/obj/item/device/radio/R = H.ears
 	R.keyslot = new /obj/item/device/encryptionkey/heads/captain
 	R.recalculateChannels()
@@ -50,6 +50,7 @@
 /datum/outfit/ert/commander/alert
 	name = "ERT Commander - High Alert"
 
+	glasses = /obj/item/clothing/glasses/thermal/eyepatch
 	backpack_contents = list(/obj/item/weapon/storage/box/engineer=1,\
 		/obj/item/weapon/melee/baton/loaded=1,\
 		/obj/item/clothing/mask/gas/sechailer/swat=1,\

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -28,7 +28,7 @@
 
 	id = /obj/item/weapon/card/id/ert
 	suit = /obj/item/clothing/suit/space/hardsuit/ert
-	
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	back = /obj/item/weapon/storage/backpack/captain
 	belt = /obj/item/weapon/storage/belt/security/full
 	backpack_contents = list(/obj/item/weapon/storage/box/engineer=1,\
@@ -42,7 +42,6 @@
 
 	if(visualsOnly)
 		return
-	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	var/obj/item/device/radio/R = H.ears
 	R.keyslot = new /obj/item/device/encryptionkey/heads/captain
 	R.recalculateChannels()


### PR DESCRIPTION
Takes away the Amber ERT commander's thermals and gives them ordinary HUDglasses.

Code Red still has them, send those guys if you want to ruin an antag's day. 

:cl: Robustin
del: Amber ERT Commanders no longer have thermal goggles 
/:cl:
