### PR TITLE
Craft black and fingerless gloves from cloth

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -182,6 +182,7 @@ var/global/list/datum/stack_recipe/cloth_recipes = list ( \
 	new/datum/stack_recipe("empty sandbag", /obj/item/weapon/emptysandbag, 4), \
 	null, \
 	new/datum/stack_recipe("fingerless gloves", /obj/item/clothing/gloves/fingerless, 1), \
+	new/datum/stack_recipe("black gloves", /obj/item/clothing/gloves/color/black, 2), \
 	)
 
 /obj/item/stack/sheet/cloth

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -182,7 +182,7 @@ var/global/list/datum/stack_recipe/cloth_recipes = list ( \
 	new/datum/stack_recipe("empty sandbag", /obj/item/weapon/emptysandbag, 4), \
 	null, \
 	new/datum/stack_recipe("fingerless gloves", /obj/item/clothing/gloves/fingerless, 1), \
-	new/datum/stack_recipe("black gloves", /obj/item/clothing/gloves/color/black, 2), \
+	new/datum/stack_recipe("black gloves", /obj/item/clothing/gloves/color/black, 3), \
 	)
 
 /obj/item/stack/sheet/cloth

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -165,6 +165,7 @@ var/global/list/datum/stack_recipe/wood_recipes = list ( \
  */
 var/global/list/datum/stack_recipe/cloth_recipes = list ( \
 	new/datum/stack_recipe("grey jumpsuit", /obj/item/clothing/under/color/grey, 3), \
+	new/datum/stack_recipe("black shoes", /obj/item/clothing/shoes/sneakers/black, 2), \
 	null, \
 	new/datum/stack_recipe("backpack", /obj/item/weapon/storage/backpack, 4), \
 	new/datum/stack_recipe("dufflebag", /obj/item/weapon/storage/backpack/dufflebag, 6), \
@@ -177,9 +178,10 @@ var/global/list/datum/stack_recipe/cloth_recipes = list ( \
 	null, \
 	new/datum/stack_recipe("improvised gauze", /obj/item/stack/medical/gauze/improvised, 1, 2, 6), \
 	new/datum/stack_recipe("rag", /obj/item/weapon/reagent_containers/glass/rag, 1), \
-	new/datum/stack_recipe("black shoes", /obj/item/clothing/shoes/sneakers/black, 2), \
 	new/datum/stack_recipe("bedsheet", /obj/item/weapon/bedsheet, 3), \
 	new/datum/stack_recipe("empty sandbag", /obj/item/weapon/emptysandbag, 4), \
+	null, \
+	new/datum/stack_recipe("fingerless gloves", /obj/item/clothing/gloves/fingerless, 1), \
 	)
 
 /obj/item/stack/sheet/cloth

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -127,7 +127,7 @@
 	name = "Botanical gloves"
 	id = "botany_gloves"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 250)
+	materials = list(MAT_BIOMASS = 150)
 	build_path = /obj/item/clothing/gloves/botanic_leather
 	category = list("initial","Leather and Cloth")
 


### PR DESCRIPTION
**Fingerless gloves will require 1 roll of cloth.
Black gloves will require 3 rolls.**

I intended for these gloves to require less biomass than botanist's leathers, as I was under the assumption that only leather gloves could let you wield botany weapon plants. Since any glove can do that, it seems to me that botanist's gloves have little to no benefit over black gloves.

**Botanist's leather gloves will have a reduced biomass cost of 150.**
This means it costs the same amount of biomass to make a pair of black gloves or leather gloves. While leathers have a lower permeability coefficient, I don't consider that a significant benefit to make it cost more biomass.

I moved the black shoes recipe to be just below the grey jumpsuit entry. It looks nice to have those two recipes in the topmost section of the stack crafting menu.

:cl: Erwgd
rscadd: You can now use cloth to make black or fingerless gloves.
tweak: Biogenerators require less biomass to produce botanist's leather gloves.
/:cl:
