### PR TITLE
Runtime fixes (cryo & monitor computer)

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -106,18 +106,18 @@
 			return
 		else if(occupant.stat == DEAD) // We don't bother with dead people.
 			return
+		if(air1.gases.len)
+			if(occupant.bodytemperature < T0C) // Sleepytime. Why? More cryo magic.
+				occupant.Sleeping((occupant.bodytemperature / sleep_factor) * 100)
+				occupant.Paralyse((occupant.bodytemperature / paralyze_factor) * 100)
 
-		if(occupant.bodytemperature < T0C) // Sleepytime. Why? More cryo magic.
-			occupant.Sleeping((occupant.bodytemperature / sleep_factor) * 100)
-			occupant.Paralyse((occupant.bodytemperature / paralyze_factor) * 100)
-
-		if(beaker)
-			if(reagent_transfer == 0) // Magically transfer reagents. Because cryo magic.
-				beaker.reagents.trans_to(occupant, 1, 10 * efficiency) // Transfer reagents, multiplied because cryo magic.
-				beaker.reagents.reaction(occupant, VAPOR)
-				air1.gases["o2"][MOLES] -= 2 / efficiency // Lets use gas for this.
-			if(++reagent_transfer >= 10 * efficiency) // Throttle reagent transfer (higher efficiency will transfer the same amount but consume less from the beaker).
-				reagent_transfer = 0
+			if(beaker)
+				if(reagent_transfer == 0) // Magically transfer reagents. Because cryo magic.
+					beaker.reagents.trans_to(occupant, 1, 10 * efficiency) // Transfer reagents, multiplied because cryo magic.
+					beaker.reagents.reaction(occupant, VAPOR)
+					air1.gases["o2"][MOLES] -= 2 / efficiency // Lets use gas for this.
+				if(++reagent_transfer >= 10 * efficiency) // Throttle reagent transfer (higher efficiency will transfer the same amount but consume less from the beaker).
+					reagent_transfer = 0
 	return 1
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/process_atmos()
@@ -125,7 +125,7 @@
 	if(!on)
 		return
 	var/datum/gas_mixture/air1 = AIR1
-	if(!NODE1 || !AIR1 || air1.gases["o2"][MOLES] < 5) // Turn off if the machine won't work.
+	if(!NODE1 || !AIR1 || !air1.gases.len || air1.gases["o2"][MOLES] < 5) // Turn off if the machine won't work.
 		on = FALSE
 		update_icon()
 		return

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -68,9 +68,14 @@
 	for(var/obj/machinery/power/terminal/term in attached.powernet.nodes)
 		var/obj/machinery/power/apc/A = term.master
 		if(istype(A))
+			var/cell_charge
+			if(!A.cell)
+				cell_charge = 0
+			else
+				cell_charge = A.cell.percent()
 			data["areas"] += list(list(
 				"name" = A.area.name,
-				"charge" = A.cell.percent(),
+				"charge" = cell_charge,
 				"load" = A.lastused_total,
 				"charging" = A.charging,
 				"eqp" = A.equipment,


### PR DESCRIPTION
Fixes a runtime when cryo cells are processed when their gas mixtures has an empty gases list var.

```
runtime error: 
[02:50:58]cannot read from list
[02:50:58]proc name: process atmos (/obj/machinery/atmospherics/components/unary/cryo_cell/process_atmos)
[02:50:58]  source file: cryo.dm,117
[02:50:58]  usr: null
[02:50:58]  src: the cryo cell (/obj/machinery/atmospherics/components/unary/cryo_cell)
[02:50:58]  src.loc: the floor (86,101,1) (/turf/open/floor/plasteel/warning)
[02:50:58]  call stack:
[02:50:58]the cryo cell (/obj/machinery/atmospherics/components/unary/cryo_cell): process atmos(0.5)
[02:50:58]Air (/datum/subsystem/air): process atmos machinery(0)
[02:50:58]Air (/datum/subsystem/air): fire(0)
[02:50:58]Master (/datum/controller/master): RunQueue()
[02:50:58]Master (/datum/controller/master): Loop()
[02:50:58]Master (/datum/controller/master): StartProcessing()
```

Fixes runtime with computer monitor linked to apc having no cell.

```
runtime error: 
[03:11:03]Cannot execute null.percent().
[03:11:03]proc name: ui data (/obj/machinery/computer/monitor/ui_data)
[03:11:03]  source file: monitor.dm,73
[03:11:03]  usr: Clint Samson (/mob/living/carbon/human)
[03:11:03]  src: Engineering Power Monitoring C... (/obj/machinery/computer/monitor)
[03:11:03]  usr.loc: the floor (154,150,1) (/turf/open/floor/plasteel/warning)
[03:11:03]  src.loc: the floor (154,151,1) (/turf/open/floor/plasteel/vault)
[03:11:03]  call stack:
[03:11:03]Engineering Power Monitoring C... (/obj/machinery/computer/monitor): ui data(Clint Samson (/mob/living/carbon/human))
[03:11:03]/datum/tgui (/datum/tgui): open()
[03:11:03]Engineering Power Monitoring C... (/obj/machinery/computer/monitor): ui interact(Clint Samson (/mob/living/carbon/human), "main", /datum/tgui (/datum/tgui), 0, null, /datum/ui_state/default (/datum/ui_state/default))
[03:11:03]Engineering Power Monitoring C... (/obj/machinery/computer/monitor): interact(Clint Samson (/mob/living/carbon/human))
[03:11:03]Engineering Power Monitoring C... (/obj/machinery/computer/monitor): attack hand(Clint Samson (/mob/living/carbon/human), 1, 1)
[03:11:03]Clint Samson (/mob/living/carbon/human): UnarmedAttack(Engineering Power Monitoring C... (/obj/machinery/computer/monitor), 1)
[03:11:03]Clint Samson (/mob/living/carbon/human): ClickOn(Engineering Power Monitoring C... (/obj/machinery/computer/monitor), "icon-x=17;icon-y=14;left=1;scr...")

```
