### PR TITLE
Allows for sabre renaming.

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -2,7 +2,6 @@
 	needs_permit = 1
 
 	var/unique_rename = 0 //allows renaming with a pen
-	var/unique_reskin = 0 //allows one-time reskinning
 
 /obj/item/weapon/melee/examine(mob/user)
 	..()

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -1,29 +1,6 @@
 /obj/item/weapon/melee
 	needs_permit = 1
 
-<<<<<<< HEAD
-=======
-	var/unique_rename = 0 //allows renaming with a pen
-
-/obj/item/weapon/melee/examine(mob/user)
-	..()
-	if(unique_rename)
-		user << "<span class='notice'>Use a pen on it to rename it.</span>"
-
-/obj/item/weapon/melee/attackby(obj/item/I, mob/user, params)
-	if(unique_rename)
-		if(istype(I, /obj/item/weapon/pen))
-			rename_weapon(user)
-	..()
-
-/obj/item/weapon/melee/proc/rename_weapon(mob/M)
-	var/input = stripped_input(M,"What do you want to name the weapon?", ,"", MAX_NAME_LEN)
-
-	if(src && input && !M.stat && in_range(M,src) && !M.restrained() && M.canmove)
-		name = input
-		M << "You name the weapon [input]. Say hello to your new friend."
-		return
->>>>>>> 04bb24d27a666b5821c9c053014095c032095f9d
 
 /obj/item/weapon/melee/chainofcommand
 	name = "chain of command"

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -1,6 +1,28 @@
 /obj/item/weapon/melee
 	needs_permit = 1
 
+	var/unique_rename = 0 //allows renaming with a pen
+	var/unique_reskin = 0 //allows one-time reskinning
+
+/obj/item/weapon/melee/examine(mob/user)
+	..()
+	if(unique_rename)
+		user << "<span class='notice'>Use a pen on it to rename it.</span>"
+
+/obj/item/weapon/melee/attackby(obj/item/I, mob/user, params)
+	if(unique_rename)
+		if(istype(I, /obj/item/weapon/pen))
+			rename_weapon(user)
+	..()
+
+/obj/item/weapon/melee/proc/rename_weapon(mob/M)
+	var/input = stripped_input(M,"What do you want to name the weapon?", ,"", MAX_NAME_LEN)
+
+	if(src && input && !M.stat && in_range(M,src) && !M.restrained() && M.canmove)
+		name = input
+		M << "You name the weapon [input]. Say hello to your new friend."
+		return
+
 /obj/item/weapon/melee/chainofcommand
 	name = "chain of command"
 	desc = "A tool used by great men to placate the frothing masses."
@@ -27,6 +49,7 @@
 	icon_state = "sabre"
 	item_state = "sabre"
 	flags = CONDUCT
+	unique_rename = 1
 	force = 15
 	throwforce = 10
 	w_class = 4

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -1,27 +1,6 @@
 /obj/item/weapon/melee
 	needs_permit = 1
 
-	var/unique_rename = 0 //allows renaming with a pen
-	var/unique_reskin = 0 //allows one-time reskinning
-
-/obj/item/weapon/melee/examine(mob/user)
-	..()
-	if(unique_rename)
-		user << "<span class='notice'>Use a pen on it to rename it.</span>"
-
-/obj/item/weapon/melee/attackby(obj/item/I, mob/user, params)
-	if(unique_rename)
-		if(istype(I, /obj/item/weapon/pen))
-			rename_weapon(user)
-	..()
-
-/obj/item/weapon/melee/proc/rename_weapon(mob/M)
-	var/input = stripped_input(M,"What do you want to name the weapon?", ,"", MAX_NAME_LEN)
-
-	if(src && input && !M.stat && in_range(M,src) && !M.restrained() && M.canmove)
-		name = input
-		M << "You name the weapon [input]. Say hello to your new friend."
-		return
 
 /obj/item/weapon/melee/chainofcommand
 	name = "chain of command"

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -1,3 +1,28 @@
+/obj/item/weapon
+
+	var/unique_rename = 0 //allows renaming with a pen
+
+/obj/item/weapon/examine(mob/user)
+	..()
+	if(unique_rename)
+		user << "<span class='notice'>Use a pen on it to rename it.</span>"
+
+/obj/item/weapon/attackby(obj/item/I, mob/user, params)
+	if(unique_rename)
+		if(istype(I, /obj/item/weapon/pen))
+			rename_weapon(user)
+	..()
+
+/obj/item/weapon/proc/rename_weapon(mob/M)
+	var/input = stripped_input(M,"What do you want to name the weapon?", ,"", MAX_NAME_LEN)
+
+	if(src && input && !M.stat && in_range(M,src) && !M.restrained() && M.canmove)
+		name = input
+		M << "You name the weapon [input]. Say hello to your new friend."
+		return
+
+
+
 /obj/item/weapon/banhammer
 	desc = "A banhammer"
 	name = "banhammer"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -14,6 +14,7 @@
 	force = 5
 	origin_tech = "combat=1"
 	needs_permit = 1
+	unique_rename = 0
 	attack_verb = list("struck", "hit", "bashed")
 
 	var/fire_sound = "gunshot"
@@ -31,11 +32,8 @@
 	var/firing_burst = 0				//Prevent the weapon from firing again while already firing
 	var/semicd = 0						//cooldown handler
 	var/weapon_weight = WEAPON_LIGHT
-
 	var/spread = 0						//Spread induced by the gun itself.
 	var/randomspread = 1				//Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.
-
-	var/unique_rename = 0 //allows renaming with a pen
 	var/unique_reskin = 0 //allows one-time reskinning
 	var/current_skin = null //the skin choice if we had a reskin
 	var/list/options = list()
@@ -90,8 +88,6 @@
 		user << "It doesn't have a firing pin installed, and won't fire."
 	if(unique_reskin && !current_skin)
 		user << "<span class='notice'>Alt-click it to reskin it.</span>"
-	if(unique_rename)
-		user << "<span class='notice'>Use a pen on it to rename it.</span>"
 
 
 /obj/item/weapon/gun/proc/process_chamber()
@@ -305,10 +301,7 @@ obj/item/weapon/gun/proc/newshot()
 			for(var/datum/action/item_action/toggle_gunlight/TGL in actions)
 				qdel(TGL)
 
-	if(unique_rename)
-		if(istype(I, /obj/item/weapon/pen))
-			rename_gun(user)
-	..()
+
 
 /obj/item/weapon/gun/proc/toggle_gunlight()
 	set name = "Toggle Gunlight"
@@ -389,13 +382,6 @@ obj/item/weapon/gun/proc/newshot()
 		update_icon()
 
 
-/obj/item/weapon/gun/proc/rename_gun(mob/M)
-	var/input = stripped_input(M,"What do you want to name the gun?", ,"", MAX_NAME_LEN)
-
-	if(src && input && !M.stat && in_range(M,src) && !M.restrained() && M.canmove)
-		name = input
-		M << "You name the gun [input]. Say hello to your new friend."
-		return
 
 
 /obj/item/weapon/gun/proc/handle_suicide(mob/living/carbon/human/user, mob/living/carbon/human/target, params)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -37,7 +37,7 @@
 
 	if(unique_rename)
 		if(istype(A, /obj/item/weapon/pen))
-			rename_gun(user)
+			rename_weapon(user)
 
 /obj/item/weapon/gun/projectile/revolver/attack_self(mob/living/user)
 	var/num_unloaded = 0


### PR DESCRIPTION
:cl: Papa Bones
tweak: You can now rename the captain's sabre by using a pen on it.
/:cl:

Requested by some schmuck on the forums.

Allows for any weapon to use the unique_rename var.
