### PR TITLE
Makes browser datum use asset cache

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -97,9 +97,9 @@
 	if (width && height)
 		window_size = "size=[width]x[height];"
 	if (stylesheets.len)
-		send_asset_list(user, stylesheets, verify=false)
+		send_asset_list(user, stylesheets, verify=FALSE)
 	if (scripts.len)
-		send_asset_list(user, scripts, verify=false)
+		send_asset_list(user, scripts, verify=FALSE)
 	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
 	if (use_onclose)
 		spawn(0)

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -40,9 +40,11 @@
 
 /datum/browser/proc/add_stylesheet(name, file)
 	stylesheets[name] = file
+	register_asset("[ckey(name)].css", file)
 
 /datum/browser/proc/add_script(name, file)
 	scripts[name] = file
+	register_asset("[ckey(name)].js", file)
 
 /datum/browser/proc/set_content(ncontent)
 	content = ncontent
@@ -54,13 +56,9 @@
 	var/key
 	var/filename
 	for (key in stylesheets)
-		filename = "[ckey(key)].css"
-		user << browse_rsc(stylesheets[key], filename)
 		head_content += "<link rel='stylesheet' type='text/css' href='[filename]'>"
 
 	for (key in scripts)
-		filename = "[ckey(key)].js"
-		user << browse_rsc(scripts[key], filename)
 		head_content += "<script type='text/javascript' src='[filename]'></script>"
 
 	var/title_attributes = "class='uiTitle'"
@@ -98,6 +96,10 @@
 	var/window_size = ""
 	if (width && height)
 		window_size = "size=[width]x[height];"
+	if (stylesheets.len)
+		send_asset_list(user, stylesheets, verify=false)
+	if (scripts.len)
+		send_asset_list(user, scripts, verify=false)
 	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
 	if (use_onclose)
 		spawn(0)


### PR DESCRIPTION
:cl:
tweak: Player Preferences window made slightly faster.
/:cl:

This should shave one or two round trips off of the lag for player preferences window, since it was sending the css for browser datums every load.
