### PR TITLE
Disconnected tesla coil arc power fix

### DIFF
--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -49,7 +49,9 @@
 
 /obj/machinery/power/tesla_coil/tesla_act(var/power)
 	being_shocked = 1
-	var/power_produced = power / power_loss
+	//don't lose arc power when it's not connected to anything
+	//please place tesla coils all around the station to maximize effectiveness
+	var/power_produced = powernet ? power / power_loss : power
 	add_avail(power_produced*input_power_multiplier)
 	flick("coilhit", src)
 	playsound(src.loc, 'sound/magic/LightningShock.ogg', 100, 1, extrarange = 5)


### PR DESCRIPTION
:cl: Cyberboss
tweak: Tesla arcs no longer lose power when passing through a coil that isn't connected to a grid
/:cl:

Is this a fix or a tweak?

Fixes #20585 
