### PR TITLE
Input-based teleportation paper no longer allows you to abuse the delay in inputting a location

### DIFF
--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -147,7 +147,7 @@
 
 	var/input_rune_key = input(user, "Choose a rune to teleport to.", "Rune to Teleport to") as null|anything in potential_runes //we know what key they picked
 	var/obj/effect/rune/teleport/actual_selected_rune = potential_runes[input_rune_key] //what rune does that key correspond to?
-	if(!src || qdeleted(src) || !user || src != user.get_active_held_item() || user.incapacitated() || !actual_selected_rune)
+	if(!src || qdeleted(src) || !user || !user.is_holding(src) || user.incapacitated() || !actual_selected_rune)
 		return ..(user, 0)
 	var/turf/target = get_turf(actual_selected_rune)
 	if(is_blocked_turf(target))

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -147,7 +147,7 @@
 
 	var/input_rune_key = input(user, "Choose a rune to teleport to.", "Rune to Teleport to") as null|anything in potential_runes //we know what key they picked
 	var/obj/effect/rune/teleport/actual_selected_rune = potential_runes[input_rune_key] //what rune does that key correspond to?
-	if(!actual_selected_rune)
+	if(!src || qdeleted(src) || !user || src != user.get_active_held_item() || user.incapacitated() || !actual_selected_rune)
 		return ..(user, 0)
 	var/turf/target = get_turf(actual_selected_rune)
 	if(is_blocked_turf(target))

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -40,7 +40,7 @@
 	if(H == src.loc || (in_range(src, H) && isturf(loc)))
 		H.set_machine(src)
 		if (href_list["spell_teleport"])
-			if (src.uses >= 1)
+			if(uses)
 				teleportscroll(H)
 	if(H)
 		attack_self(H)
@@ -51,14 +51,9 @@
 	var/A
 
 	A = input(user, "Area to jump to", "BOOYEA", A) as null|anything in teleportlocs
-	if(!A)
+	if(!src || qdeleted(src) || !user || src != user.get_active_held_item() || user.incapacitated() || !A || !uses)
 		return
 	var/area/thearea = teleportlocs[A]
-
-	if (!user || user.stat || user.restrained() || uses <= 0)
-		return
-	if(!(user == loc || (in_range(src, user) && isturf(loc))))
-		return
 
 	var/datum/effect_system/smoke_spread/smoke = new
 	smoke.set_up(2, user.loc)
@@ -66,17 +61,11 @@
 	smoke.start()
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(thearea.type))
-		if(!T.density)
-			var/clear = 1
-			for(var/obj/O in T)
-				if(O.density)
-					clear = 0
-					break
-			if(clear)
-				L+=T
+		if(!is_blocked_turf(T))
+			L += T
 
 	if(!L.len)
-		user <<"The spell matrix was unable to locate a suitable teleport destination for an unknown reason. Sorry."
+		user << "The spell matrix was unable to locate a suitable teleport destination for an unknown reason. Sorry."
 		return
 
 	if(user && user.buckled)
@@ -98,4 +87,4 @@
 		user.loc = pick(L)
 
 	smoke.start()
-	src.uses -= 1
+	uses--

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -37,7 +37,7 @@
 	if (!ishuman(usr))
 		return 1
 	var/mob/living/carbon/human/H = usr
-	if(H == src.loc || (in_range(src, H) && isturf(loc)))
+	if(H.is_holding(src))
 		H.set_machine(src)
 		if (href_list["spell_teleport"])
 			if(uses)
@@ -51,7 +51,7 @@
 	var/A
 
 	A = input(user, "Area to jump to", "BOOYEA", A) as null|anything in teleportlocs
-	if(!src || qdeleted(src) || !user || src != user.get_active_held_item() || user.incapacitated() || !A || !uses)
+	if(!src || qdeleted(src) || !user || !user.is_holding(src) || user.incapacitated() || !A || !uses)
 		return
 	var/area/thearea = teleportlocs[A]
 

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -71,20 +71,7 @@
 	if(user && user.buckled)
 		user.buckled.unbuckle_mob(user, force=1)
 
-	var/list/tempL = L.Copy()
-	var/attempt = null
-	var/success = 0
-	while(tempL.len)
-		attempt = pick(tempL)
-		user.Move(attempt)
-		if(get_turf(user) == attempt)
-			success = 1
-			break
-		else
-			tempL.Remove(attempt)
-
-	if(!success)
-		user.loc = pick(L)
+	user.forceMove(pick(L))
 
 	smoke.start()
 	uses--


### PR DESCRIPTION
:cl: Joan
bugfix: You need to be holding teleport talismans and wizard teleport scrolls in your hands when you finish the input, and cannot simply open the input and finish it whenever you get stunned.
/:cl:

Very funny. I don't want to see you doing it again.
