### PR TITLE
Adjacency check for grab and code move

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -219,6 +219,7 @@
 	Ctrl click
 	For most objects, pull
 */
+
 /mob/proc/CtrlClickOn(atom/A)
 	A.CtrlClick(src)
 	return
@@ -227,6 +228,14 @@
 	var/mob/living/ML = user
 	if(istype(ML))
 		ML.pulled(src)
+
+/mob/living/carbon/human/CtrlClick(mob/user)
+    if(ishuman(user) && Adjacent(user))
+        var/mob/living/carbon/human/H = user
+        H.dna.species.grab(H, src, H.martial_art)
+        H.changeNext_move(CLICK_CD_MELEE)
+        return TRUE
+    return ..()
 
 /*
 	Alt click

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -563,14 +563,6 @@
 		restrained = 0
 	return 1
 
-/mob/living/carbon/human/CtrlClick(mob/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		H.dna.species.grab(H, src, H.martial_art)
-		H.changeNext_move(CLICK_CD_MELEE)
-		return 1
-	return ..()
-
 /mob/living/carbon/human/proc/CQC_help()
 	set name = "Recall Teachings"
 	set desc = "You try to remember some of the basics of CQC."


### PR DESCRIPTION
Fixes human species grabs not checking for adjacency before grabbing
when using the ctrl click hotkey.

Moves the code into the click code and not down in the martial arts code

Fxies #21086 
