### PR TITLE
Add inacusiate to upgraded sleepers

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -19,7 +19,7 @@
 	var/controls_inside = FALSE
 	var/list/possible_chems = list(
 		list("epinephrine", "morphine", "salbutamol", "bicaridine", "kelotane"),
-		list("oculine"),
+		list("oculine","inacusiate"),
 		list("antitoxin", "mutadone", "mannitol", "pen_acid"),
 		list("omnizine")
 	)


### PR DESCRIPTION
Inacusiate instantly heals ear damage, but does not cure deafness. A sleeper with a nano-manipulator (or any better manipulator) will be able to inject this chem. This should benefit bombing survivors. 

:cl: Erwgd
add: Upgraded sleepers can now inject inacusiate to treat ear damage.
/:cl:
