### PR TITLE
Reorder mob living destroy

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -27,8 +27,6 @@
 	med_hud_set_status()
 
 /mob/living/Destroy()
-	..()
-
 	if(buckled)
 		buckled.unbuckle_mob(src,force=1)
 
@@ -39,6 +37,8 @@
 			qdel(I)
 	staticOverlays.len = 0
 	remove_from_all_data_huds()
+	..()
+
 	return QDEL_HINT_HARDDEL
 
 


### PR DESCRIPTION
We want to do all custom cleanup before parent call so we are not
operating in nullspace when we unbuckle and do other bits and bobs (as
that code does not expect this)
