### PR TITLE
Adds a mining gear crate to cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1248,6 +1248,7 @@ datum/supply_pack
 /datum/supply_pack/misc/minerkit
 	name = "Shaft Miner Starter Kit"
 	cost = 2500
+	access = access_qm
 	contains = list(/obj/item/weapon/pickaxe/mini,
 			/obj/item/clothing/glasses/meson,
 			/obj/item/device/t_scanner/adv_mining_scanner/lesser,
@@ -1255,6 +1256,8 @@ datum/supply_pack
 			/obj/item/weapon/storage/bag/ore,
 			/obj/item/clothing/suit/space/hardsuit/mining,
 			/obj/item/clothing/mask/gas/explorer)
+	crate_name = "shaft miner starter kit"
+	crate_type = /obj/structure/closet/crate/secure
 
 /datum/supply_pack/misc/mule
 	name = "MULEbot Crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1245,6 +1245,18 @@ datum/supply_pack
 /datum/supply_pack/misc
 	group = "Miscellaneous Supplies"
 
+/datum/supply_pack/misc/minerkit
+	name = "Shaft Miner Starter Kit"
+	cost = 2500
+	contains = list(/obj/item/weapon/pickaxe/mini,
+			/obj/item/clothing/glasses/meson,
+			/obj/item/device/t_scanner/adv_mining_scanner/lesser,
+			/obj/item/device/radio/headset/headset_cargo/mining,
+			/obj/item/weapon/storage/bag/ore,
+			/obj/item/clothing/suit/space/hardsuit/mining,
+			/obj/item/clothing/mask/gas/explorer)
+			
+
 /datum/supply_pack/misc/mule
 	name = "MULEbot Crate"
 	cost = 2000

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1255,7 +1255,6 @@ datum/supply_pack
 			/obj/item/weapon/storage/bag/ore,
 			/obj/item/clothing/suit/space/hardsuit/mining,
 			/obj/item/clothing/mask/gas/explorer)
-			
 
 /datum/supply_pack/misc/mule
 	name = "MULEbot Crate"


### PR DESCRIPTION
:cl: ma44
add: Cargo can now order a 2500 supply point crate that requires a QM or above to unlock. This crates contains a explorer suit, compact pickaxe, mesons, and a bag to hold ore with. 
/:cl:
Allows QM to employ more miners so they don't have to get crappy EVA suits when they can just order everything a miner should have to find some ores. 

Source for most popular job
http://www.ss13.eu/tgdb/tg/latest_stats.html#job_popularity
34% of all players had rolled for miner with priority set to medium/high
