### PR TITLE
Sabre armor pene nerf

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -31,7 +31,7 @@
 	throwforce = 10
 	w_class = 4
 	block_chance = 50
-	armour_penetration = 75
+	armour_penetration = 25
 	sharpness = IS_SHARP
 	origin_tech = "combat=5"
 	attack_verb = list("lunged at", "stabbed")


### PR DESCRIPTION
:cl: Yackemflam
tweak: Sabre armor penetration is now in more line with the rest of the weapons in the game.
/:cl:

A sabre should not have more armor pene than an energy sword.
It also should no negate nearly every single armor in the game without admin bullshittery.
