### PR TITLE
Fixes byond triggering 511 client required needlessly

### DIFF
--- a/code/modules/admin/verbs/fps.dm
+++ b/code/modules/admin/verbs/fps.dm
@@ -7,18 +7,18 @@
 	if(!check_rights(R_DEBUG))
 		return
 
-	var/fps = round(input("Sets game frames-per-second. Can potentially break the game","FPS", config.fps) as num|null)
+	var/new_fps = round(input("Sets game frames-per-second. Can potentially break the game (default: [config.fps])","FPS", world.fps) as num|null)
 
-	if(fps <= 0)
-		src << "<span class='danger'>Error: ticklag(): Invalid world.ticklag value. No changes made.</span>"
+	if(new_fps <= 0)
+		src << "<span class='danger'>Error: set_server_fps(): Invalid world.fps value. No changes made.</span>"
 		return
-	if(fps > config.fps)
-		if(alert(src, "You are setting fps to a high value:\n\t[fps] frames-per-second\n\tconfig.fps = [config.fps]","Warning!","Confirm","ABORT-ABORT-ABORT") != "Confirm")
+	if(new_fps > config.fps*1.5)
+		if(alert(src, "You are setting fps to a high value:\n\t[new_fps] frames-per-second\n\tconfig.fps = [config.fps]","Warning!","Confirm","ABORT-ABORT-ABORT") != "Confirm")
 			return
 
-	var/msg = "[key_name(src)] has modified world.fps to [fps]"
+	var/msg = "[key_name(src)] has modified world.fps to [new_fps]"
 	log_admin(msg, 0)
 	message_admins(msg, 0)
 	feedback_add_details("admin_verb","TICKLAG") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-	world.fps = fps
+	world.fps = new_fps


### PR DESCRIPTION
511's compiler saw a access for `fps` in a client proc and assumed we were using client side fps, so it set the dmb's required client version to 511.

Fixing that will allow us to host the game using the 511 server, while still allowing 510 clients to connect.
