### PR TITLE
Reduces damage of surgery tools

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -41,7 +41,7 @@
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	materials = list(MAT_METAL=10000, MAT_GLASS=6000)
 	flags = CONDUCT
-	force = 3
+	force = 5
 	w_class = 3
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("drilled")
@@ -52,7 +52,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "scalpel"
 	flags = CONDUCT
-	force = 3
+	force = 5
 	w_class = 1
 	throwforce = 5
 	throw_speed = 3
@@ -78,7 +78,7 @@
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	throwhitsound =  'sound/weapons/pierce.ogg'
 	flags = CONDUCT
-	force = 5
+	force = 8
 	w_class = 3
 	throwforce = 9
 	throw_speed = 2

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -41,7 +41,7 @@
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	materials = list(MAT_METAL=10000, MAT_GLASS=6000)
 	flags = CONDUCT
-	force = 15
+	force = 3
 	w_class = 3
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("drilled")
@@ -52,7 +52,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "scalpel"
 	flags = CONDUCT
-	force = 10
+	force = 3
 	w_class = 1
 	throwforce = 5
 	throw_speed = 3
@@ -78,7 +78,7 @@
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	throwhitsound =  'sound/weapons/pierce.ogg'
 	flags = CONDUCT
-	force = 15
+	force = 5
 	w_class = 3
 	throwforce = 9
 	throw_speed = 2


### PR DESCRIPTION
:cl:
del: Surgery tools now do less damage.
/:cl:

Scalpel and surgical drill do 5 damage, circular saw does 8.

Mapping is annoying when surgery has to be isolated to avoid tools being looted. I'm hoping this change will make people less keen on immediately stealing them whenever they're in sight.

This will make fucking surgery up less risky, but I think that that's actually a good change, and even when it was dangerous, people could immediately patch the person up since the tools were only really used by medical doctors.

EDIT: What inspired me to make this PR is wanting to have surgery tables more out in the open. Instead of segmenting medbay up into cryo area, sleepers, and surgery, it could all be in one more open area. You could even give medbay more than one surgery table since tools would be less risky to give everyone. Please think this over because I think it's a great idea.
