### PR TITLE
Fixed cyborgs being able to use Power Warning emote when broken.

### DIFF
--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -248,9 +248,10 @@
 	set category = "Robot Commands"
 	set name = "Power Warning"
 
-	if(!cell || !cell.charge)
-		visible_message("The power warning light on <span class='name'>[src]</span> flashes urgently.",\
-						 "You announce you are operating in low power mode.")
-		playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
-	else
-		src << "<span class='warning'>You can only use this emote when you're out of charge.</span>"
+	if(src.stat == CONSCIOUS)
+		if(!cell || !cell.charge)
+			visible_message("The power warning light on <span class='name'>[src]</span> flashes urgently.",\
+							"You announce you are operating in low power mode.")
+			playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
+		else
+			src << "<span class='warning'>You can only use this emote when you're out of charge.</span>"

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -236,7 +236,7 @@
 		else
 			src << "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>"
 
-	if (message && src.stat == CONSCIOUS)
+	if (message && stat == CONSCIOUS)
 		log_emote("[name]/[key] : [message]")
 		if (m_type & 1)
 			visible_message(message)
@@ -248,7 +248,7 @@
 	set category = "Robot Commands"
 	set name = "Power Warning"
 
-	if(src.stat == CONSCIOUS)
+	if(stat == CONSCIOUS)
 		if(!cell || !cell.charge)
 			visible_message("The power warning light on <span class='name'>[src]</span> flashes urgently.",\
 							"You announce you are operating in low power mode.")


### PR DESCRIPTION
:cl: 
bugfix: Fixed cyborgs being able to use Power Warning emote when broken.
/:cl:

Fixes #19905
