### PR TITLE
Increases airlock resistance

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -32,6 +32,7 @@ var/list/airlock_overlays = list()
 	obj_integrity = 300
 	max_integrity = 300
 	integrity_failure = 70
+	damage_deflection = 20
 
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
 	var/hackProof = 0 // if 1, this door can't be hacked by the AI
@@ -88,11 +89,6 @@ var/list/airlock_overlays = list()
 	if(glass)
 		airlock_material = "glass"
 	update_icon()
-
-/obj/machinery/door/airlock/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	if(damage_flag == "melee" && damage_amount < 20) //any melee attack below 20 dmg does nothing
-		return 0
-	. = ..()
 
 /obj/machinery/door/airlock/initialize()
 	. = ..()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -89,6 +89,11 @@ var/list/airlock_overlays = list()
 		airlock_material = "glass"
 	update_icon()
 
+/obj/machinery/door/airlock/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
+	if(damage_flag == "melee" && damage_amount < 20) //any melee attack below 20 dmg does nothing
+		return 0
+	. = ..()
+
 /obj/machinery/door/airlock/initialize()
 	. = ..()
 	if (cyclelinkeddir)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -304,6 +304,11 @@
 	obj_integrity = 500
 	max_integrity = 500
 
+/obj/machinery/door/airlock/highsecurity/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
+	if(damage_flag == "melee" && damage_amount < 50) //any melee attack below 50 dmg does nothing
+		return 0
+	. = ..()
+
 //////////////////////////////////
 /*
 	Shuttle Airlocks

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -303,7 +303,7 @@
 	explosion_block = 2
 	obj_integrity = 500
 	max_integrity = 500
-	damage_deflection = 50
+	damage_deflection = 30
 
 //////////////////////////////////
 /*
@@ -322,6 +322,7 @@
 	icon = 'icons/obj/doors/airlocks/abductor/abductor_airlock.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/abductor/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_abductor
+	damage_deflection = 30
 	opacity = 1
 	explosion_block = 3
 	hackProof = 1

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -303,11 +303,7 @@
 	explosion_block = 2
 	obj_integrity = 500
 	max_integrity = 500
-
-/obj/machinery/door/airlock/highsecurity/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	if(damage_flag == "melee" && damage_amount < 50) //any melee attack below 50 dmg does nothing
-		return 0
-	. = ..()
+	damage_deflection = 50
 
 //////////////////////////////////
 /*

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -12,6 +12,7 @@
 	max_integrity = 350
 	armor = list(melee = 30, bullet = 30, laser = 20, energy = 20, bomb = 10, bio = 100, rad = 100, fire = 80, acid = 70)
 
+
 	var/secondsElectrified = 0
 	var/shockedby = list()
 	var/visible = 1
@@ -29,6 +30,7 @@
 	var/assemblytype //the type of door frame to drop during deconstruction
 	var/auto_close //TO BE REMOVED, no longer used, it's just preventing a runtime with a map var edit.
 	var/datum/effect_system/spark_spread/spark_system
+	var/damage_deflection = 10
 
 /obj/machinery/door/New()
 	..()
@@ -160,7 +162,7 @@ obj/machinery/door/proc/try_to_crowbar(obj/item/I, mob/user)
 		return ..()
 
 /obj/machinery/door/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	if(damage_flag == "melee" && damage_amount < 10)
+	if(damage_flag == "melee" && damage_amount < damage_deflection)
 		return 0
 	. = ..()
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -12,6 +12,7 @@
 	max_integrity = 600
 	armor = list(melee = 50, bullet = 100, laser = 100, energy = 100, bomb = 50, bio = 100, rad = 100, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
+	damage_deflection = 70
 
 /obj/machinery/door/poddoor/preopen
 	icon_state = "open"
@@ -43,11 +44,6 @@
 	if(severity == 3)
 		return
 	..()
-
-/obj/machinery/door/poddoor/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	if(damage_flag == "melee" && damage_amount < 70) //any melee attack below 70 dmg does nothing
-		return 0
-	. = ..()
 
 /obj/machinery/door/poddoor/do_animate(animation)
 	switch(animation)

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -4,6 +4,7 @@
 	desc = "Heavy duty metal shutters that opens mechanically."
 	icon = 'icons/obj/doors/shutters.dmi'
 	layer = CLOSED_DOOR_LAYER
+	damage_deflection = 20
 
 /obj/machinery/door/poddoor/shutters/preopen
 	icon_state = "open"


### PR DESCRIPTION
:cl: XDTM
tweak: Airlocks are now immune to any damage below 20, to prevent pickaxe prison breaks.
tweak: High-Security Airlocks, such as the vault or the AI core's airlocks, are now immune to any damage below 30.
/:cl:
