### PR TITLE
Overhaul some atom spawn code in grenades and badmin bomb cores

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -330,6 +330,24 @@ Proc for attack log creation, because really why not
 		if(H.dna && istype(H.dna.species, species_datum))
 			. = TRUE
 
+/proc/spawn_and_random_walk(spawn_type, target, amount, walk_chance=100, max_walk=3, always_max_walk=FALSE, admin_spawn=FALSE)
+	var/turf/T = get_turf(target)
+	var/step_count = 0
+	if(!T)
+		throw EXCEPTION("attempt to spawn atom type: [spawn_type] in nullspace")
+
+	for(var/j in 1 to amount)
+		var/atom/movable/X = new spawn_type(T)
+		X.admin_spawned = admin_spawn
+
+		if(always_max_walk || prob(walk_chance))
+			if(always_max_walk)
+				step_count = max_walk
+			else
+				step_count = rand(1, max_walk)
+
+			for(var/i in 1 to step_count)
+				step(X, pick(NORTH, SOUTH, EAST, WEST))
 
 /proc/deadchat_broadcast(message, mob/follow_target=null, speaker_key=null, message_type=DEADCHAT_REGULAR)
 	for(var/mob/M in player_list)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -337,13 +337,7 @@
 
 /obj/item/weapon/bombcore/badmin/summon/detonate()
 	var/obj/machinery/syndicatebomb/B = src.loc
-	for(var/i = 0; i < amt_summon; i++)
-		var/atom/movable/X = new summon_path
-		X.admin_spawned = TRUE
-		X.loc = get_turf(src)
-		if(prob(50))
-			for(var/j = 1, j <= rand(1, 3), j++)
-				step(X, pick(NORTH,SOUTH,EAST,WEST))
+	spawn_and_random_walk(summon_path, src, amt_summon, walk_chance=50, admin_spawn=TRUE)
 	qdel(B)
 	qdel(src)
 

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -17,15 +17,8 @@
 		for(var/mob/living/carbon/C in viewers(T, null))
 			C.flash_act()
 
-		for(var/i=1, i<=deliveryamt, i++)
-			var/atom/movable/x = new spawner_type
-			x.admin_spawned = admin_spawned
-			x.loc = T
-			if(prob(50))
-				for(var/j = 1, j <= rand(1, 3), j++)
-					step(x, pick(NORTH,SOUTH,EAST,WEST))
-
-			// Spawn some hostile syndicate critters
+		// Spawn some hostile syndicate critters and spread them out
+		spawn_and_random_walk(spawner_type, T, deliveryamt, walk_chance=50, admin_spawn=admin_spawned)
 
 	qdel(src)
 


### PR DESCRIPTION
Fixes badminbomb cores and spawner grenades starting out mobs in
nullspace, also adds a helper proc to do spawning

Some admin had a _lot_ of fun yesterday

The following runtime has occurred 385 time(s).
runtime error: Simple animal being instantiated in nullspace
