### PR TITLE
Summon Magic now functions like summon guns

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1443,7 +1443,6 @@
 		ticker.mode.wizards += src
 		special_role = "Wizard"
 		assigned_role = "Wizard"
-		//ticker.mode.learn_basic_spells(current)
 		if(!wizardstart.len)
 			current.loc = pick(latejoin)
 			current << "HOT INSERTION, GO GO GO"
@@ -1451,8 +1450,6 @@
 			current.loc = pick(wizardstart)
 
 		ticker.mode.equip_wizard(current)
-		for(var/obj/item/weapon/spellbook/S in current.contents)
-			S.op = 0
 		ticker.mode.name_wizard(current)
 		ticker.mode.forge_wizard_objectives(src)
 		ticker.mode.greet_wizard(src)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -726,7 +726,7 @@ var/global/list/possible_items_special = list()
 	var/stolen_count = 0
 	var/list/all_items = owner.current.GetAllContents()	//this should get things in cheesewheels, books, etc.
 	for(var/obj/I in all_items) //Check for wanted items
-		if(is_type_in_list(I, wanted_items))
+		if(is_type_in_typecache(I, wanted_items))
 			stolen_count++
 	if(stolen_count >= 5)
 		return 1

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -706,7 +706,11 @@ var/global/list/possible_items_special = list()
 
 /datum/objective/steal_five_of_type
 	explanation_text = "Steal at least five items!"
-	var/list/wanted_items = list()
+	var/list/wanted_items = list(/obj/item)
+
+/datum/objective/steal_five_of_type/New()
+	..()
+	wanted_items = typecacheof(wanted_items)
 
 /datum/objective/steal_five_of_type/summon_guns
 	explanation_text = "Steal at least five guns!"
@@ -729,7 +733,6 @@ var/global/list/possible_items_special = list()
 	else
 		return 0
 	return 0
-
 
 
 ////////////////////////////////

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -704,18 +704,27 @@ var/global/list/possible_items_special = list()
 	else
 		explanation_text = "Free Objective"
 
-/datum/objective/summon_guns
-	explanation_text = "Steal at least five guns!"
+/datum/objective/steal_five_of_type
+	explanation_text = "Steal at least five items!"
+	var/list/wanted_items = list()
 
-/datum/objective/summon_guns/check_completion()
+/datum/objective/steal_five_of_type/summon_guns
+	explanation_text = "Steal at least five guns!"
+	wanted_items = list(/obj/item/weapon/gun)
+
+/datum/objective/steal_five_of_type/summon_magic
+	explanation_text = "Steal at least five magical artefacts!"
+	wanted_items = list(/obj/item/weapon/spellbook, /obj/item/weapon/gun/magic, /obj/item/clothing/suit/space/hardsuit/wizard, /obj/item/weapon/scrying, /obj/item/weapon/antag_spawner/contract, /obj/item/device/necromantic_stone)
+
+/datum/objective/steal_five_of_type/check_completion()
 	if(!isliving(owner.current))
 		return 0
-	var/guncount = 0
+	var/stolen_count = 0
 	var/list/all_items = owner.current.GetAllContents()	//this should get things in cheesewheels, books, etc.
-	for(var/obj/I in all_items) //Check for guns
-		if(istype(I, /obj/item/weapon/gun))
-			guncount++
-	if(guncount >= 5)
+	for(var/obj/I in all_items) //Check for wanted items
+		if(is_type_in_list(I, wanted_items))
+			stolen_count++
+	if(stolen_count >= 5)
 		return 1
 	else
 		return 0

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -14,14 +14,15 @@
 
 /datum/spellbook_entry/proc/IsAvailible() // For config prefs / gamemode restrictions - these are round applied
 	return 1
+
 /datum/spellbook_entry/proc/CanBuy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book) // Specific circumstances
 	if(book.uses<cost || limit == 0)
 		return 0
 	return 1
+
 /datum/spellbook_entry/proc/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book) //return 1 on success
 	if(!S || qdeleted(S))
 		S = new spell_type()
-
 	//Check if we got the spell already
 	for(var/obj/effect/proc_holder/spell/aspell in user.mind.spell_list)
 		if(initial(S.name) == initial(aspell.name)) // Not using directly in case it was learned from one spellbook then upgraded in another
@@ -445,7 +446,6 @@
 
 /datum/spellbook_entry/summon/guns
 	name = "Summon Guns"
-	category = "Rituals"
 	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill you. Just be careful not to stand still too long!"
 	log_name = "SG"
 
@@ -457,15 +457,14 @@
 /datum/spellbook_entry/summon/guns/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book)
 	feedback_add_details("wizard_spell_learned",log_name)
 	rightandwrong(0, user, 25)
+	active = 1
 	playsound(get_turf(user),"sound/magic/CastSummon.ogg",50,1)
 	user << "<span class='notice'>You have cast summon guns!</span>"
 	return 1
 
 /datum/spellbook_entry/summon/magic
 	name = "Summon Magic"
-	category = "Challenges"
 	desc = "Share the wonders of magic with the crew and show them why they aren't to be trusted with it at the same time."
-	cost = 0
 	log_name = "SU"
 
 /datum/spellbook_entry/summon/magic/IsAvailible()
@@ -475,11 +474,10 @@
 
 /datum/spellbook_entry/summon/magic/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book)
 	feedback_add_details("wizard_spell_learned",log_name)
-	rightandwrong(1, user, 0)
-	book.uses += 1
+	rightandwrong(1, user, 25)
 	active = 1
 	playsound(get_turf(user),"sound/magic/CastSummon.ogg",50,1)
-	user << "<span class='notice'>You have cast summon magic and gained an extra charge for your spellbook.</span>"
+	user << "<span class='notice'>You have cast summon magic!</span>"
 	return 1
 
 /datum/spellbook_entry/summon/events
@@ -518,7 +516,6 @@
 	w_class = 1
 	var/uses = 10
 	var/temp = null
-	var/op = 1
 	var/tab = null
 	var/mob/living/carbon/human/owner
 	var/list/datum/spellbook_entry/entries = list()

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -15,15 +15,22 @@
 			if(H.mind.special_role == "Wizard" || H.mind.special_role == "apprentice" || H.mind.special_role == "survivalist") continue
 		if(prob(survivor_probability) && !(H.mind in ticker.mode.traitors))
 			ticker.mode.traitors += H.mind
-			var/datum/objective/summon_guns/guns = new
-			guns.owner = H.mind
-			H.mind.objectives += guns
-			H.mind.special_role = "survivalist"
+			if(!summon_type)
+				var/datum/objective/steal_five_of_type/summon_guns/guns = new
+				guns.owner = H.mind
+				H.mind.objectives += guns
+				H.mind.special_role = "survivalist"
+				H << "<B>You are the survivalist! Your own safety matters above all else, and the only way to ensure your safety is to stockpile weapons! Grab as many guns as possible, by any means necessary. Kill anyone who gets in your way.</B>"
+			else
+				var/datum/objective/steal_five_of_type/summon_magic/magic = new
+				magic.owner = H.mind
+				H.mind.objectives += magic
+				H.mind.special_role = "amateur magician"
+				H << "<B>You are the amateur magician! Grow your newfound talent! Grab as many magical artefacts as possible, by any means necessary. Kill anyone who gets in your way.</B>"
 			var/datum/objective/survive/survive = new
 			survive.owner = H.mind
 			H.mind.objectives += survive
 			H.attack_log += "\[[time_stamp()]\] <font color='red'>Was made into a survivalist, and trusts no one!</font>"
-			H << "<B>You are the survivalist! Your own safety matters above all else, and the only way to ensure your safety is to stockpile weapons! Grab as many guns as possible, by any means necessary. Kill anyone who gets in your way.</B>"
 			H.mind.announce_objectives()
 		var/randomizeguns 			= pick(gunslist)
 		var/randomizemagic 			= pick(magiclist)


### PR DESCRIPTION
Costs points to use, causes 25% of victims to become antags, and those antags are tasked with stealing the shit that just spawned.

Removed some unused code, and added the one use cap to summon guns as well.

Reasoning behind this:

-Getting a ton of magical loot and then being unallowed to use it was pretty boring. What good is getting a magic weapon if I get banned for using?

-Getting a ton of magical loot but having no antags causes enough cause to make the round unplayable as normal (everything is broke into or horseheaded or turned into carp), but not enough cause to actually cause the round to end (especially with healing wands fixing everyone). This leads to the round being trapped in an awful purgatory where there is no reason to end it, but too messy to do jobs etc.

-Getting bonus points for the book encouraged the wizard to buy this+events (or summon guns) for free, increasing the number of wizards who would spam it.
