### PR TITLE
Makes surplus crate contents restricted by the gamemode

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -156,10 +156,14 @@ datum/supply_pack
 
 /datum/supply_pack/emergency/syndicate/fill(obj/structure/closet/crate/C)
 	var/crate_value = 50
+	var/list/uplink_items = get_uplink_items()
 	while(crate_value)
 		var/category = pick(uplink_items)
 		var/item = pick(uplink_items[category])
 		var/datum/uplink_item/I = uplink_items[category][item]
+
+		if(I.include_modes.len && !(ticker.mode in I.include_modes))
+			continue
 
 		if(!I.surplus || prob(100 - I.surplus))
 			continue

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -156,14 +156,11 @@ datum/supply_pack
 
 /datum/supply_pack/emergency/syndicate/fill(obj/structure/closet/crate/C)
 	var/crate_value = 50
-	var/list/uplink_items = get_uplink_items()
+	var/list/uplink_items = get_uplink_items(ticker.mode)
 	while(crate_value)
 		var/category = pick(uplink_items)
 		var/item = pick(uplink_items[category])
 		var/datum/uplink_item/I = uplink_items[category][item]
-
-		if(I.include_modes.len && !(ticker.mode in I.include_modes))
-			continue
 
 		if(!I.surplus || prob(100 - I.surplus))
 			continue

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -521,6 +521,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			deflecting all ranged weapon fire, but you also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/weapon/sleeping_carp_scroll
 	cost = 17
+	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 
 /datum/uplink_item/stealthy_weapons/throwingweapons

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1112,7 +1112,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 
 /datum/uplink_item/badass/surplus/spawn_item(turf/loc, obj/item/device/uplink/U)
-	var/list/uplink_items = get_uplink_items()
+	var/list/uplink_items = get_uplink_items(ticker.mode)
 
 	var/crate_value = 50
 	var/obj/structure/closet/crate/C = new(loc)
@@ -1139,7 +1139,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 0
 
 /datum/uplink_item/badass/random/spawn_item(turf/loc, obj/item/device/uplink/U)
-	var/list/uplink_items = get_uplink_items()
+	var/list/uplink_items = get_uplink_items(ticker.mode)
 	var/list/possible_items = list()
 	for(var/category in uplink_items)
 		for(var/item in uplink_items[category])


### PR DESCRIPTION
You will no longer be able to get nuke op items in the surplus crate or the random item.
Removes sleeping carp scroll from surplus crates
Fixes an edge case runtime when a null crate was ordered before an uplink was opened.

:cl: 
del: The surplus crate and random item will now only contain items allowed by the gamemode
del: removes sleeping carp scroll from surplus crates
/:cl:
Fixes #20335
