### PR TITLE
DNA Scanners' rejuvenators are now potassium iodide instead of epinephrine

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -96,7 +96,7 @@
 				occupant_status += "</div></div>"
 				occupant_status += "<div class='line'><div class='statusLabel'>Health:</div><div class='progressBar'><div style='width: [viable_occupant.health]%;' class='progressFill good'></div></div><div class='statusValue'>[viable_occupant.health] %</div></div>"
 				occupant_status += "<div class='line'><div class='statusLabel'>Radiation Level:</div><div class='progressBar'><div style='width: [viable_occupant.radiation]%;' class='progressFill bad'></div></div><div class='statusValue'>[viable_occupant.radiation] %</div></div>"
-				var/rejuvenators = viable_occupant.reagents.get_reagent_amount("epinephrine")
+				var/rejuvenators = viable_occupant.reagents.get_reagent_amount("potass_iodide")
 				occupant_status += "<div class='line'><div class='statusLabel'>Rejuvenators:</div><div class='progressBar'><div style='width: [round((rejuvenators / REJUVENATORS_MAX) * 100)]%;' class='progressFill highlight'></div></div><div class='statusValue'>[rejuvenators] units</div></div>"
 				occupant_status += "<div class='line'><div class='statusLabel'>Unique Enzymes :</div><div class='statusValue'><span class='highlight'>[viable_occupant.dna.unique_enzymes]</span></div></div>"
 				occupant_status += "<div class='line'><div class='statusLabel'>Last Operation:</div><div class='statusValue'>[last_change ? last_change : "----"]</div></div>"
@@ -350,9 +350,9 @@
 			current_screen = href_list["text"]
 		if("rejuv")
 			if(viable_occupant && viable_occupant.reagents)
-				var/epinephrine_amount = viable_occupant.reagents.get_reagent_amount("epinephrine")
-				var/can_add = max(min(REJUVENATORS_MAX - epinephrine_amount, REJUVENATORS_INJECT), 0)
-				viable_occupant.reagents.add_reagent("epinephrine", can_add)
+				var/potassiodide_amount = viable_occupant.reagents.get_reagent_amount("potass_iodide")
+				var/can_add = max(min(REJUVENATORS_MAX - potassiodide_amount, REJUVENATORS_INJECT), 0)
+				viable_occupant.reagents.add_reagent("potass_iodide", can_add)
 		if("setbufferlabel")
 			var/text = sanitize(input(usr, "Input a new label:", "Input an Text", null) as text|null)
 			if(num && text)


### PR DESCRIPTION
:cl: XDTM
tweak: Nanotrasen has now stocked the DNA Manipulators with potassium iodide instead of epinephrine as rejuvenators.
/:cl:

First off, epinephrine just does not belong there. The one use it has is stabilizing people in crit, and if you want to do that, you might as well use a sleeper.
Second, epinephrine overdoses after 30u, and the DNA machine happily lets you get up to 90 while never even telling you what you are injecting.
- This change won't benefit self testing geneticists, as they won't be able to inject it for themselves, and those who cooperate should be rewarded in efficiency, i guess. 
- Radiation damage has never been a threat to geneticists, since they spawn with antitoxin bottles in lockers and in medivends.
- This won't make spamming buffers on someone much less harmful as it heals one radiation per second versus 20 rads per buffer application.
