### PR TITLE
Makes action button for a dental implant include the pill's name

### DIFF
--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -20,7 +20,7 @@
 	tool.loc = target
 
 	var/datum/action/item_action/hands_free/activate_pill/P = new
-	P.button_icon_state = tool.icon_state
+	P.button.name = "Activate [tool.name]"
 	P.target = tool
 	P.Grant(target)
 
@@ -33,7 +33,7 @@
 /datum/action/item_action/hands_free/activate_pill/Trigger()
 	if(!..())
 		return 0
-	owner << "<span class='caution'>You grit your teeth and burst the implanted [target]!</span>"
+	owner << "<span class='caution'>You grit your teeth and burst the implanted [target.name]!</span>"
 	add_logs(owner, null, "swallowed an implanted pill", target)
 	if(target.reagents.total_volume)
 		target.reagents.reaction(owner, INGEST)


### PR DESCRIPTION
:cl: Swindly
add: The action button for a dental implant now includes the name of the pill
fix: The pill activation button now properly displays the pill's icon
/:cl:

The name of the button to activate an implanted pill is changed from "Activate Pill" to "Activate [pill name]". Now you can have a stim pill and a suicide pill implanted without needing to worry about forgetting which button to press.

Also this is a reminder that dental implants exist.
