### PR TITLE
Cloners properly preserve genetic mutations.

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -261,12 +261,12 @@ mob/living/carbon/human/updateappearance(icon_update=1, mutcolor_update=0, mutat
 /mob/proc/domutcheck()
 	return
 
-/mob/living/carbon/domutcheck()
+/mob/living/carbon/domutcheck(force_powers=0) //Set force_powers to 1 to bypass the power chance
 	if(!has_dna())
 		return
 
 	for(var/datum/mutation/human/A in good_mutations | bad_mutations | not_good_mutations)
-		if(ismob(A.check_block(src)))
+		if(ismob(A.check_block(src, force_powers)))
 			return //we got monkeyized/humanized, this mob will be deleted, no need to continue.
 
 	update_mutations_overlay()

--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -48,9 +48,9 @@
 	if(hex2num(getblock(se_string, dna_block)) >= lowest_value)
 		return 1
 
-/datum/mutation/human/proc/check_block(mob/living/carbon/human/owner)
+/datum/mutation/human/proc/check_block(mob/living/carbon/human/owner, force_powers=0)
 	if(check_block_string(owner.dna.struc_enzymes))
-		if(prob(get_chance))
+		if(prob(get_chance)||force_powers)
 			. = on_acquiring(owner)
 	else
 		. = on_losing(owner)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -163,9 +163,11 @@
 
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src)
 
+	H.hardset_dna(ui, se, H.real_name, null, mrace, features)
+
 	if(efficiency > 2)
-		for(var/A in bad_se_blocks)
-			setblock(H.dna.struc_enzymes, A, construct_block(0,2))
+		var/list/unclean_mutations = (not_good_mutations|bad_mutations)
+		H.dna.remove_mutation_group(unclean_mutations)
 	if(efficiency > 5 && prob(20))
 		randmutvg(H)
 	if(efficiency < 3 && prob(50))
@@ -197,7 +199,6 @@
 			beginning to regenerate in a cloning pod. You will \
 			become conscious when it is complete.</span>"
 
-	H.hardset_dna(ui, H.dna.struc_enzymes, H.real_name, null, mrace, features)
 	if(H)
 		H.faction |= factions
 
@@ -343,7 +344,7 @@
 	occupant.forceMove(T)
 	icon_state = "pod_0"
 	eject_wait = FALSE //If it's still set somehow.
-	occupant.domutcheck() //Waiting until they're out before possible monkeyizing.
+	occupant.domutcheck(1) //Waiting until they're out before possible monkeyizing. The 1 argument forces powers to manifest.
 	occupant = null
 
 /obj/machinery/clonepod/proc/malfunction()


### PR DESCRIPTION
:cl: XDTM
fix: Cloners now preserve your genetic mutations.
/:cl:

This means that if you get scanned while you have tourettes, you'll come out with tourettes, and if you get scanned with hulk you'll come out with hulk. Upgrading the cloner to T2 scanners will cause it to clean the bad mutations.

Also added an argument to domutcheck( ) to force power manifestation.

I think this was already the intended behaviour, due to the DNA-Cleaning upgrade already being there.
