### PR TITLE
Fixes modular console metal dupe.

### DIFF
--- a/code/modules/modular_computers/computers/machinery/modular_console.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_console.dm
@@ -13,7 +13,7 @@
 	base_idle_power_usage = 100
 	base_active_power_usage = 500
 	max_hardware_size = 3
-	steel_sheet_cost = 20
+	steel_sheet_cost = 10
 	light_strength = 2
 	_max_damage = 300
 	_break_damage = 150


### PR DESCRIPTION
> You build it for 10 metal
> You wrench it to /IMMEDIATELY/ (Why no delay?) deconstruct for 20 metal
> lmao.
> I can only fix it by changing a number 20 to a number 10 because looking at this baycode makes my head hurt really bad ;_;
