### PR TITLE
Normalizes the ed209 to match portaturret fire time

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -23,7 +23,7 @@
 	data_hud_type = DATA_HUD_SECURITY_ADVANCED
 
 	var/lastfired = 0
-	var/shot_delay = 3 //.3 seconds between shots
+	var/shot_delay = 15
 	var/lasercolor = ""
 	var/disabled = 0//A holder for if it needs to be disabled, if true it will not seach for targets, shoot at targets, or move, currently only used for lasertag
 


### PR DESCRIPTION
:cl: oranges
tweak: The ed209 can now only fire as fast as the portaturrets
/:cl:

This is to reduce their cheese usage in wizard rounds with a staff of polymorph where they can stun an entire room of people continually for an infinite amount of time.

I'm also considering adding a slowly recharging store of power that is drained by stun shots and hits, that way they can't spam stuns continually.
