### PR TITLE
Readds gender reassignment

### DIFF
--- a/code/modules/surgery/gender_reassignment.dm
+++ b/code/modules/surgery/gender_reassignment.dm
@@ -1,0 +1,34 @@
+/datum/surgery/gender_reassignment
+	name = "gender reassignment"
+	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/reshape_genitals, /datum/surgery_step/close)
+	species = list(/mob/living/carbon/human)
+	possible_locs = list("groin")
+
+
+//reshape_genitals
+/datum/surgery_step/reshape_genitals
+	name = "reshape genitals"
+	implements = list(/obj/item/weapon/scalpel = 100, /obj/item/weapon/hatchet = 50, /obj/item/weapon/wirecutters = 35)
+	time = 64
+
+/datum/surgery_step/reshape_genitals/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(target.gender == FEMALE)
+		user.visible_message("[user] begins to reshape [target]'s genitals to look more masculine.", "<span class='notice'>You begin to reshape [target]'s genitals to look more masculine...</span>")
+	else
+		user.visible_message("[user] begins to reshape [target]'s genitals to look more feminine.", "<span class='notice'>You begin to reshape [target]'s genitals to look more feminine...</span>")
+
+/datum/surgery_step/reshape_genitals/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(target.gender == FEMALE)
+		user.visible_message("[user] has made a man of [target]!", "<span class='notice'>You made [target] a man.</span>")
+		target.gender = MALE
+	else
+		user.visible_message("[user] has made a woman of [target]!", "<span class='notice'>You made [target] a woman.</span>")
+		target.gender = FEMALE
+	target.regenerate_icons()
+	return 1
+
+/datum/surgery_step/reshape_genitals/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	user.visible_message("<span class='warning'>[user] accidentally mutilates [target]'s genitals beyond the point of recognition!</span>", "<span class='warning'>You accidentally mutilate [target]'s genitals beyond the point of recognition!</span>")
+	target.gender = pick(MALE, FEMALE)
+	target.regenerate_icons()
+	return 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1822,6 +1822,7 @@
 #include "code\modules\surgery\core_removal.dm"
 #include "code\modules\surgery\dental_implant.dm"
 #include "code\modules\surgery\eye_surgery.dm"
+#include "code\modules\surgery\gender_reassignment.dm"
 #include "code\modules\surgery\generic_steps.dm"
 #include "code\modules\surgery\helpers.dm"
 #include "code\modules\surgery\implant_removal.dm"


### PR DESCRIPTION
I'm making another revert of PR that was hated by everyone and merged by a single maintainer. Because if I wouldn't do this, who will?

:cl: CoreOverload
fix: Gender Reassignment surgery is back.
/:cl:

The removal PR, #20148, was:
- A 100% meme PR by Goofball that somehow got merged for real.
- Marked as **[s]** without containing anything **secret** or **server security**.
- Quickmerged under 24h mark, **under 1h mark**, at night, without being a quickfix for a game-breaking issue.

This is an obvious maintainer abuse, and any two of the above are enough of a reason for instant revert.
