### PR TITLE
Makes Ephedrine require Morphine instead of sugar

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -124,7 +124,7 @@
 	name = "Ephedrine"
 	id = "ephedrine"
 	results = list("ephedrine" = 4)
-	required_reagents = list("sugar" = 1, "oil" = 1, "hydrogen" = 1, "diethylamine" = 1)
+	required_reagents = list("morphine" = 1, "oil" = 1, "hydrogen" = 1, "diethylamine" = 1)
 	mix_message = "The solution fizzes and gives off toxic fumes."
 
 /datum/chemical_reaction/diphenhydramine


### PR DESCRIPTION
:cl:
tweak: Ephedrine requires 1 part morphine instead of sugar
/:cl:

This is mainly to make the station more dependent on botany, as botany is good but takes a long time and has few unique chems. This is also somewhat more realistic, and makes Ephedrine/meth, some of the best chems in the game, a bit harder to make. Plus morphine has no real use outside of making people go to sleep so you can kill them.

@Shapsy said that morphine is good for stabilizing crit, but let's face it; nobody does that shit.
