### PR TITLE
Makes radstorms more obvious

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -20,6 +20,7 @@
 	var/weather_duration_upper = 1500 //See above - this is the highest possible duration
 	var/weather_sound
 	var/weather_overlay
+	var/weather_color = null
 
 	var/end_message = "<span class='danger'>The wind relents its assault.</span>" //Displayed once the wather is over
 	var/end_duration = 300 //In deciseconds, how long the "wind-down" graphic will appear before vanishing entirely
@@ -125,6 +126,7 @@
 		N.layer = overlay_layer
 		N.icon = 'icons/effects/weather_effects.dmi'
 		N.invisibility = 0
+		N.color = weather_color
 		switch(stage)
 			if(STARTUP_STAGE)
 				N.icon_state = telegraph_overlay
@@ -133,6 +135,7 @@
 			if(WIND_DOWN_STAGE)
 				N.icon_state = end_overlay
 			if(END_STAGE)
+				N.color = null
 				N.icon_state = initial(N.icon_state)
 				N.icon = 'icons/turf/areas.dmi'
 				N.layer = AREA_LAYER //Just default back to normal area stuff since I assume setting a var is faster than initial

--- a/code/datums/weather/weather_types.dm
+++ b/code/datums/weather/weather_types.dm
@@ -118,12 +118,15 @@
 	name = "radiation storm"
 	desc = "A cloud of intense radiation passes through the area dealing rad damage to those who are unprotected."
 
-	telegraph_duration = 300
-	telegraph_message = "<span class='warning'>The air begins to grow warm.</span>"
+	telegraph_duration = 600
+	telegraph_message = "<span class='danger'>The air begins to grow warm.</span>"
 
 	weather_message = "<span class='userdanger'><i>You feel waves of heat wash over you! Find shelter!</i></span>"
+	weather_overlay = "ash_storm"
 	weather_duration_lower = 600
 	weather_duration_upper = 1500
+	weather_color = "green"
+	weather_sound = 'sound/misc/bloblarm.ogg'
 
 	end_duration = 100
 	end_message = "<span class='notice'>The air seems to be cooling off again.</span>"
@@ -135,19 +138,25 @@
 	immunity_type = "rad"
 
 /datum/weather/rad_storm/impact(mob/living/L)
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		if(H.dna && H.dna.species)
-			if(!(RADIMMUNE in H.dna.species.specflags))
-				if(prob(25))
-					if(prob(25))
+	if(prob(20))
+		if(ishuman(L))
+			var/mob/living/carbon/human/H = L
+			if(H.dna && H.dna.species)
+				if(!(RADIMMUNE in H.dna.species.specflags))
+					if(prob(50))
 						randmuti(H)
-					if(prob(90))
-						randmutb(H)
-					else
-						randmutg(H)
-					H.domutcheck()
-	L.rad_act(20,1)
+						if(prob(90))
+							randmutb(H)
+						else
+							randmutg(H)
+						H.domutcheck()
+		L.rad_act(20,1)
+
+	L.adjustToxLoss(4)
+
+
+
+
 
 /datum/weather/rad_storm/end()
 	if(..())


### PR DESCRIPTION
Doubles the delay before the storm starts, It's about a full minute now
The storm uses a green colored ash storm overlay.
Makes the blobalarm sound play at the start of the actual storm.
Radiation storm changed primarily to deal tox damage with a 20% chance to do rads and a 50% chance if it does rads to mutate you.

![green](http://puu.sh/qTh1Y/8c97690978.jpg)

:cl:
tweak: Rad storms are more obvious
/:cl:
