### PR TITLE
Fixed food recipe code

### DIFF
--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -110,7 +110,6 @@
 	return 1
 
 /datum/personal_crafting/proc/construct_item(mob/user, datum/crafting_recipe/R)
-	for(var/A in R.parts)
 	var/list/contents = get_surroundings(user)
 	var/send_feedback = 1
 	if(check_contents(R, contents))

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -154,17 +154,18 @@
 			return 1
 
 //Called when you finish tablecrafting a snack.
-/obj/item/weapon/reagent_containers/food/snacks/CheckParts(list/parts_list, datum/crafting_recipe/R)
+/obj/item/weapon/reagent_containers/food/snacks/CheckParts(list/parts_list, datum/crafting_recipe/food/R)
 	..()
 	reagents.reagent_list.Cut()
 	for(var/obj/item/weapon/reagent_containers/RC in contents)
 		RC.reagents.trans_to(reagents, RC.reagents.maximum_volume)
-	contents_loop:
-		for(var/A in contents)
-			for(var/B in initial(R.parts))
-				if(istype(A, B))
-					continue contents_loop
-			qdel(A)
+	if(istype(R))
+		contents_loop:
+			for(var/A in contents)
+				for(var/B in R.real_parts)
+					if(istype(A, B))
+						continue contents_loop
+				qdel(A)
 	feedback_add_details("food_made","[type]")
 	if(bonus_reagents.len)
 		for(var/r_id in bonus_reagents)

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -1,4 +1,8 @@
+/datum/crafting_recipe/food
+	var/real_parts
+
 /datum/crafting_recipe/food/New()
+	real_parts = parts.Copy()
 	parts |= reqs
 
 //////////////////////////////////////////FOOD MIXTURES////////////////////////////////////


### PR DESCRIPTION
The way food recipe code worked, everything in the contents was getting deleted when the food was made, so things like fortune cookie fortunes were being deleted.

:cl:
fix: fortune cookies will now drop their fortunes when they are eaten.
/:cl:
