### PR TITLE
Makes changeling assign the special_role in pre_setup()

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -70,13 +70,14 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 			var/datum/mind/changeling = pick(antag_candidates)
 			antag_candidates -= changeling
 			changelings += changeling
+			changeling.special_role = "Changeling"
 			changeling.restricted_roles = restricted_jobs
 		return 1
 	else
 		return 0
 
 /datum/game_mode/changeling/post_setup()
-	modePlayer += changelings
+
 	//Decide if it's ok for the lings to have a team objective
 	//And then set it up to be handed out in forge_changeling_objectives
 	var/list/team_objectives = subtypesof(/datum/objective/changeling_team_objective)
@@ -93,10 +94,10 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	for(var/datum/mind/changeling in changelings)
 		log_game("[changeling.key] (ckey) has been selected as a changeling")
 		changeling.current.make_changeling()
-		changeling.special_role = "Changeling"
 		forge_changeling_objectives(changeling)
 		greet_changeling(changeling)
 		ticker.mode.update_changeling_icons_added(changeling)
+	modePlayer += changelings
 	..()
 
 /datum/game_mode/changeling/make_antag_chance(mob/living/carbon/human/character) //Assigns changeling to latejoiners

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -45,6 +45,7 @@
 			var/datum/mind/changeling = pick(possible_changelings)
 			antag_candidates -= changeling
 			possible_changelings -= changeling
+			changeling.special_role = "Changeling"
 			changelings += changeling
 			changeling.restricted_roles = restricted_jobs
 		return ..()
@@ -55,7 +56,6 @@
 	modePlayer += changelings
 	for(var/datum/mind/changeling in changelings)
 		changeling.current.make_changeling()
-		changeling.special_role = "Changeling"
 		forge_changeling_objectives(changeling)
 		greet_changeling(changeling)
 		ticker.mode.update_changeling_icons_added(changeling)

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -69,7 +69,7 @@
 		return
 	if(ticker.mode.changelings.len <= (changelingcap - 2) || prob(100 / (config.changeling_scaling_coeff * 4)))
 		if(ROLE_CHANGELING in character.client.prefs.be_special)
-			if(!jobban_isbanned(character.client, ROLE_CHANGELING) && !jobban_isbanned(character.client, "Syndicate"))
+			if(!jobban_isbanned(character, ROLE_CHANGELING) && !jobban_isbanned(character, "Syndicate"))
 				if(age_check(character.client))
 					if(!(character.job in restricted_jobs))
 						character.mind.make_Changling()


### PR DESCRIPTION
Might fix what's causing #20325 (wording this so github doesn't auto close it)

This should at least prevent people getting sent back to the lobby if they are a ling.

also moves adding lings to mode_player list until the end of post setup
