### PR TITLE
Make compressor efficiency good, not bad

### DIFF
--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -155,7 +155,7 @@
 
 // RPM function to include compression friction - be advised that too low/high of a compfriction value can make things screwy
 
-	rpm = max(0, rpm - (rpm*rpm)/(COMPFRICTION/efficiency))
+	rpm = max(0, rpm - (rpm*rpm)/(COMPFRICTION*efficiency))
 
 
 	if(starter && !(stat & NOPOWER))


### PR DESCRIPTION
:cl: ChemicalRascal
fix: Previously, improving the incinerator's efficiency made the RPM decay more quickly, instead of less quickly. No more!
/:cl:

Previously, compressor rpm decayed as such: max(0, rpm - [(rpm^2*efficiency)/COMPFRICTION]), where COMPFRICTION is very large.

As such, an increase in efficiency increased the rate that compressor rpm decayed at, efficiency being between 1 and 4.

This commit changes that equation to max(0, rpm - [(rpm^2)/(COMPFRICTION*efficiency)]), ergo, an increase in efficiency decreases the rate of rpm decay, making it up to four times slower instead of four times faster.
