### PR TITLE
Repairs the wizard's shuttle once and for all

### DIFF
--- a/_maps/map_files/generic/z2.dmm
+++ b/_maps/map_files/generic/z2.dmm
@@ -4164,7 +4164,9 @@
 /area/wizard_station)
 "mW" = (
 /mob/living/simple_animal/bot/medbot/mysterious{
-	name = "\improper Nobody's Perfect"
+	desc = "If you don't accidentally blow yourself up from time to time you're not really a wizard anyway.";
+	faction = list("neutral","silicon");
+	name = "Nobody's Perfect"
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
@@ -4640,6 +4642,7 @@
 /area/centcom/holding)
 "ow" = (
 /obj/structure/window/reinforced{
+	burn_state = -2;
 	color = "#008000";
 	dir = 1
 	},
@@ -5865,7 +5868,7 @@
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Storage"
 	},
-/turf/closed/indestructible/riveted/uranium,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "sW" = (
 /obj/machinery/door/airlock{
@@ -11051,7 +11054,7 @@ aa
 jc
 jc
 ju
-sK
+kP
 lQ
 kG
 kG
@@ -11306,7 +11309,7 @@ aa
 aa
 jc
 jc
-kP
+sK
 sQ
 kP
 jc

--- a/_maps/map_files/generic/z2.dmm
+++ b/_maps/map_files/generic/z2.dmm
@@ -2915,14 +2915,11 @@
 /turf/open/floor/plasteel/black,
 /area/centcom/evac)
 "iZ" = (
-/obj/item/weapon/shard{
+/turf/closed/indestructible/fakeglass{
 	color = "#008000";
-	icon_state = "small"
+	dir = 8;
+	icon_state = "fakewindows"
 	},
-/obj/structure/grille/broken{
-	color = "#008000"
-	},
-/turf/open/floor/plating/airless,
 /area/wizard_station)
 "ja" = (
 /turf/closed/indestructible/fakeglass{
@@ -3051,8 +3048,8 @@
 	},
 /area/tdome/tdomeobserve)
 "ju" = (
-/obj/structure/lattice,
-/turf/open/space/transit,
+/obj/machinery/computer/camera_advanced,
+/turf/open/floor/wood,
 /area/wizard_station)
 "jv" = (
 /obj/item/weapon/shard{
@@ -3064,9 +3061,7 @@
 /area/wizard_station)
 "jw" = (
 /obj/machinery/computer/shuttle,
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage"
-	},
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "jx" = (
 /turf/open/floor/engine/cult/airless,
@@ -3180,9 +3175,8 @@
 	},
 /area/wizard_station)
 "jP" = (
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage3"
-	},
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/plasteel/white,
 /area/wizard_station)
 "jQ" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
@@ -3305,7 +3299,7 @@
 	icon_state = "processor";
 	name = "byond random number generator"
 	},
-/turf/open/floor/plasteel/cult/airless,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "kj" = (
 /turf/open/floor/plasteel/cult/airless{
@@ -3323,7 +3317,7 @@
 	icon_state = "nim";
 	name = "wizard of yendor showcase"
 	},
-/turf/open/floor/engine/cult/airless,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "km" = (
 /turf/closed/indestructible/fakeglass{
@@ -3392,12 +3386,11 @@
 	},
 /area/wizard_station)
 "kv" = (
-/obj/effect/forcefield,
-/obj/structure/door_assembly/door_assembly_uranium{
-	anchored = 1;
-	name = "Bridge"
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Cockpit"
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult/airless,
 /area/wizard_station)
 "kw" = (
 /turf/closed/indestructible/fakeglass{
@@ -3447,7 +3440,7 @@
 /area/wizard_station)
 "kF" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/engine/cult,
+/turf/open/floor/grass,
 /area/wizard_station)
 "kG" = (
 /turf/open/floor/engine/cult,
@@ -3507,12 +3500,14 @@
 	},
 /area/shuttle/assault_pod)
 "kP" = (
-/turf/closed/wall/mineral/titanium,
+/turf/open/floor/wood,
 /area/wizard_station)
 "kQ" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Squad 4 Pod"
+/obj/structure/chair/wood/wings{
+	icon_state = "wooden_chair_wings";
+	dir = 1
 	},
+/turf/open/floor/wood,
 /area/wizard_station)
 "kR" = (
 /turf/closed/wall/shuttle{
@@ -3521,8 +3516,7 @@
 	},
 /area/wizard_station)
 "kS" = (
-/turf/open/floor/plasteel/cult,
-/turf/closed/wall/mineral/titanium/interior,
+/turf/open/floor/grass,
 /area/wizard_station)
 "kT" = (
 /obj/effect/forcefield,
@@ -3534,10 +3528,11 @@
 	},
 /area/wizard_station)
 "kV" = (
-/obj/effect/forcefield,
-/turf/open/floor/plasteel/cult{
-	icon_state = "cultdamage"
+/obj/structure/table/wood/fancy,
+/obj/item/weapon/storage/pill_bottle/dice{
+	icon_state = "magicdicebag"
 	},
+/turf/open/floor/carpet,
 /area/wizard_station)
 "kW" = (
 /turf/open/floor/plasteel/darkred/side{
@@ -3624,12 +3619,18 @@
 /turf/open/floor/plasteel/airless,
 /area/wizard_station)
 "ll" = (
-/turf/open/floor/plasteel/airless,
+/obj/structure/table/wood/fancy,
+/obj/item/weapon/skub{
+	pixel_y = 16
+	},
+/turf/open/floor/plasteel/white,
 /area/wizard_station)
 "lm" = (
-/obj/machinery/door/poddoor/preopen,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating/airless,
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Observation Room"
+	},
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "ln" = (
 /turf/open/floor/plasteel/cult{
@@ -3637,16 +3638,16 @@
 	},
 /area/wizard_station)
 "lo" = (
-/obj/effect/forcefield,
-/turf/open/floor/plasteel/cult{
-	icon_state = "cultdamage7"
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Game Room"
 	},
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "lp" = (
-/obj/effect/forcefield,
-/turf/open/floor/plasteel/cult{
-	icon_state = "cultdamage5"
-	},
+/obj/structure/table/wood/fancy,
+/obj/item/device/camera/spooky,
+/turf/open/floor/carpet,
 /area/wizard_station)
 "lq" = (
 /turf/open/floor/plasteel/black,
@@ -3710,10 +3711,8 @@
 /area/wizard_station)
 "lB" = (
 /obj/structure/table/wood/poker,
-/obj/item/toy/cards/cardhand,
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage2"
-	},
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet,
 /area/wizard_station)
 "lC" = (
 /obj/machinery/computer/telecrystals/boss,
@@ -3762,7 +3761,7 @@
 /area/wizard_station)
 "lH" = (
 /obj/machinery/vending/magivend,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "lI" = (
 /turf/open/floor/plasteel/cult{
@@ -3798,9 +3797,9 @@
 /turf/open/floor/plasteel/black,
 /area/syndicate_mothership)
 "lQ" = (
-/obj/structure/door_assembly/door_assembly_uranium{
-	anchored = 1;
-	name = "Break Room"
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Study"
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
@@ -3857,20 +3856,17 @@
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "mb" = (
-/obj/structure/rack,
-/obj/item/clothing/head/helmet/space/hardsuit/wizard,
-/turf/open/floor/engine/cult,
+/obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/turf/open/floor/grass,
 /area/wizard_station)
 "mc" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/floor/engine/cult,
+/turf/open/floor/grass,
 /area/wizard_station)
 "md" = (
-/obj/effect/forcefield,
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage"
-	},
+/obj/effect/decal/remains/xeno/larva,
+/turf/open/floor/grass,
 /area/wizard_station)
 "me" = (
 /obj/structure/flora/grass/brown,
@@ -4024,7 +4020,7 @@
 	},
 /area/wizard_station)
 "mA" = (
-/obj/structure/bookcase,
+/obj/structure/bookcase/random/reference,
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "mB" = (
@@ -4048,7 +4044,7 @@
 /mob/living/simple_animal/hostile/creature{
 	name = "Experiment 35b"
 	},
-/turf/open/floor/engine/cult,
+/turf/open/floor/grass,
 /area/wizard_station)
 "mF" = (
 /obj/machinery/door/poddoor/preopen,
@@ -4133,14 +4129,12 @@
 /obj/effect/landmark/start{
 	name = "wizard"
 	},
-/turf/open/floor/plasteel/cult{
-	icon_state = "cultdamage5"
-	},
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "mR" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/engine/cult,
+/turf/open/floor/grass,
 /area/wizard_station)
 "mS" = (
 /turf/open/floor/plasteel/cult,
@@ -4150,9 +4144,8 @@
 	},
 /area/wizard_station)
 "mT" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Squad 3 Pod"
-	},
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/grass,
 /area/wizard_station)
 "mU" = (
 /obj/machinery/camera{
@@ -4170,7 +4163,9 @@
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "mW" = (
-/obj/structure/destructible/cult/pylon,
+/mob/living/simple_animal/bot/medbot/mysterious{
+	name = "\improper Nobody's Perfect"
+	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "mX" = (
@@ -4189,14 +4184,13 @@
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "na" = (
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage4"
-	},
+/obj/item/weapon/reagent_containers/food/snacks/meat/slab/xeno,
+/turf/open/floor/grass,
 /area/wizard_station)
 "nb" = (
-/obj/structure/door_assembly/door_assembly_uranium{
-	anchored = 1;
-	name = "Corridor A"
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Observation Deck"
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
@@ -4228,9 +4222,10 @@
 /turf/open/floor/plasteel/black,
 /area/tdome/arena)
 "nh" = (
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage2"
+/obj/structure/urinal{
+	pixel_y = 28
 	},
+/turf/open/floor/plasteel/white,
 /area/wizard_station)
 "ni" = (
 /obj/effect/forcefield,
@@ -4415,10 +4410,8 @@
 /turf/open/floor/carpet,
 /area/wizard_station)
 "nL" = (
-/obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage"
-	},
+/obj/item/weapon/soap/homemade,
+/turf/open/floor/plasteel/white,
 /area/wizard_station)
 "nM" = (
 /turf/closed/wall/shuttle{
@@ -4433,9 +4426,7 @@
 	},
 /area/wizard_station)
 "nO" = (
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage7"
-	},
+/turf/open/floor/plasteel/warning,
 /area/wizard_station)
 "nP" = (
 /obj/structure/dresser,
@@ -4449,9 +4440,12 @@
 /turf/open/floor/carpet,
 /area/wizard_station)
 "nR" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Squad 2 Pod"
+/obj/structure/toilet{
+	tag = "icon-toilet00 (NORTH)";
+	icon_state = "toilet00";
+	dir = 1
 	},
+/turf/open/floor/plasteel/white,
 /area/wizard_station)
 "nS" = (
 /turf/closed/wall/shuttle,
@@ -4649,7 +4643,7 @@
 	color = "#008000";
 	dir = 1
 	},
-/turf/open/floor/plating/lava/airless,
+/turf/open/floor/plating/lava,
 /area/wizard_station)
 "ox" = (
 /obj/structure/rack,
@@ -4663,8 +4657,10 @@
 /turf/open/floor/plating/beach/sand,
 /area/centcom/holding)
 "oz" = (
-/obj/structure/shuttle/engine/heater,
-/turf/open/floor/plating/lava/airless,
+/obj/structure/shuttle/engine/heater{
+	burn_state = -2
+	},
+/turf/open/floor/plating/lava,
 /area/wizard_station)
 "oA" = (
 /obj/structure/rack,
@@ -5797,6 +5793,152 @@
 	dir = 8
 	},
 /area/holodeck/rec_center/medical)
+"sK" = (
+/obj/structure/table/wood/fancy,
+/obj/item/device/radio/intercom{
+	desc = "Talk smack through this."
+	},
+/turf/open/floor/wood,
+/area/wizard_station)
+"sL" = (
+/obj/structure/chair/wood/wings,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"sM" = (
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (EAST)";
+	icon_state = "wooden_chair_wings";
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"sN" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/figure/wizard,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"sO" = (
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (WEST)";
+	icon_state = "wooden_chair_wings";
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"sP" = (
+/obj/structure/chair/wood/wings{
+	icon_state = "wooden_chair_wings";
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"sQ" = (
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (WEST)";
+	icon_state = "wooden_chair_wings";
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/wizard_station)
+"sR" = (
+/obj/item/weapon/statuebust{
+	pixel_y = 12
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/wood,
+/area/wizard_station)
+"sS" = (
+/obj/structure/table/wood/fancy,
+/obj/item/weapon/storage/photo_album,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"sT" = (
+/obj/item/weapon/reagent_containers/food/snacks/meat/slab/corgi,
+/turf/open/floor/grass,
+/area/wizard_station)
+"sU" = (
+/obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/slime,
+/turf/open/floor/grass,
+/area/wizard_station)
+"sV" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Storage"
+	},
+/turf/closed/indestructible/riveted/uranium,
+/area/wizard_station)
+"sW" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Bathroom"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"sX" = (
+/obj/item/clothing/suit/wizrobe/black,
+/obj/item/clothing/head/wizard/black,
+/turf/open/floor/plasteel/bot,
+/area/wizard_station)
+"sY" = (
+/turf/open/floor/plasteel/bot,
+/area/wizard_station)
+"sZ" = (
+/obj/item/cardboard_cutout,
+/turf/open/floor/plasteel/bot,
+/area/wizard_station)
+"ta" = (
+/obj/structure/punching_bag,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"tb" = (
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"tc" = (
+/obj/structure/mirror/magic{
+	pixel_y = 28
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"td" = (
+/obj/item/weapon/cautery/alien,
+/turf/open/floor/plasteel/bot,
+/area/wizard_station)
+"te" = (
+/obj/item/weapon/coin/antagtoken,
+/turf/open/floor/plasteel/bot,
+/area/wizard_station)
+"tf" = (
+/obj/structure/closet/cardboard,
+/obj/item/weapon/banhammer,
+/turf/open/floor/plasteel/warning,
+/area/wizard_station)
+"tg" = (
+/obj/vehicle/scooter/skateboard{
+	tag = "icon-skateboard (EAST)";
+	icon_state = "skateboard";
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning,
+/area/wizard_station)
+"th" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Engine Room"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"ti" = (
+/obj/structure/table/wood,
+/obj/item/weapon/bikehorn/golden{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
 "tj" = (
 /turf/closed/indestructible/riveted,
 /area/awaymission/errorroom)
@@ -8619,7 +8761,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -8876,7 +9018,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -9133,7 +9275,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -9390,7 +9532,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -9647,7 +9789,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -9904,7 +10046,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -10161,7 +10303,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -10418,7 +10560,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -10650,9 +10792,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+jc
+jc
+jc
 jc
 sa
 sb
@@ -10660,6 +10802,9 @@ mA
 sb
 mV
 jc
+mo
+mO
+jc
 aa
 aa
 aa
@@ -10673,9 +10818,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -10906,10 +11048,10 @@ aa
 aa
 aa
 aa
-aa
-aa
+jc
+jc
 ju
-kV
+sK
 lQ
 kG
 kG
@@ -10917,8 +11059,10 @@ kG
 kG
 kG
 nb
-md
-ju
+kG
+kG
+jc
+jc
 aa
 aa
 aa
@@ -10927,12 +11071,10 @@ aa
 aa
 aa
 aa
-ju
 aa
 aa
 aa
 aa
-ab
 ab
 ab
 ab
@@ -11162,20 +11304,26 @@ aa
 aa
 aa
 aa
-aa
-aa
-li
-aa
-ju
+jc
+jc
+kP
+sQ
+kP
 jc
 kG
 kG
-ln
-lI
+kG
+kG
 kG
 jc
-ju
-ju
+kG
+nD
+kG
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -11184,12 +11332,6 @@ aa
 aa
 aa
 aa
-ju
-ju
-aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -11418,35 +11560,35 @@ aa
 aa
 aa
 aa
-aa
-aa
-kP
-lj
-kP
-aa
 jc
-lW
-mp
+jc
+kP
+kP
+kP
+kP
+jc
+sa
+sb
 kG
-lz
+sb
 mV
 jc
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ju
-nO
+kG
+kG
+kG
+jc
+sX
+td
+tf
+jc
+jc
+ku
 jc
 aa
 aa
 aa
-ab
+aa
+aa
 ab
 ab
 ab
@@ -11675,35 +11817,35 @@ aa
 aa
 aa
 aa
-aa
+jc
 ju
 kQ
-lk
 kP
-aa
+kP
+kP
 jc
 jc
 mo
-mB
-mP
+mz
+mO
 jc
 jc
-ju
-nh
-ju
-aa
-aa
-aa
+kG
+nD
+kG
+sV
+sY
+sY
 nO
-ju
-ju
-kj
-jx
+th
+kG
+kG
 jc
 aa
 aa
 aa
-ab
+aa
+aa
 ab
 ab
 ab
@@ -11929,38 +12071,38 @@ aa
 aa
 aa
 aa
-ju
-ju
 jc
 jc
-ju
+jc
+jc
+sK
 kP
-ll
 kP
-ju
+kP
+sR
 jc
 lX
-kF
-lz
-lI
+kG
+kG
+kG
 mW
 jc
-aa
-kj
-ju
-ju
-aa
-aa
-ju
+kG
+kG
+kG
+jc
+sZ
+te
+tg
 jc
 jc
-ok
+th
 jc
 jc
 jc
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -12185,29 +12327,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-jN
+jc
+jc
+kG
 ki
 jc
 jc
-kS
+jc
 lm
-kS
-lG
+jc
+jc
 jc
 lY
-kF
-ln
+kG
+kG
 kG
 kG
 jc
-ju
-aa
-aa
+kG
+nD
+kG
 jc
 jc
-ku
+jc
 jc
 jc
 kG
@@ -12217,7 +12359,7 @@ ow
 jc
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -12443,25 +12585,25 @@ aa
 aa
 aa
 iZ
-jv
-jO
-kj
+kG
+kG
+kG
 ku
-kE
-kT
-kT
-kT
+kG
+kG
+kG
+kG
 lH
 jc
 kG
 kG
 kG
 kG
-ln
+kG
 ku
-ne
-ni
-nr
+kG
+kG
+kG
 jc
 nC
 nD
@@ -12474,7 +12616,7 @@ ow
 oz
 oC
 aa
-ab
+aa
 ab
 ab
 ab
@@ -12701,24 +12843,24 @@ aa
 aa
 ja
 jw
-jP
-sc
+kG
+kG
 kv
-kF
-kU
 kG
 kG
-lI
+kG
+kG
+kG
 lR
 kG
 kG
 hL
 mQ
-lI
-nc
-kU
-nj
-ln
+kG
+nb
+kG
+nD
+kG
 ny
 nD
 nK
@@ -12731,7 +12873,7 @@ ow
 oz
 oC
 aa
-ab
+aa
 ab
 ab
 ab
@@ -12957,14 +13099,14 @@ aa
 aa
 aa
 jb
-jx
-jx
-kk
+kG
+kG
+kG
 ku
 kG
 kG
-ln
-lz
+kG
+kG
 lJ
 jc
 kG
@@ -12973,11 +13115,11 @@ kG
 kG
 kG
 ku
-nr
-nr
-ni
+kG
+kG
+kG
 jc
-nD
+ta
 nD
 nQ
 jc
@@ -12988,7 +13130,7 @@ ow
 oz
 oC
 aa
-ab
+aa
 ab
 ab
 ab
@@ -13215,14 +13357,14 @@ aa
 aa
 jc
 jc
-jQ
+kG
 kl
 jc
 jc
-kV
+jc
 lo
-ln
-lI
+jc
+jc
 jc
 lZ
 kG
@@ -13230,22 +13372,22 @@ kG
 kG
 kG
 jc
-aa
-ju
-aa
-jc
-jc
-ku
-jc
-jc
 kG
+nD
+kG
+jc
+jc
+jc
+jc
+jc
+ti
 kG
 oo
 ow
 jc
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -13475,9 +13617,9 @@ jc
 jc
 jc
 jc
-aa
-ju
-lp
+nD
+sM
+nD
 lp
 kV
 jc
@@ -13485,24 +13627,24 @@ ma
 mr
 mD
 kG
-mW
+kG
 jc
-aa
-aa
-aa
-ju
+kG
+kG
+kG
+jc
 nh
 nL
 jP
 jc
 jc
-sc
+ku
 jc
 jc
 jc
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -13731,12 +13873,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-ju
-aa
-ju
+jc
+sL
+sN
+sP
+nD
+sS
 jc
 jc
 mo
@@ -13744,14 +13886,14 @@ mz
 mO
 jc
 jc
-ju
-nk
-aa
-aa
-kS
-kP
+kG
+nD
+kG
+sW
+tb
+tb
 nR
-kP
+jc
 aa
 aa
 aa
@@ -13759,7 +13901,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -13988,35 +14130,35 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-ju
-lA
-ju
 jc
+jc
+sO
+nD
+sM
+nD
+iZ
 mb
-ms
+kF
 mE
 mR
-mX
+kF
+iZ
+kG
+kG
+kG
+jc
+tc
+tb
+ll
 jc
 aa
 aa
-ju
-ju
-lm
-ll
-ll
-nT
-nX
 aa
 aa
 aa
 aa
 aa
 aa
-ab
 ab
 ab
 ab
@@ -14246,34 +14388,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+jc
+jc
+sL
 lB
-aa
-jc
+sP
+ja
 mc
 kS
-mF
-kS
 mc
+sU
+mc
+ja
+kG
+nD
+kG
+jc
+jc
+jc
+jc
 jc
 aa
 aa
 aa
-ju
-kS
-kP
-kP
-kP
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-ab
 ab
 ab
 ab
@@ -14504,33 +14646,33 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+jc
+jc
+sO
+nD
+jb
 md
-kP
-mG
-kP
-mZ
-ju
-aa
-aa
-aa
-aa
-nF
-jx
-aa
-aa
-aa
+sT
+kF
+kS
+kF
+jb
+kG
+kG
+jc
+jc
 aa
 aa
 aa
 aa
 aa
 aa
-ab
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -14762,32 +14904,32 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-ju
+jc
+jc
+jc
+jc
 kF
-kP
-mH
+kS
+mc
 mT
 na
-ju
-aa
-aa
-aa
-aa
-ju
 jc
-ju
-ju
-ju
-kj
+mo
+mO
+jc
 aa
 aa
 aa
 aa
 aa
-ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -15022,15 +15164,13 @@ aa
 aa
 aa
 aa
-aa
-ju
-kP
-mI
-kP
-aa
-ju
-ju
-aa
+jc
+jc
+jc
+jc
+jc
+jc
+jc
 aa
 aa
 aa
@@ -15044,7 +15184,9 @@ aa
 aa
 aa
 aa
-ab
+aa
+aa
+aa
 ab
 ab
 ab
@@ -15280,9 +15422,6 @@ aa
 aa
 aa
 aa
-ju
-aa
-mJ
 aa
 aa
 aa
@@ -15301,7 +15440,10 @@ aa
 aa
 aa
 aa
-ab
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -15558,7 +15700,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -15815,7 +15957,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -16072,7 +16214,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 ab
 ab
 ab
@@ -16286,50 +16428,50 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -16543,50 +16685,50 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab

--- a/_maps/map_files/generic/z2.dmm
+++ b/_maps/map_files/generic/z2.dmm
@@ -4165,7 +4165,7 @@
 "mW" = (
 /mob/living/simple_animal/bot/medbot/mysterious{
 	desc = "If you don't accidentally blow yourself up from time to time you're not really a wizard anyway.";
-	faction = list("neutral","silicon");
+	faction = list("neutral","silicon","creature");
 	name = "Nobody's Perfect"
 	},
 /turf/open/floor/engine/cult,


### PR DESCRIPTION
![d10_icon](https://cloud.githubusercontent.com/assets/4176358/18942012/bce41dcc-85e3-11e6-9516-8c3b7f0ba8a5.png)

[note the glass surrounding the lava engine and the wand of engine ignition are missing here, but still exist on the map]

Wizard's den has been "restored" to its pre-invasion state (not a revert, this is just my guess at what it probably looked like before it was "destroyed" in the """""""lore"""""""). Much random loot has been added. Here's the important bits.

There's a medibot named nobody's perfect, mainly for healing wizards that happen to hurt themselves on the den. It's got some flavor editing but other than that it's a normal mysterious medibot. Can't be taken to the station.

There's an observation room where wizards can watch the station through the camera nets, can be useful if you're milling summon events/guns/magic and you don't want to immediately jump right in. There's also (defaulted to off) station radios nearby if you want to talk shit at the crew.

The bust in the observation room is a better weapon than the ritual knife (which is trash) and is mostly there as a powergamer snipe.

The gaming room is mostly fluff but the camera is actually a camera obscura so there's a one in a million chance it may be useful for something. The weird looking dice bag is just that, a weird looking dice bag.

The storage room contains a few silly items as well as the black wizard robes (same armoring as any other color). Behind two wooden barricaded doors is the engine room with a hidden Golden Bike Horn easter egg.

Though the wizard can actually access the cockpit now, the ship isn't actually a _ship_ so it's still all for show.

:cl: 
add: After years of having to live on a mostly blown up hunk of junk the wizard's ship has finally been repaired
del: No one paid attention to that lore anyway
/:cl:
