### PR TITLE
Fixes forcewalls from the wizard's den getting scattered in deep space

### DIFF
--- a/_maps/map_files/generic/z2.dmm
+++ b/_maps/map_files/generic/z2.dmm
@@ -12220,7 +12220,7 @@ jc
 kS
 lm
 kS
-lG
+lp
 jc
 lY
 kF
@@ -12486,8 +12486,8 @@ kG
 ln
 ku
 ne
-ni
-nr
+kV
+lo
 jc
 nC
 nD
@@ -12999,9 +12999,9 @@ kG
 kG
 kG
 ku
-nr
-nr
-ni
+ne
+lo
+kV
 jc
 nD
 nD


### PR DESCRIPTION
...and depressurizing the wizard's den in the process.

Something changed about how transit space selected what had to be moved, and in doing so it invalidated the placement of a few tiles in the den.
