### PR TITLE
Fixed candle box icon bug and more

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -42,9 +42,23 @@
 		else
 			user << "There are [contents.len <= 0 ? "no" : "[src.contents.len]"] [src.icon_type]s left."
 
-/obj/item/weapon/storage/fancy/CtrlClick(mob/user)
+/obj/item/weapon/storage/fancy/attack_self(mob/user)
 	fancy_open = !fancy_open
 	update_icon()
+
+/obj/item/weapon/storage/fancy/content_can_dump(atom/dest_object, mob/user)
+	. = ..()
+	if(.)
+		fancy_open = TRUE
+		update_icon()
+
+/obj/item/weapon/storage/fancy/handle_item_insertion(obj/item/W, prevent_warning = 0, mob/user)
+	fancy_open = TRUE
+	return ..()
+
+/obj/item/weapon/storage/fancy/remove_from_storage(obj/item/W, atom/new_location, burn = 0)
+	fancy_open = TRUE
+	return ..()
 
 /*
  * Donut Box
@@ -88,6 +102,10 @@
 	throwforce = 2
 	slot_flags = SLOT_BELT
 	spawn_type = /obj/item/candle
+	fancy_open = TRUE
+
+/obj/item/weapon/storage/fancy/candle_box/attack_self(mob_user)
+	return
 
 ////////////
 //CIG PACK//

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -81,7 +81,7 @@
 			if(I.on_found(user))
 				return
 		if(can_be_inserted(I,0,user))
-			src_object.remove_from_storage(I, src)
+			handle_item_insertion(I, TRUE, user)
 	orient2hud(user)
 	src_object.orient2hud(user)
 	if(user.s_active) //refresh the HUD to show the transfered contents


### PR DESCRIPTION
 - Fixed candle boxes disappearing when trying to open them
 - Changed ``storage_contents_dump_act()`` to use ``handle_item_insertion()`` instead of ``remove_from_storage()``
 - When dumping from one storage to another or out on the floor, fancy storages will now update icon properly

:cl:
tweak: Opening and closing of donut boxes, etc. is now done with clicking the object with itself.
/:cl: