### PR TITLE
Using a resonator on an existing resonator field will immediately detonate that field

### DIFF
--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -168,9 +168,9 @@
 	force = 15
 	throwforce = 10
 	var/cooldown = 0
-	var/fieldsactive = 0
 	var/burst_time = 30
 	var/fieldlimit = 4
+	var/list/fields = list()
 	origin_tech = "magnets=3;engineering=3"
 
 /obj/item/weapon/resonator/upgraded
@@ -188,14 +188,10 @@
 		R.resonance_damage *= 0.75
 		R.burst(T)
 		return
-	if(fieldsactive < fieldlimit)
+	if(fields.len < fieldlimit)
 		playsound(src,'sound/weapons/resonator_fire.ogg',50,1)
-		new /obj/effect/resonance(T, creator, burst_time)
-		fieldsactive++
-		addtimer(src, "lower_fields", burst_time)
-
-/obj/item/weapon/resonator/proc/lower_fields()
-	fieldsactive--
+		var/obj/effect/resonance/R = new /obj/effect/resonance(T, creator, burst_time, src)
+		fields += R
 
 /obj/item/weapon/resonator/attack_self(mob/user)
 	if(burst_time == 50)
@@ -220,9 +216,13 @@
 	anchored = TRUE
 	mouse_opacity = 0
 	var/resonance_damage = 20
+	var/creator
+	var/obj/item/weapon/resonator/res
 
-/obj/effect/resonance/New(loc, var/creator = null, var/timetoburst)
+/obj/effect/resonance/New(loc, set_creator, timetoburst, set_resonator)
 	..()
+	cerator = set_creator
+	res = set_resonator
 	var/turf/proj_turf = get_turf(src)
 	if(!istype(proj_turf))
 		return
@@ -232,6 +232,11 @@
 		name = "strong resonance field"
 		resonance_damage = 60
 	addtimer(src, "burst", timetoburst, FALSE, proj_turf)
+
+/obj/effect/resonance/Destroy()
+	if(res)
+		res.fields -= src
+	return ..()
 
 /obj/effect/resonance/proc/burst(turf/T)
 	playsound(src,'sound/weapons/resonator_blast.ogg',50,1)

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -190,8 +190,8 @@
 		return
 	if(fields.len < fieldlimit)
 		playsound(src,'sound/weapons/resonator_fire.ogg',50,1)
-		var/obj/effect/resonance/R = new /obj/effect/resonance(T, creator, burst_time, src)
-		fields += R
+		var/obj/effect/resonance/RE = new /obj/effect/resonance(T, creator, burst_time, src)
+		fields += RE
 
 /obj/item/weapon/resonator/attack_self(mob/user)
 	if(burst_time == 50)
@@ -221,7 +221,7 @@
 
 /obj/effect/resonance/New(loc, set_creator, timetoburst, set_resonator)
 	..()
-	cerator = set_creator
+	creator = set_creator
 	res = set_resonator
 	var/turf/proj_turf = get_turf(src)
 	if(!istype(proj_turf))
@@ -247,7 +247,7 @@
 		if(creator)
 			add_logs(creator, L, "used a resonator field on", "resonator")
 		L << "<span class='danger'>The [src.name] ruptured with you in it!</span>"
-		L.apply_damage(damage, BRUTE)
+		L.apply_damage(resonance_damage, BRUTE)
 	qdel(src)
 
 /**********************Facehugger toy**********************/

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -167,10 +167,10 @@
 	w_class = 3
 	force = 15
 	throwforce = 10
-	var/cooldown = 0
 	var/burst_time = 30
 	var/fieldlimit = 4
 	var/list/fields = list()
+	var/quick_burst_mod = 0.8
 	origin_tech = "magnets=3;engineering=3"
 
 /obj/item/weapon/resonator/upgraded
@@ -180,12 +180,13 @@
 	item_state = "resonator_u"
 	origin_tech = "materials=4;powerstorage=3;engineering=3;magnets=3"
 	fieldlimit = 6
+	quick_burst_mod = 1
 
 /obj/item/weapon/resonator/proc/CreateResonance(target, creator)
 	var/turf/T = get_turf(target)
-	var/obj/effect/resonance/R = locate(/obj/effect/resonance)
-	if(R in T)
-		R.resonance_damage *= 0.75
+	var/obj/effect/resonance/R = locate(/obj/effect/resonance) in T
+	if(R)
+		R.resonance_damage *= quick_burst_mod
 		R.burst(T)
 		return
 	if(fields.len < fieldlimit)
@@ -205,6 +206,7 @@
 	if(proximity_flag)
 		if(!check_allowed_items(target, 1))
 			return
+		user.changeNext_move(CLICK_CD_MELEE)
 		CreateResonance(target, user)
 
 /obj/effect/resonance


### PR DESCRIPTION
:cl: Joan
add: Using a resonator on an existing resonator field will immediately detonate that field. Normal resonators will reduce the damage dealt to 80% of normal, while upgraded resonators will not reduce it at all.
/:cl:

This does 80% of the field's damage(for normal, upgraded does 100%) and does not immediately produce another field on the same location.
It might be an okayish mining weapon now, in a similar way to the crusher?
