### PR TITLE
Allows spray bottles to be used in the chem dispenser

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -17,7 +17,7 @@
 	var/stream_amount = 10 //the amount of reagents transfered when in stream mode.
 	amount_per_transfer_from_this = 5
 	volume = 250
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = list(5,10,15,20,25,30,50,100)
 
 
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user)


### PR DESCRIPTION
Fixes #21093
:cl: Cyberboss
fix: Spray bottle can now be used in the chem dispenser
/:cl:
