### PR TITLE
A few tweaks and improvements to silicons.

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -401,7 +401,7 @@ var/datum/subsystem/job/SSjob
 		H << "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>"
 	if(config.minimal_access_threshold)
 		H << "<FONT color='blue'><B>As this station was initially staffed with a [config.jobs_have_minimal_access ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></font>"
-	return 1
+	return H
 
 
 /datum/subsystem/job/proc/setup_officer_positions()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -31,26 +31,7 @@
 	if(..())
 		return
 
-	R.notify_ai(2)
-
-	R.uneq_all()
-	R.hands.icon_state = "nomod"
-	R.icon_state = "robot"
-	qdel(R.module)
-	R.module = null
-
-	R.modtype = "robot"
-	R.designation = "Default"
-	R.updatename("Default")
-
-	R.update_icons()
-	R.update_headlamp()
-
-	R.speed = 0 // Remove upgrades.
-	R.ionpulse = FALSE
-	R.magpulse = FALSE
-
-	R.status_flags |= CANPUSH
+	R.ResetModule()
 
 	return 1
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -77,7 +77,7 @@ var/list/ai_list = list()
 
 	var/obj/machinery/camera/portable/builtInCamera
 
-/mob/living/silicon/ai/New(loc, var/datum/ai_laws/L, var/obj/item/device/mmi/B, var/safety = 0)
+/mob/living/silicon/ai/New(loc, datum/ai_laws/L, obj/item/device/mmi/B, safety = 0)
 	..()
 	rename_self("ai")
 	name = real_name
@@ -917,3 +917,6 @@ var/list/ai_list = list()
 		src << "Hack complete. \The [apc] is now under your \
 			exclusive control."
 		apc.update_icon()
+
+/mob/living/silicon/ai/spawned/New(loc, datum/ai_laws/L, obj/item/device/mmi/B, safety = 0)
+	..(loc,L,B,1)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1311,3 +1311,30 @@
 			locked = 1
 		notify_ai(1)
 		. = 1
+
+
+
+/mob/living/silicon/robot/proc/ResetModule()
+
+	notify_ai(2)
+
+	uneq_all()
+	hands.icon_state = "nomod"
+	icon_state = "robot"
+	qdel(module)
+	module = null
+
+	modtype = "robot"
+	designation = "Default"
+	updatename("Default")
+
+	update_icons()
+	update_headlamp()
+
+	speed = 0 // Remove upgrades.
+	ionpulse = FALSE
+	magpulse = FALSE
+
+	status_flags |= CANPUSH
+
+	return 1


### PR DESCRIPTION
Added support for latejoin borgs. Well, there was code already in there for it, but it just spawned them on the start screen.
Made resetting the module a proc on the borg instead of the upgrade.
Added a spawned subtype of the AI that won't delete itself if it doesn't find an MMI. This should greatly help out with testing AI stuff on the server since you can just spawn one in the thunderdome now instead of using AIize which send them to the AI core.

I might do some work later on adding latejoin AIs support.
