### PR TITLE
The clockwork slab's initial input menu is now an alert

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -192,7 +192,7 @@
 /obj/item/clockwork/slab/proc/access_display(mob/living/user)
 	if(!is_servant_of_ratvar(user))
 		return 0
-	var/action = input(user, "Among the swathes of information, you see...", "[src]") as null|anything in list("Recital", "Records", "Recollection")
+	var/action = alert(user, "Among the swathes of information, you see...", "[src]", "Recital", "Recollection", "Records")
 	if(!action || !user.canUseTopic(src))
 		return 0
 	switch(action)


### PR DESCRIPTION
Ha HA, slight interface improvement; we have only three choices, so we can use the faster and easier-to-use alert() proc instead of input.
