### PR TITLE
Hydroponics Multiplier Insanity

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -4,6 +4,7 @@
 	icon_state = "hydrotray"
 	density = 1
 	anchored = 1
+	pixel_y=8
 	var/waterlevel = 100	//The amount of water in the tray (max 100)
 	var/maxwater = 100		//The maximum amount of water in the tray
 	var/nutrilevel = 10		//The amount of nutrient in the tray (max 10)
@@ -23,11 +24,10 @@
 	var/obj/item/seeds/myseed = null	//The currently planted seed
 	var/rating = 1
 	var/unwrenchable = 1
-	var/recent_bee_visit = FALSE //Have we been visited by a bee recently, so bees dont overpolinate one plant
+	var/recent_bee_visit = FALSE //Have we been visited by a bee recently, so bees dont overpollinate one plant
 	var/using_irrigation = FALSE //If the tray is connected to other trays via irrigation hoses
 	var/self_sustaining = FALSE //If the tray generates nutrients and water on its own
 
-	pixel_y=8
 
 /obj/machinery/hydroponics/constructable
 	name = "hydroponics tray"
@@ -121,11 +121,11 @@
 		myseed.loc = src
 
 	if(self_sustaining)
-		adjustNutri(2 * rating)
-		adjustWater(rand(8, 10) * rating)
-		adjustWeeds(-5 * rating)
-		adjustPests(-5 * rating)
-		adjustToxic(-5 * rating)
+		adjustNutri(1)
+		adjustWater(rand(3,5))
+		adjustWeeds(-2)
+		adjustPests(-2)
+		adjustToxic(-2)
 
 	if(world.time > (lastcycle + cycledelay))
 		lastcycle = world.time
@@ -457,7 +457,8 @@
 	if(S.has_reagent("mutagen", 5) || S.has_reagent("radium", 10) || S.has_reagent("uranium", 10))
 		switch(rand(100))
 			if(91 to 100)
-				plantdies()
+				adjustHealth(-10)
+				usr << "<span class='warning'>The plant shrivels and burns.</span>"
 			if(81 to 90)
 				mutatespecie()
 			if(66 to 80)
@@ -465,13 +466,13 @@
 			if(41 to 65)
 				mutate()
 			if(21 to 41)
-				usr << "<span class='warning'>The plants don't seem to react...</span>"
+				usr << "<span class='notice'>The plants don't seem to react...</span>"
 			if(11 to 20)
 				mutateweed()
 			if(1 to 10)
 				mutatepest()
 			else
-				usr << "<span class='warning'>Nothing happens...</span>"
+				usr << "<span class='notice'>Nothing happens...</span>"
 
 	// 2 or 1 units is enough to change the yield and other stats.// Can change the yield and other stats, but requires more than mutagen
 	else if(S.has_reagent("mutagen", 2) || S.has_reagent("radium", 5) || S.has_reagent("uranium", 5))
@@ -489,18 +490,18 @@
 
 	// Nutriments
 	if(S.has_reagent("eznutriment", 1))
-		yieldmod = 1 * rating
-		mutmod = 1 * rating
+		yieldmod = 1
+		mutmod = 1
 		adjustNutri(round(S.get_reagent_amount("eznutriment") * 1))
 
 	if(S.has_reagent("left4zednutriment", 1))
-		yieldmod = 0 * rating
-		mutmod = 2 * rating
+		yieldmod = 0
+		mutmod = 2
 		adjustNutri(round(S.get_reagent_amount("left4zednutriment") * 1))
 
 	if(S.has_reagent("robustharvestnutriment", 1))
-		yieldmod = 2 * rating
-		mutmod = 0 * rating
+		yieldmod = 1.3
+		mutmod = 0
 		adjustNutri(round(S.get_reagent_amount("robustharvestnutriment") *1 ))
 
 	// Antitoxin binds shit pretty well. So the tox goes significantly down

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -34,9 +34,6 @@
 	// Stronger reagents must always come first to avoid being displaced by weaker ones.
 	// Total amount of any reagent in plant is calculated by formula: 1 + round(potency * multiplier)
 
-	var/innate_yieldmod = 0 //modifier for yield, seperate to the one in Hydro trays, as that one is SPECIFICALLY for nutriment/chems (which means it's constantly reset)
-	//This is added onto the yield mod of the hydro tray, yield *= (parent.yieldmod+innate_yieldmod)
-
 	var/weed_rate = 1 //If the chance below passes, then this many weeds sprout during growth
 	var/weed_chance = 5 //Percentage chance per tray update to grow weeds
 
@@ -105,7 +102,6 @@
 
 /obj/item/seeds/bullet_act(obj/item/projectile/Proj) //Works with the Somatoray to modify plant variables.
 	if(istype(Proj, /obj/item/projectile/energy/florayield))
-
 		var/rating = 1
 		if(istype(loc, /obj/machinery/hydroponics))
 			var/obj/machinery/hydroponics/H = loc
@@ -128,9 +124,10 @@
 		if(parent.yieldmod == 0)
 			return_yield = min(return_yield, 1)//1 if above zero, 0 otherwise
 		else
-			return_yield *= (parent.yieldmod+innate_yieldmod)
+			return_yield *= (parent.yieldmod)
 
 	return return_yield
+
 
 /obj/item/seeds/proc/harvest(mob/user = usr)
 	var/obj/machinery/hydroponics/parent = loc //for ease of access
@@ -150,6 +147,7 @@
 	parent.update_tray()
 
 	return result
+
 
 /obj/item/seeds/proc/prepare_result(var/obj/item/weapon/reagent_containers/food/snacks/grown/T)
 	if(T.reagents)

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -6,9 +6,9 @@
 #define BEE_TRAY_RECENT_VISIT	200	//How long in deciseconds until a tray can be visited by a bee again
 #define BEE_DEFAULT_COLOUR		"#e5e500" //the colour we make the stripes of the bee if our reagent has no colour (or we have no reagent)
 
-#define BEE_POLLINATE_YIELD_CHANCE		10
+#define BEE_POLLINATE_YIELD_CHANCE		33
 #define BEE_POLLINATE_PEST_CHANCE		33
-#define BEE_POLLINATE_POTENTCY_CHANCE	50
+#define BEE_POLLINATE_POTENCY_CHANCE	50
 
 /mob/living/simple_animal/hostile/poison/bees
 	name = "bee"
@@ -170,13 +170,14 @@
 
 	var/growth = health //Health also means how many bees are in the swarm, roughly.
 	//better healthier plants!
-	Hydro.health += round(growth*0.5)
+	Hydro.adjustHealth(growth*0.5)
 	if(prob(BEE_POLLINATE_PEST_CHANCE))
-		Hydro.pestlevel = max(0, --Hydro.pestlevel)
-	if(prob(BEE_POLLINATE_YIELD_CHANCE)) //Yield mod is HELLA powerful, but quite rare
-		Hydro.myseed.innate_yieldmod++
-	if(prob(BEE_POLLINATE_POTENTCY_CHANCE))
-		Hydro.myseed.potency++
+		Hydro.adjustPests(-10)
+	if(prob(BEE_POLLINATE_YIELD_CHANCE))
+		Hydro.myseed.adjust_yield(1)
+		Hydro.yieldmod = 2
+	if(prob(BEE_POLLINATE_POTENCY_CHANCE))
+		Hydro.myseed.adjust_potency(1)
 
 	if(beehome)
 		beehome.bee_resources = min(beehome.bee_resources + growth, 100)


### PR DESCRIPTION
:cl: Cheridan
tweak: Greatly reduced amount of Hydroponics yield multipliers
tweak: Somewhat reduced gaia'd tray sustainability.
tweak: Mutagen will no longer potentially cause plant instadeath based on RNG.
/:cl:

10 yield = 10 plants per harvest
10 yield \* 2 from robust harvest = 20 plants per harvest
10 \* (2 \* 4) from RnD upgrades = _80 plants per harvest_
10(2*4) \* Y where Y equals amount of innate_yieldmod upgrades given by bees (this has no cap) = what the fuck

The level of production was already enough to cause server stability issues as seen here #14827 

Gaia sustainability also got a boost from the rating of the tray, which is pointless because upgrading the tray also divides the rate that pest, water, etc all decline meaning it was literal plant godmode even without the modifier.

In exchange for client-crashing piles of cash lemons I've removed the RNG plant death from mutagen. It still does some health damage but that's healable in a number of ways.
