### PR TITLE
[WIP]Makes all oxygen internals use air mix. Reduces safe oxygen concentration ceiling to 80%

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -4,7 +4,7 @@
  *		Anesthetic
  *		Air* Removed, airmix is in oxytanks now
  *		Plasma
- *		Emergency Air
+ *		Emergency Oxygen
  */
 
 /*

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -2,9 +2,9 @@
  * Contains:
  *		Oxygen
  *		Anesthetic
- *		Air
+ *		Air* Removed, airmix is in oxytanks now
  *		Plasma
- *		Emergency Oxygen
+ *		Emergency Air
  */
 
 /*
@@ -21,8 +21,9 @@
 
 /obj/item/weapon/tank/internals/oxygen/New()
 	..()
-	air_contents.assert_gas("o2")
-	air_contents.gases["o2"][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
+	air_contents.assert_gas("o2", "n2")
+	air_contents.gases["o2"][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
+	air_contents.gases["n2"][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
 	return
 
 
@@ -53,24 +54,6 @@
 	air_contents.gases["o2"][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
 	air_contents.gases["n2o"][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
 	return
-
-/*
- * Air
- */
-/obj/item/weapon/tank/internals/air
-	name = "air tank"
-	desc = "Mixed anyone?"
-	icon_state = "oxygen"
-	force = 10
-	dog_fashion = /datum/dog_fashion/back
-
-/obj/item/weapon/tank/internals/air/New()
-	..()
-	air_contents.assert_gases("o2","n2")
-	air_contents.gases["o2"][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
-	air_contents.gases["n2"][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
-	return
-
 
 /*
  * Plasma
@@ -166,8 +149,9 @@
 
 /obj/item/weapon/tank/internals/emergency_oxygen/New()
 	..()
-	air_contents.assert_gas("o2")
-	air_contents.gases["o2"][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
+	air_contents.assert_gas("o2", "n2")
+	air_contents.gases["o2"][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
+	air_contents.gases["n2"][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
 	return
 
 /obj/item/weapon/tank/internals/emergency_oxygen/engi

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -16,7 +16,7 @@
 	new /obj/item/weapon/cartridge/rd(src)
 	new /obj/item/clothing/gloves/color/latex(src)
 	new /obj/item/device/radio/headset/heads/rd(src)
-	new /obj/item/weapon/tank/internals/air(src)
+	new /obj/item/weapon/tank/internals/oxygen(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/device/megaphone/command(src)
 	new /obj/item/clothing/suit/armor/reactive/teleport(src)

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -36,7 +36,7 @@
 			new /obj/item/clothing/mask/breath(src)
 
 		if ("tank")
-			new /obj/item/weapon/tank/internals/air(src)
+			new /obj/item/weapon/tank/internals/oxygen(src)
 			new /obj/item/clothing/mask/breath(src)
 
 		if ("both")

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -44,11 +44,11 @@ datum/supply_pack
 					/mob/living/simple_animal/bot/floorbot,
 					/mob/living/simple_animal/bot/medbot,
 					/mob/living/simple_animal/bot/medbot,
-					/obj/item/weapon/tank/internals/air,
-					/obj/item/weapon/tank/internals/air,
-					/obj/item/weapon/tank/internals/air,
-					/obj/item/weapon/tank/internals/air,
-					/obj/item/weapon/tank/internals/air,
+					/obj/item/weapon/tank/internals/oxygen,
+					/obj/item/weapon/tank/internals/oxygen,
+					/obj/item/weapon/tank/internals/oxygen,
+					/obj/item/weapon/tank/internals/oxygen,
+					/obj/item/weapon/tank/internals/oxygen,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
@@ -69,9 +69,9 @@ datum/supply_pack
 					/obj/item/weapon/tank/internals/emergency_oxygen,
 					/obj/item/weapon/tank/internals/emergency_oxygen,
 					/obj/item/weapon/tank/internals/emergency_oxygen,
-					/obj/item/weapon/tank/internals/air,
-					/obj/item/weapon/tank/internals/air,
-					/obj/item/weapon/tank/internals/air)
+					/obj/item/weapon/tank/internals/oxygen,
+					/obj/item/weapon/tank/internals/oxygen,
+					/obj/item/weapon/tank/internals/oxygen)
 	crate_name = "internals crate"
 	crate_type = /obj/structure/closet/crate/internals
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -71,7 +71,7 @@
 
 	//Breathing!
 	var/safe_oxygen_min = 16 // Minimum safe partial pressure of O2, in kPa
-	var/safe_oxygen_max = 0
+	var/safe_oxygen_max = 80 // oxygen poisoning is real shit
 	var/safe_co2_min = 0
 	var/safe_co2_max = 10 // Yes it's an arbitrary value who cares?
 	var/safe_toxins_min = 0


### PR DESCRIPTION
Requires #21049 for the damage to function properly

:cl: Cyberboss
tweak: New NT research has discovered humans take burn damage when breathing pure oxygen
tweak: As a result all provided oxygen internals now contain air mix
tweak: Various canisters of oxygen have been replaced with air canisters on our stations as well
/:cl:

TODO:
Air alarms
Update refill cans in maps
-Engineering
-Mining EVA
Convert some other cans to air
-Cyro
Ensure jetpacks won't break
