### PR TITLE
Makes the tgui subsystem clean up empty lists on ui closing

### DIFF
--- a/code/modules/tgui/subsystem.dm
+++ b/code/modules/tgui/subsystem.dm
@@ -182,8 +182,15 @@
 	processing_uis.Remove(ui) // Remove it from the list of processing UIs.
 	if(ui.user)	// If the user exists, remove it from them too.
 		ui.user.open_uis.Remove(ui)
-	var/list/uis = open_uis[src_object_key][ui.ui_key] // Remove it from the list of open UIs.
+	var/Ukey = ui.ui_key
+	var/list/uis = open_uis[src_object_key][Ukey] // Remove it from the list of open UIs.
 	uis.Remove(ui)
+	if(!uis.len)
+		var/list/uiobj = open_uis[src_object_key]
+		uiobj.Remove(Ukey)
+		if(!uiobj.len)
+			open_uis.Remove(src_object_key)
+
 	return 1 // Let the caller know we did it.
 
  /**


### PR DESCRIPTION
This should prevent the subsystem from looking like [this](http://puu.sh/r0cP5/c14a72ebca.png) at round end. (this is just the open_uis list displayed)
Fixes #19411
