### PR TITLE
Added "neutral" to drone's factions

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -46,7 +46,7 @@
 	staticOverlays = list()
 	hud_possible = list(DIAG_STAT_HUD, DIAG_HUD, ANTAG_HUD)
 	unique_name = TRUE
-	faction = list("silicon")
+	faction = list("neutral","silicon")
 	dextrous = TRUE
 	dextrous_hud_type = /datum/hud/dextrous/drone
 	var/staticChoice = "static"


### PR DESCRIPTION
:cl:
fix: fixed "friendly" xenobio mobs and mining drones attacking station drones
/:cl:

Adds neutral as a faction to station drones, as "friendly"/"docile" xenobio mobs and mining drones hated them.
