### PR TITLE
Surgery Stat Tracking

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -54,6 +54,7 @@
 	return new step_type
 
 /datum/surgery/proc/complete()
+	feedback_add_details("surgeries_completed", type)
 	qdel(src)
 
 


### PR DESCRIPTION
Adds tracking to surgeries completed

Potential issues: Everyone skips the cautery step, so doing finished surgeries might be inaccurate.
