### PR TITLE
Chasms now check their dropped atom doesn't go away after sleep

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -662,6 +662,10 @@
 	return 1
 
 /turf/open/chasm/proc/drop(atom/movable/AM)
+	//Make sure the item is still there after our sleep
+	if(!AM || qdeleted(AM))
+		return
+
 	var/turf/T = locate(drop_x, drop_y, drop_z)
 	if(T)
 		AM.visible_message("<span class='boldwarning'>[AM] falls into [src]!</span>", "<span class='userdanger'>GAH! Ah... where are you?</span>")
@@ -697,6 +701,9 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 
 /turf/open/chasm/straight_down/lava_land_surface/drop(atom/movable/AM)
+	//Make sure the item is still there after our sleep
+	if(!AM || qdeleted(AM))
+		return
 	AM.visible_message("<span class='boldwarning'>[AM] falls into [src]!</span>", "<span class='userdanger'>You stumble and stare into an abyss before you. It stares back, and you fall \
 	into the enveloping dark.</span>")
 	if(isliving(AM))


### PR DESCRIPTION
drop is called from the timer subsystem, so delays have been incurred and the item may no longer exist
