### PR TITLE
Links OOC between the two servers.

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -69,7 +69,8 @@
 					C << "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[holder.fakekey ? holder.fakekey : key]:</EM> <span class='message'>[msg]</span></span></font>"
 			else if(!(key in C.prefs.ignoring))
 				C << "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[keyname]:</EM> <span class='message'>[msg]</span></span></font>"
-
+	if(cross_allowed)
+		send2otherserver("[keyname]", msg, "OOC")
 /proc/toggle_ooc(toggle = null)
 	if(toggle != null) //if we're specifically en/disabling ooc
 		if(toggle != ooc_allowed)

--- a/code/world.dm
+++ b/code/world.dm
@@ -161,7 +161,15 @@ var/last_irc_status = 0
 				minor_announce(input["message"], "Incoming message from [input["message_sender"]]")
 				for(var/obj/machinery/computer/communications/CM in machines)
 					CM.overrideCooldown()
-
+#define CHAT_OOC 1
+			if(input["crossmessage"] == "OOC")
+				for(var/client/C in clients)
+					if(C.prefs.chat_toggles & CHAT_OOC)
+						var/sender_key = input["message_sender"]
+						var/color_of_memes = "#002eb8"
+						if(!(sender_key in C.prefs.ignoring))
+							C << "<font color='[color_of_memes]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[input["message_sender"]]:</EM> <span class='message'>[input["message"]]</span></span></font>"
+#undef CHAT_OOC
 	else if("adminmsg" in input)
 		if(!key_valid)
 			return "Bad Key"


### PR DESCRIPTION
:cl: Iamgoofball
experiment: OOC is now linked between the two servers.
/:cl:

if I say farts in OOC on Sybil, Basil will also hear farts in OOC.

If you want to mute someone just click the server hop button and mute them on that server until I code the cross-server mute button
