### PR TITLE
Standard borg mining modules

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -135,7 +135,7 @@
 	modules += new /obj/item/weapon/extinguisher(src)
 
 	modules += new /obj/item/weapon/pickaxe(src)
-	modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
+	modules += new /obj/item/device/t_scanner/adv_mining_scanner(src)
 
 	modules += new /obj/item/weapon/restraints/handcuffs/cable/zipties/cyborg(src)
 


### PR DESCRIPTION
The text of #18433 mentions adding a mining satchel to standard cyborgs, but this change was not included in the commit. Instead, the Sheet Snatcher 9000 module was added which is useless for mining as it can only pick up smelted sheets. This seems like a simple mistake.

Though after mining with standard cyborgs a bit, I'm not convinced mining satchels are the best idea. Mining alone with only a pick and a satchel is literally a gulag punishment in this game; it's not fun and nobody enjoys it. If mining is to remain a part of standard cyborgs, then it would make more sense for them to have a scanner module instead of a satchel. This would allow them to play an assistant role to other miners without being capable of mining on their own. They would still be worse at mining than mining borgs.

Bonus: Allows standard borgs to say "I can't mine by myself" when law 2 ordered to leave the station and mine. Such commands would be grief-inducing otherwise.

:cl:
add: Mining scanner module to standard borgs
del: Sheet snatcher module from standard borgs
/:cl:
