### PR TITLE
Fixes AI vision being stuck to the card/core when uploaded to a mech

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -673,7 +673,7 @@
 //Hack and From Card interactions share some code, so leave that here for both to use.
 /obj/mecha/proc/ai_enter_mech(mob/living/silicon/ai/AI, interaction)
 	AI.ai_restore_power()
-	AI.loc = src
+	AI.forceMove(src)
 	occupant = AI
 	icon_state = initial(icon_state)
 	playsound(src, 'sound/machines/windowdoor.ogg', 50, 1)


### PR DESCRIPTION
:cl: Gun Hog
fix: Fixed AIs uploaded to mechs having their camera view stuck to their card.
/:cl:

Moving an AI to a mech now uses forceMove() instead of setting the loc, fixing a bug where the AI's camera view became locked to the card from which it was uploaded.
