### PR TITLE
Modkits now only allow other races to use kinetic accelerators.

### DIFF
--- a/code/game/objects/items/devices/modificationkit.dm
+++ b/code/game/objects/items/devices/modificationkit.dm
@@ -1,8 +1,6 @@
 /obj/item/modkit
 	name = "modification kit"
-	desc = "A one-use kit, which enables kinetic accelerators to retain their \
-		charge when away from a bioelectric source, renders them immune to \
-		interference with other accelerators, as well as allowing less \
+	desc = "A one-use kit, which allows less \
 		dextrous races to use the tool."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "modkit"
@@ -19,16 +17,13 @@
 			accelerators!</span>"
 		return ..()
 	// RIP the 'improved improved improved improved kinetic accelerator
-	if(C.holds_charge && C.unique_frequency)
+	if(C.trigger_guard == TRIGGER_GUARD_ALLOW_ALL)
 		user << "<span class='warning'>This kinetic accelerator already has \
-			these upgrades.</span>"
+			been modified.</span>"
 		return ..()
-
 	user <<"<span class='notice'>You modify the [C], adjusting the trigger \
-		guard and internal capacitor.</span>"
-	C.name = "improved [C.name]"
-	C.holds_charge = TRUE
-	C.unique_frequency = TRUE
+		guard.</span>"
+	C.name = "modified [C.name]"
 	C.trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 	uses--
 	if(!uses)


### PR DESCRIPTION
:cl:
tweak: Modkits now only allow other races to use kinetic accelerators, instead of doubling your fire rate via dual wielding.
/:cl:

Modkits no longer give Kinetic Accelerators unique frequencies, they are instead simply tools for letting other races use them.

Let's talk about multipliers!
If you crunch the numbers, the proto kinetic does 2.5 Damage per time tick, and the Hyper kinetic does 3.42 Damage per time tick. That's a ~37% increase in damage over time.

And then because of modkits, you fire twice as fast because you can dual wield. So instead of a 36% boost in player damage, you're now dealing 272% of what you were doing with a single proto kinetic accelerator. This disparity is too huge. On top of this, if you have HKA's, you have mod kits, so there was no reason for them to even be seperate items in the first place.

> But Ergo, doesn't that mean Legion is even more of a pain in the ass to fight?

Yes. But that's more of a Legion problem. Long story short, clamping down on fire rate is better for creating content because the difference between "Round start" and "End game" states is colossal.
