### PR TITLE
Adds note secrecy to allow hiding notes from non-admins

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,3 +1,13 @@
+1 September 2016, by Jordie0608
+
+Modified table 'notes', adding column 'secret'.
+
+ALTER TABLE `feedback`.`notes` ADD COLUMN `secret` TINYINT(1) NOT NULL DEFAULT '0'  AFTER `server`
+
+Remember to add a prefix to the table name if you use them
+
+----------------------------------------------------
+
 19 August 2016, by Shadowlight213
 
 Changed appearance bans to be jobbans.

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -2,7 +2,7 @@
 
 Modified table 'notes', adding column 'secret'.
 
-ALTER TABLE `feedback`.`notes` ADD COLUMN `secret` TINYINT(1) NOT NULL DEFAULT '0'  AFTER `server`
+ALTER TABLE `feedback`.`notes` ADD COLUMN `secret` TINYINT(1) NOT NULL DEFAULT '1'  AFTER `server`
 
 Remember to add a prefix to the table name if you use them
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -361,7 +361,7 @@ CREATE TABLE `notes` (
   `last_editor` varchar(32),
   `edits` text,
   `server` varchar(50) NOT NULL,
-  `secret` tinyint(1) NOT NULL DEFAULT  '0',
+  `secret` tinyint(1) NOT NULL DEFAULT  '1',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -361,6 +361,7 @@ CREATE TABLE `notes` (
   `last_editor` varchar(32),
   `edits` text,
   `server` varchar(50) NOT NULL,
+  `secret` tinyint(1) NOT NULL DEFAULT  '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -356,7 +356,7 @@ CREATE TABLE `SS13_notes` (
   `last_editor` varchar(32),
   `edits` text,
   `server` varchar(50) NOT NULL,
-  `secret` tinyint(1) NOT NULL DEFAULT  '0',
+  `secret` tinyint(1) NOT NULL DEFAULT  '1',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -356,6 +356,7 @@ CREATE TABLE `SS13_notes` (
   `last_editor` varchar(32),
   `edits` text,
   `server` varchar(50) NOT NULL,
+  `secret` tinyint(1) NOT NULL DEFAULT  '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -117,9 +117,9 @@ var/savefile/Banlist
 		if (temp)
 			Banlist["minutes"] << bantimestamp
 		if(!temp)
-			add_note(ckey, "Permanently banned - [reason]", null, bannedby, 0)
+			add_note(ckey, "Permanently banned - [reason]", null, bannedby, 0, null, 0)
 		else
-			add_note(ckey, "Banned for [minutes] minutes - [reason]", null, bannedby, 0)
+			add_note(ckey, "Banned for [minutes] minutes - [reason]", null, bannedby, 0, null, 0)
 	return 1
 
 /proc/RemoveBan(foldername)

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -35,12 +35,12 @@
 	server = sanitizeSQL(server)
 	if(isnull(secret))
 		switch(alert("Hide note from being viewed by players?", "Secret Note?","Yes","No","Cancel"))
-		if("Yes")
-			secret = 1
-		if("No")
-			secret = 0
-		else
-			return
+			if("Yes")
+				secret = 1
+			if("No")
+				secret = 0
+			else
+				return
 	var/DBQuery/query_noteadd = dbcon.NewQuery("INSERT INTO [format_table_name("notes")] (ckey, timestamp, notetext, adminckey, server, secret) VALUES ('[target_sql_ckey]', '[timestamp]', '[notetext]', '[admin_sql_ckey]', '[server]', '[secret]')")
 	if(!query_noteadd.Execute())
 		var/err = query_noteadd.ErrorMsg()

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -237,7 +237,7 @@
 		if(query_convert_time.NextRow())
 			timestamp = query_convert_time.item[1]
 		if(ckey && notetext && timestamp && adminckey && server)
-			add_note(ckey, notetext, timestamp, adminckey, 0, server)
+			add_note(ckey, notetext, timestamp, adminckey, 0, server, 1)
 	notesfile.cd = "/"
 	notesfile.dir.Remove(ckey)
 

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -104,6 +104,33 @@
 		message_admins("[key_name_admin(usr)] has edited [target_ckey]'s note made by [adminckey] from<br>[old_note]<br>to<br>[new_note]")
 		show_note(target_ckey)
 
+/proc/toggle_note_secrecy(note_id)
+	if(!dbcon.IsConnected())
+		usr << "<span class='danger'>Failed to establish database connection.</span>"
+		return
+	if(!note_id)
+		return
+	note_id = text2num(note_id)
+	var/DBQuery/query_find_note_secret = dbcon.NewQuery("SELECT ckey, adminckey, secret FROM [format_table_name("notes")] WHERE id = [note_id]")
+	if(!query_find_note_secret.Execute())
+		var/err = query_find_note_secret.ErrorMsg()
+		log_game("SQL ERROR obtaining ckey, adminckey, secret from notes table. Error : \[[err]\]\n")
+		return
+	if(query_find_note_secret.NextRow())
+		var/target_ckey = query_find_note_secret.item[1]
+		var/adminckey = query_find_note_secret.item[2]
+		var/secret = text2num(query_find_note_secret.item[3])
+		var/sql_ckey = sanitizeSQL(usr.ckey)
+		var/edit_text = "Made [secret ? "not secret" : "secret"] by [sql_ckey] on [SQLtime()]<hr>"
+		var/DBQuery/query_update_note = dbcon.NewQuery("UPDATE [format_table_name("notes")] SET secret = NOT secret, last_editor = '[sql_ckey]', edits = CONCAT(IFNULL(edits,''),'[edit_text]') WHERE id = [note_id]")
+		if(!query_update_note.Execute())
+			var/err = query_update_note.ErrorMsg()
+			log_game("SQL ERROR toggling note secrecy. Error : \[[err]\]\n")
+			return
+		log_admin("[key_name(usr)] has toggled [target_ckey]'s note made by [adminckey] to [secret ? "not secret" : "secret"]")
+		message_admins("[key_name_admin(usr)] has toggled [target_ckey]'s note made by [adminckey] to [secret ? "not secret" : "secret"]")
+		show_note(target_ckey)
+
 /proc/show_note(target_ckey, index, linkless = 0)
 	var/output
 	var/navbar
@@ -120,10 +147,10 @@
 		output = navbar
 	if(target_ckey)
 		var/target_sql_ckey = sanitizeSQL(target_ckey)
-		var/DBQuery/query_get_notes = dbcon.NewQuery("SELECT id, timestamp, notetext, adminckey, last_editor, server FROM [format_table_name("notes")] WHERE ckey = '[target_sql_ckey]' ORDER BY timestamp")
+		var/DBQuery/query_get_notes = dbcon.NewQuery("SELECT secret, timestamp, notetext, adminckey, last_editor, server, id FROM [format_table_name("notes")] WHERE ckey = '[target_sql_ckey]' ORDER BY timestamp")
 		if(!query_get_notes.Execute())
 			var/err = query_get_notes.ErrorMsg()
-			log_game("SQL ERROR obtaining ckey, notetext, adminckey, last_editor, server from notes table. Error : \[[err]\]\n")
+			log_game("SQL ERROR obtaining secret, timestamp, notetext, adminckey, last_editor, server, id from notes table. Error : \[[err]\]\n")
 			return
 		output += "<h2><center>Notes of [target_ckey]</center></h2>"
 		if(!linkless)
@@ -133,15 +160,18 @@
 			output += " <a href='?_src_=holder;shownoteckeylinkless=[target_ckey]'>\[Refresh Page\]</a></center>"
 		output += ruler
 		while(query_get_notes.NextRow())
-			var/id = query_get_notes.item[1]
+			var/secret = text2num(query_get_notes.item[1])
+			if(linkless && secret)
+				continue
 			var/timestamp = query_get_notes.item[2]
 			var/notetext = query_get_notes.item[3]
 			var/adminckey = query_get_notes.item[4]
 			var/last_editor = query_get_notes.item[5]
 			var/server = query_get_notes.item[6]
+			var/id = query_get_notes.item[7]
 			output += "<b>[timestamp] | [server] | [adminckey]</b>"
 			if(!linkless)
-				output += " <a href='?_src_=holder;removenote=[id]'>\[Remove Note\]</a> <a href='?_src_=holder;editnote=[id]'>\[Edit Note\]</a>"
+				output += " <a href='?_src_=holder;removenote=[id]'>\[Remove Note\]</a> <a href='?_src_=holder;secretnote=[id]'>[secret ? "<b>\[Secret\]</b>" : "\[Not Secret\]"]</a> <a href='?_src_=holder;editnote=[id]'>\[Edit Note\]</a>"
 				if(last_editor)
 					output += " <font size='2'>Last edit by [last_editor] <a href='?_src_=holder;noteedits=[id]'>(Click here to see edit log)</a></font>"
 			output += "<br>[notetext]<hr style='background:#000000; border:0; height:1px'>"

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -1,4 +1,4 @@
-/proc/add_note(target_ckey, notetext, timestamp, adminckey, logged = 1, server)
+/proc/add_note(target_ckey, notetext, timestamp, adminckey, logged = 1, server, secret)
 	if(!dbcon.IsConnected())
 		usr << "<span class='danger'>Failed to establish database connection.</span>"
 		return
@@ -13,7 +13,7 @@
 			log_game("SQL ERROR obtaining ckey from player table. Error : \[[err]\]\n")
 			return
 		if(!query_find_ckey.NextRow())
-			if(alert(usr, "[new_ckey] has not been seen before, are you sure you want to add them to the watchlist?", "Unknown ckey", "Yes", "No", "Cancel") != "Yes")
+			if(alert(usr, "[new_ckey] has not been seen before, are you sure you want to add a note for them?", "Unknown ckey", "Yes", "No", "Cancel") != "Yes")
 				return
 		target_ckey = new_ckey
 	var/target_sql_ckey = sanitizeSQL(target_ckey)
@@ -33,7 +33,15 @@
 		if (config && config.server_name)
 			server = config.server_name
 	server = sanitizeSQL(server)
-	var/DBQuery/query_noteadd = dbcon.NewQuery("INSERT INTO [format_table_name("notes")] (ckey, timestamp, notetext, adminckey, server) VALUES ('[target_sql_ckey]', '[timestamp]', '[notetext]', '[admin_sql_ckey]', '[server]')")
+	if(isnull(secret))
+		switch(alert("Hide note from being viewed by players?", "Secret Note?","Yes","No","Cancel"))
+		if("Yes")
+			secret = 1
+		if("No")
+			secret = 0
+		else
+			return
+	var/DBQuery/query_noteadd = dbcon.NewQuery("INSERT INTO [format_table_name("notes")] (ckey, timestamp, notetext, adminckey, server, secret) VALUES ('[target_sql_ckey]', '[timestamp]', '[notetext]', '[admin_sql_ckey]', '[server]', '[secret]')")
 	if(!query_noteadd.Execute())
 		var/err = query_noteadd.ErrorMsg()
 		log_game("SQL ERROR adding new note to table. Error : \[[err]\]\n")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -234,7 +234,7 @@
 			message_admins("Ban process: A mob matching [playermob.ckey] was found at location [playermob.x], [playermob.y], [playermob.z]. Custom ip and computer id fields replaced with the ip and computer id from the located mob.")
 
 		DB_ban_record(bantype, playermob, banduration, banreason, banjob, null, banckey, banip, bancid )
-		add_note(banckey, banreason, null, usr.ckey, 0)
+		add_note(banckey, banreason, null, usr.ckey, 0, null, 0)
 
 	else if(href_list["editrights"])
 		edit_rights_topic(href_list)
@@ -535,7 +535,7 @@
 				DB_ban_record(BANTYPE_JOB_PERMA, M, -1, reason, "appearance")
 				if(M.client)
 					jobban_buildcache(M.client)
-				add_note(M.ckey, "Appearance banned - [reason]", null, usr.ckey, 0)
+				add_note(M.ckey, "Appearance banned - [reason]", null, usr.ckey, 0, null, 0)
 				message_admins("<span class='adminnotice'>[key_name_admin(usr)] appearance banned [key_name_admin(M)].</span>")
 				M << "<span class='boldannounce'><BIG>You have been appearance banned by [usr.client.ckey].</BIG></span>"
 				M << "<span class='boldannounce'>The reason is: [reason]</span>"
@@ -981,7 +981,7 @@
 							msg = job
 						else
 							msg += ", [job]"
-					add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0)
+					add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0, null, 0)
 					message_admins("<span class='adminnotice'>[key_name_admin(usr)] banned [key_name_admin(M)] from [msg] for [mins] minutes.</span>")
 					M << "<span class='boldannounce'><BIG>You have been [(msg == ("ooc" || "appearance")) ? "banned" : "jobbanned"] by [usr.client.ckey] from: [msg].</BIG></span>"
 					M << "<span class='boldannounce'>The reason is: [reason]</span>"
@@ -1004,7 +1004,7 @@
 								msg = job
 							else
 								msg += ", [job]"
-						add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0)
+						add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0, null, 0)
 						message_admins("<span class='adminnotice'>[key_name_admin(usr)] banned [key_name_admin(M)] from [msg].</span>")
 						M << "<span class='boldannounce'><BIG>You have been [(msg == ("ooc" || "appearance")) ? "banned" : "jobbanned"] by [usr.client.ckey] from: [msg].</BIG></span>"
 						M << "<span class='boldannounce'>The reason is: [reason]</span>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1104,6 +1104,10 @@
 			var/edit_log = query_noteedits.item[1]
 			usr << browse(edit_log,"window=noteedits")
 
+	else if(href_list["secretnote"])
+		var/note_id = href_list["secretnote"]
+		toggle_note_secrecy(note_id)
+
 	else if(href_list["newban"])
 		if(!check_rights(R_BAN))
 			return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -405,7 +405,7 @@ var/next_external_rsc = 0
 	if (query_get_notes.NextRow())
 		if (query_get_notes.item[1] == adminckey)
 			return
-	add_note(ckey, "Detected as using a cid randomizer.", null, adminckey, logged = 0)
+	add_note(ckey, "Detected as using a cid randomizer.", null, adminckey, 0, null, 1)
 
 
 /client/proc/check_ip_intel()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -405,7 +405,7 @@ var/next_external_rsc = 0
 	if (query_get_notes.NextRow())
 		if (query_get_notes.item[1] == adminckey)
 			return
-	add_note(ckey, "Detected as using a cid randomizer.", null, adminckey, 0, null, 1)
+	add_note(ckey, "Detected as using a cid randomizer.", null, adminckey, 0, null, 0)
 
 
 /client/proc/check_ip_intel()

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -151,7 +151,7 @@ var/global/normal_ooc_colour = OOC_COLOR
 		usr << "<span class='notice'>Sorry, that function is not enabled on this server.</span>"
 		return
 
-	show_note(usr, null, 1)
+	show_note(usr.ckey, null, 1)
 
 /client/proc/ignore_key(client)
 	var/client/C = client

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -422,8 +422,9 @@ var/next_mob_id = 0
 */
 
 /mob/verb/memory()
-	set name = "Notes"
+	set name = "Notes Memory"
 	set category = "IC"
+	set desc = "View your character's notes memory."
 	if(mind)
 		mind.show_memory(src)
 	else


### PR DESCRIPTION
:cl:
add: Notes can now be tagged as secret to be hidden from player viewed notes.
/:cl:
Can be toggled at any time but obviously only has an effect if config allows players to view their own notes.
Dedicated to @KorPhaeron 
Don't merge this unless MSO or myself are around to update the DB
