### PR TITLE
Makes space drift more on time.

### DIFF
--- a/code/controllers/subsystem/spacedrift.dm
+++ b/code/controllers/subsystem/spacedrift.dm
@@ -2,9 +2,9 @@ var/datum/subsystem/spacedrift/SSspacedrift
 
 /datum/subsystem/spacedrift
 	name = "Space Drift"
-	priority = 40
+	priority = 30
 	wait = 5
-	flags = SS_NO_INIT|SS_BACKGROUND
+	flags = SS_NO_INIT|SS_KEEP_TIMING
 
 	var/list/currentrun = list()
 	var/list/processing = list()


### PR DESCRIPTION
:cl:
tweak: tweaked the settings of the space drift subsystem to be less effected by anti-lag slowdowns
/:cl:

Removing SS_background will keep it from getting shoved out of the way by other subsystems.
Adding keeptiming will ensure that it is fired early next fire if it gets delayed due to lag,
Lowering priority will give it less time to run per tick to compensate (It almost never needs much anyways)

fixes #21024
