### PR TITLE
Crafting menu now opens on compact mode by default

### DIFF
--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -21,7 +21,7 @@
 				CAT_SPAGHETTI)
 	var/datum/action/innate/crafting/button
 	var/display_craftable_only = FALSE
-	var/display_compact = FALSE
+	var/display_compact = TRUE
 
 
 


### PR DESCRIPTION
Hopefully it is the right way to do that.

Compact mode is way better looking than the full menu.
