### PR TITLE
Abduction Tweaks

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -100,13 +100,13 @@
 /obj/item/organ/gland/pop
 	cooldown_low = 900
 	cooldown_high = 1800
-	uses = 6
+	uses = -1
 	human_only = 1
 	icon_state = "species"
 
 /obj/item/organ/gland/pop/activate()
 	owner << "<span class='notice'>You feel unlike yourself.</span>"
-	var/species = pick(list(/datum/species/lizard,/datum/species/jelly/slime,/datum/species/pod,/datum/species/fly))
+	var/species = pick(list(/datum/species/lizard,/datum/species/jelly/slime,/datum/species/pod,/datum/species/fly,/datum/species/jelly))
 	owner.set_species(species)
 
 /obj/item/organ/gland/ventcrawling
@@ -241,10 +241,10 @@
 		qdel(src)
 
 /obj/item/organ/gland/plasma
-	cooldown_low = 2400
-	cooldown_high = 3000
+	cooldown_low = 1200
+	cooldown_high = 1800
 	origin_tech = "materials=4;biotech=4;plasmatech=6;abductor=3"
-	uses = 1
+	uses = -1
 
 /obj/item/organ/gland/plasma/activate()
 	owner << "<span class='warning'>You feel bloated.</span>"
@@ -253,9 +253,9 @@
 	owner << "<span class='userdanger'>A massive stomachache overcomes you.</span>"
 	sleep(50)
 	if(!owner) return
-	owner.visible_message("<span class='danger'>[owner] explodes in a cloud of plasma!</span>")
+	owner.visible_message("<span class='danger'>[owner] vomits a cloud of plasma!</span>")
 	var/turf/open/T = get_turf(owner)
 	if(istype(T))
-		T.atmos_spawn_air("plasma=300;TEMP=[T20C]")
-	owner.gib()
+		T.atmos_spawn_air("plasma=50;TEMP=[T20C]")
+	owner.vomit()
 	return

--- a/code/game/gamemodes/miniantags/abduction/machinery/console.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/console.dm
@@ -45,7 +45,7 @@
 
 	if(experiment != null)
 		var/points = experiment.points
-		var/credits = exeriment.credits
+		var/credits = experiment.credits
 		dat += "Collected Samples : [points] <br>"
 		dat += "Gear Credits: [credits] <br>"
 		dat += "<b>Transfer data in exchange for supplies:</b><br>"

--- a/code/game/gamemodes/miniantags/abduction/machinery/console.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/console.dm
@@ -45,7 +45,9 @@
 
 	if(experiment != null)
 		var/points = experiment.points
+		var/credits = exeriment.credits
 		dat += "Collected Samples : [points] <br>"
+		dat += "Gear Credits: [credits] <br>"
 		dat += "<b>Transfer data in exchange for supplies:</b><br>"
 		dat += "<a href='?src=\ref[src];dispense=baton'>Advanced Baton</A><br>"
 		dat += "<a href='?src=\ref[src];dispense=helmet'>Agent Helmet</A><br>"
@@ -198,8 +200,8 @@
 		return ..()
 
 /obj/machinery/abductor/console/proc/Dispense(item,cost=1)
-	if(experiment && experiment.points >= cost)
-		experiment.points-=cost
+	if(experiment && experiment.credits >= cost)
+		experiment.credits -=cost
 		say("Incoming supply!")
 		if(pad)
 			flick("alien-pad", pad)

--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -7,6 +7,7 @@
 	anchored = 1
 	state_open = 1
 	var/points = 0
+	var/credits = 0
 	var/list/history = list()
 	var/list/abductee_minds = list()
 	var/flash = " - || - "
@@ -170,6 +171,7 @@
 			SendBack(H)
 			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 			points += point_reward
+			credits += point_reward
 			return "<span class='good'>Experiment successful! [point_reward] new data-points collected.</span>"
 		else
 			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 1)


### PR DESCRIPTION
:cl: XDTM
tweak: Abductors no longer delete their research data when buying new gear.
tweak: The Plasma Gland no longer gibs, but instead causes the abductee to vomit plasma every once in a while.
/:cl:

This means that buying gear won't set you back in your objective.
Another minor thing is that the species gland no longer has an use limit and has the jellyperson race added to the list.

The reason for the plasma gland change is that the abductors were clearly meant to be nonlethal: it's not fun to get a semi-antag objective, only to get randomly gibbed after a few minutes. 
This should probably apply to the bodysnatcher gland as well, but i didn't know what to change it into.
