### PR TITLE
Fixes Meat Spike Buckling

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -67,7 +67,6 @@
 			L.emote("scream")
 			L.add_splatter_floor()
 			L.adjustBruteLoss(30)
-			L.buckled = src
 			L.setDir(2)
 			buckle_mob(L, force=1)
 			var/matrix/m180 = matrix(L.transform)


### PR DESCRIPTION
The `buckle_mob(L, force=1)` did not work in meat spikes due to having `L.buckled = src` ahead of it.
This led to mobs being unable to be unbuckled from meat spikes by others and allowing meat spikes to be taken apart and moved without unbuckling the mob.

fixes #16186
fixes  #19212

:cl: 
fix: You can unbuckle mobs from meat spikes by clicking on the spike once again.
/:cl:
