### PR TITLE
Synchronize all canUseTopic headers to prevent runtimes

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -160,7 +160,7 @@
 
 
 #define BE_CLOSE 1		//in the case of a silicon, to select if they need to be next to the atom
-#define NO_DEXTERY 1	//if other mobs (monkeys, aliens, etc) can use this
+#define NO_DEXTERITY 1	//if other mobs (monkeys, aliens, etc) can use this
 //used by canUseTopic()
 
 //Sizes of mobs, used by mob/living/var/mob_size

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -159,10 +159,6 @@
 //click cooldowns, in tenths of a second
 
 
-#define BE_CLOSE 1		//in the case of a silicon, to select if they need to be next to the atom
-#define NO_DEXTERITY 1	//if other mobs (monkeys, aliens, etc) can use this
-//used by canUseTopic()
-
 //Sizes of mobs, used by mob/living/var/mob_size
 #define MOB_SIZE_TINY 0
 #define MOB_SIZE_SMALL 1

--- a/code/game/gamemodes/clock_cult/clock_machines.dm
+++ b/code/game/gamemodes/clock_cult/clock_machines.dm
@@ -212,7 +212,7 @@
 	return 1
 
 /obj/structure/destructible/clockwork/powered/mending_motor/attack_hand(mob/living/user)
-	if(user.canUseTopic(src, BE_CLOSE))
+	if(user.canUseTopic(src, be_close=TRUE))
 		if(total_accessable_power() < mob_cost)
 			user << "<span class='warning'>[src] needs more power or replicant alloy to function!</span>"
 			return 0
@@ -370,7 +370,7 @@
 		toggle(0)
 
 /obj/structure/destructible/clockwork/powered/mania_motor/attack_hand(mob/living/user)
-	if(user.canUseTopic(src, BE_CLOSE))
+	if(user.canUseTopic(src, be_close=TRUE))
 		if(!total_accessable_power() >= mania_cost)
 			user << "<span class='warning'>[src] needs more power to function!</span>"
 			return 0
@@ -410,7 +410,7 @@
 		SetLuminosity(0)
 
 /obj/structure/destructible/clockwork/powered/interdiction_lens/attack_hand(mob/living/user)
-	if(user.canUseTopic(src, BE_CLOSE))
+	if(user.canUseTopic(src, be_close=TRUE))
 		if(disabled)
 			user << "<span class='warning'>As you place your hand on the gemstone, cold tendrils of black matter crawl up your arm. You quickly pull back.</span>"
 			return 0
@@ -544,7 +544,7 @@
 				user << "<span class='warning'>The obelisk is sustaining a gateway and cannot broadcast!</span>"
 				return
 			var/input = stripped_input(usr, "Please choose a message to send over the Hierophant Network.", "Hierophant Broadcast", "")
-			if(!input || !user.canUseTopic(src, BE_CLOSE))
+			if(!input || !user.canUseTopic(src, be_close=TRUE))
 				return
 			if(gateway_active)
 				user << "<span class='warning'>The obelisk is sustaining a gateway and cannot broadcast!</span>"

--- a/code/game/gamemodes/clock_cult/clock_unsorted.dm
+++ b/code/game/gamemodes/clock_cult/clock_unsorted.dm
@@ -114,7 +114,7 @@
 		return 0
 	var/input_target_key = input(invoker, "Choose a target to form a rift to.", "Spatial Gateway") as null|anything in possible_targets
 	var/atom/movable/target = possible_targets[input_target_key]
-	if(!src || !target || !invoker || !invoker.canUseTopic(src, BE_CLOSE) || !is_servant_of_ratvar(invoker) || (istype(src, /obj/item) && invoker.get_active_held_item() != src))
+	if(!src || !target || !invoker || !invoker.canUseTopic(src, be_close=TRUE) || !is_servant_of_ratvar(invoker) || (istype(src, /obj/item) && invoker.get_active_held_item() != src))
 		return 0 //if any of the involved things no longer exist, the invoker is stunned, too far away to use the object, or does not serve ratvar, or if the object is an item and not in the mob's active hand, fail
 	var/istargetobelisk = istype(target, /obj/structure/destructible/clockwork/powered/clockwork_obelisk)
 	if(istargetobelisk)

--- a/code/game/gamemodes/devil/true_devil/_true_devil.dm
+++ b/code/game/gamemodes/devil/true_devil/_true_devil.dm
@@ -92,7 +92,7 @@
 /mob/living/carbon/true_devil/IsAdvancedToolUser()
 	return 1
 
-/mob/living/carbon/true_devil/canUseTopic(atom/movable/M, be_close = 0)
+/mob/living/carbon/true_devil/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 	if(incapacitated())
 		return 0
 	if(be_close && !in_range(M, src))

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -56,7 +56,7 @@
 			add_overlay(filling)
 
 /obj/machinery/iv_drip/MouseDrop(mob/living/target)
-	if(!ishuman(usr) || !usr.canUseTopic(src,BE_CLOSE))
+	if(!ishuman(usr) || !usr.canUseTopic(src,be_close=TRUE))
 		return
 
 	if(attached)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -664,7 +664,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	update_icon()
 
-/mob/dead/observer/canUseTopic()
+/mob/dead/observer/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 	if(check_rights(R_ADMIN, 0))
 		return 1
 	return

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -60,7 +60,7 @@
 /mob/living/carbon/alien/humanoid/Topic(href, href_list)
 	..()
 	//strip panel
-	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
+	if(usr.canUseTopic(src, be_close=TRUE, no_dexterity=TRUE))
 		if(href_list["pouches"])
 			visible_message("<span class='danger'>[usr] tries to empty [src]'s pouches.</span>", \
 							"<span class='userdanger'>[usr] tries to empty [src]'s pouches.</span>")

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -60,7 +60,7 @@
 /mob/living/carbon/alien/humanoid/Topic(href, href_list)
 	..()
 	//strip panel
-	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
 		if(href_list["pouches"])
 			visible_message("<span class='danger'>[usr] tries to empty [src]'s pouches.</span>", \
 							"<span class='userdanger'>[usr] tries to empty [src]'s pouches.</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -200,7 +200,7 @@
 /mob/living/carbon/Topic(href, href_list)
 	..()
 	//strip panel
-	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
 		if(href_list["internal"])
 			var/slot = text2num(href_list["internal"])
 			var/obj/item/ITEM = get_item_by_slot(slot)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -200,7 +200,7 @@
 /mob/living/carbon/Topic(href, href_list)
 	..()
 	//strip panel
-	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
+	if(usr.canUseTopic(src, be_close=TRUE, no_dexterity=TRUE))
 		if(href_list["internal"])
 			var/slot = text2num(href_list["internal"])
 			var/obj/item/ITEM = get_item_by_slot(slot)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -206,7 +206,7 @@
 
 
 /mob/living/carbon/human/Topic(href, href_list)
-	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
+	if(usr.canUseTopic(src, be_close=TRUE, no_dexterity=TRUE))
 
 		if(href_list["embedded_object"])
 			var/obj/item/I = locate(href_list["embedded_object"])

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -724,7 +724,7 @@
 				viewing += M.client
 		flick_overlay(image(icon,src,"electrocuted_generic",ABOVE_MOB_LAYER), viewing, anim_duration)
 
-/mob/living/carbon/human/canUseTopic(atom/movable/M, be_close = 0)
+/mob/living/carbon/human/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 	if(incapacitated() || lying )
 		return
 	if(!Adjacent(M) && (M.loc != src))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -206,7 +206,7 @@
 
 
 /mob/living/carbon/human/Topic(href, href_list)
-	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
 
 		if(href_list["embedded_object"])
 			var/obj/item/I = locate(href_list["embedded_object"])

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -819,7 +819,7 @@
 	visible_message("<span class='notice'>[user] butchers [src].</span>")
 	gib(0, 0, 1)
 
-/mob/living/canUseTopic(atom/movable/M, be_close = 0, no_dextery = 0)
+/mob/living/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 	if(incapacitated())
 		return
 	if(no_dextery)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -822,7 +822,7 @@
 /mob/living/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 	if(incapacitated())
 		return
-	if(no_dextery)
+	if(no_dexterity)
 		if(be_close && in_range(M, src))
 			return 1
 	else

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -767,7 +767,7 @@ var/list/ai_list = list()
 /mob/living/silicon/ai/can_buckle()
 	return 0
 
-/mob/living/silicon/ai/canUseTopic(atom/movable/M, be_close = 0)
+/mob/living/silicon/ai/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 	if(stat)
 		return
 	if(be_close && !in_range(M, src))

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -99,7 +99,7 @@
 
 // See software.dm for Topic()
 
-/mob/living/silicon/pai/canUseTopic(atom/movable/M)
+/mob/living/silicon/pai/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 	return 1
 /*
 // Debug command - Maybe should be added to admin verbs later

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1036,7 +1036,7 @@
 		if(3) //New Name
 			connected_ai << "<br><br><span class='notice'>NOTICE - Cyborg reclassification detected: [oldname] is now designated as [newname].</span><br>"
 
-/mob/living/silicon/robot/canUseTopic(atom/movable/M, be_close = 0)
+/mob/living/silicon/robot/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 	if(stat || lockcharge || low_power_mode)
 		return
 	if(be_close && !in_range(M, src))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -381,7 +381,7 @@
 		return 1
 	return 0
 
-/mob/living/simple_animal/canUseTopic(atom/movable/M, be_close = 0, no_dextery = 0)
+/mob/living/simple_animal/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 	if(incapacitated())
 		return 0
 	if(no_dextery || dextrous)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -384,7 +384,7 @@
 /mob/living/simple_animal/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 	if(incapacitated())
 		return 0
-	if(no_dextery || dextrous)
+	if(no_dexterity || dextrous)
 		if(be_close && !in_range(M, src))
 			return 0
 	else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -526,7 +526,7 @@ var/next_mob_id = 0
 		if(machine && in_range(src, usr))
 			show_inv(machine)
 
-	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
 		if(href_list["item"])
 			var/slot = text2num(href_list["item"])
 			var/hand_index = text2num(href_list["hand_index"])

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -857,7 +857,7 @@ var/next_mob_id = 0
 	return 0
 
 //Can the mob use Topic to interact with machines
-/mob/proc/canUseTopic()
+/mob/proc/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 	return
 
 /mob/proc/faction_check(mob/target)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -526,7 +526,7 @@ var/next_mob_id = 0
 		if(machine && in_range(src, usr))
 			show_inv(machine)
 
-	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
+	if(usr.canUseTopic(src, be_close=TRUE, no_dexterity=TRUE))
 		if(href_list["item"])
 			var/slot = text2num(href_list["item"])
 			var/hand_index = text2num(href_list["hand_index"])

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -43,7 +43,7 @@
 		return machinery_computer.update_icon()
 
 // This thing is not meant to be used on it's own, get topic data from our machinery owner.
-//obj/item/device/modular_computer/processor/canUseTopic(user, state)
+//obj/item/device/modular_computer/processor/canUseTopic(atom/movable/M, be_close = FALSE, no_dexterity = FALSE)
 //	if(!machinery_computer)
 //		return 0
 


### PR DESCRIPTION
TODO: go through and check all instances of use to ensure they properly specify which positional arguments to use
