### PR TITLE
Makes Bath Salts require Diethylamine instead of Universal Enzyme

### DIFF
--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -32,7 +32,7 @@
 	name = "bath_salts"
 	id = "bath_salts"
 	results = list("bath_salts" = 7)
-	required_reagents = list("????" = 1, "saltpetre" = 1, "nutriment" = 1, "cleaner" = 1, "enzyme" = 1, "tea" = 1, "mercury" = 1)
+	required_reagents = list("????" = 1, "saltpetre" = 1, "nutriment" = 1, "cleaner" = 1, "diethylamine" = 1, "tea" = 1, "mercury" = 1)
 	required_temp = 374
 
 /datum/chemical_reaction/aranesp


### PR DESCRIPTION
:cl:
tweak: Bath Salts now requires Diethylamine instead of Universal Enzyme
/:cl:

The recipe for Bath Salts currently includes Nutriment and Universal Enzyme. However, Nutriment and Universal Enzyme also makes Moonshine, allowing Bath Salts to be created only in very small quantities. Replacing Enzyme with Diethylamine removes this unique production restriction.
