### PR TITLE
Rapier nerf

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -32,7 +32,6 @@
 	w_class = 4
 	block_chance = 50
 	armour_penetration = 75
-	sharpness = IS_SHARP
 	origin_tech = "combat=5"
 	attack_verb = list("lunged at", "stabbed")
 	hitsound = 'sound/weapons/slash.ogg'


### PR DESCRIPTION
:cl:
del: Due to extreme expenses for Nanotrasen. The rapier is now only sharp at the tip. Testings have shown that the rapier can not remove any limbs from an assi- your target.
/:cl:

The rapier is very rediculous.
15 force
50% melee block chance
75% armor penetration
45% chance to decapitate

If anything the rapier should have lower armor penetration and we should give blunt weapons better armor penetration.
Coderbus can't into weapons well.
