### PR TITLE
Removes morphine from nurse spiders, other spider rebalances

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -1,6 +1,7 @@
 //generic procs copied from obj/effect/alien
 /obj/structure/spider
 	name = "web"
+	icon = 'icons/effects/effects.dmi'
 	desc = "it's stringy and sticky"
 	anchored = 1
 	density = 0
@@ -204,7 +205,7 @@
 
 /obj/structure/spider/cocoon/container_resist()
 	var/mob/living/user = usr
-	var/breakout_time = 2
+	var/breakout_time = 1
 	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + CLICK_CD_BREAKOUT
 	user << "<span class='notice'>You struggle against the tight bonds... (This will take about [breakout_time] minutes.)</span>"
@@ -217,7 +218,8 @@
 
 
 /obj/structure/spider/cocoon/Destroy()
+	var/turf/T = get_turf(src)
 	src.visible_message("<span class='warning'>\The [src] splits open.</span>")
 	for(var/atom/movable/A in contents)
-		A.loc = src.loc
+		A.forceMove(T)
 	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -84,9 +84,8 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	poison_per_bite = 10
+	poison_per_bite = 3
 	var/atom/cocoon_target
-	poison_type = "morphine"
 	var/fed = 0
 
 //hunters have the most poison and move the fastest, so they can find prey


### PR DESCRIPTION
Removes morphine from nurse spiders
Fixes spider web, cocoon, spiderling sprites
Halves cocoon breakout time, fixes camera going to nullspace
Fixes #20752

:cl:
del: removed morphine from nurse spiders
tweak: cocoon breakout time is faster
fix: Spiderwebs are no longer tables
/:cl:
