### PR TITLE
Stops clown mask overriding altclick

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -66,10 +66,7 @@
 	dog_fashion = /datum/dog_fashion/head/clown
 	pockets = /obj/item/weapon/storage/internal/pocket/tiny // Honk!
 
-/obj/item/clothing/mask/gas/clown_hat/attack_self(mob/user)
-	AltClick(user)
-
-/obj/item/clothing/mask/gas/clown_hat/AltClick(mob/living/user)
+/obj/item/clothing/mask/gas/clown_hat/ui_action_click(mob/user)
 	if(!istype(user) || user.incapacitated())
 		return
 


### PR DESCRIPTION
Doesn't really affect much but I figure it's probably for the best that alt-click isn't overridden.  ¯\_(ツ)_/¯
Closes #19803 
:cl:
del: Removed clicking clown mask to morph it's shape, use action button instead.
/:cl:
