### PR TITLE
Clockcult powerdraining is more likely to cause lights to burn out

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_powerdrain.dm
+++ b/code/game/gamemodes/clock_cult/clock_powerdrain.dm
@@ -38,6 +38,8 @@
 		playsound(src, 'sound/effects/light_flicker.ogg', 50, 1)
 		flicker(2)
 		. += 50
+	else if(prob(50))
+		burn_out()
 
 /mob/living/silicon/robot/power_drain(clockcult_user)
 	if((!clockcult_user || !is_servant_of_ratvar(src)) && cell && cell.charge)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -232,11 +232,8 @@
 				if(status == LIGHT_OK && trigger)
 					explode()
 			else if( prob( min(60, switchcount*switchcount*0.01) ) )
-				if(status == LIGHT_OK && trigger)
-					status = LIGHT_BURNED
-					icon_state = "[base_state]-burned"
-					on = 0
-					SetLuminosity(0)
+				if(trigger)
+					burn_out()
 			else
 				use_power = 2
 				SetLuminosity(brightness)
@@ -253,6 +250,13 @@
 		else
 			removeStaticPower(static_power_used, STATIC_LIGHT)
 
+
+/obj/machinery/light/proc/burn_out()
+	if(status == LIGHT_OK)
+		status = LIGHT_BURNED
+		icon_state = "[base_state]-burned"
+		on = 0
+		SetLuminosity(0)
 
 // attempt to set the light's on/off status
 // will not switch on if broken/burned/empty


### PR DESCRIPTION
If the light is on, it'll still drain the current amount, but if it's off it has a 50% chance to burn the fuck out.
