### PR TITLE
Staff of Change 2016

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -272,4 +272,7 @@ Difficulty: Medium
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	loot = list()
 
+/mob/living/simple_animal/hostile/megafauna/dragon/lesser/grant_achievement(medaltype,scoretype)
+	return
+
 #undef MEDAL_PREFIX

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -181,7 +181,7 @@
 		if("monkey")
 			new_mob = new /mob/living/carbon/monkey(M.loc)
 		if("robot")
-			var/robot = pick("cyborg","syndiborg","drone")
+			var/robot = pick("cyborg","syndiborg","drone","cogscarb")
 			switch(robot)
 				if("cyborg")
 					new_mob = new /mob/living/silicon/robot(M.loc)
@@ -194,6 +194,8 @@
 					new_mob = new path(M.loc)
 				if("drone")
 					new_mob = new /mob/living/simple_animal/drone/polymorphed(M.loc)
+				if("cogscarb")
+					new_mob = new /mob/living/simple_animal/drone/cogscarab(M.loc)
 			if(issilicon(new_mob))
 				new_mob.gender = M.gender
 				new_mob.invisibility = 0
@@ -211,7 +213,7 @@
 		if("animal")
 			var/path
 			if(prob(50))
-				var/beast = pick("carp","bear","mushroom","statue", "bat", "goat","killertomato", "spiderbase", "spiderhunter", "blobbernaut", "magicarp", "chaosmagicarp")
+				var/beast = pick("carp","bear","mushroom","statue", "bat", "goat","killertomato", "spiderbase", "spiderhunter", "blobbernaut", "magicarp", "chaosmagicarp", "watcher", "goliath", "headcrab", "morph", "stickman", "stickdog", "lesserdragon")
 				switch(beast)
 					if("carp")
 						path = /mob/living/simple_animal/hostile/carp
@@ -237,6 +239,20 @@
 						path = /mob/living/simple_animal/hostile/carp/ranged
 					if("chaosmagicarp")
 						path = /mob/living/simple_animal/hostile/carp/ranged/chaos
+					if("watcher")
+						path = /mob/living/simple_animal/hostile/asteroid/basilisk/watcher
+					if("goliath")
+						path = /mob/living/simple_animal/hostile/asteroid/goliath/beast
+					if("headcrab")
+						path = /mob/living/simple_animal/hostile/headcrab
+					if("morph")
+						path = /mob/living/simple_animal/hostile/morph
+					if("stickman")
+						path = /mob/living/simple_animal/hostile/stickman
+					if("stickdog")
+						path = /mob/living/simple_animal/hostile/stickman/dog
+					if("lesserdragon")
+						path = /mob/living/simple_animal/hostile/megafauna/dragon/lesser
 			else
 				var/animal = pick("parrot","corgi","crab","pug","cat","mouse","chicken","cow","lizard","chick","fox","butterfly","cak")
 				switch(animal)


### PR DESCRIPTION
It's now possible to turn into a cogscarb in the robot table

It's now possible to turn into a watcher, goliath, headslug, morph, stick man, stick dog, or lesser drake(!) in the hostile animal table

You no longer get credited with a dragon kill for killing the lesser drake.

As always the "general rule" of valid polymorph forms is that
1. They have to leave a raisable corpse
2. They can't be something the wizard could have made by other means for (no slaughter demons/statues)
3. Nothing hilariously OP (the lesser drake really isn't, and it's nice to have a "grand prize" in the pool)

:cl:
add: The staff of change has been expanded to turn you into even more things that don't have hands.
/:cl:
