### PR TITLE
Fulton Pack tweaks for better usability

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -1,8 +1,8 @@
 var/list/total_extraction_beacons = list()
 
 /obj/item/weapon/extraction_pack
-	name = "fulton material extraction pack"
-	desc = "A balloon that can be used to extract a target to a Fulton Recovery Beacon. Anything not bolted down can be moved. Link the pack to a beacon by using the pack in hand."
+	name = "fulton extraction pack"
+	desc = "A balloon that can be used to extract equipment or personnel to a Fulton Recovery Beacon. Anything not bolted down can be moved. Link the pack to a beacon by using the pack in hand."
 	icon = 'icons/obj/fulton.dmi'
 	icon_state = "extraction_pack"
 	w_class = 3
@@ -10,13 +10,7 @@ var/list/total_extraction_beacons = list()
 	var/list/beacon_networks = list("station")
 	var/uses_left = 3
 	var/can_use_indoors
-	var/safe_for_living_creatures = 0
-
-/obj/item/weapon/extraction_pack/medivac
-	name = "fulton medivac extraction pack"
-	desc = "A specialized extraction balloon capable of safely extracting living targets."
-	uses_left = 1
-	safe_for_living_creatures = 1
+	var/safe_for_living_creatures = 1
 
 /obj/item/weapon/extraction_pack/examine()
 	. = ..()
@@ -59,13 +53,17 @@ var/list/total_extraction_beacons = list()
 		if(!safe_for_living_creatures && check_for_living_mobs(A))
 			user << "[src] is not safe for use with living creatures, they wouldn't survive the trip back!"
 			return
-		if(A.loc == user || A == user) // no extracting stuff you're holding in your hands/yourself
+		if(A.loc == user) // no extracting stuff you're holding
 			return
 		if(A.anchored)
 			return
 		user << "<span class='notice'>You start attaching the pack to [A]...</span>"
 		if(do_after(user,50,target=A))
 			user << "<span class='notice'>You attach the pack to [A] and activate it.</span>"
+			if(loc == user || istype(user.back, /obj/item/weapon/storage/backpack))
+				var/obj/item/weapon/storage/backpack/B = user.back
+				if(B.can_be_inserted(src,stop_messages = 1))
+					B.handle_item_insertion(src)
 			uses_left--
 			if(uses_left <= 0)
 				user.drop_item(src)
@@ -141,16 +139,14 @@ var/list/total_extraction_beacons = list()
 
 /obj/item/fulton_core
 	name = "extraction beacon signaller"
-	desc = "Emits a signal which fulton recovery devices can lock on to. Craft with metal to create a beacon."
+	desc = "Emits a signal which fulton recovery devices can lock on to. Activate in hand to create a beacon."
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "subspace_amplifier"
 
-/datum/crafting_recipe/fulton
-	name = "Fulton Recovery Beacon"
-	result = /obj/structure/extraction_point
-	reqs = list(/obj/item/fulton_core = 1, /obj/item/stack/sheet/metal = 5)
-	time = 15
-	category = CAT_MISC
+/obj/item/fulton_core/attack_self(mob/user)
+	if(do_after(user,15,target = user) && !qdeleted(src))
+		new /obj/structure/extraction_point(get_turf(user))
+		qdel(src)
 
 /obj/structure/extraction_point
 	name = "fulton recovery beacon"

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -30,7 +30,6 @@
 		new /datum/data/mining_equipment("Kinetic Crusher", 	/obj/item/weapon/twohanded/required/mining_hammer,               	   	750),
 		new /datum/data/mining_equipment("Kinetic Accelerator", /obj/item/weapon/gun/energy/kinetic_accelerator,               	   		750),
 		new /datum/data/mining_equipment("Resonator",           /obj/item/weapon/resonator,                                    	   		800),
-		new /datum/data/mining_equipment("Medivac Balloon",     /obj/item/weapon/extraction_pack/medivac,                               800),
 		new /datum/data/mining_equipment("Fulton Pack",         /obj/item/weapon/extraction_pack,                                    	1000),
 		new /datum/data/mining_equipment("Lazarus Injector",    /obj/item/weapon/lazarus_injector,                                		1000),
 		new /datum/data/mining_equipment("Silver Pickaxe",		/obj/item/weapon/pickaxe/silver,				                  		1000),
@@ -159,7 +158,7 @@
 	return ..()
 
 /obj/machinery/mineral/equipment_vendor/proc/RedeemVoucher(obj/item/weapon/mining_voucher/voucher, mob/redeemer)
-	var/items = list("Survival Capsule and Explorer's Webbing", "Resonator and Advanced Scanner", "Mining Drone", "Medivac Kit", "Extraction Kit", "Crusher Kit")
+	var/items = list("Survival Capsule and Explorer's Webbing", "Resonator and Advanced Scanner", "Mining Drone", "Extraction and Rescue Kit", "Crusher Kit")
 
 	var/selection = input(redeemer, "Pick your equipment", "Mining Voucher Redemption") as null|anything in items
 	if(!selection || !Adjacent(redeemer) || qdeleted(voucher) || voucher.loc != redeemer)
@@ -173,13 +172,7 @@
 		if("Mining Drone")
 			new /mob/living/simple_animal/hostile/mining_drone(src.loc)
 			new /obj/item/weapon/weldingtool/hugetank(src.loc)
-		if("Medivac Kit")
-			new /obj/item/stack/sheet/metal/five(loc)
-			new /obj/item/fulton_core(loc)
-			new /obj/item/weapon/extraction_pack/medivac(loc)
-			new /obj/item/weapon/reagent_containers/hypospray/medipen/survival(loc)
-		if("Extraction Kit")
-			new /obj/item/stack/sheet/metal/five(loc)
+		if("Extraction and Rescue Kit")
 			new /obj/item/weapon/extraction_pack(loc)
 			new /obj/item/fulton_core(loc)
 		if("Crusher Kit")


### PR DESCRIPTION
:cl:
tweak: Consolidates the fulton packs into a single item and makes them more user friendly
/:cl:
- Consolidated the fulton packs into one pack. There's no more medivac only because the cargo one gave you three uses and you could fulton people out by cramming them in a locker anyway.
- Allows you to fulton yourself by directly attaching it to yourself. Again, you could fulton yourself out of lava land via a locker (And without this functionality the fulton is basically completely pointless), so might as well make its ease of use better.
- Consolidated the mining voucher fulton kits into one kit. With only one fulton type, there's no need for two kits.
- Removes the fulton beacon recipe and just lets you use a fulton beacon in hand to generate the beacon structure. Carrying around a beacon and a bunch of sheets of metal ate up a lot of inventory space for no reason.

I myself pick the Fulton pack every time I'm a miner simply because of how nice it is to be able to get back to the station whenever I want without having to walk for fifty years and rely on a slow shuttle. I've never see any one else buy them. Hopefully this makes them a more popular purchase.
