### PR TITLE
Revert "Fixes transit turfs not throwing things when they're created"

### DIFF
--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -19,9 +19,6 @@
 	dir = EAST
 
 /turf/open/space/transit/Entered(atom/movable/AM, atom/OldLoc)
-	throw_atom(AM)
-
-/turf/open/space/transit/proc/throw_atom(atom/movable/AM)
 	if(!AM)
 		return
 	var/max = world.maxx-TRANSITIONEDGE
@@ -56,14 +53,15 @@
 	AM.loc = T
 	AM.newtonian_move(dir)
 
+
+
+
 //Overwrite because we dont want people building rods in space.
 /turf/open/space/transit/attackby()
 	return
 
 /turf/open/space/transit/New()
 	update_icon()
-	for(var/atom/movable/AM in src)
-		throw_atom(AM)
 	..()
 
 /turf/open/space/transit/update_icon()


### PR DESCRIPTION
Reverts tgstation/tgstation#19853
Transit turfs are so buffed that they throw shuttles. Unless someone makes a fix I'm making this revert.
