### PR TITLE
Abandoned crates no longer have a 'z' in their code

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -11,7 +11,7 @@
 
 /obj/structure/closet/crate/secure/loot/New()
 	..()
-	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "z")
+	var/list/digits = list("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
 	code = ""
 	for(var/i = 0, i < codelen, i++)
 		var/dig = pick(digits)


### PR DESCRIPTION
If all the cheesing is gone let's at least make it intuitive and not "you won't open if you don't read the code"

:cl:
:tweak: Abandoned crates now only generates the code with 0-9 instead of 1-9 and z
/:cl:
