### PR TITLE
Removed the delay on opening and closing job slots

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -23,7 +23,7 @@ var/time_last_changed_position = 0
 	//Cooldown for closing positions in seconds
 	//if set to -1: No cooldown... probably a bad idea
 	//if set to 0: Not able to close "original" positions. You can only close positions that you have opened before
-	var/change_position_cooldown = 60
+	var/change_position_cooldown = -1
 	//Jobs you cannot open new positions for
 	var/list/blacklisted = list(
 		"AI",


### PR DESCRIPTION
:cl: iamgoofball
tweak: Removed the delay on opening and closing job slots.
/:cl:

like seriously delay in opening job slots is a pain in the ass

before you say le grief:

you can easily reverse it the same way it's done
you've got bigger problems if someone with ill intent has access to an ID console
nobody actually uses the feature because the time between opening modifications is so fucking long it takes 5 minutes to change 5 job slots which is like a quarter of a round nowadays or some shit fucfk
