### PR TITLE
Adds laptop presets, fixes a few modular computer bugs

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -392,15 +392,16 @@
 			user << "<span class='warning'>This device doesn't have any components installed.</span>"
 			return
 		var/list/component_names = list()
-		for(var/obj/item/weapon/computer_hardware/H in all_components)
+		for(var/h in all_components)
+			var/obj/item/weapon/computer_hardware/H = all_components[h]
 			component_names.Add(H.name)
 
-		var/choice = input(usr, "Which component do you want to uninstall?", "Computer maintenance", null) as null|anything in component_names
+		var/choice = input(user, "Which component do you want to uninstall?", "Computer maintenance", null) as null|anything in component_names
 
 		if(!choice)
 			return
 
-		if(!Adjacent(usr))
+		if(!Adjacent(user))
 			return
 
 		var/obj/item/weapon/computer_hardware/H = find_hardware_by_name(choice)

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -26,7 +26,7 @@
 	// This screen simply lists available programs and user may select them.
 	var/obj/item/weapon/computer_hardware/hard_drive/hard_drive = all_components[MC_HDD]
 	if(!hard_drive || !hard_drive.stored_files || !hard_drive.stored_files.len)
-		physical.visible_message("<span class='danger'>\The [src] beeps three times, it's screen displaying \"DISK ERROR\" warning.</span>")
+		user << "<span class='danger'>\The [src] beeps three times, it's screen displaying a \"DISK ERROR\" warning.</span>"
 		return // No HDD, No HDD files list or no stored files. Something is very broken.
 
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)

--- a/code/modules/modular_computers/computers/item/laptop_presets.dm
+++ b/code/modules/modular_computers/computers/item/laptop_presets.dm
@@ -1,0 +1,23 @@
+/obj/item/device/modular_computer/laptop/preset/New()
+	. = ..()
+	install_component(new /obj/item/weapon/computer_hardware/processor_unit/small)
+	install_component(new /obj/item/weapon/computer_hardware/battery(src, /obj/item/weapon/stock_parts/cell/computer))
+	install_component(new /obj/item/weapon/computer_hardware/hard_drive)
+	install_component(new /obj/item/weapon/computer_hardware/network_card)
+	install_programs()
+
+
+/obj/item/device/modular_computer/laptop/preset/proc/install_programs()
+	return
+
+
+
+
+/obj/item/device/modular_computer/laptop/preset/civillian
+	desc = "A low-end laptop often used for personal recreation."
+
+
+/obj/item/device/modular_computer/laptop/preset/civillian/install_programs()
+	var/obj/item/weapon/computer_hardware/hard_drive/hard_drive = all_components[MC_HDD]
+	hard_drive.store_file(new/datum/computer_file/program/chatclient())
+	hard_drive.store_file(new/datum/computer_file/program/nttransfer())

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -50,11 +50,12 @@
 /obj/machinery/lapvend/proc/fabricate_and_recalc_price(fabricate = 0)
 	total_price = 0
 	if(devtype == 1) 		// Laptop, generally cheaper to make it accessible for most station roles
+		var/obj/item/weapon/computer_hardware/battery/battery_module = null
 		if(fabricate)
 			fabricated_laptop = new /obj/item/device/modular_computer/laptop/buildable(src)
 			fabricated_laptop.install_component(new /obj/item/weapon/computer_hardware/battery)
+			battery_module = fabricated_laptop.all_components[MC_CELL]
 		total_price = 99
-		var/obj/item/weapon/computer_hardware/battery/battery_module = fabricated_laptop.all_components[MC_CELL]
 		switch(dev_cpu)
 			if(1)
 				if(fabricate)
@@ -111,12 +112,13 @@
 
 		return total_price
 	else if(devtype == 2) 	// Tablet, more expensive, not everyone could probably afford this.
+		var/obj/item/weapon/computer_hardware/battery/battery_module = null
 		if(fabricate)
 			fabricated_tablet = new(src)
 			fabricated_tablet.install_component(new /obj/item/weapon/computer_hardware/battery)
 			fabricated_tablet.install_component(new /obj/item/weapon/computer_hardware/processor_unit/small)
+			battery_module = fabricated_tablet.all_components[MC_CELL]
 		total_price = 199
-		var/obj/item/weapon/computer_hardware/battery/battery_module = fabricated_tablet.all_components[MC_CELL]
 		switch(dev_battery)
 			if(1) // Basic(300C)
 				if(fabricate)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1560,6 +1560,7 @@
 #include "code\modules\modular_computers\computers\item\computer_power.dm"
 #include "code\modules\modular_computers\computers\item\computer_ui.dm"
 #include "code\modules\modular_computers\computers\item\laptop.dm"
+#include "code\modules\modular_computers\computers\item\laptop_presets.dm"
 #include "code\modules\modular_computers\computers\item\processor.dm"
 #include "code\modules\modular_computers\computers\item\tablet.dm"
 #include "code\modules\modular_computers\computers\item\tablet_presets.dm"


### PR DESCRIPTION
Laptop presets were requested for mapping purposes

Fixes a few bugs related to computer component lists.
Makes the no disk error message actually show for tablets.

:cl:
fix: fixed removing modular computer components
/:cl:
