### PR TITLE
Limitied the amount of minions the Paper Wizard can summon to 9.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -31,9 +31,10 @@
 	boss_type = /mob/living/simple_animal/hostile/boss/paper_wizard
 	needs_target = FALSE
 	say_when_triggered = "Rise, my creations! Jump off your pages and into this realm!"
+	var/summoned_minions = 0
 
 /datum/action/boss/wizard_summon_minions/Trigger()
-	if(..())
+	if(summoned_minions < 9 && ..())
 		var/list/minions = list(
 		/mob/living/simple_animal/hostile/stickman,
 		/mob/living/simple_animal/hostile/stickman/ranged,
@@ -42,6 +43,7 @@
 		for(var/i in 1 to 3)
 			var/minions_chosen = pick_n_take(minions)
 			new minions_chosen (get_step(boss,pick_n_take(directions)))
+		summoned_minions += 3;
 
 
 //Mimic Ability


### PR DESCRIPTION
Fixed an issue where Paper Wizard could summon infinite minions causing it to be too overpowered with tons of stickman running around by limiting the max amount of minions it can summon to 9.
