### PR TITLE
Blacklists lattices from the tesla

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -109,6 +109,7 @@
 	if(isEmpProof())
 		return
 	..()
+	qdel(src)//to prevent bomb testing camera from exploding over and over forever
 
 /obj/machinery/camera/blob_act(obj/effect/blob/B)
 	if(B && B.loc == loc)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -15,7 +15,8 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 										/obj/machinery/field/containment,
 										/obj/structure/disposalpipe,
 										/obj/structure/sign,
-										/obj/machinery/gateway))
+										/obj/machinery/gateway,
+										/obj/structure/lattice))
 
 /obj/singularity/energy_ball
 	name = "energy ball"


### PR DESCRIPTION
Should prevent the tesla from getting stuck along the outside of the station and hopefully the bomb testing area.
Fixes https://github.com/tgstation/tgstation/issues/20199
(at least i think it should, havent tested this)
