### PR TITLE
Adds the ability for admins to lookup the name, ckey and antag status of a player from irc.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -213,6 +213,7 @@
 	var/client_error_message = "Your version of byond is too old, may have issues, and is blocked from accessing this server."
 
 	var/cross_name = "Other server"
+	var/showircname = 0
 
 /datum/configuration/New()
 	var/list/L = subtypesof(/datum/game_mode)
@@ -380,6 +381,8 @@
 					global.medal_hub = value
 				if("medal_hub_password")
 					global.medal_pass = value
+				if("show_irc_name")
+					config.showircname = 1
 				if("see_own_notes")
 					config.see_own_notes = 1
 				if("soft_popcap")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -1,4 +1,4 @@
-/proc/keywords_lookup(msg)
+/proc/keywords_lookup(msg,irc)
 
 	//This is a list of words which are ignored by the parser when comparing message contents for names. MUST BE IN LOWER CASE!
 	var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","alien","as", "i")
@@ -10,6 +10,7 @@
 	var/list/surnames = list()
 	var/list/forenames = list()
 	var/list/ckeys = list()
+	var/founds = ""
 	for(var/mob/M in mob_list)
 		var/list/indexing = list(M.real_name, M.name)
 		if(M.mind)
@@ -56,9 +57,16 @@
 							var/is_antag = 0
 							if(found.mind && found.mind.special_role)
 								is_antag = 1
+							founds += "Name: [found.name]([found.real_name]) Ckey: [found.ckey] [is_antag ? "(Antag)" : null] "
 							msg += "[original_word]<font size='1' color='[is_antag ? "red" : "black"]'>(<A HREF='?_src_=holder;adminmoreinfo=\ref[found]'>?</A>|<A HREF='?_src_=holder;adminplayerobservefollow=\ref[found]'>F</A>)</font> "
 							continue
 		msg += "[original_word] "
+	if(irc)
+		if(founds == "")
+			return "Search Failed"
+		else
+			return founds
+
 	return msg
 
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -190,6 +190,7 @@
 	var/client/C = directory[target]
 
 	var/static/stealthkey
+	var/adminname = config.showircname ? "[sender](IRC)" : "Administrator"
 
 	if(!C)
 		return "No client"
@@ -206,7 +207,7 @@
 	msg = emoji_parse(msg)
 
 	C << "<font color='red' size='4'><b>-- Administrator private message --</b></font>"
-	C << "<font color='red'>Admin PM from-<b><a href='?priv_msg=[stealthkey]'>Administrator</A></b>: [msg]</font>"
+	C << "<font color='red'>Admin PM from-<b><a href='?priv_msg=[stealthkey]'>[adminname]</A></b>: [msg]</font>"
 	C << "<font color='red'><i>Click on the administrator's name to reply.</i></font>"
 
 	//always play non-admin recipients the adminhelp sound

--- a/code/world.dm
+++ b/code/world.dm
@@ -169,6 +169,13 @@ var/last_irc_status = 0
 		else
 			return IrcPm(input["adminmsg"],input["msg"],input["sender"])
 
+	else if("namecheck" in input)
+		if(!key_valid)
+			return "Bad Key"
+		else
+			log_admin("IRC Name Check: [input["sender"]] on [input["namecheck"]]")
+			message_admins("IRC name checking on [input["namecheck"]] from [input["sender"]]")
+			return keywords_lookup(input["namecheck"],1)
 
 
 /world/Reboot(var/reason, var/feedback_c, var/feedback_r, var/time)

--- a/config/config.txt
+++ b/config/config.txt
@@ -172,6 +172,9 @@ ALLOW_HOLIDAYS
 ##Remove the # mark if you are going to use the SVN irc bot to relay adminhelps
 #USEIRCBOT
 
+##Uncomment to show the names of the admin sending a pm from IRC instead of showing as a stealthmin.
+#SHOW_IRC_NAME
+
 ##Defines the ticklag for the world.  0.9 is the normal one, 0.5 is smoother.
 TICKLAG 0.5
 


### PR DESCRIPTION
Now admins have even less reason to join the server to admin!

Also added a config option to show the names of admins pming from IRC and that they are from IRC

The antag status check has been approved by kor and is logged and messaged to admins.
