### PR TITLE
Turning into a Lesser Ash Drake no longer makes all of lavaland love you

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -260,6 +260,7 @@ Difficulty: Medium
 	melee_damage_upper = 30
 	melee_damage_lower = 30
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
+	faction = list("neutral")
 	loot = list()
 
 /mob/living/simple_animal/hostile/megafauna/dragon/lesser/grant_achievement(medaltype,scoretype)


### PR DESCRIPTION
Previously if you turned into a lesser ash drake you'd gain factions that allowed you to fight lavaland monsters/bosses without retaliation. That is bad and very cheesable.
