### PR TITLE
People who have returned to the lobby due to the pref are excluded from revhead rolls.

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -74,7 +74,7 @@
 			head_revolutionaries -= rev_mind
 			var/list/newcandidates = shuffle(antag_candidates)
 			if(newcandidates.len == 0)
-				break
+				continue
 			for(var/M in newcandidates)
 				var/datum/mind/lenin = M
 				antag_candidates -= lenin

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -68,6 +68,23 @@
 	var/list/sec = get_living_sec()
 	var/weighted_score = min(max(round(heads.len - ((8 - sec.len) / 3)),1),max_headrevs)
 
+
+	for(var/datum/mind/rev_mind in head_revolutionaries)	//People with return to lobby may still be in the lobby. Let's pick someone else in that case.
+		if(istype(rev_mind.current,/mob/new_player))
+			head_revolutionaries -= rev_mind
+			var/list/newcandidates = shuffle(antag_candidates)
+			for(var/M in newcandidates)
+				if(newcandidates.len == 0)
+					break
+				var/datum/mind/lenin = newcandidates
+				antag_candidates -= lenin
+				newcandidates -= lenin
+				if(istype(lenin.current,/mob/new_player))
+					continue
+				else
+					head_revolutionaries += lenin
+					break
+
 	while(weighted_score < head_revolutionaries.len) //das vi danya
 		var/datum/mind/trotsky = pick(head_revolutionaries)
 		antag_candidates += trotsky

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -73,10 +73,10 @@
 		if(istype(rev_mind.current,/mob/new_player))
 			head_revolutionaries -= rev_mind
 			var/list/newcandidates = shuffle(antag_candidates)
+			if(newcandidates.len == 0)
+				break
 			for(var/M in newcandidates)
-				if(newcandidates.len == 0)
-					break
-				var/datum/mind/lenin = newcandidates
+				var/datum/mind/lenin = M
 				antag_candidates -= lenin
 				newcandidates -= lenin
 				if(istype(lenin.current,/mob/new_player))


### PR DESCRIPTION
Fixes #20804

Basically, because of how rev works, if these players were force spawned in, they might lose rev if there were fewer heads. However, since they were spawned in and didn't get antag, it would be a hard tell for them that it's rev.

With this change, Basically, if you didn't roll your preferred jobs, and got sent to the lobby, you wont be forced spawned in as a rev head. However, if you DID roll your jobs and spawned in, you'll still get it.

Solution suggested by @AnturK
