### PR TITLE
Makes stoplag() less laggy

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1348,17 +1348,23 @@ proc/pick_closest_path(value)
 	CRASH(msg)
 
 //Key thing that stops lag. Cornerstone of performance in ss13, Just sitting here, in unsorted.dm.
+
+//Increases delay as the server gets more overloaded,
+//as sleeps aren't cheap and sleeping only to wake up and sleep again is wasteful
+#define DELTA_CALC max(((max(world.tick_usage, world.cpu) / 100) * max(Master.sleep_delta,1)), 1)
+
 /proc/stoplag()
-	. = 1
+	. = round(1*DELTA_CALC)
 	sleep(world.tick_lag)
 	if (world.tick_usage > TICK_LIMIT_TO_RUN) //woke up, still not enough tick, sleep for more.
-		. += 2
-		sleep(world.tick_lag*2)
+		. += round(2*DELTA_CALC)
+		sleep(world.tick_lag*2*DELTA_CALC)
 		if (world.tick_usage > TICK_LIMIT_TO_RUN) //woke up, STILL not enough tick, sleep for more.
-			. += 4
-			sleep(world.tick_lag*4)
+			. += round(4*DELTA_CALC)
+			sleep(world.tick_lag*4*DELTA_CALC)
 			//you might be thinking of adding more steps to this, or making it use a loop and a counter var
 			//	not worth it.
+#undef DELTA_CALC
 
 /proc/flash_color(mob_or_client, flash_color="#960000", flash_time=20)
 	var/client/C

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -35,6 +35,8 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	var/init_time
 	var/tickdrift = 0
 
+	var/sleep_delta
+
 	var/make_runtime = 0
 
 	// Has round started? (So we know what subsystems to run)
@@ -280,6 +282,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 
 		iteration++
 		last_run = world.time
+		src.sleep_delta = MC_AVERAGE_FAST(src.sleep_delta, sleep_delta)
 		sleep(world.tick_lag * (processing + sleep_delta))
 
 


### PR DESCRIPTION
By looking at world.cpu and mc's sleep_delta, we can get a rough prediction of how long we will need to sleep, rather then wake up, see the tick is already overran, sleep, rinse, repeat, cutting down on the amount of sleep()'s used in stoplag (and cutting down the overhead from those sleeps)

This sadly makes stoplag much more aggressive, and things under it much more slow, but the goal is to move most of the things on this to subsystems. Current targets are spacedrift (done in another pr), orbits, and throwing.

fixes #19868 (these stoplag() calls would wake up, find that world.tick_usage was still too high, sleep, and repeat, leading to 3 sleep call overheads, only to return, have the loop that called it run once, then call stoplag() again, this was stealing time from the MC.)
