### PR TITLE
Makes lavaland more atmospheric

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -304,16 +304,13 @@
 /turf/open/floor/plating/lava/burn_tile()
 	return
 
-/turf/open/floor/plating/lava/attackby(obj/item/C, mob/user, params) //Lava isn't a good foundation to build on
-	return
-
 /turf/open/floor/plating/lava/smooth
 	name = "lava"
 	baseturf = /turf/open/floor/plating/lava/smooth
 	icon = 'icons/turf/floors/lava.dmi'
 	icon_state = "unsmooth"
 	smooth = SMOOTH_MORE | SMOOTH_BORDER
-	canSmoothWith = list(/turf/closed/mineral, /turf/open/floor/plating/lava/smooth)
+	canSmoothWith = list(/turf/open/floor/plating/lava/smooth)
 
 /turf/open/floor/plating/lava/smooth/airless
 	initial_gas_mix = "TEMP=2.7"

--- a/code/game/turfs/simulated/river.dm
+++ b/code/game/turfs/simulated/river.dm
@@ -50,7 +50,7 @@
 				continue
 			else
 				var/turf/river_turf = cur_turf.ChangeTurf(turf_type)
-				river_turf.Spread(25, 10, whitelist_area)
+				river_turf.Spread(20, 9, whitelist_area)
 
 	for(var/WP in river_nodes)
 		qdel(WP)
@@ -87,6 +87,9 @@
 		var/turf/T = F
 		if(prob(probability) && T.ChangeTurf(type))
 			T.Spread(probability - prob_loss, prob_loss, whitelisted_area)
+		else if(istype(T, /turf/closed/mineral))
+			var/turf/closed/mineral/M = T
+			M.ChangeTurf(M.turf_type)
 
 
 #undef RANDOM_UPPER_X

--- a/code/game/turfs/simulated/river.dm
+++ b/code/game/turfs/simulated/river.dm
@@ -19,8 +19,8 @@
 		if (W.z != target_z || W.connected)
 			continue
 		W.connected = 1
-		var/turf/cur_turf = new turf_type(get_turf(W))
-		//cur_turf.ChangeTurf(turf_type)
+		var/turf/cur_turf = get_turf(W)
+		cur_turf.ChangeTurf(turf_type)
 		var/turf/target_turf = get_turf(pick(river_nodes - W))
 		if(!target_turf)
 			break
@@ -49,8 +49,8 @@
 				cur_turf = get_step(cur_turf, cur_dir)
 				continue
 			else
-				var/turf/open/river_turf = new turf_type(cur_turf)
-				river_turf.Spread(30, 25)
+				var/turf/river_turf = cur_turf.ChangeTurf(turf_type)
+				river_turf.Spread(25, 10, whitelist_area)
 
 	for(var/WP in river_nodes)
 		qdel(WP)
@@ -62,16 +62,31 @@
 	invisibility = INVISIBILITY_ABSTRACT
 
 
-/turf/proc/Spread(probability = 30, prob_loss = 25)
+/turf/proc/Spread(probability = 30, prob_loss = 25, whitelisted_area)
 	if(probability <= 0)
 		return
+	var/list/cardinal_turfs = list()
+	var/list/diagonal_turfs = list()
+	for(var/F in RANGE_TURFS(1, src) - src)
+		var/turf/T = F
+		var/area/new_area = get_area(T)
+		if(!T || (T.density && !istype(T, /turf/closed/mineral)) || istype(T, /turf/open/indestructible) || (whitelisted_area && !istype(new_area, whitelisted_area)))
+			continue
 
-	for(var/turf/F in orange(1, src))
-		if(!F.density || istype(F, /turf/closed/mineral))
-			var/turf/L = new src.type(F)
+		if(get_dir(src, F) in cardinal)
+			cardinal_turfs += F
+		else
+			diagonal_turfs += F
 
-			if(L && prob(probability))
-				L.Spread(probability - prob_loss)
+	for(var/F in cardinal_turfs) //cardinal turfs are always changed but don't always spread
+		var/turf/T = F
+		if(T.ChangeTurf(type) && prob(probability))
+			T.Spread(probability - prob_loss, prob_loss, whitelisted_area)
+
+	for(var/F in diagonal_turfs) //diagonal turfs only sometimes change, but will always spread if changed
+		var/turf/T = F
+		if(prob(probability) && T.ChangeTurf(type))
+			T.Spread(probability - prob_loss, prob_loss, whitelisted_area)
 
 
 #undef RANDOM_UPPER_X

--- a/code/game/turfs/simulated/river.dm
+++ b/code/game/turfs/simulated/river.dm
@@ -50,7 +50,7 @@
 				continue
 			else
 				var/turf/river_turf = cur_turf.ChangeTurf(turf_type)
-				river_turf.Spread(20, 9, whitelist_area)
+				river_turf.Spread(25, 11, whitelist_area)
 
 	for(var/WP in river_nodes)
 		qdel(WP)
@@ -67,11 +67,16 @@
 		return
 	var/list/cardinal_turfs = list()
 	var/list/diagonal_turfs = list()
+	var/logged_turf_type
 	for(var/F in RANGE_TURFS(1, src) - src)
 		var/turf/T = F
 		var/area/new_area = get_area(T)
 		if(!T || (T.density && !istype(T, /turf/closed/mineral)) || istype(T, /turf/open/indestructible) || (whitelisted_area && !istype(new_area, whitelisted_area)))
 			continue
+
+		if(!logged_turf_type && istype(T, /turf/closed/mineral))
+			var/turf/closed/mineral/M = T
+			logged_turf_type = M.turf_type
 
 		if(get_dir(src, F) in cardinal)
 			cardinal_turfs += F
@@ -80,12 +85,12 @@
 
 	for(var/F in cardinal_turfs) //cardinal turfs are always changed but don't always spread
 		var/turf/T = F
-		if(T.ChangeTurf(type) && prob(probability))
+		if(!istype(T, logged_turf_type) && T.ChangeTurf(type) && prob(probability))
 			T.Spread(probability - prob_loss, prob_loss, whitelisted_area)
 
 	for(var/F in diagonal_turfs) //diagonal turfs only sometimes change, but will always spread if changed
 		var/turf/T = F
-		if(prob(probability) && T.ChangeTurf(type))
+		if(!istype(T, logged_turf_type) && prob(probability) && T.ChangeTurf(type))
 			T.Spread(probability - prob_loss, prob_loss, whitelisted_area)
 		else if(istype(T, /turf/closed/mineral))
 			var/turf/closed/mineral/M = T

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -372,7 +372,7 @@
 		if(istype(loc, /area/mine/explored) || istype(loc, /area/lavaland/surface/outdoors/explored))
 			return
 		for(var/mob/living/simple_animal/hostile/H in urange(12,T)) //prevents mob clumps
-			if(istype(H, /mob/living/simple_animal/hostile/asteroid)
+			if(istype(H, /mob/living/simple_animal/hostile/asteroid))
 				return
 			if(ismegafauna(H) && get_dist(src, H) <= 7)
 				return

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -628,7 +628,7 @@
 	for(var/thing in contents)
 		if(droppable(thing))
 			. = 1
-			drop(thing)
+			addtimer(src, "drop", 0, FALSE, thing)
 
 /turf/open/chasm/proc/droppable(atom/movable/AM)
 	if(!isliving(AM) && !isobj(AM))

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -371,12 +371,13 @@
 	if(prob(30))
 		if(istype(loc, /area/mine/explored) || istype(loc, /area/lavaland/surface/outdoors/explored))
 			return
-		for(var/mob/living/simple_animal/hostile/asteroid/A in urange(12,T)) //prevents mob clumps
-			return
-		for(var/mob/living/simple_animal/hostile/megafauna/A in range(7,T))
-			return
-		for(var/mob/living/simple_animal/hostile/spawner/lavaland in range(3,T)) //prevents tendrils spawning in collapse range
-			return
+		for(var/mob/living/simple_animal/hostile/H in urange(12,T)) //prevents mob clumps
+			if(istype(H, /mob/living/simple_animal/hostile/asteroid)
+				return
+			if(ismegafauna(H) && get_dist(src, H) <= 7)
+				return
+			if(istype(H, /mob/living/simple_animal/hostile/spawner/lavaland) && get_dist(src, H) <= 3) //prevents tendrils spawning in collapse range
+				return
 		var/randumb = pickweight(mob_spawn_list)
 		new randumb(T)
 	return

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -371,9 +371,12 @@
 	if(prob(30))
 		if(istype(loc, /area/mine/explored) || istype(loc, /area/lavaland/surface/outdoors/explored))
 			return
-		for(var/atom/A in urange(12,T))//Lowers chance of mob clumps
-			if(istype(A, /mob/living/simple_animal/hostile/asteroid))
-				return
+		for(var/mob/living/simple_animal/hostile/asteroid/A in urange(12,T)) //prevents mob clumps
+			return
+		for(var/mob/living/simple_animal/hostile/megafauna/A in range(7,T))
+			return
+		for(var/mob/living/simple_animal/hostile/spawner/lavaland in range(3,T)) //prevents tendrils spawning in collapse range
+			return
 		var/randumb = pickweight(mob_spawn_list)
 		new randumb(T)
 	return

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -56,7 +56,7 @@
 	return
 
 /turf/closed/mineral/Spread(turf/T)
-	new src.type(T)
+	T.ChangeTurf(type)
 
 /turf/closed/mineral/random
 	var/mineralSpawnChanceList = list(
@@ -71,7 +71,7 @@
 
 	if (prob(mineralChance))
 		var/path = pickweight(mineralSpawnChanceList)
-		var/turf/T = new path(src)
+		var/turf/T = ChangeTurf(path)
 
 		if(T && istype(T, /turf/closed/mineral))
 			var/turf/closed/mineral/M = T
@@ -265,38 +265,55 @@
 	var/length = 100
 	var/mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 1, /mob/living/simple_animal/hostile/asteroid/goliath = 5, /mob/living/simple_animal/hostile/asteroid/basilisk = 4, /mob/living/simple_animal/hostile/asteroid/hivelord = 3)
 	var/sanity = 1
+	var/forward_cave_dir = 1
+	var/backward_cave_dir = 2
+	var/going_backwards = TRUE
+	var/has_data = FALSE
+	var/data_having_type = /turf/open/floor/plating/asteroid/airless/cave/has_data
 	turf_type = /turf/open/floor/plating/asteroid/airless
+
+/turf/open/floor/plating/asteroid/airless/cave/has_data //subtype for producing a tunnel with given data
+	has_data = TRUE
 
 /turf/open/floor/plating/asteroid/airless/cave/volcanic
 	mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 10, /mob/living/simple_animal/hostile/asteroid/goliath/beast = 50, /mob/living/simple_animal/hostile/asteroid/basilisk/watcher = 40, /mob/living/simple_animal/hostile/asteroid/hivelord/legion = 30,
 		/mob/living/simple_animal/hostile/spawner/lavaland = 2, /mob/living/simple_animal/hostile/spawner/lavaland/goliath = 3, /mob/living/simple_animal/hostile/spawner/lavaland/legion = 3, \
 		/mob/living/simple_animal/hostile/megafauna/dragon = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = 2)
 
+	data_having_type = /turf/open/floor/plating/asteroid/airless/cave/volcanic/has_data
 	turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 
-/turf/open/floor/plating/asteroid/airless/cave/New(loc, length, go_backwards = 1, exclude_dir = -1)
-	// If length (arg2) isn't defined, get a random length; otherwise assign our length to the length arg.
-	if(!length)
-		src.length = rand(25, 50)
+/turf/open/floor/plating/asteroid/airless/cave/volcanic/has_data //subtype for producing a tunnel with given data
+	has_data = TRUE
+
+/turf/open/floor/plating/asteroid/airless/cave/New(loc)
+	if(!has_data)
+		produce_tunnel_from_data()
+	..()
+
+/turf/open/floor/plating/asteroid/airless/cave/proc/get_cave_data(set_length, exclude_dir = -1)
+	// If set_length (arg1) isn't defined, get a random length; otherwise assign our length to the length arg.
+	if(!set_length)
+		length = rand(25, 50)
 	else
-		src.length = length
+		length = set_length
 
 	// Get our directiosn
-	var/forward_cave_dir = pick(alldirs - exclude_dir)
+	forward_cave_dir = pick(alldirs - exclude_dir)
 	// Get the opposite direction of our facing direction
-	var/backward_cave_dir = angle2dir(dir2angle(forward_cave_dir) + 180)
+	backward_cave_dir = angle2dir(dir2angle(forward_cave_dir) + 180)
 
+/turf/open/floor/plating/asteroid/airless/cave/proc/produce_tunnel_from_data(tunnel_length, excluded_dir = -1)
+	get_cave_data(tunnel_length, excluded_dir)
 	// Make our tunnels
 	make_tunnel(forward_cave_dir)
-	if(go_backwards)
+	if(going_backwards)
 		make_tunnel(backward_cave_dir)
 	// Kill ourselves by replacing ourselves with a normal floor.
 	SpawnFloor(src)
-	..()
 
 /turf/open/floor/plating/asteroid/airless/cave/proc/make_tunnel(dir)
-
 	var/turf/closed/mineral/tunnel = src
 	var/next_angle = pick(45, -45)
 
@@ -314,13 +331,18 @@
 			if(istype(edge))
 				SpawnFloor(edge)
 
+		if(!sanity)
+			break
+
 		// Move our tunnel forward
 		tunnel = get_step(tunnel, dir)
 
 		if(istype(tunnel))
 			// Small chance to have forks in our tunnel; otherwise dig our tunnel.
 			if(i > 3 && prob(20))
-				new src.type(tunnel, rand(10, 15), 0, dir)
+				var/turf/open/floor/plating/asteroid/airless/cave/C = tunnel.ChangeTurf(data_having_type)
+				C.going_backwards = FALSE
+				C.produce_tunnel_from_data(rand(10, 15), dir)
 			else
 				SpawnFloor(tunnel)
 		else //if(!istype(tunnel, src.parent)) // We hit space/normal/wall, stop our tunnel.
@@ -334,15 +356,17 @@
 
 
 /turf/open/floor/plating/asteroid/airless/cave/proc/SpawnFloor(turf/T)
-	for(var/turf/S in range(2,T))
-		if(istype(S, /turf/open/space) || istype(S.loc, /area/mine/explored))
+	for(var/S in RANGE_TURFS(1, src))
+		var/turf/NT = S
+		if(!NT || istype(NT, /turf/open/space) || istype(NT.loc, /area/mine/explored) || istype(NT.loc, /area/lavaland/surface/outdoors/explored))
 			sanity = 0
 			break
 	if(!sanity)
 		return
 
 	SpawnMonster(T)
-	new turf_type(T)
+	T.ChangeTurf(turf_type)
+
 /turf/open/floor/plating/asteroid/airless/cave/proc/SpawnMonster(turf/T)
 	if(prob(30))
 		if(istype(loc, /area/mine/explored) || istype(loc, /area/lavaland/surface/outdoors/explored))
@@ -439,6 +463,7 @@
 	var/turf_type = /turf/open/floor/plating/asteroid //Because caves do whacky shit to revert to normal
 	var/dug = 0       //0 = has not yet been dug, 1 = has already been dug
 	var/sand_type = /obj/item/weapon/ore/glass
+	var/floor_variance = 20 //probability floor has a different icon state
 
 /turf/open/floor/plating/asteroid/airless
 	initial_gas_mix = "TEMP=2.7"
@@ -452,6 +477,7 @@
 	icon_plating = "basalt"
 	environment_type = "basalt"
 	sand_type = /obj/item/weapon/ore/glass/basalt
+	floor_variance = 15
 
 /turf/open/floor/plating/asteroid/basalt/lava //lava underneath
 	baseturf = /turf/open/floor/plating/lava/smooth
@@ -481,8 +507,14 @@
 	var/proper_name = name
 	..()
 	name = proper_name
-	if(prob(20))
+	if(prob(floor_variance))
 		icon_state = "[environment_type][rand(0,12)]"
+
+/turf/open/floor/plating/asteroid/basalt/New()
+	..()
+	switch(icon_state)
+		if("basalt1", "basalt2", "basalt3") //5 and 9 are too dark to glow and make the amount of glows in tunnels too high
+			SetLuminosity(1, 1) //this is basically a 3.75% chance that a basalt floor glows
 
 /turf/open/floor/plating/asteroid/burn_tile()
 	return
@@ -555,6 +587,11 @@
 	icon_state = "[environment_type]_dug"
 	slowdown = 0
 	return
+
+/turf/open/floor/plating/asteroid/basalt/gets_dug()
+	if(!dug)
+		SetLuminosity(0)
+	..()
 
 /turf/open/floor/plating/asteroid/singularity_act()
 	return

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -994,6 +994,7 @@
 	icon_dead = "tendril"
 	faction = list("mining")
 	weather_immunities = list("lava","ash")
+	luminosity = 2
 	health = 250
 	maxHealth = 250
 	max_mobs = 3
@@ -1009,6 +1010,10 @@
 
 /mob/living/simple_animal/hostile/spawner/lavaland/New()
 	..()
+	var/turf/T = get_step(src, NORTH)
+	if(istype(T, /turf/closed/mineral))
+		var/turf/closed/mineral/M = T
+		M.gets_drilled()
 	gps = new /obj/item/device/gps/internal(src)
 
 /mob/living/simple_animal/hostile/spawner/lavaland/Destroy()
@@ -1039,6 +1044,7 @@
 /obj/effect/collapse
 	name = "collapsing necropolis tendril"
 	desc = "Get clear!"
+	luminosity = 2
 	layer = ABOVE_OPEN_TURF_LAYER
 	icon = 'icons/mob/nest.dmi'
 	icon_state = "tendril"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -994,7 +994,7 @@
 	icon_dead = "tendril"
 	faction = list("mining")
 	weather_immunities = list("lava","ash")
-	luminosity = 2
+	luminosity = 1
 	health = 250
 	maxHealth = 250
 	max_mobs = 3
@@ -1010,10 +1010,10 @@
 
 /mob/living/simple_animal/hostile/spawner/lavaland/New()
 	..()
-	var/turf/T = get_step(src, NORTH)
-	if(istype(T, /turf/closed/mineral))
-		var/turf/closed/mineral/M = T
-		M.gets_drilled()
+	for(var/F in RANGE_TURFS(1, src))
+		if(istype(F, /turf/closed/mineral))
+			var/turf/closed/mineral/M = F
+			M.ChangeTurf(M.turf_type)
 	gps = new /obj/item/device/gps/internal(src)
 
 /mob/living/simple_animal/hostile/spawner/lavaland/Destroy()
@@ -1044,7 +1044,7 @@
 /obj/effect/collapse
 	name = "collapsing necropolis tendril"
 	desc = "Get clear!"
-	luminosity = 2
+	luminosity = 1
 	layer = ABOVE_OPEN_TURF_LAYER
 	icon = 'icons/mob/nest.dmi'
 	icon_state = "tendril"


### PR DESCRIPTION
CRIPES.

:cl: Joan
rscadd: Lava bubbling up from basalt turfs now glows if in sufficient concentration.
rscadd: Necropolis tendrils now glow.
rscadd: Lava rivers now have riverbanks, and should overall look much nicer.
/:cl:
1. Fixes a bunch of issues caused by newing turfs(use ChangeTurf no exceptions)
2. Lava rivers are slightly less bland, no longer fuck up rock edging(see 1.)
3. Lighting won't fuck up on lava rivers or ruins placed over lava rivers(see 1.)
4. Lava rivers will no longer spread into ruins.

Fixes #20198
Fixes #19500

![space station 13 2016-08-28 090951](https://cloud.githubusercontent.com/assets/3886584/18033987/33130ccc-6cff-11e6-9845-5eb8e0b79f7b.png)
![space station 13 2016-08-28 113604](https://cloud.githubusercontent.com/assets/3886584/18034765/b0899e50-6d13-11e6-945b-e7c9e8ea235c.png)
