### PR TITLE
Better check for milestone in the doomsday device

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -94,9 +94,10 @@
 		detonate(T.z)
 		qdel(src)
 	else
-		if(!(sec_left % 60) && (!milestones[sec_left]))
-			milestones[sec_left] = TRUE
-			var/message = "[sec_left] SECONDS UNTIL DOOMSDAY DEVICE ACTIVATION!"
+		var/key = num2text(sec_left)
+		if(!(sec_left % 60) && !(key in milestones))
+			milestones[key] = TRUE
+			var/message = "[key] SECONDS UNTIL DOOMSDAY DEVICE ACTIVATION!"
 			minor_announce(message, "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4", 1)
 
 /obj/machinery/doomsday_device/proc/detonate(z_level = 1)


### PR DESCRIPTION
This prevents a list index out of bounds runtime by doing the check via
byonds in operator instead

This should also ensure milestones are set properly
