### PR TITLE
Gives the double esword a stun.

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -245,6 +245,11 @@
 		return
 	if((wielded) && prob(50))
 		addtimer(src, "jedi_spin", 0, TRUE, user)
+	playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
+	user.Stun(3)
+	user.Weaken(3)
+	user.apply_effect(STUTTER, 3)
+
 
 /obj/item/weapon/twohanded/dualsaber/proc/jedi_spin(mob/living/user)
 	for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2))


### PR DESCRIPTION
:cl:
tweak: Added a stun to the double-esword.
/:cl:

a player was complaining that the double-esword was too easily countered
with stuns (which every player has several of in their  bag, because
validhunting) and that the esword being very easily concealed on top of
being a 3-4 hit murder weapon wasn't enough of an advantage. So i added
a stun effect to it in order to level the playing field a little. Stun
vs. stun.
