### PR TITLE
fixes hulks throwing stunbatons

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -89,6 +89,11 @@
 		return ..()
 
 /obj/item/weapon/melee/baton/attack_self(mob/user)
+	if(user.has_dna())
+		if(user.dna.check_mutation(HULK))
+			user << "<span class='warning'>Your meaty hands are too fat to turn on the baton!</span>"
+			status = 0
+			return
 	if(bcell && bcell.charge > hitcost)
 		status = !status
 		user << "<span class='notice'>[src] is now [status ? "on" : "off"].</span>"
@@ -167,6 +172,14 @@
 
 /obj/item/weapon/melee/baton/emp_act(severity)
 	deductcharge(1000 / severity)
+	..()
+
+/obj/item/weapon/melee/baton/equipped(mob/user, slot)
+	if((slot == slot_l_hand) || (slot == slot_r_hand))
+		if(user.has_dna() && status)
+			if(user.dna.check_mutation(HULK))
+				user << "<span class='warning'>You grip the baton too hard, and accidentally turn it off!</span>"
+				status = 0
 	..()
 
 //Makeshift stun baton. Replacement for stun gloves.

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -89,9 +89,10 @@
 		return ..()
 
 /obj/item/weapon/melee/baton/attack_self(mob/user)
-	if(user.has_dna())
-		if(user.dna.check_mutation(HULK))
-			user << "<span class='warning'>Your meaty hands are too fat to turn on the baton!</span>"
+	if(user.has_dna() && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.dna.check_mutation(HULK))
+			H << "<span class='warning'>Your meaty hands are too fat to turn on the baton!</span>"
 			status = 0
 			return
 	if(bcell && bcell.charge > hitcost)
@@ -176,9 +177,10 @@
 
 /obj/item/weapon/melee/baton/equipped(mob/user, slot)
 	if((slot == slot_l_hand) || (slot == slot_r_hand))
-		if(user.has_dna() && status)
-			if(user.dna.check_mutation(HULK))
-				user << "<span class='warning'>You grip the baton too hard, and accidentally turn it off!</span>"
+		if(user.has_dna() && status && ishuman(user))
+			var/mob/living/carbon/human/H = user
+			if(H.dna.check_mutation(HULK))
+				H << "<span class='warning'>You grip the baton too hard, and accidentally turn it off!</span>"
 				status = 0
 	..()
 


### PR DESCRIPTION
> hulk is a tradeoff
> high melee viability and stun resistance
> in exchange, no real ranged combat outside of throws.
> very few items that are thrown stun, and those that do don't stun too long
> throwing batons is a hard ranged stun now
> hulks just stock up on batons and essentially have tasers

no

:cl:
fix: Hulks can no longer properly use stun batons.
/:cl:
