### PR TITLE
Dark blue slime extract freezing reaction now spawns freon instead of cooling mobs

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -249,11 +249,9 @@
 	addtimer(src, "freeze", 50, FALSE, holder)
 /datum/chemical_reaction/slimefreeze/proc/freeze(datum/reagents/holder)
 	if(holder && holder.my_atom)
-		var/turf/T = get_turf(holder.my_atom)
-		playsound(T, 'sound/effects/phasein.ogg', 100, 1)
-		for(var/mob/living/M in range(T, 7))
-			M.bodytemperature -= 240
-			M << "<span class='notice'>You feel a chill!</span>"
+		var/turf/open/T = get_turf(holder.my_atom)
+		if(istype(T))
+			T.atmos_spawn_air("freon=50;TEMP=120")
 
 
 /datum/chemical_reaction/slimefireproof


### PR DESCRIPTION
:cl: XDTM
tweak: Using plasma on dark blue slimes will now spawn freon instead of arbitrarily freezing mobs.
/:cl:

A nice counterpart to orange slimes.
