### PR TITLE
Cult: Counterplay Edition

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -67,16 +67,12 @@ This file contains the arcane tome files.
 	invoking it and choosing which talisman you desire, the paper will be converted, after some delay into a talisman.<br><br>"
 
 	text += "<font color='red'><b>Teleport</b></font><br>This rune is unique in that it requires a keyword before the scribing can begin. When invoked, it will find any other Teleport runes; \
-	If any are found, the user can choose which rune to send to. Upon activation, the rune teleports everything above it to the selected rune.<br><br>"
+	If any are found, the user can choose which rune to send to. Upon activation, the rune teleports everything above it to the selected rune, provided the selected rune is unblocked.<br><br>"
 
-	text += "<font color='red'><b>Convert</b></font><br>This rune is critical to the success of the cult. It will allow you to convert normal crew members into cultists. \
-	To do this, simply place the crew member upon the rune and invoke it. This rune requires two invokers to use. If the target to be converted is mindshield-implanted or a certain assignment, they will \
-	be unable to be converted. People the Geometer wishes sacrificed will also be ineligible for conversion, and anyone with a shielding presence like the null rod will not be converted.<br> \
-	Successful conversions will produce a tome for the new cultist.<br><br>"
-
-	text += "<font color='red'><b>Sacrifice</b></font><br><b>This rune is necessary to achieve your goals.</b> Simply place any dead creature upon the rune and invoke it (this will not \
-	target cultists!). If this creature has a mind, a soulstone will be created and the creature's soul transported to it. Sacrificing the dead can be done alone, but sacrificing living crew <b>or your cult's target</b> will require 3 cultists. \
-	Soulstones used on construct shells will move that soul into a powerful construct of your choice.<br><br>"
+	text += "<font color='red'><b>Offer</b></font><br><b>This rune is necessary to achieve your goals.</b> Placing a noncultist above it will convert them if it can and sacrifice them otherwise. \
+	It requires two invokers to convert a target and three to sacrifice a living target or the sacrifice target.<br>\
+	Successful conversions will produce a tome for the new cultist, in addition to healing them.<br> \
+	Successful sacrifices will please the Geometer, can complete your objective if it sacrificed the sacrifice target, and will attempt to place the target into a soulstone.<br><br>"
 
 	text += "<font color='red'><b>Raise Dead</b></font><br>This rune requires two corpses. To perform the ritual, place the corpse you wish to revive onto \
 	the rune and the offering body adjacent to it. When the rune is invoked, the body to be sacrificed will turn to dust, the life force flowing into the revival target. Assuming the target is not moved \
@@ -91,14 +87,14 @@ This file contains the arcane tome files.
 	The body will also take constant damage while in this form, and may even die. The user's spirit will contain their consciousness, and will allow them to freely wander the station as a ghost. This may \
 	also be used to commune with the dead.<br><br>"
 
-	text += "<font color='red'><b>Form Barrier</b></font><br>While simple, this rune serves an important purpose in defense and hindering passage. When invoked, the \
-	rune will draw a small amount of life force from the user and make the space above the rune completely dense, rendering it impassable to all but the most complex means. The rune may be invoked again to \
-	undo this effect and allow passage again.<br><br>"
+	text += "<font color='red'><b>Form Barrier</b></font><br>While simple, this rune serves an important purpose in defense and hindering passage. When invoked, the rune will draw a small amount of blood from the user \
+	and make the space above the rune completely dense, rendering it impassable for about a minute and a half. This effect will spread to other nearby Barrier Runes. \
+	The rune may be invoked again to undo this effect and allow passage again.<br><br>"
 
 	text += "<font color='red'><b>Summon Cultist</b></font><br>This rune allows the cult to free other cultists with ease. When invoked, it will allow the user to summon a single cultist to the rune from \
 	any location. It requires two invokers, and will damage each invoker slightly.<br><br>"
 
-	text += "<font color='red'><b>Blood Boil</b></font><br>When invoked, this rune will do a massive amount of damage to all non-cultist viewers, but it will also emit a small explosion upon invocation. \
+	text += "<font color='red'><b>Blood Boil</b></font><br>When invoked, this rune will rapidly do a massive amount of damage to all non-cultist viewers, but it will also emit a burst of flame once it finishes. \
 	It requires three invokers.<br><br>"
 
 	text += "<font color='red'><b>Drain Life</b></font><br>This rune will drain the life of every living creature above the rune, healing the invoker for each creature drained by it.<br><br>"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -753,6 +753,7 @@ var/list/wall_runes = list()
 
 /obj/effect/rune/wall/invoke(var/list/invokers)
 	if(recharging)
+		fail_invoke()
 		return
 	var/mob/living/user = invokers[1]
 	..()
@@ -762,7 +763,7 @@ var/list/wall_runes = list()
 	if(density)
 		spread_density()
 	user.visible_message("<span class='warning'>[user] [iscarbon(user) ? "places their hands on":"stares intently at"] [src], and [density ? "the air above it begins to shimmer" : "the shimmer above it fades"].</span>", \
-						 "<span class='cultitalic'>You channel your life energy into [src], [density ? "preventing" : "allowing"] passage above it.</span>")
+						 "<span class='cultitalic'>You channel your life energy into [src], [density ? "temporarily preventing" : "allowing"] passage above it.</span>")
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.apply_damage(2, BRUTE, pick("l_arm", "r_arm"))
@@ -770,7 +771,7 @@ var/list/wall_runes = list()
 /obj/effect/rune/wall/proc/spread_density()
 	for(var/R in wall_runes)
 		var/obj/effect/rune/wall/W = R
-		if(W.z == z && get_dist(src, W) <= 2 && !W.density)
+		if(W.z == z && get_dist(src, W) <= 2 && !W.density && !W.recharging)
 			W.density = TRUE
 			W.update_state()
 			W.spread_density()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -757,7 +757,6 @@ var/list/wall_runes = list()
 	var/mob/living/user = invokers[1]
 	..()
 	density = !density
-	air_update_turf(1)
 	update_state()
 	if(density)
 		spread_density()
@@ -791,6 +790,7 @@ var/list/wall_runes = list()
 
 /obj/effect/rune/wall/proc/update_state()
 	deltimer(density_timer)
+	air_update_turf(1)
 	if(density)
 		var/image/I = image(layer = ABOVE_MOB_LAYER, icon = 'icons/effects/effects.dmi', icon_state = "barriershimmer")
 		I.appearance_flags = RESET_COLOR

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -23,7 +23,7 @@ To draw a rune, use an arcane tome.
 	icon_state = "1"
 	unacidable = 1
 	layer = ABOVE_NORMAL_TURF_LAYER
-	color = rgb(255,0,0)
+	color = "#FF0000"
 
 	var/invocation = "Aiy ele-mayo!" //This is said by cultists when the rune is invoked.
 	var/req_cultists = 1 //The amount of cultists required around the rune to invoke it. If only 1, any cultist can invoke it.
@@ -191,7 +191,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	cultist_desc = "transforms paper into powerful magic talismans."
 	invocation = "H'drak v'loso, mir'kanas verbot!"
 	icon_state = "3"
-	color = rgb(0, 0, 255)
+	color = "#0000FF"
 
 /obj/effect/rune/imbue/invoke(var/list/invokers)
 	var/mob/living/user = invokers[1] //the first invoker is always the user
@@ -332,7 +332,7 @@ var/list/teleport_runes = list()
 	req_cultists_text = "2 for conversion, 3 for living sacrifices and sacrifice targets."
 	invocation = "Mah'weyh pleggh at e'ntrath!"
 	icon_state = "3"
-	color = rgb(255, 255, 255)
+	color = "#FFFFFF"
 	req_cultists = 1
 	allow_excess_invokers = 1
 	rune_in_use = FALSE
@@ -351,7 +351,7 @@ var/list/teleport_runes = list()
 		return
 	rune_in_use = TRUE
 	visible_message("<span class='warning'>[src] pulses blood red!</span>")
-	color = rgb(126, 23, 23)
+	color = "#7D1717"
 	..()
 	var/mob/living/L = pick(myriad_targets)
 	var/is_clock = is_servant_of_ratvar(L)
@@ -442,7 +442,7 @@ var/list/teleport_runes = list()
 	invocation = "TOK-LYR RQA-NAP G'OLT-ULOFT!!"
 	req_cultists = 9
 	icon = 'icons/effects/96x96.dmi'
-	color = rgb(125,23,23)
+	color = "#7D1717"
 	icon_state = "rune_large"
 	pixel_x = -32 //So the big ol' 96x96 sprite shows up right
 	pixel_y = -32
@@ -491,7 +491,7 @@ var/list/teleport_runes = list()
 	var/turf/T = get_turf(src)
 	sleep(40)
 	if(src)
-		color = rgb(255, 0, 0)
+		color = "#FF0000"
 	new /obj/singularity/narsie/large(T) //Causes Nar-Sie to spawn even if the rune has been removed
 	if(cult_mode)
 		cult_mode.eldergod = 0
@@ -517,7 +517,7 @@ var/list/teleport_runes = list()
 	cultist_desc = "requires two corpses, one on the rune and one adjacent to the rune. The one on the rune is brought to life, the other is turned to ash."
 	invocation = null //Depends on the name of the user - see below
 	icon_state = "1"
-	color = rgb(200, 0, 0)
+	color = "#C80000"
 
 /obj/effect/rune/raise_dead/invoke(var/list/invokers)
 	var/turf/T = get_turf(src)
@@ -623,7 +623,7 @@ var/list/teleport_runes = list()
 	invocation = "Ta'gh fara'qha fel d'amar det!"
 	icon_state = "5"
 	allow_excess_invokers = 1
-	color = rgb(77, 148, 255)
+	color = "#4D94FF"
 
 /obj/effect/rune/emp/invoke(var/list/invokers)
 	var/turf/E = get_turf(src)
@@ -653,7 +653,7 @@ var/list/teleport_runes = list()
 	cultist_desc = "severs the link between one's spirit and body. This effect is taxing and one's physical body will take damage while this is active."
 	invocation = "Fwe'sh mah erl nyag r'ya!"
 	icon_state = "7"
-	color = rgb(126, 23, 23)
+	color = "#7D1717"
 	rune_in_use = 0 //One at a time, please!
 	construct_invoke = 0
 	var/mob/living/affecting = null
@@ -726,7 +726,7 @@ var/list/wall_runes = list()
 	cultist_desc = "when invoked, makes a temporary invisible wall to block passage. Can be invoked again to reverse this."
 	invocation = "Khari'd! Eske'te tannin!"
 	icon_state = "1"
-	color = rgb(255, 0, 0)
+	color = "#C80000"
 	var/density_timer
 	var/recharging = FALSE
 
@@ -753,7 +753,6 @@ var/list/wall_runes = list()
 
 /obj/effect/rune/wall/invoke(var/list/invokers)
 	if(recharging)
-		fail_invoke()
 		return
 	var/mob/living/user = invokers[1]
 	..()
@@ -781,8 +780,9 @@ var/list/wall_runes = list()
 	if(density)
 		recharging = TRUE
 		density = FALSE
-		color = "#696969"
 		update_state()
+		color = "#696969"
+		animate(src, color = initial(color), time = 50, easing = EASE_IN)
 		addtimer(src, "recharge", 50)
 
 /obj/effect/rune/wall/proc/recharge()
@@ -797,8 +797,10 @@ var/list/wall_runes = list()
 		I.alpha = 60
 		I.color = "#701414"
 		add_overlay(I)
+		color = "#FF0000"
 	else
 		cut_overlays()
+		color = "#C80000"
 
 //Rite of Joined Souls: Summons a single cultist.
 /obj/effect/rune/summon
@@ -808,7 +810,7 @@ var/list/wall_runes = list()
 	req_cultists = 2
 	allow_excess_invokers = 1
 	icon_state = "5"
-	color = rgb(0, 255, 0)
+	color = "#00FF00"
 
 /obj/effect/rune/summon/invoke(var/list/invokers)
 	var/mob/living/user = invokers[1]
@@ -853,7 +855,7 @@ var/list/wall_runes = list()
 	cultist_desc = "boils the blood of non-believers who can see the rune, rapidly dealing extreme amounts of damage. Requires 3 invokers."
 	invocation = "Dedo ol'btoh!"
 	icon_state = "4"
-	color = rgb(200, 0, 0)
+	color = "#C80000"
 	req_cultists = 3
 	construct_invoke = 0
 	var/tick_damage = 25
@@ -919,7 +921,7 @@ var/list/wall_runes = list()
 	cultist_desc = "drains the life of all targets on the rune, restoring life to the user."
 	invocation = "Yu'gular faras desdae. Umathar uf'kal thenar!"
 	icon_state = "3"
-	color = rgb(159, 28, 52)
+	color = "#9F1C34"
 
 /obj/effect/rune/leeching/can_invoke(mob/living/user)
 	if(world.time <= user.next_move)
@@ -958,7 +960,7 @@ var/list/wall_runes = list()
 	invocation = "Gal'h'rfikk harfrandid mud'gib!" //how the fuck do you pronounce this
 	icon_state = "6"
 	construct_invoke = 0
-	color = rgb(200, 0, 0)
+	color = "#C80000"
 
 /obj/effect/rune/manifest/New(loc)
 	..()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -137,6 +137,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 		for(var/M in invokers)
 			var/mob/living/L = M
 			L.say(invocation)
+	do_invoke_glow()
+
+/obj/effect/rune/proc/do_invoke_glow()
 	var/oldtransform = transform
 	spawn(0) //animate is a delay, we want to avoid being delayed
 		animate(src, transform = matrix()*2, alpha = 0, time = 5) //fade out
@@ -296,6 +299,11 @@ var/list/teleport_runes = list()
 		return
 
 	var/turf/T = get_turf(src)
+	var/turf/target = get_turf(actual_selected_rune)
+	if(is_blocked_turf(target))
+		user << "<span class='warning'>The target rune is blocked. Attempting to teleport to it would be massively unwise.</span>"
+		fail_invoke()
+		return
 	var/movedsomething = 0
 	var/moveuserlater = 0
 	for(var/atom/movable/A in T)
@@ -305,158 +313,130 @@ var/list/teleport_runes = list()
 			continue
 		if(!A.anchored)
 			movedsomething = 1
-			A.forceMove(get_turf(actual_selected_rune))
+			A.forceMove(target)
 	if(movedsomething)
 		..()
 		visible_message("<span class='warning'>There is a sharp crack of inrushing air, and everything above the rune disappears!</span>")
 		user << "<span class='cult'>You[moveuserlater ? "r vision blurs, and you suddenly appear somewhere else":" send everything above the rune away"].</span>"
 		if(moveuserlater)
-			user.forceMove(get_turf(actual_selected_rune))
+			user.forceMove(target)
 	else
 		fail_invoke()
 
 
-//Rite of Enlightenment: Converts a normal crewmember to the cult.
-/obj/effect/rune/convert
-	cultist_name = "Convert"
-	cultist_desc = "converts a normal crewmember on top of it to the cult. Does not work on mindshield-implanted crew."
+//Rite of Offering: Converts or sacrifices a target.
+/obj/effect/rune/offer
+	cultist_name = "Offer"
+	cultist_desc = "offers a noncultist above it to Nar-Sie, either converting them or sacrificing them."
 	invocation = "Mah'weyh pleggh at e'ntrath!"
 	icon_state = "3"
-	color = rgb(200, 0, 0)
-	req_cultists = 2
-
-/obj/effect/rune/convert/invoke(var/list/invokers)
-	var/list/convertees = list()
-	var/turf/T = get_turf(src)
-	for(var/mob/living/M in T)
-		if(M.stat != DEAD && !iscultist(M) && is_convertable_to_cult(M.mind))
-			convertees |= M
-		else if(is_sacrifice_target(M.mind))
-			for(var/C in invokers)
-				C << "<span class='cultlarge'>\"I desire this one for myself. <i>SACRIFICE THEM!</i>\"</span>"
-		else if(is_servant_of_ratvar(M))
-			M.visible_message("<span class='warning'>[M]'s eyes glow a defiant yellow!</span>", \
-			"<span class='cultlarge'>\"Stop resisting. You <i>will</i> be mi-\"</span> <span class='large_brass'>\"Give up and you will feel pain unlike anything you've ever felt!\"</span>")
-			M.Weaken(4)
-	if(!convertees.len)
-		fail_invoke()
-		log_game("Convert rune failed - no eligible convertees")
-		return
-	var/mob/living/new_cultist = pick(convertees)
-	if(new_cultist.null_rod_check())
-		for(var/M in invokers)
-			M << "<span class='warning'>Something is shielding [new_cultist]'s mind!</span>"
-		fail_invoke()
-		log_game("Convert rune failed - convertee had null rod")
-		return
-	..()
-	new_cultist.visible_message("<span class='warning'>[new_cultist] writhes in pain as the markings below them glow a bloody red!</span>", \
-					  			"<span class='cultlarge'><i>AAAAAAAAAAAAAA-</i></span>")
-	ticker.mode.add_cultist(new_cultist.mind, 1)
-	new /obj/item/weapon/tome(get_turf(src))
-	new_cultist.mind.special_role = "Cultist"
-	new_cultist << "<span class='cultitalic'><b>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible, truth. The veil of reality has been ripped away \
-	and something evil takes root.</b></span>"
-	new_cultist << "<span class='cultitalic'><b>Assist your new compatriots in their dark dealings. Your goal is theirs, and theirs is yours. You serve the Geometer above all else. Bring it back.\
-	</b></span>"
-
-//Rite of Tribute: Sacrifices a crew member to Nar-Sie. Places them into a soul shard if they're in their body.
-/obj/effect/rune/sacrifice
-	cultist_name = "Sacrifice"
-	cultist_desc = "sacrifices a crew member to the Geometer. May place them into a soul shard if their spirit remains in their body."
-	icon_state = "3"
-	allow_excess_invokers = 1
-	invocation = "Barhah hra zar'garis!"
 	color = rgb(255, 255, 255)
-	rune_in_use = 0
+	req_cultists = 1
+	allow_excess_invokers = 1
+	rune_in_use = FALSE
 
-/obj/effect/rune/sacrifice/New()
-	..()
-	icon_state = "[rand(1,7)]"
-
-/obj/effect/rune/sacrifice/invoke(var/list/invokers)
+/obj/effect/rune/offer/invoke(var/list/invokers)
 	if(rune_in_use)
 		return
-	rune_in_use = 1
-	var/mob/living/user = invokers[1] //the first invoker is always the user
+	var/list/myriad_targets = list()
 	var/turf/T = get_turf(src)
-	var/list/possible_targets = list()
-	for(var/mob/living/M in T.contents)
-		if(M.mind)
-			if(M.mind in sacrificed)
-				continue
+	for(var/mob/living/M in T)
 		if(!iscultist(M))
-			possible_targets.Add(M)
-	var/mob/offering
-	if(possible_targets.len > 1) //If there's more than one target, allow choice
-		offering = input(user, "Choose an offering to sacrifice.", "Unholy Tribute") as null|anything in possible_targets
-		if(!Adjacent(user) || !src || qdeleted(src) || user.incapacitated())
-			return
-	else if(possible_targets.len) //Otherwise, if there's a target at all, pick the only one
-		offering = possible_targets[possible_targets.len]
-	if(!offering)
-		rune_in_use = 0
-		return
-	/*var/obj/item/weapon/nullrod/N = offering.null_rod_check()
-	if(N)
-		user << "<span class='warning'>Something is blocking the Geometer's magic!</span>"
-		log_game("Sacrifice rune failed - target has \a [N]!")
+			myriad_targets |= M
+	if(!myriad_targets.len)
 		fail_invoke()
-		rune_in_use = 0
-		return*/
-	if(((ishuman(offering) || isrobot(offering)) && offering.stat != DEAD) || is_sacrifice_target(offering.mind)) //Requires three people to sacrifice living targets
-		if(invokers.len < 3)
-			for(var/M in invokers)
-				M << "<span class='cultitalic'>[offering] is too greatly linked to the world! You need three acolytes!</span>"
-			fail_invoke()
-			log_game("Sacrifice rune failed - not enough acolytes and target is living")
-			rune_in_use = 0
-			return
+		log_game("Offer rune failed - no eligible targets")
+		return
+	rune_in_use = TRUE
 	visible_message("<span class='warning'>[src] pulses blood red!</span>")
 	color = rgb(126, 23, 23)
 	..()
-	sac(invokers, offering)
+	var/mob/living/L = pick(myriad_targets)
+	if(is_servant_of_ratvar(L))
+		L.visible_message("<span class='warning'>[L]'s eyes glow a defiant yellow!</span>", \
+		"<span class='cultlarge'>\"Stop resisting. You <i>will</i> be mi-\"</span>\n\
+		<span class='large_brass'>\"Give up and you will feel pain unlike anything you've ever felt!\"</span>")
+		L.Weaken(4)
+	else if(L.stat != DEAD && is_convertable_to_cult(L.mind))
+		do_convert(L, invokers)
+	else
+		do_sacrifice(L, invokers)
 	color = initial(color)
+	rune_in_use = FALSE
 
-/obj/effect/rune/sacrifice/proc/sac(var/list/invokers, mob/living/T)
-	var/sacrifice_fulfilled
-	if(T)
-		if(istype(T, /mob/living/simple_animal/pet/dog))
-			for(var/M in invokers)
-				var/mob/living/L = M
-				L << "<span class='cultlarge'>\"Even I have standards, such as they are!\"</span>"
-				if(L.reagents)
-					L.reagents.add_reagent("hell_water", 2)
-		if(T.mind)
-			sacrificed.Add(T.mind)
-			if(is_sacrifice_target(T.mind))
-				sacrifice_fulfilled = 1
-		PoolOrNew(/obj/effect/overlay/temp/cult/sac, src.loc)
+/obj/effect/rune/offer/proc/do_convert(mob/living/convertee, list/invokers)
+	if(invokers.len < 2)
 		for(var/M in invokers)
-			if(sacrifice_fulfilled)
-				M << "<span class='cultlarge'>\"Yes! This is the one I desire! You have done well.\"</span>"
-			else
-				if(ishuman(T) || isrobot(T))
-					M << "<span class='cultlarge'>\"I accept this sacrifice.\"</span>"
-				else
-					M << "<span class='cultlarge'>\"I accept this meager sacrifice.\"</span>"
-		if(T.mind)
-			var/obj/item/device/soulstone/stone = new /obj/item/device/soulstone(get_turf(src))
-			stone.invisibility = INVISIBILITY_MAXIMUM //so it's not picked up during transfer_soul()
-			if(!stone.transfer_soul("FORCE", T, usr)) //If it cannot be added
-				qdel(stone)
-			if(stone)
-				stone.invisibility = 0
-			if(!T)
-				rune_in_use = 0
-				return
-		if(isrobot(T))
-			playsound(T, 'sound/magic/Disable_Tech.ogg', 100, 1)
-			T.dust() //To prevent the MMI from remaining
+			M << "<span class='warning'>You need more invokers to convert [convertee]!</span>"
+		log_game("Offer rune failed - tried conversion with one invoker")
+		return 0
+	if(convertee.null_rod_check())
+		for(var/M in invokers)
+			M << "<span class='warning'>Something is shielding [convertee]'s mind!</span>"
+		log_game("Offer rune failed - convertee had null rod")
+		return 0
+	var/brutedamage = convertee.getBruteLoss()
+	var/burndamage = convertee.getFireLoss()
+	if(brutedamage || burndamage)
+		convertee.adjustBruteLoss(-brutedamage)
+		convertee.adjustFireLoss(-burndamage)
+	convertee.visible_message("<span class='warning'>[convertee] writhes in pain \
+	[brutedamage || burndamage ? "even as their wounds heal and close" : "as the markings below them glow a bloody red"]!</span>", \
+ 	"<span class='cultlarge'><i>AAAAAAAAAAAAAA-</i></span>")
+	ticker.mode.add_cultist(convertee.mind, 1)
+	new /obj/item/weapon/tome(get_turf(src))
+	convertee.mind.special_role = "Cultist"
+	convertee << "<span class='cultitalic'><b>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible, truth. The veil of reality has been ripped away \
+	and something evil takes root.</b></span>"
+	convertee << "<span class='cultitalic'><b>Assist your new compatriots in their dark dealings. Your goal is theirs, and theirs is yours. You serve the Geometer above all else. Bring it back.\
+	</b></span>"
+	return 1
+
+/obj/effect/rune/offer/proc/do_sacrifice(mob/living/sacrificial, list/invokers)
+	if((((ishuman(sacrificial) || isrobot(sacrificial)) && sacrificial.stat != DEAD) || is_sacrifice_target(sacrificial.mind)) && invokers.len < 3)
+		for(var/M in invokers)
+			M << "<span class='cultitalic'>[sacrificial] is too greatly linked to the world! You need three acolytes!</span>"
+		log_game("Offer rune failed - not enough acolytes and target is living or target")
+		return 0
+	var/sacrifice_fulfilled
+	if(istype(sacrificial, /mob/living/simple_animal/pet/dog))
+		for(var/M in invokers)
+			var/mob/living/L = M
+			L << "<span class='cultlarge'>\"Even I have standards, such as they are!\"</span>"
+			if(L.reagents)
+				L.reagents.add_reagent("hell_water", 2)
+
+	if(sacrificial.mind)
+		sacrificed.Add(sacrificial.mind)
+		if(is_sacrifice_target(sacrificial.mind))
+			sacrifice_fulfilled = 1
+
+	PoolOrNew(/obj/effect/overlay/temp/cult/sac, get_turf(src))
+	for(var/M in invokers)
+		if(sacrifice_fulfilled)
+			M << "<span class='cultlarge'>\"Yes! This is the one I desire! You have done well.\"</span>"
 		else
-			playsound(T, 'sound/magic/Disintegrate.ogg', 100, 1)
-			T.gib()
-	rune_in_use = 0
+			if(ishuman(sacrificial) || isrobot(sacrificial))
+				M << "<span class='cultlarge'>\"I accept this sacrifice.\"</span>"
+			else
+				M << "<span class='cultlarge'>\"I accept this meager sacrifice.\"</span>"
+
+	if(sacrificial.mind)
+		var/obj/item/device/soulstone/stone = new /obj/item/device/soulstone(get_turf(src))
+		stone.invisibility = INVISIBILITY_MAXIMUM //so it's not picked up during transfer_soul()
+		if(!stone.transfer_soul("FORCE", sacrificial, usr)) //If it cannot be added
+			qdel(stone)
+		if(stone)
+			stone.invisibility = 0
+			return 1
+
+	if(isrobot(sacrificial))
+		playsound(sacrificial, 'sound/magic/Disable_Tech.ogg', 100, 1)
+		sacrificial.dust() //To prevent the MMI from remaining
+	else
+		playsound(sacrificial, 'sound/magic/Disintegrate.ogg', 100, 1)
+		sacrificial.gib()
+	return 1
 
 //Ritual of Dimensional Rending: Calls forth the avatar of Nar-Sie upon the station.
 /obj/effect/rune/narsie
@@ -742,13 +722,20 @@ var/list/teleport_runes = list()
 	rune_in_use = 0
 
 
+var/list/wall_runes = list()
 //Rite of the Corporeal Shield: When invoked, becomes solid and cannot be passed. Invoke again to undo.
 /obj/effect/rune/wall
 	cultist_name = "Form Barrier"
-	cultist_desc = "when invoked, makes an invisible wall to block passage. Can be invoked again to reverse this."
+	cultist_desc = "when invoked, makes a temporary invisible wall to block passage. Can be invoked again to reverse this."
 	invocation = "Khari'd! Eske'te tannin!"
 	icon_state = "1"
 	color = rgb(255, 0, 0)
+	var/density_timer
+	var/recharging = FALSE
+
+/obj/effect/rune/wall/New()
+	..()
+	wall_runes += src
 
 /obj/effect/rune/wall/examine(mob/user)
 	..()
@@ -757,6 +744,7 @@ var/list/teleport_runes = list()
 
 /obj/effect/rune/wall/Destroy()
 	density = 0
+	wall_runes -= src
 	air_update_turf(1)
 	return ..()
 
@@ -767,24 +755,52 @@ var/list/teleport_runes = list()
 	return density
 
 /obj/effect/rune/wall/invoke(var/list/invokers)
+	if(recharging)
+		return
 	var/mob/living/user = invokers[1]
 	..()
 	density = !density
 	air_update_turf(1)
+	update_state()
+	if(density)
+		spread_density()
 	user.visible_message("<span class='warning'>[user] [iscarbon(user) ? "places their hands on":"stares intently at"] [src], and [density ? "the air above it begins to shimmer" : "the shimmer above it fades"].</span>", \
 						 "<span class='cultitalic'>You channel your life energy into [src], [density ? "preventing" : "allowing"] passage above it.</span>")
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		C.apply_damage(2, BRUTE, pick("l_arm", "r_arm"))
+
+/obj/effect/rune/wall/proc/spread_density()
+	for(var/R in wall_runes)
+		var/obj/effect/rune/wall/W = R
+		if(W.z == z && get_dist(src, W) <= 2 && !W.density)
+			W.density = TRUE
+			W.update_state()
+			W.spread_density()
+	density_timer = addtimer(src, "lose_density", 900)
+
+/obj/effect/rune/wall/proc/lose_density()
+	if(density)
+		recharging = TRUE
+		density = FALSE
+		color = "#696969"
+		update_state()
+		addtimer(src, "recharge", 50)
+
+/obj/effect/rune/wall/proc/recharge()
+	recharging = FALSE
+	color = initial(color)
+
+/obj/effect/rune/wall/proc/update_state()
+	deltimer(density_timer)
 	if(density)
 		var/image/I = image(layer = ABOVE_MOB_LAYER, icon = 'icons/effects/effects.dmi', icon_state = "barriershimmer")
 		I.appearance_flags = RESET_COLOR
 		I.alpha = 60
 		I.color = "#701414"
-		overlays += I
+		add_overlay(I)
 	else
-		overlays.Cut()
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		C.apply_damage(2, BRUTE, pick("l_arm", "r_arm"))
-
+		cut_overlays()
 
 //Rite of Joined Souls: Summons a single cultist.
 /obj/effect/rune/summon
@@ -836,35 +852,78 @@ var/list/teleport_runes = list()
 //Rite of Boiling Blood: Deals extremely high amounts of damage to non-cultists nearby
 /obj/effect/rune/blood_boil
 	cultist_name = "Boil Blood"
-	cultist_desc = "boils the blood of non-believers who can see the rune, dealing extreme amounts of damage. Requires 3 invokers."
+	cultist_desc = "boils the blood of non-believers who can see the rune, rapidly dealing extreme amounts of damage. Requires 3 invokers."
 	invocation = "Dedo ol'btoh!"
 	icon_state = "4"
 	color = rgb(200, 0, 0)
 	req_cultists = 3
 	construct_invoke = 0
+	var/tick_damage = 25
+	rune_in_use = FALSE
+
+/obj/effect/rune/blood_boil/do_invoke_glow()
+	return
 
 /obj/effect/rune/blood_boil/invoke(var/list/invokers)
+	if(rune_in_use)
+		return
 	..()
+	rune_in_use = TRUE
 	var/turf/T = get_turf(src)
-	visible_message("<span class='warning'>[src] briefly bubbles before exploding!</span>")
-	for(var/mob/living/carbon/C in viewers(T))
-		if(!iscultist(C))
-			var/obj/item/weapon/nullrod/N = C.null_rod_check()
-			if(N)
-				C << "<span class='userdanger'>\The [N] suddenly burns hotly before returning to normal!</span>"
-				continue
-			C << "<span class='cultlarge'>Your blood boils in your veins!</span>"
-			C.take_overall_damage(45,45)
-			C.Stun(7)
-			if(is_servant_of_ratvar(C))
-				C << "<span class='userdanger'>You feel unholy darkness dimming the Justiciar's light!</span>"
-				C.adjustStaminaLoss(30)
+	visible_message("<span class='warning'>[src] turns a bright, glowing white!</span>")
+	SetLuminosity(6)
+	color = "#FFFDF4"
 	for(var/M in invokers)
 		var/mob/living/L = M
-		L.apply_damage(15, BRUTE, pick("l_arm", "r_arm"))
+		L.apply_damage(10, BRUTE, pick("l_arm", "r_arm"))
 		L << "<span class='cultitalic'>[src] saps your strength!</span>"
+	for(var/mob/living/L in viewers(T))
+		if(!iscultist(L) && L.blood_volume)
+			var/obj/item/weapon/nullrod/N = L.null_rod_check()
+			if(N)
+				L << "<span class='userdanger'>\The [N] suddenly burns hotly before returning to normal!</span>"
+				continue
+			L << "<span class='cultlarge'>Your blood boils in your veins!</span>"
+			if(is_servant_of_ratvar(L))
+				L << "<span class='userdanger'>You feel an unholy darkness dimming the Justiciar's light!</span>"
+	animate(src, color = "#FFDF80", time = 3)
+	sleep(3)
+	if(!src)
+		return
+	for(var/mob/living/L in viewers(T))
+		if(!iscultist(L) && L.blood_volume)
+			var/obj/item/weapon/nullrod/N = L.null_rod_check()
+			if(N)
+				continue
+			L.take_overall_damage(tick_damage*0.5, tick_damage*0.5)
+			if(is_servant_of_ratvar(L))
+				L.adjustStaminaLoss(tick_damage*0.5)
+	animate(src, color = "#FCB56D", time = 3)
+	sleep(3)
+	if(!src)
+		return
+	for(var/mob/living/L in viewers(T))
+		if(!iscultist(L) && L.blood_volume)
+			var/obj/item/weapon/nullrod/N = L.null_rod_check()
+			if(N)
+				continue
+			L.take_overall_damage(tick_damage, tick_damage)
+			if(is_servant_of_ratvar(L))
+				L.adjustStaminaLoss(tick_damage*0.5)
+	animate(src, color = "#FC9B54", time = 3)
+	sleep(3)
+	if(!src)
+		return
+	for(var/mob/living/L in viewers(T))
+		if(!iscultist(L) && L.blood_volume)
+			var/obj/item/weapon/nullrod/N = L.null_rod_check()
+			if(N)
+				continue
+			L.take_overall_damage(tick_damage*1.5, tick_damage*1.5)
+			if(is_servant_of_ratvar(L))
+				L.adjustStaminaLoss(tick_damage*0.5)
+	PoolOrNew(/obj/effect/hotspot, T)
 	qdel(src)
-	explosion(T, -1, 0, 1, 5)
 
 
 //Deals brute damage to all targets on the rune and heals the invoker for each target drained.

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -867,9 +867,9 @@ var/list/wall_runes = list()
 	..()
 	rune_in_use = TRUE
 	var/turf/T = get_turf(src)
-	visible_message("<span class='warning'>[src] turns a bright, glowing white!</span>")
+	visible_message("<span class='warning'>[src] turns a bright, glowing orange!</span>")
 	SetLuminosity(6)
-	color = "#FFFDF4"
+	color = "#FC9B54"
 	for(var/M in invokers)
 		var/mob/living/L = M
 		L.apply_damage(10, BRUTE, pick("l_arm", "r_arm"))
@@ -883,18 +883,18 @@ var/list/wall_runes = list()
 			L << "<span class='cultlarge'>Your blood boils in your veins!</span>"
 			if(is_servant_of_ratvar(L))
 				L << "<span class='userdanger'>You feel an unholy darkness dimming the Justiciar's light!</span>"
+	animate(src, color = "#FCB56D", time = 4)
+	sleep(4)
+	if(!src)
+		return
+	do_area_burn(T, 0.5)
 	animate(src, color = "#FFDF80", time = 5)
 	sleep(5)
 	if(!src)
 		return
-	do_area_burn(T, 0.5)
-	animate(src, color = "#FCB56D", time = 5)
-	sleep(5)
-	if(!src)
-		return
 	do_area_burn(T, 1)
-	animate(src, color = "#FC9B54", time = 5)
-	sleep(5)
+	animate(src, color = "#FFFDF4", time = 6)
+	sleep(6)
 	if(!src)
 		return
 	do_area_burn(T, 1.5)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -325,7 +325,7 @@ var/list/teleport_runes = list()
 
 
 //Rite of Offering: Converts or sacrifices a target.
-/obj/effect/rune/offer
+/obj/effect/rune/convert
 	cultist_name = "Offer"
 	cultist_desc = "offers a noncultist above it to Nar-Sie, either converting them or sacrificing them."
 	invocation = "Mah'weyh pleggh at e'ntrath!"
@@ -335,7 +335,7 @@ var/list/teleport_runes = list()
 	allow_excess_invokers = 1
 	rune_in_use = FALSE
 
-/obj/effect/rune/offer/invoke(var/list/invokers)
+/obj/effect/rune/convert/invoke(var/list/invokers)
 	if(rune_in_use)
 		return
 	var/list/myriad_targets = list()
@@ -352,19 +352,22 @@ var/list/teleport_runes = list()
 	color = rgb(126, 23, 23)
 	..()
 	var/mob/living/L = pick(myriad_targets)
-	if(is_servant_of_ratvar(L))
-		L.visible_message("<span class='warning'>[L]'s eyes glow a defiant yellow!</span>", \
-		"<span class='cultlarge'>\"Stop resisting. You <i>will</i> be mi-\"</span>\n\
-		<span class='large_brass'>\"Give up and you will feel pain unlike anything you've ever felt!\"</span>")
-		L.Weaken(4)
-	else if(L.stat != DEAD && is_convertable_to_cult(L.mind))
-		do_convert(L, invokers)
+	var/is_clock = is_servant_of_ratvar(L)
+	var/is_convertable = is_convertable_to_cult(L.mind)
+	if(L.stat != DEAD && (is_clock || is_convertable))
+		if(is_clock)
+			L.visible_message("<span class='warning'>[L]'s eyes glow a defiant yellow!</span>", \
+			"<span class='cultlarge'>\"Stop resisting. You <i>will</i> be mi-\"</span>\n\
+			<span class='large_brass'>\"Give up and you will feel pain unlike anything you've ever felt!\"</span>")
+			L.Weaken(4)
+		else if(is_convertable)
+			do_convert(L, invokers)
 	else
 		do_sacrifice(L, invokers)
 	color = initial(color)
 	rune_in_use = FALSE
 
-/obj/effect/rune/offer/proc/do_convert(mob/living/convertee, list/invokers)
+/obj/effect/rune/convert/proc/do_convert(mob/living/convertee, list/invokers)
 	if(invokers.len < 2)
 		for(var/M in invokers)
 			M << "<span class='warning'>You need more invokers to convert [convertee]!</span>"
@@ -392,7 +395,7 @@ var/list/teleport_runes = list()
 	</b></span>"
 	return 1
 
-/obj/effect/rune/offer/proc/do_sacrifice(mob/living/sacrificial, list/invokers)
+/obj/effect/rune/convert/proc/do_sacrifice(mob/living/sacrificial, list/invokers)
 	if((((ishuman(sacrificial) || isrobot(sacrificial)) && sacrificial.stat != DEAD) || is_sacrifice_target(sacrificial.mind)) && invokers.len < 3)
 		for(var/M in invokers)
 			M << "<span class='cultitalic'>[sacrificial] is too greatly linked to the world! You need three acolytes!</span>"

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -149,9 +149,13 @@
 	var/obj/effect/rune/teleport/actual_selected_rune = potential_runes[input_rune_key] //what rune does that key correspond to?
 	if(!actual_selected_rune)
 		return ..(user, 0)
+	var/turf/target = get_turf(actual_selected_rune)
+	if(is_blocked_turf(target))
+		user << "<span class='warning'>The target rune is blocked. Attempting to teleport to it would be massively unwise.</span>"
+		return ..(user, 0)
 	user.visible_message("<span class='warning'>Dust flows from [user]'s hand, and they disappear in a flash of red light!</span>", \
 						 "<span class='cultitalic'>You speak the words of the talisman and find yourself somewhere else!</span>")
-	user.forceMove(get_turf(actual_selected_rune))
+	user.forceMove(target)
 	return ..()
 
 

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -349,8 +349,8 @@
 /obj/item/weapon/paper/talisman/construction/afterattack(obj/item/stack/sheet/target, mob/user, proximity_flag, click_parameters)
 	..()
 	if(proximity_flag && iscultist(user))
+		var/turf/T = get_turf(target)
 		if(istype(target, /obj/item/stack/sheet/metal))
-			var/turf/T = get_turf(target)
 			if(target.use(25))
 				new /obj/structure/constructshell(T)
 				user << "<span class='warning'>The talisman clings to the metal and twists it into a construct shell!</span>"

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -359,16 +359,16 @@
 				qdel(src)
 			else
 				user << "<span class='warning'>You need more metal to produce a construct shell!</span>"
-			if(istype(target, /obj/item/stack/sheet/plasteel))
-				var/quantity = min(target.amount, uses)
-				uses -= quantity
-				new /obj/item/stack/sheet/runed_metal(T,quantity)
-				target.use(quantity)
-				user << "<span class='warning'>The talisman clings to the plasteel, transforming it into runed metal!</span>"
-				user << sound('sound/effects/magic.ogg',0,1,25)
-				invoke(user, 1)
-				if(uses <= 0)
-					qdel(src)
+		else if(istype(target, /obj/item/stack/sheet/plasteel))
+			var/quantity = min(target.amount, uses)
+			uses -= quantity
+			new /obj/item/stack/sheet/runed_metal(T,quantity)
+			target.use(quantity)
+			user << "<span class='warning'>The talisman clings to the plasteel, transforming it into runed metal!</span>"
+			user << sound('sound/effects/magic.ogg',0,1,25)
+			invoke(user, 1)
+			if(uses <= 0)
+				qdel(src)
 		else
 			user << "<span class='warning'>The talisman must be used on metal or plasteel!</span>"
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -526,7 +526,7 @@
 	return max(0, enemy_minimum_age - C.player_age)
 
 /datum/game_mode/proc/replace_jobbaned_player(mob/living/M, role_type, pref)
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [role_type]?", "[role_type]", null, pref, 100, M)
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [role_type]?", "[role_type]", null, pref, 50, M)
 	var/mob/dead/observer/theghost = null
 	if(candidates.len)
 		theghost = pick(candidates)

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -251,7 +251,7 @@
 			break
 
 	if(!chosen_ghost)	//Failing that, we grab a ghost
-		var/list/consenting_candidates = pollCandidates("Would you like to play as a Shade?", "Cultist", null, ROLE_CULTIST, poll_time = 100)
+		var/list/consenting_candidates = pollCandidates("Would you like to play as a Shade?", "Cultist", null, ROLE_CULTIST, poll_time = 50)
 		if(consenting_candidates.len)
 			chosen_ghost = pick(consenting_candidates)
 	if(!T)


### PR DESCRIPTION
:cl: Joan
rscadd: Combined the Convert and Sacrifice runes into one rune. It'll convert targets that are alive and eligible, and attempt to sacrifice them otherwise. The only changes to mechanics are that: Converting someone will heal them of all brute and burn damage they had, and sacrificing anything will always produce a soulstone(but will still only sometimes fill it)
tweak: You can no longer teleport to Teleport runes that have dense objects on top of them.
experiment: Wall runes will now activate other nearby wall runes when activated, but will automatically disable after a minute and a half of continuous activity and become unusable for 5 seconds.
experiment: The Blood Boil rune no longer does all of its damage instantly or stuns, but if you remain in range for the full duration you will be sent deep into critical.
/:cl:

The general idea is to give runes at least basic counterplay; stick a fueltank on a teleport rune, wait a wall rune out, run from an active blood boil rune, etc.

And, for usability, merging the convert and sac runes like this means less rune fiddling and more shoving people on the rune.
