### PR TITLE
Removes retardation preventing you from using machines

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -313,11 +313,6 @@ Class Procs:
 	if(!user.IsAdvancedToolUser() && !IsAdminGhost(user))
 		usr << "<span class='warning'>You don't have the dexterity to do this!</span>"
 		return 1
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(prob(H.getBrainLoss()))
-			user << "<span class='warning'>You momentarily forget how to use [src]!</span>"
-			return 1
 	if(!is_interactable())
 		return 1
 	if(set_machine)


### PR DESCRIPTION
:cl: Cheridan
tweak: Brain damage no longer causes machines to be inoperable.
/:cl:

Fixes #18901

PLEASE STOP MAKING FUN OF RETARDED PEOPLE, MY LITTLE BROTHER IAMGOOFBALL IS RETARDED AND IT'S VERY CRUEL AND INSENSITIVE.

Seriously though, it's just a frustrating, buggy-feeling mechanic (dropped inputs on console messages, UI on machinery getting greyed out on every tick where you fail the check, unable to do basic shit like refilling internals or opening cloner doors)

If someone has a good idea to replace this I'll consider it, I can't really think of a good replacement
