### PR TITLE
Fixes things getting diag directions from diag movements.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -64,6 +64,7 @@
 						moving_diagonally = SECOND_DIAG_STEP
 						. = step(src, SOUTH)
 			moving_diagonally = 0
+			return
 
 	if(!loc || (loc == oldloc && oldloc != newloc))
 		last_move = 0


### PR DESCRIPTION
And really, if we already call move() twice from the diagonal move, there is no need to continue with the rest of this proc, certainly not with the bit that calls setDir, since it would override the setDir from the . = step()

This might break things in special snowflake objects, but some basic testing showed no issues.

Fixes #20728 as well as an unreported bug where PA parts refused to link up if they were ever pull moved
