### PR TITLE
Fixes lattices appearing after lava explosion

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -235,6 +235,9 @@
 	slowdown = 2
 	luminosity = 1
 
+/turf/open/floor/plating/lava/ex_act()
+	return
+
 /turf/open/floor/plating/lava/airless
 	initial_gas_mix = "TEMP=2.7"
 


### PR DESCRIPTION
:cl: Nicho1010
fix: Fixed lattices appearing after exploding lava
/:cl:

Fixes issue described in #20345 by making lava ignore explosions.

This is my second PR so I hope everything is correct. Thanks to xxalpha for helping out with some things.

EDIT:

Forgot to include this just in case

https://www.youtube.com/watch?v=qd7YkJ5dUFA

As seen in video explosion does not generate lattices anymore.
