### PR TITLE
Soul Vessels can now be used similarly to soulstones

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -900,6 +900,7 @@
 	dead_message = "<span class='deadsay'>Its cogwheel, scratched and dented, lies motionless.</span>"
 	fluff_names = list("Servant")
 	clockwork = TRUE
+	autoping = FALSE
 
 /obj/item/device/mmi/posibrain/soul_vessel/New()
 	..()
@@ -914,6 +915,52 @@
 		user << "<span class='warning'>You fiddle around with [src], to no avail.</span>"
 		return 0
 	..()
+
+/obj/item/device/mmi/posibrain/soul_vessel/attack(mob/living/target, mob/living/carbon/human/user)
+	if(!is_servant_of_ratvar(user) || !ishuman(target) || used || (brainmob && brainmob.key))
+		..()
+	if(is_servant_of_ratvar(target))
+		user << "<span class='heavy_alloy'>\"It would be more wise to revive your allies, friend.\"</span>"
+		return
+	var/mob/living/carbon/human/H = target
+	var/obj/item/bodypart/head/HE = H.get_bodypart("head")
+	var/obj/item/organ/brain/B = H.getorgan(/obj/item/organ/brain)
+	if(!HE)
+		user << "<span class='warning'>[H] has no head, and thus no mind!</span>"
+		return
+	if(H.stat == CONSCIOUS)
+		user << "<span class='warning'>[H] must be dead or unconscious to claim their mind!</span>"
+		return
+	if(H.head)
+		var/obj/item/I = H.head
+		if(I.flags_inv & HIDEHAIR)
+			user << "<span class='warning'>[H]'s head is covered, remove [H.head] first!</span>"
+			return
+	if(H.wear_mask)
+		var/obj/item/I = H.wear_mask
+		if(I.flags_inv & HIDEHAIR)
+			user << "<span class='warning'>[H]'s head is covered, remove [H.wear_mask] first!</span>"
+			return
+	if(!B)
+		user << "<span class='warning'>[H] has no brain, and thus no mind to claim!</span>"
+		return
+	if(!H.key)
+		user << "<span class='warning'>[H] has no mind to claim!</span>"
+		return
+	playsound(H, 'sound/misc/splort.ogg', 60, 1, -1)
+	playsound(H, 'sound/magic/clockwork/anima_fragment_attack.ogg', 40, 1, -1)
+	H.status_flags |= FAKEDEATH //we want to make sure they don't deathgasp and maybe possibly explode
+	H.death()
+	H.status_flags &= ~FAKEDEATH
+	brainmob.name = H.real_name
+	brainmob.real_name = H.real_name
+	brainmob.timeofhostdeath = H.timeofdeath
+	user.visible_message("<span class='warning'>[user] presses [src] to [H]'s head, ripping through the skull and carefully extracting the brain!</span>", \
+	"<span class='brass'>You extract [H]'s consciousness from their body, trapping it in the soul vessel.</span>")
+	transfer_personality(H)
+	B.Remove(H)
+	qdel(B)
+	H.update_hair()
 
 /obj/item/clockwork/daemon_shell
 	name = "daemon shell"

--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -883,7 +883,9 @@
 
 /obj/item/device/mmi/posibrain/soul_vessel //Soul vessel: An ancient positronic brain with a lawset catered to serving Ratvar.
 	name = "soul vessel"
-	desc = "A heavy brass cube with a single protruding cogwheel."
+	desc = "A heavy brass cube, three inches to a side, with a single protruding cogwheel."
+	var/clockwork_desc = "A soul vessel, an ancient relic that can attract the souls of the damned or simply rip a mind from an unconscious or dead human.\n\
+	<span class='brass'>If active, can serve as a positronic brain, placable in cyborg shells or clockwork construct shells.</span>"
 	icon = 'icons/obj/clockwork_objects.dmi'
 	icon_state = "soul_vessel"
 	req_access = list()
@@ -909,6 +911,13 @@
 /obj/item/device/mmi/posibrain/soul_vessel/Destroy()
 	all_clockwork_objects -= src
 	return ..()
+
+/obj/item/device/mmi/posibrain/soul_vessel/examine(mob/user)
+	if((is_servant_of_ratvar(user) || isobserver(user)) && clockwork_desc)
+		desc = clockwork_desc
+	..()
+	desc = initial(desc)
+
 
 /obj/item/device/mmi/posibrain/soul_vessel/attack_self(mob/living/user)
 	if(!is_servant_of_ratvar(user))

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -708,7 +708,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	whispered = TRUE
 	object_path = /obj/item/device/mmi/posibrain/soul_vessel
 	creator_message = "<span class='brass'>You form a soul vessel, which can be used in-hand to attract spirits, or used on an unconscious or dead human to extract their consciousness.</span>"
-	usage_tip = "The vessel can be used in-hand, to draw in random spirits, or on an unconscious or dead human to extract their consciousness."
+	usage_tip = "The vessel can be used as a teleport target for Spatial Gateway, though it is generally better-used by placing it in a shell."
 	tier = SCRIPTURE_SCRIPT
 
 

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -707,8 +707,8 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	consumed_components = list("vanguard_cogwheel" = 1, "guvax_capacitor" = 1)
 	whispered = TRUE
 	object_path = /obj/item/device/mmi/posibrain/soul_vessel
-	creator_message = "<span class='brass'>You form a soul vessel, which immediately begins drawing in the damned.</span>"
-	usage_tip = "The vessel functions as a servant for tier unlocking but not for invocation."
+	creator_message = "<span class='brass'>You form a soul vessel, which can be used in-hand to attract spirits, or used on an unconscious or dead human to extract their consciousness.</span>"
+	usage_tip = "The vessel can be used in-hand, to draw in random spirits, or on an unconscious or dead human to extract their consciousness."
 	tier = SCRIPTURE_SCRIPT
 
 

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -14,6 +14,7 @@ var/global/posibrain_notif_cooldown = 0
 	req_access = list(access_robotics)
 	mecha = null//This does not appear to be used outside of reference in mecha.dm.
 	braintype = "Android"
+	var/autoping = TRUE //if it pings on creation immediately
 	var/begin_activation_message = "<span class='notice'>You carefully locate the manual activation switch and start the positronic brain's boot process.</span>"
 	var/success_message = "<span class='notice'>The positronic brain pings, and its lights start flashing. Success!</span>"
 	var/fail_message = "<span class='notice'>The positronic brain buzzes quietly, and the golden lights fade away. Perhaps you could try again?</span>"
@@ -148,7 +149,8 @@ var/global/posibrain_notif_cooldown = 0
 	brainmob.real_name = brainmob.name
 	brainmob.loc = src
 	brainmob.container = src
-	ping_ghosts("created", TRUE)
+	if(autoping)
+		ping_ghosts("created", TRUE)
 	..()
 
 


### PR DESCRIPTION
:cl: Joan
rscadd: Soul Vessels can now be used on unconscious or dead humans to extract their consciousness, much like a soulstone.
tweak: Soul Vessels no longer automatically ping ghosts when created, though they can still be used in-hand to ping ghosts.
/:cl:
