### PR TITLE
Gives the warden a cycler shotgun

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -102,7 +102,7 @@
 	new /obj/item/weapon/storage/box/flashbangs(src)
 	new /obj/item/weapon/storage/belt/security/full(src)
 	new /obj/item/device/flashlight/seclite(src)
-	new /obj/item/clothing/gloves/krav_maga/sec(src)
+	new /obj/item/weapon/gun/projectile/shotgun/automatic/dual_tube(src)
 	new /obj/item/weapon/door_remote/head_of_security(src)
 
 /obj/structure/closet/secure_closet/security

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -177,7 +177,7 @@
 	icon_state = "cycler"
 	origin_tech = "combat=4;materials=2"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube
-	w_class = 5
+	w_class = 3
 	var/toggled = 0
 	var/obj/item/ammo_box/magazine/internal/shot/alternate_magazine
 


### PR DESCRIPTION
Gives the warden the dual magazine shotgun from https://github.com/tgstation/tgstation/pull/17118

> Has two tubes, which you can toggle between by using the gun inhand. For example, you could fill one tube with riot ammo, and another with buckshot. Basically the UTS 15

Replaces his gloves because

1) I'd feel guilty just piling more gear into sec for no reason

2) I feel a shotgun is more thematically appropriate to the Warden based on some vague criteria I just made up

3) The gloves are very situational as you'll usually have a baton/gun/flashbang anyway.

4) The gloves are basically stungloves if you recolour them or hide them under a suit.

If people really want the gloves though I guess I can just close this or give him both or a choice or something 

:cl: Kor
add: The Warden has a new dual magazine shotgun.  Click to toggle tubes, alt+click to pump.
del: The Warden no longer has martial arts gloves.
/:cl:
