### PR TITLE
Refactors slaving summoned mobs to their creators/sentience potions now convert to users antag team

### DIFF
--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -162,14 +162,10 @@
 		user << "<span class='warning'>Unable to connect to Syndicate command. Please wait and try again later or use the teleporter on your uplink to get your points refunded.</span>"
 
 /obj/item/weapon/antag_spawner/nuke_ops/spawn_antag(client/C, turf/T)
-	var/new_op_code = "Ask your leader!"
 	var/mob/living/carbon/human/M = new/mob/living/carbon/human(T)
 	C.prefs.copy_to(M)
 	M.key = C.key
-	var/obj/machinery/nuclearbomb/nuke = locate("syndienuke") in nuke_list
-	if(nuke)
-		new_op_code = nuke.r_code
-	M.mind.make_Nuke(T, new_op_code, 0, FALSE)
+	M.mind.make_Nuke(T, nuke_code = null, 0, FALSE)
 	var/newname = M.dna.species.random_name(M.gender,0,ticker.mode.nukeops_lastname)
 	M.mind.name = newname
 	M.real_name = newname
@@ -213,12 +209,7 @@
 	R.mmi.brainmob.name = brainopsname
 
 	R.key = C.key
-	ticker.mode.syndicates += R.mind
-	ticker.mode.update_synd_icons_added(R.mind)
-	R.mind.special_role = "syndicate"
-	R.faction = list("syndicate")
-
-
+	R.mind.make_Nuke(T, nuke_code = null,leader=0, telecrystals = TRUE)
 
 ///////////SLAUGHTER DEMON
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -23,10 +23,6 @@
 		return 0
 	if(issilicon(mind.current) || isbot(mind.current) || isdrone(mind.current))
 		return 0 //can't convert machines, that's ratvar's thing
-	if(isguardian(mind.current))
-		var/mob/living/simple_animal/hostile/guardian/G = mind.current
-		if(!iscultist(G.summoner))
-			return 0 //can't convert it unless the owner is converted
 	if(is_sacrifice_target(mind))
 		return 0
 	if(mind.enslaved_to && !iscultist(mind.enslaved_to))

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -284,6 +284,9 @@
 		synd_mind.current.real_name = synd_mind.name
 	return
 
+/proc/is_nuclear_operative(mob/M)
+	return M && istype(M) && M.mind && ticker && ticker.mode && M.mind in ticker.mode.syndicates
+
 /datum/outfit/syndicate
 	name = "Syndicate Operative - Basic"
 

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -554,7 +554,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	var/mob/living/simple_animal/hostile/guardian/G = new pickedtype(user, theme)
 	G.summoner = user
 	G.key = key
-	G.faction |= user.faction
+	G.mind.enslave_mind_to_creator(user)
 	switch(theme)
 		if("tech")
 			user << "[G.tech_fluff_string]"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -191,7 +191,7 @@
 		SM.key = theghost.key
 		SM.languages_spoken |= HUMAN
 		SM.languages_understood |= HUMAN
-		SM.faction = user.faction
+		SM.mind.enslave_mind_to_creator(user)
 		SM.sentience_act()
 		SM << "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>"
 		SM << "<span class='userdanger'>You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost.</span>"
@@ -499,31 +499,8 @@
 	G << "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost."
 	G.mind.store_memory("<b>Serve [user.real_name], your creator.</b>")
 
-	var/golem_becomes_antag = FALSE
-	if(iscultist(user)) //If the golem's master is a part of a team antagonist, immediately make the golem one, too
-		ticker.mode.add_cultist(G.mind)
-		golem_becomes_antag = TRUE
-	else if(is_gangster(user))
-		ticker.mode.add_gangster(G.mind, user.mind.gang_datum, TRUE)
-		golem_becomes_antag = TRUE
-	else if(is_handofgod_redcultist(user) || is_handofgod_redprophet(user))
-		ticker.mode.add_hog_follower(G.mind, "Red")
-		golem_becomes_antag = TRUE
-	else if(is_handofgod_bluecultist(user) || is_handofgod_blueprophet(user))
-		ticker.mode.add_hog_follower(G.mind, "Blue")
-		golem_becomes_antag = TRUE
-	else if(is_revolutionary_in_general(user))
-		ticker.mode.add_revolutionary(G.mind)
-		golem_becomes_antag = TRUE
-	else if(is_servant_of_ratvar(user))
-		add_servant_of_ratvar(G)
-		golem_becomes_antag = TRUE
+	G.mind.enslave_mind_to_creator(user)
 
-	G.mind.enslaved_to = user
-	if(golem_becomes_antag)
-		G << "<span class='userdanger'>Despite your servitude to another cause, your true master remains [user.real_name]. This will never change unless your master's body is destroyed.</span>"
-	if(user.mind.special_role)
-		message_admins("[key_name_admin(G)](<A HREF='?_src_=holder;adminmoreinfo=\ref[G]'>?</A>) has been summoned by [key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>), an antagonist.")
 	log_game("[key_name(G)] was made a golem by [key_name(user)].")
 	log_admin("[key_name(G)] was made a golem by [key_name(user)].")
 	qdel(src)


### PR DESCRIPTION
I wanted to turn Cayenne into an op when sentienced so he'd show up on the round report and it spiralled a bit out of control.

The golem creation mind linking thing Xhuis did was generalized/cleaned up and redone as a mind proc. 

Summoning a Guardian/Holoparasite, using a sentience potion, or summoning a golem will now link their mind to yours, making them autoconvert to your team, and be unable to be converted/deconverted as long as your body still exists. It will also now alert admins when a traitor creates a slaved mob of any type (mining drone, sentience potion, etc) 

:cl: Kor
add: Players created by sentience potions, mining drone upgrades, or Guardian/Holoparsite summoners will now automatically join the users antagonist team, if any.
add: Mobs created in this manner will no longer be convertable/deconvertable unless their creator is first converted/deconverted.
add: Cayenne will now officially become an operative when given a sentience potion.
/:cl:
