### PR TITLE
Makes drag/drop that dont have any use call click

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -9,11 +9,11 @@
 	if(!usr || !over) return
 	if(over == src)
 		return usr.client.Click(src, src_location, src_control, params)
-	if(!Adjacent(usr) || !over.Adjacent(usr)) return // should stop you from dragging through windows
+	if(!Adjacent(usr) || !over.Adjacent(usr))
+		return usr.client.Click(src, src_location, src_control, params) // should stop you from dragging through windows
 
-	over.MouseDrop_T(src,usr)
-	return
+	if(!over.MouseDrop_T(src,usr))
+		usr.client.Click(src, src_location, src_control, params)
 
 // recieve a mousedrop
 /atom/proc/MouseDrop_T(atom/dropping, mob/user)
-	return

--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -18,6 +18,7 @@
 	if(isabductor(target))
 		return
 	close_machine(target)
+	. = TRUE
 
 /obj/machinery/abductor/experiment/attack_hand(mob/user)
 	if(..())

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -93,6 +93,7 @@
 	if(user.stat || user.lying || !Adjacent(user) || !user.Adjacent(target) || !iscarbon(target) || !user.IsAdvancedToolUser())
 		return
 	close_machine(target)
+	. = TRUE
 
 /obj/machinery/sleeper/attackby(obj/item/I, mob/user, params)
 	if(!state_open && !occupant)

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -137,6 +137,7 @@ Nah
 	if (pipe.anchored)
 		return
 
+	. = TRUE
 	qdel(pipe)
 
 /obj/machinery/pipedispenser/disposal/attack_hand(mob/user)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -192,6 +192,7 @@
 			target.visible_message("<span class='warning'>[user] pushes [target] into [src] and shuts its door!<span>", "<span class='userdanger'>[user] shoves you into [src] and shuts the door!</span>")
 		close_machine(target)
 		add_fingerprint(user)
+	. = TRUE
 
 /obj/machinery/suit_storage_unit/proc/cook()
 	if(uv_cycles)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -782,6 +782,7 @@
 		log_append_to_last("Permission denied.")
 		return
 	var/passed
+	. = TRUE
 	if(dna_lock)
 		if(user.has_dna())
 			var/mob/living/carbon/C = user

--- a/code/game/objects/items/weapons/implants/implantchair.dm
+++ b/code/game/objects/items/weapons/implants/implantchair.dm
@@ -51,7 +51,7 @@
 	data["ready_implants"]  = ready_implants
 	data["ready"] = ready
 	data["replenishing"] = replenishing
-	
+
 	return data
 
 /obj/machinery/implantchair/ui_act(action, params)
@@ -137,6 +137,7 @@
 	if(user.stat || user.lying || !Adjacent(user) || !user.Adjacent(target) || !iscarbon(target) || !user.IsAdvancedToolUser())
 		return
 	close_machine(target)
+	. = TRUE
 
 /obj/machinery/implantchair/close_machine(mob/user)
 	if((isnull(user) || istype(user)) && state_open)
@@ -189,4 +190,3 @@
 	log_game("[key_name_admin(user)] brainwashed [key_name_admin(C)] with objective '[objective]'.")
 	return 1
 
-	

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -71,6 +71,7 @@
 			if(!L.incapacitated() && I == L.get_active_held_item())
 				if(can_be_inserted(I, 0))
 					handle_item_insertion(I, 0 , L)
+					. = TRUE
 
 
 //Check if this storage can dump the items

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -63,7 +63,7 @@
 	if(ismob(O) && user == O && iscarbon(user))
 		if(user.canmove)
 			climb_structure(user)
-			return
+			return 1
 	if ((!( istype(O, /obj/item/weapon) ) || user.get_active_held_item() != O))
 		return
 	if(isrobot(user))
@@ -72,7 +72,7 @@
 		return
 	if (O.loc != src.loc)
 		step(O, get_dir(O, src))
-	return
+	return 1
 
 /obj/structure/proc/climb_structure(mob/user)
 	src.add_fingerprint(user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -274,6 +274,7 @@
 		actuallyismob = 1
 	else if(!istype(O, /obj/item))
 		return
+	. = TRUE
 	var/turf/T = get_turf(src)
 	var/list/targets = list(O, src)
 	add_fingerprint(user)
@@ -290,9 +291,9 @@
 				L.Weaken(2)
 			O.forceMove(T)
 			close()
+		return
 	else
 		O.forceMove(T)
-	return 1
 
 /obj/structure/closet/relaymove(mob/user)
 	if(user.stat || !isturf(loc) || !isliving(user))

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -249,6 +249,7 @@ var/global/list/crematoriums = new/list()
 			return
 	if(!ismob(user) || user.lying || user.incapacitated())
 		return
+	. = TRUE
 	O.loc = src.loc
 	if (user != O)
 		visible_message("<span class='warning'>[user] stuffs [O] into [src].</span>")

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -505,6 +505,7 @@
 		return
 	if(!user.drop_item())
 		return
+	. = TRUE
 	if(O.loc != src.loc)
 		step(O, get_dir(O, src))
 

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -49,6 +49,7 @@
 		return
 	for(var/obj/structure/transit_tube_pod/pod in loc)
 		return //no fun allowed
+	. = TRUE
 	var/obj/structure/transit_tube_pod/T = new/obj/structure/transit_tube_pod(src)
 	R.transfer_fingerprints_to(T)
 	T.add_fingerprint(user)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -164,6 +164,7 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell/MouseDrop_T(mob/target, mob/user)
 	if(user.stat || user.lying || !Adjacent(user) || !user.Adjacent(target) || !iscarbon(target) || !user.IsAdvancedToolUser())
 		return
+	. = TRUE
 	close_machine(target)
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/attackby(obj/item/I, mob/user, params)

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -64,6 +64,7 @@
 	if(!istype(target))
 		return
 	if(ismonkey(target))
+		. = TRUE
 		stuff_monkey_in(target, user)
 
 /obj/machinery/monkey_recycler/proc/stuff_monkey_in(mob/living/carbon/monkey/target, mob/living/user)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -334,6 +334,7 @@ var/global/mulebot_count = 0
 	if(!istype(AM))
 		return
 
+	. = TRUE
 	load(AM)
 
 // called to load a crate
@@ -738,7 +739,7 @@ var/global/mulebot_count = 0
 		unload(get_dir(loc, A))
 	else
 		..()
-		
+
 /mob/living/simple_animal/bot/mulebot/insertpai(mob/user, obj/item/device/paicard/card)
 	if(..())
 		visible_message("[src] safeties are locked on.")

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -333,6 +333,7 @@
 	check_ass() //Just to make sure that you can re-drag somebody onto it after they moved off.
 	if (!istype(target) || target.anchored || target.buckled || !Adjacent(user) || !Adjacent(target) || !user.canUseTopic(src, 1) || target == ass || copier_blocked())
 		return
+	. = TRUE
 	src.add_fingerprint(user)
 	if(target == user)
 		user.visible_message("[user] starts climbing onto the photocopier!", "<span class='notice'>You start climbing onto the photocopier...</span>")

--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -113,6 +113,7 @@
 
 /obj/machinery/disposal/MouseDrop_T(mob/living/target, mob/living/user)
 	if(istype(target))
+		. = TRUE
 		stuff_mob_in(target, user)
 
 /obj/machinery/disposal/proc/stuff_mob_in(mob/living/target, mob/living/user)


### PR DESCRIPTION
Makes drag/drop that dont have any particular defined behaviour be treated as just click on the dragged object
:cl: Razharas
tweak: Makes clicking something in heat of battle a bit easier by making drag&drops that dont have any effect be counted as clicks
/:cl:

Makes drag/drop that dont have any use call click
