### PR TITLE
Ripley Speed Boost

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -2,7 +2,9 @@
 	desc = "Autonomous Power Loader Unit. This newer model is refitted with powerful armour against the dangers of the EVA mining process."
 	name = "\improper APLU \"Ripley\""
 	icon_state = "ripley"
-	step_in = 5
+	step_in = 4 //Move speed, lower is faster.
+	var/hi_pres_step_in = 4 //step_in while in high pressure.
+	var/lo_pres_step_in = 2 //step_in while in low/zero pressure.
 	max_temperature = 20000
 	health = 200
 	lights_power = 7
@@ -72,7 +74,7 @@
 	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE"
 	name = "\improper DEATH-RIPLEY"
 	icon_state = "deathripley"
-	step_in = 3
+	hi_pres_step_in = 3
 	opacity=0
 	lights_power = 7
 	wreckage = /obj/structure/mecha_wreckage/ripley/deathripley
@@ -150,11 +152,11 @@
 	var/pressure = environment.return_pressure()
 
 	if(pressure < 40)
-		step_in = 3
+		step_in = lo_pres_step_in
 		for(var/obj/item/mecha_parts/mecha_equipment/drill/drill in equipment)
 			drill.equip_cooldown = initial(drill.equip_cooldown)/2
 	else
-		step_in = 5
+		step_in = hi_pres_step_in
 		for(var/obj/item/mecha_parts/mecha_equipment/drill/drill in equipment)
 			drill.equip_cooldown = initial(drill.equip_cooldown)
 


### PR DESCRIPTION
:cl: Gun Hog
tweak: Nanotrasen Robotics Division is proud to announce slightly less clunky leg servo designs relating to the "Ripley" APLU and "Firefighter" exosuits. Tests show increased mobility in both high and low pressure environments. The previous designer has been fired for incompetence.
/:cl:

Ripley mechs are now faster!
- Standard and Firefighter Ripey mechs are faster both on station and in
  lavaland/space. (low pressure) by one level each.
- The Deathsquad (admin) Ripley is now faster in low pressure as well.

Inspiration for this PR may be found in this forum post: https://tgstation13.org/phpBB/viewtopic.php?f=10&t=7844&view=unread#p210861

It is my hope that this PR makes Ripley mechs great for mining again, and the on-station speed boost makes them tolerable to transport from Robotics to Mining.
