### PR TITLE
Clicking a floor with a bodybag or roller bed now deploys them directly.

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -9,10 +9,18 @@
 	w_class = 2
 
 /obj/item/bodybag/attack_self(mob/user)
-	var/obj/structure/closet/body_bag/R = new unfoldedbag_path(user.loc)
+	deploy_bodybag(user, user.loc)
+
+/obj/item/bodybag/afterattack(atom/target, mob/user, proximity)
+	if(proximity)
+		if(isopenturf(target))
+			deploy_bodybag(user, target)
+
+/obj/item/bodybag/proc/deploy_bodybag(mob/user, atom/location)
+	var/obj/structure/closet/body_bag/R = new unfoldedbag_path(location)
+	R.open(user)
 	R.add_fingerprint(user)
 	qdel(src)
-
 
 /obj/item/weapon/storage/box/bodybags
 	name = "body bags"
@@ -36,7 +44,8 @@
 	mob_storage_capacity = 2
 	open_sound = 'sound/items/zip.ogg'
 	close_sound = 'sound/items/zip.ogg'
-
+	integrity_failure = 0
+	material_drop = /obj/item/stack/sheet/cloth
 
 /obj/structure/closet/body_bag/attackby(obj/item/I, mob/user, params)
 	if (istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/toy/crayon))

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -49,6 +49,27 @@
 	resistance_flags = 0
 	var/foldabletype = /obj/item/roller
 
+/obj/structure/bed/roller/attackby(obj/item/weapon/W, mob/user, params)
+	if(istype(W,/obj/item/roller/robo))
+		var/obj/item/roller/robo/R = W
+		if(R.loaded)
+			user << "<span class='warning'>You already have a roller bed docked!</span>"
+			return
+
+		if(has_buckled_mobs())
+			if(buckled_mobs.len > 1)
+				unbuckle_all_mobs()
+				user.visible_message("<span class='notice'>[user] unbuckles all creatures from [src].</span>")
+			else
+				user_unbuckle_mob(buckled_mobs[1],user)
+		else
+			R.loaded = src
+			forceMove(R)
+			user.visible_message("[user] collects [src].", "<span class='notice'>You collect [src].</span>")
+		return 1
+	else
+		return ..()
+
 /obj/structure/bed/roller/MouseDrop(over_object, src_location, over_location)
 	. = ..()
 	if(over_object == usr && Adjacent(usr))
@@ -60,7 +81,8 @@
 			usr << "<span class='warning'>You can't do that right now!</span>"
 			return 0
 		usr.visible_message("[usr] collapses \the [src.name].", "<span class='notice'>You collapse \the [src.name].</span>")
-		new foldabletype(get_turf(src))
+		var/obj/structure/bed/roller/B = new foldabletype(get_turf(src))
+		usr.put_in_hands(B)
 		qdel(src)
 
 /obj/structure/bed/roller/post_buckle_mob(mob/living/M)
@@ -84,7 +106,16 @@
 
 
 /obj/item/roller/attack_self(mob/user)
-	var/obj/structure/bed/roller/R = new /obj/structure/bed/roller(user.loc)
+	deploy_roller(user, user.loc)
+
+/obj/item/roller/afterattack(obj/target, mob/user , proximity)
+	if(!proximity)
+		return
+	if(isopenturf(target))
+		deploy_roller(user, target)
+
+/obj/item/roller/proc/deploy_roller(mob/user, atom/location)
+	var/obj/structure/bed/roller/R = new /obj/structure/bed/roller(location)
 	R.add_fingerprint(user)
 	qdel(src)
 
@@ -101,36 +132,14 @@
 	..()
 	user << "The dock is [loaded ? "loaded" : "empty"]"
 
-/obj/item/roller/robo/attack_self(mob/user)
+/obj/item/roller/robo/deploy_roller(mob/user, atom/location)
 	if(loaded)
 		var/obj/structure/bed/roller/R = loaded
-		R.loc = user.loc
+		R.loc = location
 		user.visible_message("[user] deploys [loaded].", "<span class='notice'>You deploy [loaded].</span>")
 		loaded = null
 	else
 		user << "<span class='warning'>The dock is empty!</span>"
-
-/obj/item/roller/robo/afterattack(obj/target, mob/user , proximity)
-	if(istype(target,/obj/structure/bed/roller))
-		if(!proximity)
-			return
-		if(loaded)
-			user << "<span class='warning'>You already have a roller bed docked!</span>"
-			return
-
-		var/obj/structure/bed/roller/R = target
-		if(R.has_buckled_mobs())
-			if(R.buckled_mobs.len > 1)
-				R.unbuckle_all_mobs()
-				user.visible_message("<span class='notice'>[user] unbuckles all creatures from [R].</span>")
-			else
-				R.user_unbuckle_mob(R.buckled_mobs[1],user)
-
-		loaded = target
-		target.loc = src
-		user.visible_message("[user] collects [loaded].", "<span class='notice'>You collect [loaded].</span>")
-	..()
-
 
 //Dog bed
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -31,6 +31,7 @@
 	var/close_sound = 'sound/machines/click.ogg'
 	var/cutting_sound = 'sound/items/Welder.ogg'
 	var/material_drop = /obj/item/stack/sheet/metal
+	var/material_drop_amount = 3
 
 /obj/structure/closet/New()
 	..()
@@ -188,8 +189,8 @@
 		return open(user)
 
 /obj/structure/closet/deconstruct(disassembled = TRUE)
-	if(ispath(material_drop) && !(flags & NODECONSTRUCT))
-		new material_drop(loc)
+	if(ispath(material_drop) && material_drop_amount && !(flags & NODECONSTRUCT))
+		new material_drop(loc, material_drop_amount)
 	qdel(src)
 
 /obj/structure/closet/obj_break(damage_flag)

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -6,6 +6,7 @@
 	resistance_flags = FLAMMABLE
 	obj_integrity = 70
 	max_integrity = 70
+	integrity_failure = 0
 	can_weld_shut = 0
 	cutting_tool = /obj/item/weapon/wirecutters
 	open_sound = 'sound/effects/rustle2.ogg'

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -6,6 +6,7 @@
 	allow_objects = FALSE
 	breakout_time = 1
 	material_drop = /obj/item/stack/sheet/mineral/wood
+	material_drop_amount = 4
 	var/obj/item/weapon/tank/internals/emergency_oxygen/tank
 
 /obj/structure/closet/crate/critter/New()
@@ -14,11 +15,9 @@
 
 /obj/structure/closet/crate/critter/Destroy()
 	var/turf/T = get_turf(src)
-	tank.loc = T
-	tank = null
-
-	for(var/i in 1 to rand(2, 5))
-		new material_drop(T)
+	if(tank)
+		tank.forceMove(T)
+		tank = null
 
 	return ..()
 


### PR DESCRIPTION
- When deployed, the bodybag automatically starts "open" now.
- Tweaked the amount of metal dropped by destroyed closets.
- Bodybag structures no longer drop metal on destruction.
- Admin deleting a critter crate no longer drops wood, but it still does when destroyed and the wood it drops is now all in a single stack.
- Added a drop_material_amount var to closets to make the amount of material dropped vary for different closet types.
- Click dragging a roller bed now puts it in your hand after being folded (for consistency with bodybag)
- Cardboard box closets no longer have an integrity failure level (there's no opening mechanism to break in a cardboard box...). Same for bodybag "closets".

:cl: phil235
tweak: Clicking a floor with a bodybag or roller bed now deploys them directly (and the bodybag starts open)
/:cl:
