### PR TITLE
Fixed the Paper Wizard summoning bug.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -31,7 +31,7 @@
 	boss_type = /mob/living/simple_animal/hostile/boss/paper_wizard
 	needs_target = FALSE
 	say_when_triggered = "Rise, my creations! Jump off your pages and into this realm!"
-	var/summoned_minions = 0
+	var/static/summoned_minions = 0
 
 /datum/action/boss/wizard_summon_minions/Trigger()
 	if(summoned_minions < 9 && ..())

--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -34,7 +34,7 @@
 	var/static/summoned_minions = 0
 
 /datum/action/boss/wizard_summon_minions/Trigger()
-	if(summoned_minions < 9 && ..())
+	if(summoned_minions <= 6 && ..())
 		var/list/minions = list(
 		/mob/living/simple_animal/hostile/stickman,
 		/mob/living/simple_animal/hostile/stickman/ranged,
@@ -42,7 +42,7 @@
 		var/list/directions = cardinal.Copy()
 		for(var/i in 1 to 3)
 			var/minions_chosen = pick_n_take(minions)
-			new minions_chosen (get_step(boss,pick_n_take(directions)))
+			new minions_chosen (get_step(boss,pick_n_take(directions)), 1)
 		summoned_minions += 3;
 
 

--- a/code/modules/mob/living/simple_animal/hostile/stickman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stickman.dm
@@ -28,6 +28,7 @@
 	check_friendly_fire = 1
 	status_flags = CANPUSH
 	var/datum/action/boss/wizard_summon_minions/changesummons = /datum/action/boss/wizard_summon_minions/
+	var/summoned_by_wizard = 0;
 
 /mob/living/simple_animal/hostile/stickman/ranged
 	ranged = 1
@@ -47,10 +48,12 @@
 	icon_living = "stickdog"
 	icon_dead = "stickdog_dead"
 
-/mob/living/simple_animal/hostile/stickman/New()
+/mob/living/simple_animal/hostile/stickman/New(var/turf/loc, var/wizard_summoned)
 	..()
 	new /obj/effect/overlay/temp/paper_scatter(src)
+	summoned_by_wizard = wizard_summoned
 
 /mob/living/simple_animal/hostile/stickman/death()
 	..()
-	changesummons.summoned_minions --
+	if(summoned_by_wizard == 1)
+		changesummons.summoned_minions --

--- a/code/modules/mob/living/simple_animal/hostile/stickman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stickman.dm
@@ -27,6 +27,7 @@
 	faction = list("hostile","stickman")
 	check_friendly_fire = 1
 	status_flags = CANPUSH
+	var/datum/action/boss/wizard_summon_minions/changesummons = /datum/action/boss/wizard_summon_minions/
 
 /mob/living/simple_animal/hostile/stickman/ranged
 	ranged = 1
@@ -49,3 +50,7 @@
 /mob/living/simple_animal/hostile/stickman/New()
 	..()
 	new /obj/effect/overlay/temp/paper_scatter(src)
+
+/mob/living/simple_animal/hostile/stickman/death()
+	..()
+	changesummons.summoned_minions --


### PR DESCRIPTION
:cl:
fix:  Fixed Paper Wizard summoning only 9 minions in its lifespan by making the dead stickman decrease it's summoned_minions variable
/:cl:

Note : Paper Wizard summoning over 9 minions is not a bug (but an intended feature :^) ) creating a "cockroach" effect by summoning 9-12 minions if they are not killed quickly.
