### PR TITLE
Adds a bunch of cyborg limbs to the surgery closet

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -22,8 +22,8 @@
 	new /obj/item/weapon/storage/box/rxglasses(src)
 
 /obj/structure/closet/secure_closet/medical2
-	name = "anesthetic closet"
-	desc = "Used to knock people out."
+	name = "surgery supplies"
+	desc = "Contains a variety of useful supplies for surgery."
 	req_access = list(access_surgery)
 
 /obj/structure/closet/secure_closet/medical2/New()
@@ -32,6 +32,18 @@
 		new /obj/item/weapon/tank/internals/anesthetic(src)
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/mask/breath/medical(src)
+	for(var/i in 1 to 2)
+		new /obj/item/robot_parts/l_arm(src)
+	for(var/i in 1 to 2)
+		new /obj/item/robot_parts/r_arm(src)
+	for(var/i in 1 to 2)
+		new /obj/item/robot_parts/l_leg(src)
+	for(var/i in 1 to 2)
+		new /obj/item/robot_parts/r_leg(src)
+	for(var/i in 1 to 2)
+		new /obj/item/robot_parts/chest(src)
+	for(var/i in 1 to 2)
+		new /obj/item/robot_parts/head(src)
 
 /obj/structure/closet/secure_closet/medical3
 	name = "medical doctor's locker"


### PR DESCRIPTION
:cl:
add: Added robot limbs to the surgery closet, for MD's to more easily replace lost limbs. Or augment people, whatever.
/:cl:
- Adds a set of robot limbs to the surgery closet

Nobody ever gets augmented around here and it's stupid that in the future you wouldn't have spare limbs lying around to replace ones lost in workplace hazards. I mean, look at Dead Space, they had tons of cloning facilities dedicated to generating limbs and organs.

I considered just putting basic limbs in there but I realized that it's more entertaining if they're robot limbs, and people get augmented. You don't have any flashes or an endoskeleton, so you can't make a cyborg though. And robotics has a bunch of stuff to do anyway, so into the MD pile it goes.
