### PR TITLE
Changes miner breath mask to gas mask

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -70,7 +70,7 @@
 
 /obj/item/weapon/storage/box/survival_mining/New()
 	..()
-	new /obj/item/clothing/mask/breath(src)
+	new /obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen/engi(src)
 	new /obj/item/weapon/crowbar/red(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)


### PR DESCRIPTION
Most jobs that have a specific mask start with that specific type of mask in their box instead of a breath mask, see syndies, security, HOS, etc.

It looks really dumb when miners wear a breathmask with the explorer suit,

And a better question, why not?
