### PR TITLE
Slightly buffs augmented limbs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -443,10 +443,10 @@
 				informed = 1
 			switch(severity)
 				if(1)
-					L.receive_damage(0,10)
-					src.Stun(10)
-				if(2)
 					L.receive_damage(0,5)
+					src.Stun(7)
+				if(2)
+					L.receive_damage(0,2)
 					src.Stun(5)
 	..()
 


### PR DESCRIPTION
Down from a 2 hit critical from emps when fully augged to a 4 hit critical.
Come on, cyborgs are fully electronic and they don't die instantly, and augmented limbs still have organics in them.
LOWERS STUN TIME TO 7 FROM 10. STILL ENOUGH TO TOOLBOX SOMEONE's FACE IN.
:cl: Mekhi
experimental: Augmented limbs are slightly less vulnerable to EMP interference.
:cl:
