### PR TITLE
Removes roundstart medipen

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -62,7 +62,6 @@
 	..()
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen(src)
-	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 
 /obj/item/weapon/storage/box/survival/radio/New()
 	..()
@@ -73,7 +72,6 @@
 	new /obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen/engi(src)
 	new /obj/item/weapon/crowbar/red(src)
-	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 
 
 // Engineer survival box
@@ -81,7 +79,6 @@
 	..()
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen/engi(src)
-	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 
 /obj/item/weapon/storage/box/engineer/radio/New()
 	..()
@@ -98,7 +95,6 @@
 	..()
 	new /obj/item/clothing/mask/gas/sechailer(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen(src)
-	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 
 /obj/item/weapon/storage/box/security/radio/New()
 	..()


### PR DESCRIPTION
:cl:
del: Due to price gouging by Unimed, NT has cut down on the distribution of auto-injectors.
/:cl:

Hugbox reduction. Oxygen is for squares.

NOTE THEY ARE STILL IN MEDKITS
