### PR TITLE
Helmet obscures eye slot

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -5,7 +5,7 @@
 	flags = HEADBANGPROTECT
 	item_state = "helmet"
 	armor = list(melee = 40, bullet = 30, laser = 30,energy = 10, bomb = 25, bio = 0, rad = 0, fire = 50, acid = 50)
-	flags_inv = HIDEEARS
+	flags_inv = HIDEEARS|HIDEEYES
 	cold_protection = HEAD
 	min_cold_protection_temperature = HELMET_MIN_TEMP_PROTECT
 	heat_protection = HEAD

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -35,6 +35,7 @@
 /obj/item/clothing/head/helmet/blueshirt
 	icon_state = "blueshift"
 	item_state = "blueshift"
+	flags_inv = HIDEEARS
 
 /obj/item/clothing/head/helmet/riot
 	name = "riot helmet"


### PR DESCRIPTION
This PR makes the helmet obscure the eye inventory slot, meaning one can't remove glasses without taking off the helmet first. Right now only the ears are obscured by the helmet, even though the visor you see would block glasses from being taken off.

This affects the standard helmet, its bulletproof variant and the laser tag helmets. I have made an overriding flags_inv for the Blue Shift variant of the helmet; this helmet has no visor, so only obscures ears.

:cl: Erwgd
:tweak: Standard helmets now obscure the eyes, so remove the helmet to be able to remove any eyewear.
/:cl:
