### PR TITLE
fixes burning thrown items in lava. (mostly)

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -242,6 +242,10 @@
 	if(burn_stuff(AM))
 		START_PROCESSING(SSobj, src)
 
+/turf/open/floor/plating/lava/hitby(atom/movable/AM)
+	if(burn_stuff(AM))
+		START_PROCESSING(SSobj, src)
+
 /turf/open/floor/plating/lava/process()
 	if(!burn_stuff())
 		STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
There is still an edge case this doesn't detect (if there is something else on the turf, that thing will receive the hit by,) and I don't feel like rewriting all of throwing code or adding snowflake to all thrown items to fix it.
