### PR TITLE
Properly guard air removal in some atmos machines

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -65,7 +65,7 @@ Acts like a normal vent, but has an input AND output.
 	..()
 
 	if(!on)
-		return 0
+		return FALSE
 	var/datum/gas_mixture/air1 = AIR1
 	var/datum/gas_mixture/air2 = AIR2
 
@@ -85,6 +85,9 @@ Acts like a normal vent, but has an input AND output.
 				var/transfer_moles = pressure_delta*environment.volume/(air1.temperature * R_IDEAL_GAS_EQUATION)
 
 				var/datum/gas_mixture/removed = air1.remove(transfer_moles)
+				//Removed can be null if there is no atmosphere in air1
+				if(!removed)
+					return FALSE
 
 				loc.assume_air(removed)
 				air_update_turf()
@@ -105,6 +108,9 @@ Acts like a normal vent, but has an input AND output.
 				var/transfer_moles = pressure_delta*air2.volume/(environment.temperature * R_IDEAL_GAS_EQUATION)
 
 				var/datum/gas_mixture/removed = loc.remove_air(transfer_moles)
+				//removed can be null if there is no air in the location
+				if(!removed))
+					return FALSE
 
 				air2.merge(removed)
 				air_update_turf()
@@ -112,7 +118,7 @@ Acts like a normal vent, but has an input AND output.
 				var/datum/pipeline/parent2 = PARENT2
 				parent2.update = 1
 
-	return 1
+	return TRUE
 
 	//Radio remote control
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -109,7 +109,7 @@ Acts like a normal vent, but has an input AND output.
 
 				var/datum/gas_mixture/removed = loc.remove_air(transfer_moles)
 				//removed can be null if there is no air in the location
-				if(!removed))
+				if(!removed)
 					return FALSE
 
 				air2.merge(removed)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -184,9 +184,10 @@
 
 			//Take a gas sample
 			var/datum/gas_mixture/removed = tile.remove_air(transfer_moles)
-			var/list/removed_gases = removed.gases
-			if (isnull(removed)) //in space
+			//Nothing left to remove from the tile
+			if (isnull(removed))
 				return
+			var/list/removed_gases = removed.gases
 
 			//Filter it
 			var/datum/gas_mixture/filtered_out = new


### PR DESCRIPTION
Scrubbers had the guard, but were trying to access gases before
checking, leading to a lot of needless runtimes. dp vents did not seem
to check at all
