### PR TITLE
Makes cult structures breakable and readds cult recipes to runed metal

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -224,7 +224,14 @@ var/global/list/datum/stack_recipe/cardboard_recipes = list ( \
  * Runed Metal
  */
 
-var/global/list/datum/stack_recipe/runed_metal_recipes = list ()
+var/global/list/datum/stack_recipe/runed_metal_recipes = list ( \
+	new/datum/stack_recipe("runed door", /obj/machinery/door/airlock/cult, 1, time = 50, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("runed girder", /obj/structure/girder/cult, 1, time = 50, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("pylon", /obj/structure/cult/pylon, 3, time = 40, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("forge", /obj/structure/cult/forge, 4, time = 40, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("archives", /obj/structure/cult/tome, 2, time = 40, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("altar", /obj/structure/cult/talisman, 4, time = 40, one_per_turf = 1, on_floor = 1), \
+	)
 
 /obj/item/stack/sheet/runed_metal
 	name = "runed metal"


### PR DESCRIPTION
:cl: CHAD-BRO
add: Structure code from clockwork cult to all blood cult structures.
add: Cult structure recipes back to runed metal.
/:cl:

I'm not too experienced with BYOND or coding in general, but I just couldn't sit idle while nobody did anything about cult structures being invincible other than just removing them wholesale. So I used what I knew worked in game and copied the code from clockwork_structures to cult_structures and with a few changes to wording it ended up working.

There's currently no way to examine them to see how much health they have left or any way to repair them. 

It's not perfect but I figure this is a pretty good start to a problem nobody seems to want to address.
