### PR TITLE
Fixes weird limb updating bug

### DIFF
--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -213,8 +213,7 @@
 
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
-		if(!BP.no_update)
-			BP.update_limb()
+		BP.update_limb()
 
 	//LOAD ICONS
 	if(limb_icon_cache[icon_render_key])

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -200,9 +200,19 @@
 			original_owner = source
 	else if(original_owner && owner != original_owner) //Foreign limb
 		no_update = 1
-		return
 	else
 		C = owner
+		no_update = 0
+
+	if(C.disabilities & HUSK)
+		species_id = "husk" //overrides species_id
+		dmg_overlay_type = "" //no damage overlay shown when husked
+		should_draw_gender = FALSE
+		should_draw_greyscale = FALSE
+		no_update = 1
+
+	if(no_update)
+		return
 
 	if(!animal_origin)
 		var/mob/living/carbon/human/H = C
@@ -239,12 +249,6 @@
 
 	else if(animal_origin == MONKEY_BODYPART) //currently monkeys are the only non human mob to have damage overlays.
 		dmg_overlay_type = animal_origin
-
-	if(C.disabilities & HUSK)
-		species_id = "husk" //overrides species_id
-		dmg_overlay_type = "" //no damage overlay shown when husked
-		should_draw_gender = FALSE
-		should_draw_greyscale = FALSE
 
 	if(status == BODYPART_ROBOTIC)
 		dmg_overlay_type = "robotic"

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -80,8 +80,7 @@
 		return
 	var/turf/T = get_turf(owner)
 	var/mob/living/carbon/C = owner
-	if(!no_update)
-		update_limb(1)
+	update_limb(1)
 	C.bodyparts -= src
 	if(held_index)
 		C.unEquip(owner.get_item_for_held_index(held_index), 1)


### PR DESCRIPTION
Where once a limb became no_update it could never properly update again even if attached to its original owner.

Husking now has special privilege and can occur even if attached to a foreign host.

Fixes #20685 (wasn't actually my fault, not completely)
