### PR TITLE
Tweak military belt TC cost from 3 -> 1

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -799,7 +799,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	name = "Military Belt"
 	desc = "A robust seven-slot red belt that is capable of holding all manner of tatical equipment."
 	item = /obj/item/weapon/storage/belt/military
-	cost = 3
+	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/medkit


### PR DESCRIPTION
Military belts:
- Costs 3 TC (as much as an edagger+soap combo)
- Compromises stealth and reveals your syndie status to all
- max_w_class = 2
- Looks cool

Fanny packs:
- Freely available around the station
- Does not compromise stealth
- max_w_class = 2
- Looks like a dork

Let's face it, the only reason people buy military belts is to look cool, and looking cool shouldn't break bank.

:cl:
tweak: Changed military belt TC cost from 3 -> 1
/:cl:
