### PR TITLE
Allows the HoP to open extra chaplain slots

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -34,8 +34,7 @@ var/time_last_changed_position = 0
 		"Head of Security",
 		"Chief Engineer",
 		"Research Director",
-		"Chief Medical Officer",
-		"Chaplain")
+		"Chief Medical Officer")
 
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %
 	var/max_relative_positions = 30 //30%: Seems reasonable, limit of 6 @ 20 players

--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -34,7 +34,18 @@ Chaplain
 	if(visualsOnly)
 		return
 
+
 	var/obj/item/weapon/storage/book/bible/B = new /obj/item/weapon/storage/book/bible/booze(H)
+
+	if(ticker && ticker.Bible_deity_name)
+		B.deity_name = ticker.Bible_deity_name
+		B.name = ticker.Bible_name
+		H << "There is already an established religion onboard the station. You are an acoylte of [ticker.Bible_deity_name]. Defer to the Chaplain."
+		H.equip_to_slot_or_del(B, slot_in_backpack)
+		var/obj/item/weapon/nullrod/N = new(H)
+		H.equip_to_slot_or_del(N, slot_in_backpack)
+		return
+
 	var/new_religion = "Christianity"
 	if(H.client && H.client.prefs.custom_names["religion"])
 		new_religion = H.client.prefs.custom_names["religion"]

--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -40,7 +40,7 @@ Chaplain
 	if(ticker && ticker.Bible_deity_name)
 		B.deity_name = ticker.Bible_deity_name
 		B.name = ticker.Bible_name
-		H << "There is already an established religion onboard the station. You are an acoylte of [ticker.Bible_deity_name]. Defer to the Chaplain."
+		H << "There is already an established religion onboard the station. You are an acolyte of [ticker.Bible_deity_name]. Defer to the Chaplain."
 		H.equip_to_slot_or_del(B, slot_in_backpack)
 		var/obj/item/weapon/nullrod/N = new(H)
 		H.equip_to_slot_or_del(N, slot_in_backpack)


### PR DESCRIPTION
Allows multiple chaplains to spawn without fucking up the ticker. The later chaplains will spawn with the bible of the original one, and they spawn with their own weapon.

Maybe I'll add a new ID icon and actually change their job title if people don't hate the idea.
