### PR TITLE
Removes CQC & RNG beams from Watchers/Basilisks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -91,7 +91,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/GiveTarget(new_target)
 	if(..()) //we have a target
-		if(isliving(target))
+		if(isliving(target) && !target.Adjacent(targets_from) && ranged_cooldown <= world.time)//No more being shot at point blank or spammed with RNG beams
 			OpenFire(target)
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/ex_act(severity, target)


### PR DESCRIPTION
:cl:
tweak: Watchers no longer randomly fire beams at you when damaged, and no longer beam you at point blank.
/:cl:

Watchers/Basilisks no longer will randomly shoot beams at you when damaged (Was previously a 40% chance) to make them more readable and predictable to players, and will no longer shoot their beams in melee range, like every other ranged mob.
