### PR TITLE
Sanity check circuit var is a path to a type before trying to construct an instance of it

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -19,7 +19,10 @@
 	..(location)
 	if(C && istype(C))
 		circuit = C
-	else if(circuit)
+	//Some machines, oldcode arcades mostly, new themselves, so circuit
+	//can already be an instance of a type and trying to new that will
+	//cause a runtime
+	else if(ispath(circuit))
 		circuit = new circuit(null)
 	power_change()
 	update_icon()


### PR DESCRIPTION
Some old code (arcades primarily) src.New themselves, which means circuit
is already a type when this code runs and so it trys to new the type and
throws a confusing runtime

Credit to @GinjaNinja32 for spotting bug and suggesting the fix

TODO: rewrite arcades, like completely
