### PR TITLE
Fix legion hivecore incorrect preserved method definition

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -834,7 +834,7 @@
 		healing injuries."
 
 /obj/item/organ/hivelord_core/legion/preserved(implanted = 0)
-	..(implanted)
+	..()
 	desc = "[src] has been stabilized. It no longer crackles with power, but it's healing properties are preserved indefinitely."
 
 /obj/item/weapon/legion_skull

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -833,8 +833,8 @@
 	desc = "[src] has become inert, it crackles no more and is useless for \
 		healing injuries."
 
-/obj/item/organ/hivelord_core/legion/preserved()
-	..()
+/obj/item/organ/hivelord_core/legion/preserved(implanted = 1)
+	..(implanted)
 	desc = "[src] has been stabilized. It no longer crackles with power, but it's healing properties are preserved indefinitely."
 
 /obj/item/weapon/legion_skull

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -833,7 +833,7 @@
 	desc = "[src] has become inert, it crackles no more and is useless for \
 		healing injuries."
 
-/obj/item/organ/hivelord_core/legion/preserved(implanted = 1)
+/obj/item/organ/hivelord_core/legion/preserved(implanted = 0)
 	..(implanted)
 	desc = "[src] has been stabilized. It no longer crackles with power, but it's healing properties are preserved indefinitely."
 


### PR DESCRIPTION
It will now correctly handle the implanted variable and pass it through to the parent so the handling can trigger
