### PR TITLE
Virus symptoms' statistics now get a random modifier when generated.

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -65,8 +65,7 @@ var/list/advance_cures = 	list(
 			symptoms = GenerateSymptoms(0, 2)
 		else
 			for(var/datum/symptom/S in D.symptoms)
-				symptoms += new S.type
-
+				symptoms += S
 	Refresh()
 	..(process, D)
 	return
@@ -126,7 +125,7 @@ var/list/advance_cures = 	list(
 	if(!(src.IsSame(D)))
 		var/list/possible_symptoms = shuffle(D.symptoms)
 		for(var/datum/symptom/S in possible_symptoms)
-			AddSymptom(new S.type)
+			AddSymptom(S)
 
 /datum/disease/advance/proc/HasSymptom(datum/symptom/S)
 	for(var/datum/symptom/symp in symptoms)
@@ -269,8 +268,13 @@ var/list/advance_cures = 	list(
 
 // Randomly generate a symptom, has a chance to lose or gain a symptom.
 /datum/disease/advance/proc/Evolve(min_level, max_level)
-	var/s = safepick(GenerateSymptoms(min_level, max_level, 1))
+	var/datum/symptom/s = safepick(GenerateSymptoms(min_level, max_level, 1))
 	if(s)
+		//Randomize Symptom Stats
+		s.stealth += rand(-1,1)
+		s.resistance += rand(-1,1)
+		s.stage_speed += rand(-2,2)
+		s.transmittable += rand(-2,2)
 		AddSymptom(s)
 		Refresh(1)
 	return

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -28,6 +28,14 @@ var/global/const/SYMPTOM_ACTIVATION_PROB = 5
 			return
 	CRASH("We couldn't assign an ID!")
 
+/datum/symptom/proc/Copy()
+	var/datum/symptom/C = new src.type
+	C.stealth = src.stealth
+	C.resistance = src.resistance
+	C.stage_speed = src.stage_speed
+	C.transmittable = src.transmittable
+	return C
+
 
 // Called when processing of the advance disease, which holds this symptom, starts.
 /datum/symptom/proc/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -22,12 +22,6 @@ var/global/const/SYMPTOM_ACTIVATION_PROB = 5
 /datum/symptom/New()
 	var/list/S = list_symptoms
 
-	//Randomize Symptom Stats
-	stealth += rand(-1,1)
-	resistance += rand(-1,1)
-	stage_speed += rand(-2,2)
-	transmittable += rand(-2,2)
-
 	for(var/i = 1; i <= S.len; i++)
 		if(src.type == S[i])
 			id = "[i]"

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -21,11 +21,19 @@ var/global/const/SYMPTOM_ACTIVATION_PROB = 5
 
 /datum/symptom/New()
 	var/list/S = list_symptoms
+
+	//Randomize Symptom Stats
+	stealth += rand(-1,1)
+	resistance += rand(-1,1)
+	stage_speed += rand(-2,2)
+	transmittable += rand(-2,2)
+
 	for(var/i = 1; i <= S.len; i++)
 		if(src.type == S[i])
 			id = "[i]"
 			return
 	CRASH("We couldn't assign an ID!")
+
 
 // Called when processing of the advance disease, which holds this symptom, starts.
 /datum/symptom/proc/Start(datum/disease/advance/A)

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -227,9 +227,12 @@
 							dat += "<b>Description: </b> [(D.desc||"none")]<BR>"
 							dat += "<b>Spread:</b> [(D.spread_text||"none")]<BR>"
 							dat += "<b>Possible cure:</b> [(D.cure_text||"none")]<BR><BR>"
-
 							if(istype(D, /datum/disease/advance))
 								var/datum/disease/advance/A = D
+								dat += "<b>Stealth:</b> [(A.totalStealth())]<BR>"
+								dat += "<b>Resistance:</b> [(A.totalResistance())]<BR>"
+								dat += "<b>Stage Speed:</b> [(A.totalStageSpeed())]<BR>"
+								dat += "<b>Transmission:</b> [(A.totalTransmittable())]<BR><BR>"
 								dat += "<b>Symptoms:</b> "
 								var/english_symptoms = list()
 								for(var/datum/symptom/S in A.symptoms)


### PR DESCRIPTION
:cl: XDTM
add: Virus symptoms' statistics now get a random modifier when generated.
add: PanD.E.M.I.C. now tells you the total stats of viruses inside.
/:cl:

Stealth and Resistance can get from -1 to +1, and Stage Speed and Transmittability from -2 to +2. If you want a different stat set, you'll have to find that symptom again.
This could allow some more freedom in creating viruses, moving away from pre-determined virus "recipes".
