### PR TITLE
Replaces Taunting Tirade with a much more useful scripture

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -357,6 +357,7 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 /datum/clockwork_scripture/component_syphon/scripture_effects()
 	var/final_printout = "<span class='brass'>Added the following components to your slab:</span>"
 	var/list/components_gained = list("belligerent_eye" = 0, "vanguard_cogwheel" = 0, "guvax_capacitor" = 0, "replicant_alloy" = 0, "hierophant_ansible" = 0)
+	var/mindless_component = FALSE
 	for(var/mob/living/L in hearers(1, get_turf(invoker)))
 		if(!is_servant_of_ratvar(L) && L.stat == DEAD)
 			var/component_id
@@ -370,16 +371,21 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 					for(var/i in clockwork_component_cache)
 						current_components += clockwork_component_cache[i]
 				amount_to_produce = max(1, rand(3, 6) - round(current_components*0.1))
-			for(var/i in 1 to amount_to_produce)
-				component_id = get_weighted_component_id(slab)
-				slab.stored_components[component_id]++
-				components_gained[component_id]++
-				animation_type = get_component_animation_type(component_id)
-				var/obj/effect/overlay/temp/animation = PoolOrNew(animation_type, get_turf(L))
-				animation.transform = matrix()*0.75
-				animation.pixel_x = rand(-10, 10)
-				animation.pixel_y = rand(-10, -2)
-				animate(animation, pixel_y = animation.pixel_y + 10, alpha = 50, time = 10, easing = EASE_OUT)
+			else if(!mindless_component)
+				mindless_component = TRUE
+			else
+				amount_to_produce = 0
+			if(amount_to_produce)
+				for(var/i in 1 to amount_to_produce)
+					component_id = get_weighted_component_id(slab)
+					slab.stored_components[component_id]++
+					components_gained[component_id]++
+					animation_type = get_component_animation_type(component_id)
+					var/obj/effect/overlay/temp/animation = PoolOrNew(animation_type, get_turf(L))
+					animation.transform = matrix()*0.75
+					animation.pixel_x = rand(-10, 10)
+					animation.pixel_y = rand(-10, -2)
+					animate(animation, pixel_y = animation.pixel_y + 10, alpha = 50, time = 10, easing = EASE_OUT)
 			playsound(L, 'sound/magic/WandODeath.ogg', 50, 1)
 			L.visible_message("<span class='warning'>[L] collapses in on [L.p_them()]self!</span>")
 			for(var/obj/item/W in L)

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -389,7 +389,8 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 			playsound(L, 'sound/magic/WandODeath.ogg', 50, 1)
 			L.visible_message("<span class='warning'>[L] collapses in on [L.p_them()]self!</span>")
 			for(var/obj/item/W in L)
-				L.unEquip(W)
+				if(!L.unEquip(W))
+					qdel(W)
 			L.dust()
 	var/gained = FALSE
 	for(var/i in components_gained)

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -917,7 +917,8 @@
 				L.visible_message("<span class='warning'>[L] collapses in on [L.p_them()]self as [src] flares bright blue!</span>")
 				L << "<span class='inathneq_large'>\"[text2ratvar("Your life will not be wasted.")]\"</span>"
 				for(var/obj/item/W in L)
-					L.unEquip(W)
+					if(!L.unEquip(W))
+						qdel(W)
 				L.dust()
 			else
 				vitality_drained = L.adjustToxLoss(1.5)

--- a/code/game/gamemodes/clock_cult/clock_unsorted.dm
+++ b/code/game/gamemodes/clock_cult/clock_unsorted.dm
@@ -203,6 +203,21 @@
 		else
 			return null
 
+/proc/get_component_animation_type(id)
+	switch(id)
+		if("belligerent_eye")
+			return /obj/effect/overlay/temp/ratvar/component
+		if("vanguard_cogwheel")
+			return /obj/effect/overlay/temp/ratvar/component/cogwheel
+		if("guvax_capacitor")
+			return /obj/effect/overlay/temp/ratvar/component/capacitor
+		if("replicant_alloy")
+			return /obj/effect/overlay/temp/ratvar/component/alloy
+		if("hierophant_ansible")
+			return /obj/effect/overlay/temp/ratvar/component/ansible
+		else
+			return null
+
 /proc/generate_cache_component(specific_component_id) //generates a component in the global component cache, either random based on lowest or a specific component
 	if(specific_component_id)
 		clockwork_component_cache[specific_component_id]++

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -288,6 +288,24 @@
 	pixel_y = -16
 	pixel_x = -16
 
+/obj/effect/overlay/temp/ratvar/component
+	icon = 'icons/obj/clockwork_objects.dmi'
+	icon_state = "belligerent_eye"
+	layer = ABOVE_MOB_LAYER
+	duration = 10
+
+/obj/effect/overlay/temp/ratvar/component/cogwheel
+	icon_state = "vanguard_cogwheel"
+
+/obj/effect/overlay/temp/ratvar/component/capacitor
+	icon_state = "guvax_capacitor"
+
+/obj/effect/overlay/temp/ratvar/component/alloy
+	icon_state = "replicant_alloy"
+
+/obj/effect/overlay/temp/ratvar/component/ansible
+	icon_state = "hierophant_ansible"
+
 /obj/effect/overlay/temp/ratvar/sigil
 	name = "glowing circle"
 	icon = 'icons/effects/clockwork_effects.dmi'


### PR DESCRIPTION
:cl: Joan
rscdel: Removed Taunting Tirade.
rscadd: Added Component Syphon, which transmutes all nearby nonservant corpses into components, which are automatically stored in the invoker's slab. The amount of components produced depends on the number of components in the slab and global cache.
wip: Component Syphon has the same cost as Taunting Tirade did.
/:cl:

It will only ever produce one component from mindless mobs(even if you do a bunch at once), which is probably not worth the capacitor cost.
