### PR TITLE
Possibly fixes exponentially increasing stock prices

### DIFF
--- a/code/modules/stock_market/stocks.dm
+++ b/code/modules/stock_market/stocks.dm
@@ -90,7 +90,7 @@
 /datum/stock/proc/frc(amt)
 	var/shares = available_shares + outside_shareholders * average_shares
 	var/fr = amt / 100 / shares * fluctuational_coefficient * fluctuation_rate * max(-(current_trend / 100), 1)
-	if (fr < 0 && speculation < 0 || fr > 0 && speculation > 0)
+	if ((fr < 0 && speculation < 0) || (fr > 0 && speculation > 0))
 		fr *= max(abs(speculation) / 5, 1)
 	else
 		fr /= max(abs(speculation) / 5, 1)


### PR DESCRIPTION
I think because of improper bracketing of this `if`, it haywires.
Unfortunately, testing this would be...iffy, so I'm going with my gut here.

Testing with this shown no anomalies, so at least I don't think this breaks anything.

EDIT: Here's my reasoning:
1. I noticed that `supplyGrowth()` affects the `current_value` of shares without goofchecks:tm:
2. If `fr` is negative, it increases the share price based on their current value;
3. Because of trends/fluctuations, which I assume at least tend to have a...trend...if the `fr` is negative, it keeps increasing the value of shares exponentially;
4. `supplyGrowth()` calls `frc(amt)` function that has this faulty if, therefore, I think this is the cause of the problem.
