### PR TITLE
You can smuggle smuggler's satchels to a future shift

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -1,0 +1,60 @@
+var/datum/subsystem/persistence/SSpersistence
+
+/datum/subsystem/persistence
+	name = "Persistence"
+	init_order = -100
+	flags = SS_NO_FIRE
+	var/savefile/secret_satchels
+	var/list/new_secret_satchels = list() //these are objects
+	var/list/old_secret_satchels = list() //these are associate
+
+/datum/subsystem/persistence/New()
+	NEW_SS_GLOBAL(SSpersistence)
+
+/datum/subsystem/persistence/Initialize()
+	PlaceSecretSatchel()
+	..()
+
+/datum/subsystem/persistence/proc/CollectData()
+	CollectSecretSatchels()
+
+/datum/subsystem/persistence/proc/PlaceSecretSatchel()
+	var/list/satchels = list()
+	var/list/invalid_satchels = list()
+	secret_satchels = new /savefile("data/npc_saves/SecretSatchels.sav")
+	while(!secret_satchels.eof)
+		var/list/potential_satchel = list()
+		secret_satchels >> potential_satchel
+		if(potential_satchel["map"] != MAP_NAME)
+			invalid_satchels += potential_satchel
+			continue
+		satchels += potential_satchel
+	if(satchels.len < 1)
+		return
+	var/list/chosen_satchel = pick_n_take(satchels)
+	old_secret_satchels = satchels + invalid_satchels
+	secret_satchels << old_secret_satchels
+	var/path = text2path(chosen_satchel["object"])
+	var/obj/item/weapon/storage/backpack/satchel/flat/secret/F = new(chosen_satchel["loc"])
+	new path(F) //runtimes intentionally if satchel item has had its path changed/removed
+
+/datum/subsystem/persistence/proc/CollectSecretSatchels()
+	world << "<span class='boldannounce'>Here we go</span>"
+	var/list/saved_satchels = list()
+	for(var/A in new_secret_satchels)
+		world << "<span class='boldannounce'>we got satch!</span>"
+		var/obj/item/weapon/storage/backpack/satchel/flat/F = A
+		if(qdeleted(F) || F.z != ZLEVEL_STATION || F.invisibility != INVISIBILITY_MAXIMUM)
+			continue
+		var/list/savable_obj = list()
+		for(var/obj/O in F)
+			if(ispath(O,/obj/item/stack/tile/plasteel) || ispath(O,/obj/item/weapon/crowbar) || O.admin_spawned)
+				continue
+			savable_obj += O.type
+		if(savable_obj.len < 1)
+			continue
+		world << "<span class='boldannounce'>and it's valid!</span>"
+		saved_satchels += list("map" = MAP_NAME, "loc" = F.loc, "object" = pick(savable_obj))
+	world << "<span class='boldannounce'>AAAAAAA HERE COMES PAIN</span>"
+	secret_satchels << old_secret_satchels + saved_satchels
+	world << "<span class='boldannounce'>we did it reddit</span>"

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -5,7 +5,7 @@ var/datum/subsystem/persistence/SSpersistence
 	init_order = -100
 	flags = SS_NO_FIRE
 	var/savefile/secret_satchels
-	var/list/satchel_blacklist 		= list() //these are typecaches
+	var/list/satchel_blacklist 		= list() //this is a typecache
 	var/list/new_secret_satchels 	= list() //these are objects
 	var/list/old_secret_satchels 	= list() //these are just vars
 
@@ -22,7 +22,7 @@ var/datum/subsystem/persistence/SSpersistence
 /datum/subsystem/persistence/proc/PlaceSecretSatchel()
 	var/list/satchels = list()
 	secret_satchels = new /savefile("data/npc_saves/SecretSatchels_[MAP_NAME].sav")
-	satchel_blacklist = typecacheof(/obj/item/stack/tile/plasteel) + typecacheof(/obj/item/weapon/crowbar)
+	satchel_blacklist = typecacheof(list(/obj/item/stack/tile/plasteel, /obj/item/weapon/crowbar))
 
 	secret_satchels >> satchels
 	if(!satchels.len || satchels.len < 20) //guards against low drop pools assuring that one player can reliably find his own gear.

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -451,6 +451,8 @@ var/datum/subsystem/ticker/ticker
 			dellog += "Failures : [SSgarbage.didntgc[path]] \n"
 		world.log << dellog
 
+	//Collects persistence features
+	SSpersistence.CollectData()
 	return 1
 
 /datum/subsystem/ticker/proc/send_tip_of_the_round()

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -486,6 +486,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	name = "nuclear authentication disk"
 	desc = "Better keep this safe."
 	icon_state = "nucleardisk"
+	persistence_replacement = /obj/item/weapon/disk/fakenucleardisk
 
 /obj/item/weapon/disk/nuclear/New()
 	..()
@@ -556,3 +557,8 @@ This is here to make the tiles around the station mininuke change when it's arme
 	log_game("[src] has been destroyed in [COORD(diskturf)]. Moving it to \
 		[COORD(targetturf)].")
 	return QDEL_HINT_LETMELIVE //Cancel destruction unless forced
+
+/obj/item/weapon/disk/fakenucleardisk
+	name = "cheap plastic imitation of the nuclear authentication disk"
+	desc = "Broken dreams and a faint oder of cheese."
+	icon_state = "nucleardisk"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -516,6 +516,7 @@
 	throw_speed = 2
 	throw_range = 5
 	w_class = 1
+	persistence_replacement = /obj/item/weapon/spellbook/oneuse/random
 	var/uses = 10
 	var/temp = null
 	var/op = 1
@@ -707,6 +708,7 @@
 	name = "spellbook of "
 	uses = 1
 	desc = "This template spellbook was never meant for the eyes of man..."
+	persistence_replacement = null
 
 /obj/item/weapon/spellbook/oneuse/New()
 	..()

--- a/code/game/objects/items/weapons/implants/implantuplink.dm
+++ b/code/game/objects/items/weapons/implants/implantuplink.dm
@@ -28,7 +28,18 @@
 
 /obj/item/weapon/implanter/uplink
 	name = "implanter (uplink)"
+	persistence_replacement = /obj/item/weapon/implanter/weakuplink
 
 /obj/item/weapon/implanter/uplink/New()
 	imp = new /obj/item/weapon/implant/uplink(src)
 	..()
+/obj/item/weapon/implanter/weakuplink
+	name = "implanter (uplink)"
+
+/obj/item/weapon/implanter/weakuplink/New()
+	imp = new /obj/item/weapon/implant/uplink/weak(src)
+	..()
+
+/obj/item/weapon/implant/uplink/weak/New()
+	..()
+	hidden_uplink.telecrystals = 5

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -288,6 +288,7 @@
 	..()
 	PoolOrNew(/obj/item/stack/tile/plasteel, src)
 	new /obj/item/weapon/crowbar(src)
+	SSpersistence.new_secret_satchels += src
 
 /obj/item/weapon/storage/backpack/satchel/flat/secret/
 	var/list/reward_one_of_these = list() //Intended for map editing

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -18,6 +18,8 @@
 	var/on_blueprints = FALSE //Are we visible on the station blueprints at roundstart?
 	var/force_blueprints = FALSE //forces the obj to be on the blueprints, regardless of when it was created.
 
+	var/persistence_replacement = null //have something WAY too amazing to live to the next round? Set a new path here. Overuse of this var will make me upset.
+
 /obj/New()
 	..()
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -152,6 +152,7 @@
 #include "code\controllers\subsystem\npcpool.dm"
 #include "code\controllers\subsystem\objects.dm"
 #include "code\controllers\subsystem\pai.dm"
+#include "code\controllers\subsystem\persistence.dm"
 #include "code\controllers\subsystem\pool.dm"
 #include "code\controllers\subsystem\radio.dm"
 #include "code\controllers\subsystem\server_maintenance.dm"


### PR DESCRIPTION
:exclamation: YOUR FIRST INSTINCT MAY BE TO THINK THIS IS OP TRASH, BUT READ MY COMMENTS, IT'S NOT :exclamation: 

Hidden Smuggler Satchels hidden beneath the station now persist between rounds, though there's no assurances of WHEN they'll appear next and only one will ever appear in any given round.

Cavets: 
*Only one random item in a satchel is saved.
*The more satchels are hidden, the less likely any one satchel is to be in a round. At the very least, there has to be 20 satchels in rotation to have one appear in the next round, so at the very best, your odds of "reclaiming" a satchel are 5%
*Satchels are bound to the maps in which they are hidden, and only on the station z level
*It's a path save, so things you put together yourself like TTV or things with reagent components will only spawn in as their vanilla bits.
*Admin shenanigans can't be saved.
*Certain very high risk items can be replaced with less dangerous look alikes on a case by case basis

:cl:
add: Smuggler satchels left behind hidden on the station can now reappear in a later round.
experiment: There's absolutely no way of knowing when exactly it will reappear however...
add: Only one item in the satchel will remain when the satchel reappears.
add: Items are saved in their <b>initial</b> forms, so saving things like chemical grenades will only disappoint you.
add: The item pool is map specific and needs to be a certain size before satchels can start reappearing, so get to hiding that loot!
/:cl:
