### PR TITLE
Snpc fixes and improvements

### DIFF
--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -72,6 +72,8 @@
 	var/forceProcess = 0
 	var/processTime = 8
 	var/lastProc = 0
+	var/walkdebug = 0	//causes sparks in our path target. used for debugging
+	var/debugexamine = 0 //If we show debug info in our examine
 	var/showexaminetext = 1	//If we show our telltale examine text
 
 	var/list/knownStrings = list()
@@ -374,8 +376,8 @@
 			var/datum/objective_item/steal/S = new A
 			traitorTarget = locate(S.targetitem) in world
 		if(SNPC_MARTYR) // MY LIFE FOR SPESZUL
-			var/targetType = pick(/obj/structure/particle_accelerator,/obj/machinery/gravity_generator/main,/obj/machinery/power/smes)
-			traitorTarget = locate(targetType) in world
+			var/targetType = pick(/obj/machinery/gravity_generator/main/station,/obj/machinery/power/smes/engineering,/obj/machinery/telecomms/hub)
+			traitorTarget = locate(targetType) in machines
 		if(SNPC_PSYCHO) // YOU'RE LIKE A FLESH BICYLE AND I WANT TO DISMANTLE YOU
 			traitorTarget = null
 
@@ -758,8 +760,8 @@
 	spawn(0)
 		call(src,Proc)(src)
 
-/mob/living/carbon/human/interactive/proc/tryWalk(turf/inTarget)
-	if(restrictedJob) // we're a job that has to stay in our home
+/mob/living/carbon/human/interactive/proc/tryWalk(turf/inTarget, override = 0)
+	if(restrictedJob && !override) // we're a job that has to stay in our home
 		if(!(get_turf(inTarget) in get_area_turfs(job2area(myjob))))
 			TARGET = null
 			return
@@ -800,6 +802,13 @@
 	set background = 1
 	if(!target)
 		return 0
+
+	if(walkdebug)
+		var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread
+		spark_system.set_up(5, 0, target)
+		spark_system.attach(target)
+		spark_system.start()
+
 
 	if(myPath.len <= 0)
 		myPath = get_path_to(src, get_turf(target), /turf/proc/Distance, MAX_RANGE_FIND + 1, 250,1, id=Path_ID)
@@ -1070,27 +1079,27 @@
 					if(change)
 						HP.attackby(internalBeaker,src)
 
-	var/obj/item/weapon/reagent_containers/food/snacks/grown/GF = locate(/obj/item/weapon/reagent_containers/food/snacks/grown) in view(12,src)
-	if(GF)
-		if(!Adjacent(GF))
-			tryWalk(get_turf(GF))
-		else
-			GF.attackby(internalBag,src)
+		var/obj/item/weapon/reagent_containers/food/snacks/grown/GF = locate(/obj/item/weapon/reagent_containers/food/snacks/grown) in view(12,src)
+		if(GF)
+			if(!Adjacent(GF))
+				tryWalk(get_turf(GF))
+			else
+				GF.attackby(internalBag,src)
 
-	if(internalBag.contents.len > 0)
-		var/obj/machinery/smartfridge/SF = locate(/obj/machinery/smartfridge) in range(12,src)
-		if(!Adjacent(SF))
-			tryWalk(get_turf(SF))
-		else
-			customEmote("[src] [pick("gibbers","drools","slobbers","claps wildly","spits")], upending the [internalBag]'s contents all over the [SF]!")
-			//smartfridges call updateUsrDialog when you call attackby, so we're going to have to cheese-magic-space this
-			for(var/obj/toLoad in internalBag.contents)
-				if(contents.len >= SF.max_n_of_items)
-					break
-				if(SF.accept_check(toLoad))
-					SF.load(toLoad)
-				else
-					qdel(toLoad) // destroy everything we dont need
+		if(internalBag.contents.len > 0)
+			var/obj/machinery/smartfridge/SF = locate(/obj/machinery/smartfridge) in range(12,src)
+			if(!Adjacent(SF))
+				tryWalk(get_turf(SF), 1)
+			else
+				customEmote("[src] [pick("gibbers","drools","slobbers","claps wildly","spits")], upending the [internalBag]'s contents all over the [SF]!")
+				//smartfridges call updateUsrDialog when you call attackby, so we're going to have to cheese-magic-space this
+				for(var/obj/toLoad in internalBag.contents)
+					if(contents.len >= SF.max_n_of_items)
+						break
+					if(SF.accept_check(toLoad))
+						SF.load(toLoad)
+					else
+						qdel(toLoad) // destroy everything we dont need
 
 /mob/living/carbon/human/interactive/proc/bartend(obj)
 	if(shouldModulePass())
@@ -1149,11 +1158,11 @@
 	var/mob/living/carbon/human/clownTarget
 	var/list/clownPriority = list()
 
-	var/obj/item/weapon/reagent_containers/spray/S
-	if(!locate(/obj/item/weapon/reagent_containers/spray) in allContents)
-		new/obj/item/weapon/reagent_containers/spray(src)
-	else
-		S = locate(/obj/item/weapon/reagent_containers/spray) in allContents
+	var/obj/item/weapon/reagent_containers/spray/S = locate(/obj/item/weapon/reagent_containers/spray) in allContents
+
+	if(!S)
+		S = new/obj/item/weapon/reagent_containers/spray(src)
+		S.amount_per_transfer_from_this = 10
 
 	for(var/mob/living/carbon/human/C in rangeCheck)
 		var/pranksNearby = 100
@@ -1263,8 +1272,7 @@
 				sleep(25)
 
 /mob/living/carbon/human/interactive/proc/customEmote(var/text)
-	for(var/mob/living/carbon/M in view(src))
-		M.show_message("<span class='notice'>[text]</span>", 2)
+	visible_message("<span class='notice'>[text]</span>")
 
 // START COOKING MODULE
 /mob/living/carbon/human/interactive/proc/cookingwithmagic(var/obj/item/weapon/reagent_containers/food/snacks/target)
@@ -1321,7 +1329,7 @@
 		if(SF)
 			if(SF.contents.len > 0)
 				if(!Adjacent(SF))
-					tryWalk(get_turf(SF))
+					tryWalk(get_turf(SF),1)
 				else
 					customEmote("[src] [pick("gibbers","drools","slobbers","claps wildly","spits")], grabbing various foodstuffs from [SF] and sticking them in it's mouth!")
 					for(var/obj/item/A in SF.contents)
@@ -1624,4 +1632,12 @@
 	targetInterestShift = 2 // likewise
 	faction += "bot_grey"
 	graytide = 1
+	..()
+
+//Walk softly and carry a big stick
+/mob/living/carbon/human/interactive/robust/New()
+	TRAITS |= TRAIT_FRIENDLY
+	TRAITS |= TRAIT_ROBUST
+	TRAITS |= TRAIT_SMART
+	faction += "bot_power"
 	..()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -278,6 +278,10 @@
 				var/mob/living/carbon/human/interactive/auto = src
 				if(auto.showexaminetext)
 					msg += "<span class='deadsay'>[t_He] [t_is] appears to be some sort of sick automaton, [t_his] eyes are glazed over and [t_his] mouth is slightly agape.</span>\n"
+				if(auto.debugexamine)
+					var/dodebug = auto.doing2string(auto.doing)
+					var/interestdebug = auto.interest2string(auto.interest)
+					msg += "<span class='deadsay'>[t_He] [t_is] appears to be [interestdebug] and [dodebug].</span>\n"
 			else if(!key)
 				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)


### PR DESCRIPTION
Tightens up the snpc martyr targeting to only target reachable things and to use machines list, not world
Fixes botany snpcs not offloading stuff into the smartfridge.
Adds a couple of debug vars to snpcs.

debugexamine will show some text related to the snpc's current status
debugwalk will cause sparks to appear where the snpc is targeting.
