### PR TITLE
Fixes loading of Winter and Medical Holodeck.

### DIFF
--- a/_maps/map_files/generic/z2.dmm
+++ b/_maps/map_files/generic/z2.dmm
@@ -5810,7 +5810,7 @@
 /area/holodeck/rec_center/winterwonderland)
 "se" = (
 /turf/open/floor/holofloor/snow/cold,
-/area/holodeck/rec_center/medical)
+/area/holodeck/rec_center/winterwonderland)
 "sf" = (
 /obj/structure/flora/bush,
 /turf/open/floor/holofloor/snow/cold,


### PR DESCRIPTION
The Winter Wonderland Holodeck area was zoned as the Emergency Medical area, breaking both. This corrects that allowing both areas to load normally again.

fixes #18892
fixes #18918

:cl: 
fix: The Emergency Medical and Winter Wonderland Holodeck programs work once again.
/:cl:
