### PR TITLE
fixes a bug in monkey examining

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -37,7 +37,7 @@
 		if(t=="head")
 			msg += "<span class='deadsay'><B>[t_His] [parse_zone(t)] is missing!</B></span>\n"
 			continue
-		msg += "<<span class='warning'><B>[t_His] [parse_zone(t)] is missing!</B></span>\n"
+		msg += "<span class='warning'><B>[t_His] [parse_zone(t)] is missing!</B></span>\n"
 
 	msg += "<span class='warning'>"
 	var/temp = getBruteLoss()


### PR DESCRIPTION
extra < would display in the message like so:
![<](http://puu.sh/rBinH/b228ee0ab2.png)
