### PR TITLE
Makes SpaceDrifting a subsystem

### DIFF
--- a/code/controllers/subsystem/spacedrift.dm
+++ b/code/controllers/subsystem/spacedrift.dm
@@ -1,0 +1,54 @@
+var/datum/subsystem/spacedrift/SSspacedrift
+
+/datum/subsystem/spacedrift
+	name = "Space Drift"
+	priority = 40
+	wait = 5
+	flags = SS_NO_INIT|SS_BACKGROUND
+
+	var/list/currentrun = list()
+	var/list/processing = list()
+
+/datum/subsystem/spacedrift/New()
+	NEW_SS_GLOBAL(SSspacedrift)
+
+
+/datum/subsystem/spacedrift/stat_entry()
+	..("P:[processing.len]")
+
+
+/datum/subsystem/spacedrift/fire(resumed = 0)
+	if (!resumed)
+		src.currentrun = processing.Copy()
+
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+
+	while (currentrun.len)
+		var/atom/movable/AM = currentrun[currentrun.len]
+		currentrun.len--
+		if (!AM)
+			processing -= AM
+			if (MC_TICK_CHECK)
+				return
+			continue
+		if (!AM.loc || AM.loc != AM.inertia_last_loc || AM.Process_Spacemove(0))
+			AM.inertia_dir = 0
+		if (!AM.inertia_dir)
+			AM.inertia_last_loc = null
+			processing -= AM
+			if (MC_TICK_CHECK)
+				return
+			continue
+
+		var/old_dir = AM.dir
+		var/old_loc = AM.loc
+		step(AM, AM.inertia_dir)
+		if (AM.loc == old_loc)
+			AM.inertia_dir = 0
+
+		AM.setDir(old_dir)
+		AM.inertia_last_loc = AM.loc
+		if (MC_TICK_CHECK)
+			return
+

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -13,6 +13,7 @@
 	var/verb_exclaim = "exclaims"
 	var/verb_yell = "yells"
 	var/inertia_dir = 0
+	var/inertia_last_loc
 	var/pass_flags = 0
 	var/moving_diagonally = 0 //0: not doing a diagonal move. 1 and 2: doing the first/second step of the diagonal move
 	glide_size = 8
@@ -71,18 +72,14 @@
 	last_move = direct
 	setDir(direct)
 
-	spawn(5)	// Causes space drifting. /tg/station has no concept of speed, we just use 5
-		if(loc && direct && last_move == direct)
-			if(loc == newloc) //Remove this check and people can accelerate. Not opening that can of worms just yet.
-				newtonian_move(last_move)
-
 	if(. && has_buckled_mobs() && !handle_buckled_mob_movement(loc,direct)) //movement failed due to buckled mob(s)
 		. = 0
 
 //Called after a successful Move(). By this point, we've already moved
 /atom/movable/proc/Moved(atom/OldLoc, Dir)
+	if (!inertia_dir)
+		newtonian_move(Dir)
 	return 1
-
 
 /atom/movable/Destroy()
 	. = ..()
@@ -172,13 +169,16 @@
 	if(pulledby)
 		return 1
 
+	if(throwing)
+		return 1
+
 	if(locate(/obj/structure/lattice) in range(1, get_turf(src))) //Not realistic but makes pushing things in space easier
 		return 1
 
 	return 0
 
-/atom/movable/proc/newtonian_move(direction) //Only moves the object if it's under no gravity
 
+/atom/movable/proc/newtonian_move(direction) //Only moves the object if it's under no gravity
 	if(!loc || Process_Spacemove(0))
 		inertia_dir = 0
 		return 0
@@ -186,10 +186,9 @@
 	inertia_dir = direction
 	if(!direction)
 		return 1
-
-	var/old_dir = dir
-	. = step(src, direction)
-	setDir(old_dir)
+	inertia_last_loc = loc
+	SSspacedrift.processing[src] = src
+	return 1
 
 /atom/movable/proc/checkpass(passflag)
 	return pass_flags&passflag
@@ -294,6 +293,7 @@
 				return 1
 
 		throw_impact(get_turf(src))  // we haven't hit something yet and we still must, let's hit the ground.
+	newtonian_move(init_dir)
 	return 1
 
 /atom/movable/proc/hitcheck()

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -49,6 +49,7 @@
 			for(var/A in tile)
 				if(is_cleanable(A))
 					qdel(A)
+	. = ..()
 
 
 /obj/vehicle/janicart/examine(mob/user)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -156,6 +156,7 @@
 #include "code\controllers\subsystem\radio.dm"
 #include "code\controllers\subsystem\server_maintenance.dm"
 #include "code\controllers\subsystem\shuttles.dm"
+#include "code\controllers\subsystem\spacedrift.dm"
 #include "code\controllers\subsystem\stickyban.dm"
 #include "code\controllers\subsystem\sun.dm"
 #include "code\controllers\subsystem\tgui.dm"


### PR DESCRIPTION
Sleeps and Spawns are costly, by moving it to a subsystem, we remove the 500 or so atoms drifting thru space each with their own spawn() cost, instead uniting it under the 1 sleep of the MC.

Doing this changed the total cost of Move() from 255s to 175s over 3.6 million calls, ie a ~30% reduction.

Reduces some lag from meteor and explosions (meta station is bearable on meteor mode now, but still laggy), increases the speed of explosions and throw by removing a bunch of their overhead.
