### PR TITLE
Bubblegum's charge now goes the full distance to the target

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -348,9 +348,9 @@
 				if(L.&& L.client)
 					L.client.played = 0
 
-/proc/has_gravity(atom/AT, turf/T)
-	if(!T)
-		T = get_turf(AT)
+/atom/proc/has_gravity(turf/T)
+	if(!T || !isturf(T))
+		T = get_turf(src)
 	var/area/A = get_area(T)
 	if(istype(T, /turf/open/space)) // Turf never has gravity
 		return 0

--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -66,7 +66,7 @@
 		processing = 0
 		var/turf/T = get_turf(holder)
 		if(T != oldposition)
-			if(!has_gravity(T))
+			if(!T.has_gravity())
 				var/obj/effect/particle_effect/ion_trails/I = PoolOrNew(effect_type, oldposition)
 				I.setDir(holder.dir)
 				flick("ion_fade", I)

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -144,6 +144,9 @@
 		appearance = mimiced_atom.appearance
 		setDir(mimiced_atom.dir)
 		mouse_opacity = 0
+
+/obj/effect/overlay/temp/decoy/fading/New(loc, atom/mimiced_atom)
+	..()
 	animate(src, alpha = 0, time = duration)
 
 /obj/effect/overlay/temp/cult

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -281,7 +281,7 @@
 		check_break(M)
 
 /obj/structure/table/glass/proc/check_break(mob/living/M)
-	if(has_gravity(M) && M.mob_size > MOB_SIZE_SMALL)
+	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL)
 		table_shatter(M)
 
 /obj/structure/table/glass/proc/table_shatter(mob/M)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -31,7 +31,7 @@
 	icon_state = "[magboot_state][magpulse]"
 	user << "<span class='notice'>You [magpulse ? "enable" : "disable"] the mag-pulse traction system.</span>"
 	user.update_inv_shoes()	//so our mob-overlays update
-	user.update_gravity(user.mob_has_gravity())
+	user.update_gravity(user.has_gravity())
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -45,7 +45,7 @@
 	if(leaping || stat || buckled || lying)
 		return
 
-	if(!has_gravity(src) || !has_gravity(A))
+	if(!has_gravity() || !A.has_gravity())
 		src << "<span class='alertalien'>It is unsafe to leap without gravity!</span>"
 		//It's also extremely buggy visually, so it's balance+bugfix
 		return

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -15,7 +15,7 @@
 		return 0
 	return ..()
 
-/mob/living/carbon/human/mob_has_gravity()
+/mob/living/carbon/human/has_gravity()
 	. = ..()
 	if(!.)
 		if(mob_negates_gravity())

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -849,7 +849,7 @@
 		. -= 2
 
 	if(!(H.status_flags & IGNORESLOWDOWN))
-		if(!has_gravity(H))
+		if(!H.has_gravity())
 			if(FLYING in specflags)
 				. += speedmod
 				return

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -43,7 +43,7 @@
 	//stuff in the stomach
 	handle_stomach()
 
-	update_gravity(mob_has_gravity())
+	update_gravity(has_gravity())
 
 	if(machine)
 		machine.check_eye(src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -602,7 +602,7 @@
 			. += config.walk_speed
 
 /mob/living/proc/makeTrail(turf/T)
-	if(!has_gravity(src))
+	if(!has_gravity())
 		return
 	var/blood_exists = 0
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -9,7 +9,7 @@
 	else //I'm not removing that shitton of tabs, unneeded as they are. -- Urist
 		//Being dead doesn't mean your temperature never changes
 
-		update_gravity(mob_has_gravity())
+		update_gravity(has_gravity())
 
 		if(malfhack && malfhack.aidisabled)
 			deltimer(malfhacking)

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -11,7 +11,7 @@
 /mob/living/silicon/robot/mob_negates_gravity()
 	return magpulse
 
-/mob/living/silicon/robot/mob_has_gravity()
+/mob/living/silicon/robot/has_gravity()
 	return ..() || mob_negates_gravity()
 
 /mob/living/silicon/robot/experience_pressure_difference(pressure_difference, direction)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -251,7 +251,7 @@
 /mob/living/simple_animal/drone/mob_negates_gravity()
 	return 1
 
-/mob/living/simple_animal/drone/mob_has_gravity()
+/mob/living/simple_animal/drone/has_gravity()
 	return ..() || mob_negates_gravity()
 
 /mob/living/simple_animal/drone/experience_pressure_difference(pressure_difference, direction)

--- a/code/modules/mob/living/simple_animal/guardian/types/charger.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/charger.dm
@@ -38,7 +38,7 @@
 
 /mob/living/simple_animal/hostile/guardian/charger/Move()
 	if(charging)
-		PoolOrNew(/obj/effect/overlay/temp/decoy, list(loc,src))
+		PoolOrNew(/obj/effect/overlay/temp/decoy/fading, list(loc,src))
 	. = ..()
 
 /mob/living/simple_animal/hostile/guardian/charger/snapback()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -112,7 +112,7 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Move()
 	if(!stat)
-		playsound(src.loc, 'sound/effects/meteorimpact.ogg', 200, 1, 0, 1)
+		playsound(src.loc, 'sound/effects/meteorimpact.ogg', 200, 1, 2, 1)
 	if(charging)
 		PoolOrNew(/obj/effect/overlay/temp/decoy/fading, list(loc,src))
 		DestroySurroundings()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -112,9 +112,9 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Move()
 	if(!stat)
-		playsound(src.loc, 'sound/effects/meteorimpact.ogg', 200, 1)
+		playsound(src.loc, 'sound/effects/meteorimpact.ogg', 200, 1, 0, 1)
 	if(charging)
-		PoolOrNew(/obj/effect/overlay/temp/decoy, list(loc,src))
+		PoolOrNew(/obj/effect/overlay/temp/decoy/fading, list(loc,src))
 		DestroySurroundings()
 	. = ..()
 	if(charging)
@@ -136,7 +136,6 @@ Difficulty: Hard
 	var/turf/T = get_turf(target)
 	if(!T)
 		return
-	PoolOrNew(/obj/effect/overlay/temp/dragon_swoop, T)
 	charging = 1
 	original_charge_loc = get_turf(src)
 	if(get_dist(src, T) > 7) //the target is far enough away we can charge longer without losing vision
@@ -145,8 +144,12 @@ Difficulty: Hard
 		charge_range = initial(charge_range) //the target is closer we need to do shorter charges to avoid losing vision
 	DestroySurroundings()
 	walk(src, 0)
-	sleep(5)
-	throw_at(T, charge_range, 1, src, 0, 1)
+	setDir(get_dir(src, T))
+	var/obj/effect/overlay/temp/decoy/D = PoolOrNew(/obj/effect/overlay/temp/decoy, list(loc,src))
+	D.color = "#FF0000"
+	animate(D, alpha = 0, color = initial(D.color), transform = matrix()*2, time = 7)
+	sleep(7)
+	throw_at(T, charge_range, 1, src, 0)
 	charging = 0
 	Goto(target, move_to_delay, minimum_distance)
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -138,10 +138,7 @@ Difficulty: Hard
 		return
 	charging = 1
 	original_charge_loc = get_turf(src)
-	if(get_dist(src, T) > 7) //the target is far enough away we can charge longer without losing vision
-		charge_range = 18
-	else
-		charge_range = initial(charge_range) //the target is closer we need to do shorter charges to avoid losing vision
+	charge_range = max(get_dist(src, T) + 5, initial(charge_range)) //always try to overshoot the target by 5 tiles, minimum 10 tiles
 	DestroySurroundings()
 	walk(src, 0)
 	setDir(get_dir(src, T))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -46,6 +46,8 @@ Difficulty: Hard
 	del_on_death = 1
 	loot = list(/obj/structure/closet/crate/necropolis/bubblegum)
 	var/charging = 0
+	var/charge_range = 10
+	var/turf/original_charge_loc
 	medal_type = MEDAL_PREFIX
 	score_type = BUBBLEGUM_SCORE
 	deathmessage = "sinks into a pool of blood, fleeing the battle. You've won, for now... "
@@ -118,6 +120,11 @@ Difficulty: Hard
 	if(charging)
 		DestroySurroundings()
 
+/mob/living/simple_animal/hostile/megafauna/bubblegum/has_gravity(turf/T)
+	if(charging && original_charge_loc && target && target.z && original_charge_loc.z == target.z && get_dist(src, original_charge_loc) < charge_range)
+		return 0
+	return ..()
+
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/triple_charge()
 	charge()
 	sleep(10)
@@ -126,15 +133,22 @@ Difficulty: Hard
 	charge()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge()
-	var/turf/T = get_step_away(target, src)
-	charging = 1
-	DestroySurroundings()
+	var/turf/T = get_turf(target)
+	if(!T)
+		return
 	PoolOrNew(/obj/effect/overlay/temp/dragon_swoop, T)
+	charging = 1
+	original_charge_loc = get_turf(src)
+	if(get_dist(src, T) > 7) //the target is far enough away we can charge longer without losing vision
+		charge_range = 18
+	else
+		charge_range = initial(charge_range) //the target is closer we need to do shorter charges to avoid losing vision
+	DestroySurroundings()
+	walk(src, 0)
 	sleep(5)
-	walk(src,0)
-	throw_at(T, 7, 1, src, 0)
+	throw_at(T, charge_range, 1, src, 0, 1)
 	charging = 0
-	Goto(target,move_to_delay,minimum_distance)
+	Goto(target, move_to_delay, minimum_distance)
 
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Bump(atom/A)
@@ -148,16 +162,15 @@ Difficulty: Hard
 	if(!charging)
 		return ..()
 
-	else if(A)
-		if(isliving(A))
-			var/mob/living/L = A
-			L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] slams into you!</span>")
-			L.apply_damage(40, BRUTE)
-			playsound(get_turf(L), 'sound/effects/meteorimpact.ogg', 100, 1)
-			shake_camera(L, 4, 3)
-			shake_camera(src, 2, 3)
-			var/throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(L, src)))
-			L.throw_at_fast(throwtarget)
+	else if(isliving(A))
+		var/mob/living/L = A
+		L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] slams into you!</span>")
+		L.apply_damage(40, BRUTE)
+		playsound(get_turf(L), 'sound/effects/meteorimpact.ogg', 100, 1)
+		shake_camera(L, 4, 3)
+		shake_camera(src, 2, 3)
+		var/throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(L, src)))
+		L.throw_at_fast(throwtarget, 3)
 
 	charging = 0
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -120,11 +120,6 @@ Difficulty: Hard
 	if(charging)
 		DestroySurroundings()
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/has_gravity(turf/T)
-	if(charging && original_charge_loc && target && target.z && original_charge_loc.z == target.z && get_dist(src, original_charge_loc) < charge_range)
-		return 0
-	return ..()
-
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/triple_charge()
 	charge()
 	sleep(10)
@@ -134,19 +129,18 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge()
 	var/turf/T = get_turf(target)
-	if(!T)
+	if(!T || T == loc)
 		return
+	PoolOrNew(/obj/effect/overlay/temp/dragon_swoop, T)
 	charging = 1
-	original_charge_loc = get_turf(src)
-	charge_range = max(get_dist(src, T) + 5, initial(charge_range)) //always try to overshoot the target by 5 tiles, minimum 10 tiles
 	DestroySurroundings()
 	walk(src, 0)
 	setDir(get_dir(src, T))
 	var/obj/effect/overlay/temp/decoy/D = PoolOrNew(/obj/effect/overlay/temp/decoy, list(loc,src))
 	D.color = "#FF0000"
-	animate(D, alpha = 0, color = initial(D.color), transform = matrix()*2, time = 7)
-	sleep(7)
-	throw_at(T, charge_range, 1, src, 0)
+	animate(D, alpha = 0, color = initial(D.color), transform = matrix()*2, time = 5)
+	sleep(5)
+	throw_at(T, get_dist(src, T), 1, src, 0)
 	charging = 0
 	Goto(target, move_to_delay, minimum_distance)
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -46,8 +46,6 @@ Difficulty: Hard
 	del_on_death = 1
 	loot = list(/obj/structure/closet/crate/necropolis/bubblegum)
 	var/charging = 0
-	var/charge_range = 10
-	var/turf/original_charge_loc
 	medal_type = MEDAL_PREFIX
 	score_type = BUBBLEGUM_SCORE
 	deathmessage = "sinks into a pool of blood, fleeing the battle. You've won, for now... "

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -303,9 +303,6 @@
 				break
 	. = dense_object_backup
 
-/mob/proc/mob_has_gravity(turf/T)
-	return has_gravity(src, T)
-
 /mob/proc/mob_negates_gravity()
 	return 0
 

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -372,7 +372,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	for(var/mob/M in mob_list)
 		if(M.z != z)
 			continue
-		M.update_gravity(M.mob_has_gravity())
+		M.update_gravity(M.has_gravity())
 		if(M.client)
 			shake_camera(M, 15, 1)
 			M.playsound_local(T, 'sound/effects/alert.ogg', 100, 1, 0.5)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -129,7 +129,7 @@
 
 
 /obj/vehicle/Process_Spacemove(direction)
-	if(has_gravity(src))
+	if(has_gravity())
 		return 1
 
 	if(pulledby)


### PR DESCRIPTION
I had to rework has_gravity() to do what I originally wanted to do so that's this pr now?

Big change; has_gravity() is now an atom proc instead of a global, so you can actually override it.
Removed mob_has_gravity() because it'd be redundant.

Basically; instead of bubblegum's charges having a max range of 7, they have a max range of 'however many tiles it is to the target'
