### PR TITLE
Fixes bad area in ruined birthday lavaland ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -690,7 +690,7 @@ d
 d
 e
 e
-B
+N
 e
 e
 d


### PR DESCRIPTION
Fixes #21083

It had a space area instead of explored mining.
