### PR TITLE
Turrets can no longer shoot when unwrenched

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -464,7 +464,7 @@
 
 
 /obj/machinery/porta_turret/proc/popUp()	//pops the turret up
-	if(disabled)
+	if(disabled || !anchored)
 		return
 	if(raising || raised)
 		return


### PR DESCRIPTION
Fixes #16017

:cl: Cyberboss
fix: Turrets can no longer shoot when unwrenched
/:cl:
