### PR TITLE
Replaces tcomms bus in metastation tcomms storage with circuit

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -53303,7 +53303,7 @@
 /area/bridge)
 "bOg" = (
 /obj/structure/rack,
-/obj/machinery/telecomms/bus,
+/obj/item/weapon/circuitboard/machine/telecomms/bus,
 /obj/item/weapon/circuitboard/machine/telecomms/broadcaster,
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;


### PR DESCRIPTION
Not sure why there was a bus machine in there.
@Metacide was that intentional?
