### PR TITLE
Bone dagger now contains no metal

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -121,6 +121,7 @@
 	desc = "A sharpened bone. The bare mimimum in survival."
 	force = 15
 	throwforce = 15
+	materials = list()
 
 /obj/item/weapon/kitchen/knife/combat/cyborg
 	name = "cyborg knife"


### PR DESCRIPTION
The bone dagger previously inherited the kitchen knife's 12000 metal, allowing it to be recycled in the autolathe.
