### PR TITLE
[WIP]Breathe now properly uses the species defined safe gas values

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -71,11 +71,11 @@
 
 	//Breathing!
 	var/safe_oxygen_min = 16 // Minimum safe partial pressure of O2, in kPa
-	var/safe_oxygen_max = 0
+	var/safe_oxygen_max = 100	//TODO: make internals an air mix so we can set this properly to 80
 	var/safe_co2_min = 0
 	var/safe_co2_max = 10 // Yes it's an arbitrary value who cares?
 	var/safe_toxins_min = 0
-	var/safe_toxins_max = 0.05
+	var/safe_toxins_max = 0.05	//Don't set this to zero, or you'll get div by zero errors
 	var/SA_para_min = 1 //Sleeping agent
 	var/SA_sleep_min = 5 //Sleeping agent
 	var/BZ_trip_balls_min = 1 //BZ gas.

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -733,7 +733,7 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 	specflags = list(NOBLOOD,RADIMMUNE,NOTRANSSTING,VIRUSIMMUNE,NOHUNGER)
 	safe_oxygen_min = 0 //We don't breath this
 	safe_toxins_min = 16 //We breath THIS!
-	safe_toxins_max = 0
+	safe_toxins_max = 100
 	dangerous_existence = 1 //So so much
 	blacklisted = 1 //See above
 	burnmod = 2

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -782,12 +782,6 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 	say_mod = "beep boops" //inherited from a user's real species
 	sexes = 0
 	specflags = list(NOTRANSSTING,NOBREATH,VIRUSIMMUNE,NODISMEMBER,NOHUNGER) //all of these + whatever we inherit from the real species
-	safe_oxygen_min = 0
-	safe_toxins_min = 0
-	safe_toxins_max = 0
-	safe_co2_max = 0
-	SA_para_min = 0
-	SA_sleep_min = 0
 	dangerous_existence = 1
 	blacklisted = 1
 	meat = null
@@ -906,12 +900,6 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 	id = "android"
 	say_mod = "states"
 	specflags = list(NOBREATH,RESISTTEMP,NOBLOOD,VIRUSIMMUNE,PIERCEIMMUNE,NOHUNGER,EASYLIMBATTACHMENT)
-	safe_oxygen_min = 0
-	safe_toxins_min = 0
-	safe_toxins_max = 0
-	safe_co2_max = 0
-	SA_para_min = 0
-	SA_sleep_min = 0
 	meat = null
 	damage_overlay_type = "synth"
 	limbs_id = "synth"

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -149,8 +149,8 @@
 			adjustOxyLoss(min(5*ratio, 3))
 			oxygen_used = breath_gases["o2"][MOLES]*ratio
 		else if(O2_partialpressure > safe_oxygen_max)
-			//we burn when breathing too much oxy
-			adjustFireLoss(3)
+			//oxygen poisoning
+			adjustToxLoss(1)
 		else
 			adjustOxyLoss(3)
 		failed_last_breath = 1


### PR DESCRIPTION
Fixes #9369 maybe other things too.

:cl: Cyberboss
add: Species can now properly set safe min/max concentrations of breathable gases
tweak: Atmos alarms will now alarm when the gases are outside the human acceptable range
fix: Plasmamen now take toxic damage when breathing oxygen
/:cl:

TODO: The atmos alarm change
