### PR TITLE
One Liner Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -382,7 +382,6 @@
 		visible_message("<span class='warning'>[src] looks unharmed.</span>")
 	else
 		adjustBruteLoss(damage)
-		updatehealth()
 
 /mob/living/simple_animal/movement_delay()
 	. = ..()


### PR DESCRIPTION
This PR fixes all human `null.handle_fall()` runtimes in one line.

Some simple animals drop a corpse on death and then del themselves. But `updatehealth()` on all simple animals was being called twice on any attack, first time by `adjustBruteLoss` and second time by `attack_threshold_check`.

When qdel-on-death mob was killed, this resulted in second `death()` being called on already nullspaced simple animal, causing it to drop a new corpse in nullspace. And that corpse caused a`null.handle_fall()` runtime.

Fixes #19839
