### PR TITLE
Replace health config with damage multiplier config

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -79,3 +79,9 @@
  #define WEAPON_LIGHT 0
  #define WEAPON_MEDIUM 1
  #define WEAPON_HEAVY 2
+
+
+//Health Defines
+
+#define HEALTH_THRESHOLD_CRIT 0
+#define HEALTH_THRESHOLD_DEAD -100

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -137,9 +137,6 @@
 	var/alert_desc_red_downto = "The station's destruction has been averted. There is still however an immediate serious threat to the station. Security may have weapons unholstered at all times, random searches are allowed and advised."
 	var/alert_desc_delta = "Destruction of the station is imminent. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill."
 
-	var/health_threshold_crit = 0
-	var/health_threshold_dead = -100
-
 	var/revival_pod_plants = 1
 	var/revival_cloning = 1
 	var/revival_brain_life = -1
@@ -166,6 +163,8 @@
 
 	var/silent_ai = 0
 	var/silent_borg = 0
+
+	var/damage_multiplier = 1 //Modifier for damage to all mobs. Impacts healing as well.
 
 	var/allowwebclient = 0
 	var/webclientmembersonly = 0
@@ -452,10 +451,8 @@
 
 		else if(type == "game_options")
 			switch(name)
-				if("health_threshold_crit")
-					config.health_threshold_crit	= text2num(value)
-				if("health_threshold_dead")
-					config.health_threshold_dead	= text2num(value)
+				if("damage_multiplier")
+					config.damage_multiplier		= text2num(value)
 				if("revival_pod_plants")
 					config.revival_pod_plants		= text2num(value)
 				if("revival_cloning")

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -515,7 +515,7 @@
 			H.Weaken(4)
 		if(H.staminaloss && !H.sleeping)
 			var/total_health = (H.health - H.staminaloss)
-			if(total_health <= config.health_threshold_crit && !H.stat)
+			if(total_health <= HEALTH_THRESHOLD_CRIT && !H.stat)
 				H.visible_message("<span class='warning'>[user] delivers a heavy hit to [H]'s head, knocking them out cold!</span>", \
 									   "<span class='userdanger'>[user] knocks you unconscious!</span>")
 				H.SetSleeping(30)

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -239,7 +239,7 @@
 		if(host)
 			var/resulthealth = round((host.health / host.maxHealth) * 100, 0.5)
 			if(iscarbon(host))
-				resulthealth = round((abs(config.health_threshold_dead - host.health) / abs(config.health_threshold_dead - host.maxHealth)) * 100)
+				resulthealth = round((abs(HEALTH_THRESHOLD_DEAD - host.health) / abs(HEALTH_THRESHOLD_DEAD - host.maxHealth)) * 100)
 			stat(null, "Host Health: [resulthealth]%")
 			if(ratvar_awakens)
 				stat(null, "You are [recovering ? "un" : ""]able to deploy!")
@@ -444,7 +444,7 @@
 		return 0
 	var/resulthealth = round((host.health / host.maxHealth) * 100, 0.5)
 	if(iscarbon(host))
-		resulthealth = round((abs(config.health_threshold_dead - host.health) / abs(config.health_threshold_dead - host.maxHealth)) * 100)
+		resulthealth = round((abs(HEALTH_THRESHOLD_DEAD - host.health) / abs(HEALTH_THRESHOLD_DEAD - host.maxHealth)) * 100)
 	if(!ratvar_awakens && host.stat != DEAD && resulthealth > 60) //if above 20 health, fails
 		src << "<span class='warning'>Your host must be at 60% or less health to emerge like this!</span>"
 		return

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -135,7 +135,7 @@
 		data["occupant"]["stat"] = occupant.stat
 		data["occupant"]["health"] = occupant.health
 		data["occupant"]["maxHealth"] = occupant.maxHealth
-		data["occupant"]["minHealth"] = config.health_threshold_dead
+		data["occupant"]["minHealth"] = HEALTH_THRESHOLD_DEAD
 		data["occupant"]["bruteLoss"] = occupant.getBruteLoss()
 		data["occupant"]["oxyLoss"] = occupant.getOxyLoss()
 		data["occupant"]["toxLoss"] = occupant.getToxLoss()

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -182,8 +182,8 @@
 
 	icon_state = "pod_1"
 	//Get the clone body ready
-	H.adjustCloneLoss(CLONE_INITIAL_DAMAGE)     //Yeah, clones start with very low health, not with random, because why would they start with random health
-	H.adjustBrainLoss(CLONE_INITIAL_DAMAGE)
+	H.setCloneLoss(CLONE_INITIAL_DAMAGE)     //Yeah, clones start with very low health, not with random, because why would they start with random health
+	H.setBrainLoss(CLONE_INITIAL_DAMAGE)
 	H.Paralyse(4)
 
 	if(grab_ghost_when == CLONER_FRESH_CLONE)
@@ -231,10 +231,10 @@
 			occupant.Paralyse(4)
 
 			 //Slowly get that clone healed and finished.
-			occupant.adjustCloneLoss(-((speed_coeff/2)))
+			occupant.adjustCloneLoss(-((speed_coeff/2) * config.damage_multiplier))
 
 			//Premature clones may have brain damage.
-			occupant.adjustBrainLoss(-((speed_coeff/2)))
+			occupant.adjustBrainLoss(-((speed_coeff/2) * config.damage_multiplier))
 
 			//So clones don't die of oxyloss in a running pod.
 			if (occupant.reagents.get_reagent_amount("salbutamol") < 30)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -354,7 +354,7 @@
 		return 1
 
 /obj/item/weapon/twohanded/shockpaddles/attack(mob/M, mob/user)
-	var/halfwaycritdeath = (config.health_threshold_crit + config.health_threshold_dead) / 2
+	var/halfwaycritdeath = (HEALTH_THRESHOLD_CRIT + HEALTH_THRESHOLD_DEAD) / 2
 
 	if(busy)
 		return

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -212,7 +212,7 @@
 		occupantData["stat"] = occupant.stat
 		occupantData["health"] = occupant.health
 		occupantData["maxHealth"] = occupant.maxHealth
-		occupantData["minHealth"] = config.health_threshold_dead
+		occupantData["minHealth"] = HEALTH_THRESHOLD_DEAD
 		occupantData["bruteLoss"] = occupant.getBruteLoss()
 		occupantData["oxyLoss"] = occupant.getOxyLoss()
 		occupantData["toxLoss"] = occupant.getToxLoss()

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -20,7 +20,7 @@
 		if(health<= -maxHealth || !getorgan(/obj/item/organ/brain))
 			death()
 			return
-		if(paralysis || sleeping || getOxyLoss() > 50 || (status_flags & FAKEDEATH) || health <= config.health_threshold_crit)
+		if(paralysis || sleeping || getOxyLoss() > 50 || (status_flags & FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT)
 			if(stat == CONSCIOUS)
 				stat = UNCONSCIOUS
 				blind_eyes(1)

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -56,7 +56,7 @@
 
 /mob/living/carbon/brain/can_be_revived()
 	. = 1
-	if(!container || health <= config.health_threshold_dead)
+	if(!container || health <= HEALTH_THRESHOLD_DEAD)
 		return 0
 
 /mob/living/carbon/brain/update_sight()

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -68,7 +68,7 @@
 
 	if(brainmob)
 		if(brainmob.client)
-			if(brainmob.health <= config.health_threshold_dead)
+			if(brainmob.health <= HEALTH_THRESHOLD_DEAD)
 				user << "It's lifeless and severely damaged."
 			else
 				user << "You can feel the small spark of life still left in this one."

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -22,7 +22,7 @@
 /mob/living/carbon/brain/update_stat()
 	if(status_flags & GODMODE)
 		return
-	if(health <= config.health_threshold_dead)
+	if(health <= HEALTH_THRESHOLD_DEAD)
 		if(stat != DEAD)
 			death()
 		var/obj/item/organ/brain/BR

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -634,7 +634,7 @@
 	if(!client)
 		return
 
-	if(stat == UNCONSCIOUS && health <= config.health_threshold_crit)
+	if(stat == UNCONSCIOUS && health <= HEALTH_THRESHOLD_CRIT)
 		var/severity = 0
 		switch(health)
 			if(-20 to -10) severity = 1
@@ -712,10 +712,10 @@
 	if(status_flags & GODMODE)
 		return
 	if(stat != DEAD)
-		if(health<= config.health_threshold_dead || !getorgan(/obj/item/organ/brain))
+		if(health<= HEALTH_THRESHOLD_DEAD || !getorgan(/obj/item/organ/brain))
 			death()
 			return
-		if(paralysis || sleeping || getOxyLoss() > 50 || (status_flags & FAKEDEATH) || health <= config.health_threshold_crit)
+		if(paralysis || sleeping || getOxyLoss() > 50 || (status_flags & FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT)
 			if(stat == CONSCIOUS)
 				stat = UNCONSCIOUS
 				blind_eyes(1)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -837,7 +837,7 @@
 		var/they_breathe = (!(NOBREATH in C.dna.species.specflags))
 		var/they_lung = C.getorganslot("lungs")
 
-		if(C.health > config.health_threshold_crit)
+		if(C.health > HEALTH_THRESHOLD_CRIT)
 			return
 
 		src.visible_message("[src] performs CPR on [C.name]!", "<span class='notice'>You perform CPR on [C.name].</span>")

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -10,7 +10,7 @@
 		total_burn	+= BP.burn_dam
 	health = maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute
 	update_stat()
-	if(((maxHealth - total_burn) < config.health_threshold_dead) && stat == DEAD )
+	if(((maxHealth - total_burn) < HEALTH_THRESHOLD_DEAD) && stat == DEAD )
 		ChangeToHusk()
 		if(on_fire)
 			shred_clothing()

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -113,7 +113,7 @@
 	return 1//Humans can use guns and such
 
 /mob/living/carbon/human/InCritical()
-	return (health <= config.health_threshold_crit && stat == UNCONSCIOUS)
+	return (health <= HEALTH_THRESHOLD_CRIT && stat == UNCONSCIOUS)
 
 /mob/living/carbon/human/reagent_check(datum/reagent/R)
 	return dna.species.handle_chemicals(R,src)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -479,7 +479,7 @@
 		H.losebreath = 0
 
 		var/takes_crit_damage = (!(NOCRITDAMAGE in specflags))
-		if((H.health < config.health_threshold_crit) && takes_crit_damage)
+		if((H.health < HEALTH_THRESHOLD_CRIT) && takes_crit_damage)
 			H.adjustBruteLoss(1)
 
 /datum/species/proc/spec_death(gibbed, mob/living/carbon/human/H)
@@ -1169,7 +1169,7 @@
 	if(!breath || (breath.total_moles() == 0) || !lungs)
 		if(H.reagents.has_reagent("epinephrine") && lungs)
 			return
-		if(H.health >= config.health_threshold_crit)
+		if(H.health >= HEALTH_THRESHOLD_CRIT)
 			H.adjustOxyLoss(HUMAN_MAX_OXYLOSS)
 			if(!lungs)
 				H.adjustOxyLoss(1)
@@ -1329,7 +1329,7 @@
 	if(!H || !safe_breath_min) //the other args are either: Ok being 0 or Specifically handled.
 		return 0
 
-	if(!(NOBREATH in specflags) || (H.health <= config.health_threshold_crit))
+	if(!(NOBREATH in specflags) || (H.health <= HEALTH_THRESHOLD_CRIT))
 		if(prob(20))
 			H.emote("gasp")
 		if(breath_pp > 0)

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -37,7 +37,7 @@
 
 	// If whispering your last words, limit the whisper based on how close you are to death.
 	if(critical)
-		var/health_diff = round(-config.health_threshold_dead + health)
+		var/health_diff = round(-HEALTH_THRESHOLD_DEAD + health)
 		// If we cut our message short, abruptly end it with a-..
 		var/message_len = length(message)
 		message = copytext(message, 1, health_diff) + "[message_len > health_diff ? "-.." : "..."]"

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -48,7 +48,7 @@
 
 	var/datum/gas_mixture/breath
 
-	if(health <= config.health_threshold_crit || (pulledby && pulledby.grab_state >= GRAB_KILL && !getorganslot("breathing_tube")))
+	if(health <= HEALTH_THRESHOLD_CRIT || (pulledby && pulledby.grab_state >= GRAB_KILL && !getorganslot("breathing_tube")))
 		losebreath++
 
 	//Suffocate
@@ -311,7 +311,7 @@
 	if(sleeping)
 		handle_dreams()
 		AdjustSleeping(-1)
-		if(prob(10) && health>config.health_threshold_crit)
+		if(prob(10) && health>HEALTH_THRESHOLD_CRIT)
 			emote("snore")
 
 	var/restingpwr = 1 + 4 * resting

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,13 +1,3 @@
-/* I am informed this was added by Giacom to reduce mob-stacking in escape pods.
-It's sorta problematic atm due to the shuttle changes I am trying to do
-Sorry Giacom. Please don't be mad :(
-/mob/living/Life()
-	..()
-	var/area/A = get_area(loc)
-	if(A && A.push_dir)
-		push_mob_back(src, A.push_dir)
-*/
-
 /mob/living/New()
 	. = ..()
 	generateStaticOverlay()
@@ -216,7 +206,7 @@ Sorry Giacom. Please don't be mad :(
 	set hidden = 1
 	if (InCritical())
 		src.attack_log += "[src] has [whispered ? "whispered his final words" : "succumbed to death"] with [round(health, 0.1)] points of health!"
-		src.adjustOxyLoss(src.health - config.health_threshold_dead)
+		src.adjustOxyLoss(src.health - HEALTH_THRESHOLD_DEAD)
 		updatehealth()
 		if(!whispered)
 			src << "<span class='notice'>You have given up life and succumbed to death.</span>"
@@ -272,7 +262,7 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustBruteLoss(amount, updating_health=1)
 	if(status_flags & GODMODE)
 		return 0
-	bruteloss = Clamp(bruteloss + amount, 0, maxHealth*2)
+	bruteloss = Clamp((bruteloss + (amount * config.damage_multiplier)), 0, maxHealth*2)
 	if(updating_health)
 		updatehealth()
 
@@ -282,7 +272,7 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustOxyLoss(amount, updating_health=1)
 	if(status_flags & GODMODE)
 		return 0
-	oxyloss = Clamp(oxyloss + amount, 0, maxHealth*2)
+	oxyloss = Clamp((oxyloss + (amount * config.damage_multiplier)), 0, maxHealth*2)
 	if(updating_health)
 		updatehealth()
 
@@ -299,7 +289,7 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustToxLoss(amount, updating_health=1)
 	if(status_flags & GODMODE)
 		return 0
-	toxloss = Clamp(toxloss + amount, 0, maxHealth*2)
+	toxloss = Clamp((toxloss + (amount * config.damage_multiplier)), 0, maxHealth*2)
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -317,7 +307,7 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustFireLoss(amount, updating_health=1)
 	if(status_flags & GODMODE)
 		return 0
-	fireloss = Clamp(fireloss + amount, 0, maxHealth*2)
+	fireloss = Clamp((fireloss + (amount * config.damage_multiplier)), 0, maxHealth*2)
 	if(updating_health)
 		updatehealth()
 
@@ -327,7 +317,7 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustCloneLoss(amount, updating_health=1)
 	if(status_flags & GODMODE)
 		return 0
-	cloneloss = Clamp(cloneloss + amount, 0, maxHealth*2)
+	cloneloss = Clamp((cloneloss + (amount * config.damage_multiplier)), 0, maxHealth*2)
 	if(updating_health)
 		updatehealth()
 
@@ -344,7 +334,7 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustBrainLoss(amount)
 	if(status_flags & GODMODE)
 		return 0
-	brainloss = Clamp(brainloss + amount, 0, maxHealth*2)
+	brainloss = Clamp((brainloss + (amount * config.damage_multiplier)), 0, maxHealth*2)
 
 /mob/living/proc/setBrainLoss(amount)
 	if(status_flags & GODMODE)
@@ -541,7 +531,7 @@ Sorry Giacom. Please don't be mad :(
 //proc called by revive(), to check if we can actually ressuscitate the mob (we don't want to revive him and have him instantly die again)
 /mob/living/proc/can_be_revived()
 	. = 1
-	if(health <= config.health_threshold_dead)
+	if(health <= HEALTH_THRESHOLD_DEAD)
 		return 0
 
 /mob/living/proc/update_damage_overlays()
@@ -1026,7 +1016,7 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/carbon/human/update_stamina()
 	if(staminaloss)
 		var/total_health = (health - staminaloss)
-		if(total_health <= config.health_threshold_crit && !stat)
+		if(total_health <= HEALTH_THRESHOLD_CRIT && !stat)
 			src << "<span class='notice'>You're too exhausted to keep going...</span>"
 			Weaken(5)
 			setStaminaLoss(health - 2)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -60,7 +60,7 @@
 	if(status_flags & GODMODE)
 		return
 	if(stat != DEAD)
-		if(health <= config.health_threshold_dead)
+		if(health <= HEALTH_THRESHOLD_DEAD)
 			death()
 			return
 		else if(stat == UNCONSCIOUS)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -152,7 +152,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
 		if(summoner)
 			var/resulthealth
 			if(iscarbon(summoner))
-				resulthealth = round((abs(config.health_threshold_dead - summoner.health) / abs(config.health_threshold_dead - summoner.maxHealth)) * 100)
+				resulthealth = round((abs(HEALTH_THRESHOLD_DEAD - summoner.health) / abs(HEALTH_THRESHOLD_DEAD - summoner.maxHealth)) * 100)
 			else
 				resulthealth = round((summoner.health / summoner.maxHealth) * 100, 0.5)
 			stat(null, "Summoner Health: [resulthealth]%")
@@ -197,7 +197,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	if(summoner && hud_used && hud_used.healths)
 		var/resulthealth
 		if(iscarbon(summoner))
-			resulthealth = round((abs(config.health_threshold_dead - summoner.health) / abs(config.health_threshold_dead - summoner.maxHealth)) * 100)
+			resulthealth = round((abs(HEALTH_THRESHOLD_DEAD - summoner.health) / abs(HEALTH_THRESHOLD_DEAD - summoner.maxHealth)) * 100)
 		else
 			resulthealth = round((summoner.health / summoner.maxHealth) * 100, 0.5)
 		hud_used.healths.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#efeeef'>[resulthealth]%</font></div>"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -290,23 +290,23 @@
 
 /mob/living/simple_animal/adjustBruteLoss(amount)
 	if(damage_coeff[BRUTE])
-		. = adjustHealth(amount*damage_coeff[BRUTE])
+		. = adjustHealth(amount * damage_coeff[BRUTE] * config.damage_multiplier)
 
 /mob/living/simple_animal/adjustFireLoss(amount)
 	if(damage_coeff[BURN])
-		. = adjustHealth(amount*damage_coeff[BURN])
+		. = adjustHealth(amount * damage_coeff[BURN] * config.damage_multiplier)
 
 /mob/living/simple_animal/adjustOxyLoss(amount)
 	if(damage_coeff[OXY])
-		. = adjustHealth(amount*damage_coeff[OXY])
+		. = adjustHealth(amount * damage_coeff[OXY] * config.damage_multiplier)
 
 /mob/living/simple_animal/adjustToxLoss(amount)
 	if(damage_coeff[TOX])
-		. = adjustHealth(amount*damage_coeff[TOX])
+		. = adjustHealth(amount * damage_coeff[TOX] * config.damage_multiplier)
 
 /mob/living/simple_animal/adjustCloneLoss(amount)
 	if(damage_coeff[CLONE])
-		. = adjustHealth(amount*damage_coeff[CLONE])
+		. = adjustHealth(amount * damage_coeff[CLONE] * config.damage_multiplier)
 
 /mob/living/simple_animal/adjustStaminaLoss(amount)
 	return

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -234,7 +234,7 @@
 		Feedstop(0, 0)
 		return
 
-	add_nutrition(rand(7,15))
+	add_nutrition((rand(7,15) * config.damage_multiplier))
 
 	//Heal yourself.
 	adjustBruteLoss(-3)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -96,8 +96,8 @@
 /obj/item/bodypart/proc/take_damage(brute, burn)
 	if(owner && (owner.status_flags & GODMODE))
 		return 0	//godmode
-	brute	= max(brute,0)
-	burn	= max(burn,0)
+	brute	= max(brute * config.damage_multiplier,0)
+	burn	= max(burn * config.damage_multiplier,0)
 
 
 	if(status == ORGAN_ROBOTIC) //This makes robolimbs not damageable by chems and makes it stronger

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -1,11 +1,7 @@
 ### HEALTH ###
 
-# level of health at which a mob becomes unconscious (crit)
-HEALTH_THRESHOLD_CRIT 0
-
-# level of health at which a mob becomes dead
-HEALTH_THRESHOLD_DEAD -100
-
+#Damage multiplier, effects both weapons and healing on all mobs. For example, 1.25 would result in 25% higher damage.
+DAMAGE_MULTIPLIER 1
 
 ### REVIVAL ###
 


### PR DESCRIPTION
Added a damage multiplier instead, which works for all mobs without breaking things like cloning and HUDs. A revival of https://github.com/tgstation/tgstation/pull/16336

Fixes #16297

Fixes #16298

Closes #19960

Fixes a couple of bugs and hopefully puts an end to the "buffs every single weapon" PRs.
