### PR TITLE
Removed chaplain soulstone from metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -84552,7 +84552,6 @@
 	pixel_x = 4
 	},
 /obj/item/organ/heart,
-/obj/item/device/soulstone/anybody/chaplain,
 /obj/effect/landmark{
 	name = "revenantspawn"
 	},


### PR DESCRIPTION
Requested by @lzimann 
Rip the ling destroyer

:cl:
del: The metastation chaplain soulstone has been removed
/:cl:
