### PR TITLE
Adds the new arm cybernetics implants to the game

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -158,9 +158,20 @@
 	id = "ci-surgical"
 	req_tech = list("materials" = 4, "engineering" = 4, "biotech" = 5, "powerstorage" = 4, "programming" = 3)
 	build_type = PROTOLATHE | MECHFAB
-	materials = list (MAT_METAL = 2500, MAT_GLASS = 2000, MAT_GOLD = 2000, MAT_SILVER = 750)
+	materials = list (MAT_METAL = 4500, MAT_GLASS = 1500, MAT_GOLD = 2000, MAT_SILVER = 750)
 	construction_time = 200
 	build_path = /obj/item/organ/cyberimp/arm/surgery
+	category = list("Misc", "Medical Designs")
+
+/datum/design/cyberimp_flash
+	name = "Photon Projector implant"
+	desc = "A fancy name for an implantable self-recharging flashbulb device that doubles has a high intensity flashlight."
+	id = "ci-flash"
+	req_tech = list("materials" = 5, "engineering" = 4, "biotech" = 5, "powerstorage" = 4, "programming" = 4, "plasmatech" = 3, "magnets" = 4, "combat" = 4)
+	build_type = PROTOLATHE | MECHFAB
+	materials = list (MAT_METAL = 1500, MAT_GLASS = 3000, MAT_GOLD = 1750, MAT_SILVER = 1750, MAT_URANIUM = 1500, MAT_DIAMOND = 250, MAT_PLASMA = 2000)
+	construction_time = 200
+	build_path = /obj/item/organ/cyberimp/arm/flash
 	category = list("Misc", "Medical Designs")
 
 /datum/design/cyberimp_medical_hud

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -152,6 +152,17 @@
 	build_path = /obj/item/organ/cyberimp/arm/toolset
 	category = list("Misc", "Medical Designs")
 
+/datum/design/cyberimp_surgical
+	name = "Surgical Toolkit implant"
+	desc = "A full kit of surgical tools that can be implanted into a human's arm."
+	id = "ci-surgical"
+	req_tech = list("materials" = 4, "engineering" = 4, "biotech" = 5, "powerstorage" = 4, "programming" = 3)
+	build_type = PROTOLATHE | MECHFAB
+	materials = list (MAT_METAL = 2500, MAT_GLASS = 2000, MAT_GOLD = 2000, MAT_SILVER = 750)
+	construction_time = 200
+	build_path = /obj/item/organ/cyberimp/arm/surgery
+	category = list("Misc", "Medical Designs")
+
 /datum/design/cyberimp_medical_hud
 	name = "Medical HUD implant"
 	desc = "These cybernetic eyes will display a medical HUD over everything you see. Wiggle eyes to control."

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1017,6 +1017,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 /datum/uplink_item/cyber_implants
 	category = "Cybernetic Implants"
 	surplus = 0
+	refundable = TRUE
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/cyber_implants/spawn_item(turf/loc, obj/item/device/uplink/U)
@@ -1050,6 +1051,49 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "This implant will attempt to revive you if you lose consciousness. It must be implanted via surgery."
 	item = /obj/item/organ/cyberimp/chest/reviver
 	cost = 8
+
+/datum/uplink_item/cyber_implants/esword	//This is a bad idea
+	name = "Arm Energy-Blade Projector"
+	desc = "An illegal cybernetic combat implant that allows the user to project a blade of lethal energy from their hand."
+	item = /obj/item/organ/cyberimp/arm/esword
+	cost = 12
+	player_minimum = 30
+
+/datum/uplink_item/cyber_implants/esword/traitor	//This is a worse idea
+	name = "Arm Energy-Blade Projector"
+	desc = "An illegal cybernetic combat implant that allows the user to project a blade of lethal energy from their hand."
+	item = /obj/item/organ/cyberimp/arm/esword
+	cost = 16
+	include_modes = list()
+	exclude_modes = list(/datum/game_mode/nuclear)
+	player_minimum = 30
+
+/datum/uplink_item/cyber_implants/medibeam
+	name = "Medical Beam Arm Implant"
+	desc = "An cybernetic implant that gives the user an extendable medical beamgun in their arm"
+	item = /obj/item/organ/cyberimp/arm/medibeam
+	cost = 20
+	player_minimum = 15
+
+/datum/uplink_item/cyber_implants/flash
+	name = "Arm Photon Projection Implant"
+	desc = "A glorified self-recharging flash that is implanted into a user's arm."
+	item = /obj/item/organ/cyberimp/arm/flash
+	include_modes = list()
+	cost = 6
+
+/datum/uplink_item/cyber_implants/baton			//This is a _really_ bad idea
+	name = "Arm Electrification Implant"
+	desc = "An illegal cybernetic combat implant that allows the user to extend a prod that stun others with their arm."
+	item = /obj/item/organ/cyberimp/arm/baton
+	cost = 16
+	player_minimum = 25
+
+/datum/uplink_item/cyber_implants/combat_melee	//If those were really bad ideas, this one must be the worst.
+	name = "Melee Combat Arm Implant"
+	desc = "A set of cybernetic implants combined in one value package for insertion into a user's arm. Contains energy blade, medical beam, flash, and stun-arm implant modules."
+	item = /obj/item/organ/cyberimp/arm/combat
+	cost = 48 //12 + 20 + 6 + 16 = 54 * 0.9 = 48.6
 
 /datum/uplink_item/cyber_implants/bundle
 	name = "Cybernetic Implants Bundle"


### PR DESCRIPTION
# **As soon as I can this will be split into two to three PRs for research levels rnd construction, and uplink stuff**

I didn't have time to test this as of now
Surgical implant can now be printed in R&D a higher cost then the toolset implant.
Flash implant can now be printed in R&D for a high cost (Probably a bad idea/needs nerf to 3-5 seconds of cooldown and longer burnout, cost is reasonably high on par with xray implants.)
Energy Blade implant added to uplink at 12 TC cost (Esword is 8 TC) for nuclear operatives, and 16 TC cost for traitors. Minimum 30 players to buy.(This is probably a really bad idea/needs to cost way more as it's basiclly a nodrop esword, and in the end will probably not work for traitor gamemode as it will probably just promote murderbones.)
Medical Beamgun implant added to uplink at 20 TC (Normal 15/16 IIRC) cost for nuclear operatives. Minimum 15 players.
Flash implant added to uplink at 6 TC for both operatives and traitors.
Stunbaton implant added to uplink at 16 TC for operatives. TODO: Add cooldown to this so it's not just an infinite stunbaton without 10 damage beating. (This will either need a really obvious sprite or won't work out in the end as it's basiclly stungloves.)
Operatives can buy the implant with all 4 functions of the combat implants for a discounted price of 48 TC (Ok this might not be good, but I guess it's balanced by the fact that you can't have more then one module active at a time..?)
:cl: Mekhi
rscadd: "Photon Projection" [Flash] implant added to R&D for a high research and material cost.
rscadd: Surgical Toolset implant added to R&D for a slightly higher cost then the Toolset Implant, and similar research requirements
rscadd: Traitors can now buy flash and energy-blade cybernetic implants.
rscadd: Nuclear Operatives can now buy the new cybernetic combat implants, including a flash, energy blade, stunprod, and the medical beam for 48 TC.
rscadd: All cybernetic implants come with autoimplanters.
:cl:
