### PR TITLE
Xenomorph Tweaks

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -69,6 +69,7 @@
 #define UNARMED_ATTACK 2
 #define PROJECTILE_ATTACK 3
 #define THROWN_PROJECTILE_ATTACK 4
+#define LEAP_ATTACK 5
 
 
 //Gun Stuff

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -31,6 +31,8 @@
 /obj/item/weapon/shield/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
 	if(attack_type == THROWN_PROJECTILE_ATTACK)
 		final_block_chance += 30
+	if(attack_type == LEAP_ATTACK)
+		final_block_chance = 100
 	return ..()
 
 /obj/item/weapon/shield/riot/roman

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -7,7 +7,7 @@
 	name = "alien"
 	voice_name = "alien"
 	icon = 'icons/mob/alien.dmi'
-	gender = NEUTER
+	gender = FEMALE //All xenos are girls!!
 	dna = null
 	faction = list("alien")
 	ventcrawler = 2

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -68,13 +68,15 @@
 			var/blocked = 0
 			if(ishuman(A))
 				var/mob/living/carbon/human/H = A
-				if(H.check_shields(90, "the [name]", src, attack_type = THROWN_PROJECTILE_ATTACK))
+				if(H.check_shields(0, "the [name]", src, attack_type = THROWN_PROJECTILE_ATTACK))
 					blocked = 1
 			if(!blocked)
 				L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
 				L.Weaken(5)
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
 				step_towards(src,L)
+			else
+				weakened = 2
 
 			toggle_leap(0)
 			pounce_cooldown = !pounce_cooldown

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -84,7 +84,7 @@
 				pounce_cooldown = !pounce_cooldown
 		else if(A.density && !A.CanPass(src))
 			visible_message("<span class ='danger'>[src] smashes into [A]!</span>", "<span class ='alertalien'>[src] smashes into [A]!</span>")
-			weakened = 2
+			Weaken(2, 1, 1)
 
 		if(leaping)
 			leaping = 0

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -76,7 +76,7 @@
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
 				step_towards(src,L)
 			else
-				weakened = 2
+				Weaken(2, 1, 1)
 
 			toggle_leap(0)
 			pounce_cooldown = !pounce_cooldown

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -68,7 +68,7 @@
 			var/blocked = 0
 			if(ishuman(A))
 				var/mob/living/carbon/human/H = A
-				if(H.check_shields(0, "the [name]", src, attack_type = THROWN_PROJECTILE_ATTACK))
+				if(H.check_shields(0, "the [name]", src, attack_type = LEAP_ATTACK))
 					blocked = 1
 			if(!blocked)
 				L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -48,7 +48,7 @@
 
 /mob/living/carbon/alien/humanoid/royal/queen/movement_delay()
 	. = ..()
-	. += 5
+	. += 3
 
 //Queen verbs
 /obj/effect/proc_holder/alien/lay_egg

--- a/code/modules/mob/living/carbon/alien/larva/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/larva/update_icons.dm
@@ -5,7 +5,7 @@
 
 /mob/living/carbon/alien/larva/update_icons()
 	var/state = 0
-	if(amount_grown > 150)
+	if(amount_grown > 80)
 		state = 2
 	else if(amount_grown > 50)
 		state = 1

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -137,8 +137,6 @@ var/const/MAX_ACTIVE_TIME = 400
 	if(iscarbon(M))
 		var/mob/living/carbon/target = M
 		if(target.wear_mask)
-			if(prob(20))
-				return 0
 			var/obj/item/clothing/W = target.wear_mask
 			if(W.flags & NODROP)
 				return 0

--- a/code/modules/mob/living/carbon/human/human_attackalien.dm
+++ b/code/modules/mob/living/carbon/human/human_attackalien.dm
@@ -22,29 +22,18 @@
 			if(!dismembering_strike(M, M.zone_selected)) //Dismemberment successful
 				return 1
 			apply_damage(damage, BRUTE, affecting, armor_block)
-			if (prob(30))
-				visible_message("<span class='danger'>[M] has wounded [src]!</span>", \
-					"<span class='userdanger'>[M] has wounded [src]!</span>")
-				apply_effect(4, WEAKEN, armor_block)
-				add_logs(M, src, "attacked")
+			add_logs(M, src, "attacked")
 			updatehealth()
 
-		if(M.a_intent == "disarm")
-			var/randn = rand(1, 100)
-			if (randn <= 80)
+		if(M.a_intent == "disarm") //Always drop item in hand, if no item, get stunned instead.
+			if(get_active_hand() && drop_item())
+				playsound(loc, 'sound/weapons/slash.ogg', 25, 1, -1)
+				visible_message("<span class='danger'>[M] disarmed [src]!</span>", \
+						"<span class='userdanger'>[M] disarmed [src]!</span>")
+			else
 				playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 				Weaken(5)
 				add_logs(M, src, "tackled")
 				visible_message("<span class='danger'>[M] has tackled down [src]!</span>", \
 					"<span class='userdanger'>[M] has tackled down [src]!</span>")
-			else
-				if (randn <= 99)
-					playsound(loc, 'sound/weapons/slash.ogg', 25, 1, -1)
-					drop_item()
-					visible_message("<span class='danger'>[M] disarmed [src]!</span>", \
-						"<span class='userdanger'>[M] disarmed [src]!</span>")
-				else
-					playsound(loc, 'sound/weapons/slashmiss.ogg', 50, 1, -1)
-					visible_message("<span class='danger'>[M] has tried to disarm [src]!</span>", \
-						"<span class='userdanger'>[M] has tried to disarm [src]!</span>")
 	return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -716,7 +716,6 @@
 		if(!(lying))
 			M.do_attack_animation(src)
 			if (prob(85))
-				Stun(2)
 				step(src,get_dir(M,src))
 				addtimer(src, "step", 5, FALSE, src, get_dir(M, src))
 				add_logs(M, src, "pushed")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -715,17 +715,18 @@
 	if (M.a_intent =="disarm")
 		if(!(lying))
 			M.do_attack_animation(src)
-			if (prob(85))
-				step(src,get_dir(M,src))
-				addtimer(src, "step", 5, FALSE, src, get_dir(M, src))
-				add_logs(M, src, "pushed")
-				playsound(loc, 'sound/weapons/pierce.ogg', 50, 1, -1)
-				visible_message("<span class='danger'>[M] has forced back [src]!</span>", \
-								"<span class='userdanger'>[M] has forced back [src]!</span>")
+			if(get_active_hand())
+				uneq_active()
+				visible_message("<span class='danger'>[M] disarmed [src]!</span>", \
+				"<span class='userdanger'>[M] has disabled [src]'s active module!</span>")
+				add_logs(M, src, "disarmed")
 			else
-				playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
-				visible_message("<span class='danger'>[M] took a swipe at [src]!</span>", \
-								"<span class='userdanger'>[M] took a swipe at [src]!</span>")
+				Stun(2)
+				step(src,get_dir(M,src))
+				add_logs(M, src, "pushed")
+				visible_message("<span class='danger'>[M] has forced back [src]!</span>", \
+				"<span class='userdanger'>[M] has forced back [src]!</span>")
+			playsound(loc, 'sound/weapons/pierce.ogg', 50, 1, -1)
 	else
 		..()
 	return

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -337,7 +337,7 @@
 
 	action_icon_state = "repulse"
 
-/obj/effect/proc_holder/spell/aoe_turf/repulse/cast(list/targets,mob/user = usr)
+/obj/effect/proc_holder/spell/aoe_turf/repulse/cast(list/targets,mob/user = usr, var/stun_amt = 2)
 	var/list/thrownatoms = list()
 	var/atom/throwtarget
 	var/distfromcaster
@@ -362,7 +362,7 @@
 		else
 			if(istype(AM, /mob/living))
 				var/mob/living/M = AM
-				M.Weaken(2)
+				M.Weaken(stun_amt)
 				M << "<span class='userdanger'>You're thrown back by [user]!</span>"
 			AM.throw_at_fast(throwtarget, ((Clamp((maxthrow - (Clamp(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow))), 1,user)//So stuff gets tossed around at the same time.
 
@@ -384,4 +384,4 @@
 		var/mob/living/carbon/C = user
 		playsound(C.loc, 'sound/voice/hiss5.ogg', 80, 1, 1)
 		C.spin(6,1)
-	..()
+	..(targets, user, 3)


### PR DESCRIPTION
All PR contents on behalf of @WJohn.

:cl: WJohnston, Gun Hog
tweak: Xenos are now considered female.
tweak: Hunter pounce are now always blocked by shields, and may be blocked more often by other protective items.
tweak: Alien Queen is now somewhat faster.
tweak: Adjusted larva growth sprites.
tweak: Removed 20% facehugger failure chance for masks.
tweak: Disarm now always forces a person to drop an item in the active hand, and if a person's hand is empty/undroppable, Disarm will always result in a tackle.
tweak: Cyborgs disarmed by a Xeno will first disable their selected module, and if there is none selected, the cyborg will be pushed back and stunned.
tweak: Tail Sweep now has a slightly longer stun.
/:cl:
