### PR TITLE
Fixes lava being retarded

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -239,8 +239,8 @@
 	initial_gas_mix = "TEMP=2.7"
 
 /turf/open/floor/plating/lava/Entered(atom/movable/AM)
-	burn_stuff()
-	START_PROCESSING(SSobj, src)
+	if(burn_stuff(AM))
+		START_PROCESSING(SSobj, src)
 
 /turf/open/floor/plating/lava/process()
 	if(!burn_stuff())
@@ -257,9 +257,12 @@
 
 /turf/open/floor/plating/lava/TakeTemperature(temp)
 
-/turf/open/floor/plating/lava/proc/burn_stuff()
+/turf/open/floor/plating/lava/proc/burn_stuff(AM)
 	. = 0
-	for(var/thing in contents)
+	var/thing_to_check = src
+	if (AM)
+		thing_to_check = list(AM)
+	for(var/thing in thing_to_check)
 		if(isobj(thing))
 			var/obj/O = thing
 			if(O.burn_state == LAVA_PROOF || O.throwing)


### PR DESCRIPTION
:cl: 
fix: Fixed lava sometimes doing massive amounts of damage.
/:cl:

By looping thru the turf on entered, it caused more issues than it needed to. By making it only act on the new thing on entered, and loop thru the turf only on process(). This avoids all sorts of issues and fixes it applying a burn multiple times quickly to everything if a bunch of things entered the turf at once.

I fear i might have to do the same to chasms
