### PR TITLE
Improve ruin overlay code for tape device

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -258,7 +258,10 @@
 
 
 /obj/item/device/tape/proc/ruin()
-	add_overlay("ribbonoverlay")
+	//Lets not add infinite amounts of overlays when our fireact is called
+	//repeatedly
+	if(!ruined)
+		add_overlay("ribbonoverlay")
 	ruined = 1
 
 


### PR DESCRIPTION
This will prevent some cases where the overlay list will grow immensely huge in response to repeated fire_act calls.
