### PR TITLE
Tweaks smoke and foam layers

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -7,7 +7,7 @@
 	opacity = 0
 	anchored = 1
 	density = 0
-	layer = ABOVE_ALL_MOB_LAYER
+	layer = WALL_OBJ_LAYER
 	mouse_opacity = 0
 	var/amount = 3
 	animate_movement = 0

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -9,6 +9,7 @@
 	pixel_x = -32
 	pixel_y = -32
 	opacity = 0
+	layer = FLY_LAYER
 	anchored = 1
 	mouse_opacity = 0
 	animate_movement = 0
@@ -25,6 +26,8 @@
 	var/step = alpha / frames
 	for(var/i = 0, i < frames, i++)
 		alpha -= step
+		if(alpha < 160)
+			opacity = 0 //if we were blocking view, we aren't now because we're fading out
 		stoplag()
 
 /obj/effect/particle_effect/smoke/New()


### PR DESCRIPTION
Smoke is now above all mobs and standard objects.
Foam is now below large mobs(but still above wall objects/most mobs)
