### PR TITLE
[this pr is ready please stop ignoring it :)] Adds combat cybernetic implants to the uplink

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -192,7 +192,7 @@
 	desc = "An illegal, and highly dangerous cybernetic implant that can project a deadly blade of concentrated enregy."
 	contents = newlist(/obj/item/weapon/melee/energy/blade)
 
-/obj/item/organ/cyberimp/arm/medibeam
+/obj/item/organ/cyberimp/arm/medbeam
 	name = "integrated medical beamgun"
 	desc = "A cybernetic implant that allows the user to project a healing beam from their hand."
 	contents = newlist(/obj/item/weapon/gun/medbeam)

--- a/code/modules/surgery/organs/autoimplanter.dm
+++ b/code/modules/surgery/organs/autoimplanter.dm
@@ -63,3 +63,33 @@
 	desc = "A single use autoimplanter that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
 	storedorgan = new/obj/item/organ/cyberimp/eyes/hud/medical()
 	uses = 1
+
+/obj/item/device/autoimplanter/esword
+	name = "Energy Blade Autoimplanter"
+	desc = "A single use autoimplanter that contains an energy blade implant, removable by screwdriver. However, once you remove it, you can no longer put it back in."
+	storedorgan = new/obj/item/organ/cyberimp/arm/esword()
+	uses = 1
+
+/obj/item/device/autoimplanter/baton
+	name = "Stun-Arm Autoimplanter"
+	desc = "A single use autoimplanter that contains a stun-arm implant, removable by screwdriver. However, once you remove it, you can no longer put it back in."
+	storedorgan = new/obj/item/organ/cyberimp/arm/baton()
+	uses = 1
+
+/obj/item/device/autoimplanter/medbeam
+	name = "Medibeam Autoimplanter"
+	desc = "A single use autoimplanter that contains a medical beamgun implant, removable by screwdriver. However, once you remove it, you can no longer put it back in."
+	storedorgan = new/obj/item/organ/cyberimp/arm/medbeam()
+	uses = 1
+
+/obj/item/device/autoimplanter/flash
+	name = "Photon Projecotr Autoimplanter"
+	desc = "A single use autoimplanter that contains a photon projector implant, removable by screwdriver. However, once you remove it, you can no longer put it back in."
+	storedorgan = new/obj/item/organ/cyberimp/arm/flash()
+	uses = 1
+
+/obj/item/device/autoimplanter/combat/melee
+	name = "Melee Combat Set Autoimplanter"
+	desc = "A single use autoimplanter that contains an implant containing a set of melee combat augments, as well as a medical beamgun, removable by screwdriver. However, once you remove it, you can no longer put it back in."
+	storedorgan = new/obj/item/organ/cyberimp/arm/combat()
+	uses = 1

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1034,13 +1034,9 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	player_minimum = 30
 
 /datum/uplink_item/cyber_implants/esword/traitor	//This is a worse idea
-	name = "Arm Energy-Blade Projector"
-	desc = "An illegal cybernetic combat implant that allows the user to project a blade of lethal energy from their hand."
-	item = /obj/item/device/autoimplanter/esword
 	cost = 16
 	include_modes = list()
 	exclude_modes = list(/datum/game_mode/nuclear)
-	player_minimum = 30
 
 /datum/uplink_item/cyber_implants/medbeam
 	name = "Medical Beam Arm Implant"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1026,6 +1026,49 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 		else
 			return ..()
 
+/datum/uplink_item/cyber_implants/esword	//This is a bad idea
+	name = "Arm Energy-Blade Projector"
+	desc = "An illegal cybernetic combat implant that allows the user to project a blade of lethal energy from their hand."
+	item = /obj/item/device/autoimplanter/esword
+	cost = 12
+	player_minimum = 30
+
+/datum/uplink_item/cyber_implants/esword/traitor	//This is a worse idea
+	name = "Arm Energy-Blade Projector"
+	desc = "An illegal cybernetic combat implant that allows the user to project a blade of lethal energy from their hand."
+	item = /obj/item/device/autoimplanter/esword
+	cost = 16
+	include_modes = list()
+	exclude_modes = list(/datum/game_mode/nuclear)
+	player_minimum = 30
+
+/datum/uplink_item/cyber_implants/medbeam
+	name = "Medical Beam Arm Implant"
+	desc = "An cybernetic implant that gives the user an extendable medical beamgun in their arm"
+	item = /obj/item/device/autoimplanter/medbeam
+	cost = 20
+	player_minimum = 15
+
+/datum/uplink_item/cyber_implants/flash
+	name = "Arm Photon Projection Implant"
+	desc = "A glorified self-recharging flash that is implanted into a user's arm."
+	item = /obj/item/device/autoimplanter/flash
+	include_modes = list()
+	cost = 6
+
+/datum/uplink_item/cyber_implants/baton			//This is a _really_ bad idea
+	name = "Arm Electrification Implant"
+	desc = "An illegal cybernetic combat implant that allows the user to extend a prod that stun others with their arm."
+	item = /obj/item/device/autoimplanter/baton
+	cost = 16
+	player_minimum = 25
+
+/datum/uplink_item/cyber_implants/combat_melee	//If those were really bad ideas, this one must be the worst.
+	name = "Melee Combat Arm Implant"
+	desc = "A set of cybernetic implants combined in one value package for insertion into a user's arm. Contains energy blade, medical beam, flash, and stun-arm implant modules."
+	item = /obj/item/device/autoimplanter/combat/melee
+	cost = 48 //12 + 20 + 6 + 16 = 54 * 0.9 = 48.6
+
 /datum/uplink_item/cyber_implants/thermals
 	name = "Thermal Vision Implant"
 	desc = "These cybernetic eyes will give you thermal vision. They must be implanted via surgery."


### PR DESCRIPTION
## DNM because balance concerns needs discussion etc etc

Adds combat implants to uplink, which would include an energy blade, flash, stun-arm, and medical beamgun, as well as a very costly but still discounted implant that has all 4 items in 1!
Energy blade costs 12 TC for nuclear operatives, 16 TC for traitors. Normal hand-held eswords are 8 TC, and have armor penetration, and block chance. The implant version do not have block chance, or armor penetration, but only make a quiet sparking on activation ( Unless I really should put something else as the sound)
Flash costs 6 TC for both.
Stun-arm costs 16 TC and is only for nuclear operatives.
Medical-Beamgun costs 20 TC (normal handheld item 16 TC) for nuclear operatives
An implant with all 4 items built into it is available to nuclear operatives for 48 TC.
:cl: Mekhi
rscadd: Traitors can now purchase the Energy Blade implant for 16 TC, and the Photon Projector implant for 6 TC.
rscadd: Nuclear Operatives can now purchase the Energy Blade implant for 12 TC, the Photon Projector implant for 6 TC, Medical Beam implant for 20 TC, Stun Arm implant for 16 TC, and an arm implant with all 4 for 48 TC which is a 10% off deal!
tweak: Photon Projector is just a fancy way of saying a flash that also works as a flashlight and never burns out unless it is exposed to electromagnetic burst radiation.
:cl:

Honestly the only balance concern I see with this is nukeops having what's basiclly stungloves and traitors getting a murderbone-tier weapon, even without the AP and block chance the esword implant is still really strong and has sharpness if that other PR goes in.
