### PR TITLE
Hopefully adds enough security officer spawns that #19757 will never happen again

### DIFF
--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -41906,6 +41906,9 @@
 	pixel_x = 0;
 	tag = ""
 	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
 /turf/open/floor/plasteel/black,
 /area/security/main)
 "bFQ" = (
@@ -43441,6 +43444,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/main)

--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -33050,6 +33050,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
 /turf/open/floor/plasteel/darkred/side{
 	tag = "icon-darkred (NORTHEAST)";
 	dir = 5
@@ -39228,6 +39231,9 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
 /turf/open/floor/plasteel/darkred/corner{
 	tag = "icon-darkredcorners (EAST)";
 	dir = 4
@@ -39270,6 +39276,9 @@
 	icon_state = "4-8";
 	pixel_x = 0;
 	tag = ""
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
 	},
 /turf/open/floor/plasteel/darkred/corner{
 	tag = "icon-darkredcorners (NORTH)";

--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -47019,6 +47019,9 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "bPn" = (
@@ -50190,6 +50193,9 @@
 /area/maintenance/starboard)
 "bVS" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "bVT" = (
@@ -55925,11 +55931,11 @@
 /turf/closed/wall/mineral/titanium/interior,
 /area/shuttle/transport)
 "ciH" = (
-/turf/open/floor/plasteel/shuttle,
-/turf/closed/wall/shuttle/interior{
-	icon_state = "swall_f6"
+/obj/effect/landmark/start{
+	name = "Security Officer"
 	},
-/area/shuttle/transport)
+/turf/open/floor/plasteel,
+/area/security/main)
 "ciI" = (
 /turf/open/space,
 /area/shuttle/syndicate)
@@ -56365,6 +56371,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -85163,7 +85172,7 @@ bLD
 bMO
 bOe
 bPm
-bOj
+ciH
 cjq
 bSX
 bUl
@@ -86191,7 +86200,7 @@ bEg
 bMR
 bOi
 bVS
-bOj
+ciH
 cjs
 bTb
 bUi
@@ -86666,11 +86675,11 @@ aSD
 aSA
 aSF
 aTP
-aWE
+aWF
 aWF
 aWG
 aWF
-aWE
+aWF
 aTP
 bcp
 aTS
@@ -88208,11 +88217,11 @@ aSI
 aSA
 aUL
 aTP
-aWE
+aWF
 aWF
 aYJ
 aWF
-aWE
+aWF
 aTP
 bcq
 aSA

--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -46499,6 +46499,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "bOf" = (
@@ -46533,6 +46536,9 @@
 	external_pressure_bound = 101.325;
 	on = 1;
 	pressure_checks = 1
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -56338,6 +56344,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
 	},
 /turf/open/floor/plasteel,
 /area/security/main)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9126,9 +9126,6 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aqh" = (
-/obj/effect/landmark/start{
-	name = "Security Officer"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
 	pixel_y = 0
@@ -9846,6 +9843,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
 	},
 /turf/open/floor/plasteel/red/side,
 /area/security/main)
@@ -123096,7 +123096,7 @@ ajI
 akS
 ame
 ddO
-anC
+ddO
 ddO
 aru
 asM
@@ -124897,7 +124897,7 @@ ams
 anI
 aoP
 aqg
-arz
+arx
 asT
 ajJ
 avi
@@ -125152,7 +125152,7 @@ ajP
 ala
 amt
 dem
-anJ
+dem
 dem
 arB
 asU

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9862,6 +9862,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
 /turf/open/floor/plasteel/red/side,
 /area/security/main)
 "arx" = (
@@ -92815,11 +92818,22 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ddO" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall15";
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/shuttle/escape)
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/security/main)
 "ddP" = (
 /obj/structure/table,
 /obj/item/weapon/restraints/handcuffs{
@@ -92959,10 +92973,17 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "dem" = (
-/turf/closed/wall/shuttle{
-	icon_state = "diagonalWall3"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair{
+	dir = 8
 	},
-/area/shuttle/escape)
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/security/main)
 "den" = (
 /obj/structure/table,
 /obj/item/weapon/folder/red{
@@ -123074,9 +123095,9 @@ aed
 ajI
 akS
 ame
+ddO
 anC
-anC
-anC
+ddO
 aru
 asM
 auf
@@ -124362,7 +124383,7 @@ amq
 boY
 aoN
 aqe
-arz
+arx
 asR
 aui
 avi
@@ -125130,9 +125151,9 @@ aed
 ajP
 ala
 amt
+dem
 anJ
-anJ
-anJ
+dem
 arB
 asU
 auk

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -3702,6 +3702,9 @@
 	},
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahL" = (
@@ -91638,8 +91641,8 @@ abO
 abO
 afb
 abo
-agv
-afU
+afg
+ahb
 ahG
 aik
 cBV


### PR DESCRIPTION
This is 15, count em, 15, security spawn points for dream, efficiency, meta, and box, because under normal circumstances we should never have more than 150 players.
Fixes #19757 at least hopefully send help
Also fixes the mining shuttle corners on efficiency, which I missed before.
