### PR TITLE
Centcom won't ask the station to nuke itself if the blob is dead.

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -96,7 +96,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 		message_sent = TRUE
 
 		sleep(24000) //40 minutes, plus burst_delay*3(minimum of 6 minutes, maximum of 8)
-
-		send_intercept(2) //if the blob has been alive this long, it's time to bomb it
+		if(!replacementmode)
+			send_intercept(2) //if the blob has been alive this long, it's time to bomb it
 
 	return ..()


### PR DESCRIPTION
If you defeat a blob and let the mulligan play out centcom will no longer command you to nuke yourself at the 40 minute mark.
