### PR TITLE
Fixes efficiency AI sat wiring

### DIFF
--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -795,11 +795,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light/small,
 /obj/machinery/flasher{
 	id = "AI";
@@ -815,14 +810,6 @@
 	pixel_y = 2;
 	req_access_txt = "16"
 	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/open/floor/plasteel/black,
 /area/turret_protected/ai)
 "abW" = (
@@ -832,11 +819,6 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;


### PR DESCRIPTION
The input and output were on the same grid leading to the smes charging itself and not the apcs.
Fexes #20025 
:cl:
fix: The efficiency AI sat SMES will now charge the APCs instead of itself.
/:cl:
