### PR TITLE
 Fun with cloning Frankensteins

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -384,6 +384,9 @@
 	R.fields["blood_type"] = subject.dna.blood_type
 	R.fields["features"] = subject.dna.features
 	R.fields["factions"] = subject.faction
+
+	DetectForeignDNA(subject, R)
+
 	//Add an implant if needed
 	var/obj/item/weapon/implant/health/imp = locate(/obj/item/weapon/implant/health, subject)
 	if(!imp)
@@ -399,3 +402,23 @@
 
 	src.records += R
 	scantemp = "Subject successfully scanned."
+
+/obj/machinery/computer/cloning/proc/DetectForeignDNA(mob/living/carbon/human/subject,datum/data/record/R )
+	var/domestic_limbs = 0
+	var/foreign_limbs = 0
+	var/list/foreign_limb_species = list()
+	for(var/A in subject.bodyparts)
+		var/obj/item/bodypart/B = A
+		if(B.status != ORGAN_ORGANIC)
+			continue
+		if(!B.original_owner || B.original_owner == subject)
+			domestic_limbs++
+			continue
+		foreign_limbs++
+		if(B.species_id != subject.dna.species.limbs_id)
+			foreign_limb_species += B.limb_species
+	if(!domestic_limbs && !foreign_limbs) //strictly speaking this person probably shouldn't be clonable but whatever
+		return
+	var/chance_to_assimilate = (foreign_limbs/(domestic_limbs+foreign_limbs))*100
+	if(prob(chance_to_assimilate) && !isemptylist(foreign_limb_species))
+		R.fields["mrace"] = pick(foreign_limb_species)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -7,6 +7,7 @@
 	icon_state = ""
 	layer = BELOW_MOB_LAYER //so it isn't hidden behind objects when on the floor
 	var/mob/living/carbon/human/owner = null
+	var/mob/living/carbon/human/original_owner = null
 	var/status = ORGAN_ORGANIC
 	var/body_zone //"chest", "l_arm", etc , used for def_zone
 	var/body_part = null //bitflag used to check which clothes cover this bodypart
@@ -30,6 +31,7 @@
 	var/px_x = 0
 	var/px_y = 0
 
+	var/limb_species //A path
 	var/state_flags
 
 /obj/item/bodypart/examine(mob/user)
@@ -186,6 +188,11 @@
 	var/mob/living/carbon/human/H
 	if(source)
 		H = source
+		if(!original_owner)
+			original_owner = source
+	else if(original_owner && owner != original_owner) //Foreign limb
+		no_update = 1
+		return
 	else
 		H = owner
 	if(!istype(H))
@@ -195,6 +202,7 @@
 
 	var/datum/species/S = H.dna.species
 	species_id = S.limbs_id
+	limb_species = S.type
 
 	if(S.use_skintones)
 		skin_tone = H.skin_tone


### PR DESCRIPTION
It's now possible for a body with limbs taken from other races to be cloned as that race instead of their own. The more of their body is replaced with foreign limbs the more likely this is to happen.

Fixes a bug where limbs attached to new owners would turn into the same kind of limbs as the owners if dropped again.

Currently untested. Scope of pull may increase at some later point.
