### PR TITLE
Added technology and design disks that can hold more than one entry.

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -128,7 +128,9 @@
 		busy = 1
 		var/obj/item/weapon/disk/design_disk/D = O
 		if(do_after(user, 14.4, target = src))
-			files.AddDesign2Known(D.blueprint)
+			for(var/B in D.blueprints)
+				if(B)
+					files.AddDesign2Known(B)
 
 		busy = 0
 		return 1

--- a/code/modules/cargo/exports/research.dm
+++ b/code/modules/cargo/exports/research.dm
@@ -7,13 +7,19 @@
 
 /datum/export/tech/get_cost(obj/O)
 	var/obj/item/weapon/disk/tech_disk/D = O
-	if(!D.stored)
-		return 0
-	var/datum/tech/tech = D.stored
-	return ..() * tech.getCost(techLevels[tech.id])
+	var/cost = 0
+	for(var/V in D.tech_stored)
+		if(!V)
+			continue
+		var/datum/tech/tech = V
+		cost += tech.getCost(techLevels[tech.id])
+	return ..() * cost
 
 /datum/export/tech/sell_object(obj/O)
 	..()
 	var/obj/item/weapon/disk/tech_disk/D = O
-	var/datum/tech/tech = D.stored
-	techLevels[tech.id] = tech.level
+	for(var/V in D.tech_stored)
+		if(!V)
+			continue
+		var/datum/tech/tech = V
+		techLevels[tech.id] = tech.level

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -140,7 +140,9 @@
 		processing = 1
 		var/obj/item/weapon/disk/design_disk/D = O
 		if(do_after(user, 10, target = src))
-			files.AddDesign2Known(D.blueprint)
+			for(var/B in D.blueprints)
+				if(B)
+					files.AddDesign2Known(B)
 		processing = 0
 		return 1
 	else

--- a/code/modules/ninja/suit/suit_attackby.dm
+++ b/code/modules/ninja/suit/suit_attackby.dm
@@ -41,15 +41,24 @@
 
 		else if(istype(I, /obj/item/weapon/disk/tech_disk))//If it's a data disk, we want to copy the research on to the suit.
 			var/obj/item/weapon/disk/tech_disk/TD = I
-			if(TD.stored)//If it has something on it.
+			var/has_research = 0
+			for(var/V in  TD.tech_stored)
+				if(V)
+					has_research = 1
+					break
+			if(has_research)//If it has something on it.
 				U << "Research information detected, processing..."
 				if(do_after(U,s_delay, target = src))
-					for(var/datum/tech/current_data in stored_research)
-						if(current_data.id==TD.stored.id)
-							if(current_data.level<TD.stored.level)
-								current_data.level=TD.stored.level
-							break
-					TD.stored = null
+					for(var/V1 in 1 to TD.max_tech_stored)
+						var/datum/tech/new_data = TD.tech_stored[V1]
+						TD.tech_stored[V1] = null
+						if(!new_data)
+							continue
+						for(var/V2 in stored_research)
+							var/datum/tech/current_data = V2
+							if(current_data.id == new_data.id)
+								current_data.level = max(current_data.level, new_data.level)
+								break
 					U << "<span class='notice'>Data analyzed and updated. Disk erased.</span>"
 				else
 					U << "<span class='userdanger'>ERROR</span>: Procedure interrupted. Process terminated."

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -46,15 +46,24 @@ other types of metals and chemistry for reagents).
 ////////////////////////////////////////
 
 /obj/item/weapon/disk/design_disk
-	name = "Component Design Disk"
+	name = "component design disk"
 	desc = "A disk for storing device design data for construction in lathes."
 	icon_state = "datadisk1"
-	materials = list(MAT_METAL=100, MAT_GLASS=100)
-	var/datum/design/blueprint
+	materials = list(MAT_METAL=300, MAT_GLASS=100)
+	var/list/blueprints = list()
+	var/max_blueprints = 1
 
 /obj/item/weapon/disk/design_disk/New()
 	src.pixel_x = rand(-5, 5)
 	src.pixel_y = rand(-5, 5)
+	for(var/i in 1 to max_blueprints)
+		blueprints += null
+
+/obj/item/weapon/disk/design_disk/adv
+	name = "advanced component design disk"
+	desc = "A disk for storing device design data for construction in lathes. This one has extra storage space."
+	materials = list(MAT_METAL=300, MAT_GLASS=100, MAT_SILVER = 50)
+	max_blueprints = 5
 
 ///////////////////////////////////
 /////Non-Board Computer Stuff//////
@@ -94,6 +103,16 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/disk/design_disk
 	category = list("Electronics")
 
+/datum/design/design_disk_adv
+	name = "Advanced Design Storage Disk"
+	desc = "Produce additional disks for storing device designs."
+	id = "design_disk_adv"
+	req_tech = list("programming" = 3)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 300, MAT_GLASS = 100, MAT_SILVER=50)
+	build_path = /obj/item/weapon/disk/design_disk/adv
+	category = list("Electronics")
+
 /datum/design/tech_disk
 	name = "Technology Data Storage Disk"
 	desc = "Produce additional disks for storing technology data."
@@ -104,6 +123,25 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/disk/tech_disk
 	category = list("Electronics")
 
+/datum/design/tech_disk_adv
+	name = "Advanced Technology Data Storage Disk"
+	desc = "Produce disks with extra storage capacity for storing technology data."
+	id = "tech_disk_adv"
+	req_tech = list("programming" = 3)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 300, MAT_GLASS = 100, MAT_SILVER=50)
+	build_path = /obj/item/weapon/disk/tech_disk/adv
+	category = list("Electronics")
+
+/datum/design/tech_disk_super_adv
+	name = "Quantum Technology Data Storage Disk"
+	desc = "Produce disks with extremely large storage capacity for storing technology data."
+	id = "tech_disk_super_adv"
+	req_tech = list("programming" = 6)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 300, MAT_GLASS = 100, MAT_SILVER=100, MAT_GOLD=100)
+	build_path = /obj/item/weapon/disk/tech_disk/super_adv
+	category = list("Electronics")
 
 /////////////////////////////////////////
 /////////////////Mining//////////////////

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -289,12 +289,42 @@ research holder datum.
 	return cost
 
 /obj/item/weapon/disk/tech_disk
-	name = "Technology Disk"
+	name = "technology disk"
 	desc = "A disk for storing technology data for further research."
 	icon_state = "datadisk0"
-	materials = list(MAT_METAL=30, MAT_GLASS=10)
-	var/datum/tech/stored
+	materials = list(MAT_METAL=300, MAT_GLASS=100)
+	var/list/tech_stored = list()
+	var/max_tech_stored = 1
 
 /obj/item/weapon/disk/tech_disk/New()
 	src.pixel_x = rand(-5, 5)
 	src.pixel_y = rand(-5, 5)
+	for(var/i in 1 to max_tech_stored)
+		tech_stored += null
+
+/obj/item/weapon/disk/tech_disk/adv
+	name = "advanced technology disk"
+	desc = "A disk for storing technology data for further research. This one has extra storage space."
+	materials = list(MAT_METAL=300, MAT_GLASS=100, MAT_SILVER=50)
+	max_tech_stored = 5
+
+/obj/item/weapon/disk/tech_disk/super_adv
+	name = "quantum technology disk"
+	desc = "A disk for storing technology data for further research. This one has extremely large storage space."
+	materials = list(MAT_METAL=300, MAT_GLASS=100, MAT_SILVER=100, MAT_GOLD=100)
+	max_tech_stored = 10
+
+/obj/item/weapon/disk/tech_disk/debug
+	name = "centcomm technology disk"
+	desc = "A debug item for research"
+	materials = list()
+	max_tech_stored = 0
+
+/obj/item/weapon/disk/tech_disk/debug/New()
+	..()
+	var/list/techs = subtypesof(/datum/tech)
+	max_tech_stored = techs.len
+	for(var/V in techs)
+		var/datum/tech/T = new V()
+		tech_stored += T
+		T.level = 8

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -22,11 +22,12 @@
 	name = "Golem Creation Disk"
 	desc = "A gift from the Liberator."
 	icon_state = "datadisk1"
+	max_blueprints = 1
 
 /obj/item/weapon/disk/design_disk/golem_shell/New()
 	..()
 	var/datum/design/golem_shell/G = new
-	blueprint = G
+	blueprints[1] = G
 
 /datum/design/golem_shell
 	name = "Golem Shell Construction"


### PR DESCRIPTION
:cl:
rscadd: Space floppy-disk technology has advanced to the point that multiple technologies or designs can be stored on a single disk.
/:cl:
Also made technology disks have the same materials as they cost to create.

Tier 1 tech disks hold 1 technology, require programming 1, and cost 300 metal and 100 glass
Tier 2 tech disks hold 5 technologies, require programming 3, and cost 300 metal, 100 glass, and 50 silver
Tier 3 tech disks hold 10 technologies, require programming 6, and cost 300 metal, 100 glass, 100 silver, and 100 gold

Tier 1 design disks hold 1 design, require programming 1, and cost 300 metal and 100 glass
Tier 2 design disks hold 5 designs, require programming 3, and cost 300 metal, 100 glass, and 50 silver

Added a debug design disk that has all technologies at level 8, because it's faster than deconstructing a research object seven times.
