### PR TITLE
tesla grille nerf

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -271,9 +271,9 @@
 						if(dist <= 3)
 							closest_mob = A
 				if(closest_mob)
-					var/shock_damage = C.powernet.avail * 0.08
+					var/shock_damage = C.powernet.avail * 0.0002//setting shock damage for later. equals 1/5000 the power in the grid
 					src.Beam(closest_mob, icon_state="lightning[rand(1,12)]", icon='icons/effects/effects.dmi', time=5)
-					closest_mob.electrocute_act(shock_damage, src, 1, tesla_shock = 1)//ZAP for 1/5000 of the amount of power, which is from 15-25 with 200000W
+					closest_mob.electrocute_act(shock_damage, src, 1)//ZAP, damage should be about 40 with 200000W
 					playsound(src.loc, 'sound/magic/LightningShock.ogg', 100, 1, extrarange = 5)
 	take_damage(tforce)
 


### PR DESCRIPTION
So teslagrilles have been basically instakilling people since they were added. According to the comment that's also been with them since they were added, the intent was to divide the power under the grille by 5000, doing a moderate 40 damage at 200,000W. However, must have fucked up how they input it, since they only divided it by 12.5, meaning 200,000W would do 16,000 burn damage.

Yeah

(I might be wrong if powernet.avail isn't actually directly equal to the W in the power grid)
(This is untested)

:cl: 
fix: Tesla shocks from grilles will no longer do thousands and thousands of damage. They now properly deal burn damage that is equal to the current power in the powernet divided by 5000.
/:cl:
