### PR TITLE
carbon mob bullet act now checks it's target zone exists before continuing

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -9,6 +9,14 @@
 	if(head && (head.flags & HEADBANGPROTECT))
 		return 1
 
+//Overridden so we can handle when it hits a limb that doesn't exist
+mob/living/carbon/bullet_act(obj/item/projectile/P, def_zone)
+	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
+	if(!affecting) //that zone is dismembered
+		. = bullet_act(P, "chest")//act on chest instead
+	else
+		. = ..()//Proceed with standard handling
+
 /mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
 	if(affecting && affecting.dismemberable && affecting.get_damage() >= (affecting.max_damage - P.dismemberment))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -3,11 +3,12 @@
 	var/organnum = 0
 
 	if(def_zone)
+		//Can pass in a bodypart or zone, so lets shortcut that handling
 		if(islimb(def_zone))
 			return checkarmor(def_zone, type)
-		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(def_zone))
+		//Note the check_zone call, this changes UI target values to bodypart zones
+		var/obj/item/bodypart/affecting = get_bodypart(check_zone(def_zone))
 		return checkarmor(affecting, type)
-		//If a specific bodypart is targetted, check how that bodypart is protected and return the value.
 
 	//If you don't specify a bodypart, it checks ALL your bodyparts for protection, and averages out the values
 	for(var/X in bodyparts)


### PR DESCRIPTION
Bullet act on carbon mobs will check the zone exists as a bodypart, or fall back onto the chest.

Also fixes an unreported bug where check_armor uses ran_zone to decide which zone to get the armor for, even though all instances of use of this proc do not expect this behaviour. So sometimes randomly you would get armor values for a different area and then apply to the limb originally chosen by projectile or attack code.
