### PR TITLE
Makes runtime's family persistence only work on kittens

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -115,7 +115,7 @@
 	var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
 	family = list()
 	if(!dead)
-		for(var/mob/living/simple_animal/pet/cat/C in mob_list)
+		for(var/mob/living/simple_animal/pet/cat/kitten/C in mob_list)
 			if(istype(C,type) || C.stat || !C.z || !C.butcher_results) //That last one is a work around for hologram cats
 				continue
 			if(C.type in family)


### PR DESCRIPTION
If a cat was brought on station, runtime would save it to their family. Next round, runtime would proceed to make more and more babies continuously until they were slain.

:cl:
del: Centcom has cut back on their cat carrier budget and will now only be able to bring kittens along with runtime.
/:cl:
