### PR TITLE
Fixes a typo in peacekeeper barrier code

### DIFF
--- a/code/game/objects/items/weapons/holosign_creator.dm
+++ b/code/game/objects/items/weapons/holosign_creator.dm
@@ -231,7 +231,7 @@
 	density = 1
 	holo_integrity = 1
 
-/obj/effect/overlay/holograph/barrier/CanPass()
+/obj/effect/overlay/holograph/barrier/cyborg/CanPass()
 	return 0
 
 /obj/effect/overlay/holograph/barrier/cyborg/hacked


### PR DESCRIPTION
> I accidently made all holobarriers unable to be passed no matter what instead of the cyborg varient
> Woops.
