### PR TITLE
Fixes for cyborg stack using variant 2 #20521

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -105,7 +105,9 @@
 
 /obj/item/stack/Topic(href, href_list)
 	..()
-	if (usr.restrained() || usr.stat || !usr.is_holding(src))
+	if (usr.restrained() || usr.stat || (!usr.is_holding(src) && isliving(usr)))
+		return
+	if (usr.get_active_held_item() != src && iscyborg(usr))
 		return
 	if (href_list["make"])
 		if (src.get_amount() < 1) qdel(src) //Never should happen


### PR DESCRIPTION
Fixes stack using by checking holding item for livings and checking active held item for cyborgs.

Fixes #20521
