### PR TITLE
Beepsky will now save the station by stuncuffing ops v3 FIX N' REBALANCE EDITION

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -600,7 +600,7 @@
 		threatcount -= 1
 		
 	//Agent cards lower threatlevel.
- 	if(istype(idcard, /obj/item/weapon/card/id/syndicate))
+	if(istype(idcard, /obj/item/weapon/card/id/syndicate))
 		threatcount -= 5
 
 	return threatcount

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -598,6 +598,10 @@
 	//mindshield implants imply trustworthyness
 	if(isloyal(src))
 		threatcount -= 1
+		
+	//Agent cards lower threatlevel.
+ 	if(istype(idcard, /obj/item/weapon/card/id/syndicate))
+		threatcount -= 5
 
 	return threatcount
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -585,7 +585,7 @@
 
 	//check for syndicate dresscode violations
 	if(istype(wear_suit, /obj/item/clothing/suit/space/hardsuit/syndi) || istype(head, /obj/item/clothing/head/helmet/space/hardsuit/syndi))
-		threatcount += 2
+		threatcount += 3
 		
 	//arrest dem ops
 	if(istype(wear_mask, /obj/item/clothing/mask/gas/syndicate))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -589,7 +589,7 @@
 		
 	//arrest dem ops
 	if(istype(wear_mask, /obj/item/clothing/mask/gas/syndicate))
-		threatcount += 6
+		threatcount += 2
 
 	//Check for nonhuman scum
 	if(dna && dna.species.id && dna.species.id != "human")
@@ -597,7 +597,7 @@
 
 	//mindshield implants imply trustworthyness
 	if(isloyal(src))
-		threatcount -= 2
+		threatcount -= 1
 
 	return threatcount
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -583,17 +583,21 @@
 	if(istype(head, /obj/item/clothing/head/wizard) || istype(head, /obj/item/clothing/head/helmet/space/hardsuit/wizard))
 		threatcount += 2
 
+	//check for syndicate dresscode violations
+	if(istype(wear_suit, /obj/item/clothing/suit/space/hardsuit/syndi) || istype(head, /obj/item/clothing/head/helmet/space/hardsuit/syndi))
+		threatcount += 2
+		
+	//arrest dem ops
+	if(istype(wear_mask, /obj/item/clothing/mask/gas/syndicate))
+		threatcount += 6
+
 	//Check for nonhuman scum
 	if(dna && dna.species.id && dna.species.id != "human")
 		threatcount += 1
 
 	//mindshield implants imply trustworthyness
 	if(isloyal(src))
-		threatcount -= 1
-
-	//Agent cards lower threatlevel.
-	if(istype(idcard, /obj/item/weapon/card/id/syndicate))
-		threatcount -= 5
+		threatcount -= 2
 
 	return threatcount
 


### PR DESCRIPTION
:cl: Beepsky VS Ops
add: syndicate hardsuits and masks now affect securitron threat level
/:cl:

EVERYONE CALM DOWN OPS SUCKS ANYWAY AND WIZARD CLOTHES ALREADY AFFECT THREAT LEVEL.

ALSO ANY DECENT OP CAN SHOOT BEEPSKY LIKE ONCE AND KILL HIM.

Ok fine the agent card part was removed. now the **syndi gear just affects threat level the same as wizard gear. It's really not that weird.**

**The op must be wearing a syndie hardsuit, mask and have a weapon in-hand for beepsky to arrest them.**
