### PR TITLE
Box Atmos Waste Line Addition

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -2805,21 +2805,15 @@
 /turf/open/floor/plating,
 /area/security/main)
 "agd" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 4
-	},
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f5";
-	dir = 2
-	},
-/area/shuttle/pod_3)
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/turf/open/floor/plasteel,
+/area/atmos)
 "age" = (
-/turf/open/space,
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f9";
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
-/area/shuttle/pod_3)
+/turf/open/floor/plasteel,
+/area/atmos)
 "agf" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -2976,10 +2970,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "agv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
 	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/atmos)
 "agw" = (
@@ -4770,8 +4763,10 @@
 /area/shuttle/labor)
 "ajY" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Unfiltered to Port";
+	on = 0
 	},
 /turf/open/floor/plasteel,
 /area/atmos)
@@ -43474,7 +43469,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Unfiltered to Mix";
-	on = 0
+	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
@@ -94526,7 +94521,7 @@ bRF
 bSM
 bTS
 bUQ
-bWa
+agd
 bUO
 bVZ
 bVZ
@@ -94783,7 +94778,7 @@ bRE
 bSL
 bPe
 agv
-bOd
+age
 bOd
 bXT
 bXT

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -7114,8 +7114,7 @@
 /area/shuttle/labor)
 "aoZ" = (
 /obj/machinery/atmospherics/components/binary/valve{
-	name = "Waste Release";
-	step_y = 0
+	name = "Waste Release"
 	},
 /turf/open/floor/plasteel,
 /area/atmos)

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -7113,7 +7113,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/labor)
 "aoZ" = (
-/obj/machinery/atmospherics/components/binary/valve{
+/obj/machinery/atmospherics/components/binary/valve/digital{
 	name = "Waste Release"
 	},
 /turf/open/floor/plasteel,
@@ -7390,7 +7390,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
 	frequency = 1441;
-	id = "inc_in"
+	id = "waste_out"
 	},
 /turf/open/floor/plating/airless,
 /area/atmos)
@@ -93244,7 +93244,7 @@ bMK
 cbz
 ccx
 cbA
-ama
+cbA
 cfi
 bRH
 cgV
@@ -94520,7 +94520,7 @@ bRF
 bSM
 bTS
 bUQ
-agd
+bWa
 bUO
 bVZ
 bVZ
@@ -94776,8 +94776,8 @@ bQu
 bRE
 bSL
 bPe
-agv
-age
+bOd
+bOd
 bOd
 bXT
 bXT
@@ -95033,7 +95033,7 @@ bQx
 bRH
 bSO
 bTU
-ajY
+bUS
 bUS
 bUS
 bXU
@@ -95290,7 +95290,7 @@ bQw
 bRG
 bSN
 bTT
-ajZ
+bUR
 bWb
 bUR
 bTT

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -2976,10 +2976,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "agv" = (
-/turf/open/floor/plasteel/red/side{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/area/security/main)
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel,
+/area/atmos)
 "agw" = (
 /obj/structure/table,
 /obj/machinery/syndicatebomb/training,
@@ -4767,16 +4769,19 @@
 /turf/open/floor/plating,
 /area/shuttle/labor)
 "ajY" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/shuttle/labor)
-"ajZ" = (
-/turf/open/space,
-/turf/closed/wall/shuttle{
-	dir = 2;
-	icon_state = "swall_f10";
-	layer = 2
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/area/shuttle/labor)
+/turf/open/floor/plasteel,
+/area/atmos)
+"ajZ" = (
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/atmos)
 "aka" = (
 /obj/structure/chair{
 	dir = 1
@@ -5397,14 +5402,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "alk" = (
-/obj/structure/grille,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 1
 	},
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/labor)
+/turf/open/floor/plasteel,
+/area/atmos)
 "all" = (
 /obj/machinery/mineral/labor_claim_console{
 	machinedir = 2;
@@ -5733,10 +5735,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fpmaint2)
 "alX" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/bz,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/atmos)
 "alY" = (
@@ -5754,8 +5756,12 @@
 /turf/open/floor/plasteel/black,
 /area/shuttle/labor)
 "ama" = (
-/turf/closed/wall/shuttle,
-/area/shuttle/labor)
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Waste to Filtering";
+	on = 1
+	},
+/turf/open/floor/plasteel,
+/area/atmos)
 "amb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
@@ -7112,19 +7118,19 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/labor)
 "aoZ" = (
-/turf/open/space,
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f5";
-	dir = 2
+/obj/machinery/atmospherics/components/binary/valve{
+	name = "Waste Release";
+	step_y = 0
 	},
-/area/shuttle/labor)
+/turf/open/floor/plasteel,
+/area/atmos)
 "apa" = (
-/turf/open/space,
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f9";
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/area/shuttle/labor)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/atmos)
 "apb" = (
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
@@ -7372,8 +7378,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fsmaint2)
 "apF" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/shuttle/pod_1)
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plating,
+/area/atmos)
 "apG" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel,
@@ -7384,9 +7393,13 @@
 /turf/open/floor/plating,
 /area/shuttle/pod_1)
 "apI" = (
-/obj/machinery/portable_atmospherics/canister/freon,
-/turf/open/floor/plasteel/floorgrime,
-/area/toxins/storage)
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "inc_in"
+	},
+/turf/open/floor/plating/airless,
+/area/atmos)
 "apJ" = (
 /turf/closed/wall,
 /area/mining_construction)
@@ -43461,7 +43474,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Unfiltered to Mix";
-	on = 1
+	on = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
@@ -50691,6 +50704,7 @@
 /area/atmos)
 "cgX" = (
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/atmos)
 "cgY" = (
@@ -93236,7 +93250,7 @@ bMK
 cbz
 ccx
 cbA
-cbA
+ama
 cfi
 bRH
 cgV
@@ -93748,14 +93762,14 @@ bXS
 bXS
 bMK
 cbB
-bRA
-bTP
-bOd
-bOd
-cfP
+alk
+alX
+aoZ
+bQt
+apa
 cgX
-bMQ
-apQ
+apF
+apI
 bOh
 bOh
 bOh
@@ -94008,7 +94022,7 @@ bQt
 cBJ
 cdy
 bOd
-bOd
+bRy
 cfR
 cha
 civ
@@ -94768,7 +94782,7 @@ bQu
 bRE
 bSL
 bPe
-bOd
+agv
 bOd
 bOd
 bXT
@@ -95025,7 +95039,7 @@ bQx
 bRH
 bSO
 bTU
-bUS
+ajY
 bUS
 bUS
 bXU
@@ -95282,7 +95296,7 @@ bQw
 bRG
 bSN
 bTT
-bUR
+ajZ
 bWb
 bUR
 bTT


### PR DESCRIPTION
Really we just need a space exit point **inside** atmos, not half-way to the AI sat

:cl: Cyberboss
add: The waste line now has a digital valve leading to space (off by default) along with a port on it's far side
/:cl:

![untitled](https://cloud.githubusercontent.com/assets/8171642/18943133/a42c5378-85eb-11e6-977a-91cdcdeac435.png)

Pic outdated. Circles 1, and 3 have been reverted. And the manual valve has been changed to digital
