### PR TITLE
You can now use sheets from any hand

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -111,7 +111,7 @@
 
 /obj/item/stack/Topic(href, href_list)
 	..()
-	if ((usr.restrained() || usr.stat || usr.get_active_hand() != src))
+	if (usr.restrained() || usr.stat || (usr.get_active_hand() != src && usr.get_inactive_hand() != src))
 		return
 	if (href_list["make"])
 		if (src.get_amount() < 1) qdel(src) //Never should happen


### PR DESCRIPTION
I'm not sure why sheets were restricted to active hand only. This restriction did nothing but annoyed engineers.

:cl: CoreOverload
tweak: You can now use sheets from any hand, not just the active one.
/:cl:
