### PR TITLE
Attempts to stop Bubblegum's charge indicator from being wildly inaccurate

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -137,8 +137,10 @@ Difficulty: Hard
 	DestroySurroundings()
 	PoolOrNew(/obj/effect/overlay/temp/dragon_swoop, T)
 	sleep(5)
+	walk(src,0)
 	throw_at(T, 7, 1, src, 0)
 	charging = 0
+	Goto(target,move_to_delay,minimum_distance)
 
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Bump(atom/A)


### PR DESCRIPTION
:cl:
fix: Bubblegum's charge indicator should be significantly more accurate now.
/:cl:

This should make him actually stop when he hits his charge location instead of speeding entirely past it while still in the charge state. Seemed to locally, anyway.
