### PR TITLE
Officer's Sabre Tweaks

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -36,7 +36,7 @@
 	armour_penetration = 75
 	sharpness = IS_SHARP
 	origin_tech = "combat=5"
-	attack_verb = list("lunged at", "stabbed")
+	attack_verb = list("slashed", "cut")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	materials = list(MAT_METAL = 1000)
 

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -433,7 +433,10 @@
 
 
 
+
 /obj/item/weapon/storage/belt/sabre/AltClick(mob/user)
+	if(isalien(user) || user.incapacitated() || user.lying)
+		return
 	if(contents.len)
 		var/obj/item/I = contents[1]
 		user.visible_message("[user] takes [I] out of [src].", "<span class='notice'>You take [I] out of [src].</span>",\

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -435,7 +435,7 @@
 
 
 /obj/item/weapon/storage/belt/sabre/AltClick(mob/user)
-	if(isalien(user) || user.incapacitated() || user.lying)
+	if(!ishuman(user) || user.incapacitated() || user.lying)
 		return
 	if(contents.len)
 		var/obj/item/I = contents[1]

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -431,6 +431,19 @@
 		/obj/item/weapon/melee/sabre
 		)
 
+
+
+/obj/item/weapon/storage/belt/sabre/AltClick(mob/user)
+	if(contents.len)
+		var/obj/item/I = contents[1]
+		user.visible_message("[user] takes [I] out of [src].", "<span class='notice'>You take [I] out of [src].</span>",\
+		)
+		user.put_in_hands(I)
+		update_icon(I)
+	else
+		user << "[src] is empty."
+	return
+
 /obj/item/weapon/storage/belt/sabre/update_icon()
 	icon_state = "sheath"
 	item_state = "sheath"
@@ -441,6 +454,7 @@
 		var/mob/living/L = loc
 		L.regenerate_icons()
 	..()
+
 
 /obj/item/weapon/storage/belt/sabre/New()
 	..()

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -435,7 +435,7 @@
 
 
 /obj/item/weapon/storage/belt/sabre/AltClick(mob/user)
-	if(!ishuman(user) || user.incapacitated() || user.lying)
+	if(!ishuman(user) || !user.canUseTopic(src))
 		return
 	if(contents.len)
 		var/obj/item/I = contents[1]

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -439,10 +439,9 @@
 		user.visible_message("[user] takes [I] out of [src].", "<span class='notice'>You take [I] out of [src].</span>",\
 		)
 		user.put_in_hands(I)
-		update_icon(I)
+		update_icon()
 	else
 		user << "[src] is empty."
-	return
 
 /obj/item/weapon/storage/belt/sabre/update_icon()
 	icon_state = "sheath"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -421,7 +421,7 @@
 
 /obj/item/weapon/storage/belt/sabre
 	name = "sabre sheath"
-	desc = "An ornate sheath designed to hold an officer's blade."
+	desc = "An ornate sheath designed to hold an officer's blade. Alt-Click to quickly draw the sheathed blade."
 	icon_state = "sheath"
 	item_state = "sheath"
 	storage_slots = 1


### PR DESCRIPTION
:cl: Papa Bones
tweak: You can now quick-draw the officer's sabre from its sheath by alt-clicking it.
/:cl:
Allows for quickdrawing the sabre.
Also changes the attack text since it's no longer a rapier, and it doesn't make sense that it can dismember with point lunges and thrusts.
