### PR TITLE
[s]Little fix and var in proc removal

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -5,7 +5,7 @@
 // the same logical /area have the parent /area object... well, you would be mistaken.  If you
 // want to find machines, mobs, etc, in the same logical area, you will need to check all the
 // related areas.  This returns a master contents list to assist in that.
-/proc/area_contents(area/A)
+/proc/area_contents(var/area/A)
 	if(!istype(A)) return null
 	var/list/contents = list()
 	for(var/area/LSA in A.related)
@@ -47,6 +47,8 @@
 	power_change()		// all machines set to current power level, also updates icon
 
 	blend_mode = BLEND_MULTIPLY // Putting this in the constructor so that it stops the icons being screwed up in the map editor.
+
+
 
 /area/proc/poweralert(state, obj/source)
 	if (state != poweralm)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -5,7 +5,7 @@
 // the same logical /area have the parent /area object... well, you would be mistaken.  If you
 // want to find machines, mobs, etc, in the same logical area, you will need to check all the
 // related areas.  This returns a master contents list to assist in that.
-/proc/area_contents(var/area/A)
+/proc/area_contents(area/A)
 	if(!istype(A)) return null
 	var/list/contents = list()
 	for(var/area/LSA in A.related)
@@ -47,8 +47,6 @@
 	power_change()		// all machines set to current power level, also updates icon
 
 	blend_mode = BLEND_MULTIPLY // Putting this in the constructor so that it stops the icons being screwed up in the map editor.
-
-
 
 /area/proc/poweralert(state, obj/source)
 	if (state != poweralm)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -5,7 +5,7 @@
 // the same logical /area have the parent /area object... well, you would be mistaken.  If you
 // want to find machines, mobs, etc, in the same logical area, you will need to check all the
 // related areas.  This returns a master contents list to assist in that.
-/proc/area_contents(var/area/A)
+/proc/area_contents(area/A)
 	if(!istype(A)) return null
 	var/list/contents = list()
 	for(var/area/LSA in A.related)

--- a/code/game/gamemodes/antag_hud.dm
+++ b/code/game/gamemodes/antag_hud.dm
@@ -41,7 +41,7 @@
 
 //MIND PROCS
 //these are called by mind.transfer_to()
-/datum/mind/proc/transfer_antag_huds(datum/atom_hud/antag/newhud)
+/datum/mind/proc/transfer_antag_huds(var/datum/atom_hud/antag/newhud)
 	leave_all_huds()
 	ticker.mode.set_antag_hud(current, antag_hud_icon_state)
 	if(newhud)

--- a/code/game/gamemodes/antag_hud.dm
+++ b/code/game/gamemodes/antag_hud.dm
@@ -41,7 +41,7 @@
 
 //MIND PROCS
 //these are called by mind.transfer_to()
-/datum/mind/proc/transfer_antag_huds(var/datum/atom_hud/antag/newhud)
+/datum/mind/proc/transfer_antag_huds(datum/atom_hud/antag/newhud)
 	leave_all_huds()
 	ticker.mode.set_antag_hud(current, antag_hud_icon_state)
 	if(newhud)

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -132,15 +132,7 @@ The console is located at computer/gulag_teleporter.dm
 			if(istype(W, /obj/item/weapon/restraints/handcuffs))
 				W.forceMove(get_turf(src))
 				continue
-			if(istype(W, /obj/item/weapon/implant))
-				continue
-			if(istype(W, /obj/item/clothing/suit/space/eva/plasmaman))
-				continue
-			if(istype(W, /obj/item/clothing/head/helmet/space/plasmaman))
-				continue
-			if(istype(W, /obj/item/weapon/tank/internals/plasmaman))
-				continue
-			if(istype(W, /obj/item/clothing/under/plasmaman))
+			if(istype(W, /obj/item/weapon/implant/storage))
 				continue
 			if(linked_reclaimer)
 				linked_reclaimer.stored_items[occupant] += W

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -140,6 +140,8 @@ The console is located at computer/gulag_teleporter.dm
 				continue
 			if(istype(W, /obj/item/weapon/tank/internals/plasmaman))
 				continue
+			if(istype(W, /obj/item/clothing/under/plasmaman))
+				continue
 			if(linked_reclaimer)
 				linked_reclaimer.stored_items[occupant] += W
 				linked_reclaimer.contents += W

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -132,7 +132,13 @@ The console is located at computer/gulag_teleporter.dm
 			if(istype(W, /obj/item/weapon/restraints/handcuffs))
 				W.forceMove(get_turf(src))
 				continue
-			if(istype(W, /obj/item/weapon/implant/storage))
+			if(istype(W, /obj/item/weapon/implant))
+				continue
+			if(istype(W, /obj/item/clothing/suit/space/eva/plasmaman))
+				continue
+			if(istype(W, /obj/item/clothing/head/helmet/space/plasmaman))
+				continue
+			if(istype(W, /obj/item/weapon/tank/internals/plasmaman))
 				continue
 			if(linked_reclaimer)
 				linked_reclaimer.stored_items[occupant] += W

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -21,9 +21,17 @@ The console is located at computer/gulag_teleporter.dm
 	var/jumpsuit_type = /obj/item/clothing/under/rank/prisoner
 	var/shoes_type = /obj/item/clothing/shoes/sneakers/orange
 	var/obj/machinery/gulag_item_reclaimer/linked_reclaimer = null
+	var/list/required_items
 
 /obj/machinery/gulag_teleporter/New()
 	..()
+	required_items = typecacheof(list(
+				/obj/item/weapon/implant,
+				/obj/item/clothing/suit/space/eva/plasmaman,
+				/obj/item/clothing/under/plasmaman,
+				/obj/item/clothing/head/helmet/space/plasmaman,
+				/obj/item/weapon/tank/internals,
+				/obj/item/clothing/mask))
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/gulag_teleporter(null)
 	B.apply_default_parts(src)
 	addtimer(src, "locate_reclaimer", 5)
@@ -128,11 +136,9 @@ The console is located at computer/gulag_teleporter.dm
 	if(linked_reclaimer)
 		linked_reclaimer.stored_items[occupant] = list()
 	for(var/obj/item/W in occupant)
-		if(occupant.unEquip(W))
+		if(!is_type_in_typecache(W, required_items) && occupant.unEquip(W))
 			if(istype(W, /obj/item/weapon/restraints/handcuffs))
 				W.forceMove(get_turf(src))
-				continue
-			if(istype(W, /obj/item/weapon/implant/storage))
 				continue
 			if(linked_reclaimer)
 				linked_reclaimer.stored_items[occupant] += W
@@ -146,7 +152,7 @@ The console is located at computer/gulag_teleporter.dm
 		return
 	strip_occupant()
 	var/mob/living/carbon/human/prisoner = occupant
-	if(jumpsuit_type)
+	if(!isplasmaman(prisoner) && jumpsuit_type)
 		prisoner.equip_to_appropriate_slot(new jumpsuit_type)
 	if(shoes_type)
 		prisoner.equip_to_appropriate_slot(new shoes_type)

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -31,7 +31,8 @@ The console is located at computer/gulag_teleporter.dm
 				/obj/item/clothing/under/plasmaman,
 				/obj/item/clothing/head/helmet/space/plasmaman,
 				/obj/item/weapon/tank/internals,
-				/obj/item/clothing/mask))
+				/obj/item/clothing/mask/breath,
+				/obj/item/clothing/mask/gas))
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/gulag_teleporter(null)
 	B.apply_default_parts(src)
 	addtimer(src, "locate_reclaimer", 5)


### PR DESCRIPTION
:cl: Jalleo
fix: Gulag Teleporter of two issues any more please report them.
/:cl:

Fixes #19819,#19724
The whole plasmaman and implants getting removed when the occupant goes through the teleporter.
Also removes var/ from one or two proc declarations.
