### PR TITLE
AI now uses the updated crew manifest

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -294,8 +294,7 @@ var/list/ai_list = list()
 /mob/living/silicon/ai/proc/ai_roster()
 	var/dat = "<html><head><title>Crew Roster</title></head><body><b>Crew Roster:</b><br><br>"
 
-	for(var/datum/data/record/t in sortRecord(data_core.general))
-		dat += t.fields["name"] + " - " + t.fields["rank"] + "<br>"
+	dat += data_core.get_manifest()
 	dat += "</body></html>"
 
 	src << browse(dat, "window=airoster")


### PR DESCRIPTION
:cl: Gun Hog
tweak: The AI's Crew Manifest button now uses the updated styling.
/:cl:

The same one that ghosts use.
**EDIT:**

![screenshot 2016-08-10 09 11 20](https://cloud.githubusercontent.com/assets/4955510/17575079/e8673508-5f2b-11e6-9c2b-f09d45715e79.png)
