### PR TITLE
Adds Advanced Stock Parts crate to cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -739,6 +739,25 @@
 /datum/supply_pack/science
 	group = "Science"
 
+/datum/supply_pack/science/stock_parts
+	name = "Advanced Stock Parts"
+	cost = 2000
+	contains = list(/obj/item/weapon/stock_parts/manipulator/pico,
+					/obj/item/weapon/stock_parts/manipulator/pico,
+					/obj/item/weapon/stock_parts/manipulator/pico,
+					/obj/item/weapon/stock_parts/matter_bin/super,
+					/obj/item/weapon/stock_parts/matter_bin/super,
+					/obj/item/weapon/stock_parts/matter_bin/super,
+					/obj/item/weapon/stock_parts/micro_laser/high,
+					/obj/item/weapon/stock_parts/micro_laser/high,
+					/obj/item/weapon/stock_parts/scanning_module/adv,
+					/obj/item/weapon/stock_parts/scanning_module/adv,
+					/obj/item/weapon/stock_parts/capacitor/adv,
+					/obj/item/weapon/stock_parts/capacitor/adv,
+					)
+	crate_name = "stock parts crate"
+
+
 /datum/supply_pack/science/robotics
 	name = "Robotics Assembly Crate"
 	cost = 1000

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -753,8 +753,7 @@
 					/obj/item/weapon/stock_parts/scanning_module/adv,
 					/obj/item/weapon/stock_parts/scanning_module/adv,
 					/obj/item/weapon/stock_parts/capacitor/adv,
-					/obj/item/weapon/stock_parts/capacitor/adv,
-					)
+					/obj/item/weapon/stock_parts/capacitor/adv)
 	crate_name = "stock parts crate"
 
 


### PR DESCRIPTION
:cl: XDTM
add: Cargo can now order an Advanced Stock Parts crate, which contains upgraded versions of normal machine components.
/:cl:

This contains the parts that R&D can normally research and make without any assistance, so this crate should be bought if R&D is unable or unwilling to simply produce them.
Should i add a RPED to the crate?
