### PR TITLE
Formally removes the cursed heart from the spellbook

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -397,18 +397,6 @@
 	item_path = /obj/item/weapon/twohanded/singularityhammer
 	log_name = "SI"
 
-/datum/spellbook_entry/item/cursed_heart
-	name = "Cursed Heart"
-	desc = "A heart that has been revived by dark magicks, the user must \
-	concentrate to ensure the heart beats, but every beat heals them. It \
-	must beat every 6 seconds. The heart is fickle, and will not work for a \
-	lich."
-	item_path = /obj/item/organ/heart/cursed/wizard
-	log_name = "CH"
-	cost = 1
-	category = "Defensive"
-
-
 /datum/spellbook_entry/item/battlemage
 	name = "Battlemage Armour"
 	desc = "An ensorcelled suit of armour, protected by a powerful shield. The shield can completly negate sixteen attacks before being permanently depleted."


### PR DESCRIPTION
Cursed heart:
1. Kills you if you aren't aware of how it works, ending the round instantly
2. Can only be practiced with on the very rare chance that you roll wizard
3. Cannot be refunded if you buy it and realize how needy it is
4. Requires really annoying micromanagement even when used correctly
5. Kills you if you get stunned, ever
6. Is never used as a result

Stats page seems to reveal that people actually used cursed heart, but unfortunately its abbreviation on the stats page was accidentally made the same as the charge spell, which is also purchasable.

I just really hate how much of a wizard snipe item this is, on the very rare instance I've seen it in use it's always led to the death of the wizard.
