### PR TITLE
Re-adds the codex gigas to metastation.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55653,6 +55653,7 @@
 	},
 /obj/item/clothing/under/suit_jacket/red,
 /obj/effect/decal/cleanable/cobweb,
+/obj/item/weapon/book/codex_gigas,
 /turf/open/floor/engine/cult,
 /area/library)
 "bSi" = (


### PR DESCRIPTION
Somehow, the codex gigas was missing from metastation.  This re-adds it.
