### PR TITLE
Adjusted the blobs required for blobs to win in the blob mode

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -32,7 +32,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 	var/blob_point_rate = 3
 	var/blob_base_starting_points = 80
 
-	var/blobwincount = 350
+	var/blobwincount = 250
 
 	var/messagedelay_low = 2400 //in deciseconds
 	var/messagedelay_high = 3600 //blob report will be sent after a random value between these (minimum 4 minutes, maximum 6 minutes)
@@ -42,7 +42,8 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 /datum/game_mode/blob/pre_setup()
 	cores_to_spawn = max(round(num_players()/players_per_core, 1), 1)
 
-	blobwincount = initial(blobwincount) * cores_to_spawn
+	var/win_multiplier = 1 + (0.1 * cores_to_spawn)
+	blobwincount = initial(blobwincount) * cores_to_spawn * win_multiplier
 
 	for(var/j = 0, j < cores_to_spawn, j++)
 		if (!antag_candidates.len)


### PR DESCRIPTION
:cl: Joan
tweak: Blobs will generally require fewer blobs to win during the blob mode, which should hopefully make the mode end faster at lower overmind amounts.
/:cl:

Amount by number of overminds;
1. 275 (from 350)
2. 600 (from 700)
3. 975 (from 1050)
4. 1400 (same as current)
5. 1875 (from 1750, why the hell do you have five blobs)
