### PR TITLE
Abandoned crate fix

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -153,6 +153,7 @@
 /obj/structure/closet/crate/secure/loot/attack_hand(mob/user)
 	if(locked)
 		user << "<span class='notice'>The crate is locked with a Deca-code lock.</span>"
+		user << "<span class='notice'>Deca-code locks have a 4-digit code using numbers from 0-9 with no repeat digits</span>"
 		var/input = input(usr, "Enter [codelen] digits.", "Deca-Code Lock", "") as text
 		if(user.canUseTopic(src, 1))
 			if (input == code)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -11,7 +11,7 @@
 
 /obj/structure/closet/crate/secure/loot/New()
 	..()
-	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "z")
+	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
 	code = ""
 	for(var/i = 0, i < codelen, i++)
 		var/dig = pick(digits)
@@ -164,7 +164,7 @@
 				user << "<span class='notice'>You leave the crate alone.</span>"
 			else
 				user << "<span class='warning'>A red light flashes.</span>"
-				lastattempt = replacetext(input, 0, "z")
+				lastattempt = input
 				attempts--
 				if(attempts == 0)
 					boom(user)
@@ -204,6 +204,7 @@
 						++bulls
 					else if(a)
 						++cows
+				user << "<span class='notice'>The last code used was [lastattempt]</span>"
 				user << "<span class='notice'>Last code attempt had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions.</span>"
 			return
 	return ..()


### PR DESCRIPTION
:cl:
tweak: Abandoned crates no longer use "z" in place of "0" in their code. They now only use the numbers 0-9.
/:cl:

Im mainly making this pull for two reasons:
1. I think it makes more sense for the code to have the numbers 0-9, not 1-9 and "z".
2. When a crate has the char "z" in its code, it does funky things to the multitool checking code ability, which makes cracking the code for the crate basically impossible.

The helpful hints are just to be a bit more user-friendly.
This pull was mainly done because of #20487 (and also because my brother wanted me to fix them)
