### PR TITLE
Virology Expansion Pack: You'll Only Make These After Shuttle Call Edition

### DIFF
--- a/code/datums/diseases/advance/symptoms/bluespace.dm
+++ b/code/datums/diseases/advance/symptoms/bluespace.dm
@@ -1,0 +1,43 @@
+/*
+//////////////////////////////////////
+
+Bluespace Instability
+
+	Noticeable.
+	Lowers resistance.
+	Decreases stage speed.
+	Increases transmittablity slightly.
+	Fatal Level.
+
+Bonus
+	Causes the mob to randomly teleport, as if he crushed a bluespace crystal.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/bluespace
+
+	name = "Bluespace Instability"
+	stealth = -2
+	resistance = -2
+	stage_speed = -1
+	transmittable = 1
+	level = 7
+	severity = 5
+
+/datum/symptom/bluespace/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB/2))
+		var/mob/living/M = A.affected_mob
+		var/blink_range = 6  //A bluespace crystal is 8, for reference
+		switch(A.stage)
+			if(5)
+				PoolOrNew(/obj/effect/particle_effect/sparks, M.loc)
+				playsound(M.loc, "sparks", 50, 1)
+				do_teleport(M, get_turf(M), blink_range, asoundin = 'sound/effects/phasein.ogg')
+				M << "<span class='userdanger'>[pick("Your body folds into bluespace!", "You teleport!", "You're suddenly somewhere else!")]</span>"
+
+			else
+				M << "<span class='warning'>[pick("You feel unstable.", "You feel dizzy.")]</span>"
+
+	return

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -76,7 +76,7 @@ Bonus
 	resistance = -0
 	stage_speed = -1
 	transmittable = -2
-	level = 7
+	level = 8
 	severity = 3
 
 /datum/symptom/asphyxiation/Activate(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/damage_converter.dm
+++ b/code/datums/diseases/advance/symptoms/damage_converter.dm
@@ -82,7 +82,7 @@ Bonus
 	resistance = -2
 	stage_speed = -2
 	transmittable = 0
-	level = 7
+	level = 8
 
 /datum/symptom/damage_converter_uranium/Activate(datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -81,7 +81,7 @@ Bonus
 	resistance = -2
 	stage_speed = -2
 	transmittable = -2
-	level = 7
+	level = 8
 	severity = 6
 
 /datum/symptom/alkali/Activate(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -32,3 +32,50 @@ BONUS
 		var/mob/living/M = A.affected_mob
 		M << "<span class='warning'>[pick("Your head hurts.", "Your head starts pounding.")]</span>"
 	return
+
+/*
+//////////////////////////////////////
+
+Cluster Headache
+
+	Noticable.
+	Highly resistant.
+	Increases stage speed.
+	Not transmittable.
+	High Level
+
+BONUS
+	Causes extreme pain at random times! Stuns and does some brain damage.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/headache/cluster
+
+	name = "Cluster Headache"
+	stealth = -2
+	resistance = 4
+	stage_speed = 2
+	transmittable = 0
+	level = 5
+	severity = 1
+
+/datum/symptom/headache/cluster/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB))
+		var/mob/living/M = A.affected_mob
+		switch(A.stage)
+			if(4)
+				M << "<span class='userdanger'>Your feel an intense pain inside your head!</span>"
+				M.Stun(2)
+
+			if(5)
+				M << "<span class='userdanger'>[pick("You feel an incredible pain behind your eyes!", "YOUR HEAD HURTS!")]</span>"
+				M.Weaken(4)
+				if(M.getBrainLoss()<=45)
+					M.adjustBrainLoss(5)
+					M.updatehealth()
+
+			else
+				M << "<span class='warning'>[pick("Your head really hurts.", "You feel needles in your brain.")]</span>"
+	return

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -60,7 +60,7 @@ Bonus
 	resistance = -2
 	stage_speed = -2
 	transmittable = -2
-	level = 8
+	level = 9
 
 /datum/symptom/aptx/Activate(datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/radiation.dm
+++ b/code/datums/diseases/advance/symptoms/radiation.dm
@@ -10,7 +10,7 @@ Radioactive Metabolism
 	Fatal Level.
 
 Bonus
-	Emits radioactive pulses.
+	The mob randomly emits radioactive pulses.
 
 //////////////////////////////////////
 */
@@ -22,12 +22,12 @@ Bonus
 	resistance = -2
 	stage_speed = 2
 	transmittable = -4
-	level = 7
+	level = 8
 	severity = 6
 
 /datum/symptom/radioactive/Activate(datum/disease/advance/A)
 	..()
-	if(prob(SYMPTOM_ACTIVATION_PROB))
+	if(prob(SYMPTOM_ACTIVATION_PROB/2))
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(2,3)
@@ -39,5 +39,5 @@ Bonus
 
 /datum/symptom/radioactive/proc/Radpulse(mob/living/M, datum/disease/advance/A)
 	var/get_rad = ((sqrt(20+A.totalStageSpeed()))*10)
-	radiation_pulse(get_turf(src), 1, 4, get_rad, 0)
+	radiation_pulse(get_turf(M), 1, 4, get_rad, 0)
 	return 1

--- a/code/datums/diseases/advance/symptoms/radiation.dm
+++ b/code/datums/diseases/advance/symptoms/radiation.dm
@@ -1,0 +1,43 @@
+/*
+//////////////////////////////////////
+
+Radioactive Metabolism
+
+	Noticeable.
+	Lowers resistance.
+	Increases stage speed.
+	No change to transmittability.
+	Fatal Level.
+
+Bonus
+	Emits radioactive pulses.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/radioactive
+
+	name = "Radioactive Metabolism"
+	stealth = -1
+	resistance = -2
+	stage_speed = 2
+	transmittable = -4
+	level = 7
+	severity = 6
+
+/datum/symptom/radioactive/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB))
+		var/mob/living/M = A.affected_mob
+		switch(A.stage)
+			if(2,3)
+				M << "<span class='warning'>[pick("You feel nauseous.", "Your skin glows eerily.")]</span>"
+			if(4,5)
+				M << "<span class='userdanger'>[pick("A flash of light outlines your bones.", "You feel a strong heat irradiate from inside you.")]</span>"
+				Radpulse(M, A)
+	return
+
+/datum/symptom/radioactive/proc/Radpulse(mob/living/M, datum/disease/advance/A)
+	var/get_rad = ((sqrt(20+A.totalStageSpeed()))*10)
+	radiation_pulse(get_turf(src), 1, 4, get_rad, 0)
+	return 1

--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -38,3 +38,51 @@ Bonus
 	var/get_cold = (sqrt(16+A.totalStealth()*2))+(sqrt(21+A.totalResistance()*2))
 	M.bodytemperature = min(M.bodytemperature - (get_cold * A.stage), BODYTEMP_COLD_DAMAGE_LIMIT + 1)
 	return 1
+
+
+/*
+//////////////////////////////////////
+
+Mitochondrial Depolarization (aka Freezing)
+
+	Noticeable.
+	Decreases resistance.
+	Heavily decreases stage speed.
+	Little transmittable.
+	Fatal level.
+
+Bonus
+	Freezes your body.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/freezing
+
+	name = "Mitochondrial Depolarization"
+	stealth = -1
+	resistance = -2
+	stage_speed = -4
+	transmittable = 1
+	level = 7
+	severity = 5
+
+/datum/symptom/freezing/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB))
+		var/mob/living/carbon/M = A.affected_mob
+		switch(A.stage)
+			if(3)
+				M << "<span class='warning'>[pick("You feel cold.", "You feel as if you can't warm up.", "You start shivering.")]</span>"
+				M.emote("shiver")
+
+			if(4,5)
+				M << "<span class='userdanger'>[pick("Your skin starts freezing!", "You feel cold!", "You can't feel your limbs!")]</span>"
+				M.emote("shiver")
+				Freeze(M, A)
+	return
+
+/datum/symptom/freezing/proc/Freeze(mob/living/M, datum/disease/advance/A)
+	var/get_cold = (sqrt(16+A.totalStealth()*2))+(sqrt(21+A.totalResistance()*2))
+	M.bodytemperature = min(M.bodytemperature - (get_cold * A.stage), 40)
+	return 1

--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -64,7 +64,7 @@ Bonus
 	resistance = -2
 	stage_speed = -4
 	transmittable = 1
-	level = 7
+	level = 5
 	severity = 5
 
 /datum/symptom/freezing/Activate(datum/disease/advance/A)
@@ -73,11 +73,11 @@ Bonus
 		var/mob/living/carbon/M = A.affected_mob
 		switch(A.stage)
 			if(3)
-				M << "<span class='warning'>[pick("You feel cold.", "You feel as if you can't warm up.", "You start shivering.")]</span>"
+				M << "<span class='warning'>[pick("You feel cold.", "You feel as if you can't warm up.", "You shiver.")]</span>"
 				M.emote("shiver")
 
 			if(4,5)
-				M << "<span class='userdanger'>[pick("Your skin starts freezing!", "You feel cold!", "You can't feel your limbs!")]</span>"
+				M << "<span class='warning'>[pick("Your skin freezes!", "You feel extremely cold!")]</span>"
 				M.emote("shiver")
 				Freeze(M, A)
 	return

--- a/code/datums/diseases/advance/symptoms/shock.dm
+++ b/code/datums/diseases/advance/symptoms/shock.dm
@@ -76,7 +76,6 @@ Bonus
 	level = 9
 	severity = 5
 
-	var/original_siemens
 
 /datum/symptom/tesla/Activate(datum/disease/advance/A)
 	..()
@@ -103,12 +102,3 @@ Bonus
 				M << "<span class='warning'>[pick("You feel charged.", "You feel currents of electricity wash over your skin.", "You feel insulated.")]</span>"
 
 	return
-
-/datum/symptom/tesla/Start(datum/disease/advance/A) //Make the mob immune to shocks, mainly to prevent self-shocking
-	var/mob/living/M = A.affected_mob
-	original_siemens = M.siemens_coeff
-	M.siemens_coeff = 0
-
-/datum/symptom/tesla/End(datum/disease/advance/A)
-	var/mob/living/M = A.affected_mob
-	M.siemens_coeff = original_siemens

--- a/code/datums/diseases/advance/symptoms/shock.dm
+++ b/code/datums/diseases/advance/symptoms/shock.dm
@@ -1,0 +1,114 @@
+/*
+//////////////////////////////////////
+
+Overloaded Nerves
+
+	Noticeable.
+	Resistant.
+	Decreases stage speed.
+	No transmittability.
+	Fatal Level.
+
+Bonus
+	The mob will receive an electric shock once in a while. Insulation does not help.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/shock
+
+	name = "Overloaded Nerves"
+	stealth = -2
+	resistance = 1
+	stage_speed = -1
+	transmittable = 0
+	level = 7
+	severity = 5
+
+/datum/symptom/shock/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB))
+		var/mob/living/M = A.affected_mob
+		switch(A.stage)
+			if(1,2)
+				M << "<span class='warning'>[pick("Your hairs stand on end.", "You feel a small static discharge.")]</span>"
+			if(3,4)
+				if(prob(25))
+					M << "<span class='warning'>Your arm twitches.</span>"
+					var/obj/item/I = M.get_active_hand()
+					if(I && I.w_class == 1)
+						M.drop_item()
+				else
+					M << "<span class='warning'>You feel a small shock run down your spine.</span>"
+			if(5)
+				M << "<span class='warning'>You feel a surge of static electricity.</span>"
+				M.reagents.add_reagent("teslium", 4)
+
+
+
+	return
+
+
+/*
+//////////////////////////////////////
+
+Viral Electric Net
+
+	Very noticeable.
+	Lowers resistance.
+	Decreases stage speed.
+	Reduces transmittability.
+	Fatal Level.
+
+Bonus
+	The mob will become immune to shocks and sometimes arc tesla bolts end emit EMP pulses.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/tesla
+
+	name = "Viral Electric Net"
+	stealth = -3
+	resistance = -2
+	stage_speed = -2
+	transmittable = -2
+	level = 9
+	severity = 5
+
+	var/original_siemens
+
+/datum/symptom/tesla/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB/2))
+		var/mob/living/M = A.affected_mob
+		switch(A.stage)
+			if(4)
+				if (prob(15))
+					M << "<span class='warning'>You scramble nearby electronics.</span>"
+					empulse(get_turf(M), 1, 1)
+				else
+					M << "<span class='warning'>Electricity arcs off you into the ground.</span>"
+			if(5)
+				if(prob(50))
+					M << "<span class='userdanger'>[pick("You release your static charge!", "You emit a powerful shock!")]</span>"
+					playsound(get_turf(M), 'sound/magic/LightningShock.ogg', 100, 1, extrarange = 5)
+					tesla_zap(get_turf(M), 3, 8000)
+				else
+					M << "<span class='userdanger'>You emit an electromagnetic pulse!</span>"
+					empulse(get_turf(M), 2, 4)
+
+			else
+
+				M << "<span class='warning'>[pick("You feel charged.", "You feel currents of electricity wash over your skin.", "You feel insulated.")]</span>"
+
+	return
+
+/datum/symptom/tesla/Start(datum/disease/advance/A) //Make the mob immune to shocks, mainly to prevent self-shocking
+	var/mob/living/M = A.affected_mob
+	original_siemens = M.siemens_coeff
+	M.siemens_coeff = 0
+
+/datum/symptom/tesla/End(datum/disease/advance/A)
+	var/mob/living/M = A.affected_mob
+	M.siemens_coeff = original_siemens

--- a/code/datums/diseases/advance/symptoms/stimulant.dm
+++ b/code/datums/diseases/advance/symptoms/stimulant.dm
@@ -36,3 +36,89 @@ Bonus
 				if(prob(SYMPTOM_ACTIVATION_PROB * 5))
 					M << "<span class='notice'>[pick("You feel restless.", "You feel like running laps around the station.")]</span>"
 	return
+
+/*
+//////////////////////////////////////
+
+Hormonal Hyperglands
+
+	Noticeable.
+	Lowers resistance.
+	Decreases stage speed tremendously.
+	Decreases transmittablity tremendously.
+	Moderate Level.
+
+Bonus
+	The body starts generating high-power hormones, causing emotional imbalance.
+	Emotions can be useful or harmful.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/emotion
+
+	name = "Hormonal Hyperglands"
+	stealth = -1
+	resistance = -1
+	stage_speed = -4
+	transmittable = -4
+	level = 8
+
+/datum/symptom/emotion/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB/2))
+		var/mob/living/M = A.affected_mob
+		var/mood = null
+		switch(A.stage)
+			if(5)
+				mood = rand(1,5)
+				if (M.health < 30)
+					mood++ //Being wounded increases the odds of determination, and prevents depression
+				switch (mood)
+					if(1) //Depression: You just feel tired and slow down, because why bother.
+						M << "<span class='warning'>You feel depressed.</span>"
+						M.emote("sigh")
+						M.reagents.add_reagent("tirizene", 10)
+					if(2) //Happiness/calmness: You feel as if you're painless and healthy.
+						M << "<span class='notice'>Your feel all your stress and pain washing away...</span>"
+						if (M.reagents.get_reagent_amount("krokodil") < 4)
+							M.reagents.add_reagent("krokodil", 5)
+						if (M.reagents.get_reagent_amount("morphine") < 4)
+							M.reagents.add_reagent("morphine", 5)
+						if (M.reagents.get_reagent_amount("mine_salve") < 10)
+							M.reagents.add_reagent("mine_salve", 10)
+						M.drowsiness += 10
+					if(3) //Focus: Removes anything that affects your mind, like drugs and alcohol.
+						M << "<span class='notice'>You clear your thoughts, and all distractions fade into the background.</span>"
+						M.reagents.add_reagent("mannitol", 10)
+						M.reagents.add_reagent("antihol", 10)
+						M.reagents.remove_all_type(/datum/reagent/drug, 10, 0, 1)
+						M.set_drugginess(0)
+						M.stuttering = 0
+						M.hallucination = 0
+					if(4) //Anger: You snap out of stuns and become harder to keep down, but you move oddly and get angry with unexistent things.
+						M << "<span class='userdanger'>Your fly into a rage!</span>"
+						if (M.reagents.get_reagent_amount("bath_salts") < 4)
+							M.reagents.add_reagent("bath_salts", 5)
+						M.setStunned(0, 0)
+						M.setParalysis(0, 0)
+						M.setWeakened(0, 0)
+						M.setSleeping(0, 0)
+						M.hallucination += 30
+						M.emote("scream")
+						if (prob(35)
+							M.say( pick( list("DIE!!", "ALLAHU AKBAR!!", "BY THE POWER OF GREYSKULL!!", "HULK SMASH!!", "HONK!!") ) )
+
+					if(5,6) //Determination: Lets you tough out your wounds. You ain't dying today.
+						M << "<span class='notice'>You are filled with determination.</span>"
+						if (M.reagents.get_reagent_amount("epinephrine") < 10)
+							M.reagents.add_reagent("epinephrine", 10)
+						if (M.reagents.get_reagent_amount("atropine") < 10)
+							M.reagents.add_reagent("atropine", 10)
+						if (M.reagents.get_reagent_amount("tricordrazine") < 10)
+							M.reagents.add_reagent("tricordrazine", 10)
+
+			else
+				if(prob(SYMPTOM_ACTIVATION_PROB * 5))
+					M << "<span class='notice'>[pick("You feel angry.", "You feel calm.", "You feel focused", "You feel happy.", "You feel depressed.", "You feel strong.")]</span>"
+	return

--- a/code/datums/diseases/advance/symptoms/stimulant.dm
+++ b/code/datums/diseases/advance/symptoms/stimulant.dm
@@ -40,7 +40,7 @@ Bonus
 /*
 //////////////////////////////////////
 
-Hormonal Hyperglands
+Hormonal Hypertrophy
 
 	Noticeable.
 	Lowers resistance.
@@ -57,7 +57,7 @@ Bonus
 
 /datum/symptom/emotion
 
-	name = "Hormonal Hyperglands"
+	name = "Hormonal Hypertrophy"
 	stealth = -1
 	resistance = -1
 	stage_speed = -4
@@ -81,33 +81,30 @@ Bonus
 						M.reagents.add_reagent("tirizene", 10)
 					if(2) //Happiness/calmness: You feel as if you're painless and healthy.
 						M << "<span class='notice'>Your feel all your stress and pain washing away...</span>"
-						if (M.reagents.get_reagent_amount("krokodil") < 4)
-							M.reagents.add_reagent("krokodil", 5)
-						if (M.reagents.get_reagent_amount("morphine") < 4)
-							M.reagents.add_reagent("morphine", 5)
-						if (M.reagents.get_reagent_amount("mine_salve") < 10)
+						if (M.reagents.get_reagent_amount("krokodil") < 4) //happy
+							M.reagents.add_reagent("krokodil", 4)
+						if (M.reagents.get_reagent_amount("morphine") < 4) //no slowdown from pain
+							M.reagents.add_reagent("morphine", 4)
+						if (M.reagents.get_reagent_amount("mine_salve") < 10) //you can't feel your wounds
 							M.reagents.add_reagent("mine_salve", 10)
-						M.drowsiness += 10
-					if(3) //Focus: Removes anything that affects your mind, like drugs and alcohol.
+						M.drowsyness += 10
+					if(3) //Focus: Removes anything that affects your mind.
 						M << "<span class='notice'>You clear your thoughts, and all distractions fade into the background.</span>"
 						M.reagents.add_reagent("mannitol", 10)
-						M.reagents.add_reagent("antihol", 10)
-						M.reagents.remove_all_type(/datum/reagent/drug, 10, 0, 1)
+						M.reagents.add_reagent("antihol", 10) //also removes confusion and similar
 						M.set_drugginess(0)
 						M.stuttering = 0
 						M.hallucination = 0
-					if(4) //Anger: You snap out of stuns and become harder to keep down, but you move oddly and get angry with unexistent things.
+					if(4) //Anger: You snap out of stuns and become harder to keep down, but you move oddly and get angry with unexistant things.
 						M << "<span class='userdanger'>Your fly into a rage!</span>"
 						if (M.reagents.get_reagent_amount("bath_salts") < 4)
 							M.reagents.add_reagent("bath_salts", 5)
-						M.setStunned(0, 0)
-						M.setParalysis(0, 0)
-						M.setWeakened(0, 0)
-						M.setSleeping(0, 0)
+						M.SetStunned(0)
+						M.SetParalysis(0)
+						M.SetWeakened(0)
+						M.SetSleeping(0)
 						M.hallucination += 30
 						M.emote("scream")
-						if (prob(35)
-							M.say( pick( list("DIE!!", "ALLAHU AKBAR!!", "BY THE POWER OF GREYSKULL!!", "HULK SMASH!!", "HONK!!") ) )
 
 					if(5,6) //Determination: Lets you tough out your wounds. You ain't dying today.
 						M << "<span class='notice'>You are filled with determination.</span>"
@@ -120,5 +117,5 @@ Bonus
 
 			else
 				if(prob(SYMPTOM_ACTIVATION_PROB * 5))
-					M << "<span class='notice'>[pick("You feel angry.", "You feel calm.", "You feel focused", "You feel happy.", "You feel depressed.", "You feel strong.")]</span>"
+					M << "<span class='notice'>[pick("You feel angry", "You feel calm", "You feel focused", "You feel happy", "You feel depressed", "You feel strong")][pick(" for a moment.", ", but it quickly passes.")]</span>"
 	return

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1200,12 +1200,12 @@
 	id = "weakplasmavirusfood"
 	color = "#CEC3C6" // rgb: 206,195,198
 
-/datum/reagent/uranium/uraniumvirusfood
+/datum/reagent/toxin/mutagen/mutagenvirusfood/gold
 	name = "conductive mutagenic agar"
 	id = "goldvirusfood"
 	color = "#DEDE20" // rgb: 222,222,32
 
-/datum/reagent/uranium/uraniumvirusfood/unstable
+/datum/reagent/uranium/uraniumvirusfood
 	name = "unstable uranium gel"
 	id = "uraniumplasmavirusfood_unstable"
 	color = "#2FF2CB" // rgb: 47,242,203

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1201,9 +1201,9 @@
 	color = "#CEC3C6" // rgb: 206,195,198
 
 /datum/reagent/uranium/uraniumvirusfood
-	name = "decaying uranium gel"
-	id = "uraniumvirusfood"
-	color = "#67ADBA" // rgb: 103,173,186
+	name = "conductive mutagenic agar"
+	id = "goldvirusfood"
+	color = "#DEDE20" // rgb: 222,222,32
 
 /datum/reagent/uranium/uraniumvirusfood/unstable
 	name = "unstable uranium gel"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -175,11 +175,11 @@
 	required_reagents = list("salglu_solution" = 1, "mutagenvirusfood" = 1)
 	result_amount = 2
 
-/datum/chemical_reaction/virus_food_uranium
-	name = "Decaying uranium gel"
-	id = "uraniumvirusfood"
-	result = "uraniumvirusfood"
-	required_reagents = list("uranium" = 1, "virusfood" = 1)
+/datum/chemical_reaction/virus_food_gold
+	name = "Conductive mutagenic agar"
+	id = "goldvirusfood"
+	result = "goldvirusfood"
+	required_reagents = list("gold" = 1, "mutagenvirusfood" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/virus_food_uranium_plasma
@@ -289,8 +289,8 @@
 
 	name = "Mix Virus 10"
 	id = "mixvirus10"
-	required_reagents = list("uraniumvirusfood" = 5)
-	level_min = 6
+	required_reagents = list("goldvirusfood" = 1)
+	level_min = 7
 	level_max = 7
 
 /datum/chemical_reaction/mix_virus/mix_virus_11
@@ -298,16 +298,16 @@
 	name = "Mix Virus 11"
 	id = "mixvirus11"
 	required_reagents = list("uraniumplasmavirusfood_unstable" = 5)
-	level_min = 7
-	level_max = 7
+	level_min = 8
+	level_max = 8
 
 /datum/chemical_reaction/mix_virus/mix_virus_12
 
 	name = "Mix Virus 12"
 	id = "mixvirus12"
 	required_reagents = list("uraniumplasmavirusfood_stable" = 5)
-	level_min = 8
-	level_max = 8
+	level_min = 9
+	level_max = 9
 
 /datum/chemical_reaction/mix_virus/rem_virus
 


### PR DESCRIPTION
:cl: XDTM
add: You can now make level 7 symptoms with Conductive Mutagenic Agar, made with gold and mutagenic agar. Previous levels 7-8 are now 8-9.
add: There are now several new high-level symptoms. Don't catch em all.
/:cl:

Adds an intermediate virology level: level 7 is now made with gold and mutagenic agar, while previous levels 7 and 8 are now 8 and 9. So there is something inbetween "you have it roundstart" and "you need 15 bars of uranium".

Adds Bluespace Instability, which causes the mob to randomly teleport as if it crushed a (smaller) bluespace crystal. (Lv7)
Adds Cluster Headache, which causes the mob to feel intense headaches. (i.e. short stuns + some brain damage). (Lv5)
Adds Radioactive Metabolism, which causes the mob to rarely emit radioactive pulses. (Lv8)
Adds Mithocondrial Depolarization, which causes the mob to be extremely cold. (Lv5)
Adds Overloaded Nerves, which will shocks the mob with Teslium. (Lv7)
Adds Viral Electric Net, which will cause the mob to shoot short-ranged tesla bolts and EMP pulses. The mob is not immune to his own shocks unless it wears gloves/hardsuit. (Lv9)
Adds Hormonal Hypertrophy, which causes the mob to receive random buffs/debuffs connected to a particular emotion. (Lv8)

I'll need feedback on the balance of these symptoms, of course.
