### PR TITLE
Megaphone no longer have special say code to handle their effect.

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -24,6 +24,7 @@
 #define SPAN_PAPYRUS "papyrus"
 #define SPAN_REALLYBIG "reallybig"
 #define SPAN_COMMAND "command_headset"
+#define SPAN_CLOWN "clown"
 
 //bitflag #defines for return value of the radio() proc.
 #define ITALICS 1

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -585,3 +585,8 @@ obj/item/proc/item_action_slot_check(slot, mob/user)
 		. = "<span class='notice'>[user] lights [A] with [src].</span>"
 	else
 		. = ""
+
+
+//when an item modify our speech spans when in our active hand. Override this to modify speech spans.
+/obj/item/proc/get_held_item_speechspans(mob/living/carbon/user)
+	return

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -6,54 +6,22 @@
 	w_class = 2
 	flags = FPRINT
 	siemens_coefficient = 1
-
 	var/spamcheck = 0
 	var/emagged = 0
-	var/insults = 0
-	var/voicespan = "command_headset" // sic
-	var/list/insultmsg = list("FUCK EVERYONE!", "DEATH TO LIZARDS!", "ALL SECURITY TO SHOOT ME ON SIGHT!", "I HAVE A BOMB!", "CAPTAIN IS A COMDOM!", "FOR THE SYNDICATE!", "VIVA!", "HONK!")
+	var/list/voicespan = list(SPAN_COMMAND)
 
-/obj/item/device/megaphone/attack_self(mob/living/carbon/human/user)
-	if(user.client)
-		if(user.client.prefs.muted & MUTE_IC)
-			src << "<span class='warning'>You cannot speak in IC (muted).</span>"
-			return
-
-	if(!ishuman(user))
-		user << "<span class='warning'>You don't know how to use this!</span>"
-		return
-
+/obj/item/device/megaphone/get_held_item_speechspans(mob/living/carbon/user)
 	if(spamcheck > world.time)
 		user << "<span class='warning'>\The [src] needs to recharge!</span>"
-		return
-
-	var/message = copytext(sanitize(input(user, "Shout a message?", "Megaphone", null)  as text),1,MAX_MESSAGE_LEN)
-	if(!message)
-		return
-
-	message = capitalize(message)
-	if(!user.can_speak(message))
-		user << "<span class='warning'>You find yourself unable to speak at all!</span>"
-		return
-
-	if ((src.loc == user && user.stat == 0))
-		if(emagged)
-			if(insults)
-				user.say(pick(insultmsg),"machine", list(voicespan))
-				insults--
-			else
-				user << "<span class='warning'>*BZZZZzzzzzt*</span>"
-		else
-			user.say(message,"machine", list(voicespan))
-
+	else
 		playsound(loc, 'sound/items/megaphone.ogg', 100, 0, 1)
 		spamcheck = world.time + 50
-		return
+		return voicespan
 
 /obj/item/device/megaphone/emag_act(mob/user)
 	user << "<span class='warning'>You overload \the [src]'s voice synthesizer.</span>"
 	emagged = 1
-	insults = rand(1, 3)	//to prevent dickflooding
+	voicespan = list(SPAN_REALLYBIG, "userdanger")
 
 /obj/item/device/megaphone/sec
 	name = "security megaphone"
@@ -71,4 +39,4 @@
 	name = "clown's megaphone"
 	desc = "Something that should not exist."
 	icon_state = "megaphone-clown"
-	voicespan = "clown"
+	voicespan = list(SPAN_CLOWN)

--- a/code/modules/mob/living/carbon/say.dm
+++ b/code/modules/mob/living/carbon/say.dm
@@ -24,3 +24,7 @@
 	var/obj/item/organ/tongue/T = getorganslot("tongue")
 	if(T)
 		. |= T.get_spans()
+
+	var/obj/item/I = get_active_held_item()
+	if(I)
+		. |= I.get_held_item_speechspans(src)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -92,10 +92,11 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 
 	if(message_mode != MODE_WHISPER) //whisper() calls treat_message(); double process results in "hisspering"
 		message = treat_message(message)
-	spans += get_spans()
 
 	if(!message)
 		return
+
+	spans += get_spans()
 
 	//Log of what we've said, plain message, no spans or junk
 	say_log += message


### PR DESCRIPTION
:cl: phil235
tweak: You no longer have to click a megaphone to use it, you simply keep it in your active hand and talk normally.
/:cl:
- The megaphone is no longer used by clicking it and entering a message, you simply keep it in your active hand and talk normally.
- Removes the insults feature of the emagged megaphone because it does pretty much nothing good (and stops working after three messages).
- The span of the emagged megaphone is now big and red.
- Made some things into defines like they should.
- The speech bubble shown when using a megaphone is now a default speech bubble as opposed to a 'machine' bubble.
