### PR TITLE
Simple animals with force thresholds now properly handle damage_coeff

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -378,10 +378,15 @@
 		return 1
 
 /mob/living/simple_animal/proc/attack_threshold_check(damage, damagetype = BRUTE)
-	if(damage <= force_threshold || !damage_coeff[damagetype])
+	if(!damage_coeff[damagetype])
+		damage = 0
+	else
+		damage *= damage_coeff[damagetype]
+
+	if(damage >= 0 && damage <= force_threshold)
 		visible_message("<span class='warning'>[src] looks unharmed.</span>")
 	else
-		adjustBruteLoss(damage)
+		adjustHealth(damage * config.damage_multiplier)
 
 /mob/living/simple_animal/movement_delay()
 	. = ..()


### PR DESCRIPTION
Basically, damage is affected by the damage_coeff first, then checked if it's above the force threshold, THEN we take standard adjustHealth() damage if it was above the threshold.

This is different from how it currently is:
Damage is checked if it's above the force threshold, then if it was above the threshold we passed the damage through adjustBruteLoss()(regardless of what the damagetype actually was)

Or in other words if you hit a blobbernaut with a welder it takes 15 damage instead of 7.5, but if you hit it with a null rod it takes no damage(instead of 9) because it was halved and hit the force threshold.
