### PR TITLE
Minor modernization of nanotrasen death commandos

### DIFF
--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -328,7 +328,7 @@
 	name = "Death Commando"
 
 	uniform = /obj/item/clothing/under/color/green
-	suit = /obj/item/clothing/suit/space/hardsuit/deathsquad
+	suit = /obj/item/clothing/suit/space/hardsuit/shielded/swat
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/combat
 	mask = /obj/item/clothing/mask/gas/sechailer/swat

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -677,7 +677,7 @@
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	unacidable = 1
-	helmettype = /obj/item/clothing/head/helmet/hardsuit/shielded/swat
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/shielded/swat
 	dog_fashion = /datum/dog_fashion/back/deathsquad
 
 /obj/item/clothing/head/helmet/space/hardsuit/shielded/swat

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -662,3 +662,32 @@
 	item_state = "syndie_helm"
 	item_color = "syndi"
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
+
+///SWAT version
+/obj/item/clothing/suit/space/hardsuit/shielded/swat
+	name = "death commando spacesuit"
+	desc = "an advanced hardsuit favored by commandos for use in special operations."
+	icon_state = "deathsquad"
+	item_state = "swat_suit"
+	item_color = "syndi"
+	max_charges = 4
+	current_charges = 4
+	recharge_delay = 15
+	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
+	strip_delay = 130
+	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
+	unacidable = 1
+	helmettype = /obj/item/clothing/head/helmet/hardsuit/shielded/swat
+	dog_fashion = /datum/dog_fashion/back/deathsquad
+
+/obj/item/clothing/head/helmet/space/hardsuit/shielded/swat
+	name = "death commando helmet"
+	desc = "A tactical helmet with built in energy shielding."
+	icon_state = "deathsquad"
+	item_state = "deathsquad"
+	item_color = "syndi"
+	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
+	strip_delay = 130
+	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
+	unacidable = 1
+	actions_types = list()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -182,8 +182,8 @@
 	apply_damage(5, BRUTE, affecting, run_armor_check(affecting, "melee"))
 	return
 
-/mob/living/carbon/human/bullet_act()
-	if(martial_art && martial_art.deflection_chance) //Some martial arts users can deflect projectiles!
+/mob/living/carbon/human/bullet_act(p)
+	if(martial_art && martial_art.deflection_chance && p!=/obj/item/projectile/beam/pulse) //Some martial arts users can deflect projectiles!
 		if(!prob(martial_art.deflection_chance))
 			return ..()
 		if(!src.lying && dna && !dna.check_mutation(HULK)) //But only if they're not lying down, and hulks can't do it

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -182,8 +182,8 @@
 	apply_damage(5, BRUTE, affecting, run_armor_check(affecting, "melee"))
 	return
 
-/mob/living/carbon/human/bullet_act(p)
-	if(martial_art && martial_art.deflection_chance && p!=/obj/item/projectile/beam/pulse) //Some martial arts users can deflect projectiles!
+/mob/living/carbon/human/bullet_act()
+	if(martial_art && martial_art.deflection_chance) //Some martial arts users can deflect projectiles!
 		if(!prob(martial_art.deflection_chance))
 			return ..()
 		if(!src.lying && dna && !dna.check_mutation(HULK)) //But only if they're not lying down, and hulks can't do it


### PR DESCRIPTION
:cl: kilkun
add: Adds a shielded deathsquad hardsuit. it has four charges and recharges after 15 seconds of not being shot (compared to the syndicate 3 charges and 20 second recharge rate)
tweak: All death commandos now spawn with this new hardsuit. The previous hardsuit was not removed.
/:cl:

Before this PR Syndicate SWAT technically were superior to Deathsquad due to having the shielded hardsuit that granted 3 free hits of no damage and the SAW barely doing less damage than a pulse rifle. This meant that 5 nuke ops with the right loadout would have no problem taking on 5 squaddies.

This isn't the only problem, as traitors, the station and generally everybody has slowly gotten more powerful over time, Deathsquad's equipment has remained relatively stagnant. We no longer play a game where 50 burn rifles with a shit ton of ammo and 80% reduction on two damage types is as threatening as it once was.

To rectify this and restore Deathsquad above Syndicate SWAT, their hardsuits now have energy shields that are slightly more effective than Syndicate energy shields. The result makes Deathsquad much more formidable, distinguishing them further from code red ERT, while not overtly changing too much about them, retaining the general effectiveness of their equipment.. The original plan for this PR also included pulse beams passing through energy shields and not being deflectable by martial arts, but I decided on ditching these for both balance and the lack of support in the code for these kinds of exceptions, without rewriting the relevant underlying procs.

It's a very simple change, and something that's long overdue. Deathsquad has been deprecated for a long while now and the hope that this very minor change will be the buff that they've sorely needed for some many months.

The old SWAT suit was not removed due to the existence of a tacticool locker that contains it that I'm fairly sure is space loot. Upon request I can purge it to prevent item bloat.
