### PR TITLE
Fixes a bit of brasscode

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -346,17 +346,12 @@
 
 /obj/machinery/door/window/clockwork/New(loc, set_dir)
 	..()
-	if(set_dir)
-		var/obj/effect/E = PoolOrNew(/obj/effect/overlay/temp/ratvar/door/window, get_turf(src))
-		setDir(set_dir)
-		E.setDir(set_dir)
-		made_glow = TRUE
-	debris += new/obj/item/stack/sheet/brass(src)
+	debris += new/obj/item/stack/sheet/brass(src, 2)
 	change_construction_value(2)
 
 /obj/machinery/door/window/clockwork/setDir(direct)
 	if(!made_glow)
-		var/obj/effect/E = PoolOrNew(/obj/effect/overlay/temp/ratvar/window/single, get_turf(src))
+		var/obj/effect/E = PoolOrNew(/obj/effect/overlay/temp/ratvar/door/window, get_turf(src))
 		E.setDir(direct)
 		made_glow = TRUE
 	..()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -391,6 +391,7 @@
 	icon = 'icons/obj/smooth_structures/brass_table.dmi'
 	icon_state = "brass_table"
 	frame = /obj/structure/table_frame/brass
+	framestack = /obj/item/stack/sheet/brass
 	buildstack = /obj/item/stack/sheet/brass
 	framestackamount = 1
 	buildstackamount = 1

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -516,19 +516,20 @@
 
 /obj/structure/window/reinforced/clockwork/New(loc, direct)
 	..()
+	for(var/obj/item/I in debris)
+		debris -= I
+		qdel(I)
 	if(!fulltile)
 		if(direct)
 			var/obj/effect/E = PoolOrNew(/obj/effect/overlay/temp/ratvar/window/single, get_turf(src))
 			setDir(direct)
 			E.setDir(direct)
 			made_glow = TRUE
+		debris += new/obj/item/stack/sheet/brass(src, 1)
 	else
 		PoolOrNew(/obj/effect/overlay/temp/ratvar/window, get_turf(src))
 		made_glow = TRUE
-	for(var/obj/item/I in debris)
-		debris -= I
-		qdel(I)
-	debris += new/obj/item/stack/sheet/brass(src)
+		debris += new/obj/item/stack/sheet/brass(src, 2)
 	change_construction_value(fulltile ? 3 : 2)
 
 /obj/structure/window/reinforced/clockwork/setDir(direct)


### PR DESCRIPTION
Brass tables now properly drop more brass instead of rods.
Brass windows/windoors drop brass equal to the amount used to construct them; magic clockwork brass is real hard to destroy.
Fixes excessive glow creation on brass windoors.
