### PR TITLE
Removed bluespace gigabeacon from golem ship.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -539,7 +539,7 @@ j
 l
 l
 l
-s
+l
 l
 l
 l


### PR DESCRIPTION
:cl: Akkryls
del: Removed telebeacon from the golem ship on lavaland.
/:cl:

Removed the bluespace gigabeacon from the golem ship on lavaland.
