### PR TITLE
Fixes motion alarms

### DIFF
--- a/_maps/map_files/BirdStation/BirdStation.dmm
+++ b/_maps/map_files/BirdStation/BirdStation.dmm
@@ -1435,7 +1435,7 @@
 /area/space)
 "adL" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "adM" = (
@@ -1550,12 +1550,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aec" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aed" = (
@@ -1564,7 +1564,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aee" = (
@@ -1584,7 +1584,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aeg" = (
@@ -1592,7 +1592,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aeh" = (
@@ -1681,7 +1681,7 @@
 	uses = 10
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aeq" = (
@@ -1689,7 +1689,7 @@
 	network = "tcommsat"
 	},
 /turf/open/floor/plasteel,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "aer" = (
@@ -1785,7 +1785,7 @@
 /area/engine/engineering)
 "aeB" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aeC" = (
@@ -1840,7 +1840,7 @@
 "aeI" = (
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "aeJ" = (
@@ -1926,7 +1926,7 @@
 /area/space)
 "aeU" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "aeV" = (
@@ -1935,7 +1935,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aeW" = (
@@ -1953,7 +1953,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aeY" = (
@@ -2052,13 +2052,13 @@
 	layer = 4.1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "afm" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "afn" = (
@@ -2067,12 +2067,12 @@
 	},
 /obj/machinery/ntnet_relay,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "afo" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "afp" = (
@@ -2080,7 +2080,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "afq" = (
@@ -2171,19 +2171,19 @@
 "afC" = (
 /obj/machinery/telecomms/bus/preset_one/birdstation,
 /turf/open/floor/bluegrid,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "afD" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/bluegrid,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "afE" = (
 /obj/machinery/telecomms/broadcaster/preset_left/birdstation,
 /turf/open/floor/bluegrid,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "afF" = (
@@ -2191,7 +2191,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "afG" = (
@@ -2206,7 +2206,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "afI" = (
@@ -2344,24 +2344,24 @@
 "afX" = (
 /obj/machinery/telecomms/server/presets/common/birdstation,
 /turf/open/floor/bluegrid,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "afY" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "afZ" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/bluegrid,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "aga" = (
 /obj/machinery/announcement_system,
 /turf/open/floor/bluegrid,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "agb" = (
@@ -2373,7 +2373,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "agc" = (
@@ -2515,19 +2515,19 @@
 "agv" = (
 /obj/machinery/telecomms/processor/preset_one/birdstation,
 /turf/open/floor/bluegrid,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "agw" = (
 /obj/machinery/message_server,
 /turf/open/floor/bluegrid,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "agx" = (
 /obj/machinery/telecomms/receiver/preset_left/birdstation,
 /turf/open/floor/bluegrid,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "agy" = (
@@ -2535,7 +2535,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "agz" = (
@@ -2543,7 +2543,7 @@
 	name = "Cyborg"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "agA" = (
@@ -2551,7 +2551,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "agB" = (
@@ -2559,12 +2559,12 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "agC" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "agD" = (
@@ -2700,23 +2700,23 @@
 "agP" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "agQ" = (
 /obj/machinery/door/window/southright,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "agR" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "agS" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "agT" = (
@@ -2724,7 +2724,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "agU" = (
@@ -2855,7 +2855,7 @@
 "ahl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "ahm" = (
@@ -2863,7 +2863,7 @@
 	network = "tcommsat"
 	},
 /turf/open/floor/plasteel,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "ahn" = (
@@ -2876,7 +2876,7 @@
 	layer = 4.1
 	},
 /turf/open/floor/plasteel,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "aho" = (
@@ -2887,12 +2887,12 @@
 	},
 /obj/item/weapon/pen,
 /turf/open/floor/plasteel,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "ahp" = (
 /turf/open/floor/plasteel/neutral,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "ahq" = (
@@ -2904,7 +2904,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "ahr" = (
@@ -2912,7 +2912,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "ahs" = (
@@ -2930,7 +2930,7 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "ahu" = (
@@ -3060,7 +3060,7 @@
 "ahL" = (
 /obj/item/device/radio/beacon,
 /turf/open/floor/plasteel/neutral,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "ahM" = (
@@ -3068,7 +3068,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "ahN" = (
@@ -3076,7 +3076,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "ahO" = (
@@ -3088,7 +3088,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "ahP" = (
@@ -3096,7 +3096,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "ahQ" = (
@@ -3180,7 +3180,7 @@
 "aic" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/neutral,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "aid" = (
@@ -3193,7 +3193,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "aie" = (
@@ -3204,7 +3204,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "aif" = (
@@ -3213,7 +3213,7 @@
 	layer = 4.1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "aig" = (
@@ -3223,7 +3223,7 @@
 	},
 /obj/structure/cable/cyan,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "aih" = (
@@ -3346,7 +3346,7 @@
 	req_access_txt = "61"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "aiy" = (
@@ -3358,7 +3358,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/turret_protected/tcomeast{
+/area/ai_monitored/turret_protected/tcomeast{
 	name = "\improper Telecommunications Chamber"
 	})
 "aiz" = (
@@ -4116,7 +4116,7 @@
 	})
 "akh" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aki" = (
 /turf/closed/wall,
 /area/gateway)
@@ -4248,11 +4248,11 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "akA" = (
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "akB" = (
 /obj/structure/table,
 /obj/item/weapon/aiModule/reset,
@@ -4260,14 +4260,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "akC" = (
 /obj/structure/table,
 /obj/item/weapon/aiModule/core/full/asimov,
 /obj/item/weapon/aiModule/core/full/asimovpp,
 /obj/item/weapon/aiModule/core/full/corp,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "akD" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
@@ -4378,26 +4378,26 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "akT" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "akU" = (
 /obj/machinery/door/airlock/command{
 	name = "command door";
 	req_access_txt = "19"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "akV" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "akW" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "akX" = (
 /obj/machinery/computer/upload/borg,
 /obj/structure/window/reinforced{
@@ -4412,7 +4412,7 @@
 	req_access_txt = "55"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "akY" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
 	anchored = 1;
@@ -4424,7 +4424,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "akZ" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/fsmaint)
@@ -4571,7 +4571,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "alt" = (
 /obj/machinery/computer/upload/ai,
 /obj/structure/window/reinforced{
@@ -4586,7 +4586,7 @@
 	req_access_txt = "55"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "alu" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
 	anchored = 1;
@@ -4595,7 +4595,7 @@
 	name = "incredibly heavy plant"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "alv" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -4732,19 +4732,19 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "alN" = (
 /obj/machinery/porta_turret/ai{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "alO" = (
 /obj/structure/table,
 /obj/item/weapon/aiModule/supplied/freeform,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "alP" = (
 /obj/structure/table,
 /obj/item/weapon/aiModule/core/full/tyrant,
@@ -4756,7 +4756,7 @@
 /obj/item/weapon/aiModule/supplied/protectStation,
 /obj/item/weapon/aiModule/supplied/safeguard,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "alQ" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -4934,7 +4934,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "amo" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/captain{
@@ -5736,7 +5736,7 @@
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aok" = (
@@ -5756,7 +5756,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aom" = (
@@ -5765,7 +5765,7 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "aon" = (
@@ -7376,7 +7376,7 @@
 	d2 = 2
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "asa" = (
@@ -7624,7 +7624,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "asG" = (
@@ -7958,13 +7958,13 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "att" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai{
+/area/ai_monitored/turret_protected/ai{
 	name = "\improper AI Core"
 	})
 "atu" = (
@@ -8391,7 +8391,7 @@
 	radio_channel = "AI Private"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior{
+/area/ai_monitored/turret_protected/aisat_interior{
 	name = "\improper AI Core Lobby"
 	})
 "auE" = (

--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -411,40 +411,40 @@
 /area/aisat)
 "aaP" = (
 /turf/closed/wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aaQ" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aaR" = (
 /obj/structure/cable/white{
 	tag = "icon-1-10";
 	icon_state = "1-10"
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aaS" = (
 /obj/structure/cable/white{
 	tag = "icon-5-10";
 	icon_state = "5-10"
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aaT" = (
 /obj/machinery/porta_turret_construct,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aaU" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aaV" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aaW" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -461,13 +461,13 @@
 	start_active = 1
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aaX" = (
 /obj/machinery/porta_turret_construct,
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aaY" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -477,7 +477,7 @@
 	dir = 6
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aaZ" = (
 /obj/structure/cable/white{
 	tag = "icon-2-4";
@@ -495,14 +495,14 @@
 	tag = "icon-darkbluecorners (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aba" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abb" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0";
@@ -519,7 +519,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abc" = (
 /obj/structure/cable/white{
 	tag = "icon-2-8";
@@ -533,7 +533,7 @@
 	tag = "icon-darkbluecorners (EAST)";
 	dir = 4
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abd" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -544,7 +544,7 @@
 	dir = 10
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abe" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -552,7 +552,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abf" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -560,7 +560,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abg" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -568,11 +568,11 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abh" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abi" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -585,7 +585,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abj" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
@@ -593,14 +593,14 @@
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abk" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abl" = (
 /turf/closed/wall/r_wall,
 /area/aisat)
@@ -610,14 +610,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abn" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abo" = (
 /obj/effect/landmark/start{
 	name = "AI"
@@ -666,13 +666,13 @@
 	pixel_y = -25
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abp" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abq" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -680,7 +680,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abr" = (
 /obj/structure/cable/blue{
 	tag = "icon-1-2";
@@ -747,7 +747,7 @@
 	broken = 1;
 	icon_state = "platingdmg2"
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abv" = (
 /obj/effect/landmark{
 	name = "tripai"
@@ -778,7 +778,7 @@
 	pixel_y = 23
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abw" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -787,7 +787,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abx" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0";
@@ -801,7 +801,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aby" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -813,7 +813,7 @@
 	pixel_x = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abz" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -824,7 +824,7 @@
 	dir = 8
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abA" = (
 /obj/machinery/door/window{
 	dir = 4;
@@ -833,7 +833,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abB" = (
 /obj/effect/landmark{
 	name = "tripai"
@@ -864,7 +864,7 @@
 	pixel_y = -27
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abC" = (
 /turf/open/space,
 /obj/item/weapon/dice/d8{
@@ -886,7 +886,7 @@
 	broken = 1;
 	icon_state = "platingdmg2"
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abD" = (
 /obj/structure/cable/blue{
 	tag = "icon-1-2";
@@ -927,7 +927,7 @@
 	icon_state = "0-10"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abF" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -951,7 +951,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abH" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -967,7 +967,7 @@
 	icon_state = "2-5"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abI" = (
 /obj/machinery/power/terminal{
 	icon_state = "term";
@@ -987,7 +987,7 @@
 	tag = "icon-0-2"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1003,7 +1003,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abK" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
@@ -1014,7 +1014,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abL" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -1025,7 +1025,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abM" = (
 /obj/machinery/light{
 	dir = 4
@@ -1035,7 +1035,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abN" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -1044,7 +1044,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abO" = (
 /obj/structure/cable/white{
 	tag = "icon-1-4";
@@ -1058,7 +1058,7 @@
 	tag = "icon-darkbluecorners (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abP" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
@@ -1068,14 +1068,14 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abQ" = (
 /obj/structure/cable/white{
 	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abR" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0";
@@ -1092,7 +1092,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abS" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
@@ -1102,7 +1102,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abT" = (
 /obj/structure/cable/white{
 	tag = "icon-1-8";
@@ -1119,7 +1119,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	tag = "icon-darkbluecorners"
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abU" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -1127,7 +1127,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -1136,21 +1136,21 @@
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	tag = "icon-manifold-r-f (NORTH)";
 	dir = 1
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abX" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1160,7 +1160,7 @@
 	tag = "s"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abZ" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue"
@@ -1179,7 +1179,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/warningline,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aca" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1191,20 +1191,20 @@
 	start_active = 1
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acb" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -1213,15 +1213,15 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "ace" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acf" = (
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acg" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -1236,15 +1236,15 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "ach" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aci" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acj" = (
 /turf/open/space,
 /obj/machinery/porta_turret/syndicate{
@@ -1291,20 +1291,20 @@
 /area/aisat)
 "aco" = (
 /turf/closed/wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acp" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acq" = (
 /obj/structure/table,
 /obj/item/weapon/secbot_assembly,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acr" = (
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acs" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";
@@ -1314,7 +1314,7 @@
 	tag = "icon-warningline (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "act" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";
@@ -1325,7 +1325,7 @@
 	tag = "icon-warningline (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acu" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";
@@ -1341,14 +1341,14 @@
 	tag = "icon-warningline (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acv" = (
 /obj/structure/table,
 /obj/item/robot_suit,
 /obj/item/bodypart/head/robot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acw" = (
 /obj/structure/cable/blue{
 	tag = "icon-1-2";
@@ -1415,7 +1415,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acF" = (
 /obj/structure/table,
 /obj/item/bodypart/l_arm/robot,
@@ -1430,17 +1430,17 @@
 	tag = "icon-darkbluecorners (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acG" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acH" = (
 /obj/structure/cable/blue{
 	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acI" = (
 /obj/structure/table,
 /obj/item/bodypart/r_arm/robot,
@@ -1454,7 +1454,7 @@
 	tag = "icon-darkbluecorners (EAST)";
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/blue{
@@ -1462,7 +1462,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acK" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets{
@@ -1498,7 +1498,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acO" = (
 /obj/structure/table,
 /obj/structure/cable/blue{
@@ -1513,7 +1513,7 @@
 /obj/item/device/assembly/flash/handheld,
 /obj/item/bodypart/r_leg/robot,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acP" = (
 /obj/structure/cable/blue{
 	tag = "icon-4-8";
@@ -1523,7 +1523,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acQ" = (
 /obj/structure/cable/blue{
 	tag = "icon-4-8";
@@ -1533,7 +1533,7 @@
 	dir = 10
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acR" = (
 /obj/structure/cable/blue{
 	tag = "icon-1-2";
@@ -1552,7 +1552,7 @@
 	tag = "icon-darkblue (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acS" = (
 /obj/structure/cable/blue{
 	tag = "icon-4-8";
@@ -1562,7 +1562,7 @@
 	dir = 6
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acT" = (
 /obj/structure/cable/blue{
 	tag = "icon-4-8";
@@ -1572,7 +1572,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acU" = (
 /obj/structure/table,
 /obj/item/bodypart/l_leg/robot,
@@ -1588,7 +1588,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/item/device/assembly/flash/handheld,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/blue{
@@ -1599,7 +1599,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "acW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -1647,14 +1647,14 @@
 	dir = 8
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkblue/corner{
 	tag = "icon-darkbluecorners (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "add" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0";
@@ -1667,14 +1667,14 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ade" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/darkblue/corner{
 	tag = "icon-darkbluecorners (EAST)";
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adf" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -1684,7 +1684,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/lattice,
@@ -1727,14 +1727,14 @@
 	tag = "icon-darkblue (WEST)";
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1;
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adm" = (
 /obj/structure/cable/blue{
 	tag = "icon-2-4";
@@ -1745,7 +1745,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adn" = (
 /obj/structure/cable/blue{
 	tag = "icon-4-8";
@@ -1756,7 +1756,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ado" = (
 /obj/structure/cable/blue{
 	tag = "icon-0-8";
@@ -1778,7 +1778,7 @@
 	tag = "icon-darkblue (EAST)";
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adp" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1802,31 +1802,31 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adt" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adu" = (
 /obj/structure/cable/blue{
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adv" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adx" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/closed/wall/mineral/titanium,
@@ -1871,14 +1871,14 @@
 /area/space)
 "adD" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adE" = (
 /obj/structure/cable/blue{
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -1948,7 +1948,7 @@
 	req_one_access_txt = "65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "adM" = (
 /obj/structure/cable/blue{
 	tag = "icon-1-2";
@@ -37033,7 +37033,7 @@
 /area/engine/gravity_generator)
 "bxj" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bxk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
@@ -37042,7 +37042,7 @@
 	tag = "icon-0-2"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bxl" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -37050,7 +37050,7 @@
 	name = "HIGH VOLTAGE"
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bxm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -37962,7 +37962,7 @@
 	tag = "icon-vault (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bzn" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (EAST)";
@@ -37982,7 +37982,7 @@
 	tag = "icon-warningline (EAST)";
 	dir = 4
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bzo" = (
 /obj/machinery/computer/upload/ai,
 /obj/structure/window/reinforced{
@@ -38006,7 +38006,7 @@
 	tag = "icon-vault (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bzp" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (WEST)";
@@ -38026,7 +38026,7 @@
 	tag = "icon-warningline (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bzq" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
@@ -38039,7 +38039,7 @@
 	tag = "icon-vault (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bzr" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38745,14 +38745,14 @@
 	tag = "icon-warndark (NORTHEAST)";
 	dir = 5
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bAQ" = (
 /obj/structure/sign/kiddieplaque{
 	pixel_x = -32;
 	pixel_y = 32
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bAR" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (EAST)";
@@ -38762,7 +38762,7 @@
 	tag = "icon-warningline (EAST)";
 	dir = 4
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bAS" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -38770,7 +38770,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bAT" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (WEST)";
@@ -38780,10 +38780,10 @@
 	tag = "icon-warningline (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bAU" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bAV" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -38807,7 +38807,7 @@
 	network = list("Sat")
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bAW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
@@ -38817,14 +38817,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bAX" = (
 /turf/closed/wall,
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bAY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bAZ" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32
@@ -39892,7 +39892,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bCP" = (
 /obj/structure/table,
 /obj/item/weapon/aiModule/reset,
@@ -39901,7 +39901,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bCQ" = (
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 10;
@@ -39915,7 +39915,7 @@
 	tag = "icon-warningline (SOUTHWEST)";
 	dir = 10
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bCR" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue"
@@ -39924,7 +39924,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/warningline,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bCS" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue"
@@ -39938,7 +39938,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/warningline,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bCT" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue"
@@ -39956,7 +39956,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/warningline,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bCU" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue"
@@ -39972,7 +39972,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/warningline,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bCV" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue"
@@ -39987,7 +39987,7 @@
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/warningline,
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bCW" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue"
@@ -40005,7 +40005,7 @@
 	start_active = 1
 	},
 /turf/open/floor/plasteel/warningline,
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bCX" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -41223,14 +41223,14 @@
 	tag = "icon-vault (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bFg" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bFh" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (EAST)";
@@ -41244,7 +41244,7 @@
 	tag = "icon-warningline (EAST)";
 	dir = 4
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bFi" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/white{
@@ -41260,14 +41260,14 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bFj" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bFk" = (
 /obj/structure/cable/white{
 	tag = "icon-1-4";
@@ -41278,7 +41278,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bFl" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
@@ -41293,7 +41293,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bFm" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
@@ -41310,7 +41310,7 @@
 	tag = "icon-warndark (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bFn" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
@@ -41324,14 +41324,14 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bFo" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bFp" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
@@ -41348,7 +41348,7 @@
 	tag = "icon-warndark (EAST)";
 	dir = 4
 	},
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bFq" = (
 /obj/structure/cable/green{
 	tag = "icon-4-8";
@@ -42710,7 +42710,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bHr" = (
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 9;
@@ -42724,7 +42724,7 @@
 	tag = "icon-warningline (NORTHWEST)";
 	dir = 9
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bHs" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";
@@ -42737,7 +42737,7 @@
 	tag = "icon-warningline (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bHt" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";
@@ -42754,7 +42754,7 @@
 	tag = "icon-warningline (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bHu" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";
@@ -42776,7 +42776,7 @@
 	tag = "icon-warningline (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bHv" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";
@@ -42800,7 +42800,7 @@
 	tag = "icon-warningline (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bHw" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";
@@ -42822,7 +42822,7 @@
 	tag = "icon-warningline (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bHx" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";
@@ -42839,7 +42839,7 @@
 	tag = "icon-warningline (NORTH)";
 	dir = 1
 	},
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bHy" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -43923,7 +43923,7 @@
 	tag = "icon-warndark (SOUTHEAST)";
 	dir = 6
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bJv" = (
 /obj/structure/table,
 /obj/item/weapon/folder/blue,
@@ -43938,22 +43938,22 @@
 	start_active = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bJw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white,
 /turf/open/floor/plating,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bJx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bJy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bJz" = (
 /obj/structure/cable/green{
 	tag = "icon-0-4";
@@ -44716,7 +44716,7 @@
 	tag = "icon-vault (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bKR" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (EAST)";
@@ -44736,7 +44736,7 @@
 	tag = "icon-warningline (EAST)";
 	dir = 4
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bKS" = (
 /obj/machinery/computer/upload/borg,
 /obj/structure/window/reinforced{
@@ -44754,7 +44754,7 @@
 	tag = "icon-vault (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bKT" = (
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (WEST)";
@@ -44774,7 +44774,7 @@
 	tag = "icon-warningline (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bKU" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
@@ -44787,7 +44787,7 @@
 	tag = "icon-vault (WEST)";
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bKV" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{

--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -279,7 +279,7 @@
 /area/shuttle/abandoned)
 "aaR" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aaS" = (
 /turf/closed/wall/shuttle{
 	icon_state = "swall7"
@@ -490,7 +490,7 @@
 /area/shuttle/abandoned)
 "abm" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abn" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
@@ -499,7 +499,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abo" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -652,7 +652,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abG" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber West";
@@ -660,23 +660,23 @@
 	start_active = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abH" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abI" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abJ" = (
 /obj/structure/table,
 /obj/item/device/paicard,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abK" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets{
@@ -772,7 +772,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -780,7 +780,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abU" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -800,7 +800,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abV" = (
 /obj/machinery/power/terminal,
 /obj/machinery/door/window{
@@ -810,7 +810,7 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abW" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -826,7 +826,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abX" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -835,7 +835,7 @@
 	tag = ""
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "abY" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
@@ -961,7 +961,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "ack" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -976,7 +976,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -984,7 +984,7 @@
 	icon_state = "1-4"
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acm" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -998,7 +998,7 @@
 	d2 = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1006,7 +1006,7 @@
 	icon_state = "1-8"
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aco" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1021,7 +1021,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acp" = (
 /turf/open/space,
 /turf/closed/wall/mineral/plastitanium{
@@ -1115,7 +1115,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acA" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -1131,7 +1131,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acB" = (
 /obj/effect/landmark{
 	name = "tripai"
@@ -1155,7 +1155,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acC" = (
 /obj/effect/landmark{
 	name = "tripai"
@@ -1178,7 +1178,7 @@
 	pixel_y = -4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acD" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -1192,7 +1192,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acE" = (
 /obj/machinery/light{
 	dir = 4
@@ -1205,7 +1205,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acF" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -1267,7 +1267,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -1278,7 +1278,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acN" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
@@ -1310,7 +1310,7 @@
 	req_access_txt = "28"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -1319,13 +1319,13 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -1411,7 +1411,7 @@
 "acX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1419,7 +1419,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "acZ" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -1442,7 +1442,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "ada" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/door/window{
@@ -1462,7 +1462,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "adb" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1487,17 +1487,17 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "adc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "add" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "ade" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/glass/beaker{
@@ -1591,7 +1591,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "adm" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
@@ -1603,7 +1603,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "adn" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber East";
@@ -1612,7 +1612,7 @@
 	start_active = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "ado" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-09";
@@ -1620,7 +1620,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "adp" = (
 /obj/machinery/suit_storage_unit/syndicate,
 /turf/open/floor/mineral/plastitanium,
@@ -1692,7 +1692,7 @@
 /area/shuttle/abandoned)
 "adw" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "adx" = (
@@ -1703,25 +1703,25 @@
 	pixel_y = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "ady" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "adz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "adA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "adB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -1815,7 +1815,7 @@
 /area/shuttle/abandoned)
 "adK" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "adL" = (
@@ -1828,7 +1828,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "adM" = (
@@ -1851,7 +1851,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "adN" = (
@@ -1866,7 +1866,7 @@
 	pixel_y = 29
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "adO" = (
@@ -1877,7 +1877,7 @@
 	name = "AI Chamber Blast Shutter"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "adP" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "AI Chamber";
@@ -1894,7 +1894,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "adQ" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the AI satellite.";
@@ -1904,7 +1904,7 @@
 	},
 /obj/machinery/computer/station_alert,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "adR" = (
@@ -1932,7 +1932,7 @@
 /obj/item/weapon/pen,
 /obj/structure/table,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "adS" = (
@@ -1945,7 +1945,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "adT" = (
@@ -2031,12 +2031,12 @@
 	},
 /obj/structure/table,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "aec" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "aed" = (
@@ -2047,12 +2047,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "aee" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aef" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -2060,12 +2060,12 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aeg" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aeh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2076,14 +2076,14 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aei" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aej" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "aek" = (
@@ -2096,14 +2096,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "ael" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/item/weapon/wrench,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "aem" = (
@@ -2253,7 +2253,7 @@
 /obj/item/clothing/head/welding,
 /obj/structure/table,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "aez" = (
@@ -2261,7 +2261,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "aeA" = (
@@ -2278,7 +2278,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "aeB" = (
@@ -2294,13 +2294,13 @@
 	pressure_checks = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "aeC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "aeD" = (
@@ -2326,7 +2326,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aeE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2337,7 +2337,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aeF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2357,7 +2357,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aeG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2368,7 +2368,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aeH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2388,7 +2388,7 @@
 	req_access = list(65)
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aeI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2403,7 +2403,7 @@
 	req_one_access_txt = "65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "aeJ" = (
@@ -2417,7 +2417,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "aeK" = (
@@ -2428,7 +2428,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "aeL" = (
@@ -2436,7 +2436,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "aeM" = (
@@ -2447,7 +2447,7 @@
 	},
 /obj/structure/table,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "aeN" = (
@@ -2567,7 +2567,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkblue/corner,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "afa" = (
@@ -2578,7 +2578,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/darkblue/side,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "afb" = (
@@ -2596,7 +2596,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "afc" = (
@@ -2611,7 +2611,7 @@
 	req_one_access_txt = "65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "afd" = (
@@ -2632,21 +2632,21 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "afe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aff" = (
 /mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "afg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "afh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -2658,11 +2658,11 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/darkblue/corner,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "afi" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "afj" = (
@@ -2673,7 +2673,7 @@
 	},
 /obj/machinery/recharge_station,
 /turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "afk" = (
@@ -2685,7 +2685,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light/small,
 /turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "afl" = (
@@ -2931,7 +2931,7 @@
 "afB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "afC" = (
@@ -2945,7 +2945,7 @@
 	req_one_access_txt = "65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "afD" = (
@@ -2962,20 +2962,20 @@
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 10
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "afE" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkblue/side,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "afF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/side,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "afG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light/small,
@@ -2986,7 +2986,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/side,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "afH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -2994,13 +2994,13 @@
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 6
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "afI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "afJ" = (
@@ -3008,7 +3008,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "afK" = (
@@ -3016,7 +3016,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "afL" = (
@@ -3227,7 +3227,7 @@
 	start_active = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "agg" = (
@@ -3237,7 +3237,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "agh" = (
@@ -3245,26 +3245,26 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "agi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agj" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Antechamber";
 	req_one_access_txt = "65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agl" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -3393,13 +3393,13 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "agy" = (
 /obj/machinery/bluespace_beacon,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "agz" = (
@@ -3414,7 +3414,7 @@
 	pressure_checks = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "agA" = (
@@ -3427,7 +3427,7 @@
 	req_access = list(29)
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "agB" = (
@@ -3441,7 +3441,7 @@
 /turf/open/floor/plating/warnplate{
 	dir = 9
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agC" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 31
@@ -3462,13 +3462,13 @@
 /turf/open/floor/plating/warnplate{
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -3485,12 +3485,12 @@
 /turf/open/floor/plating/warnplate{
 	dir = 5
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agG" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -3624,7 +3624,7 @@
 /turf/open/floor/plating/warnplate{
 	dir = 1
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "agT" = (
@@ -3633,7 +3633,7 @@
 /turf/open/floor/plating/warnplate{
 	dir = 1
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "agU" = (
@@ -3641,14 +3641,14 @@
 /turf/open/floor/plating/warnplate{
 	dir = 1
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "agV" = (
 /turf/open/floor/plating/warnplate{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1;
@@ -3657,19 +3657,19 @@
 	scrub_Toxins = 0
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	on = 1
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "agZ" = (
 /obj/machinery/door/airlock/external{
 	name = "MiniSat External Access";
@@ -3677,10 +3677,10 @@
 	req_access_txt = "65;13"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aha" = (
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ahb" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3902,14 +3902,14 @@
 /turf/open/floor/plating/warnplate{
 	dir = 10
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ahw" = (
 /obj/structure/transit_tube{
 	icon_state = "E-SW"
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/warnplate,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ahx" = (
 /obj/structure/transit_tube/station{
 	dir = 1
@@ -3917,7 +3917,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating/warnplate,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ahy" = (
 /obj/structure/transit_tube{
 	icon_state = "W-SE"
@@ -3926,7 +3926,7 @@
 /turf/open/floor/plating/warnplate{
 	dir = 6
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ahz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -3934,7 +3934,7 @@
 	icon_state = "D-SW"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ahA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -3945,7 +3945,7 @@
 	name = "EXTERNAL AIRLOCK"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ahB" = (
 /obj/structure/table,
 /obj/item/weapon/surgicaldrill,
@@ -19815,7 +19815,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aLT" = (
 /obj/machinery/light_switch{
 	pixel_x = -28
@@ -21063,7 +21063,7 @@
 	network = list("SS13","RD")
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aOo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -21477,7 +21477,7 @@
 	req_access = list(65)
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aPl" = (
 /obj/structure/sink{
 	dir = 4;
@@ -22866,7 +22866,7 @@
 /area/maintenance/fore)
 "aSb" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aSc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
@@ -23279,13 +23279,13 @@
 /obj/item/weapon/aiModule/core/full/corp,
 /obj/item/weapon/aiModule/core/full/custom,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aSY" = (
 /obj/machinery/computer/upload/ai,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aSZ" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -23296,13 +23296,13 @@
 	network = list("SS13","RD","AIUpload")
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aTa" = (
 /obj/machinery/computer/upload/borg,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aTb" = (
 /obj/structure/table,
 /obj/item/weapon/aiModule/supplied/oxygen,
@@ -23322,7 +23322,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aTc" = (
 /obj/structure/closet/crate,
 /obj/structure/window/reinforced,
@@ -23792,12 +23792,12 @@
 	pixel_y = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aUe" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aUf" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -23805,7 +23805,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aUg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23815,7 +23815,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aUh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24210,10 +24210,10 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aVb" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aVc" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
@@ -24224,7 +24224,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aVd" = (
 /obj/structure/sign/kiddieplaque{
 	pixel_x = -32
@@ -24233,7 +24233,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aVe" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/bot,
@@ -24632,10 +24632,10 @@
 	},
 /obj/item/weapon/aiModule/supplied/quarantine,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aVX" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aVY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -24644,7 +24644,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aVZ" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -24652,7 +24652,7 @@
 	},
 /obj/item/weapon/aiModule/supplied/protectStation,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aWa" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/light/small{
@@ -25213,7 +25213,7 @@
 	dir = 6
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aXc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -25226,7 +25226,7 @@
 	pixel_y = -28
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aXd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25234,7 +25234,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aXe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
@@ -25243,7 +25243,7 @@
 	scrub_Toxins = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aXf" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25251,7 +25251,7 @@
 	},
 /obj/item/weapon/aiModule/supplied/freeform,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aXg" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/bot,
@@ -25767,7 +25767,7 @@
 "aYf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25780,11 +25780,11 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYi" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel/bot,
@@ -26214,7 +26214,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -26226,7 +26226,7 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYZ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -26238,7 +26238,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aZb" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/bar,
@@ -56683,7 +56683,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Storage"
 	})
 "cjR" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21316,7 +21316,7 @@
 /area/storage/primary)
 "aKF" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aKG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
@@ -22066,14 +22066,14 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aMh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aMi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -22087,7 +22087,7 @@
 	id = "AI"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aMj" = (
 /obj/structure/sign/kiddieplaque{
 	pixel_y = 32
@@ -22103,7 +22103,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aMk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -22113,20 +22113,20 @@
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aMl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aMm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aMn" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22728,10 +22728,10 @@
 	id = "AI"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aNB" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aNC" = (
 /obj/structure/table,
 /obj/machinery/door/window{
@@ -22753,7 +22753,7 @@
 /obj/item/weapon/aiModule/zeroth/oneHuman,
 /obj/item/weapon/aiModule/reset/purge,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aND" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/device/radio/intercom{
@@ -23493,13 +23493,13 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aPc" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aPd" = (
 /obj/machinery/computer/upload/borg,
 /obj/structure/window/reinforced{
@@ -23520,11 +23520,11 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aPe" = (
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aPf" = (
 /obj/machinery/computer/upload/ai,
 /obj/structure/window/reinforced{
@@ -23545,13 +23545,13 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aPg" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aPh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1;
@@ -24320,7 +24320,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aQx" = (
 /obj/structure/table,
 /obj/structure/cable/yellow{
@@ -24330,7 +24330,7 @@
 	},
 /obj/item/weapon/aiModule/supplied/quarantine,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aQy" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -24338,7 +24338,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aQz" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -24346,7 +24346,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aQA" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -24363,7 +24363,7 @@
 	uses = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aQB" = (
 /obj/structure/table,
 /obj/structure/cable/yellow{
@@ -24373,7 +24373,7 @@
 	},
 /obj/item/weapon/aiModule/supplied/freeform,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aQC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -24383,7 +24383,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aQD" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -24998,7 +24998,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aRJ" = (
 /obj/machinery/power/apc{
 	cell_type = 5000;
@@ -25016,7 +25016,7 @@
 	network = list("SS13","RD","AIUpload")
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aRK" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -25029,7 +25029,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aRL" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
@@ -25043,7 +25043,7 @@
 	network = list("SS13","RD","AIUpload")
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aRM" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -25061,7 +25061,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aRN" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -25848,7 +25848,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aTf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -25856,13 +25856,13 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aTg" = (
 /obj/machinery/porta_turret/ai{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aTh" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -26579,7 +26579,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aUy" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -27000,7 +27000,7 @@
 	})
 "aVk" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aVl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -27008,7 +27008,7 @@
 	icon_state = "2-4"
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aVm" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -27018,7 +27018,7 @@
 	d2 = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aVn" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -27027,7 +27027,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aVo" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -27346,7 +27346,7 @@
 /area/hallway/primary/central)
 "aVR" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "aVS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	on = 1;
@@ -27394,7 +27394,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 6
 	},
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "aVT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -27407,7 +27407,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/vault,
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "aVU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
@@ -27437,7 +27437,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 10
 	},
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "aVV" = (
 /obj/structure/sign/directions/security{
 	desc = "A direction sign, pointing out which way the security department is.";
@@ -27797,7 +27797,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aWG" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -27812,7 +27812,7 @@
 	scrub_Toxins = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aWH" = (
 /obj/structure/showcase{
 	density = 0;
@@ -27825,7 +27825,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aWI" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -27868,7 +27868,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aWK" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -27881,13 +27881,13 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aWL" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aWM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -28281,7 +28281,7 @@
 "aXt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "aXu" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Network Access";
@@ -28293,11 +28293,11 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault,
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "aXv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload_foyer)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "aXw" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -28701,21 +28701,21 @@
 	dir = 8
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aYi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aYj" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aYk" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0";
 	uses = 10
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aYl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -28726,7 +28726,7 @@
 	dir = 5
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aYm" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -28737,7 +28737,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aYn" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -28748,7 +28748,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aYo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -29800,7 +29800,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aZW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29810,7 +29810,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aZX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -29819,7 +29819,7 @@
 	name = "AI core shutters"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aZY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29829,7 +29829,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "aZZ" = (
 /obj/structure/showcase{
 	density = 0;
@@ -29844,7 +29844,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "baa" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -30686,7 +30686,7 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/greengrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bbq" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/flasher{
@@ -30697,7 +30697,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bbr" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0";
@@ -30705,7 +30705,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bbs" = (
 /obj/machinery/vending/assist,
 /obj/machinery/light/small{
@@ -30742,7 +30742,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 10
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bbv" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0";
@@ -30756,7 +30756,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bbw" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/flasher{
@@ -30767,7 +30767,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bbx" = (
 /obj/effect/landmark{
 	name = "tripai"
@@ -30808,7 +30808,7 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/greengrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bby" = (
 /turf/open/floor/plating/warnplate{
 	dir = 2
@@ -31888,7 +31888,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bdk" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light/small{
@@ -31923,7 +31923,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bdm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	req_access_txt = 1
@@ -32527,7 +32527,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "beu" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -33491,13 +33491,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bgb" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bgc" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/pump,
@@ -33518,7 +33518,7 @@
 	d2 = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bge" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -33527,7 +33527,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bgf" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -34502,11 +34502,11 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bhS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bhT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -34514,7 +34514,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bhU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -34524,20 +34524,20 @@
 	uses = 10
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bhV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bhW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9;
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bhX" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/phone{
@@ -34557,7 +34557,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bhY" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -35782,7 +35782,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bjZ" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -35793,7 +35793,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bka" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Aft";
@@ -35807,12 +35807,12 @@
 	scrub_Toxins = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bkb" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bkc" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -35836,7 +35836,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bke" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/blue{
@@ -35847,7 +35847,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bkf" = (
 /obj/effect/landmark{
 	name = "Observer-Start"
@@ -36701,16 +36701,16 @@
 	})
 "blD" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "blE" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "blF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "blG" = (
 /obj/machinery/power/terminal{
 	icon_state = "term";
@@ -36722,7 +36722,7 @@
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "blH" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/secure{
@@ -37742,7 +37742,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "bns" = (
@@ -37756,7 +37756,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "bnt" = (
@@ -37764,7 +37764,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "bnu" = (
@@ -37773,7 +37773,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bnv" = (
 /obj/structure/showcase{
 	density = 0;
@@ -37791,11 +37791,11 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bnw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bnx" = (
 /obj/structure/showcase{
 	density = 0;
@@ -37810,7 +37810,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bny" = (
 /obj/machinery/door/airlock/highsecurity{
 	icon_state = "door_closed";
@@ -37837,7 +37837,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bnz" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -38956,7 +38956,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "bps" = (
@@ -38967,7 +38967,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "bpt" = (
@@ -38990,7 +38990,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "bpu" = (
@@ -38998,7 +38998,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bpv" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -39014,13 +39014,13 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bpw" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bpx" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39031,7 +39031,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bpy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -39039,7 +39039,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bpz" = (
 /obj/machinery/power/apc{
 	aidisabled = 0;
@@ -39062,7 +39062,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bpA" = (
 /obj/machinery/power/terminal{
 	icon_state = "term";
@@ -40283,7 +40283,7 @@
 	req_one_access_txt = "32;19"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "brH" = (
@@ -40297,7 +40297,7 @@
 	d2 = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "brI" = (
@@ -40308,7 +40308,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "brJ" = (
@@ -40329,7 +40329,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "brK" = (
@@ -40345,7 +40345,7 @@
 	req_one_access_txt = "32;19"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "brL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8";
@@ -40356,7 +40356,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "brM" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8";
@@ -40373,7 +40373,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "brN" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -40392,7 +40392,7 @@
 	},
 /mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "brO" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8";
@@ -40404,7 +40404,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "brP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8";
@@ -40417,7 +40417,7 @@
 	d2 = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "brQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8";
@@ -40430,7 +40430,7 @@
 	req_access_txt = "32"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "brR" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -40692,7 +40692,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 6
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bsl" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -41476,7 +41476,7 @@
 	pixel_y = -23
 	},
 /turf/open/floor/plasteel/vault,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "btx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -41852,7 +41852,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "btZ" = (
@@ -41877,7 +41877,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bua" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -41899,7 +41899,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "bub" = (
@@ -41907,7 +41907,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "buc" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -41924,7 +41924,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bud" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -41933,7 +41933,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bue" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -41942,11 +41942,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "buf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/darkblue/corner,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bug" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -41967,7 +41967,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "buh" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41976,7 +41976,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/area/turret_protected/tcomfoyer{
+/area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"
 	})
 "bui" = (
@@ -43707,7 +43707,7 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/greengrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bxj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45672,7 +45672,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "bAC" = (
 /obj/effect/landmark/start{
 	name = "Bartender"
@@ -45808,7 +45808,7 @@
 	},
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/darkblue/corner,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bAR" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -22399,7 +22399,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYu" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -22420,7 +22420,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22435,38 +22435,38 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYy" = (
 /obj/machinery/ai_status_display,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aYC" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -22957,13 +22957,13 @@
 /area/bridge/meeting_room)
 "aZR" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aZS" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aZT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22971,13 +22971,13 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aZU" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "aZV" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/captain)
@@ -23519,11 +23519,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bbk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bbl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/event_spawn,
@@ -23531,14 +23531,14 @@
 /area/crew_quarters/sleep)
 "bbm" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bbn" = (
 /obj/structure/table,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bbo" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -23549,7 +23549,7 @@
 "bbp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bbq" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -23857,7 +23857,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bcf" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -23866,7 +23866,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bcg" = (
 /obj/structure/table,
 /obj/item/weapon/aiModule/supplied/freeform,
@@ -23877,7 +23877,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bch" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -24265,7 +24265,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bdg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -24273,12 +24273,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bdh" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bdi" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/wood,
@@ -24684,7 +24684,7 @@
 	},
 /obj/item/weapon/aiModule/core/full/custom,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bec" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -24693,7 +24693,7 @@
 	scrub_Toxins = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bed" = (
 /obj/machinery/power/apc{
 	cell_type = 5000;
@@ -24703,7 +24703,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bee" = (
 /obj/machinery/computer/upload/ai,
 /obj/machinery/flasher{
@@ -24712,7 +24712,7 @@
 	pixel_y = -21
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bef" = (
 /obj/machinery/computer/upload/borg,
 /obj/item/device/radio/intercom{
@@ -24723,7 +24723,7 @@
 	pixel_y = -29
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "beg" = (
 /obj/structure/table,
 /obj/item/weapon/aiModule/supplied/oxygen,
@@ -24746,14 +24746,14 @@
 	},
 /obj/item/weapon/aiModule/supplied/protectStation,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "beh" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bei" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -25282,33 +25282,33 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bft" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bfu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bfv" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bfw" = (
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bfx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bfy" = (
 /obj/structure/table/wood,
 /obj/item/weapon/paper_bin{
@@ -25323,7 +25323,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "bfA" = (
 /obj/structure/table/wood,
 /obj/item/weapon/hand_tele,
@@ -56113,7 +56113,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "csE" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -56186,12 +56186,12 @@
 "csN" = (
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "csO" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "csP" = (
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
@@ -56216,18 +56216,18 @@
 	icon_state = "Block"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "csU" = (
 /obj/structure/transit_tube/station{
 	reverse_launch = 1
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "csV" = (
 /turf/open/floor/plating/warnplate{
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "csW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -56235,7 +56235,7 @@
 /turf/open/floor/plating/warnplate{
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "csX" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -56246,7 +56246,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "csY" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -56282,14 +56282,14 @@
 	req_access_txt = "65;13"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctb" = (
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctd" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -56307,7 +56307,7 @@
 "ctg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cth" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -56316,7 +56316,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cti" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -56324,7 +56324,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctj" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Pod Access";
@@ -56340,13 +56340,13 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/closed/wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctl" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -56377,19 +56377,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctp" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctr" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -56406,7 +56406,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cts" = (
 /obj/structure/rack{
 	dir = 1
@@ -56427,11 +56427,11 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
@@ -56440,7 +56440,7 @@
 	scrub_Toxins = 0
 	},
 /turf/open/floor/plasteel/grimy,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctv" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -56455,18 +56455,18 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctx" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /turf/open/floor/plasteel/grimy,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cty" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctz" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "teledoor";
@@ -56476,7 +56476,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56486,7 +56486,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctB" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
@@ -56511,7 +56511,7 @@
 "ctE" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctF" = (
 /obj/machinery/button/door{
 	id = "teledoor";
@@ -56528,7 +56528,7 @@
 /turf/open/floor/plasteel/darkwarning{
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctG" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -56540,7 +56540,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/grimy,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctH" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -31
@@ -56553,11 +56553,11 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctJ" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56571,27 +56571,27 @@
 	name = "Cyborg"
 	},
 /turf/open/floor/plasteel/grimy,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctK" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Teleporter";
 	req_access_txt = "17;65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctL" = (
 /obj/machinery/teleport/station,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctM" = (
 /obj/machinery/bluespace_beacon,
 /turf/open/floor/plasteel/darkwarning{
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctN" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	icon_state = "intact";
@@ -56614,7 +56614,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/grimy,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctQ" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -56628,7 +56628,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctR" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -56651,7 +56651,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/grimy,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctT" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -56665,13 +56665,13 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56688,11 +56688,11 @@
 	},
 /obj/structure/chair,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctW" = (
 /obj/machinery/computer/teleporter,
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctX" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Teleporter";
@@ -56709,22 +56709,22 @@
 /turf/open/floor/plasteel/darkwarning{
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctY" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "ctZ" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cua" = (
 /turf/closed/wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cub" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -56733,7 +56733,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuc" = (
 /obj/structure/rack{
 	dir = 1
@@ -56745,7 +56745,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cud" = (
 /obj/machinery/turretid{
 	control_area = null;
@@ -56764,7 +56764,7 @@
 	network = list("MiniSat")
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cue" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -56773,10 +56773,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuf" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cug" = (
@@ -56787,7 +56787,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuh" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/rack,
@@ -56795,22 +56795,22 @@
 /obj/item/weapon/crowbar/red,
 /obj/item/clothing/head/welding,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cui" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuj" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cul" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -56824,11 +56824,11 @@
 	req_one_access_txt = "65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cum" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cun" = (
@@ -56839,7 +56839,7 @@
 /turf/open/floor/plating/warnplate{
 	icon_plating = "warnplate"
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuo" = (
@@ -56852,7 +56852,7 @@
 	tag = "icon-warnplatecorner";
 	dir = 2
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cup" = (
@@ -56873,7 +56873,7 @@
 /turf/open/floor/plating/warnplate{
 	icon_plating = "warnplate"
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuq" = (
@@ -56885,7 +56885,7 @@
 /turf/open/floor/plating/warnplate{
 	icon_plating = "warnplate"
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cur" = (
@@ -56902,7 +56902,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cus" = (
 /obj/structure/showcase{
 	density = 0;
@@ -56922,7 +56922,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cut" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -56946,7 +56946,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuv" = (
 /obj/structure/showcase{
 	density = 0;
@@ -56965,14 +56965,14 @@
 /turf/open/floor/plating/warnplate{
 	icon_plating = "warnplate"
 	},
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cuw" = (
 /turf/open/floor/plating/warnplate{
 	icon_plating = "warnplate"
 	},
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cux" = (
@@ -56995,16 +56995,16 @@
 /turf/open/floor/plating/warnplate/corner{
 	dir = 1
 	},
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cuy" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuA" = (
@@ -57028,7 +57028,7 @@
 /turf/open/floor/plating/warnplate{
 	dir = 4
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuB" = (
@@ -57049,14 +57049,14 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuC" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuD" = (
@@ -57086,13 +57086,13 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuF" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -57110,7 +57110,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57123,7 +57123,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuH" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -57139,7 +57139,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cuI" = (
@@ -57149,7 +57149,7 @@
 	scrub_Toxins = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cuJ" = (
@@ -57158,7 +57158,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cuK" = (
@@ -57188,7 +57188,7 @@
 /turf/open/floor/plating/warnplate{
 	dir = 8
 	},
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cuL" = (
@@ -57202,7 +57202,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuM" = (
@@ -57220,7 +57220,7 @@
 /turf/open/floor/plating/warnplate{
 	dir = 4
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuN" = (
@@ -57234,7 +57234,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuO" = (
@@ -57250,7 +57250,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuP" = (
@@ -57264,7 +57264,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -57281,7 +57281,7 @@
 	req_one_access_txt = "65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -57294,7 +57294,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57319,7 +57319,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -57331,7 +57331,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cuU" = (
@@ -57350,7 +57350,7 @@
 	req_one_access_txt = "65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cuV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -57359,7 +57359,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cuW" = (
@@ -57380,7 +57380,7 @@
 	tag = ""
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cuX" = (
@@ -57398,7 +57398,7 @@
 /turf/open/floor/plating/warnplate{
 	dir = 8
 	},
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cuY" = (
@@ -57408,7 +57408,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cuZ" = (
@@ -57418,16 +57418,16 @@
 	},
 /mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/plasteel/darkblue/corner,
-/area/turret_protected/AIsatextAS{
+/area/ai_monitored/turret_protected/AIsatextAS{
 	name = "AI Satellite Atmospherics"
 	})
 "cva" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cvb" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cvc" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32;
@@ -57446,7 +57446,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cvd" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -57459,7 +57459,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/corner,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cve" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57483,11 +57483,11 @@
 	req_access = list(65)
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cvf" = (
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cvg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -57497,7 +57497,7 @@
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cvh" = (
@@ -57507,7 +57507,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cvi" = (
@@ -57517,22 +57517,22 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFP{
+/area/ai_monitored/turret_protected/AIsatextFP{
 	name = "AI Satellite Service"
 	})
 "cvj" = (
 /turf/closed/wall,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvk" = (
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvl" = (
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cvm" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -57540,13 +57540,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvo" = (
@@ -57562,12 +57562,12 @@
 	req_one_access_txt = "65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvp" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cvq" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -57579,7 +57579,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvr" = (
@@ -57587,32 +57587,32 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cvs" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvu" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvv" = (
 /turf/closed/wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cvw" = (
 /turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvx" = (
@@ -57645,13 +57645,13 @@
 	pixel_y = -25
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cvy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvz" = (
@@ -57662,7 +57662,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvA" = (
@@ -57695,13 +57695,13 @@
 	pixel_y = -25
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cvB" = (
 /obj/structure/rack,
 /obj/item/weapon/crowbar/red,
 /obj/item/weapon/wrench,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvC" = (
@@ -57711,19 +57711,19 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvD" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvE" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvF" = (
@@ -57748,7 +57748,7 @@
 	dir = 8
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvH" = (
@@ -57758,7 +57758,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvI" = (
@@ -57775,7 +57775,7 @@
 	scrub_Toxins = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvJ" = (
@@ -57788,7 +57788,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvK" = (
@@ -57810,7 +57810,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvM" = (
@@ -57824,7 +57824,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvN" = (
@@ -57838,7 +57838,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvO" = (
@@ -57856,7 +57856,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvQ" = (
@@ -57864,7 +57864,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvR" = (
@@ -57874,7 +57874,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvS" = (
@@ -57882,7 +57882,7 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvT" = (
@@ -57894,7 +57894,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvU" = (
@@ -57909,7 +57909,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvV" = (
@@ -57919,7 +57919,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvW" = (
@@ -57929,12 +57929,12 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvX" = (
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvY" = (
@@ -57942,7 +57942,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cvZ" = (
@@ -57952,7 +57952,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cwa" = (
@@ -57964,7 +57964,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cwb" = (
@@ -57974,7 +57974,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cwc" = (
@@ -57989,7 +57989,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cwd" = (
@@ -58008,14 +58008,14 @@
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cwe" = (
 /obj/structure/sign/securearea,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58029,7 +58029,7 @@
 	req_one_access_txt = "65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwg" = (
 /obj/machinery/airalarm{
 	frequency = 1439;
@@ -58039,7 +58039,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwh" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -58054,13 +58054,13 @@
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58069,7 +58069,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -58084,23 +58084,23 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwm" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/white,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58111,7 +58111,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwp" = (
 /obj/structure/chair/office/dark,
 /obj/structure/extinguisher_cabinet{
@@ -58119,24 +58119,24 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwq" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cwr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cws" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58150,7 +58150,7 @@
 	req_access_txt = "65"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58163,7 +58163,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwv" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -58173,7 +58173,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cww" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -58185,7 +58185,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwx" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -58196,7 +58196,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
@@ -58209,7 +58209,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58227,7 +58227,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwB" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -58237,13 +58237,13 @@
 	pixel_x = 32
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwD" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -58257,7 +58257,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwE" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -58286,7 +58286,7 @@
 	network = list("MiniSat")
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cwF" = (
 /obj/structure/chair{
 	dir = 1
@@ -59273,7 +59273,7 @@
 	req_access_txt = "65;13"
 	},
 /turf/open/floor/plating,
-/area/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/aisat_interior)
 "czl" = (
 /obj/machinery/door/window/northright,
 /obj/effect/decal/remains/human,
@@ -59995,7 +59995,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cAS" = (
 /obj/effect/landmark/start{
 	name = "AI"
@@ -60036,7 +60036,7 @@
 	pixel_y = -28
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cAT" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0";
@@ -60044,7 +60044,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cAU" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -60078,7 +60078,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cAW" = (
 /obj/structure/showcase{
 	density = 0;
@@ -60095,7 +60095,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cAX" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -60116,7 +60116,7 @@
 	pixel_y = 0
 	},
 /turf/closed/wall,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cAZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60124,7 +60124,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cBa" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -60134,7 +60134,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cBb" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
@@ -60142,7 +60142,7 @@
 	network = list("MiniSat")
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cBc" = (
 /obj/machinery/power/terminal{
 	icon_state = "term";
@@ -60153,14 +60153,14 @@
 	uses = 10
 	},
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cBd" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cBe" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -60169,7 +60169,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai)
 "cBf" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat External South";
@@ -60206,7 +60206,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/ai_monitored/turret_protected/ai_upload)
 "cBk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60481,7 +60481,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
+/area/ai_monitored/turret_protected/AIsatextFS{
 	name = "AI Satellite Hallway"
 	})
 "cBT" = (

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -102,8 +102,8 @@ var/datum/subsystem/events/SSevent
 
 /datum/round_event/proc/findEventArea() //Here's a nice proc to use to find an area for your event to land in!
 	var/list/safe_areas = list(
-	/area/turret_protected/ai,
-	/area/turret_protected/ai_upload,
+	/area/ai_monitored/turret_protected/ai,
+	/area/ai_monitored/turret_protected/ai_upload,
 	/area/engine,
 	/area/solar,
 	/area/holodeck,

--- a/code/datums/weather/weather_types.dm
+++ b/code/datums/weather/weather_types.dm
@@ -132,7 +132,7 @@
 	end_message = "<span class='notice'>The air seems to be cooling off again.</span>"
 
 	area_type = /area
-	protected_areas = list(/area/maintenance, /area/turret_protected/ai_upload, /area/turret_protected/ai_upload_foyer, /area/turret_protected/ai)
+	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer, /area/ai_monitored/turret_protected/ai)
 	target_z = ZLEVEL_STATION
 
 	immunity_type = "rad"

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -83,7 +83,9 @@ var/list/teleportlocs = list()
 
 /area/engine/
 
-/area/turret_protected/
+/area/ai_monitored	//stub defined ai_monitored.dm
+
+/area/ai_monitored/turret_protected/
 
 /area/arrival
 	requires_power = 0
@@ -1231,22 +1233,22 @@ var/list/teleportlocs = list()
 	icon_state = "storage"
 
 
-/area/turret_protected/
+/area/ai_monitored/turret_protected/
 	ambientsounds = list('sound/ambience/ambimalf.ogg')
 
-/area/turret_protected/ai_upload
+/area/ai_monitored/turret_protected/ai_upload
 	name = "AI Upload Chamber"
 	icon_state = "ai_upload"
 
-/area/turret_protected/ai_upload_foyer
+/area/ai_monitored/turret_protected/ai_upload_foyer
 	name = "AI Upload Access"
 	icon_state = "ai_foyer"
 
-/area/turret_protected/ai
+/area/ai_monitored/turret_protected/ai
 	name = "AI Chamber"
 	icon_state = "ai_chamber"
 
-/area/turret_protected/aisat
+/area/ai_monitored/turret_protected/aisat
 	name = "AI Satellite"
 	icon_state = "ai"
 
@@ -1254,35 +1256,35 @@ var/list/teleportlocs = list()
 	name = "AI Satellite Exterior"
 	icon_state = "yellow"
 
-/area/turret_protected/aisat_interior
+/area/ai_monitored/turret_protected/aisat_interior
 	name = "AI Satellite Antechamber"
 	icon_state = "ai"
 
-/area/turret_protected/AIsatextFP
+/area/ai_monitored/turret_protected/AIsatextFP
 	name = "AI Sat Ext"
 	icon_state = "storage"
 	luminosity = 1
 	lighting_use_dynamic = DYNAMIC_LIGHTING_IFSTARLIGHT
 
-/area/turret_protected/AIsatextFS
+/area/ai_monitored/turret_protected/AIsatextFS
 	name = "AI Sat Ext"
 	icon_state = "storage"
 	luminosity = 1
 	lighting_use_dynamic = DYNAMIC_LIGHTING_IFSTARLIGHT
 
-/area/turret_protected/AIsatextAS
+/area/ai_monitored/turret_protected/AIsatextAS
 	name = "AI Sat Ext"
 	icon_state = "storage"
 	luminosity = 1
 	lighting_use_dynamic = DYNAMIC_LIGHTING_IFSTARLIGHT
 
-/area/turret_protected/AIsatextAP
+/area/ai_monitored/turret_protected/AIsatextAP
 	name = "AI Sat Ext"
 	icon_state = "storage"
 	luminosity = 1
 	lighting_use_dynamic = DYNAMIC_LIGHTING_IFSTARLIGHT
 
-/area/turret_protected/NewAIMain
+/area/ai_monitored/turret_protected/NewAIMain
 	name = "AI Main New"
 	icon_state = "storage"
 
@@ -1327,22 +1329,22 @@ var/list/teleportlocs = list()
 	name = "Abandoned Satellite"
 	icon_state = "tcomsatcham"
 
-/area/turret_protected/tcomsat
+/area/ai_monitored/turret_protected/tcomsat
 	name = "Telecoms Satellite"
 	icon_state = "tcomsatlob"
 	ambientsounds = list('sound/ambience/ambisin2.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/ambigen10.ogg')
 
-/area/turret_protected/tcomfoyer
+/area/ai_monitored/turret_protected/tcomfoyer
 	name = "Telecoms Foyer"
 	icon_state = "tcomsatentrance"
 	ambientsounds = list('sound/ambience/ambisin2.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/ambigen10.ogg')
 
-/area/turret_protected/tcomwest
+/area/ai_monitored/turret_protected/tcomwest
 	name = "Telecommunications Satellite West Wing"
 	icon_state = "tcomsatwest"
 	ambientsounds = list('sound/ambience/ambisin2.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/ambigen10.ogg')
 
-/area/turret_protected/tcomeast
+/area/ai_monitored/turret_protected/tcomeast
 	name = "Telecommunications Satellite East Wing"
 	icon_state = "tcomsateast"
 	ambientsounds = list('sound/ambience/ambisin2.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/ambigen10.ogg')
@@ -1641,7 +1643,7 @@ var/list/the_station_areas = list (
 	/area/ai_monitored/storage/eva, //do not try to simplify to "/area/ai_monitored" --rastaf0
 //	/area/ai_monitored/storage/secure,	//not present on map
 //	/area/ai_monitored/storage/emergency,	//not present on map
-	/area/turret_protected/ai_upload, //do not try to simplify to "/area/turret_protected" --rastaf0
-	/area/turret_protected/ai_upload_foyer,
-	/area/turret_protected/ai,
+	/area/ai_monitored/turret_protected/ai_upload, //do not try to simplify to "/area/ai_monitored/turret_protected" --rastaf0
+	/area/ai_monitored/turret_protected/ai_upload_foyer,
+	/area/ai_monitored/turret_protected/ai,
 )

--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -15,7 +15,6 @@
 /area/ai_monitored/Entered(atom/movable/O)
 	..()
 	if (ismob(O) && motioncameras.len)
-		world << "[src] calling enter for [O]"
 		for(var/obj/machinery/camera/cam in motioncameras)
 			cam.newTarget(O)
 			return
@@ -23,7 +22,6 @@
 /area/ai_monitored/Exited(atom/movable/O)
 	..()
 	if (ismob(O) && motioncameras.len)
-		world << "[src] calling exit for [O]"
 		for(var/obj/machinery/camera/cam in motioncameras)
 			cam.lostTarget(O)
 			return

--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -1,24 +1,29 @@
 /area/ai_monitored
 	name = "AI Monitored Area"
-	var/obj/machinery/camera/motioncamera = null
+	var/list/obj/machinery/camera/motioncameras = list()
+	var/list/motionTargets = list()
 
-
-/area/ai_monitored/New()
+/area/ai_monitored/initialize()
 	..()
-	// locate and store the motioncamera
-	spawn (20) // spawn on a delay to let turfs/objs load
-		for (var/obj/machinery/camera/M in src)
-			if(M.isMotion())
-				motioncamera = M
-				M.area_motion = src
+	for (var/obj/machinery/camera/M in src)
+		if(M.isMotion())
+			motioncameras.Add(M)
+			M.area_motion = src
+
+//Only need to use one camera
 
 /area/ai_monitored/Entered(atom/movable/O)
 	..()
-	if (ismob(O) && motioncamera)
-		motioncamera.newTarget(O)
+	if (ismob(O) && motioncameras.len)
+		world << "[src] calling enter for [O]"
+		for(var/obj/machinery/camera/cam in motioncameras)
+			cam.newTarget(O)
+			return
 
 /area/ai_monitored/Exited(atom/movable/O)
-	if (ismob(O) && motioncamera)
-		motioncamera.lostTarget(O)
-
-
+	..()
+	if (ismob(O) && motioncameras.len)
+		world << "[src] calling exit for [O]"
+		for(var/obj/machinery/camera/cam in motioncameras)
+			cam.lostTarget(O)
+			return

--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -15,13 +15,15 @@
 /area/ai_monitored/Entered(atom/movable/O)
 	..()
 	if (ismob(O) && motioncameras.len)
-		for(var/obj/machinery/camera/cam in motioncameras)
+		for(var/X in motioncameras)
+			var/obj/machinery/camera/cam = X
 			cam.newTarget(O)
 			return
 
 /area/ai_monitored/Exited(atom/movable/O)
 	..()
 	if (ismob(O) && motioncameras.len)
-		for(var/obj/machinery/camera/cam in motioncameras)
+		for(var/X in motioncameras)
+			var/obj/machinery/camera/cam = X
 			cam.lostTarget(O)
 			return

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -1,7 +1,7 @@
 /proc/power_failure()
 	priority_announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", 'sound/AI/poweroff.ogg')
 	for(var/obj/machinery/power/smes/S in machines)
-		if(istype(get_area(S), /area/turret_protected) || S.z != ZLEVEL_STATION)
+		if(istype(get_area(S), /area/ai_monitored/turret_protected) || S.z != ZLEVEL_STATION)
 			continue
 		S.charge = 0
 		S.output_level = 0
@@ -9,7 +9,7 @@
 		S.update_icon()
 		S.power_change()
 
-	var/list/skipped_areas = list(/area/engine/engineering, /area/turret_protected/ai)
+	var/list/skipped_areas = list(/area/engine/engineering, /area/ai_monitored/turret_protected/ai)
 
 	for(var/area/A in world)
 		if( !A.requires_power || A.always_unpowered )

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -1,6 +1,6 @@
 /obj/machinery/camera
 
-	var/list/motionTargets = list()
+	var/list/localMotionTargets = list()
 	var/detectTime = 0
 	var/area/ai_monitored/area_motion = null
 	var/alarm_delay = 30 // Don't forget, there's another 3 seconds in queueAlarm()
@@ -15,28 +15,32 @@
 		if (elapsed > alarm_delay)
 			triggerAlarm()
 	else if (detectTime == -1)
-		for (var/mob/target in motionTargets)
-			if (target.stat == 2) lostTarget(target)
-			// If not detecting with motion camera...
-			if (!area_motion)
-				// See if the camera is still in range
-				if(!in_range(src, target))
-					// If they aren't in range, lose the target.
-					lostTarget(target)
+		for (var/mob/target in getTargetList())
+			if (target.stat == 2 || \
+			(!area_motion && !in_range(src, target)))
+				// If not part of a monitored area and the camera is not in range
+				lostTarget(target)
+
+/obj/machinery/camera/proc/getTargetList()
+	if(area_motion)
+		return area_motion.motionTargets
+	return localMotionTargets
 
 /obj/machinery/camera/proc/newTarget(mob/target)
 	if(isAI(target))
 		return 0
 	if (detectTime == 0)
 		detectTime = world.time // start the clock
-	if (!(target in motionTargets))
-		motionTargets += target
+	var/list/targets = getTargetList()
+	if (!(target in targets))
+		targets += target
 	return 1
 
 /obj/machinery/camera/proc/lostTarget(mob/target)
-	if (target in motionTargets)
-		motionTargets -= target
-	if (motionTargets.len == 0)
+	var/list/targets = getTargetList()
+	if (target in targets)
+		targets -= target
+	if (targets.len == 0)
 		cancelAlarm()
 
 /obj/machinery/camera/proc/cancelAlarm()

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -16,9 +16,8 @@
 			triggerAlarm()
 	else if (detectTime == -1)
 		for (var/mob/target in getTargetList())
-			if (target.stat == 2 || \
-			(!area_motion && !in_range(src, target)))
-				// If not part of a monitored area and the camera is not in range
+			if (target.stat == DEAD || (!area_motion && !in_range(src, target)))
+				//If not part of a monitored area and the camera is not in range or the target is dead
 				lostTarget(target)
 
 /obj/machinery/camera/proc/getTargetList()

--- a/code/game/turfs/simulated/dirtystation.dm
+++ b/code/game/turfs/simulated/dirtystation.dm
@@ -95,7 +95,7 @@
 	if(prob(75))	//low dirt  - 1/60
 		return
 
-	if(istype(A, /area/turret_protected) || istype(A, /area/security))	//chance of incident
+	if(istype(A, /area/ai_monitored/turret_protected) || istype(A, /area/security))	//chance of incident
 		if(prob(20))
 			if(prob(5))
 				new /obj/effect/decal/cleanable/blood/gibs/old(src)


### PR DESCRIPTION
Roast me

:cl: Cyberboss
fix: Fixed motion alarms instantly triggering and de/un/re/triggering
/:cl:

The relevant changes are in motion.dm and ai_monitored.dm. Everything else is a replacement of /area/turret_protected -> /area/ai_monitored/turret_protected which is why this PR is a bitch.
