### PR TITLE
Lets lattice spawn in ruins by removing overzealous deletion behavior

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -16,8 +16,6 @@
 
 /obj/structure/lattice/New()
 	..()
-	if(!(istype(src.loc, /turf/open/space)))
-		qdel(src)
 	for(var/obj/structure/lattice/LAT in src.loc)
 		if(LAT != src)
 			qdel(LAT)


### PR DESCRIPTION
Lattice had a weird line in new() that automatically destroyed them if they weren't on space. The thing is that during the normal course of play the only way to make a lattice is in the attacked_by of the space turf. Due to the ordering of how maps are loaded in all lattice were automatically deleting themselves even if spawning over what would eventually be space. 

It was bugging me.
