### PR TITLE
[s]I'll build my own cid randomizer detector! with blackjack! and hookers!

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -70,6 +70,8 @@
 	var/forbid_singulo_possession = 0
 	var/useircbot = 0
 
+	var/check_randomizer = 0
+
 	//IP Intel vars
 	var/ipintel_email
 	var/ipintel_rating_bad = 1
@@ -402,6 +404,8 @@
 					config.notify_new_player_age = text2num(value)
 				if("irc_first_connection_alert")
 					config.irc_first_connection_alert = 1
+				if("check_randomizer")
+					config.check_randomizer = 1
 				if("ipintel_email")
 					if (value != "ch@nge.me")
 						config.ipintel_email = value

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -385,7 +385,7 @@ var/next_external_rsc = 0
 			return TRUE
 
 /client/proc/note_randomizer_user()
-	var/const/adminckey = "CID RANDOMIZER DETECTOR"
+	var/const/adminckey = "CID-Error"
 	var/sql_ckey = sanitizeSQL(ckey)
 	//check to see if we noted them in the last day.
 	var/DBQuery/query_get_notes = dbcon.NewQuery("SELECT id FROM [format_table_name("notes")] WHERE ckey = '[sql_ckey]' AND adminckey = '[adminckey]' AND timestamp + INTERVAL 1 DAY < NOW()")

--- a/config/config.txt
+++ b/config/config.txt
@@ -111,6 +111,9 @@ HOSTEDBY Yournamehere
 ## Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting)
 GUEST_BAN
 
+## Comment to disable checking for the cid randomizer dll. (disabled if database isn't enabled or connected)
+CHECK_RANDOMIZER
+
 ### IPINTEL:
 ### This allows you to detect likely proxies by checking ips against getipintel.net
 ## Rating to warn at: (0.90 is good, 1 is 100% likely to be a spammer/proxy, 0.8 is 80%, etc) anything equal to or higher then this number triggers an admin warning

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -631,7 +631,7 @@ menu "menu"
 	elem
 		name = ""
 		category = "&File"
-	elem
+	elem "reconnectbutton"
 		name = "&Reconnect"
 		category = "&File"
 		command = ".reconnect"


### PR DESCRIPTION
CID randomizer detector, non-~~stolen~~ported edition!

Closes #20056

When a user's cid doesn't match their last cid, we open a new game window to the server, and close the old one, if it changed again, we disallow the connection.

They are free to try again once they remove the randomizer dll.

Admins are notified on first match for the user, and it will leave a note on the user as long as it hasn't left one recently.

It is a config, defaults on, but requires db before actually activating.
