### PR TITLE
Correctly remove components from modular_computers on damage or deletion

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_damage.dm
+++ b/code/modules/modular_computers/computers/item/computer_damage.dm
@@ -9,7 +9,7 @@
 
 	if(component_probability)
 		for(var/I in all_components)
-			var/obj/item/weapon/computer_hardware/H = I
+			var/obj/item/weapon/computer_hardware/H = all_components[I]
 			if(prob(component_probability))
 				H.take_damage(round(amount / 2))
 
@@ -40,7 +40,7 @@
 	var/turf/newloc = get_turf(src)
 	new /obj/item/stack/sheet/metal(newloc, round(steel_sheet_cost/2))
 	for(var/C in all_components)
-		var/obj/item/weapon/computer_hardware/H = C
+		var/obj/item/weapon/computer_hardware/H = all_components[C]
 		uninstall_component(H)
 		H.forceMove(newloc)
 		if(prob(25))


### PR DESCRIPTION
```
 for(var/x in keyedlist)
```

returns the keys, not the values in byond
