### PR TITLE
Hyper-kinetics now have splash damage

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -96,6 +96,13 @@
 	if(colour)
 		color = colour
 
+/obj/effect/overlay/temp/kinetic_blast
+	name = "kinetic explosion"
+	icon = 'icons/obj/projectiles.dmi'
+	icon_state = "kinetic_blast"
+	layer = ABOVE_ALL_MOB_LAYER
+	duration = 4
+
 /obj/effect/overlay/temp/explosion
 	name = "explosion"
 	icon = 'icons/effects/96x96.dmi'

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -79,7 +79,7 @@
 	target.apply_damage(force * fisto_setting, BRUTE)
 	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as they punch [target.name]!</span>", \
 		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
-	PoolOrNew(/obj/effect/kinetic_blast, target.loc)
+	PoolOrNew(/obj/effect/overlay/temp/kinetic_blast, target.loc)
 	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
 	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -134,15 +134,15 @@
 	desc = "An upgraded, superior version of the proto-kinetic accelerator."
 	icon_state = "kineticgun_u"
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/super)
-	overheat_time = 15
+	overheat_time = 14
 	origin_tech = "materials=5;powerstorage=3;engineering=4;magnets=3;combat=3"
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/hyper
 	name = "hyper-kinetic accelerator"
-	desc = "An upgraded, even more superior version of the proto-kinetic accelerator."
+	desc = "A high-power upgraded version of the proto-kinetic accelerator. It affects a much larger area than the standard accelerator at the cost of firing much slower."
 	icon_state = "kineticgun_h"
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/hyper)
-	overheat_time = 14
+	overheat_time = 16
 	origin_tech = "materials=6;powerstorage=4;engineering=4;magnets=4;combat=4"
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -167,7 +167,7 @@
 		target_turf = get_turf(src)
 	PoolOrNew(/obj/effect/overlay/temp/explosion, target_turf)
 	for(var/turf/T in range(1, target_turf))
-		if(istype(T, /turf/closed/mineral))
+		if(istype(T, /turf/closed/mineral) && T != target)
 			var/turf/closed/mineral/M = T
 			M.gets_drilled(firer)
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -166,17 +166,16 @@
 	if(!target_turf)
 		target_turf = get_turf(src)
 	PoolOrNew(/obj/effect/overlay/temp/explosion, target_turf)
-	for(var/T in RANGE_TURFS(1, target_turf))
-		if(istype(T, /turf/closed/mineral) && T != target)
+	for(var/T in RANGE_TURFS(1, target_turf) - target)
+		if(istype(T, /turf/closed/mineral))
 			var/turf/closed/mineral/M = T
 			M.gets_drilled(firer)
 
-	for(var/mob/living/L in range(1, target_turf))
-		if(L != firer)
-			var/armor = L.run_armor_check(def_zone, flag, "", "", armour_penetration)
-			L.apply_damage(damage*0.5, damage_type, def_zone, armor)
-			if(L != target)
-				L << "<span class='userdanger'>You're struck by a [name]!</span>"
+	for(var/mob/living/L in range(1, target_turf) - firer)
+		var/armor = L.run_armor_check(def_zone, flag, "", "", armour_penetration)
+		L.apply_damage(damage*0.5, damage_type, def_zone, armor)
+		if(L != target)
+			L << "<span class='userdanger'>You're struck by a [name]!</span>"
 
 /obj/item/projectile/kinetic/hyper/on_range()
 	aoe_blast()

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -166,7 +166,7 @@
 	if(!target_turf)
 		target_turf = get_turf(src)
 	PoolOrNew(/obj/effect/overlay/temp/explosion, target_turf)
-	for(var/turf/T in range(1, target_turf))
+	for(var/T in RANGE_TURFS(1, target_turf))
 		if(istype(T, /turf/closed/mineral) && T != target)
 			var/turf/closed/mineral/M = T
 			M.gets_drilled(firer)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -128,16 +128,10 @@
 	damage_type = BRUTE
 	flag = "bomb"
 	range = 3
-	var/splash = 0
 
 /obj/item/projectile/kinetic/super
 	damage = 11
 	range = 4
-
-/obj/item/projectile/kinetic/hyper
-	damage = 12
-	range = 5
-	splash = 1
 
 /obj/item/projectile/kinetic/New()
 	var/turf/proj_turf = get_turf(src)
@@ -146,12 +140,12 @@
 	var/datum/gas_mixture/environment = proj_turf.return_air()
 	var/pressure = environment.return_pressure()
 	if(pressure < 50)
-		name = "full strength kinetic force"
+		name = "full strength [name]"
 		damage *= 4
 	..()
 
 /obj/item/projectile/kinetic/on_range()
-	new /obj/effect/kinetic_blast(src.loc)
+	PoolOrNew(/obj/effect/overlay/temp/kinetic_blast, loc)
 	..()
 
 /obj/item/projectile/kinetic/on_hit(atom/target)
@@ -160,23 +154,37 @@
 	if(istype(target_turf, /turf/closed/mineral))
 		var/turf/closed/mineral/M = target_turf
 		M.gets_drilled(firer)
-	new /obj/effect/kinetic_blast(target_turf)
-	if(src.splash)
-		for(var/turf/T in range(splash, target_turf))
-			if(istype(T, /turf/closed/mineral))
-				var/turf/closed/mineral/M = T
-				M.gets_drilled(firer)
+	PoolOrNew(/obj/effect/overlay/temp/kinetic_blast, target_turf)
 
-
-/obj/effect/kinetic_blast
+/obj/item/projectile/kinetic/hyper
 	name = "kinetic explosion"
-	icon = 'icons/obj/projectiles.dmi'
-	icon_state = "kinetic_blast"
-	layer = ABOVE_ALL_MOB_LAYER
+	damage = 8 //33% of our damage is AOE explosion, so this is equivalent to 12
+	range = 5
 
-/obj/effect/kinetic_blast/New()
-	spawn(4)
-		qdel(src)
+/obj/item/projectile/kinetic/hyper/proc/aoe_blast(atom/target)
+	var/turf/target_turf = get_turf(target)
+	if(!target_turf)
+		target_turf = get_turf(src)
+	PoolOrNew(/obj/effect/overlay/temp/explosion, target_turf)
+	for(var/turf/T in range(1, target_turf))
+		if(istype(T, /turf/closed/mineral))
+			var/turf/closed/mineral/M = T
+			M.gets_drilled(firer)
+
+	for(var/mob/living/L in range(1, target_turf))
+		if(L != firer)
+			var/armor = L.run_armor_check(def_zone, flag, "", "", armour_penetration)
+			L.apply_damage(damage*0.5, damage_type, def_zone, armor)
+			if(L != target)
+				L << "<span class='userdanger'>You're struck by a [name]!</span>"
+
+/obj/item/projectile/kinetic/hyper/on_range()
+	aoe_blast()
+	..()
+
+/obj/item/projectile/kinetic/hyper/on_hit(atom/target)
+	aoe_blast(target)
+	. = ..()
 
 /obj/item/projectile/beam/wormhole
 	name = "bluespace beam"


### PR DESCRIPTION
:cl: Joan
rscadd: Hyper-kinetic accelerators now have splash damage, which is 33% of its normal damage and will not hit the firer, but only fire as fast as a normal kinetic accelerator.
tweak: Super-kinetic accelerators fire like a tenth of a second faster.
bugfix: Hyper-kinetic shots that directly strike gibtonite will no longer cause it to explode.
/:cl:
