### PR TITLE
Bubblegum will no longer blood warp directly on top of a target

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -169,17 +169,25 @@ Difficulty: Hard
 
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_warp()
-	var/found_bloodpool = FALSE
+	var/obj/effect/decal/cleanable/blood/found_bloodpool
+	var/list/pools = list()
+	var/can_jaunt = FALSE
 	for(var/obj/effect/decal/cleanable/blood/nearby in view(src,2))
-		found_bloodpool = TRUE
+		can_jaunt = TRUE
+		break
+	if(!can_jaunt)
+		return
+	for(var/obj/effect/decal/cleanable/blood/nearby in oview(get_turf(target),2))
+		pools += nearby
+	if(pools.len)
+		shuffle(pools)
+		found_bloodpool = pick(pools)
 	if(found_bloodpool)
-		for(var/obj/effect/decal/cleanable/blood/H in view(target,2))
-			visible_message("<span class='danger'>[src] sinks into the blood...</span>")
-			playsound(get_turf(src), 'sound/magic/enter_blood.ogg', 100, 1, -1)
-			forceMove(get_turf(H))
-			playsound(get_turf(src), 'sound/magic/exit_blood.ogg', 100, 1, -1)
-			visible_message("<span class='danger'>And springs back out!</span>")
-			break
+		visible_message("<span class='danger'>[src] sinks into the blood...</span>")
+		playsound(get_turf(src), 'sound/magic/enter_blood.ogg', 100, 1, -1)
+		forceMove(get_turf(found_bloodpool))
+		playsound(get_turf(src), 'sound/magic/exit_blood.ogg', 100, 1, -1)
+		visible_message("<span class='danger'>And springs back out!</span>")
 
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_spray()


### PR DESCRIPTION
Actually a buff; most of the time when it blood jaunts, it'll immediately charge, and jaunting on top of someone would cause that to miss.
