### PR TITLE
Makes Alien Alloy give roughly 1/3rd of supply points via exporting and prevents it from being able to be made in a protolathe

### DIFF
--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -114,7 +114,7 @@
 // Major players would pay a lot to get some, so you can get a lot of money from producing and selling those.
 // Just don't forget to fire all your production staff before the end of month.
 /datum/export/stack/abductor
-	cost = 10000
+	cost = 3500
 	message = "of alien alloy"
 	export_types = list(/obj/item/stack/sheet/mineral/abductor)
 

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -571,14 +571,3 @@ datum/design/diagnostic_hud_night
 	materials = list(MAT_METAL = 1000, MAT_GLASS = 500, MAT_PLASMA = 1500, MAT_URANIUM = 200)
 	build_path = /obj/item/weapon/weldingtool/experimental
 	category = list("Equipment")
-
-
-/datum/design/alienalloy
-	name = "Alien Alloy"
-	desc = "A sheet of reverse-engineered alien alloy."
-	id = "alienalloy"
-	req_tech = list("abductor" = 1, "materials" = 7, "plasmatech" = 2)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 4000, MAT_PLASMA = 4000)
-	build_path = /obj/item/stack/sheet/mineral/abductor
-	category = list("Stock Parts")

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -579,6 +579,6 @@ datum/design/diagnostic_hud_night
 	id = "alienalloy"
 	req_tech = list("abductor" = 1, "materials" = 7, "plasmatech" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 12000, MAT_PLASMA = 12000)
+	materials = list(MAT_METAL = 4000, MAT_PLASMA = 4000)
 	build_path = /obj/item/stack/sheet/mineral/abductor
 	category = list("Stock Parts")

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -579,6 +579,6 @@ datum/design/diagnostic_hud_night
 	id = "alienalloy"
 	req_tech = list("abductor" = 1, "materials" = 7, "plasmatech" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 4000, MAT_PLASMA = 4000)
+	materials = list(MAT_METAL = 12000, MAT_PLASMA = 12000)
 	build_path = /obj/item/stack/sheet/mineral/abductor
 	category = list("Stock Parts")


### PR DESCRIPTION
:cl: Something Something
tweak: Alien Alloy will now provide only 3500 supply points instead of 10000 per sheet
delete: No longer can make alien alloy with a protolathe
/:cl:

Fixes https://github.com/tgstation/tgstation/issues/20495
Alien Alloy is used to multiple the profits of plasma, expect you shouldn't be able to get over 500% increase

EDIT: Does some fun stuff that makes alien alloy no longer producible in a protolathe, cause that's some bullshit
(ma44 is nerfing cargo exports, what kind of drugs is he on)
