### PR TITLE
Removes ~50ms of input lag from movement.

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -12,7 +12,26 @@
 			return 1
 	return (!mover.density || !density || lying)
 
+//there are bugs with byond's default versions of these verbs
+/client/verb/moveup()
+	set name = ".moveup"
+	set instant = 1
+	Move(get_step(mob, NORTH), NORTH)
 
+/client/verb/movedown()
+	set name = ".movedown"
+	set instant = 1
+	Move(get_step(mob, SOUTH), SOUTH)
+
+/client/verb/moveright()
+	set name = ".moveright"
+	set instant = 1
+	Move(get_step(mob, EAST), EAST)
+
+/client/verb/moveleft()
+	set name = ".moveleft"
+	set instant = 1
+	Move(get_step(mob, WEST), WEST)
 
 /client/Northeast()
 	swap_hand()
@@ -90,14 +109,14 @@
 
 
 /client/Move(n, direct)
+	if(world.time < move_delay)
+		return 0
 	if(!mob || !mob.loc)
 		return 0
 	if(mob.notransform)
 		return 0	//This is sota the goto stop mobs from moving var
 	if(mob.control_object)
 		return Move_object(direct)
-	if(world.time < move_delay)
-		return 0
 	if(!isliving(mob))
 		return mob.Move(n,direct)
 	if(mob.stat == DEAD)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -111,6 +111,7 @@
 /client/Move(n, direct)
 	if(world.time < move_delay)
 		return 0
+	move_delay = world.time+world.tick_lag //this is here because Move() can now be called mutiple times per tick
 	if(!mob || !mob.loc)
 		return 0
 	if(mob.notransform)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -22,25 +22,25 @@ macro "default"
 		command = "westface"
 	elem
 		name = "WEST+REP"
-		command = ".west"
+		command = ".moveleft"
 	elem
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem
 		name = "NORTH+REP"
-		command = ".north"
+		command = ".moveup"
 	elem
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem
 		name = "EAST+REP"
-		command = ".east"
+		command = ".moveright"
 	elem
 		name = "CTRL+SOUTH"
 		command = "southface"
 	elem
 		name = "SOUTH+REP"
-		command = ".south"
+		command = ".movedown"
 	elem
 		name = "INSERT"
 		command = "a-intent right"
@@ -61,13 +61,13 @@ macro "default"
 		command = "a-intent harm"
 	elem
 		name = "CTRL+A+REP"
-		command = ".west"
+		command = ".moveleft"
 	elem
 		name = "CTRL+B"
 		command = "resist"
 	elem
 		name = "CTRL+D+REP"
-		command = ".east"
+		command = ".moveright"
 	elem
 		name = "CTRL+E"
 		command = "quick-equip"
@@ -85,10 +85,10 @@ macro "default"
 		command = ".southwest"
 	elem
 		name = "CTRL+S+REP"
-		command = ".south"
+		command = ".movedown"
 	elem
 		name = "CTRL+W+REP"
-		command = ".north"
+		command = ".moveup"
 	elem
 		name = "CTRL+X"
 		command = ".northeast"
@@ -153,25 +153,25 @@ macro "hotkeys"
 		command = "westface"
 	elem
 		name = "WEST+REP"
-		command = ".west"
+		command = ".moveleft"
 	elem
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem
 		name = "NORTH+REP"
-		command = ".north"
+		command = ".moveup"
 	elem
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem
 		name = "EAST+REP"
-		command = ".east"
+		command = ".moveright"
 	elem
 		name = "CTRL+SOUTH"
 		command = "southface"
 	elem
 		name = "SOUTH+REP"
-		command = ".south"
+		command = ".movedown"
 	elem
 		name = "INSERT"
 		command = "a-intent right"
@@ -204,10 +204,10 @@ macro "hotkeys"
 		command = "a-intent harm"
 	elem
 		name = "A+REP"
-		command = ".west"
+		command = ".moveleft"
 	elem
 		name = "CTRL+A+REP"
-		command = ".west"
+		command = ".moveleft"
 	elem
 		name = "B"
 		command = "resist"
@@ -216,10 +216,10 @@ macro "hotkeys"
 		command = "resist"
 	elem
 		name = "D+REP"
-		command = ".east"
+		command = ".moveright"
 	elem
 		name = "CTRL+D+REP"
-		command = ".east"
+		command = ".moveright"
 	elem
 		name = "E"
 		command = "quick-equip"
@@ -261,19 +261,19 @@ macro "hotkeys"
 		command = ".southwest"
 	elem "s_key"
 		name = "S+REP"
-		command = ".south"
+		command = ".movedown"
 	elem
 		name = "CTRL+S+REP"
-		command = ".south"
+		command = ".movedown"
 	elem
 		name = "T"
 		command = "say"
 	elem "w_key"
 		name = "W+REP"
-		command = ".north"
+		command = ".moveup"
 	elem
 		name = "CTRL+W+REP"
-		command = ".north"
+		command = ".moveup"
 	elem
 		name = "X"
 		command = ".northeast"
@@ -342,25 +342,25 @@ macro "robot-default"
 		command = "westface"
 	elem
 		name = "WEST+REP"
-		command = ".west"
+		command = ".moveleft"
 	elem
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem
 		name = "NORTH+REP"
-		command = ".north"
+		command = ".moveup"
 	elem
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem
 		name = "EAST+REP"
-		command = ".east"
+		command = ".moveright"
 	elem
 		name = "CTRL+SOUTH"
 		command = "southface"
 	elem
 		name = "SOUTH+REP"
-		command = ".south"
+		command = ".movedown"
 	elem
 		name = "INSERT"
 		command = "a-intent right"
@@ -381,7 +381,7 @@ macro "robot-default"
 		command = "a-intent left"
 	elem
 		name = "CTRL+A+REP"
-		command = ".west"
+		command = ".moveleft"
 	elem
 		name = "CTRL+B"
 		command = "resist"
@@ -390,7 +390,7 @@ macro "robot-default"
 		command = "ooc"
 	elem
 		name = "CTRL+D+REP"
-		command = ".east"
+		command = ".moveright"
 	elem
 		name = "CTRL+F"
 		command = "a-intent left"
@@ -402,10 +402,10 @@ macro "robot-default"
 		command = "unequip-module"
 	elem
 		name = "CTRL+S+REP"
-		command = ".south"
+		command = ".movedown"
 	elem
 		name = "CTRL+W+REP"
-		command = ".north"
+		command = ".moveup"
 	elem
 		name = "CTRL+X"
 		command = ".northeast"
@@ -464,25 +464,25 @@ macro "robot-hotkeys"
 		command = "westface"
 	elem
 		name = "WEST+REP"
-		command = ".west"
+		command = ".moveleft"
 	elem
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem
 		name = "NORTH+REP"
-		command = ".north"
+		command = ".moveup"
 	elem
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem
 		name = "EAST+REP"
-		command = ".east"
+		command = ".moveright"
 	elem
 		name = "CTRL+SOUTH"
 		command = "southface"
 	elem
 		name = "SOUTH+REP"
-		command = ".south"
+		command = ".movedown"
 	elem
 		name = "INSERT"
 		command = "a-intent right"
@@ -515,10 +515,10 @@ macro "robot-hotkeys"
 		command = "a-intent left"
 	elem
 		name = "A+REP"
-		command = ".west"
+		command = ".moveleft"
 	elem
 		name = "CTRL+A+REP"
-		command = ".west"
+		command = ".moveleft"
 	elem
 		name = "B"
 		command = "resist"
@@ -533,10 +533,10 @@ macro "robot-hotkeys"
 		command = "ooc"
 	elem
 		name = "D+REP"
-		command = ".east"
+		command = ".moveright"
 	elem
 		name = "CTRL+D+REP"
-		command = ".east"
+		command = ".moveright"
 	elem
 		name = "F"
 		command = "a-intent left"
@@ -557,19 +557,19 @@ macro "robot-hotkeys"
 		command = "unequip-module"
 	elem "s_key"
 		name = "S+REP"
-		command = ".south"
+		command = ".movedown"
 	elem
 		name = "CTRL+S+REP"
-		command = ".south"
+		command = ".movedown"
 	elem
 		name = "T"
 		command = "say"
 	elem "w_key"
 		name = "W+REP"
-		command = ".north"
+		command = ".moveup"
 	elem
 		name = "CTRL+W+REP"
-		command = ".north"
+		command = ".moveup"
 	elem
 		name = "X"
 		command = ".northeast"


### PR DESCRIPTION
:cl:
del: The server will no longer wait until the next tick to process movement key presses. Movements should now be ~25-50ms more responsive.
/:cl:

This removes about 50ms of input lag from movement by telling byond to not wait until the next tick to process the key press.
