### PR TITLE
Add an exception for null locations being added to turf proximity

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1239,6 +1239,8 @@ B --><-- A
 
 /proc/add_to_proximity_list(atom/A, range)
 	var/turf/T = get_turf(A)
+	if(!T || !A.loc)
+		throw EXCEPTION("Someone adding a prox sensor in nullspace")
 	var/list/L = block(locate(T.x - range, T.y - range, T.z), locate(T.x + range, T.y + range, T.z))
 	for(var/B in L)
 		var/turf/C = B


### PR DESCRIPTION
Been trying to track this bug for a while and not getting any results, so adding some more debug runtimes.

Fairly certain the cause is a camera in nullspace but this will confirm for sure.
