### PR TITLE
Adds a config option to use account creation age for job timers.

### DIFF
--- a/code/__HELPERS/bandetect.dm
+++ b/code/__HELPERS/bandetect.dm
@@ -10,6 +10,8 @@
 
 	if(query.NextRow())
 		var/diff = text2num(query.item[1])
+		if(config.use_account_age_for_jobs)
+			player_age = max(0,diff)	//So job code soesn't freak out if they are time traveling.
 		if(diff < YOUNG)
 			var/msg = "(IP: [address], ID: [computer_id]) is a new BYOND account made on [y]-[m]-[d]."
 			if(diff < 0)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -82,6 +82,7 @@
 	var/admin_legacy_system = 0	//Defines whether the server uses the legacy admin system with admins.txt or the SQL system. Config option in config.txt
 	var/ban_legacy_system = 0	//Defines whether the server uses the legacy banning system with the files in /data or the SQL system. Config option in config.txt
 	var/use_age_restriction_for_jobs = 0 //Do jobs use account age restrictions? --requires database
+	var/use_account_age_for_jobs = 0	//Uses the time they made the account for the job restriction stuff. New player joining alerts should be unaffected.
 	var/see_own_notes = 0 //Can players see their own admin notes (read-only)? Config option in config.txt
 
 	//Population cap vars
@@ -268,6 +269,8 @@
 					config.ban_legacy_system = 1
 				if("use_age_restriction_for_jobs")
 					config.use_age_restriction_for_jobs = 1
+				if("use_account_age_for_jobs")
+					config.use_account_age_for_jobs = 1
 				if("lobby_countdown")
 					config.lobby_countdown = text2num(value)
 				if("round_end_countdown")

--- a/config/config.txt
+++ b/config/config.txt
@@ -23,6 +23,9 @@ BAN_LEGACY_SYSTEM
 ## you have noone older than 0 days, since noone has been logged yet. Only turn this on once you have had the database up for 30 days.
 #USE_AGE_RESTRICTION_FOR_JOBS
 
+# Uncomment this to have the job system use the player's account creation date, rather than the when they first joined the server for job timers.
+#USE_ACCOUNT_AGE_FOR_JOBS
+
 ## log OOC channel
 LOG_OOC
 


### PR DESCRIPTION
Requested by @KorPhaeron.
This will use the date that they created their byond account rather than when they joined the server first as the age for job checks.
Since join date checks are after new player alerts, this shouldn't mess anything up I don't think.

:cl:
add: Added config option to use byond account creation age for job limits.
/:cl:
