### PR TITLE
Fix for the new virology chems

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1200,6 +1200,23 @@
 	id = "weakplasmavirusfood"
 	color = "#CEC3C6" // rgb: 206,195,198
 
+/datum/reagent/toxin/plasma/uraniumvirusfood
+	name = "decaying uranium gel"
+	id = "uraniumvirusfood"
+	description = "mutates blood"
+	color = "#006600" // rgb: 0,102,0
+
+/datum/reagent/toxin/plasma/uraniumvirusfood/unstable
+	name = "unstable uranium gel"
+	id = "uraniumplasmavirusfood_unstable"
+	color = "#009900" // rgb: 0,153,0
+
+/datum/reagent/toxin/plasma/uraniumvirusfood/stable
+	name = "stable uranium gel"
+	id = "uraniumplasmavirusfood_stable"
+	color = "#00cc00" // rgb: 0,204,0
+
+
 /datum/reagent/royal_bee_jelly
 	name = "royal bee jelly"
 	id = "royal_bee_jelly"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1200,18 +1200,18 @@
 	id = "weakplasmavirusfood"
 	color = "#CEC3C6" // rgb: 206,195,198
 
-/datum/reagent/toxin/plasma/uraniumvirusfood
+/datum/reagent/uranium/uraniumvirusfood
 	name = "decaying uranium gel"
 	id = "uraniumvirusfood"
 	description = "mutates blood"
 	color = "#006600" // rgb: 0,102,0
 
-/datum/reagent/toxin/plasma/uraniumvirusfood/unstable
+/datum/reagent/uranium/uraniumvirusfood/unstable
 	name = "unstable uranium gel"
 	id = "uraniumplasmavirusfood_unstable"
 	color = "#009900" // rgb: 0,153,0
 
-/datum/reagent/toxin/plasma/uraniumvirusfood/stable
+/datum/reagent/uranium/uraniumvirusfood/stable
 	name = "stable uranium gel"
 	id = "uraniumplasmavirusfood_stable"
 	color = "#00cc00" // rgb: 0,204,0

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -193,14 +193,14 @@
 	name = "Stable uranium gel"
 	id = "uraniumvirusfood_gold"
 	result = "uraniumplasmavirusfood_stable"
-	required_reagents = list("uranium" = 10, "gold" = 10, "plasmavirusfood" = 1)
+	required_reagents = list("uranium" = 10, "gold" = 10, "weakplasmavirusfood" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/virus_food_uranium_plasma_silver
 	name = "Stable uranium gel"
 	id = "uraniumvirusfood_silver"
 	result = "uraniumplasmavirusfood_stable"
-	required_reagents = list("uranium" = 10, "silver" = 10, "plasmavirusfood" = 1)
+	required_reagents = list("uranium" = 10, "silver" = 10, "weakplasmavirusfood" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/mix_virus


### PR DESCRIPTION
:cl: XDTM
tweak: Stable Uranium Gel now requires weak virus plasma instead of virus plasma.
fix: Uranium Gels are now actually makeable.
/:cl:

This should fix the issues described in #19797.
