### PR TITLE
Vanguard now only stuns for 25% of the absorbed stuns, from 50%

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -223,10 +223,10 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 
 
 
-/datum/clockwork_scripture/vanguard //Vanguard: Provides twenty seconds of stun immunity. At the end of the twenty seconds, 50% of all stuns absorbed are applied to the invoker.
+/datum/clockwork_scripture/vanguard //Vanguard: Provides twenty seconds of stun immunity. At the end of the twenty seconds, 25% of all stuns absorbed are applied to the invoker.
 	descname = "Self Stun Immunity"
 	name = "Vanguard"
-	desc = "Provides twenty seconds of stun immunity. At the end of the twenty seconds, the invoker is stunned for the equivalent of 50% of all stuns they absorbed. \
+	desc = "Provides twenty seconds of stun immunity. At the end of the twenty seconds, the invoker is stunned for the equivalent of 25% of all stuns they absorbed. \
 	Excessive absorption will cause unconsciousness."
 	invocations = list("Shield me...", "...from darkness!")
 	channel_time = 30
@@ -251,7 +251,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 		var/vanguard = invoker.stun_absorption["vanguard"]
 		var/stuns_blocked = 0
 		if(vanguard)
-			stuns_blocked = min(vanguard["stuns_absorbed"] * 0.5, 20)
+			stuns_blocked = min(vanguard["stuns_absorbed"] * 0.25, 20)
 		if(invoker.stat != DEAD)
 			var/message_to_invoker = "<span class='warning'>You feel your Vanguard quietly fade...</span>"
 			var/otheractiveabsorptions = FALSE


### PR DESCRIPTION
:cl: Joan
tweak: Vanguard now only stuns for 25% of absorbed stuns, from 50%.
/:cl:

This is still frankly a shitton of time given just how many stuns you can absorb but hey, buff if you don't get stunned 50 times.
