### PR TITLE
Intensifies the secret satchel system so people will actually use it

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -13,23 +13,33 @@ var/datum/subsystem/persistence/SSpersistence
 	NEW_SS_GLOBAL(SSpersistence)
 
 /datum/subsystem/persistence/Initialize()
-	if(!PlaceSecretSatchel())
-		PlaceFreeSatchel()
+	secret_satchels = new /savefile("data/npc_saves/SecretSatchels.sav")
+	satchel_blacklist = typecacheof(list(/obj/item/stack/tile/plasteel, /obj/item/weapon/crowbar))
+	secret_satchels[MAP_NAME] >> old_secret_satchels
+
+	var/list/expanded_old_satchels = list()
+	var/placed_satchels = 0
+
+	if(!isnull(old_secret_satchels))
+		expanded_old_satchels = splittext(old_secret_satchels,"#")
+		if(PlaceSecretSatchel(expanded_old_satchels))
+			placed_satchels++
+	else
+		expanded_old_satchels.len = 0
+
+	var/list/free_satchels = list()
+	for(var/turf/T in shuffle(block(locate(TRANSITIONEDGE,TRANSITIONEDGE,ZLEVEL_STATION), locate(world.maxx-TRANSITIONEDGE,world.maxy-TRANSITIONEDGE,ZLEVEL_STATION)))) //Nontrivially expensive but it's roundstart only
+		if(istype(T,/turf/open/floor) && !istype(T,/turf/open/floor/plating/))
+			free_satchels += new /obj/item/weapon/storage/backpack/satchel/flat/secret(T)
+			if(!isemptylist(free_satchels) && ((free_satchels.len + placed_satchels) >= (50 - expanded_old_satchels.len) * 0.1)) //up to six tiles, more than enough to kill anything that moves
+				break
+
 	..()
 
 /datum/subsystem/persistence/proc/CollectData()
 	CollectSecretSatchels()
 
-/datum/subsystem/persistence/proc/PlaceSecretSatchel()
-	secret_satchels = new /savefile("data/npc_saves/SecretSatchels.sav")
-	satchel_blacklist = typecacheof(list(/obj/item/stack/tile/plasteel, /obj/item/weapon/crowbar))
-
-	secret_satchels[MAP_NAME] >> old_secret_satchels
-
-	if(isnull(old_secret_satchels))
-		return 0
-
-	var/list/expanded_old_satchels = splittext(old_secret_satchels,"#")
+/datum/subsystem/persistence/proc/PlaceSecretSatchel(list/expanded_old_satchels)
 	var/satchel_string
 
 	if(expanded_old_satchels.len >= 20) //guards against low drop pools assuring that one player cannot reliably find his own gear.
@@ -54,18 +64,6 @@ var/datum/subsystem/persistence/SSpersistence
 		F.hide(1)
 	new path(F)
 	return 1
-
-/datum/subsystem/persistence/proc/PlaceFreeSatchel()
-	var/satchel_placed = FALSE
-	var/breakout = 0
-	while(!satchel_placed && breakout <= 5)
-		for(var/V in shuffle(get_area_turfs(pick(the_station_areas))))
-			var/turf/T = V
-			if(istype(T,/turf/open/floor) && !istype(T,/turf/open/floor/plating/))
-				new /obj/item/weapon/storage/backpack/satchel/flat/secret(T)
-				satchel_placed = TRUE
-				break
-		breakout++
 
 /datum/subsystem/persistence/proc/CollectSecretSatchels()
 	for(var/A in new_secret_satchels)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -690,7 +690,8 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 /datum/uplink_item/stealthy_tools/smugglersatchel
 	name = "Smuggler's Satchel"
 	desc = "This satchel is thin enough to be hidden in the gap between plating and tiling; great for stashing \
-			your stolen goods. Comes with a crowbar and a floor tile inside."
+			your stolen goods. Comes with a crowbar and a floor tile inside. Properly hidden satchels have been \
+			known to survive intact even beyond the current shift. "
 	item = /obj/item/weapon/storage/backpack/satchel/flat
 	cost = 2
 	surplus = 30


### PR DESCRIPTION
So over a month ago I got https://github.com/tgstation/tgstation/pull/19838 merged. As a safety I made it so it would require at least twenty satchels (on a single map) to pick one to restore to the round.

It's only ever actually fired maybe half a dozen times.

Due to REALLY low seeding rates, and the contraints of the system, it took over three weeks to get sybil/boxstation up to 20 satchels. Someone found something, took it, and the list fell back to 19 where it's sat ever since.

No other server/map has come even close to 20.

So in the interest of _having the mechanic actually mean something_ I've made it easier to do.

---
1. The number of free satchels now inversely scales with how small the drop table is:
   0 in table: 6 free satchels
   1 - 9 in table: 5 free satchels
   10 - 19 in table: 4 free satchels
   20 - 29 in table: 2 free satchels + a persistent satchel
   30 - 39 in table: 1 free satchel + a persistent satchel
   40 or greater in table: No free satchels + a persistent satchel
2. Where the free satchel(s) end up is now truly random, as opposed to using a list that favored hard to reach AI areas and excluded hallways.
3. The description of the satchel in the uplink now alludes to this feature so people don't forget entirely about it.

:cl:
add: The secret satchels system has been updated to hide more smuggler's satchels hidden randomly under the station
experiment: In case you forgot about the secret satchel system, basically if you take a smuggler's satchel (a traitor item also occasionally found under a random tile in the station [USE T-RAYS]), stow away an item in it, and bury it under the floor tiles that item can reappear in a random later round!
/:cl:
