### PR TITLE
Fixes maploader being unable to load lattices.

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -38,7 +38,7 @@
 
 /turf/open/space/TakeTemperature(temp)
 
-/turf/open/space/proc/RemoveLattice()
+/turf/open/space/RemoveLattice()
 	return
 
 /turf/open/space/AfterChange()

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -38,6 +38,9 @@
 
 /turf/open/space/TakeTemperature(temp)
 
+/turf/open/space/proc/RemoveLattice()
+	return
+
 /turf/open/space/AfterChange()
 	..()
 	atmos_overlay_types.Cut()


### PR DESCRIPTION
maploader calls afterchange, afterchange calls removelattice, you know the rest.

because removelattice is only done on afterchange, it should never run for space turfs.
