### PR TITLE
Fixes bar sign being unwrenchable and changeable into a small sign. 

### DIFF
--- a/code/game/objects/structures/barsigns.dm
+++ b/code/game/objects/structures/barsigns.dm
@@ -8,6 +8,7 @@
 	max_integrity = 500
 	integrity_failure = 250
 	armor = list(melee = 20, bullet = 20, laser = 20, energy = 100, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 50)
+	buildable_sign = 0
 	var/list/barsigns=list()
 	var/list/hiddensigns
 	var/emagged = 0

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -7,6 +7,7 @@
 	obj_integrity = 100
 	max_integrity = 100
 	armor = list(melee = 50, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 50)
+	var/buildable_sign = 1 //unwrenchable and modifiable
 
 /obj/structure/sign/basic
 	name = "blank sign"
@@ -24,7 +25,7 @@
 			playsound(loc, 'sound/items/welder.ogg', 80, 1)
 
 /obj/structure/sign/attackby(obj/item/O, mob/user, params)
-	if(istype(O, /obj/item/weapon/wrench))
+	if(istype(O, /obj/item/weapon/wrench) && buildable_sign)
 		user.visible_message("<span class='notice'>[user] starts removing [src]...</span>", \
 							 "<span class='notice'>You start unfastening [src].</span>")
 		playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
@@ -37,7 +38,7 @@
 		SB.icon_state = icon_state
 		SB.sign_path = type
 		qdel(src)
-	else if(istype(O, /obj/item/weapon/pen))
+	else if(istype(O, /obj/item/weapon/pen) && buildable_sign)
 		var/list/sign_types = list("Secure Area", "Biohazard", "High Voltage", "Radiation", "Hard Vacuum Ahead", "Disposal: Leads To Space", "Danger: Fire", "No Smoking", "Medbay", "Science", "Chemistry", \
 		"Hydroponics", "Xenobiology")
 		var/obj/structure/sign/sign_type


### PR DESCRIPTION
Ideally barsign shouldn't be a child of sign since they share practically no code, but I really don't want to have to go change the path on every map, so a simple var should do for now.

Fixes #20929
