### PR TITLE
Revert "Removes the NULL Crate"

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -143,6 +143,15 @@
 	crate_name = "emergency crate"
 	crate_type = /obj/structure/closet/crate/internals
 
+/datum/supply_pack/emergency/syndicate
+	name = "NULL_ENTRY"
+	hidden = TRUE
+	cost = 14000
+	contains = list(/obj/item/weapon/storage/box/syndicate)
+	crate_name = "emergency crate"
+	crate_type = /obj/structure/closet/crate/internals
+	dangerous = TRUE
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Security ////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Reverts tgstation/tgstation#20048

Because this change sucked. And now, with cash memeons and stocks being gone, cargo had to actually earn their points.
