### PR TITLE
Cult balance pass

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -358,7 +358,7 @@
 
 	else
 		C << "<span class='danger'>The veil cannot be torn here!</span>"
-	/*
+
 /obj/item/device/flashlight/flare/culttorch
 	name = "void torch"
 	desc = "Used by veteran cultists to instantly transport items to their needful bretheren."
@@ -372,16 +372,28 @@
 	on = 1
 	var/charges = 3
 	
-/obj/item/device/flashlight/flare/culttorch(atom/movable/A, mob/user, proximity)
+/obj/item/device/flashlight/flare/culttorch
+	name = "void torch"
+	desc = "Used by veteran cultists to instantly transport items to their needful bretheren."
+	w_class = 2
+	brightness_on = 1
+	icon_state = "torch-on"
+	item_state = "torch-on"
+	color = "#ff0000"
+	on_damage = 15
+	slot_flags = null
+	on = 1
+	var/charges = 3
+
+/obj/item/device/flashlight/flare/culttorch/afterattack(atom/movable/A, mob/user, proximity)
 	if(!proximity)
 		return
 
-	if(istype(A, obj/item))
-			
-		var/mob/living/user = invokers[1]
+	if(istype(A, /obj/item))
+
 		var/list/cultists = list()
 		for(var/datum/mind/M in ticker.mode.cult)
-			if(!(M.current in invokers) && M.current && M.current.stat != DEAD)
+			if(!(user) && M.current && M.current.stat != DEAD)
 				cultists |= M.current
 		var/mob/living/cultist_to_receive = input(user, "Who do you wish to call to [src]?", "Followers of the Geometer") as null|anything in cultists
 		if(!Adjacent(user) || !src || qdeleted(src) || user.incapacitated())
@@ -398,14 +410,15 @@
 			user << "<span class='cultitalic'>[cultist_to_receive] is not a follower of the Geometer!</span>"
 			log_game("Void torch failed - target was deconverted")
 			return
-		user << "<span class='cultitalic'>You ignite [A] with \the [src], turning it to ash, but through the torch's flames you see that [A] has reached [cultist_to_receive]!")
+		user << "<span class='cultitalic'>You ignite [A] with \the [src], turning it to ash, but through the torch's flames you see that [A] has reached [cultist_to_receive]!"
 		user << "\The [src] now has [charges] charge\s."
 		cultist_to_receive.put_in_hands(A)
 		charges--
 		if(charges == 0)
 			qdel(src)
+
 	else
+		..()
 		user << "<span class='warning'>\The [src] can only transport items!</span>"
-return
-*/
+		return
 

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -358,3 +358,54 @@
 
 	else
 		C << "<span class='danger'>The veil cannot be torn here!</span>"
+	/*
+/obj/item/device/flashlight/flare/culttorch
+	name = "void torch"
+	desc = "Used by veteran cultists to instantly transport items to their needful bretheren."
+	w_class = 2
+	brightness_on = 1
+	icon_state = "torch-on"
+	item_state = "torch-on"
+	color = "#ff0000"
+	on_damage = 15
+	slot_flags = null
+	on = 1
+	var/charges = 3
+	
+/obj/item/device/flashlight/flare/culttorch(atom/movable/A, mob/user, proximity)
+	if(!proximity)
+		return
+
+	if(istype(A, obj/item))
+			
+		var/mob/living/user = invokers[1]
+		var/list/cultists = list()
+		for(var/datum/mind/M in ticker.mode.cult)
+			if(!(M.current in invokers) && M.current && M.current.stat != DEAD)
+				cultists |= M.current
+		var/mob/living/cultist_to_receive = input(user, "Who do you wish to call to [src]?", "Followers of the Geometer") as null|anything in cultists
+		if(!Adjacent(user) || !src || qdeleted(src) || user.incapacitated())
+			return
+		if(!cultist_to_receive)
+			user << "<span class='cultitalic'>You require a destination!</span>"
+			log_game("Void torch failed - no target")
+			return
+		if(cultist_to_receive.stat == DEAD)
+			user << "<span class='cultitalic'>[cultist_to_receive] has died!</span>"
+			log_game("Void torch failed  - target died")
+			return
+		if(!iscultist(cultist_to_receive))
+			user << "<span class='cultitalic'>[cultist_to_receive] is not a follower of the Geometer!</span>"
+			log_game("Void torch failed - target was deconverted")
+			return
+		user << "<span class='cultitalic'>You ignite [A] with \the [src], turning it to ash, but through the torch's flames you see that [A] has reached [cultist_to_receive]!")
+		user << "\The [src] now has [charges] charge\s."
+		cultist_to_receive.put_in_hands(A)
+		charges--
+		if(charges == 0)
+			qdel(src)
+	else
+		user << "<span class='warning'>\The [src] can only transport items!</span>"
+return
+*/
+

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -371,19 +371,6 @@
 	slot_flags = null
 	on = 1
 	var/charges = 3
-	
-/obj/item/device/flashlight/flare/culttorch
-	name = "void torch"
-	desc = "Used by veteran cultists to instantly transport items to their needful bretheren."
-	w_class = 2
-	brightness_on = 1
-	icon_state = "torch-on"
-	item_state = "torch-on"
-	color = "#ff0000"
-	on_damage = 15
-	slot_flags = null
-	on = 1
-	var/charges = 3
 
 /obj/item/device/flashlight/flare/culttorch/afterattack(atom/movable/A, mob/user, proximity)
 	if(!proximity)

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -215,7 +215,7 @@
 	flags_inv = HIDEJUMPSUIT
 	allowed = list(/obj/item/weapon/tome,/obj/item/weapon/melee/cultblade)
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = -100, bullet = -100, laser = -100,energy = -100, bomb = -100, bio = -100, rad = -100)
+	armor = list(melee = -50, bullet = -50, laser = -100,energy = -50, bomb = -50, bio = -50, rad = -50)
 	slowdown = -1
 	hooded = 1
 	hoodtype = /obj/item/clothing/head/berserkerhood
@@ -227,7 +227,7 @@
 	body_parts_covered = HEAD
 	flags = NODROP
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS
-	armor = list(melee = -100, bullet = -100, laser = -100,energy = -100, bomb = -100, bio = -100, rad = -100)
+	armor = list(melee = -50, bullet = -50, laser = -50,energy = -50, bomb = -50, bio = -50, rad = -50)
 
 /obj/item/clothing/suit/hooded/cultrobes/berserker/equipped(mob/living/user, slot)
 	..()
@@ -286,7 +286,7 @@
 		user << "<span class='notice'>We have exhausted our ability to curse the shuttle.</span>"
 		return
 	if(SSshuttle.emergency.mode == SHUTTLE_CALL)
-		var/cursetime = 1500
+		var/cursetime = 1800
 		var/timer = SSshuttle.emergency.timeLeft(1) + cursetime
 		SSshuttle.emergency.setTimer(timer)
 		user << "<span class='danger'>You shatter the orb! A dark essence spirals into the air, then disappears.</span>"
@@ -295,12 +295,12 @@
 		sleep(20)
 		var/global/list/curses
 		if(!curses)
-			curses = list("A fuel technician just slit his own throat and begged for death. The shuttle will be delayed by two minutes.",
-			"The shuttle's navigation programming was replaced by a file containing two words, IT COMES. The shuttle will be delayed by two minutes.",
-			"The shuttle's custodian tore out his guts and began painting strange shapes on the floor. The shuttle will be delayed by two minutes.",
-			"A shuttle engineer began screaming 'DEATH IS NOT THE END' and ripped out wires until an arc flash seared off her flesh. The shuttle will be delayed by two minutes.",
-			"A shuttle inspector started laughing madly over the radio and then threw herself into an engine turbine. The shuttle will be delayed by two minutes.",
-			"The shuttle dispatcher was found dead with bloody symbols carved into their flesh. The shuttle will be delayed by two minutes.")
+			curses = list("A fuel technician just slit his own throat and begged for death. The shuttle will be delayed by three minutes.",
+			"The shuttle's navigation programming was replaced by a file containing two words, IT COMES. The shuttle will be delayed by three minutes.",
+			"The shuttle's custodian tore out his guts and began painting strange shapes on the floor. The shuttle will be delayed by three minutes.",
+			"A shuttle engineer began screaming 'DEATH IS NOT THE END' and ripped out wires until an arc flash seared off her flesh. The shuttle will be delayed by three minutes.",
+			"A shuttle inspector started laughing madly over the radio and then threw herself into an engine turbine. The shuttle will be delayed by three minutes.",
+			"The shuttle dispatcher was found dead with bloody symbols carved into their flesh. The shuttle will be delayed by three minutes.")
 		var/message = pick_n_take(curses)
 		priority_announce("[message]", "System Failure", 'sound/misc/notice1.ogg')
 		curselimit++
@@ -310,7 +310,7 @@
 	desc = "This relic teleports you forward a medium distance."
 	icon = 'icons/obj/cult.dmi'
 	icon_state ="shifter"
-	var/uses = 2
+	var/uses = 4
 
 /obj/item/device/cult_shift/examine(mob/user)
 	..()
@@ -333,7 +333,7 @@
 	if(!iscultist(user))
 		user.unEquip(src, 1)
 		step(src, pick(alldirs))
-		user << "<span class='warning'>\The [src] flickers out of your hands, too eager to move!</span>"
+		user << "<span class='warning'>\The [src] flickers out of your hands, your connection to this dimension is too strong!</span>"
 		return
 
 	var/mob/living/carbon/C = user

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -177,15 +177,16 @@ var/list/blacklisted_pylon_turfs = typecacheof(list(
 	if(cooldowntime > world.time)
 		user << "<span class='cultitalic'>The magic in [src] is weak, it will be ready to use again in [getETA()].</span>"
 		return
-	var/choice = alert(user,"You flip through the black pages of the archives...",,"Supply Talisman","Shuttle Curse","Veil Shifter")
+	var/choice = alert(user,"You flip through the black pages of the archives...",,"Supply Talisman","Shuttle Curse","Veil Walker Set")
 	var/pickedtype
 	switch(choice)
 		if("Supply Talisman")
 			pickedtype = /obj/item/weapon/paper/talisman/supply/weak
 		if("Shuttle Curse")
 			pickedtype = /obj/item/device/shuttle_curse
-		if("Veil Shifter")
+		if("Veil Walker Set")
 			pickedtype = /obj/item/device/cult_shift
+			pickedtype = /obj/item/device/flashlight/flare/culttorch
 	if(src && !qdeleted(src) && anchored && pickedtype && Adjacent(user) && !user.incapacitated() && iscultist(user) && cooldowntime <= world.time)
 		cooldowntime = world.time + 2400
 		var/obj/item/N = new pickedtype(get_turf(src))

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -56,6 +56,7 @@
 	dat += "Please choose the chant to be imbued into the fabric of reality.<BR>"
 	dat += "<HR>"
 	dat += "<A href='?src=\ref[src];rune=newtome'>N'ath reth sh'yro eth d'raggathnor!</A> - Summons an arcane tome, used to scribe runes and communicate with other cultists.<BR>"
+	dat += "<A href='?src=\ref[src];rune=metal'>Ar'Tee ess!</A> - Provides 5 runed metal.<BR>"
 	dat += "<A href='?src=\ref[src];rune=teleport'>Sas'so c'arta forbici!</A> - Allows you to move to a selected teleportation rune.<BR>"
 	dat += "<A href='?src=\ref[src];rune=emp'>Ta'gh fara'qha fel d'amar det!</A> - Allows you to destroy technology in a short range.<BR>"
 	dat += "<A href='?src=\ref[src];rune=runestun'>Fuu ma'jin!</A> - Allows you to stun a person by attacking them with the talisman.<BR>"
@@ -76,6 +77,8 @@
 				if("newtome")
 					var/obj/item/weapon/tome/T = new(usr)
 					usr.put_in_hands(T)
+				if("newtome")
+					new /obj/item/stack/sheet/runed_metal(get_turf(usr),5)
 				if("teleport")
 					var/obj/item/weapon/paper/talisman/teleport/T = new(usr)
 					usr.put_in_hands(T)
@@ -102,6 +105,7 @@
 				qdel(src)
 
 /obj/item/weapon/paper/talisman/supply/weak
+	dat += "<A href='?src=\ref[src];rune=metal'>Ar'Tee ess!</A> - Provides 5 runed metal.<BR>"
 	uses = 2
 
 //Rite of Translocation: Same as rune

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -77,7 +77,10 @@
 				if("newtome")
 					var/obj/item/weapon/tome/T = new(usr)
 					usr.put_in_hands(T)
-				if("newtome")
+				if("metal")
+					if(istype(src, /obj/item/weapon/paper/talisman/supply/weak))
+						usr.visible_message("<span class='cultitalic'>Lesser supply talismans lack the strength to materialize runed metal!</span>")
+						return
 					new /obj/item/stack/sheet/runed_metal(get_turf(usr),5)
 				if("teleport")
 					var/obj/item/weapon/paper/talisman/teleport/T = new(usr)
@@ -105,7 +108,7 @@
 				qdel(src)
 
 /obj/item/weapon/paper/talisman/supply/weak
-	dat += "<A href='?src=\ref[src];rune=metal'>Ar'Tee ess!</A> - Provides 5 runed metal.<BR>"
+	cultist_name = "Lesser Supply Talisman"
 	uses = 2
 
 //Rite of Translocation: Same as rune

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -138,10 +138,6 @@
 	mouse_opacity = 0
 	var/atom/linked
 
-/obj/effect/overlay/cult(mob/user)
-	if(linked)
-		linked.examine(user)
-
 /obj/effect/overlay/cult/ex_act()
 	return FALSE
 

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -134,6 +134,11 @@
 		setDir(mimiced_atom.dir)
 	animate(src, alpha = 0, time = duration)
 
+/obj/effect/overlay/cult/floor
+	icon = 'icons/turf/floors.dmi'
+	icon_state = "cult"
+	layer = TURF_LAYER
+
 /obj/effect/overlay/temp/cult
 	randomdir = 0
 	duration = 10

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -134,6 +134,23 @@
 		setDir(mimiced_atom.dir)
 	animate(src, alpha = 0, time = duration)
 
+/obj/effect/overlay/cult
+	mouse_opacity = 0
+	var/atom/linked
+
+/obj/effect/overlay/cult(mob/user)
+	if(linked)
+		linked.examine(user)
+
+/obj/effect/overlay/cult/ex_act()
+	return FALSE
+
+/obj/effect/overlay/cult/Destroy()
+	if(linked)
+		linked = null
+	..()
+	return QDEL_HINT_PUTINPOOL
+
 /obj/effect/overlay/cult/floor
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "cult"

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -224,12 +224,12 @@ var/global/list/datum/stack_recipe/cardboard_recipes = list ( \
  */
 
 var/global/list/datum/stack_recipe/runed_metal_recipes = list ( \
-	new/datum/stack_recipe("runed door", /obj/machinery/door/airlock/cult, 3, time = 50, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("runed door", /obj/machinery/door/airlock/cult, 1, time = 50, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("runed girder", /obj/structure/girder/cult, 1, time = 50, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("pylon", /obj/structure/cult/pylon, 3, time = 40, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("forge", /obj/structure/cult/forge, 5, time = 40, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("forge", /obj/structure/cult/forge, 4, time = 40, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("archives", /obj/structure/cult/tome, 2, time = 40, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("altar", /obj/structure/cult/talisman, 5, time = 40, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("altar", /obj/structure/cult/talisman, 4, time = 40, one_per_turf = 1, on_floor = 1), \
 	)
 
 /obj/item/stack/sheet/runed_metal

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -150,7 +150,27 @@
 
 /turf/open/floor/engine/cult
 	name = "engraved floor"
-	icon_state = "cult"
+	icon_state = "plating"
+	var/obj/effect/clockwork/overlay/floor/realappearence
+
+/turf/open/floor/engine/cult/New()
+	..()
+	PoolOrNew(/obj/effect/overlay/temp/cult/turf/open/floor, src)
+	realappearence = PoolOrNew(/obj/effect/overlay/cult/floor, src)
+	realappearence.linked = src
+
+/turf/open/floor/engine/cult/Destroy()
+	be_removed()
+	return ..()
+
+/turf/open/floor/engine/cult/ChangeTurf(path, defer_change = FALSE)
+	if(path != type)
+		be_removed()
+	return ..()
+
+/turf/open/floor/engine/cult/proc/be_removed()
+	qdel(realappearence)
+	realappearence = null
 
 /turf/open/floor/engine/cult/New()
 	PoolOrNew(/obj/effect/overlay/temp/cult/turf/open/floor, src)


### PR DESCRIPTION
I tested these changes myself, it is working as intended(tm). 

:cl: Robustin
add: The initial supply talisman can now be used to create runed metal, 5 per use
add: The void torch is now available from the altar, use it to transport any item instantly to any cultist! It appears alongside the veil shifter as part of the "Veil Walker" set. 
add: Cult floors no longer appear on mesons! 
tweak: Flagellant's Robes now increases damage taken by 50%, down from 100%
tweak: Veil Shifter has 4 uses, up from 2
tweak: Shuttle curse now delays shuttle 3 minutes, up from 2.5 minutes
tweak: Cult forges, archives, and airlocks have had their cost reduced by 1 runed metal each
/:cl:
