### PR TITLE
Fix Spectral Blade not counting orbiting ghosts correctly

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -536,8 +536,9 @@
 			orbiters += A.orbiters
 
 	for(var/thing in orbiters)
-		if (isobserver(thing))
-			var/mob/dead/observer/G = thing
+		var/datum/orbit/O = thing
+		if (isobserver(O.orbiter))
+			var/mob/dead/observer/G = O.orbiter
 			ghost_counter++
 			G.invisibility = 0
 			current_spirits |= G


### PR DESCRIPTION
I forgot that I made orbiters store orbit datums, not the atom orbiting.

:cl:
fix: Spectral sword now tracks orbiting ghosts correctly.
/:cl:

fixes #21135
