### PR TITLE
Revert "Assasinate objective only picks crewmembers as targets"

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -23,18 +23,9 @@
 /datum/objective/proc/get_target()
 	return target
 
-
-/datum/objective/proc/get_crewmember_minds()
-	. = list()
-	for(var/V in data_core.locked)
-		var/datum/data/record/R = V
-		var/mob/M = R.fields["reference"]
-		if(M && M.mind)
-			. += M
-
 /datum/objective/proc/find_target()
 	var/list/possible_targets = list()
-	for(var/datum/mind/possible_target in get_crewmember_minds())
+	for(var/datum/mind/possible_target in ticker.minds)
 		if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != 2) && is_unique_objective(possible_target))
 			possible_targets += possible_target
 	if(possible_targets.len > 0)
@@ -43,7 +34,7 @@
 	return target
 
 /datum/objective/proc/find_target_by_role(role, role_type=0, invert=0)//Option sets either to check assigned role or special role. Default to assigned., invert inverts the check, eg: "Don't choose a Ling"
-	for(var/datum/mind/possible_target in get_crewmember_minds())
+	for(var/datum/mind/possible_target in ticker.minds)
 		if((possible_target != owner) && ishuman(possible_target.current))
 			var/is_role = 0
 			if(role_type)


### PR DESCRIPTION
Reverts tgstation/tgstation#19937

This seems to be causing assassinate objectives to fail to be created period.
Traitors are getting free objectives instead.
