### PR TITLE
Adds an achievement for examining a genuine meteor as a living mob

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -160,6 +160,15 @@
 /obj/effect/meteor/ex_act()
 	return
 
+#define METEOR_MEDAL "Your Life Before Your Eyes"
+
+/obj/effect/meteor/examine(mob/user)
+	if(!admin_spawned && isliving(user))
+		UnlockMedal(METEOR_MEDAL,user.client)
+	..()
+
+#undef METEOR_MEDAL
+
 /obj/effect/meteor/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/pickaxe))
 		make_debris()


### PR DESCRIPTION
does what the title says
adminspawned meteors dont count so admins can still spawn, possess, and walk around as meteors without fucking up achievements

expect people running towards meteors and standing around in space during meteor storms

@Shadowlight213 i'm pretty sure i did this right, please check my code and set up the actual achievement page thank you :)

:cl: PKPenguin321
add: There's now an achievement for managing to examine a meteor as a living mob!
/:cl:
