### PR TITLE
Station Charter now keeps the server name in the game's window name after renaming the station

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -19,7 +19,7 @@
 
 /datum/game_mode/abduction/announce()
 	world << "<B>The current game mode is - Abduction!</B>"
-	world << "There are alien <b>abductors</b> sent to [world.name] to perform nefarious experiments!"
+	world << "There are alien <b>abductors</b> sent to [station_name()] to perform nefarious experiments!"
 	world << "<b>Abductors</b> - kidnap the crew and replace their organs with experimental ones."
 	world << "<b>Crew</b> - don't get abducted and stop the abductors."
 

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -80,10 +80,13 @@
 	response_timer_id = null
 
 /obj/item/station_charter/proc/rename_station(designation, mob/user)
-	world.name = designation
+	if(config && config.server_name)
+		world.name = "[config.server_name]: [designation]"
+	else
+		world.name = designation
 	station_name = designation
-	minor_announce("[user.real_name] has designated your station as [world.name]", "Captain's Charter", 0)
-	log_game("[key_name(user)] has renamed the station as [world.name]")
+	minor_announce("[user.real_name] has designated your station as [station_name]", "Captain's Charter", 0)
+	log_game("[key_name(user)] has renamed the station as [station_name].")
 
 	name = "station charter for [world.name]"
 	desc = "An official document entrusting the governance of \

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -85,12 +85,12 @@
 	else
 		world.name = designation
 	station_name = designation
-	minor_announce("[user.real_name] has designated your station as [station_name]", "Captain's Charter", 0)
-	log_game("[key_name(user)] has renamed the station as [station_name].")
+	minor_announce("[user.real_name] has designated your station as [station_name()]", "Captain's Charter", 0)
+	log_game("[key_name(user)] has renamed the station as [station_name()].")
 
-	name = "station charter for [world.name]"
+	name = "station charter for [station_name()]"
 	desc = "An official document entrusting the governance of \
-		[world.name] and surrounding space to Captain [user]."
+		[station_name()] and surrounding space to Captain [user]."
 
 	if(!unlimited_uses)
 		used = TRUE

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -64,7 +64,7 @@
 		if(ANTIDOTE_NEEDED)
 			SSshuttle.centcom_message += "Virus samples incoming."
 		if(PIZZA_DELIVERY)
-			SSshuttle.centcom_message += "Pizza delivery for [world.name]"
+			SSshuttle.centcom_message += "Pizza delivery for [station_name()]"
 
 /datum/round_event/shuttle_loan/tick()
 	if(dispatched)

--- a/code/modules/stock_market/computer.dm
+++ b/code/modules/stock_market/computer.dm
@@ -10,7 +10,7 @@
 
 /obj/machinery/computer/stockexchange/New()
 	..()
-	logged_in = "[world.name] Cargo Department"
+	logged_in = "[station_name()] Cargo Department"
 
 /obj/machinery/computer/stockexchange/proc/balance()
 	if (!logged_in)


### PR DESCRIPTION
This only changes how the name is displayed in the game's window. If you rename the station it will only show up the new name, with this, it will keep the Server name: New name(the way it already is before anyone renames the station).

same as #20994 
