### PR TITLE
Fixes chem implants being unusable

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_chem.dm
+++ b/code/game/objects/items/weapons/implants/implant_chem.dm
@@ -64,6 +64,6 @@
 /obj/item/weapon/implantcase/chem/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W,/obj/item/weapon/reagent_containers/syringe) && imp)
 		W.afterattack(imp, user, params)
-		return 1
+		return TRUE
 	else
 		return ..()

--- a/code/game/objects/items/weapons/implants/implant_chem.dm
+++ b/code/game/objects/items/weapons/implants/implant_chem.dm
@@ -62,7 +62,8 @@
 	..()
 	
 /obj/item/weapon/implantcase/chem/attackby(obj/item/weapon/W, mob/user, params)
-	if(imp)
-		imp.attackby(W, user, params)
-	else 
+	if(istype(W,/obj/item/weapon/reagent_containers/syringe) && imp)
+		W.afterattack(imp, user, params)
+		return 1
+	else
 		return ..()


### PR DESCRIPTION
:cl: Swindly
fix: Chem implants can now be properly filled and implanted
/:cl:

Implanters were unable to take implants from chem implant cases because chem implant cases called their implants' attackby() while transferring implants is handled by the attackby() of the implant case. Syringes were unable to fill implants because the flags of implants were not shared with implant cases and the transferring of reagents is handled by the syringe's afterattack() and not the target's attackby().

Fixes https://github.com/tgstation/tgstation/issues/19889
