### PR TITLE
Tightens up when attorney badges add/remove their speech bubble

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -409,12 +409,14 @@ BLIND     // can't see anything
 			adjusted = DIGITIGRADE_STYLE
 		H.update_inv_w_uniform()
 
-	if(hastie)
-		hastie.on_uniform_equip(src, user)
+		if(hastie && H.w_uniform == src)
+			hastie.on_uniform_equip(src, user)
 
 /obj/item/clothing/under/dropped(mob/user)
-	if(hastie)
-		hastie.on_uniform_dropped(src, user)
+	if(hastie && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(src in H.held_items)
+			hastie.on_uniform_dropped(src, user)
 	..()
 
 /obj/item/clothing/under/attackby(obj/item/I, mob/user, params)

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -29,6 +29,10 @@
 	for(var/armor_type in armor)
 		U.armor[armor_type] += armor[armor_type]
 
+	if(ishuman(U.loc))
+		var/mob/living/carbon/human/H = U.loc
+		if(H.w_uniform == U)
+			on_uniform_equip(U)
 	return 1
 
 
@@ -46,6 +50,12 @@
 		pixel_y += 8
 	layer = initial(layer)
 	U.cut_overlays()
+
+	if(ishuman(U.loc))
+		var/mob/living/carbon/human/H = U.loc
+		if(H.w_uniform == U)
+			on_uniform_dropped(U)
+
 	U.hastie = null
 
 /obj/item/clothing/tie/proc/on_uniform_equip(obj/item/clothing/under/U)
@@ -394,13 +404,9 @@
 		on_uniform_dropped(U)
 
 /obj/item/clothing/tie/lawyers_badge/on_uniform_equip(obj/item/clothing/under/U)
-	if(!isliving(U.loc))
-		return
 	var/mob/living/L = U.loc
 	L.bubble_icon = "lawyer"
 
 /obj/item/clothing/tie/lawyers_badge/on_uniform_dropped(obj/item/clothing/under/U)
-	if(!isliving(U.loc))
-		return
 	var/mob/living/L = U.loc
 	L.bubble_icon = initial(L.bubble_icon)


### PR DESCRIPTION
Speech bubbles can now only be added or removed in these specific instances:
- The uniform is equipped to a human's w_uniform
- The uniform is unequipped to a human's hands
- The badge is removed/adde to a uniform already in the human's w_uniform slot

Should fix #20857

:warning: Doesn't currently work :warning: 
