### PR TITLE
Removes various unnecessary reagents in Survival medipens.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1058,6 +1058,33 @@ datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/M)
 	..()
 	. = 1
 
+/datum/reagent/medicine/miningnanites
+	name = "Nanites"
+	id = "miningnanites"
+	description = "It's mining magic. We don't have to explain it."
+	color = "#C8A5DC" // rgb: 200, 165, 220
+	overdose_threshold = 3 //To prevent people stacking massive amounts of a very strong healing reagent
+	can_synth = 0
+
+/datum/reagent/medicine/miningnanites/on_mob_life(mob/living/M)
+	if(M.getBruteLoss() > 50)
+		M.adjustBruteLoss(-5.5*REM, 0)
+	else
+		M.adjustBruteLoss(-2.5*REM, 0)
+	if(M.getFireLoss() > 50)
+		M.adjustFireLoss(-5.5*REM, 0)
+	else
+		M.adjustFireLoss(-2.5*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/medicine/miningnanites/overdose_process(mob/living/M)
+	M.adjustBruteLoss(3*REM, 0)
+	M.adjustFireLoss(3*REM, 0)
+	M.adjustToxLoss(3*REM, 0)
+	..()
+	. = 1
+
 //used for changeling's adrenaline power
 /datum/reagent/medicine/changelingAdrenaline
 	name = "Adrenaline"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1067,8 +1067,7 @@ datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/M)
 	can_synth = 0
 
 /datum/reagent/medicine/miningnanites/on_mob_life(mob/living/M)
-	M.adjustBruteLoss(-5.5*REM, 0)
-	M.adjustFireLoss(-5.5*REM, 0)
+	M.heal_bodypart_damage(5,5, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1067,14 +1067,8 @@ datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/M)
 	can_synth = 0
 
 /datum/reagent/medicine/miningnanites/on_mob_life(mob/living/M)
-	if(M.getBruteLoss() > 50)
-		M.adjustBruteLoss(-5.5*REM, 0)
-	else
-		M.adjustBruteLoss(-2.5*REM, 0)
-	if(M.getFireLoss() > 50)
-		M.adjustFireLoss(-5.5*REM, 0)
-	else
-		M.adjustFireLoss(-2.5*REM, 0)
+	M.adjustBruteLoss(-5.5*REM, 0)
+	M.adjustFireLoss(-5.5*REM, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -130,9 +130,9 @@
 	name = "survival medipen"
 	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. "
 	icon_state = "stimpen"
-	volume = 82
-	amount_per_transfer_from_this = 82
-	list_reagents = list("nanites" = 2, "salbutamol" = 10, "coffee" = 20, "leporazine" = 20, "tricordrazine" = 15, "epinephrine" = 10, "omnizine" = 5, "stimulants" = 10)
+	volume = 50
+	amount_per_transfer_from_this = 50
+	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "tricordrazine" = 15, "epinephrine" = 10)
 
 /obj/item/weapon/reagent_containers/hypospray/medipen/species_mutator
 	name = "species mutator medipen"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -130,9 +130,9 @@
 	name = "survival medipen"
 	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. "
 	icon_state = "stimpen"
-	volume = 50
-	amount_per_transfer_from_this = 50
-	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "tricordrazine" = 15, "epinephrine" = 10)
+	volume = 55
+	amount_per_transfer_from_this = 55
+	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "tricordrazine" = 20, "epinephrine" = 10)
 
 /obj/item/weapon/reagent_containers/hypospray/medipen/species_mutator
 	name = "species mutator medipen"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -128,11 +128,11 @@
 
 /obj/item/weapon/reagent_containers/hypospray/medipen/survival
 	name = "survival medipen"
-	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. "
+	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. WARNING: Do not inject more than one pen in quick succession."
 	icon_state = "stimpen"
-	volume = 55
-	amount_per_transfer_from_this = 55
-	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "tricordrazine" = 20, "epinephrine" = 10)
+	volume = 52
+	amount_per_transfer_from_this = 52
+	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "tricordrazine" = 15, "epinephrine" = 10, "miningnanites" = 2)
 
 /obj/item/weapon/reagent_containers/hypospray/medipen/species_mutator
 	name = "species mutator medipen"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -130,9 +130,9 @@
 	name = "survival medipen"
 	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. WARNING: Do not inject more than one pen in quick succession."
 	icon_state = "stimpen"
-	volume = 52
-	amount_per_transfer_from_this = 52
-	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "tricordrazine" = 15, "epinephrine" = 10, "miningnanites" = 2)
+	volume = 57
+	amount_per_transfer_from_this = 57
+	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "tricordrazine" = 15, "epinephrine" = 10, "miningnanites" = 2, "omnizine" = 5)
 
 /obj/item/weapon/reagent_containers/hypospray/medipen/species_mutator
 	name = "species mutator medipen"


### PR DESCRIPTION
:cl: 
del: Removed Stimulants and Coffee from survival pens.
tweak: Nanites have been replaced with Mining Nanites which heal more when you are lower health, and do not have the ridiculous healing Adminorazine had.
/:cl:

This is simply ridiculous; Nanites are literally renamed Adminorazine and is given to deathsquad and code red ERT. It should have never been given to crew.

Here's a list of what Nanites did;
M.reagents.remove_all_type(/datum/reagent/toxin, 5*REM, 0, 1)
    M.setCloneLoss(0, 0)
    M.setOxyLoss(0, 0)
    M.radiation = 0
    M.heal_bodypart_damage(5,5, 0)
    M.adjustToxLoss(-5, 0)
    M.hallucination = 0
    M.setBrainLoss(0)
    M.disabilities = 0
    M.set_blurriness(0)
    M.set_blindness(0)
    M.SetWeakened(0, 0)
    M.SetStunned(0, 0)
    M.SetParalysis(0, 0)
    M.silent = 0
    M.dizziness = 0
    M.drowsyness = 0
    M.stuttering = 0
    M.slurring = 0
    M.confused = 0
    M.SetSleeping(0, 0)
    M.jitteriness = 0
    for(var/datum/disease/D in M.viruses)
        if(D.severity == NONTHREAT)
            continue
        D.spread_text = "Remissive"
        D.stage--
        if(D.stage < 1)
            D.cure()
    ..()
    . = 1
