### PR TITLE
AI megafauna ranged attacks no longer delay attack checking

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -84,9 +84,7 @@ Difficulty: Hard
 		if(health > maxHealth/2 && !client)
 			addtimer(src, "charge", 0)
 		else
-			addtimer(src, "charge", 0)
-			addtimer(src, "charge", 10)
-			addtimer(src, "charge", 20)
+			addtimer(src, "triple_charge", 0)
 
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/New()
@@ -125,6 +123,13 @@ Difficulty: Hard
 	. = ..()
 	if(charging)
 		DestroySurroundings()
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/triple_charge()
+	charge()
+	sleep(10)
+	charge()
+	sleep(10)
+	charge()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge()
 	var/turf/T = get_step_away(target, src)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -69,25 +69,24 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/OpenFire()
 	var/anger_modifier = Clamp(((maxHealth - health)/50),0,20)
+	if(charging)
+		return
 	ranged_cooldown = world.time + ranged_cooldown_time
 
-	if(!charging)
-		blood_warp()
+	blood_warp()
 
 	if(prob(25))
-		blood_spray()
+		addtimer(src, "blood_spray", 0)
 
 	else if(prob(5+anger_modifier/2))
 		slaughterlings()
-	else if(!charging)
+	else
 		if(health > maxHealth/2 && !client)
-			charge()
+			addtimer(src, "charge", 0)
 		else
-			charge()
-			sleep(10)
-			charge()
-			sleep(10)
-			charge()
+			addtimer(src, "charge", 0)
+			addtimer(src, "charge", 10)
+			addtimer(src, "charge", 20)
 
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/New()
@@ -186,16 +185,17 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_spray()
 	visible_message("<span class='danger'>[src] sprays a stream of gore!</span>")
-	spawn(0)
-		var/turf/E = get_edge_target_turf(src, src.dir)
-		var/range = 10
-		for(var/turf/J in getline(src,E))
-			if(!range || J.density)
-				break
-			playsound(J,'sound/effects/splat.ogg', 100, 1, -1)
-			new /obj/effect/decal/cleanable/blood(J)
-			range--
-			sleep(1)
+	var/turf/E = get_edge_target_turf(src, src.dir)
+	var/range = 10
+	var/turf/previousturf = get_turf(src)
+	for(var/turf/J in getline(src,E))
+		if(!range || !previousturf.CanAtmosPass(J))
+			break
+		playsound(J,'sound/effects/splat.ogg', 100, 1, -1)
+		new /obj/effect/decal/cleanable/blood(J)
+		range--
+		previousturf = J
+		sleep(1)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/slaughterlings()
 	visible_message("<span class='danger'>[src] summons a shoal of slaughterlings!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -194,7 +194,10 @@ Difficulty: Hard
 	var/range = 10
 	var/turf/previousturf = get_turf(src)
 	for(var/turf/J in getline(src,E))
-		if(!range || !previousturf.CanAtmosPass(J))
+		if(!range)
+			break
+		PoolOrNew(/obj/effect/overlay/temp/bloodsplatter, list(previousturf, get_dir(previousturf, J)))
+		if(!previousturf.CanAtmosPass(J))
 			break
 		playsound(J,'sound/effects/splat.ogg', 100, 1, -1)
 		new /obj/effect/decal/cleanable/blood(J)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -76,7 +76,7 @@ Difficulty: Very Hard
 			double_spiral()
 		else
 			visible_message("<span class='colossus'>\"<b>Judgement.</b>\"</span>")
-			spiral_shoot(rand(0, 1))
+			addtimer(src, "spiral_shoot", 0, FALSE, rand(0, 1))
 
 	else if(prob(20))
 		ranged_cooldown = world.time + 30
@@ -87,13 +87,7 @@ Difficulty: Very Hard
 			blast()
 		else
 			ranged_cooldown = world.time + 40
-			dir_shots(diagonals)
-			sleep(10)
-			dir_shots(cardinal)
-			sleep(10)
-			dir_shots(diagonals)
-			sleep(10)
-			dir_shots(cardinal)
+			addtimer(src, "alternating_dir_shots", 0)
 
 
 /mob/living/simple_animal/hostile/megafauna/colossus/New()
@@ -129,6 +123,14 @@ Difficulty: Very Hard
 		AT.pixel_y += random_y
 	..()
 
+/mob/living/simple_animal/hostile/megafauna/colossus/proc/alternating_dir_shots()
+	dir_shots(diagonals)
+	sleep(10)
+	dir_shots(cardinal)
+	sleep(10)
+	dir_shots(diagonals)
+	sleep(10)
+	dir_shots(cardinal)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/double_spiral()
 	visible_message("<span class='colossus'>\"<b>Die.</b>\"</span>")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -180,8 +180,9 @@ Difficulty: Medium
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/fire_wall(dir)
 	var/turf/E = get_edge_target_turf(src, dir)
 	var/range = 10
+	var/turf/previousturf = get_turf(src)
 	for(var/turf/J in getline(src,E))
-		if(!range || J.density)
+		if(!range || !previousturf.CanAtmosPass(J))
 			break
 		range--
 		PoolOrNew(/obj/effect/hotspot,J)
@@ -190,6 +191,7 @@ Difficulty: Medium
 			if(L != src)
 				L.adjustFireLoss(20)
 				L << "<span class='userdanger'>You're hit by the drake's fire breath!</span>"
+		previousturf = J
 		sleep(1)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/swoop_attack(fire_rain = 0, atom/movable/manual_target)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -151,17 +151,15 @@ Difficulty: Medium
 
 	if(prob(15 + anger_modifier) && !client)
 		if(health < maxHealth/2)
-			swoop_attack(1)
+			addtimer(src, "swoop_attack", 0, FALSE, 1)
 		else
 			fire_rain()
 
 	else if(prob(10+anger_modifier) && !client && !swooping)
 		if(health > maxHealth/2)
-			swoop_attack()
+			addtimer(src, "swoop_attack", 0)
 		else
-			swoop_attack()
-			swoop_attack()
-			swoop_attack()
+			addtimer(src, "triple_swoop", 0)
 	else
 		fire_walls()
 
@@ -193,6 +191,11 @@ Difficulty: Medium
 				L << "<span class='userdanger'>You're hit by the drake's fire breath!</span>"
 		previousturf = J
 		sleep(1)
+
+/mob/living/simple_animal/hostile/megafauna/dragon/proc/triple_swoop()
+	swoop_attack()
+	swoop_attack()
+	swoop_attack()
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/swoop_attack(fire_rain = 0, atom/movable/manual_target)
 	if(stat || swooping)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -80,12 +80,14 @@ Difficulty: Medium
 			minimum_distance = 0
 			speed = 0
 			charging = 1
-			spawn(50)
-				ranged = 1
-				retreat_distance = 5
-				minimum_distance = 5
-				speed = 2
-				charging = 0
+			addtimer(src, "reset_charge", 50)
+
+/mob/living/simple_animal/hostile/megafauna/legion/proc/reset_charge()
+	ranged = 1
+	retreat_distance = 5
+	minimum_distance = 5
+	speed = 2
+	charging = 0
 
 /mob/living/simple_animal/hostile/megafauna/legion/death()
 	if(health > 0)


### PR DESCRIPTION
This means that any of the attacks that used sleep()s will no longer wait until the sleeps end to check if the mob can attack its target, so, say, if the colossus does its single spiral attack, it won't wait until the spiral ends to try and melee attack/move towards the target.

This should have no effect on the attack patterns, but it may make some megafauna weaker because they're not immediately attacking if they end up in range after using a ranged attack, because they checked first. That won't apply to anything that put them instantly in range, though, so bubblegum teleporting on top of you will still totally attack you!

It also does not apply to player-controlled megafauna, as they handle ranged attacking differently.

Drake fire walls and bubblegum blood spray will no longer go through turfs that cannot be passed by air.
