### PR TITLE
Grills now properly tesla bolt when things are tossed at them

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -265,7 +265,7 @@
 			var/obj/structure/cable/C = T.get_cable_node()
 			if(C)
 				playsound(src.loc, 'sound/magic/LightningShock.ogg', 100, 1, extrarange = 5)
-				tesla_zap(src, 3, C.powernet.avail * 0.02) //Zap for 1/50 of the amount of power.
+				tesla_zap(src, 3, C.powernet.avail * 0.01) //Zap for 1/100 of the amount of power. At a million watts in the grid, it will be as powerful as a tesla revolver shot.
 	take_damage(tforce)
 
 /obj/structure/grille/storage_contents_dump_act(obj/item/weapon/storage/src_object, mob/user)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -264,17 +264,8 @@
 			var/turf/T = get_turf(src)
 			var/obj/structure/cable/C = T.get_cable_node()
 			if(C)
-				var/mob/living/closest_mob
-				for(var/A in oview(src, 3))
-					if(istype(A, /mob/living))
-						var/dist = get_dist(src, A)
-						if(dist <= 3)
-							closest_mob = A
-				if(closest_mob)
-					var/shock_damage = C.powernet.avail * 0.0002//setting shock damage for later. equals 1/5000 the power in the grid
-					src.Beam(closest_mob, icon_state="lightning[rand(1,12)]", time=5)
-					closest_mob.electrocute_act(shock_damage, src, 1)//ZAP, damage should be about 40 with 200000W
-					playsound(src.loc, 'sound/magic/LightningShock.ogg', 100, 1, extrarange = 5)
+				playsound(src.loc, 'sound/magic/LightningShock.ogg', 100, 1, extrarange = 5)
+				tesla_zap(src, 3, C.powernet.avail * 0.02) //Zap for 1/50 of the amount of power.
 	take_damage(tforce)
 
 /obj/structure/grille/storage_contents_dump_act(obj/item/weapon/storage/src_object, mob/user)


### PR DESCRIPTION
Teslium PR made tesla engine and only tesla engine blow machinery up on tesla bolt so this should be safe.
Tesla grills now normally tesla zap instead of special snowflake measures to only target mobs.
:cl:Mekhi
tweak: Grills now Tesla shock properly.
:cl:
