### PR TITLE
GitLab migration under consideration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+#We've moved!
+###This project is now on [GitLab.](https://gitlab.com/)
+
+###You can now access the /tg/station branch of SS13 at this URL: https://gitlab.com/tgstation/tgstation
+
+----
+
 ##/tg/station v1.0.1
 
 [![Build Status](https://travis-ci.org/tgstation/tgstation.png)](https://travis-ci.org/tgstation/tgstation)


### PR DESCRIPTION
### Earlier today, the DNS provider GitHub uses, DynDNS, was pounded with a Distributed Denial of Service attack.

This disrupted connections to GitHub, as well as many other sites, as a DNS translates the website address, (github.com) to the IP address that the webserver is assigned by their ISP.

This didn't mean that GitHub was taken down itself, its own webservers were still up and running, but if you tried to connect to them with github.com, it would not resolve.

Contrary to this, https://gitlab.com, a competitor to GitHub, was still working fine as they do not use DynDNS. We are considering moving over to GitLab at this time.

This decision is ultimately up to the project managers, who will decide whether we move to GitLab or stay with GitHub.

This PR serves as both an announcement and discussion for this move, which may or may not happen.

@MrStonedOne has set up a GitLab profile under https://gitlab.com/tgstation/tgstation/, which we will be using if the decision is made to move to GitLab.
