### PR TITLE
WHYYY DEL WHY

### DIFF
--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -23,9 +23,11 @@
 				pitchfork = new pitchfork_type
 				C.put_in_hands(pitchfork)
 
-/obj/effect/proc_holder/spell/targeted/summon_pitchfork/Del()
+/obj/effect/proc_holder/spell/targeted/summon_pitchfork/Destroy()
 	if(pitchfork)
 		qdel(pitchfork)
+		pitchfork = null
+	return ..()
 
 /obj/effect/proc_holder/spell/targeted/summon_pitchfork/greater
 	pitchfork_type = /obj/item/weapon/twohanded/pitchfork/demonic/greater


### PR DESCRIPTION
Whyyyyyyy. `Del` is so old that it should never be even remotely seen in the code anymore except for `Client/Del`. Even having `Del` **_defined**_ for a type causes massive overhead for no discernible reason when it's naturally GC'd (that is, without `qdel`+the garbage controller). On top of this extra performance hit, it means references to this (when it's not naturally GC'd) and from this will not be cleared when it _is_ `qdel`'d, meaning it will end up being hard deleted  by the garbage controller (which will be even more expensive than need be because of this defined `Del`).

Just whyyyyy whyyyyy!
