### PR TITLE
+10 viscerator max health

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -150,8 +150,8 @@
 	icon_state = "viscerator_attack"
 	icon_living = "viscerator_attack"
 	pass_flags = PASSTABLE
-	health = 15
-	maxHealth = 15
+	health = 25
+	maxHealth = 25
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	attacktext = "cuts"


### PR DESCRIPTION
despite https://github.com/tgstation/tgstation/pull/19451 viscerators are still poopy butt. it turns out that the number of viscerators barely matters when you can kill all of them with one laser gun (or a fire extinguisher if you're willing to run backwards as you swing it.)

now they will survive 3 hits from 10 brute weapons, and more than 1 laser
