### PR TITLE
Added some has_buckled_mobs() checks.

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -69,7 +69,7 @@
 	if(over_object == usr && Adjacent(usr))
 		if(!ishuman(usr))
 			return 0
-		if(buckled_mobs.len)
+		if(has_buckled_mobs())
 			return 0
 		if(usr.incapacitated())
 			usr << "<span class='warning'>You can't do that right now!</span>"

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
@@ -50,7 +50,7 @@
 		var/hc = pipe_air.heat_capacity()
 		var/mob/living/heat_source = buckled_mobs[1]
 		//Best guess-estimate of the total bodytemperature of all the mobs, since they share the same environment it's ~ok~ to guess like this
-		var/avg_temp = (pipe_air.temperature * hc + (heat_source.bodytemperature * buckled_mobs.len) * 3500) / (hc + (buckled_mobs.len * 3500))
+		var/avg_temp = (pipe_air.temperature * hc + (heat_source.bodytemperature * buckled_mobs.len) * 3500) / (hc + (buckled_mobs ? buckled_mobs.len * 3500 : 0))
 		for(var/m in buckled_mobs)
 			var/mob/living/L = m
 			L.bodytemperature = avg_temp

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -559,7 +559,7 @@
 	if(!has_buckled_mobs() && prob(25))
 		for(var/mob/living/V in src.loc)
 			entangle(V)
-			if(buckled_mobs && buckled_mobs.len)
+			if(has_buckled_mobs())
 				break //only capture one mob at a time
 
 

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -44,7 +44,7 @@
 	if(M.get_num_legs() < 2)
 		vehicle_move_delay ++
 		if(M.get_num_arms() <= 0)
-			if(buckled_mobs.len)//to prevent the message displaying twice due to unbuckling
+			if(has_buckled_mobs())//to prevent the message displaying twice due to unbuckling
 				M << "<span class='warning'>Your limbless body flops off \the [src].</span>"
 			unbuckle_mob(M)
 


### PR DESCRIPTION
This was causing rollerbeds to be uncollapsible unless you buckled someone to them first.
