### PR TITLE
Drying racks are now less like machines

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -307,16 +307,20 @@ Class Procs:
 	if(!(flags & NODECONSTRUCT))
 		on_deconstruction()
 		if(component_parts && component_parts.len)
-			var/obj/structure/frame/machine/M = new /obj/structure/frame/machine(loc)
-			M.anchored = anchored
-			if(!disassembled)
-				M.obj_integrity = M.max_integrity * 0.5 //the frame is already half broken
-			transfer_fingerprints_to(M)
-			M.state = 2
-			M.icon_state = "box_1"
+			spawn_frame(disassembled)
 			for(var/obj/item/I in component_parts)
 				I.forceMove(loc)
 	qdel(src)
+
+/obj/machinery/proc/spawn_frame(disassembled)
+	var/obj/structure/frame/machine/M = new /obj/structure/frame/machine(loc)
+	. = M
+	M.anchored = anchored
+	if(!disassembled)
+		M.obj_integrity = M.max_integrity * 0.5 //the frame is already half broken
+	transfer_fingerprints_to(M)
+	M.state = 2
+	M.icon_state = "box_1"
 
 /obj/machinery/obj_break(damage_flag)
 	if(!(flags & NODECONSTRUCT))

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -245,9 +245,14 @@
 		component_parts.Cut()
 	component_parts = null
 
+/obj/machinery/smartfridge/drying_rack/on_deconstruction()
+	new /obj/item/stack/sheet/mineral/wood(loc, 10)
+	..()
+
 /obj/machinery/smartfridge/drying_rack/RefreshParts()
 /obj/machinery/smartfridge/drying_rack/default_deconstruction_screwdriver()
 /obj/machinery/smartfridge/drying_rack/exchange_parts()
+/obj/machinery/smartfridge/drying_rack/spawn_frame()
 
 /obj/machinery/smartfridge/drying_rack/default_deconstruction_crowbar(obj/item/weapon/crowbar/C, ignore_panel = 1)
 	..()
@@ -298,10 +303,6 @@
 		if(S.dried_type)
 			return 1
 	return 0
-
-/obj/machinery/smartfridge/drying_rack/deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/mineral/wood (loc, 10)
-	qdel(src)
 
 /obj/machinery/smartfridge/drying_rack/proc/toggle_drying(forceoff = 0)
 	if(drying || forceoff)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -239,6 +239,19 @@
 	icon_off = "drying_rack"
 	var/drying = 0
 
+/obj/machinery/smartfridge/drying_rack/New()
+	..()
+	if(component_parts && component_parts.len)
+		component_parts.Cut()
+	component_parts = null
+
+/obj/machinery/smartfridge/drying_rack/RefreshParts()
+/obj/machinery/smartfridge/drying_rack/default_deconstruction_screwdriver()
+/obj/machinery/smartfridge/drying_rack/exchange_parts()
+
+/obj/machinery/smartfridge/drying_rack/default_deconstruction_crowbar(obj/item/weapon/crowbar/C, ignore_panel = 1)
+	..()
+
 /obj/machinery/smartfridge/drying_rack/interact(mob/user)
 	var/dat = ..()
 	if(dat)


### PR DESCRIPTION
Drying racks will now no longer respond to screwdrivers, or trying to swap out parts.
They also no longer use matter bins and stay at the default max_n_of_items, which is 1500.

Fixes #20846
