### PR TITLE
Make say handling short out earlier to prevent runtimes

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -60,6 +60,9 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 
 /mob/living/say(message, bubble_type,var/list/spans = list())
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
+	if(!message || message == "")
+		return
+
 
 	if(stat == DEAD)
 		say_dead(message)
@@ -92,9 +95,6 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 
 	if(message_mode != MODE_WHISPER) //whisper() calls treat_message(); double process results in "hisspering"
 		message = treat_message(message)
-
-	if(!message)
-		return
 
 	spans += get_spans()
 


### PR DESCRIPTION
The code does not appear to expect a message of the form "", but
does not carry out the check for a message until much later

Run time

```
runtime error: 
[02:47:58]list index out of bounds
[02:47:58]proc name: TongueSpeech (/obj/item/organ/tongue/zombie/TongueSpeech)
[02:47:58]  source file: organ_internal.dm,347
[02:47:58]  usr: Smells-the-Feet (/mob/living/carbon/human)
[02:47:58]  src: the rotting tongue (/obj/item/organ/tongue/zombie)
[02:47:58]  usr.loc: the plating (53,127,1) (/turf/open/floor/plating)
[02:47:58]  src.loc: null
[02:47:58]  call stack:
[02:47:58]the rotting tongue (/obj/item/organ/tongue/zombie): TongueSpeech("")
[02:47:58]Smells-the-Feet (/mob/living/carbon/human): treat message("")
[02:47:58]Smells-the-Feet (/mob/living/carbon/human): treat message("")
[02:47:58]Smells-the-Feet (/mob/living/carbon/human): say("", null, /list (/list))
[02:47:58]Smells-the-Feet (/mob/living/carbon/human): Say("")
```
