### PR TITLE
Allows removing materials from shell dispensers

### DIFF
--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -268,6 +268,11 @@
 			user << "<span class='warning'>The [src] isn't accepting the \
 				[sheets].</span>"
 
+	else if(istype(O, /obj/item/weapon/crowbar))
+		materials.retrieve_all()
+		playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
+		user << "<span class='notice'>You retrieve the materials from [src].</span>"
+
 	else if(istype(O, /obj/item/weapon/weldingtool))
 		if(!(stat & BROKEN))
 			user << "<span class='warning'>[src] doesn't need repairs.</span>"


### PR DESCRIPTION
:cl: XDTM
add: You can now retrieve materials inserted in a Drone Shell Dispenser with a crowbar.
/:cl:
