### PR TITLE
Fixes issues with packagewrap, trashbag, handlabeler, 

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -93,6 +93,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	// Needs to be in /obj/item because corgis can wear a lot of
 	// non-clothing items
 	var/datum/dog_fashion/dog_fashion = null
+	var/no_direct_insertion = 0 //items that require MouseDrop() to be inserted in a storage item. e.g. packageWrap
 
 
 /obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
@@ -295,37 +296,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 // Due to storage type consolidation this should get used more now.
 // I have cleaned it up a little, but it could probably use more.  -Sayu
 /obj/item/attackby(obj/item/weapon/W, mob/user, params)
-	if(istype(W,/obj/item/weapon/storage))
-		var/obj/item/weapon/storage/S = W
-		if(S.use_to_pickup)
-			if(S.collection_mode) //Mode is set to collect multiple items on a tile and we clicked on a valid one.
-				if(isturf(src.loc))
-					var/list/rejections = list()
-					var/success = 0
-					var/failure = 0
-
-					for(var/obj/item/I in src.loc)
-						if(S.collection_mode == 2 && !istype(I,src.type)) // We're only picking up items of the target type
-							failure = 1
-							continue
-						if(I.type in rejections) // To limit bag spamming: any given type only complains once
-							continue
-						if(!S.can_be_inserted(I))	// Note can_be_inserted still makes noise when the answer is no
-							rejections += I.type	// therefore full bags are still a little spammy
-							failure = 1
-							continue
-
-						success = 1
-						S.handle_item_insertion(I, 1)	//The 1 stops the "You put the [src] into [S]" insertion message from being displayed.
-					if(success && !failure)
-						user << "<span class='notice'>You put everything [S.preposition] [S].</span>"
-					else if(success)
-						user << "<span class='notice'>You put some things [S.preposition] [S].</span>"
-					else
-						user << "<span class='warning'>You fail to pick anything up with [S]!</span>"
-
-			else if(S.can_be_inserted(src))
-				S.handle_item_insertion(src)
+	return 0 //always call afterattack
 
 
 // afterattack() and attack() prototypes moved to _onclick/item_attack.dm for consistency

--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -33,18 +33,7 @@
 	amount = 25
 	max_amount = 25
 	burn_state = FLAMMABLE
-
-/obj/item/proc/can_be_package_wrapped() //can the item be wrapped with package wrapper into a delivery package
-	return 1
-
-/obj/item/weapon/storage/can_be_package_wrapped()
-	return 0
-
-/obj/item/weapon/storage/box/can_be_package_wrapped()
-	return 1
-
-/obj/item/smallDelivery/can_be_package_wrapped()
-	return 0
+	no_direct_insertion = 1
 
 /obj/item/stack/packageWrap/afterattack(obj/target, mob/user, proximity)
 	if(!proximity)
@@ -56,7 +45,7 @@
 
 	if(istype(target, /obj/item))
 		var/obj/item/I = target
-		if(!I.can_be_package_wrapped())
+		if(istype(I, /obj/item/smallDelivery))
 			return
 		if(user.r_hand == I || user.l_hand == I)
 			if(!user.unEquip(I))

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -23,8 +23,9 @@
 	burntime = 20
 
 /obj/item/weapon/storage/backpack/attackby(obj/item/weapon/W, mob/user, params)
-	playsound(src.loc, "rustle", 50, 1, -5)
-	return ..()
+	. = ..()
+	if(.)
+		playsound(src.loc, "rustle", 50, 1, -5)
 
 /*
  * Backpack Types

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -39,6 +39,7 @@
 	storage_slots = 30
 	can_hold = list() // any
 	cant_hold = list(/obj/item/weapon/disk/nuclear)
+	no_direct_insertion = 1
 
 /obj/item/weapon/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] puts the [src.name] over their head and starts chomping at the insides! Disgusting!</span>")

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -28,18 +28,15 @@
 				icon_state = icon_locked
 				user << "<span class='danger'>You lock the [src.name]!</span>"
 				close_all()
-				return
 			else
 				icon_state = icon_closed
 				user << "<span class='danger'>You unlock the [src.name]!</span>"
-				return
 		else
 			user << "<span class='danger'>Access Denied.</span>"
-			return
-	if(!locked)
-		return ..()
-	else
+	else if(locked && !W.no_direct_insertion)
 		user << "<span class='danger'>It's locked!</span>"
+	else
+		return ..()
 
 /obj/item/weapon/storage/lockbox/MouseDrop(over_object, src_location, over_location)
 	if (locked)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -36,31 +36,30 @@
 		if (istype(W, /obj/item/weapon/screwdriver))
 			if (do_after(user, 20/W.toolspeed, target = src))
 				src.open =! src.open
-				user.show_message("<span class='notice'>You [open ? "open" : "close"] the service panel.</span>", 1)
+				user << "<span class='notice'>You [open ? "open" : "close"] the service panel.</span>"
 			return
-		if ((istype(W, /obj/item/device/multitool)) && (src.open == 1)&& (!src.l_hacking))
-			user.show_message("<span class='danger'>Now attempting to reset internal memory, please hold.</span>", 1)
-			src.l_hacking = 1
+		else if ((istype(W, /obj/item/device/multitool)) && open && (!l_hacking))
+			user << "<span class='danger'>Now attempting to reset internal memory, please hold.</span>"
+			l_hacking = 1
 			if (do_after(usr, 100/W.toolspeed, target = src))
 				if (prob(40))
 					src.l_setshort = 1
 					src.l_set = 0
 					user.show_message("<span class='danger'>Internal memory reset.  Please give it a few seconds to reinitialize.</span>", 1)
 					sleep(80)
-					src.l_setshort = 0
-					src.l_hacking = 0
+					l_setshort = 0
+					l_hacking = 0
 				else
-					user.show_message("<span class='danger'>Unable to reset internal memory.</span>", 1)
-					src.l_hacking = 0
+					user << "<span class='danger'>Unable to reset internal memory.</span>"
+					l_hacking = 0
 			else
-				src.l_hacking = 0
-			return
-		//At this point you have exhausted all the special things to do when locked
-		// ... but it's still locked.
-		return
+				l_hacking = 0
+		else if(!W.no_direct_insertion)
+			user << "<span class='danger'>It's locked!</span>"
 
-	// -> storage/attackby() what with handle insertion, etc
-	return ..()
+	else
+		// -> storage/attackby() what with handle insertion, etc
+		return ..()
 
 /obj/item/weapon/storage/secure/emag_act(mob/user)
 	if(locked)
@@ -98,7 +97,7 @@
 
 /obj/item/weapon/storage/secure/Topic(href, href_list)
 	..()
-	if ((usr.stat || usr.restrained()) || (get_dist(src, usr) > 1))
+	if (usr.incapacitated() || get_dist(src, usr) > 1)
 		return
 	if (href_list["type"])
 		if (href_list["type"] == "E")

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -76,7 +76,7 @@
 		if(iscarbon(user) || isdrone(user))
 			var/mob/living/L = user
 			if(!L.incapacitated() && I == L.get_active_hand())
-				if(can_be_inserted(I, 0 , L))
+				if(can_be_inserted(I, 0))
 					handle_item_insertion(I, 0 , L)
 
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -37,16 +37,19 @@
 			return
 
 		// this must come before the screen objects only block, dunno why it wasn't before
-		if(over_object == M && (src.ClickAccessible(M, depth=STORAGE_VIEW_DEPTH) || Adjacent(M)))
+		if(over_object == M && (ClickAccessible(M, depth=STORAGE_VIEW_DEPTH) || Adjacent(M)))
 			orient2hud(M)
 			if(M.s_active)
 				M.s_active.close(M)
 			show_to(M)
 			return
 
-		if(!M.restrained() && !M.stat)
+		if(!M.incapacitated())
 			if(!istype(over_object, /obj/screen))
-				return content_can_dump(over_object, M)
+				if(no_direct_insertion && istype(over_object, /obj/item/weapon/storage))
+					return ..()
+				else
+					return content_can_dump(over_object, M)
 
 			if(loc != usr || (loc && loc.loc == usr))
 				return
@@ -65,6 +68,17 @@
 						M.put_in_l_hand(src)
 
 			add_fingerprint(usr)
+
+
+/obj/item/weapon/storage/MouseDrop_T(atom/movable/O, mob/user)
+	if(istype(O, /obj/item))
+		var/obj/item/I = O
+		if(iscarbon(user) || isdrone(user))
+			var/mob/living/L = user
+			if(!L.incapacitated() && I == L.get_active_hand())
+				if(can_be_inserted(I, 0 , L))
+					handle_item_insertion(I, 0 , L)
+
 
 //Check if this storage can dump the items
 /obj/item/weapon/storage/proc/content_can_dump(atom/dest_object, mob/user)
@@ -372,20 +386,47 @@
 		remove_from_storage(Item, src.loc, burn)
 
 //This proc is called when you want to place an item into the storage item.
-/obj/item/weapon/storage/attackby(obj/item/W, mob/user, params)
-	..()
-	if(istype(W, /obj/item/weapon/hand_labeler))
-		var/obj/item/weapon/hand_labeler/labeler = W
-		if(labeler.mode)
-			return 0
-	. = 1 //no afterattack
-	if(isrobot(user))
-		return	//Robots can't interact with storage items.
+/obj/item/weapon/storage/attackby(obj/item/I, mob/user, params)
+	if(I.no_direct_insertion)
+		return 0
+	if(can_be_inserted(I, 0))
+		handle_item_insertion(I, 0, user)
+		return 1 //no afterattack
 
-	if(!can_be_inserted(W, 0 , user))
+
+/obj/item/weapon/storage/afterattack(atom/A, mob/user, proximity, params)
+	if(!proximity || !istype(A, /obj/item))
 		return
+	var/obj/item/W = A
+	if(use_to_pickup)
+		if(collection_mode) //Mode is set to collect multiple items on a tile and we clicked on a valid one.
+			if(isturf(W.loc))
+				var/list/rejections = list()
+				var/success = 0
+				var/failure = 0
 
-	handle_item_insertion(W, 0 , user)
+				for(var/obj/item/I in W.loc)
+					if(collection_mode == 2 && !istype(I, W.type)) // We're only picking up items of the target type
+						failure = 1
+						continue
+					if(I.type in rejections) // To limit bag spamming: any given type only complains once
+						continue
+					if(!can_be_inserted(I, 0))
+						rejections += I.type	// therefore full bags are still a little spammy
+						failure = 1
+						continue
+
+					success = 1
+					handle_item_insertion(I, 1)	//The 1 stops the "You put the [src] into [S]" insertion message from being displayed.
+				if(success && !failure)
+					user << "<span class='notice'>You put everything [preposition] [src].</span>"
+				else if(success)
+					user << "<span class='notice'>You put some things [preposition] [src].</span>"
+				else
+					user << "<span class='warning'>You fail to pick anything up with [src]!</span>"
+
+		else if(can_be_inserted(W, 0))
+			handle_item_insertion(W)
 
 
 /obj/item/weapon/storage/attack_hand(mob/user)
@@ -426,7 +467,7 @@
 	set name = "Switch Gathering Method"
 	set category = "Object"
 
-	if(usr.stat || !usr.canmove || usr.restrained())
+	if(usr.incapacitated())
 		return
 
 	collection_mode = (collection_mode+1)%3
@@ -443,7 +484,7 @@
 	set name = "Empty Contents"
 	set category = "Object"
 
-	if((!ishuman(usr) && (loc != usr)) || usr.stat || usr.restrained() ||!usr.canmove)
+	if((!ishuman(usr) && (loc != usr)) || usr.incapacitated())
 		return
 
 	do_quick_empty()

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -142,7 +142,7 @@
 				R.user_unbuckle_mob(R.buckled_mobs[1],user)
 
 		loaded = target
-		target.loc = src
+		target.forceMove(src)
 		user.visible_message("[user] collects [loaded].", "<span class='notice'>You collect [loaded].</span>")
 	..()
 

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -14,6 +14,8 @@
 	evidencebagEquip(I, user)
 
 /obj/item/weapon/evidencebag/attackby(obj/item/I, mob/user, params)
+	if(I.no_direct_insertion)
+		return ..()
 	if(evidencebagEquip(I, user))
 		return 1
 
@@ -60,7 +62,7 @@
 	add_overlay("evidence")	//should look nicer for transparent stuff. not really that important, but hey.
 
 	desc = "An evidence bag containing [I]. [I.desc]"
-	I.loc = src
+	I.forceMove(src)
 	w_class = I.w_class
 	return 1
 

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -4,6 +4,8 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler0"
 	item_state = "flight"
+	no_direct_insertion = 0
+	flags = NOBLUDGEON
 	var/label = null
 	var/labels_left = 30
 	var/mode = 0
@@ -68,6 +70,7 @@
 		user << "<span class='warning'>You don't have the dexterity to use [src]!</span>"
 		return
 	mode = !mode
+	no_direct_insertion = !no_direct_insertion
 	icon_state = "labeler[mode]"
 	if(mode)
 		user << "<span class='notice'>You turn on [src].</span>"


### PR DESCRIPTION
and other potential items that must have an effect when clicking a storage item. Clicking a storage item with those items does not try to insert them in the container but instead calls their afterattack effect directly. The var used for those items is var/no_direct_insertion. To try to insert those items in a storage item you must use click&drag.

Fixes trashbag not being able to pick up pillbottles, evidence bags.
Fixes packagewrap not being able to wrap backpacks, pillbottles, all sorts of bags.
Fixes packagewrapping a locked lockbox showing "it's locked!"
The hand labeler no longer does an attack when labeling certain things.
Backpack only make rustling noise if insertion is successful.

:cl: phil235
tweak: Putting packagewrap or hand labeler in a backpack is now done by clicking and dragging.
fix: You can now wrap backpacks and other storage items with packagewrap.
/:cl:
