### PR TITLE
Ups the player and station name length limits

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -22,9 +22,9 @@
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN			1024
-#define MAX_NAME_LEN			26
+#define MAX_NAME_LEN			52
 #define MAX_BROADCAST_LEN		512
-#define MAX_CHARTER_LEN			50
+#define MAX_CHARTER_LEN			100
 
 //MINOR TWEAKS/MISC
 #define AGE_MIN				17	//youngest a character can be

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -22,9 +22,9 @@
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN			1024
-#define MAX_NAME_LEN			52
+#define MAX_NAME_LEN			42
 #define MAX_BROADCAST_LEN		512
-#define MAX_CHARTER_LEN			100
+#define MAX_CHARTER_LEN			80
 
 //MINOR TWEAKS/MISC
 #define AGE_MIN				17	//youngest a character can be


### PR DESCRIPTION
:cl: Iamgoofball
tweak: Station and Character names are now allowed to be longer.
/:cl:

I think they could use a buff in length, as I've seen captains have pretty creative names get cut in half and the joke ruined, and the name limit is really fucking small like come on goddamn
