### PR TITLE
"TWEAK and HOTFIX with PERSISTENCE" or "Secret Satchel's Hot Fix 4: Incoming goes Hawaiian"

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -47,6 +47,7 @@ var/datum/subsystem/persistence/SSpersistence
 	if(istype(F.loc,/turf/open/floor) && !istype(F.loc,/turf/open/floor/plating/))
 		F.hide(1)
 	new path(F)
+	return 1
 
 /datum/subsystem/persistence/proc/PlaceFreeSatchel()
 	for(var/V in shuffle(get_area_turfs(pick(the_station_areas))))

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -13,7 +13,8 @@ var/datum/subsystem/persistence/SSpersistence
 	NEW_SS_GLOBAL(SSpersistence)
 
 /datum/subsystem/persistence/Initialize()
-	PlaceSecretSatchel()
+	if(!PlaceSecretSatchel())
+		PlaceFreeSatchel()
 	..()
 
 /datum/subsystem/persistence/proc/CollectData()
@@ -24,19 +25,20 @@ var/datum/subsystem/persistence/SSpersistence
 	satchel_blacklist = typecacheof(list(/obj/item/stack/tile/plasteel, /obj/item/weapon/crowbar))
 
 	secret_satchels >> old_secret_satchels
-	if(isnull(old_secret_satchels))
-		return
+	if(isnull(old_secret_satchels) || isemptylist(old_secret_satchels))
+		old_secret_satchels = list()
+		return 0
 
 	var/list/chosen_satchel
 	if(old_secret_satchels.len >= 20) //guards against low drop pools assuring that one player cannot reliably find his own gear.
 		chosen_satchel = pick_n_take(old_secret_satchels)
 	secret_satchels << old_secret_satchels
 	if(!chosen_satchel || chosen_satchel.len != 3) //Malformed
-		return
+		return 0
 
 	var/path = text2path(chosen_satchel[3]) //If the item no longer exist, this returns null
 	if(!path)
-		return
+		return 0
 
 	var/obj/item/weapon/storage/backpack/satchel/flat/F = new()
 	F.x = chosen_satchel[1]
@@ -45,6 +47,13 @@ var/datum/subsystem/persistence/SSpersistence
 	if(istype(F.loc,/turf/open/floor) && !istype(F.loc,/turf/open/floor/plating/))
 		F.hide(1)
 	new path(F)
+
+/datum/subsystem/persistence/proc/PlaceFreeSatchel()
+	for(var/V in shuffle(get_area_turfs(pick(the_station_areas))))
+		var/turf/T = V
+		if(istype(T,/turf/open/floor) && !istype(T,/turf/open/floor/plating/))
+			new /obj/item/weapon/storage/backpack/satchel/flat/secret(T)
+			break
 
 /datum/subsystem/persistence/proc/CollectSecretSatchels()
 	for(var/A in new_secret_satchels)
@@ -61,6 +70,9 @@ var/datum/subsystem/persistence/SSpersistence
 				savable_obj += O.type
 		if(savable_obj.len < 1)
 			continue
-		old_secret_satchels.len += 1
-		old_secret_satchels[old_secret_satchels.len] = list(F.x, F.y, "[pick(savable_obj)]")
+		if(isemptylist(old_secret_satchels))
+			old_secret_satchels = list(list(F.x, F.y, "[pick(savable_obj)]"))
+		else
+			old_secret_satchels.len += 1
+			old_secret_satchels[old_secret_satchels.len] = list(F.x, F.y, "[pick(savable_obj)]")
 	secret_satchels << old_secret_satchels


### PR DESCRIPTION
Stomps out the last of the null/list() runtimes, persistence should absolutely work regardless of the status of saves now.

Absolutely.

A satchel will now always spawn even if there aren't enough satchels in the pool. It'll just be empty! I'm doing this to help bootstrap the pools. Keep in mind that if a free satchel isn't found it won't save to the list, as there'll be nothing in there worth saving.

:cl:
add: A slight change to the secret satchel system described below: If a satchel cannot be spawned due to there not being enough hidden satchels to choose from, a <b>free</b> empty satchel will spawn hidden SOMEWHERE on the station. Dig it up and bury it with something interesting!
/:cl:
