### PR TITLE
Reworked the Longevity symptom

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -124,40 +124,6 @@ Bonus
 					M.resistances -= res
 		M << "<span class='warning'>You feel weaker.</span>"
 
-/*
-//////////////////////////////////////
-
-Longevity
-
-	Medium hidden boost.
-	Large resistance boost.
-	Large stage speed boost.
-	Large transmittablity boost.
-	High Level.
-
-Bonus
-	After a certain amount of time the symptom will cure itself.
-
-//////////////////////////////////////
-*/
-
-/datum/symptom/heal/longevity
-
-	name = "Longevity"
-	stealth = 3
-	resistance = 4
-	stage_speed = 4
-	transmittable = 4
-	level = 3
-	var/longevity = 30
-
-/datum/symptom/heal/longevity/Heal(mob/living/M, datum/disease/advance/A)
-	longevity -= 1
-	if(!longevity)
-		A.cure()
-
-/datum/symptom/heal/longevity/Start(datum/disease/advance/A)
-	longevity = rand(initial(longevity) - 5, initial(longevity) + 5)
 
 /*
 //////////////////////////////////////

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -63,3 +63,45 @@ BONUS
 				M << "<span class='notice'>You feel better, but no different from before.</span>"
 			if(5)
 				M << "<span class='notice'>You feel off, but nothing interesting happens.</span>"
+
+/*
+//////////////////////////////////////
+
+Viral aggressive metabolism (ex-Longevity)
+
+	No stealth.
+	Small resistance boost.
+	Reduced stage speed.
+	Large transmittablity boost.
+	High Level.
+
+Bonus
+	The virus starts at stage 5 and decrease over time until it self cures.
+	Stages still increase naturally with stage speed.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/viralreverse
+
+	name = "Viral aggressive metabolism"
+	stealth = 0
+	resistance = 1
+	stage_speed = -2
+	transmittable = 3
+	level = 3
+
+/datum/symptom/viralreverse/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB))
+		var/mob/living/M = A.affected_mob
+		Heal(M, A)
+	return
+
+/datum/symptom/viralreverse/proc/Heal(mob/living/M, datum/disease/advance/A)
+	A.stage -= 1
+	if(A.stage < 2)
+		A.cure()
+
+/datum/symptom/viralreverse/Start(datum/disease/advance/A)
+	A.stage = 5


### PR DESCRIPTION
:cl: XDTM
del: Removed the Longevity symptom.
add: Added Viral Aggressive Metabolism, which will make viruses act quickly but decay over time.
/:cl:

The new symptom is called Viral Aggressive Metabolism, and makes any virus that has it as symptom start from stage 5 but decay in stages over time, curing itself when getting on stage 1.
The virus will still increase in stages depending on stage speed, like normal ones, so it'll last longer with stage speed.

Should still fit the niche of Longevity, while making it a bit more unique than "extra stats".
