### PR TITLE
Brig/Medbay door button now opens simultaneously

### DIFF
--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -50,9 +50,9 @@
 		if(D.id_tag == src.id)
 			if(specialfunctions & OPEN)
 				if(D.density)
-					D.open()
+					addtimer(D,"open",0,FALSE)
 				else
-					D.close()
+					addtimer(D,"close",0,FALSE)
 			if(specialfunctions & IDSCAN)
 				D.aiDisabledIdScanner = !D.aiDisabledIdScanner
 			if(specialfunctions & BOLTS)

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -46,13 +46,14 @@
 
 /obj/item/device/assembly/control/airlock/activate()
 	cooldown = 1
+	var/doors_need_closing = FALSE
+	var/list/obj/machinery/door/airlock/open_or_close = list()
 	for(var/obj/machinery/door/airlock/D in airlocks)
 		if(D.id_tag == src.id)
 			if(specialfunctions & OPEN)
-				if(D.density)
-					addtimer(D,"open",0,FALSE)
-				else
-					addtimer(D,"close",0,FALSE)
+				open_or_close += D
+				if(!D.density)
+					doors_need_closing = TRUE
 			if(specialfunctions & IDSCAN)
 				D.aiDisabledIdScanner = !D.aiDisabledIdScanner
 			if(specialfunctions & BOLTS)
@@ -68,6 +69,10 @@
 					D.secondsElectrified = 0
 			if(specialfunctions & SAFE)
 				D.safe = !D.safe
+
+	for(var/D in open_or_close)
+		addtimer(D, doors_need_closing ? "close" : "open",0,FALSE)
+
 	sleep(10)
 	cooldown = 0
 


### PR DESCRIPTION
Fixes #14941

:cl: Cyberboss
fix: Fixed a bug that caused door buttons to open doors one after another rather than simultaneously like they are suppose to
/:cl:

![untitled](https://cloud.githubusercontent.com/assets/8171642/19624108/5800b962-98b5-11e6-9c4a-29777aa8daae.png)
