### PR TITLE
Makes sniper rifle bullets travel significantly faster

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -228,6 +228,7 @@
 //// SNIPER BULLETS
 
 /obj/item/projectile/bullet/sniper
+	speed = 0		//360 alwaysscope.
 	damage = 70
 	stun = 5
 	weaken = 5


### PR DESCRIPTION
No, this doesn't make them hitscan.
:cl:
rscadd: Sniper rifles now accelerate their bullets to extreme velocities instead of the average slow bullet.
:cl:
Tested. Works as intended.
