### PR TITLE
Better handling of falling back on bodyparts for humans

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1151,7 +1151,8 @@
 			def_zone = ran_zone(def_zone)
 		BP = H.get_bodypart(check_zone(def_zone))
 		if(!BP)
-			BP = H.bodyparts[1]
+			//fall back to chest
+			BP = H.get_bodypart("chest")
 
 	switch(damagetype)
 		if(BRUTE)


### PR DESCRIPTION
This caused a runtime to fire, however, this doesn't fix the runtime (which is due to a mob missing all its bodyparts) but I think it's a saner approach to dealing with missing bodyparts.
