### PR TITLE
Cogscarabs no longer show up in the staff of change pool

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -181,7 +181,7 @@
 		if("monkey")
 			new_mob = new /mob/living/carbon/monkey(M.loc)
 		if("robot")
-			var/robot = pick("cyborg","syndiborg","drone","cogscarb")
+			var/robot = pick("cyborg","syndiborg","drone")
 			switch(robot)
 				if("cyborg")
 					new_mob = new /mob/living/silicon/robot(M.loc)
@@ -194,8 +194,6 @@
 					new_mob = new path(M.loc)
 				if("drone")
 					new_mob = new /mob/living/simple_animal/drone/polymorphed(M.loc)
-				if("cogscarb")
-					new_mob = new /mob/living/simple_animal/drone/cogscarab(M.loc)
 			if(issilicon(new_mob))
 				new_mob.gender = M.gender
 				new_mob.invisibility = 0


### PR DESCRIPTION
Cogscarabs no longer show up in the staff of change pool, because they're intrinsically an antagonist/antag role and wow guess what xenobio has magicarp of change abuse as an option
