### PR TITLE
Plasma cutters have double range in low pressure

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -231,8 +231,9 @@
 	if(environment)
 		var/pressure = environment.return_pressure()
 		if(pressure < 60)
-			name = "full strength plasma blast"
+			name = "full strength [name]"
 			damage *= 4
+			range *= 2
 	..()
 
 /obj/item/projectile/plasma/on_hit(atom/target)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -221,7 +221,7 @@
 	icon_state = "plasmacutter"
 	damage_type = BRUTE
 	damage = 5
-	range = 5
+	range = 3.5 //works as 4, but doubles to 7
 
 /obj/item/projectile/plasma/New()
 	var/turf/proj_turf = get_turf(src)
@@ -247,11 +247,11 @@
 
 /obj/item/projectile/plasma/adv
 	damage = 7
-	range = 7
+	range = 5
 
 /obj/item/projectile/plasma/adv/mech
 	damage = 10
-	range = 8
+	range = 6
 
 
 /obj/item/projectile/gravityrepulse


### PR DESCRIPTION
:cl: Joan
add: Plasma cutters(normal, advanced, and mech) now have double range in low pressure areas, but slightly lower range in high pressure areas.
/:cl:

Or in other words a standard cutter goes through 7 tiles of rock on lavaland, 4 otherwise, advanced goes through 10, 5 otherwise, and mech goes through 12, 6 otherwise.
Basically, super good for making single-tile tunnels.
