### PR TITLE
extinguisher is now caught up with fastmos.

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -98,7 +98,7 @@
 			usr << "<span class='warning'>\The [src] is empty!</span>"
 			return
 
-		if (world.time < src.last_use + 20)
+		if (world.time < src.last_use + 12)
 			return
 
 		src.last_use = world.time


### PR DESCRIPTION
:cl: Yackemflam
tweak: extinguishers now spray faster
/:cl:

The fire extinguisher can't fight a fire at all with how fast fire spread vs how long the recharge is.
