### PR TITLE
i see it thrown around very frequently, both in common and command.

### DIFF
--- a/strings/brain_damage_lines.json
+++ b/strings/brain_damage_lines.json
@@ -54,7 +54,8 @@
         "Tajaran has warrrres, if you have coin",
         "I'VE GOT BALLS OF STEEL",
         "NO I'M ONNA KILL YOU MOTHERFUCKER OLD STYLE",
-        "i will snatch erry motherfucker birthday"
+        "i will snatch erry motherfucker birthday",
+        "hey i don't wanna step on any toes but could people maybe curtail their use of the word l**ger and its derivatives on the station?"
     ],
 
     "mutations": [


### PR DESCRIPTION
thing is, it's a slur against lizards and it makes me incredibly uncomfortable to see it get used so often. i get that people do some really ridiculous and illogical things on the station sometimes and its tempting to use words that match the magnitude of their errors, but please try and use words other than that one? i'd really appreciate that
