### PR TITLE
Makes ListTargets() much much faster.

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -67,6 +67,14 @@
 		return 0
 	return L[A.type]
 
+//returns a new list with only atoms that are in typecache L
+/proc/typecache_filter_list(list/atoms, list/typecache)
+	. = list()
+	for (var/thing in atoms)
+		var/atom/A = thing
+		if (typecache[A.type])
+			. += A
+
 //Like typesof() or subtypesof(), but returns a typecache instead of a list
 /proc/typecacheof(path, ignore_root_path)
 	if(ispath(path))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -543,7 +543,8 @@ Turf and target are seperate in case you want to teleport some distance from a t
 				return 0
 			if(current.opacity)
 				return 0
-			for(var/atom/A in current)
+			for(var/thing in current)
+				var/atom/A = thing
 				if(A.opacity)
 					return 0
 			current = get_step_towards(current, target_turf)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -89,7 +89,7 @@
 		var/list/Mobs = hearers(vision_range, targets_from) - src //Remove self, so we don't suicide
 		. += Mobs
 
-		var/static/hostile_machines = typecacheof(/obj/machinery/porta_turret, /obj/mecha)
+		var/static/hostile_machines = typecacheof(list(/obj/machinery/porta_turret, /obj/mecha))
 
 		for(var/HM in typecache_filter_list(range(vision_range, targets_from), hostile_machines))
 			if(can_see(targets_from, HM, vision_range))

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -83,25 +83,20 @@
 
 //////////////HOSTILE MOB TARGETTING AND AGGRESSION////////////
 
-
 /mob/living/simple_animal/hostile/proc/ListTargets()//Step 1, find out what we can see
 	. = list()
 	if(!search_objects)
 		var/list/Mobs = hearers(vision_range, targets_from) - src //Remove self, so we don't suicide
 		. += Mobs
 
-		var/hostile_machines = list()
-		for(var/mecha in mechas_list)
-			hostile_machines += mecha
-		for(var/obj/machinery/porta_turret/P in machines)
-			hostile_machines += P
-		for(var/M in hostile_machines)
-			if(get_dist(M, targets_from) <= vision_range && can_see(targets_from, M, vision_range))
-				. += M
+		var/static/hostile_machines = typecacheof(/obj/machinery/porta_turret, /obj/mecha)
+
+		for(var/HM in typecache_filter_list(range(vision_range, targets_from), hostile_machines))
+			if(can_see(targets_from, HM, vision_range))
+				. += HM
 	else
 		var/list/Objects = oview(vision_range, targets_from)
 		. += Objects
-
 
 /mob/living/simple_animal/hostile/proc/FindTarget(var/list/possible_targets, var/HasTargetsList = 0)//Step 2, filter down possible targets to things we actually care about
 	. = list()


### PR DESCRIPTION
fixes #19855
profiles: (A is original, the rest are various variations I thought up)

```
/mob/living/simple_animal/hostile/proc/ListTargetsG    42.008      118.524      118.559       195594
/mob/living/simple_animal/hostile/proc/ListTargetsF    27.078       42.788       42.813       195267
/mob/living/simple_animal/hostile/proc/ListTargetsE    32.423       48.520       48.540       195401
/mob/living/simple_animal/hostile/proc/ListTargetsD    46.633      118.919      118.938       195455
/mob/living/simple_animal/hostile/proc/ListTargetsC    63.589       90.622       90.646       195630
/mob/living/simple_animal/hostile/proc/ListTargetsB    62.156       88.851       88.880       195159
/mob/living/simple_animal/hostile/proc/ListTargetsA   382.978      383.049      383.087       195578
/mob/living/simple_animal/hostile/proc/ListTargets      4.748      895.996      896.142      1368084
```

i went with E because F had a few edge cases that weren't handled correctly.
