### PR TITLE
Makes black box code less retarded

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -287,10 +287,11 @@ Difficulty: Very Hard
 	return TRUE
 
 /obj/machinery/smartfridge/black_box/New()
-	var/static/obj/machinery/smartfridge/black_box/current = src
-	if (current && current != src)
+	var/static/obj/machinery/smartfridge/black_box/current
+	if(current && current != src)
 		qdel(src, force=TRUE)
 		return
+	current = src
 	ReadMemory()
 
 /obj/machinery/smartfridge/black_box/process()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -277,7 +277,7 @@ Difficulty: Very Hard
 	use_power = 0
 	var/memory_saved = FALSE
 	var/list/stored_items = list()
-	var/list/blacklist = typecacheof(list(/obj/item/weapon/spellbook))
+	var/static/list/blacklist = typecacheof(list(/obj/item/weapon/spellbook))
 
 /obj/machinery/smartfridge/black_box/accept_check(obj/item/O)
 	if(!istype(O))


### PR DESCRIPTION
Not returning when qdeling for dupe (from killing a second colossus) caused byond to **_hard delete**_ the entire contents, as they wouldn't be in the contents when destroy() ran, but would be when the garbage collector hard deleted it.

Hard deleting the 200 some items people decided to put in this thing takes awhile, a long ass while.

Also made the code faster and less loopy and more up-to-date with current systems.

@KorPhaeron 
@Shadowlight213 
@optimumtact 
