### PR TITLE
Buffs the Medical Beamgun

### DIFF
--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -110,6 +110,8 @@
 		PoolOrNew(/obj/effect/overlay/temp/heal, list(get_turf(target), "#80F5FF"))
 	target.adjustBruteLoss(-4)
 	target.adjustFireLoss(-4)
+	target.adjustToxLoss(-3)
+	target.adjustOxyLoss(-3)
 	return
 
 /obj/item/weapon/gun/medbeam/proc/on_beam_release(var/mob/living/target)


### PR DESCRIPTION
Medbeam gun now heals toxins and oxygen damage.
:cl:
tweak: Nanotrasen has reprogrammed their medical beamgun nanite streams to heal toxins and simulate the effects of oxygen as well!
:cl:
