### PR TITLE
Fixes being able to use an invalid limb for augmentations/prosthetic replacments

### DIFF
--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -21,14 +21,16 @@
 	var/obj/item/bodypart/L = null // L because "limb"
 
 
-
 /datum/surgery_step/add_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/obj/item/robot_parts/aug = tool
+	if(istype(aug) && aug.body_zone != target_zone)
+		user << "<span class='warning'>[tool] isn't the right type for [parse_zone(target_zone)].</span>"
+		return -1
 	L = surgery.organ
 	if(L)
 		user.visible_message("[user] begins to augment [target]'s [parse_zone(user.zone_selected)].", "<span class ='notice'>You begin to augment [target]'s [parse_zone(user.zone_selected)]...</span>")
 	else
 		user.visible_message("[user] looks for [target]'s [parse_zone(user.zone_selected)].", "<span class ='notice'>You look for [target]'s [parse_zone(user.zone_selected)]...</span>")
-
 
 
 //ACTUAL SURGERIES
@@ -38,7 +40,6 @@
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/replace, /datum/surgery_step/saw, /datum/surgery_step/add_limb)
 	species = list(/mob/living/carbon/human)
 	possible_locs = list("r_arm","l_arm","r_leg","l_leg","chest","head")
-
 
 //SURGERY STEP SUCCESSES
 

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -36,6 +36,7 @@
 		user.visible_message("[user] begins to replace [target]'s [parse_zone(target_zone)].", "<span class ='notice'>You begin to replace [target]'s [parse_zone(target_zone)]...</span>")
 	else
 		user << "<span class='warning'>[tool] isn't the right type for [parse_zone(target_zone)].</span>"
+		return -1
 
 /datum/surgery_step/add_prosthetic/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/obj/item/bodypart/L


### PR DESCRIPTION
:cl: 
fix: You can no longer use the incorrect limb type during augmentation
fix: You can no longer use the incorrect limb type during prosthetic replacement
/:cl:

For prosthetic replacement it told the user it was wrong, but never stopped them.
For augmentation, it never bothered to check.

Thanks to @GunHog for bringing this to my attention and pointing out /both/ surgeries were broken _sigh_
