### PR TITLE
[FIX]Anomalous Crystals are now RESISTANCE FLAGS = INDESTRUCTIBLE

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -366,7 +366,7 @@ Difficulty: Very Hard
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	icon_state = "anomaly_crystal"
 	luminosity = 8
-	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	use_power = 0
 	density = 1
 	languages_spoken = ALL


### PR DESCRIPTION
I think I spelled indestructible wrong.
Now it can actually be used without breaking from usage, as almost all of the activation methods imply doing damage to it.
:cl: Mekhi
fix: Anomalous Crystals are now unable to be broken by usage.
:cl:
