### PR TITLE
Adds gas canister crates to cargo

### DIFF
--- a/_maps/map_files/MiniStation/cargopacks.dm
+++ b/_maps/map_files/MiniStation/cargopacks.dm
@@ -1,31 +1,3 @@
-/datum/supply_pack/engineering/oxygen
-	name = "Oxygen Canister"
-	cost = 15
-	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
-	crate_name = "oxygen canister crate"
-	crate_type = /obj/structure/closet/crate/large
-
-/datum/supply_pack/engineering/toxins
-	name = "Plasma Canister"
-	cost = 30
-	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
-	crate_name = "plasma canister crate"
-	crate_type = /obj/structure/closet/crate/large
-
-/datum/supply_pack/engineering/nitrogen
-	name = "Nitrogen Canister"
-	cost = 20
-	contains = list(/obj/machinery/portable_atmospherics/canister/nitrogen)
-	crate_name = "nitrogen canister crate"
-	crate_type = /obj/structure/closet/crate/large
-
-/datum/supply_pack/engineering/carbon_dio
-	name = "Carbon Dioxide Canister"
-	cost = 35
-	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
-	crate_name = "carbon dioxide canister crate"
-	crate_type = /obj/structure/closet/crate/large
-
 /obj/machinery/hydroponics/constructable/unattached
 	anchored = 0
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -452,6 +452,27 @@ datum/supply_pack
 	crate_name = "fuel tank crate"
 	crate_type = /obj/structure/closet/crate/large
 
+/datum/supply_pack/engineering/oxygen
+	name = "Oxygen Canister"
+	cost = 1500
+	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
+	crate_name = "oxygen canister crate"
+	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/engineering/nitrogen
+	name = "Nitrogen Canister"
+	cost = 2000
+	contains = list(/obj/machinery/portable_atmospherics/canister/nitrogen)
+	crate_name = "nitrogen canister crate"
+	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/engineering/carbon_dio
+	name = "Carbon Dioxide Canister"
+	cost = 3000
+	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
+	crate_name = "carbon dioxide canister crate"
+	crate_type = /obj/structure/closet/crate/large
+
 /datum/supply_pack/engineering/tools
 	name = "Toolbox Crate"
 	contains = list(/obj/item/weapon/storage/toolbox/electrical,
@@ -829,6 +850,33 @@ datum/supply_pack
 	crate_type = /obj/structure/closet/crate/secure
 	dangerous = TRUE
 
+/datum/supply_pack/science/plasma_canister
+	name = "Plasma Canister"
+	cost = 3000
+	access = access_rd
+	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
+	crate_name = "plasma canister crate"
+	crate_type = /obj/structure/closet/crate/secure
+	dangerous = TRUE
+
+/datum/supply_pack/science/bz_canister
+	name = "BZ Canister"
+	cost = 4000
+	access = access_rd
+	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
+	crate_name = "bz canister crate"
+	crate_type = /obj/structure/closet/crate/secure
+	dangerous = TRUE
+
+/datum/supply_pack/science/freon_canister
+	name = "Freon Canister"
+	cost = 6000
+	access = access_rd
+	contains = list(/obj/machinery/portable_atmospherics/canister/freon)
+	crate_name = "freon canister crate"
+	crate_type = /obj/structure/closet/crate/secure
+	dangerous = TRUE
+
 /datum/supply_pack/science/research
 	name = "Machine Prototype Crate"
 	cost = 8000
@@ -1199,6 +1247,13 @@ datum/supply_pack
 	cost = 1200
 	contains = list(/obj/structure/reagent_dispensers/watertank/high)
 	crate_name = "high-capacity water tank crate"
+	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/misc/water_vapor
+	name = "Water Vapor Canister"
+	cost = 2500
+	contains = list(/obj/machinery/portable_atmospherics/canister/water_vapor)
+	crate_name = "water vapor canister crate"
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/misc/lasertag

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -473,6 +473,14 @@ datum/supply_pack
 	crate_name = "carbon dioxide canister crate"
 	crate_type = /obj/structure/closet/crate/large
 
+/datum/supply_pack/science/nitrous_oxide_canister
+	name = "Nitrous Oxide Canister"
+	cost = 3000
+	access = access_atmospherics
+	contains = list(/obj/machinery/portable_atmospherics/canister/nitrous_oxide)
+	crate_name = "nitrous oxide canister crate"
+	crate_type = /obj/structure/closet/crate/secure
+
 /datum/supply_pack/engineering/tools
 	name = "Toolbox Crate"
 	contains = list(/obj/item/weapon/storage/toolbox/electrical,
@@ -847,15 +855,6 @@ datum/supply_pack
 	contains = list(/obj/item/device/transfer_valve,
 					/obj/item/device/transfer_valve)
 	crate_name = "tank transfer valves crate"
-	crate_type = /obj/structure/closet/crate/secure
-	dangerous = TRUE
-
-/datum/supply_pack/science/plasma_canister
-	name = "Plasma Canister"
-	cost = 3000
-	access = access_rd
-	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
-	crate_name = "plasma canister crate"
 	crate_type = /obj/structure/closet/crate/secure
 	dangerous = TRUE
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -5,6 +5,7 @@ datum/supply_pack
 	var/contraband = FALSE
 	var/cost = 700 // Minimum cost, or infinite points are possible.
 	var/access = FALSE
+	var/access_any = FALSE
 	var/list/contains = null
 	var/crate_name = "crate"
 	var/crate_type = /obj/structure/closet/crate
@@ -17,6 +18,8 @@ datum/supply_pack
 	C.name = crate_name
 	if(access)
 		C.req_access = list(access)
+	if(access_any)
+		C.req_one_access = access_any
 
 	fill(C)
 
@@ -861,7 +864,7 @@ datum/supply_pack
 /datum/supply_pack/science/bz_canister
 	name = "BZ Canister"
 	cost = 4000
-	access = access_rd
+	access_any = list(access_rd, access_atmospherics)
 	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
 	crate_name = "bz canister crate"
 	crate_type = /obj/structure/closet/crate/secure
@@ -870,7 +873,7 @@ datum/supply_pack
 /datum/supply_pack/science/freon_canister
 	name = "Freon Canister"
 	cost = 6000
-	access = access_rd
+	access_any = list(access_rd, access_atmospherics)
 	contains = list(/obj/machinery/portable_atmospherics/canister/freon)
 	crate_name = "freon canister crate"
 	crate_type = /obj/structure/closet/crate/secure


### PR DESCRIPTION
:cl: XDTM
add: Canisters of any type of gas are now orderable in cargo. Dangerous experimental gases will require Research Director approval.
/:cl:

The reason for this is that there isn't currently any way of actually obtaining new canisters outside of the rounstart ones, and this would make them somewhat renewable.

<s>I'm not sure if ordering a plasma canister makes sense, though, since the station is supposed to _produce_ it, but it's pretty hard to make one since you can't convert mined plasma to gas outside of spilling plasma beakers.</s>
Can't buy plasma from those you're mining plasma for.
