### PR TITLE
Add logging for spiderlings spawned by botany + refactor spawning code

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -330,6 +330,15 @@ Proc for attack log creation, because really why not
 		if(H.dna && istype(H.dna.species, species_datum))
 			. = TRUE
 
+/proc/spawn_atom_to_turf(spawn_type, target, amount, admin_spawn=FALSE)
+	var/turf/T = get_turf(target)
+	if(!T)
+		throw EXCEPTION("attempt to spawn atom type: [spawn_type] in nullspace")
+
+	for(var/j in 1 to amount)
+		var/atom/X = new spawn_type(T)
+		X.admin_spawned = admin_spawn
+	
 /proc/spawn_and_random_walk(spawn_type, target, amount, walk_chance=100, max_walk=3, always_max_walk=FALSE, admin_spawn=FALSE)
 	var/turf/T = get_turf(target)
 	var/step_count = 0

--- a/code/game/gamemodes/changeling/powers/spiders.dm
+++ b/code/game/gamemodes/changeling/powers/spiders.dm
@@ -8,9 +8,6 @@
 
 //Makes some spiderlings. Good for setting traps and causing general trouble.
 /obj/effect/proc_holder/changeling/spiders/sting_action(mob/user)
-	for(var/i=0, i<2, i++)
-		var/obj/structure/spider/spiderling/S = new(user.loc)
-		S.grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/hunter
-
+	spawn_atom_to_turf(/obj/structure/spider/spiderling/hunter, user, 2, FALSE)
 	feedback_add_details("changeling_powers","SI")
 	return 1

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -95,6 +95,12 @@
 	pixel_y = rand(6,-6)
 	START_PROCESSING(SSobj, src)
 
+/obj/structure/spider/spiderling/hunter
+	grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/hunter
+
+/obj/structure/spider/spiderling/nurse
+	grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/nurse
+
 /obj/structure/spider/spiderling/Bump(atom/user)
 	if(istype(user, /obj/structure/table))
 		src.loc = user.loc

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -29,8 +29,9 @@
 
 	while((spawncount >= 1) && vents.len)
 		var/obj/vent = pick(vents)
-		var/obj/structure/spider/spiderling/S = new(vent.loc)
+		var/spawn_type = /obj/structure/spider/spiderling
 		if(prob(66))
-			S.grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/nurse
+			spawn_type = /obj/structure/spider/spiderling/nurse
+		spawn_atom_to_turf(spawn_type, vent, 1, FALSE)
 		vents -= vent
 		spawncount--

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -440,16 +440,17 @@
 		dead = 1
 
 
-/obj/machinery/hydroponics/proc/mutatepest()
-	if(pestlevel > 5)
-		visible_message("<span class='warning'>The pests seem to behave oddly...</span>")
-		for(var/i=0, i<3, i++)
-			var/obj/structure/spider/spiderling/S = new(src.loc)
-			S.grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/hunter
-	else
-		usr << "<span class='warning'>The pests seem to behave oddly, but quickly settle down...</span>"
 
-/obj/machinery/hydroponics/proc/applyChemicals(datum/reagents/S)
+/obj/machinery/hydroponics/proc/mutatepest(mob/user)
+	if(pestlevel > 5)
+		message_admins("[ADMIN_LOOKUPFLW(user)] caused spiderling pests to spawn in a hydro tray")
+		log_game("[key_name(user)] caused spiderling pests to spawn in a hydro tray")
+		visible_message("<span class='warning'>The pests seem to behave oddly...</span>")
+		spawn_atom_to_turf(/obj/structure/spider/spiderling/hunter, src, 3, FALSE)
+	else
+		user << "<span class='warning'>The pests seem to behave oddly, but quickly settle down...</span>"
+
+/obj/machinery/hydroponics/proc/applyChemicals(datum/reagents/S, mob/user)
 	if(myseed)
 		myseed.on_chem_reaction(S) //In case seeds have some special interactions with special chems, currently only used by vines
 
@@ -458,7 +459,7 @@
 		switch(rand(100))
 			if(91 to 100)
 				adjustHealth(-10)
-				usr << "<span class='warning'>The plant shrivels and burns.</span>"
+				user << "<span class='warning'>The plant shrivels and burns.</span>"
 			if(81 to 90)
 				mutatespecie()
 			if(66 to 80)
@@ -466,13 +467,13 @@
 			if(41 to 65)
 				mutate()
 			if(21 to 41)
-				usr << "<span class='notice'>The plants don't seem to react...</span>"
+				user << "<span class='notice'>The plants don't seem to react...</span>"
 			if(11 to 20)
 				mutateweed()
 			if(1 to 10)
-				mutatepest()
+				mutatepest(user)
 			else
-				usr << "<span class='notice'>Nothing happens...</span>"
+				user << "<span class='notice'>Nothing happens...</span>"
 
 	// 2 or 1 units is enough to change the yield and other stats.// Can change the yield and other stats, but requires more than mutagen
 	else if(S.has_reagent("mutagen", 2) || S.has_reagent("radium", 5) || S.has_reagent("uranium", 5))
@@ -668,9 +669,9 @@
 			if(33	to 65)
 				mutateweed()
 			if(1   to 32)
-				mutatepest()
+				mutatepest(user)
 			else
-				usr << "<span class='warning'>Nothing happens...</span>"
+				user << "<span class='warning'>Nothing happens...</span>"
 
 /obj/machinery/hydroponics/attackby(obj/item/O, mob/user, params)
 	//Called when mob user "attacks" it with object O
@@ -755,7 +756,7 @@
 			if(istype(reagent_source, /obj/item/weapon/reagent_containers/food/snacks) || istype(reagent_source, /obj/item/weapon/reagent_containers/pill))
 				qdel(reagent_source)
 
-			H.applyChemicals(S)
+			H.applyChemicals(S, user)
 
 			S.clear_reagents()
 			qdel(S)


### PR DESCRIPTION
Adds a log with an admin message for when spiderlings are spawned by a
botany user adding mutagen or adminordrazine, it also adds a helper
method for spawning atoms to handle a little bit of the copypaste where it can
