### PR TITLE
Fixes stat check in swap minds event

### DIFF
--- a/code/modules/events/wizard/shuffle.dm
+++ b/code/modules/events/wizard/shuffle.dm
@@ -82,7 +82,7 @@
 	var/list/mobs	 = list()
 
 	for(var/mob/living/carbon/human/H in living_mob_list)
-		if(!H.stat || !H.mind || (H.mind in ticker.mode.wizards) || (H.mind in ticker.mode.apprentices))
+		if(H.stat || !H.mind || (H.mind in ticker.mode.wizards) || (H.mind in ticker.mode.apprentices))
 			continue //the wizard(s) are spared on this one
 		mobs += H
 


### PR DESCRIPTION
Previously, it only swapped people who were in crit

:cl:
fix: The Swap minds wizard event will now function
/:cl:
