### PR TITLE
Hopefully fixes arm replacement not working

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -84,7 +84,7 @@
 	C.bodyparts -= src
 	if(held_index)
 		C.unEquip(owner.get_item_for_held_index(held_index), 1)
-		C.hand_bodyparts[held_index] = null
+		C.hand_bodyparts -= src
 
 	owner = null
 


### PR DESCRIPTION
Fixes #20866 

I did some testing and didn't seem to cause any problem.
Now when an arm is dismembered, it won't set a null to hand_bodyparts, instead it will just remove itself from the list.
