### PR TITLE
Make sure some proximity system items clean up when destroyed

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -31,6 +31,10 @@
 	else
 		bulb = new /obj/item/device/assembly/flash/handheld(src)
 
+/obj/machinery/flasher/Destroy()
+	remove_from_proximity_list(src, range)
+	..()
+
 /obj/machinery/flasher/Move()
 	remove_from_proximity_list(src, range)
 	..()

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -81,6 +81,9 @@
 	if(scanning)
 		addtimer(src, "sense", 0)
 
+/obj/item/device/assembly/prox_sensor/Destroy()
+	remove_from_proximity_list(src, sensitivity)
+	..()
 
 /obj/item/device/assembly/prox_sensor/toggle_scan(scan)
 	if(!secured)


### PR DESCRIPTION
This prevents a runtime from when the item was destroyed but left as a null in the turf proximity list
