### PR TITLE
Station Charter now keeps the server name in the game's window name after renaming the station

### DIFF
--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -80,10 +80,13 @@
 	response_timer_id = null
 
 /obj/item/station_charter/proc/rename_station(designation, mob/user)
-	world.name = designation
+	if(config && config.server_name)
+		world.name = "[config.server_name]: [designation]"
+	else
+		world.name = designation
 	station_name = designation
-	minor_announce("[user.real_name] has designated your station as [world.name]", "Captain's Charter", 0)
-	log_game("[key_name(user)] has renamed the station as [world.name]")
+	minor_announce("[user.real_name] has designated your station as [station_name]", "Captain's Charter", 0)
+	log_game("[key_name(user)] has renamed the station as [station_name].")
 
 	name = "station charter for [world.name]"
 	desc = "An official document entrusting the governance of \


### PR DESCRIPTION
This only changes how the name is displayed in the game's window. If you rename the station it will only show up the new name, with this, it will keep the Server name: New name(the way it already is before anyone renames the station).
