### PR TITLE
Prevent infinite loops with DROPDEL items and del_on_death simple mobs

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -344,6 +344,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 		var/datum/action/A = X
 		A.Remove(user)
 	if(DROPDEL & flags)
+		//Prevents infinite loops where Destroy() calls an objects dropped() function
+		flags &= ~DROPDEL
 		qdel(src)
 
 // called just as an item is picked up (loc is not yet changed)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -301,6 +301,9 @@
 	if(del_on_death)
 		ghostize()
 		stat = DEAD
+		//Prevent infinite loops if the mob Destroy() is overriden in such
+		//a manner as to cause a call to death() again
+		del_on_death = FALSE
 		qdel(src)
 	else
 		health = 0


### PR DESCRIPTION
We unset the flag just before calling qdel, preventing infinite loops where
the objects Destroy() also calls it's dropped() method, which is the case for a number of
items

We also do this for simple mobs with del_on_death set as they could also potentially introduce infinite loops of Destroy() -> death()
