### PR TITLE
Adds in a gatling commando and AI assassin outfit. Tweaks the assassin outfit.

### DIFF
--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -207,6 +207,8 @@
 	sec_briefcase.handle_item_insertion(new /obj/item/weapon/gun/energy/ionrifle,1)
 	sec_briefcase.handle_item_insertion(new /obj/item/weapon/grenade/plastic/x4,1)
 	sec_briefcase.handle_item_insertion(new /obj/item/weapon/implanter/emp,1)
+	sec_briefcase.handle_item_insertion(new /obj/item/weapon/aiModule/reset,1)
+	
 /datum/outfit/centcom_commander
 	name = "Centcom Commander"
 

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -195,19 +195,14 @@
 	belt = /obj/item/device/pda/heads
 	back = /obj/item/weapon/storage/backpack/black
 
-	backpack_contents = list(/obj/item/weapon/storage/toolbox/syndicate,1)
-
-	var/obj/item/weapon/storage/secure/briefcase/sec_briefcase = H.l_hand
-	for(var/obj/item/briefcase_item in sec_briefcase)
-		qdel(briefcase_item)
-	for(var/i=3, i>0, i--)
-		sec_briefcase.handle_item_insertion(new /obj/item/weapon/aiModule/syndicate,1)
-	sec_briefcase.handle_item_insertion(new /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow,1)
-	sec_briefcase.handle_item_insertion(new /obj/item/weapon/grenade/clusterbuster/emp,2)
-	sec_briefcase.handle_item_insertion(new /obj/item/weapon/gun/energy/ionrifle,1)
-	sec_briefcase.handle_item_insertion(new /obj/item/weapon/grenade/plastic/x4,1)
-	sec_briefcase.handle_item_insertion(new /obj/item/weapon/implanter/emp,1)
-	sec_briefcase.handle_item_insertion(new /obj/item/weapon/aiModule/reset,1)
+	backpack_contents = list(/obj/item/weapon/storage/toolbox/syndicate,1\
+	/obj/item/weapon/aiModule/syndicate,1\
+	/obj/item/weapon/gun/energy/kinetic_accelerator/crossbow,1\
+	/obj/item/weapon/grenade/clusterbuster/emp,2\
+	/obj/item/weapon/gun/energy/ionrifle,1\
+	/obj/item/weapon/grenade/plastic/x4,1\
+	/obj/item/weapon/implanter/emp,1\
+	/obj/item/weapon/aiModule/reset,1)
 	
 /datum/outfit/centcom_commander
 	name = "Centcom Commander"

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -168,7 +168,8 @@
 	sec_briefcase.handle_item_insertion(new /obj/item/weapon/gun/projectile/revolver/mateba,1)
 	sec_briefcase.handle_item_insertion(new /obj/item/ammo_box/a357,1)
 	sec_briefcase.handle_item_insertion(new /obj/item/weapon/grenade/plastic/x4,1)
-
+	sec_briefcase.handle_item_insertion(new /obj/item/weapon/grenade/syndieminibomb,1) //You can replace this with a HE grenade, and the kit already comes with a syndicate ID
+	sec_briefcase.handle_item_insertion(new /obj/item/weapon/implanter/adrenalin,1)
 	var/obj/item/device/pda/heads/pda = H.belt
 	pda.owner = H.real_name
 	pda.ownjob = "Reaper"

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -181,6 +181,32 @@
 	W.registered_name = H.real_name
 	W.update_label(H.real_name)
 
+/datum/outfit/AI_Assassin //For when you need a preset outfit to deal with AI or mechs
+	name = "AI Assassin"
+
+	uniform = /obj/item/clothing/under/suit_jacket
+	shoes = /obj/item/clothing/shoes/sneakers/black
+	gloves = /obj/item/clothing/gloves/color/black
+	ears = /obj/item/device/radio/headset
+	glasses = /obj/item/clothing/glasses/sunglasses
+	l_pocket = /obj/item/device/multitool/ai_detect
+	l_hand = /obj/item/weapon/storage/secure/briefcase
+	id = /obj/item/weapon/card/id/syndicate
+	belt = /obj/item/device/pda/heads
+	back = /obj/item/weapon/storage/backpack/black
+
+	backpack_contents = list(/obj/item/weapon/storage/toolbox/syndicate,1)
+
+	var/obj/item/weapon/storage/secure/briefcase/sec_briefcase = H.l_hand
+	for(var/obj/item/briefcase_item in sec_briefcase)
+		qdel(briefcase_item)
+	for(var/i=3, i>0, i--)
+		sec_briefcase.handle_item_insertion(new /obj/item/weapon/aiModule/syndicate,1)
+	sec_briefcase.handle_item_insertion(new /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow,1)
+	sec_briefcase.handle_item_insertion(new /obj/item/weapon/grenade/clusterbuster/emp,2)
+	sec_briefcase.handle_item_insertion(new /obj/item/weapon/gun/energy/ionrifle,1)
+	sec_briefcase.handle_item_insertion(new /obj/item/weapon/grenade/plastic/x4,1)
+	sec_briefcase.handle_item_insertion(new /obj/item/weapon/implanter/emp,1)
 /datum/outfit/centcom_commander
 	name = "Centcom Commander"
 
@@ -349,6 +375,46 @@
 		/obj/item/weapon/storage/box/flashbangs=1,\
 		/obj/item/device/flashlight=1,\
 		/obj/item/weapon/grenade/plastic/x4=1)
+
+/datum/outfit/death_commando/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
+	var/obj/item/device/radio/R = H.ears
+	R.set_frequency(CENTCOM_FREQ)
+	R.freqlock = 1
+
+	var/obj/item/weapon/implant/mindshield/L = new/obj/item/weapon/implant/mindshield(H)//Here you go Deuryn
+	L.imp_in = H
+	L.implanted = 1
+	H.sec_hud_set_implants()
+
+
+	var/obj/item/weapon/card/id/W = H.wear_id
+	W.icon_state = "centcom"
+	W.access = get_all_accesses()//They get full station access.
+	W.access += get_centcom_access("Death Commando")//Let's add their alloted Centcom access.
+	W.assignment = "Death Commando"
+	W.registered_name = H.real_name
+	W.update_label(W.registered_name, W.assignment)
+
+/datum/outfit/gatling_commando //For when you need a mech killer or suppression fire support. The backpack will have infinite energy until overheated
+	name = "Laser Gatling Death Commando"
+
+	uniform = /obj/item/clothing/under/color/green
+	suit = /obj/item/clothing/suit/space/hardsuit/deathsquad
+	shoes = /obj/item/clothing/shoes/combat/swat
+	gloves = /obj/item/clothing/gloves/combat
+	mask = /obj/item/clothing/mask/gas/sechailer/swat
+	glasses = /obj/item/clothing/glasses/hud/toggle/thermal
+	back = /obj/item/weapon/minigunpack
+	l_pocket = /obj/item/weapon/melee/energy/sword/saber
+	r_pocket = /obj/item/weapon/shield/energy
+	suit_store = /obj/item/weapon/tank/internals/emergency_oxygen
+	belt = /obj/item/weapon/gun/projectile/revolver/mateba
+	r_hand = /obj/item/weapon/gun/projectile/minigun
+	id = /obj/item/weapon/card/id
+	ears = /obj/item/device/radio/headset/headset_cent/alt
 
 /datum/outfit/death_commando/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)


### PR DESCRIPTION
NOTE THAT THIS IS SOME PRESETS FOR ADMIN SPAWN ONLY, THESE ARE NOT BUNDLES YOU CAN SPAWN WITH

Makes the assassin able to pursue or escape easier and also has a tool to quickly gib a body after shooting them with a .357 or eswording

The gatling commando is a DS commando that doesn't have a backpack; instead they are given a laser gatling gun. This provides immense firepower, expect they do not have much to offer besides that. 

The AI assassin comes with many useful tools (such as emp clusterbangs, AI uploads and a ion rifle) to deal with murderous AIs, mechs or regular borgs. Can also be paired with DS to help kill the traitorous station, break into areas and disable the enemies laser guns. 
