### PR TITLE
Fixes door timing mode

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -994,7 +994,7 @@ var/list/airlock_overlays = list()
 	if(autoclose && normalspeed)
 		addtimer(src, "autoclose", 150)
 	else if(autoclose && !normalspeed)
-		addtimer(src, "autoclose", 10)
+		addtimer(src, "autoclose", 15)
 
 	if(!density)
 		return 1


### PR DESCRIPTION
Would you believe it was going too fast?

:cl: Cyberboss
fix: Airlock speed mode now works
/:cl:

Fixes #20877
