### PR TITLE
Minor anomalous crystal fixes

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -25,6 +25,7 @@
 				playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 100 , 0, 0)
 				icon = 'icons/obj/flora/pinetrees.dmi'
 				icon_state = "tree_stump"
+				density = 0
 				pixel_x = -16
 				name += " stump"
 				cut = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -428,7 +428,7 @@ Difficulty: Very Hard
 	ActivationReaction(null,"bomb")
 
 /obj/machinery/anomalous_crystal/random/New()//Just a random crysal spawner for loot
-	var/random_crystal = pick(typesof(/obj/machinery/anomalous_crystal) - /obj/machinery/anomalous_crystal/random)
+	var/random_crystal = pick(typesof(/obj/machinery/anomalous_crystal) - /obj/machinery/anomalous_crystal/random - /obj/machinery/anomalous_crystal)
 	new random_crystal(loc)
 	qdel(src)
 


### PR DESCRIPTION
Not even bothering to put this in the changelog.
- Removes density on tree stumps, as they were otherwise permanent blocked terrain (These can be spawned by one of the crystals)
- Removed the chance for the random anomalous crystal to spawn as the default type, which does literally nothing. Can't believe I forgot to do this.
