### PR TITLE
Exporting seeds of a plant will now always give supply points

### DIFF
--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -31,6 +31,8 @@
 	if(!cost)
 		return 0
 
-	var/potDiff = max(S.potency - discoveredPlants[S.type], 0)
-
-	return round(..() * potDiff)
+	var/potDiff = (S.potency - discoveredPlants[S.type])
+	if(potDiff < 1)
+		return round(S.rarity * S.potency / 10)
+	else
+		return round(..() * potDiff)


### PR DESCRIPTION
:cl: 
:add: Makes it so you can export any plant's seeds (expect the starting plants as they have no rarity) and always give supply points based on rarity and potency, equation for price is rarity \* potency / 10
/:cl:

Credit to @PKPenguin321 and @MrPerson for bug fixes and help
