### PR TITLE
[DNM]Enables telecomms heat system.

### DIFF
--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -55156,7 +55156,9 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "cgF" = (
-/obj/machinery/telecomms/bus/preset_three,
+/obj/machinery/telecomms/bus/preset_three{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55170,7 +55172,9 @@
 	},
 /area/tcommsat/server)
 "cgH" = (
-/obj/machinery/telecomms/processor/preset_three,
+/obj/machinery/telecomms/processor/preset_three{
+	heatgen = 0
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
@@ -55178,7 +55182,9 @@
 	},
 /area/tcommsat/server)
 "cgI" = (
-/obj/machinery/telecomms/processor/preset_one,
+/obj/machinery/telecomms/processor/preset_one{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55192,7 +55198,9 @@
 	},
 /area/tcommsat/server)
 "cgK" = (
-/obj/machinery/telecomms/bus/preset_one,
+/obj/machinery/telecomms/bus/preset_one{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55421,7 +55429,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_2)
 "chp" = (
-/obj/machinery/telecomms/server/presets/security,
+/obj/machinery/telecomms/server/presets/security{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55441,7 +55451,9 @@
 	},
 /area/tcommsat/server)
 "chr" = (
-/obj/machinery/telecomms/server/presets/command,
+/obj/machinery/telecomms/server/presets/command{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55469,7 +55481,9 @@
 	},
 /area/tcommsat/server)
 "chv" = (
-/obj/machinery/telecomms/server/presets/medical,
+/obj/machinery/telecomms/server/presets/medical{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55489,7 +55503,9 @@
 	},
 /area/tcommsat/server)
 "chx" = (
-/obj/machinery/telecomms/server/presets/science,
+/obj/machinery/telecomms/server/presets/science{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55673,7 +55689,9 @@
 /turf/open/space,
 /area/space)
 "chY" = (
-/obj/machinery/telecomms/processor/preset_four,
+/obj/machinery/telecomms/processor/preset_four{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55691,7 +55709,9 @@
 	},
 /area/tcommsat/server)
 "cia" = (
-/obj/machinery/telecomms/bus/preset_four,
+/obj/machinery/telecomms/bus/preset_four{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55706,7 +55726,9 @@
 	},
 /area/tcommsat/server)
 "cic" = (
-/obj/machinery/telecomms/bus/preset_two,
+/obj/machinery/telecomms/bus/preset_two{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55726,7 +55748,9 @@
 	},
 /area/tcommsat/server)
 "cie" = (
-/obj/machinery/telecomms/processor/preset_two,
+/obj/machinery/telecomms/processor/preset_two{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55838,7 +55862,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "cit" = (
-/obj/machinery/telecomms/server/presets/engineering,
+/obj/machinery/telecomms/server/presets/engineering{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55852,7 +55878,9 @@
 	},
 /area/tcommsat/server)
 "civ" = (
-/obj/machinery/telecomms/server/presets/common,
+/obj/machinery/telecomms/server/presets/common{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55873,7 +55901,9 @@
 /turf/closed/wall,
 /area/tcommsat/server)
 "ciy" = (
-/obj/machinery/telecomms/server/presets/supply,
+/obj/machinery/telecomms/server/presets/supply{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -55887,7 +55917,9 @@
 	},
 /area/tcommsat/server)
 "ciA" = (
-/obj/machinery/telecomms/server/presets/service,
+/obj/machinery/telecomms/server/presets/service{
+	heatgen = 0
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -50159,6 +50159,10 @@
 	},
 /area/tcommsat/server)
 "bIl" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel/circuit/gcircuit{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -51798,9 +51802,10 @@
 	},
 /area/tcommsat/server)
 "bLp" = (
-/obj/item/weapon/twohanded/required/kirbyplants{
-	icon_state = "plant-21";
-	layer = 4.1
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	target_temperature = 80;
+	dir = 2;
+	on = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer{
@@ -90483,11 +90488,11 @@
 	},
 /area/shuttle/supply)
 "cYZ" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s5";
-	dir = 2
-	},
-/area/shuttle/supply)
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "cZa" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -90496,17 +90501,23 @@
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "cZb" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall15";
-	dir = 2
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 140;
+	on = 1;
+	pressure_checks = 0
 	},
-/area/shuttle/supply)
+/turf/open/floor/plasteel/black{
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/tcommsat/server)
 "cZc" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s9";
-	dir = 2
-	},
-/area/shuttle/supply)
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/hidden,
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "cZd" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating,
@@ -90596,21 +90607,30 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "cZs" = (
-/turf/open/floor/plasteel/shuttle,
-/turf/closed/wall/shuttle/interior{
-	icon_state = "swall_f10"
+/obj/machinery/door/airlock/hatch{
+	name = "Telecoms Server Room"
 	},
-/area/shuttle/transport)
-"cZt" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	icon_state = "intact";
 	dir = 4
 	},
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s5";
-	dir = 2
+/turf/open/floor/plasteel/black,
+/area/tcommsat/server)
+"cZt" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	icon_state = "intact";
+	dir = 4
 	},
-/area/shuttle/transport)
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "cZu" = (
 /obj/structure/closet/crate,
 /turf/open/floor/mineral/titanium/blue,
@@ -90622,11 +90642,20 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "cZw" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s9";
-	dir = 2
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 120;
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
 	},
-/area/shuttle/transport)
+/turf/open/floor/plasteel/black{
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/tcommsat/server)
 "cZx" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/bot,
@@ -147927,7 +147956,7 @@ bBr
 bCY
 bEI
 bGl
-bIk
+cZb
 bIk
 bLu
 bQj
@@ -148439,9 +148468,9 @@ bxz
 bzr
 bBt
 bLp
-bEJ
-bEJ
-bEJ
+cYZ
+cYZ
+cZc
 bJK
 bIk
 bIk
@@ -148698,7 +148727,7 @@ bBu
 bDb
 bEK
 bGn
-bEK
+cZs
 bJL
 bMW
 bMY
@@ -148955,7 +148984,7 @@ bBv
 bDc
 bEJ
 bEJ
-bEJ
+cZt
 bJM
 bLs
 bLs
@@ -149469,7 +149498,7 @@ bBx
 bDe
 bEI
 bGl
-bIk
+cZw
 bIk
 bMX
 bQm

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -7112,19 +7112,28 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/labor)
 "aoZ" = (
-/turf/open/space,
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f5";
-	dir = 2
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 140;
+	on = 1;
+	pressure_checks = 0
 	},
-/area/shuttle/labor)
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/tcommsat/server)
 "apa" = (
-/turf/open/space,
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f9";
-	dir = 2
+/obj/machinery/airalarm/server{
+	dir = 4;
+	pixel_x = -22;
+	pixel_y = 0
 	},
-/area/shuttle/labor)
+/turf/open/floor/plasteel/black{
+	name = "Mainframe Floor";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/tcommsat/server)
 "apb" = (
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
@@ -7372,8 +7381,20 @@
 /turf/open/floor/plating,
 /area/maintenance/fsmaint2)
 "apF" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/shuttle/pod_1)
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 120;
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/tcommsat/server)
 "apG" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel,
@@ -7384,9 +7405,15 @@
 /turf/open/floor/plating,
 /area/shuttle/pod_1)
 "apI" = (
-/obj/machinery/portable_atmospherics/canister/freon,
-/turf/open/floor/plasteel/floorgrime,
-/area/toxins/storage)
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/bluegrid{
+	name = "Mainframe Base";
+	initial_gas_mix = "n2=100;TEMP=80"
+	},
+/area/tcommsat/server)
 "apJ" = (
 /turf/closed/wall,
 /area/mining_construction)
@@ -45777,7 +45804,11 @@
 	},
 /area/tcommsat/server)
 "bWH" = (
-/obj/structure/table,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8;
+	on = 1;
+	target_temperature = 80
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 9
 	},
@@ -45788,6 +45819,10 @@
 /obj/structure/cable{
 	icon_state = "0-2";
 	d2 = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	icon_state = "manifold";
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
@@ -46305,6 +46340,7 @@
 	d2 = 2
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bXG" = (
@@ -47029,6 +47065,7 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bZt" = (
@@ -47476,6 +47513,7 @@
 	},
 /area/tcommsat/computer)
 "cao" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -48026,6 +48064,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cbp" = (
@@ -49369,6 +49408,10 @@
 /area/maintenance/aft)
 "cdZ" = (
 /obj/machinery/telecomms/processor/preset_two,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel/black{
 	name = "Mainframe Floor";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -49376,6 +49419,10 @@
 /area/tcommsat/server)
 "cea" = (
 /obj/machinery/telecomms/server/presets/service,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel/black{
 	name = "Mainframe Floor";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -49383,6 +49430,10 @@
 /area/tcommsat/server)
 "ceb" = (
 /obj/machinery/telecomms/bus/preset_one,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel/black{
 	name = "Mainframe Floor";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -49393,6 +49444,10 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -49400,6 +49455,10 @@
 /area/tcommsat/server)
 "ced" = (
 /obj/machinery/telecomms/server/presets/science,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel/black{
 	name = "Mainframe Floor";
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -49416,6 +49475,9 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "ceg" = (
@@ -85520,12 +85582,12 @@ bVI
 bWB
 bWB
 bYz
-bYz
+apa
 cag
 cbl
 bYz
 bWB
-bWB
+apF
 bVI
 cax
 cbx
@@ -87059,7 +87121,7 @@ cCf
 bNI
 bUz
 bVI
-bWB
+aoZ
 bWB
 bYz
 bZq
@@ -87067,7 +87129,7 @@ cal
 cbm
 bYz
 bWB
-bWB
+apI
 bVI
 cay
 ccw

--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -11,6 +11,7 @@
 	anchored = 1
 	use_power = 0
 	idle_power_usage = 0
+	heatgen = 0	//Places that use this usually can't support a cooling system
 	machinetype = 6
 	var/intercept = 0 // if nonzero, broadcasts all messages to syndicate channel
 

--- a/code/game/machinery/telecomms/machines/broadcaster.dm
+++ b/code/game/machinery/telecomms/machines/broadcaster.dm
@@ -17,8 +17,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	use_power = 1
 	idle_power_usage = 25
 	machinetype = 5
-	/*heatgen = 0
-	delay = 7*/
+	heatgen = 0
+	delay = 7
 
 /obj/machinery/telecomms/broadcaster/receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)
 	// Don't broadcast rejected signals

--- a/code/game/machinery/telecomms/machines/bus.dm
+++ b/code/game/machinery/telecomms/machines/bus.dm
@@ -17,7 +17,7 @@
 	use_power = 1
 	idle_power_usage = 50
 	machinetype = 2
-	//heatgen = 20
+	heatgen = 20
 	netspeed = 40
 	var/change_frequency = 0
 

--- a/code/game/machinery/telecomms/machines/hub.dm
+++ b/code/game/machinery/telecomms/machines/hub.dm
@@ -18,7 +18,7 @@
 	use_power = 1
 	idle_power_usage = 80
 	machinetype = 7
-	//heatgen = 40
+	heatgen = 40
 	long_range_link = 1
 	netspeed = 40
 

--- a/code/game/machinery/telecomms/machines/processor.dm
+++ b/code/game/machinery/telecomms/machines/processor.dm
@@ -16,8 +16,8 @@
 	use_power = 1
 	idle_power_usage = 30
 	machinetype = 3
-	//heatgen = 100
-	//delay = 5
+	heatgen = 100
+	delay = 5
 	var/process_mode = 1 // 1 = Uncompress Signals, 0 = Compress Signals
 
 /obj/machinery/telecomms/processor/receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)

--- a/code/game/machinery/telecomms/machines/receiver.dm
+++ b/code/game/machinery/telecomms/machines/receiver.dm
@@ -16,7 +16,7 @@
 	use_power = 1
 	idle_power_usage = 30
 	machinetype = 1
-	//heatgen = 0
+	heatgen = 0
 
 /obj/machinery/telecomms/receiver/receive_signal(datum/signal/signal)
 

--- a/code/game/machinery/telecomms/machines/relay.dm
+++ b/code/game/machinery/telecomms/machines/relay.dm
@@ -15,7 +15,7 @@
 	use_power = 1
 	idle_power_usage = 30
 	machinetype = 8
-	//heatgen = 0
+	heatgen = 0
 	netspeed = 5
 	long_range_link = 1
 	var/broadcasting = 1

--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -16,7 +16,7 @@
 	use_power = 1
 	idle_power_usage = 15
 	machinetype = 4
-	//heatgen = 50
+	heatgen = 50
 	var/list/log_entries = list()
 	var/list/stored_names = list()
 	var/list/TrafficActions = list()


### PR DESCRIPTION
:cl:
add: Telecomms now generates and is affected by, heat.
add: Added cooler systems to telecomms rooms on box and meta.
/:cl:

Also adds cooling loops to box and meta.
Dream already had one setup, mini and efficiency telecomms have had their head generation disabled due to map design not accommodating a cold room.

:hand: :warning: DO NOT MERGE YET :warning: :hand: 
Testing uncovered some weird bug in saycode, where it turns out that delays in the signal cause delays in your local speech when talking over the radio. See #20876
