### PR TITLE
Mapping object to help set baseturfs

### DIFF
--- a/code/modules/ruins/objects_and_mobs/ruin_mapping_aids.dm
+++ b/code/modules/ruins/objects_and_mobs/ruin_mapping_aids.dm
@@ -9,5 +9,6 @@
 /obj/effect/baseturf_helper/initialize()
 	..()
 	var/area/thearea = get_area(src)
+	for(var/turf/T in get_area_turfs(thearea, z))
 		if(T.baseturf != T.type) //Don't break indestructible walls and the like
 			T.baseturf = baseturf

--- a/code/modules/ruins/objects_and_mobs/ruin_mapping_aids.dm
+++ b/code/modules/ruins/objects_and_mobs/ruin_mapping_aids.dm
@@ -1,0 +1,13 @@
+//These landmarks can be placed in rooms/ruins to set the baseturfs of every turf in the area. Easier than having potentially unlimited subtypes of every turf or having to manually edit the turfs in the map editor
+
+/obj/effect/baseturf_helper
+	name = "lava baseturf editor"
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "syndballoon"
+	var/baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+
+/obj/effect/baseturf_helper/initialize()
+	..()
+	var/area/thearea = get_area(src)
+		if(T.baseturf != T.type) //Don't break indestructible walls and the like
+			T.baseturf = baseturf

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1754,6 +1754,7 @@
 #include "code\modules\ruins\ruin_areas.dm"
 #include "code\modules\ruins\objects_and_mobs\ash_walker_den.dm"
 #include "code\modules\ruins\objects_and_mobs\necropolis_gate.dm"
+#include "code\modules\ruins\objects_and_mobs\ruin_mapping_aids.dm"
 #include "code\modules\ruins\objects_and_mobs\sin_ruins.dm"
 #include "code\modules\security_levels\keycard_authentication.dm"
 #include "code\modules\security_levels\security_levels.dm"


### PR DESCRIPTION
You place the object in an area.

It sets all the turfs in that area to have the chosen baseturf.

I'm not sure if this is a good idea but the current system of having one substype of every turf for every time you want a different baseturf, or the mapper manually editing baseturfs in every map kinda sucks.

I'll actually test this if a maintainer tells me this solution is allowed.
