### PR TITLE
Modern violence/fix#19596

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -175,13 +175,13 @@
 		updateUsrDialog()
 	else if(href_list["remove"])
 		if(copy)
-			remove_photocopy(copy)
+			remove_photocopy(copy, usr)
 			copy = null
 		else if(photocopy)
-			remove_photocopy(photocopy)
+			remove_photocopy(photocopy, usr)
 			photocopy = null
 		else if(doccopy)
-			remove_photocopy(doccopy)
+			remove_photocopy(doccopy, usr)
 			doccopy = null
 		else if(check_ass())
 			ass << "<span class='notice'>You feel a slight pressure on your ass.</span>"
@@ -256,7 +256,7 @@
 				if(!user.drop_item())
 					return
 				copy = O
-				do_insertion(O)
+				do_insertion(O, user)
 		else
 			user << "<span class='warning'>There is already something in [src]!</span>"
 
@@ -265,7 +265,7 @@
 			if(!user.drop_item())
 				return
 			photocopy = O
-			do_insertion(O)
+			do_insertion(O, user)
 		else
 			user << "<span class='warning'>There is already something in [src]!</span>"
 
@@ -274,7 +274,7 @@
 			if(!user.drop_item())
 				return
 			doccopy = O
-			do_insertion(O)
+			do_insertion(O, user)
 		else
 			user << "<span class='warning'>There is already something in [src]!</span>"
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -84,6 +84,7 @@
 							c.info += "</font>"
 							c.name = copy.name
 							c.fields = copy.fields
+							c.update_icon()
 							c.updateinfolinks()
 							toner--
 					busy = 1

--- a/html/changelogs/ModernViolence-fix#19596.yml
+++ b/html/changelogs/ModernViolence-fix#19596.yml
@@ -1,0 +1,4 @@
+author: "ModernViolence"
+delete-after: True
+changes: 
+  - bugfix: "Photocopier fixes: proper sprites for not empty copies; removing originals now does not delete them"


### PR DESCRIPTION
:cl: Fix #19596 
fix: Fixed taking originals out of photocopier.
fix: Fixed sprite for new copies of not empty papers.
:cl:

Testing done:
1. Copying papers, photos, employment contracts works properly.
*Copies of employment contracts have correct path - _/obj/item/weapon/paper
/contract/employment_ and correct contents.
2. Taking out originals works properly for humans and silicons (for silicons the original must not be put in their hands).
3. Insertion of papers, photos, employment contracts.
