### PR TITLE
[mapmerger] load python version test before everything else

### DIFF
--- a/tools/mapmerge/map_helpers.py
+++ b/tools/mapmerge/map_helpers.py
@@ -1,4 +1,3 @@
-import collections
 import sys
 
 try:
@@ -9,6 +8,8 @@ try:
 except:
     print("ERROR: Something went wrong, you might be running an incompatible version of Python. The current minimum version required is [3.5].\nYour version: {}".format(sys.version))
     sys.exit()
+
+import collections
 
 error = {0:"OK", 1:"WARNING: Key lengths are different, all the lines change."}
 

--- a/tools/mapmerge/mapmerger.py
+++ b/tools/mapmerge/mapmerger.py
@@ -1,7 +1,7 @@
+import map_helpers
 import sys
 import os
 import pathlib
-import map_helpers
 import shutil
 
 #main("../../_maps/")


### PR DESCRIPTION
Python version error message does not appear if you don't have pathlib, which you might not have if you're using 2.7.

Changed it to load map_helpers.py first so this works as intended.