### PR TITLE
Temporarily removes stock computers (#GoofFixYourShit)

### DIFF
--- a/_maps/map_files/BirdStation/BirdStation.dmm
+++ b/_maps/map_files/BirdStation/BirdStation.dmm
@@ -8037,7 +8037,6 @@
 /area/maintenance/fsmaint)
 "atE" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/carpet,
 /area/maintenance/fsmaint)
 "atF" = (
@@ -23787,7 +23786,6 @@
 /area/maintenance/fsmaint)
 "ZAw" = (
 /obj/structure/table,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ZAx" = (
@@ -64051,13 +64049,13 @@ bee
 aTF
 aUr
 aUr
-aWF
-aXi
+aWG
+aWG
 bep
 aWI
 bep
-aXi
-aZO
+aWG
+aWG
 aTK
 bew
 baZ
@@ -66107,13 +66105,13 @@ aUr
 aUr
 aUr
 aUr
-aWJ
-aXi
-aXi
-aXi
-aXi
-aXi
-aZR
+aWG
+aWG
+aWG
+aWG
+aWG
+aWG
+aWG
 aTK
 beA
 beA

--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -53984,7 +53984,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "ccw" = (
@@ -61644,7 +61643,6 @@
 "csf" = (
 /obj/structure/table,
 /obj/item/device/multitool,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "csg" = (
@@ -62385,7 +62383,6 @@
 	dir = 6
 	},
 /obj/item/weapon/storage/firstaid/regular,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "ctF" = (
@@ -66105,7 +66102,6 @@
 /obj/structure/table,
 /obj/item/weapon/folder/yellow,
 /obj/item/weapon/pen/red,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/darkbrown/corner{
 	tag = "icon-darkbrowncorners (EAST)";
 	dir = 4

--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -30133,7 +30133,6 @@
 	pixel_x = 4;
 	pixel_y = 3
 	},
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bhw" = (
@@ -35575,7 +35574,6 @@
 	},
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen/red,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "btj" = (
@@ -37106,7 +37104,6 @@
 	pixel_x = -1;
 	pixel_y = -1
 	},
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bwb" = (
@@ -41610,7 +41607,6 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/brown,
 /area/quartermaster/qm)
 "bFe" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -23419,7 +23419,6 @@
 /area/quartermaster/qm)
 "aOT" = (
 /obj/structure/table,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/brown{
 	dir = 1
 	},
@@ -31126,7 +31125,6 @@
 	})
 "bbW" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/brown{
 	dir = 5
 	},
@@ -36885,7 +36883,6 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/arrival{
 	dir = 2
 	},
@@ -36997,7 +36994,6 @@
 	})
 "bmb" = (
 /obj/structure/table,
-/obj/machinery/computer/stockexchange,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -26;

--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -2557,7 +2557,6 @@
 	on = 1
 	},
 /obj/structure/table,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/caution/corner{
 	dir = 4
 	},

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -29064,7 +29064,6 @@
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen/red,
 /obj/structure/table,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bnH" = (
@@ -32564,7 +32563,6 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "buF" = (
@@ -34287,7 +34285,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/brown{
 	dir = 2
 	},
@@ -40899,7 +40896,6 @@
 /obj/structure/table/reinforced,
 /obj/item/device/destTagger,
 /obj/item/device/destTagger,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bLG" = (


### PR DESCRIPTION
:cl:
del: Stock computers have been temporarily removed due to imbalances.
/:cl:

They are completely OP right now, and the responsibility to fix their balance is on goof.
This PR just removes them from the maps and they can be readded later after balance

And before you say "Well botany can already get you shittons of points" that is another thing that has to be balanced seperately, and isn't justification for this being broken, I have a seperate idea on how to fix that for a different PR
