### PR TITLE
Clockcult fixes

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -242,7 +242,7 @@ This file's folder contains:
 	clockwork_objective = pick(possible_objectives)
 	switch(clockwork_objective)
 		if("escape")
-			required_escapees = max(1, roundstart_player_count / 3) //33% of the player count must be cultists
+			required_escapees = round(max(1, roundstart_player_count / 3)) //33% of the player count must be cultists
 			clockwork_explanation = "Ensure that [required_escapees] servants of Ratvar escape from [station_name()]."
 		if("gateway")
 			clockwork_explanation = "Construct a Gateway to the Celestial Derelict and free Ratvar."

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -242,7 +242,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	return 1
 
 /datum/clockwork_scripture/vanguard/scripture_effects()
-	invoker.add_stun_absorption("vanguard", world.time + total_duration, 1, "'s yellow aura momentarily intensifies!", "Your ward absorbs the stun!", " is radiating with a soft yellow light!")
+	invoker.add_stun_absorption("vanguard", total_duration, 1, "'s yellow aura momentarily intensifies!", "Your ward absorbs the stun!", " is radiating with a soft yellow light!")
 	invoker.visible_message("<span class='warning'>[invoker] begins to faintly glow!</span>", "<span class='brass'>You will absorb all stuns for the next twenty seconds.</span>")
 	spawn(total_duration)
 		if(!invoker)

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -244,11 +244,11 @@
 	if(!is_servant_of_ratvar(user))
 		return 0
 	if(!clockwork_component_cache["replicant_alloy"])
-		user << "<span class='warning'>[src] contains no Replicant Alloy!</span>"
+		user << "<span class='warning'>There is no Replicant Alloy in the global component cache!</span>"
 		return 0
 	var/obj/item/clockwork/component/replicant_alloy/A = new(get_turf(src))
 	user.visible_message("<span class='notice'>[user] withdraws [A] from [src].</span>", "<span class='notice'>You withdraw [A] from [src].</span>")
-	user.put_in_hands(the_component)
+	user.put_in_hands(A)
 	return 1
 
 /obj/structure/clockwork/cache/examine(mob/user)

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -243,24 +243,12 @@
 /obj/structure/clockwork/cache/attack_hand(mob/user)
 	if(!is_servant_of_ratvar(user))
 		return 0
-	var/list/possible_components = list()
-	for(var/i in clockwork_component_cache)
-		if(clockwork_component_cache[i])
-			possible_components += get_component_name(i)
-	if(!possible_components.len)
-		user << "<span class='warning'>[src] is empty!</span>"
+	if(!clockwork_component_cache["replicant_alloy"])
+		user << "<span class='warning'>[src] contains no Replicant Alloy!</span>"
 		return 0
-	var/componentid = get_component_id(input(user, "Choose a component to withdraw.", name) as null|anything in possible_components)
-	if(!user || !user.canUseTopic(src) || !componentid)
-		return 0
-	var/obj/item/clockwork/component/the_component
-	var/component_path = text2path("/obj/item/clockwork/component/[componentid]")
-	if(clockwork_component_cache[componentid])
-		the_component = new component_path(get_turf(src))
-		clockwork_component_cache[componentid]--
-	if(the_component)
-		user.visible_message("<span class='notice'>[user] withdraws [the_component] from [src].</span>", "<span class='notice'>You withdraw [the_component] from [src].</span>")
-		user.put_in_hands(the_component)
+	var/obj/item/clockwork/component/replicant_alloy/A = new(get_turf(src))
+	user.visible_message("<span class='notice'>[user] withdraws [A] from [src].</span>", "<span class='notice'>You withdraw [A] from [src].</span>")
+	user.put_in_hands(the_component)
 	return 1
 
 /obj/structure/clockwork/cache/examine(mob/user)


### PR DESCRIPTION
Escape objective properly rounds down.
Vanguard no longer potentially has the entire round as its duration.
You can only remove Replicant Alloy from caches, as literally nothing else has a use outside of it.
