### PR TITLE
Stable mutation toxins

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -30,14 +30,6 @@
 		return 0
 	return ..()
 
-
-/datum/species/human/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
-	if(chem.id == "mutationtoxin")
-		H << "<span class='danger'>Your flesh rapidly mutates!</span>"
-		H.set_species(/datum/species/jelly/slime)
-		H.reagents.del_reagent(chem.type)
-		return 1
-
 //Curiosity killed the cat's wagging tail.
 /datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	if(H)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -361,8 +361,8 @@
 	color = "#13BC5E" // rgb: 19, 188, 94
 
 /datum/reagent/stableslimetoxin
-	name = "Human Mutation Toxin"
-	id = "humanmutationtoxin"
+	name = "Stable Mutation Toxin"
+	id = "stablemutationtoxin"
 	description = "A humanizing toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	metabolization_rate = INFINITY //So it instantly removes all of itself

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -354,12 +354,6 @@
 	..()
 	return
 
-/datum/reagent/slimetoxin
-	name = "Mutation Toxin"
-	id = "mutationtoxin"
-	description = "A corruptive toxin produced by slimes."
-	color = "#13BC5E" // rgb: 19, 188, 94
-
 /datum/reagent/stableslimetoxin
 	name = "Stable Mutation Toxin"
 	id = "stablemutationtoxin"
@@ -388,7 +382,7 @@
 
 	return 1
 
-/datum/reagent/stableslimetoxin/classic
+/datum/reagent/stableslimetoxin/classic //The one from plasma on green slimes
 	name = "Mutation Toxin"
 	id = "mutationtoxin"
 	description = "A corruptive toxin produced by slimes."
@@ -420,14 +414,6 @@
 	race = /datum/species/pod
 	mutationtext = "<span class='danger'>The pain subsides. You feel... plantlike.</span>"
 
-/datum/reagent/stableslimetoxin/shadow
-	name = "Shadow Mutation Toxin"
-	id = "shadowmutationtoxin"
-	description = "A dark toxin produced by slimes."
-	color = "#5EFF3B" //RGB: 94, 255, 59
-	race = /datum/species/shadow
-	mutationtext = "<span class='danger'>The pain subsides. You feel... darker.</span>"
-
 /datum/reagent/stableslimetoxin/jelly
 	name = "Imperfect Mutation Toxin"
 	id = "jellymutationtoxin"
@@ -444,6 +430,24 @@
 	race = /datum/species/golem/random
 	mutationtext = "<span class='danger'>The pain subsides. You feel... rocky.</span>"
 
+/datum/reagent/stableslimetoxin/abductor
+	name = "Abductor Mutation Toxin"
+	id = "abductormutationtoxin"
+	description = "An alien toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/abductor
+	mutationtext = "<span class='danger'>The pain subsides. You feel... alien.</span>"
+
+/datum/reagent/stableslimetoxin/android
+	name = "Android Mutation Toxin"
+	id = "androidmutationtoxin"
+	description = "A robotic toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/android
+	mutationtext = "<span class='danger'>The pain subsides. You feel... artificial.</span>"
+
+
+//BLACKLISTED RACES
 /datum/reagent/stableslimetoxin/skeleton
 	name = "Skeleton Mutation Toxin"
 	id = "skeletonmutationtoxin"
@@ -460,13 +464,23 @@
 	race = /datum/species/zombie //Not the infectious kind. The days of xenobio zombie outbreaks are long past.
 	mutationtext = "<span class='danger'>The pain subsides. You feel... undead.</span>"
 
-/datum/reagent/stableslimetoxin/abductor
-	name = "Abductor Mutation Toxin"
-	id = "abductormutationtoxin"
-	description = "An alien toxin produced by slimes."
+/datum/reagent/stableslimetoxin/ash
+	name = "Ash Mutation Toxin"
+	id = "ashmutationtoxin"
+	description = "An ashen toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
-	race = /datum/species/abductor
-	mutationtext = "<span class='danger'>The pain subsides. You feel... alien.</span>"
+	race = /datum/species/lizard/ashwalker
+	mutationtext = "<span class='danger'>The pain subsides. You feel... savage.</span>"
+
+
+//DANGEROUS RACES
+/datum/reagent/stableslimetoxin/shadow
+	name = "Shadow Mutation Toxin"
+	id = "shadowmutationtoxin"
+	description = "A dark toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/shadow
+	mutationtext = "<span class='danger'>The pain subsides. You feel... darker.</span>"
 
 /datum/reagent/stableslimetoxin/plasma
 	name = "Plasma Mutation Toxin"
@@ -475,14 +489,6 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/plasmaman
 	mutationtext = "<span class='danger'>The pain subsides. You feel... flammable.</span>"
-
-/datum/reagent/stableslimetoxin/android
-	name = "Android Mutation Toxin"
-	id = "androidmutationtoxin"
-	description = "A robotic toxin produced by slimes."
-	color = "#5EFF3B" //RGB: 94, 255, 59
-	race = /datum/species/android
-	mutationtext = "<span class='danger'>The pain subsides. You feel... artificial.</span>"
 
 /datum/reagent/stableslimetoxin/unstable //PSYCH
 	name = "Unstable Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -360,38 +360,6 @@
 	description = "A corruptive toxin produced by slimes."
 	color = "#13BC5E" // rgb: 19, 188, 94
 
-/datum/reagent/unstableslimetoxin
-	name = "Unstable Mutation Toxin"
-	id = "unstablemutationtoxin"
-	description = "An unstable and unpredictable corruptive toxin produced by slimes."
-	color = "#5EFF3B" //RGB: 94, 255, 59
-	metabolization_rate = INFINITY //So it instantly removes all of itself
-
-/datum/reagent/unstableslimetoxin/on_mob_life(mob/living/carbon/human/H)
-	..()
-	H << "<span class='warning'><b>You crumple in agony as your flesh wildly morphs into new forms!</b></span>"
-	H.visible_message("<b>[H]</b> falls to the ground and screams as their skin bubbles and froths!") //'froths' sounds painful when used with SKIN.
-	H.Weaken(3, 0)
-	spawn(30)
-		if(!H || qdeleted(H))
-			return
-		var/list/possible_morphs = list()
-		for(var/type in subtypesof(/datum/species))
-			var/datum/species/S = type
-			if(initial(S.blacklisted))
-				continue
-			possible_morphs += S
-
-		var/current_species = H.dna.species.type
-		var/datum/species/mutation = pick(possible_morphs)
-		if(mutation && mutation != current_species)
-			H << "<span class='danger'>The pain subsides. You feel... different.</span>"
-			H.set_species(mutation)
-		else
-			H << "<span class='danger'>The pain vanishes suddenly. You feel no different.</span>"
-
-	return 1
-
 /datum/reagent/stableslimetoxin
 	name = "Human Mutation Toxin"
 	id = "humanmutationtoxin"
@@ -420,6 +388,14 @@
 
 	return 1
 
+/datum/reagent/stableslimetoxin/classic
+	name = "Mutation Toxin"
+	id = "mutationtoxin"
+	description = "A corruptive toxin produced by slimes."
+	color = "#13BC5E" // rgb: 19, 188, 94
+	race = /datum/species/jelly/slime
+	mutationtext = "<span class='danger'>The pain subsides. Your whole body feels like slime.</span>"
+
 /datum/reagent/stableslimetoxin/lizard
 	name = "Lizard Mutation Toxin"
 	id = "lizardmutationtoxin"
@@ -427,7 +403,6 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/lizard
 	mutationtext = "<span class='danger'>The pain subsides. You feel... scaly.</span>"
-
 
 /datum/reagent/stableslimetoxin/fly
 	name = "Fly Mutation Toxin"
@@ -500,6 +475,31 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/plasmaman
 	mutationtext = "<span class='danger'>The pain subsides. You feel... flammable.</span>"
+
+/datum/reagent/stableslimetoxin/android
+	name = "Android Mutation Toxin"
+	id = "androidmutationtoxin"
+	description = "A robotic toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/android
+	mutationtext = "<span class='danger'>The pain subsides. You feel... artificial.</span>"
+
+/datum/reagent/stableslimetoxin/unstable //PSYCH
+	name = "Unstable Mutation Toxin"
+	id = "unstablemutationtoxin"
+	description = "An unstable and unpredictable corruptive toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	mutationtext = "<span class='danger'>The pain subsides. You feel... different.</span>"
+
+/datum/reagent/stableslimetoxin/unstable/on_mob_life(mob/living/carbon/human/H)
+	var/list/possible_morphs = list()
+	for(var/type in subtypesof(/datum/species))
+		var/datum/species/S = type
+		if(initial(S.blacklisted))
+			continue
+		possible_morphs += S
+	race = pick(possible_morphs)
+	..()
 
 /datum/reagent/mulligan
 	name = "Mulligan Toxin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -392,6 +392,115 @@
 
 	return 1
 
+/datum/reagent/stableslimetoxin
+	name = "Human Mutation Toxin"
+	id = "humanmutationtoxin"
+	description = "A humanizing toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	metabolization_rate = INFINITY //So it instantly removes all of itself
+	var/datum/species/race = /datum/species/human
+	var/mutationtext = "<span class='danger'>The pain subsides. You feel... human.</span>"
+
+/datum/reagent/stableslimetoxin/on_mob_life(mob/living/carbon/human/H)
+	..()
+	H << "<span class='warning'><b>You crumple in agony as your flesh wildly morphs into new forms!</b></span>"
+	H.visible_message("<b>[H]</b> falls to the ground and screams as their skin bubbles and froths!") //'froths' sounds painful when used with SKIN.
+	H.Weaken(3, 0)
+	spawn(30)
+		if(!H || qdeleted(H))
+			return
+
+		var/current_species = H.dna.species.type
+		var/datum/species/mutation = race
+		if(mutation && mutation != current_species)
+			H << mutationtext
+			H.set_species(mutation)
+		else
+			H << "<span class='danger'>The pain vanishes suddenly. You feel no different.</span>"
+
+	return 1
+
+/datum/reagent/stableslimetoxin/lizard
+	name = "Lizard Mutation Toxin"
+	id = "lizardmutationtoxin"
+	description = "A lizarding toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/lizard
+	mutationtext = "<span class='danger'>The pain subsides. You feel... scaly.</span>"
+
+
+/datum/reagent/stableslimetoxin/fly
+	name = "Fly Mutation Toxin"
+	id = "flymutationtoxin"
+	description = "An insectifying toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/fly
+	mutationtext = "<span class='danger'>The pain subsides. You feel... buzzy.</span>"
+
+/datum/reagent/stableslimetoxin/pod
+	name = "Podperson Mutation Toxin"
+	id = "podmutationtoxin"
+	description = "A vegetalizing toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/pod
+	mutationtext = "<span class='danger'>The pain subsides. You feel... plantlike.</span>"
+
+/datum/reagent/stableslimetoxin/shadow
+	name = "Shadow Mutation Toxin"
+	id = "shadowmutationtoxin"
+	description = "A dark toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/shadow
+	mutationtext = "<span class='danger'>The pain subsides. You feel... darker.</span>"
+
+/datum/reagent/stableslimetoxin/jelly
+	name = "Imperfect Mutation Toxin"
+	id = "jellymutationtoxin"
+	description = "An jellyfying toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/jelly
+	mutationtext = "<span class='danger'>The pain subsides. You feel... wobbly.</span>"
+
+/datum/reagent/stableslimetoxin/golem
+	name = "Golem Mutation Toxin"
+	id = "golemmutationtoxin"
+	description = "A crystal toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/golem/random
+	mutationtext = "<span class='danger'>The pain subsides. You feel... rocky.</span>"
+
+/datum/reagent/stableslimetoxin/skeleton
+	name = "Skeleton Mutation Toxin"
+	id = "skeletonmutationtoxin"
+	description = "A scary toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/skeleton
+	mutationtext = "<span class='danger'>The pain subsides. You feel... spooky.</span>"
+
+/datum/reagent/stableslimetoxin/zombie
+	name = "Zombie Mutation Toxin"
+	id = "zombiemutationtoxin"
+	description = "An undead toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/zombie //Not the infectious kind. The days of xenobio zombie outbreaks are long past.
+	mutationtext = "<span class='danger'>The pain subsides. You feel... undead.</span>"
+
+/datum/reagent/stableslimetoxin/abductor
+	name = "Abductor Mutation Toxin"
+	id = "abductormutationtoxin"
+	description = "An alien toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/abductor
+	mutationtext = "<span class='danger'>The pain subsides. You feel... alien.</span>"
+
+/datum/reagent/stableslimetoxin/plasma
+	name = "Plasma Mutation Toxin"
+	id = "plasmamutationtoxin"
+	description = "A plasma-based toxin produced by slimes."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/plasmaman
+	mutationtext = "<span class='danger'>The pain subsides. You feel... flammable.</span>"
+
 /datum/reagent/mulligan
 	name = "Mulligan Toxin"
 	id = "mulligan"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -149,7 +149,7 @@
 	name = "Shadow Mutation Toxin"
 	id = "shadowmutationtoxin"
 	results = list("shadowmutationtoxin" = 1)
-	required_reagents = list("amutationtoxin" = 1, "liquid_dark_matter" = 1) //only reagent i could think of
+	required_reagents = list("amutationtoxin" = 1, "liquid_dark_matter" = 1, "holywater" = 1)
 
 /datum/chemical_reaction/pod_mutation_toxin
 	name = "Podperson Mutation Toxin"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -107,6 +107,81 @@
 	required_reagents = list("carbon" = 1, "oxygen" = 2)
 	required_temp = 777 // pure carbon isn't especially reactive.
 
+////////////////////////////////// Mutation Toxins ///////////////////////////////////
+
+/datum/chemical_reaction/human_mutation_toxin
+	name = "Human Mutation Toxin"
+	id = "humanmutationtoxin"
+	results = list("humanmutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "blood" = 1) //classic
+
+/datum/chemical_reaction/lizard_mutation_toxin
+	name = "Lizard Mutation Toxin"
+	id = "lizardmutationtoxin"
+	results = list("lizardmutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "radium" = 1) //mutant
+
+/datum/chemical_reaction/fly_mutation_toxin
+	name = "Fly Mutation Toxin"
+	id = "flymutationtoxin"
+	results = list("flymutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "mutagen" = 1) //VERY mutant
+
+/datum/chemical_reaction/jelly_mutation_toxin
+	name = "Imperfect Mutation Toxin"
+	id = "jellymutationtoxin"
+	results = list("jellymutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "slimejelly" = 1) //why would you even make this
+
+/datum/chemical_reaction/plasma_mutation_toxin
+	name = "Plasma Mutation Toxin"
+	id = "plasmamutationtoxin"
+	results = list("plasmamutationtoxin" = 1)
+	required_reagents = list("amutationtoxin" = 1, "plasma" = 1) //this is very fucking powerful, so it needs the advanced toxin to make
+
+/datum/chemical_reaction/golem_mutation_toxin
+	name = "Golem Mutation Toxin"
+	id = "golemmutationtoxin"
+	results = list("golemmutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "silver" = 1) //not too hard to get but also not just there in xenobio
+
+/datum/chemical_reaction/shadow_mutation_toxin
+	name = "Shadow Mutation Toxin"
+	id = "shadowmutationtoxin"
+	results = list("shadowmutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "liquid_dark_matter" = 1) //only reagent i could think of
+
+/datum/chemical_reaction/pod_mutation_toxin
+	name = "Podperson Mutation Toxin"
+	id = "podmutationtoxin"
+	results = list("podmutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "eznutriment" = 1) //plant food
+
+/datum/chemical_reaction/skeleton_mutation_toxin
+	name = "Skeleton Mutation Toxin"
+	id = "skeletonmutationtoxin"
+	results = list("skeletonmutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "milk" = 1) //good for yer bones
+
+/datum/chemical_reaction/zombie_mutation_toxin
+	name = "Zombie Mutation Toxin"
+	id = "zombiemutationtoxin"
+	results = list("zombiemutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "toxin" = 1)
+
+/datum/chemical_reaction/abductor_mutation_toxin
+	name = "Abductor Mutation Toxin"
+	id = "abductormutationtoxin"
+	results = list("abductormutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "morphine" = 1)
+
+/datum/chemical_reaction/mulligan
+	name = "Mulligan"
+	id = "mulligan"
+	results = list("mulligan" = 1)
+	required_reagents = list("humanmutationtoxin" = 1, "mutagen" = 1) //a fancy recipe for mulligan
+
+
 ////////////////////////////////// VIROLOGY //////////////////////////////////////////
 
 /datum/chemical_reaction/virus_food

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -137,7 +137,7 @@
 	name = "Plasma Mutation Toxin"
 	id = "plasmamutationtoxin"
 	results = list("plasmamutationtoxin" = 1)
-	required_reagents = list("amutationtoxin" = 1, "plasma" = 1) //this is very fucking powerful, so it needs the advanced toxin to make
+	required_reagents = list("skeletonmutationtoxin" = 1, "plasma" = 1, "uranium" = 1) //this is very fucking powerful, so it's hard to make
 
 /datum/chemical_reaction/golem_mutation_toxin
 	name = "Golem Mutation Toxin"
@@ -149,7 +149,7 @@
 	name = "Shadow Mutation Toxin"
 	id = "shadowmutationtoxin"
 	results = list("shadowmutationtoxin" = 1)
-	required_reagents = list("unstablemutationtoxin" = 1, "liquid_dark_matter" = 1) //only reagent i could think of
+	required_reagents = list("amutationtoxin" = 1, "liquid_dark_matter" = 1) //only reagent i could think of
 
 /datum/chemical_reaction/pod_mutation_toxin
 	name = "Podperson Mutation Toxin"
@@ -161,19 +161,25 @@
 	name = "Skeleton Mutation Toxin"
 	id = "skeletonmutationtoxin"
 	results = list("skeletonmutationtoxin" = 1)
-	required_reagents = list("unstablemutationtoxin" = 1, "milk" = 1) //good for yer bones
+	required_reagents = list("amutationtoxin" = 1, "milk" = 1) //good for yer bones
 
 /datum/chemical_reaction/zombie_mutation_toxin
 	name = "Zombie Mutation Toxin"
 	id = "zombiemutationtoxin"
 	results = list("zombiemutationtoxin" = 1)
-	required_reagents = list("unstablemutationtoxin" = 1, "toxin" = 1)
+	required_reagents = list("amutationtoxin" = 1, "toxin" = 1) //blacklisted species so it's harder to get
 
 /datum/chemical_reaction/abductor_mutation_toxin
 	name = "Abductor Mutation Toxin"
 	id = "abductormutationtoxin"
 	results = list("abductormutationtoxin" = 1)
 	required_reagents = list("unstablemutationtoxin" = 1, "morphine" = 1)
+
+/datum/chemical_reaction/android_mutation_toxin
+	name = "Android Mutation Toxin"
+	id = "androidmutationtoxin"
+	results = list("androidmutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "teslium" = 1) //beep boop
 
 /datum/chemical_reaction/mulligan
 	name = "Mulligan"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -133,42 +133,6 @@
 	results = list("jellymutationtoxin" = 1)
 	required_reagents = list("unstablemutationtoxin" = 1, "slimejelly" = 1) //why would you even make this
 
-/datum/chemical_reaction/plasma_mutation_toxin
-	name = "Plasma Mutation Toxin"
-	id = "plasmamutationtoxin"
-	results = list("plasmamutationtoxin" = 1)
-	required_reagents = list("skeletonmutationtoxin" = 1, "plasma" = 1, "uranium" = 1) //this is very fucking powerful, so it's hard to make
-
-/datum/chemical_reaction/golem_mutation_toxin
-	name = "Golem Mutation Toxin"
-	id = "golemmutationtoxin"
-	results = list("golemmutationtoxin" = 1)
-	required_reagents = list("unstablemutationtoxin" = 1, "silver" = 1) //not too hard to get but also not just there in xenobio
-
-/datum/chemical_reaction/shadow_mutation_toxin
-	name = "Shadow Mutation Toxin"
-	id = "shadowmutationtoxin"
-	results = list("shadowmutationtoxin" = 1)
-	required_reagents = list("amutationtoxin" = 1, "liquid_dark_matter" = 1, "holywater" = 1)
-
-/datum/chemical_reaction/pod_mutation_toxin
-	name = "Podperson Mutation Toxin"
-	id = "podmutationtoxin"
-	results = list("podmutationtoxin" = 1)
-	required_reagents = list("unstablemutationtoxin" = 1, "eznutriment" = 1) //plant food
-
-/datum/chemical_reaction/skeleton_mutation_toxin
-	name = "Skeleton Mutation Toxin"
-	id = "skeletonmutationtoxin"
-	results = list("skeletonmutationtoxin" = 1)
-	required_reagents = list("amutationtoxin" = 1, "milk" = 1) //good for yer bones
-
-/datum/chemical_reaction/zombie_mutation_toxin
-	name = "Zombie Mutation Toxin"
-	id = "zombiemutationtoxin"
-	results = list("zombiemutationtoxin" = 1)
-	required_reagents = list("amutationtoxin" = 1, "toxin" = 1) //blacklisted species so it's harder to get
-
 /datum/chemical_reaction/abductor_mutation_toxin
 	name = "Abductor Mutation Toxin"
 	id = "abductormutationtoxin"
@@ -181,11 +145,58 @@
 	results = list("androidmutationtoxin" = 1)
 	required_reagents = list("unstablemutationtoxin" = 1, "teslium" = 1) //beep boop
 
+/datum/chemical_reaction/pod_mutation_toxin
+	name = "Podperson Mutation Toxin"
+	id = "podmutationtoxin"
+	results = list("podmutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "eznutriment" = 1) //plant food
+
+/datum/chemical_reaction/golem_mutation_toxin
+	name = "Golem Mutation Toxin"
+	id = "golemmutationtoxin"
+	results = list("golemmutationtoxin" = 1)
+	required_reagents = list("unstablemutationtoxin" = 1, "silver" = 1) //not too hard to get but also not just there in xenobio
+
+
+//BLACKLISTED RACES
+/datum/chemical_reaction/skeleton_mutation_toxin
+	name = "Skeleton Mutation Toxin"
+	id = "skeletonmutationtoxin"
+	results = list("skeletonmutationtoxin" = 1)
+	required_reagents = list("amutationtoxin" = 1, "milk" = 1) //good for yer bones
+
+/datum/chemical_reaction/zombie_mutation_toxin
+	name = "Zombie Mutation Toxin"
+	id = "zombiemutationtoxin"
+	results = list("zombiemutationtoxin" = 1)
+	required_reagents = list("amutationtoxin" = 1, "toxin" = 1)
+
+/datum/chemical_reaction/ash_mutation_toxin //ash lizard
+	name = "Ash Mutation Toxin"
+	id = "ashmutationtoxin"
+	results = list("ashmutationtoxin" = 1)
+	required_reagents = list("amutationtoxin" = 1, "lizardmutationtoxin" = 1, "ash" = 1)
+
+
+//DANGEROUS RACES
+/datum/chemical_reaction/plasma_mutation_toxin
+	name = "Plasma Mutation Toxin"
+	id = "plasmamutationtoxin"
+	results = list("plasmamutationtoxin" = 1)
+	required_reagents = list("skeletonmutationtoxin" = 1, "plasma" = 1, "uranium" = 1) //this is very fucking powerful, so it's hard to make
+
+/datum/chemical_reaction/shadow_mutation_toxin
+	name = "Shadow Mutation Toxin"
+	id = "shadowmutationtoxin"
+	results = list("shadowmutationtoxin" = 1)
+	required_reagents = list("amutationtoxin" = 1, "liquid_dark_matter" = 1, "holywater" = 1)
+
+//Technically a mutation toxin
 /datum/chemical_reaction/mulligan
 	name = "Mulligan"
 	id = "mulligan"
 	results = list("mulligan" = 1)
-	required_reagents = list("humanmutationtoxin" = 1, "mutagen" = 1) //a fancy recipe for mulligan
+	required_reagents = list("humanmutationtoxin" = 1, "mutagen" = 1)
 
 
 ////////////////////////////////// VIROLOGY //////////////////////////////////////////

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -109,10 +109,10 @@
 
 ////////////////////////////////// Mutation Toxins ///////////////////////////////////
 
-/datum/chemical_reaction/human_mutation_toxin
-	name = "Human Mutation Toxin"
-	id = "humanmutationtoxin"
-	results = list("humanmutationtoxin" = 1)
+/datum/chemical_reaction/stable_mutation_toxin
+	name = "Stable Mutation Toxin"
+	id = "stablemutationtoxin"
+	results = list("stablemutationtoxin" = 1)
 	required_reagents = list("unstablemutationtoxin" = 1, "blood" = 1) //classic
 
 /datum/chemical_reaction/lizard_mutation_toxin


### PR DESCRIPTION
:cl: XDTM
add: You can now stabilize unstable mutation toxin with different chems to get the race you want.
/:cl:

Recipes:

Add these to unstable mutation toxin. These were all obtainable already.
- Human: blood
- Lizard: radium
- Flyperson: mutagen
- Golem: silver
- Podperson: EZ nutrient
- Jelly: slime jelly
- Abductor: morphine (doesn't make much sense but it's all i could think of)
- Android: teslium

These need ADVANCED mutation toxin (from black slimes) instead of unstable.
- Skeleton: milk
- Zombie: toxin
- Ash Lizard: advanced mut. toxin + lizard mut. toxin + ash
- Shadow: liquid dark matter (stabilized ofc) + holy water
- Plasmaman: skeleton mutation toxin + plasma + uranium (if you can shoot advanced mutation toxin into people they're dead already so this should not be too unbalanced, plus it's pretty expensive)

Also added a recipe for the mulligan toxin, with human mutation toxin + mutagen.

Idea from https://tgstation13.org/phpBB/viewtopic.php?f=9&t=7953#p213479
