### PR TITLE
Fixes subsystem cost calculation being much higher then true

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -140,7 +140,7 @@
 		statclick = new/obj/effect/statclick/debug("Initializing...", src)
 
 	if(can_fire)
-		msg = "[round(cost*ticks,1)]ms|[round(tick_usage,1)]%|[round(ticks,0.1)]\t[msg]"
+		msg = "[round(cost,1)]ms|[round(tick_usage,1)]%|[round(ticks,0.1)]\t[msg]"
 	else
 		msg = "OFFLINE\t[msg]"
 


### PR DESCRIPTION
I tried to take how many ticks it took to fully run into account twice, once when i saved SS.cost, and again when displaying it, this version was less precise, so I removed it.
