### PR TITLE
Roundstart Fashion [Glasses]

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -52,6 +52,13 @@
 		var/datum/tech/D = new path()
 		tech_list[D.id] = D
 
+	//Valid fashion items (just glasses right now)
+	for(var/obj/item/clothing/glasses/G in init_subtypes(/obj/item/clothing/glasses))
+		if(G.cosmetic)
+			glasses_list[G.name] = G.type
+			world.log << "Valido!"
+		world.log << "[G.name] [G.type]"
+
 	init_subtypes(/datum/crafting_recipe, crafting_recipes)
 
 /* // Uncomment to debug chemical reaction list.

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -35,6 +35,9 @@ var/global/list/wings_list = list()
 var/global/list/wings_open_list = list()
 var/global/list/r_wings_list = list()
 
+	//Fashion items
+var/global/list/glasses_list = list("none")
+
 var/global/list/ghost_forms_with_directions_list = list("ghost") //stores the ghost forms that support directional sprites
 var/global/list/ghost_forms_with_accessories_list = list("ghost") //stores the ghost forms that support hair and other such things
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -61,7 +61,7 @@ var/list/preferences_datums = list()
 	var/eye_color = "000"				//Eye color
 	var/datum/species/pref_species = new /datum/species/human()	//Mutant race
 	var/list/features = list("mcolor" = "FFF", "tail_lizard" = "Smooth", "tail_human" = "None", "snout" = "Round", "horns" = "None", "ears" = "None", "wings" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None", "legs" = "Normal Legs")
-
+	var/list/fashion = list("glasses" = null)
 	var/list/custom_names = list("clown", "mime", "ai", "cyborg", "religion", "deity")
 		//Mob preview
 	var/icon/preview_icon = null
@@ -119,7 +119,7 @@ var/list/preferences_datums = list()
 /datum/preferences/proc/ShowChoices(mob/user)
 	if(!user || !user.client)
 		return
-	update_preview_icon()
+	update_preview_icon(fashion)
 	user << browse_rsc(preview_icon, "previewicon.png")
 	var/dat = "<center>"
 
@@ -235,6 +235,14 @@ var/list/preferences_datums = list()
 				dat += "<span style='border: 1px solid #161616; background-color: #[eye_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=eyes;task=input'>Change</a><BR>"
 
 				dat += "</td>"
+
+			dat += "<td valign='top' width='7%'>"
+
+			dat += "<h3>Glasses</h3>"
+
+			dat += "<a href='?_src_=prefs;preference=glasses;task=input'>[fashion["glasses"]]</a><BR>"
+
+			dat += "</td>"
 
 			if(config.mutant_races) //We don't allow mutant bodyparts for humans either unless this is true.
 
@@ -467,7 +475,7 @@ var/list/preferences_datums = list()
 		HTML += "The job ticker is not yet finished creating jobs, please try again later"
 		HTML += "<center><a href='?_src_=prefs;preference=job;task=close'>Done</a></center><br>" // Easier to press up here.
 
-	else 
+	else
 		HTML += "<b>Choose occupation chances</b><br>"
 		HTML += "<div align='center'>Left-click to raise an occupation preference, right-click to lower it.<br></div>"
 		HTML += "<center><a href='?_src_=prefs;preference=job;task=close'>Done</a></center><br>" // Easier to press up here.
@@ -922,6 +930,11 @@ var/list/preferences_datums = list()
 					var/new_eyes = input(user, "Choose your character's eye colour:", "Character Preference") as color|null
 					if(new_eyes)
 						eye_color = sanitize_hexcolor(new_eyes)
+
+				if("glasses")
+					var/new_glasses = input(user, "Choose your character's glasses:", "Character Preference") as anything in glasses_list
+					if(new_glasses)
+						fashion["glasses"] = new_glasses
 
 				if("species")
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -294,6 +294,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	else
 		S["feature_human_tail"]				>> features["tail_human"]
 		S["feature_human_ears"]				>> features["ears"]
+	S["fashion_glasses"]	>> fashion["glasses"]
 	S["clown_name"]			>> custom_names["clown"]
 	S["mime_name"]			>> custom_names["mime"]
 	S["ai_name"]			>> custom_names["ai"]
@@ -354,6 +355,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	features["spines"] 	= sanitize_inlist(features["spines"], spines_list)
 	features["body_markings"] 	= sanitize_inlist(features["body_markings"], body_markings_list)
 	features["feature_lizard_legs"]	= sanitize_inlist(features["legs"], legs_list, "Normal Legs")
+	fashion["glasses"] = sanitize_inlist(fashion["glasses"], glasses_list)
 
 	joblessrole	= sanitize_integer(joblessrole, 1, 3, initial(joblessrole))
 	job_civilian_high = sanitize_integer(job_civilian_high, 0, 65535, initial(job_civilian_high))
@@ -406,6 +408,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["feature_lizard_spines"]			<< features["spines"]
 	S["feature_lizard_body_markings"]	<< features["body_markings"]
 	S["feature_lizard_legs"]			<< features["legs"]
+	S["fashion_glasses"]	<< fashion["glasses"]
 	S["clown_name"]			<< custom_names["clown"]
 	S["mime_name"]			<< custom_names["mime"]
 	S["ai_name"]			<< custom_names["ai"]

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -19,6 +19,7 @@
 	var/can_flashlight = 0
 	var/gang //Is this a gang outfit?
 	var/scan_reagents = 0 //Can the wearer see reagents while it's equipped?
+	var/cosmetic = FALSE //Only set to true for items that have no practical use besides their appearence
 
 	//Var modification - PLEASE be careful with this I know who you are and where you live
 	var/list/user_vars_to_edit = list() //VARNAME = VARVALUE eg: "name" = "butts"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -77,12 +77,14 @@
 	desc = "Yarr."
 	icon_state = "eyepatch"
 	item_state = "eyepatch"
+	cosmetic = TRUE
 
 /obj/item/clothing/glasses/monocle
 	name = "monocle"
 	desc = "Such a dapper eyepiece!"
 	icon_state = "monocle"
 	item_state = "headset" // lol
+	cosmetic = TRUE
 
 /obj/item/clothing/glasses/material
 	name = "Optical Material Scanner"
@@ -120,18 +122,21 @@
 	icon_state = "glasses"
 	item_state = "glasses"
 	vision_correction = 1 //corrects nearsightedness
+	cosmetic = TRUE
 
 /obj/item/clothing/glasses/regular/hipster
 	name = "Prescription Glasses"
 	desc = "Made by Uncool. Co."
 	icon_state = "hipster_glasses"
 	item_state = "hipster_glasses"
+	cosmetic = TRUE
 
 /obj/item/clothing/glasses/gglasses
 	name = "Green Glasses"
 	desc = "Forest green glasses, like the kind you'd wear when hatching a nasty scheme."
 	icon_state = "gglasses"
 	item_state = "gglasses"
+	cosmetic = TRUE
 
 /obj/item/clothing/glasses/sunglasses
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
@@ -226,6 +231,7 @@
 //	vision_flags = BLIND
 	flash_protect = 2
 	tint = 3			// to make them blind
+	cosmetic = TRUE
 
 /obj/item/clothing/glasses/sunglasses/big
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Larger than average enhanced shielding blocks many flashes."
@@ -273,12 +279,14 @@
 	desc = "A pair of goggles meant for low temperatures."
 	icon_state = "cold"
 	item_state = "cold"
+	cosmetic = TRUE
 
 /obj/item/clothing/glasses/heat
 	name = "heat goggles"
 	desc = "A pair of goggles meant for high temperatures."
 	icon_state = "heat"
 	item_state = "heat"
+	cosmetic = TRUE
 
 /obj/item/clothing/glasses/orange
 	name = "orange glasses"
@@ -286,6 +294,7 @@
 	icon_state = "orangeglasses"
 	item_state = "orangeglasses"
 	glass_colour_type = /datum/client_colour/glass_colour/lightorange
+	cosmetic = TRUE
 
 /obj/item/clothing/glasses/red
 	name = "red glasses"
@@ -293,6 +302,7 @@
 	icon_state = "redglasses"
 	item_state = "redglasses"
 	glass_colour_type = /datum/client_colour/glass_colour/red
+	cosmetic = TRUE
 
 /obj/item/clothing/glasses/godeye
 	name = "eye of god"

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -45,7 +45,7 @@
 /datum/job/proc/equip_items(mob/living/carbon/human/H)
 
 //But don't override this
-/datum/job/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/job/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE, list/fashion)
 	if(!H)
 		return 0
 
@@ -53,7 +53,7 @@
 	H.dna.species.before_equip_job(src, H, visualsOnly)
 
 	if(outfit)
-		H.equipOutfit(outfit, visualsOnly)
+		H.equipOutfit(outfit, visualsOnly, fashion)
 
 	H.dna.species.after_equip_job(src, H, visualsOnly)
 
@@ -192,3 +192,39 @@
 		if(H && announcement_systems.len)
 			var/obj/machinery/announcement_system/announcer = pick(announcement_systems)
 			announcer.announce("NEWHEAD", H.real_name, H.job, channels)
+
+/datum/outfit/proc/apply_fashion(list/fashion)
+	for(var/O in fashion)
+		var/obj/item/I = new fashion[O]
+		if(!istype(I) || isemptylist(I.slot_flags))
+			continue
+		switch(I.slot_flags[1])
+			if(SLOT_ICLOTHING)
+				bump_to_backpack(uniform, I.type)
+			else if(SLOT_OCLOTHING)
+				bump_to_backpack(suit, I.type)
+			else if(SLOT_BACK)
+				bump_to_backpack(null, I.type)
+			else if(SLOT_BELT)
+				bump_to_backpack(belt, I.type)
+			else if(SLOT_GLOVES)
+				bump_to_backpack(gloves, I.type)
+			else if(SLOT_FEET)
+				bump_to_backpack(shoes, I.type)
+			else if(SLOT_HEAD)
+				bump_to_backpack(head, I.type)
+			else if(SLOT_MASK)
+				bump_to_backpack(mask, I.type)
+			else if(SLOT_EARS)
+				bump_to_backpack(ears, I.type)
+			else if(SLOT_EYES)
+				bump_to_backpack(glasses, I.type)
+			else if(SLOT_ID)
+				bump_to_backpack(id, I.type)
+			else if(SLOT_POCKET)
+				bump_to_backpack(l_pocket, I.type)
+
+/datum/outfit/proc/bump_to_backpack(replaced, fashion_item)
+	if(replaced)
+		backpack_contents += replaced
+	replaced = fashion_item

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -294,7 +294,7 @@
 
 	return shredded
 
-/mob/living/carbon/human/proc/equipOutfit(outfit, visualsOnly = FALSE)
+/mob/living/carbon/human/proc/equipOutfit(outfit, visualsOnly = FALSE, list/fashion)
 	var/datum/outfit/O = null
 
 	if(ispath(outfit))
@@ -305,5 +305,6 @@
 			return 0
 	if(!O)
 		return 0
-
+	if(fashion)
+		O.apply_fashion(fashion)
 	return O.equip(src, visualsOnly)


### PR DESCRIPTION
[Not actually functional yet]

Allows for the option of choosing roundstart gear, currently proof of concepted here with glasses. If a job natively spawns with something in that slot, the default gear is instead put in the backpack at round start. 

Glasses selection here is based on all glasses that have no special effects (beyond the things that every pair of glasses do). "Cosmetic" lens as they were.

TODO:
- [ ] Make the dang thing actually work
- [ ] Figure out where to put these options in the UI because my go to zone for this stuff is just stuffed full of lizards
- [ ] Fend off balance concerns
- [x] Procrastinate

A request by @Niknakflak 
