### PR TITLE
Observer huds now only trigger for mobs

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -500,7 +500,7 @@ var/next_mob_id = 0
 
 	var/mob/mob_eye = creatures[eye_name]
 	//Istype so we filter out points of interest that are not mobs
-	if(client && mob_eye && istype(mob_eye)
+	if(client && mob_eye && istype(mob_eye))
 		client.eye = mob_eye
 		if(isobserver(src))
 			src.client.screen = list()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -499,8 +499,8 @@ var/next_mob_id = 0
 		return
 
 	var/mob/mob_eye = creatures[eye_name]
-
-	if(client && mob_eye)
+	//Istype so we filter out points of interest that are not mobs
+	if(client && mob_eye && istype(mob_eye)
 		client.eye = mob_eye
 		if(isobserver(src))
 			src.client.screen = list()


### PR DESCRIPTION
getpois can return items that are not mobs, such as the capture the flag
machinery, so we avoid trying to set the observers hud for these items

Fixes another runtime
