### PR TITLE
[s] Prevents Garbage Collector from freezing if minigun is spawned by itself by admins

### DIFF
--- a/code/modules/projectiles/guns/projectile/laser_gatling.dm
+++ b/code/modules/projectiles/guns/projectile/laser_gatling.dm
@@ -124,11 +124,11 @@
 	else
 		qdel(src)
 
-/obj/item/weapon/gun/projectile/minigun/shoot_live_shot(mob/living/user as mob|obj, pointblank = 0, mob/pbtarget = null, message = 1)
+/obj/item/weapon/gun/projectile/minigun/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params, zone_override)
 	if(ammo_pack)
 		if(ammo_pack.overheat < ammo_pack.overheat_max)
-			. = ..()
-			ammo_pack.overheat++
+			ammo_pack.overheat += burst_size
+			..()
 		else
 			user << "The gun's heat sensor locked the trigger to prevent lens damage."
 
@@ -141,9 +141,9 @@
 	if(!ammo_pack)
 		if(istype(loc,/obj/item/weapon/minigunpack)) //We should spawn inside a ammo pack so let's use that one.
 			ammo_pack = loc
+			..()
 		else
 			qdel(src)//No pack, no gun
-	..()
 
 /obj/item/weapon/gun/projectile/minigun/dropped(mob/living/user)
 	ammo_pack.attach_gun(user)


### PR DESCRIPTION
If you spawn the minigun (rather than the backpack), it will qdel() itself...but still run the parent. Which causes something that makes StonedMC (and by extension, the entire server) hang for 5-10 minutes while it tries to delete the minigun during the next garbage collector call.

If you want to test this on the server (bless you, you evil, evil thing), just spawn in the `/obj/item/weapon/gun/projectile/minigun` item and watch the server (local or live, your choice, really) freeze within 5 minutes.

As a bonus, also actually prevents minigun from firing when it's overheated.
