### PR TITLE
Re-activated random mutations on cloning

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -309,6 +309,12 @@ mob/living/carbon/human/updateappearance(icon_update=1, mutcolor_update=0, mutat
 	var/datum/mutation/human/HM = pick(good_mutations)
 	. = HM.force_give(M)
 
+/proc/randmutvg(mob/living/carbon/M)
+	if(!M.has_dna())
+		return
+	var/datum/mutation/human/HM = pick((good_mutations) - mutations_list[HULK] - mutations_list[DWARFISM])
+	. = HM.force_give(M)
+
 /proc/randmuti(mob/living/carbon/M)
 	if(!M.has_dna())
 		return

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -167,7 +167,7 @@
 		for(var/A in bad_se_blocks)
 			setblock(H.dna.struc_enzymes, A, construct_block(0,2))
 	if(efficiency > 5 && prob(20))
-		randmutg(H)
+		randmutvg(H)
 	if(efficiency < 3 && prob(50))
 		var/mob/M = randmutb(H)
 		if(ismob(M))
@@ -197,7 +197,7 @@
 			beginning to regenerate in a cloning pod. You will \
 			become conscious when it is complete.</span>"
 
-	H.hardset_dna(ui, se, H.real_name, null, mrace, features)
+	H.hardset_dna(ui, H.dna.struc_enzymes, H.real_name, null, mrace, features)
 	if(H)
 		H.faction |= factions
 


### PR DESCRIPTION
:cl: XDTM
add: Cloning can now give bad mutations if unupgraded!
add: Cloning can, however, give you good ones if upgraded!
/:cl:

Basically the clone pod just ignored the mutations proc and used the SE in the cloning record.
As with my previous PR, the beneficial mutations exclude hulk and dwarfism.
Technically a fix.
