### PR TITLE
Firelemon explosion is now delayed

### DIFF
--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -111,6 +111,8 @@
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.throw_mode_on()
+	icon_state = "firelemon_active"
+	playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 	addtimer(src, "prime", rand(10, 60))
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/firelemon/burn()
@@ -126,8 +128,6 @@
 	qdel(src) //Ensuring that it's deleted by its own explosion
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/firelemon/proc/prime()
-	icon_state = "firelemon_active"
-	playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 	switch(seed.potency) //Combustible lemons are alot like IEDs, lots of flame, very little bang.
 		if(0 to 30)
 			update_mob()

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -111,7 +111,7 @@
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.throw_mode_on()
-	prime()
+	addtimer(src, "prime", rand(10, 60))
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/firelemon/burn()
 	prime()


### PR DESCRIPTION
This was most likely the intended behaviour since it already set throwing mode on, despite instantly exploding. The delay is between 1 and 6 seconds to make them very unreliable.
