### PR TITLE
Readds irradiate failure to nuclear gun on EMP

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -79,3 +79,46 @@
 	ammo_x_offset = 1
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/disabler)
 	selfcharge = 1
+	var/fail_tick = 0
+	var/fail_chance = 80
+
+/obj/item/weapon/gun/energy/gun/nuclear/process()
+	if(fail_tick > 0)
+		fail_tick--
+	..()
+
+/obj/item/weapon/gun/energy/gun/nuclear/shoot_live_shot()
+	failcheck()
+	update_icon()
+	..()
+
+/obj/item/weapon/gun/energy/gun/nuclear/proc/failcheck()
+	if(!prob(fail_chance) && istype(loc, /mob/living))
+		var/mob/living/M = loc
+		switch(fail_tick)
+			if(0 to 200)
+				fail_tick += (2*(100-fail_chance))
+				M.rad_act(40)
+				M << "<span class='userdanger'>Your [name] feels warmer.</span>"
+			if(201 to INFINITY)
+				SSobj.processing.Remove(src)
+				M.rad_act(80)
+				crit_fail = 1
+				M << "<span class='userdanger'>Your [name]'s reactor overloads!</span>"
+
+/obj/item/weapon/gun/energy/gun/nuclear/emp_act(severity)
+	..()
+	fail_chance = max(fail_chance - round(15/severity), 0)
+
+/obj/item/weapon/gun/energy/gun/nuclear/update_icon()
+	..()
+	if(crit_fail)
+		overlays += "[icon_state]_fail_3"
+	else
+		switch(fail_tick)
+			if(0)
+				overlays += "[icon_state]_fail_0"
+			if(1 to 150)
+				overlays += "[icon_state]_fail_1"
+			if(151 to INFINITY)
+				overlays += "[icon_state]_fail_2"

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -80,7 +80,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/disabler)
 	selfcharge = 1
 	var/fail_tick = 0
-	var/fail_chance = 80
+	var/fail_chance = 0
 
 /obj/item/weapon/gun/energy/gun/nuclear/process()
 	if(fail_tick > 0)
@@ -93,11 +93,11 @@
 	..()
 
 /obj/item/weapon/gun/energy/gun/nuclear/proc/failcheck()
-	if(!prob(fail_chance) && istype(loc, /mob/living))
+	if(prob(fail_chance) && istype(loc, /mob/living))
 		var/mob/living/M = loc
 		switch(fail_tick)
 			if(0 to 200)
-				fail_tick += (2*(100-fail_chance))
+				fail_tick += (2*(fail_chance))
 				M.rad_act(40)
 				M << "<span class='userdanger'>Your [name] feels warmer.</span>"
 			if(201 to INFINITY)
@@ -108,17 +108,17 @@
 
 /obj/item/weapon/gun/energy/gun/nuclear/emp_act(severity)
 	..()
-	fail_chance = max(fail_chance - round(15/severity), 0)
+	fail_chance = min(fail_chance + round(15/severity), 100)
 
 /obj/item/weapon/gun/energy/gun/nuclear/update_icon()
 	..()
 	if(crit_fail)
-		overlays += "[icon_state]_fail_3"
+		add_overlay("[icon_state]_fail_3")
 	else
 		switch(fail_tick)
 			if(0)
-				overlays += "[icon_state]_fail_0"
+				add_overlay("[icon_state]_fail_0")
 			if(1 to 150)
-				overlays += "[icon_state]_fail_1"
+				add_overlay("[icon_state]_fail_1")
 			if(151 to INFINITY)
-				overlays += "[icon_state]_fail_2"
+				add_overlay("[icon_state]_fail_2")


### PR DESCRIPTION
Readds unique failure mechanic to advanced energy gun that was removed in  #17576 along with reliability. If the gun gets EMPed, each time the gun is fired there's a low chance it'll irradiate you, if this happens enough it'll stop auto-charging. Further EMPs the gun increases this chance. This also fixes part of the icon being missing.

I considered adding additonal boons to the gun however RD-made auto-charging seems reasonable enough for the rare occurance of irradiating you. Thoughts?

:cl:
add: Advanced Energy Guns once again have a chance to irradiate you if EMPed.
/:cl:
