### PR TITLE
Fixes space movement

### DIFF
--- a/code/controllers/subsystem/spacedrift.dm
+++ b/code/controllers/subsystem/spacedrift.dm
@@ -32,8 +32,15 @@ var/datum/subsystem/spacedrift/SSspacedrift
 			if (MC_TICK_CHECK)
 				return
 			continue
+
+		if (AM.inertia_next_move > world.time)
+			if (MC_TICK_CHECK)
+				return
+			continue
+
 		if (!AM.loc || AM.loc != AM.inertia_last_loc || AM.Process_Spacemove(0))
 			AM.inertia_dir = 0
+
 		if (!AM.inertia_dir)
 			AM.inertia_last_loc = null
 			processing -= AM
@@ -43,7 +50,10 @@ var/datum/subsystem/spacedrift/SSspacedrift
 
 		var/old_dir = AM.dir
 		var/old_loc = AM.loc
+		AM.inertia_moving = TRUE
 		step(AM, AM.inertia_dir)
+		AM.inertia_moving = FALSE
+		AM.inertia_next_move = world.time + AM.inertia_move_delay
 		if (AM.loc == old_loc)
 			AM.inertia_dir = 0
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -13,7 +13,10 @@
 	var/verb_exclaim = "exclaims"
 	var/verb_yell = "yells"
 	var/inertia_dir = 0
-	var/inertia_last_loc
+	var/atom/inertia_last_loc
+	var/inertia_moving = 0
+	var/inertia_next_move = 0
+	var/inertia_move_delay = 5
 	var/pass_flags = 0
 	var/moving_diagonally = 0 //0: not doing a diagonal move. 1 and 2: doing the first/second step of the diagonal move
 	glide_size = 8
@@ -71,13 +74,13 @@
 
 	last_move = direct
 	setDir(direct)
-
 	if(. && has_buckled_mobs() && !handle_buckled_mob_movement(loc,direct)) //movement failed due to buckled mob(s)
 		. = 0
 
 //Called after a successful Move(). By this point, we've already moved
 /atom/movable/proc/Moved(atom/OldLoc, Dir)
-	if (!inertia_dir)
+	if (!inertia_moving)
+		inertia_next_move = world.time + inertia_move_delay
 		newtonian_move(Dir)
 	return 1
 


### PR DESCRIPTION
Fixed some issues with space movement, namely that it didn't trigger when something moved of its own accord after it was already scheduled to get space moved.

:cl: 
fix: Fixed space/nograv movement not triggering when atoms moved twice quickly in space/nograv
/:cl:
