### PR TITLE
Fixes minimap crashes.

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -113,7 +113,9 @@ var/datum/subsystem/minimap/SSminimap
 		obj = locate(/obj/structure/window) in tile
 		if(obj)
 			obj_icons += new /icon('icons/obj/smooth_structures/window.dmi', "window", SOUTH)
-
+		obj = locate(/obj/structure/table) in tile
+		if(obj)
+			obj_icons += new /icon('icons/obj/smooth_structures/table.dmi', "table", SOUTH)
 		for(var/I in obj_icons)
 			var/icon/obj_icon = I
 			tile_icon.Blend(obj_icon, ICON_OVERLAY)

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -120,7 +120,7 @@ var/datum/subsystem/minimap/SSminimap
 
 		obj = locate(/obj/structure) in tile
 		if(obj)
-			obj_icons += getFlatIcon(obj)
+			obj_icons += new /icon(obj.icon, obj.icon_state, obj.dir, 1, 0)
 		obj = locate(/obj/machinery) in tile
 		if(obj)
 			obj_icons += new /icon(obj.icon, obj.icon_state, obj.dir, 1, 0)

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -73,23 +73,9 @@ var/datum/subsystem/minimap/SSminimap
 	// Scale it up to our target size.
 	minimap.Scale(MINIMAP_SIZE, MINIMAP_SIZE)
 
-	var/counter = 512
 	// Loop over turfs and generate icons.
 	for(var/T in block(locate(x1, y1, z), locate(x2, y2, z)))
 		generate_tile(T, minimap)
-
-		//byond bug, this fixes OOM crashes by flattening and reseting the minimap icon holder every so and so tiles
-		counter--
-		if(counter <= 0)
-			counter = 512
-			var/icon/flatten = new /icon()
-			flatten.Insert(minimap, "", SOUTH, 1, 0)
-			del(minimap)
-			minimap = flatten
-			stoplag() //we have to sleep in order to get byond to clear out the proc's garbage bin
-
-		CHECK_TICK
-
 
 	// Create a new icon and insert the generated minimap, so that BYOND doesn't generate different directions.
 	var/icon/final = new /icon()
@@ -99,7 +85,7 @@ var/datum/subsystem/minimap/SSminimap
 /datum/subsystem/minimap/proc/generate_tile(turf/tile, icon/minimap)
 	var/icon/tile_icon
 	var/obj/obj
-	var/list/obj_icons = list()
+	var/list/obj_icons
 	// Don't use icons for space, just add objects in space if they exist.
 	if(istype(tile, /turf/open/space))
 		obj = locate(/obj/structure/lattice/catwalk) in tile
@@ -116,7 +102,7 @@ var/datum/subsystem/minimap/SSminimap
 			tile_icon = new /icon('icons/obj/atmospherics/pipes/transit_tube.dmi', obj.icon_state, obj.dir)
 	else
 		tile_icon = new /icon(tile.icon, tile.icon_state, tile.dir)
-		obj_icons.Cut()
+		obj_icons = list()
 
 		obj = locate(/obj/structure) in tile
 		if(obj)
@@ -137,4 +123,3 @@ var/datum/subsystem/minimap/SSminimap
 		tile_icon.Scale(TILE_SIZE, TILE_SIZE)
 		// Add the tile to the minimap.
 		minimap.Blend(tile_icon, ICON_OVERLAY, ((tile.x - 1) * TILE_SIZE), ((tile.y - 1) * TILE_SIZE))
-		del(tile_icon)


### PR DESCRIPTION
:cl:
fix: Fixes minimap generation crashes by making parts of it less precise
/:cl:
getflaticon is the cause, so we just don't use it: http://www.byond.com/forum/?post=2024837#comment21043538

This should also be a decent speed up from old code
