### PR TITLE
Fix spelling in spellbook usage message

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -719,8 +719,12 @@
 		recoil(user)
 	else
 		user.mind.AddSpell(S)
-		user <<"<span class='notice'>you rapidly read through the arcane book. Suddenly you realize you understand [spellname]!</span>"
-		user.attack_log += text("\[[time_stamp()]\] <font color='orange'>[user.real_name] ([user.ckey]) learned the spell [spellname] ([S]).</font>")
+		user << "<span class='notice'>You rapidly read through \
+			the arcane book. Suddenly you realize you understand \
+			[spellname]!</span>"
+		user.attack_log += text("\[[time_stamp()]\] \
+			<font color='orange'>[user.real_name] ([user.ckey]) \
+			learned the spell [spellname] ([S]).</font>")
 		onlearned(user)
 
 /obj/item/weapon/spellbook/oneuse/proc/recoil(mob/user)


### PR DESCRIPTION
IT'S TIME FOR LINE LENGTHS TO MATTER AGAIN.

Specifically, we're changing the 'you' to a 'You'
