### PR TITLE
CQC tweaks, improvements and fixes [and adds and utilizes martial art blocks)

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -559,7 +559,7 @@
 		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 	add_logs(A, D, "disarmed with CQC")
 	if(restraining)
-		if(D = current_target)
+		if(D == current_target)
 			D.visible_message("<span class='danger'>[A] puts [D] into a chokehold!</span>", \
 								"<span class='userdanger'>[A] puts you into a chokehold!</span>")
 			D.SetSleeping(20)

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -571,16 +571,16 @@
 
 /mob/living/carbon/human/proc/CQC_help()
 	set name = "Recall Teachings"
-	set desc = "You try to remember some of the basics of cqc."
-	set category = "cqc"
+	set desc = "You try to remember some of the basics of CQC."
+	set category = "CQC"
 
-	usr << "<b><i>You try to remember some of the basics of cqc.</i></b>"
+	usr << "<b><i>You try to remember some of the basics of CQC.</i></b>"
 
 	usr << "<span class='notice'>Slam</span>: Grab Harm. Slam opponent into the ground, weakens and knocks down."
 	usr << "<span class='notice'>CQC Kick</span>: Harm Disarm Harm. Knocks opponent away. Knocks out stunned or weakened opponents."
 	usr << "<span class='notice'>Restrain</span>: Grab Grab. Locks opponents into a restraining position, disarm to knock them out with a choke hold."
 	usr << "<span class='notice'>Pressure</span>: Disarm Grab. Decent stamina damage."
-	usr << "<span class='notice'>Consecutive cqc</span>: Harm Harm Disarm. Mainly offensive move, huge damage and decent stamina damage."
+	usr << "<span class='notice'>Consecutive CQC</span>: Harm Harm Disarm. Mainly offensive move, huge damage and decent stamina damage."
 	usr << "<span class='notice'>Disorient and Disarm</span>: Harm Grab. Deal a hit to opponent's jaw to disorient them, and then steal what they are holding."
 
 

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -515,7 +515,7 @@
 		bonus_damage += 5
 		picked_hit_type = "stomps on"
 	D.apply_damage(bonus_damage, BRUTE)
-	if(picked_hit_type == "kicks" || picked_hit_type == "stomps")
+	if(picked_hit_type == "kicks" || picked_hit_type == "stomps on")
 		playsound(get_turf(D), 'sound/weapons/cqchit2.ogg', 50, 1, -1)
 	else
 		playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, 1, -1)

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -645,13 +645,13 @@
 		name = "empty scroll"
 		icon_state = "blankscroll"
 
-/obj/item/weapon/CQC_manual
+/obj/item/weapon/cqc_manual
 	name = "old manual"
 	desc = "A small, black manual. There are drawn instructions of tactical hand-to-hand combat."
 	icon = 'icons/obj/library.dmi'
 	icon_state ="cqcmanual"
 
-/obj/item/weapon/CQC_manual/attack_self(mob/living/carbon/human/user)
+/obj/item/weapon/cqc_manual/attack_self(mob/living/carbon/human/user)
 	if(!istype(user) || !user)
 		return
 	user <<"<span class='boldannounce'>You remember the basics of CQC.</span>"

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -460,7 +460,7 @@
 	return 1
 
 /datum/martial_art/cqc/proc/Restrain(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(restraining && A.pulling == D)
+	if(restraining)
 		if(A.grab_state < GRAB_NECK)
 			A.grab_state = GRAB_NECK
 		return

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -461,8 +461,6 @@
 
 /datum/martial_art/cqc/proc/Restrain(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(restraining)
-		if(A.grab_state < GRAB_NECK)
-			A.grab_state = GRAB_NECK
 		return
 	if(!D.stat)
 		D.visible_message("<span class='warning'>[A] locks [D] into a restraining position!</span>", \
@@ -498,8 +496,6 @@
 			D.stop_pulling()
 			add_logs(A, D, "grabbed", addition="aggressively")
 			A.grab_state = GRAB_AGGRESSIVE //Instant aggressive grab
-			if(!A.pulling)
-				restraining = 0
 
 	return 1
 
@@ -556,6 +552,8 @@
 							"<span class='userdanger'>[A] puts you into a chokehold!</span>")
 		D.SetSleeping(20)
 		restraining = 0
+		if(A.grab_state < GRAB_NECK)
+			A.grab_state = GRAB_NECK
 	else
 		restraining = 0
 		return 0

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -7,6 +7,7 @@
 	var/datum/martial_art/base = null // The permanent style
 	var/deflection_chance = 0 //Chance to deflect projectiles
 	var/block_chance = 0 //Chance to block melee attacks using items while on throw mode.
+	var/restraining = 0 //used in cqc's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
 	var/help_verb = null
 
 /datum/martial_art/proc/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -22,6 +23,7 @@
 	if(D != current_target)
 		current_target = D
 		streak = ""
+		restraining = 0
 	streak = streak+element
 	if(length(streak) > max_streak_length)
 		streak = copytext(streak,2)
@@ -389,16 +391,15 @@
 
 //cqc
 #define SLAM_COMBO "GH"
-#define KICK_COMBO "HDH"
+#define KICK_COMBO "HH"
 #define RESTRAIN_COMBO "GG"
 #define PRESSURE_COMBO "DG"
 #define CONSECUTIVE_COMBO "HHD"
-#define STRIKE_COMBO "HG"
+#define STRIKE_COMBO "DD"
 /datum/martial_art/cqc
-	name = "cqc"
+	name = "CQC"
 	help_verb = /mob/living/carbon/human/proc/CQC_help
-	var/restraining = 0 //used in cqc's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
-	block_chance = 65
+	block_chance = 70
 
 /datum/martial_art/cqc/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(findtext(streak,SLAM_COMBO))
@@ -517,10 +518,10 @@
 	add_to_streak("H",D)
 	if(check_streak(A,D))
 		return 1
-	add_logs(A, D, "cqc'd")
+	add_logs(A, D, "CQC'd")
 	A.do_attack_animation(D)
-	var/picked_hit_type = pick("cqc'd", "Big Bossed")
-	var/bonus_damage = 10
+	var/picked_hit_type = pick("CQC'd", "Big Bossed")
+	var/bonus_damage = 13
 	if(D.weakened || D.resting || D.lying)
 		bonus_damage += 5
 		picked_hit_type = "stomps on"
@@ -559,14 +560,13 @@
 		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 	add_logs(A, D, "disarmed with CQC")
 	if(restraining)
-		if(D == current_target)
-			D.visible_message("<span class='danger'>[A] puts [D] into a chokehold!</span>", \
-								"<span class='userdanger'>[A] puts you into a chokehold!</span>")
-			D.SetSleeping(20)
-			restraining = 0
-		else
-			restraining = 0
-			return 0
+		D.visible_message("<span class='danger'>[A] puts [D] into a chokehold!</span>", \
+							"<span class='userdanger'>[A] puts you into a chokehold!</span>")
+		D.SetSleeping(20)
+		restraining = 0
+	else
+		restraining = 0
+		return 0
 	return 1
 
 /mob/living/carbon/human/proc/CQC_help()
@@ -577,7 +577,7 @@
 	usr << "<b><i>You try to remember some of the basics of cqc.</i></b>"
 
 	usr << "<span class='notice'>Slam</span>: Grab Harm. Slam opponent into the ground, weakens and knocks down."
-	usr << "<span class='notice'>cqc Kick</span>: Harm Disarm Harm. Knocks opponent away. Knocks out stunned or weakened opponents."
+	usr << "<span class='notice'>CQC Kick</span>: Harm Disarm Harm. Knocks opponent away. Knocks out stunned or weakened opponents."
 	usr << "<span class='notice'>Restrain</span>: Grab Grab. Locks opponents into a restraining position, disarm to knock them out with a choke hold."
 	usr << "<span class='notice'>Pressure</span>: Disarm Grab. Decent stamina damage."
 	usr << "<span class='notice'>Consecutive cqc</span>: Harm Harm Disarm. Mainly offensive move, huge damage and decent stamina damage."

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -6,6 +6,7 @@
 	var/temporary = 0
 	var/datum/martial_art/base = null // The permanent style
 	var/deflection_chance = 0 //Chance to deflect projectiles
+	var/block_chance = 0 //Chance to block melee attacks using items while on throw mode.
 	var/help_verb = null
 
 /datum/martial_art/proc/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -396,7 +397,8 @@
 /datum/martial_art/CQC
 	name = "CQC"
 	help_verb = /mob/living/carbon/human/proc/CQC_help
-	var/restrained = 0 //used in CQC's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
+	var/restraining = 0 //used in CQC's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
+	block_chance = 65
 
 /datum/martial_art/CQC/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(findtext(streak,SLAM_COMBO))
@@ -458,14 +460,14 @@
 	return 1
 
 /datum/martial_art/CQC/proc/Restrain(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(restrained)
+	if(restraining)
 		return
 	if(!D.stat)
 		D.visible_message("<span class='warning'>[A] locks [D] into a restraining position!</span>", \
 							"<span class='userdanger'>[A] locks you into a restraining position!</span>")
 		D.adjustStaminaLoss(20)
 		D.Stun(5)
-		restrained = 1
+		restraining = 1
 	return 1
 
 /datum/martial_art/CQC/proc/Consecutive(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -507,7 +509,7 @@
 			add_logs(A, D, "grabbed", addition="aggressively")
 			A.grab_state = GRAB_AGGRESSIVE //Instant aggressive grab
 			if(!A.pulling)
-				restrained = 0
+				restraining = 0
 
 	return 1
 
@@ -556,11 +558,15 @@
 							"<span class='userdanger'>[A] attempted to disarm [D]!</span>")
 		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 	add_logs(A, D, "disarmed with CQC")
-	if(restrained)
-		D.visible_message("<span class='danger'>[A] puts [D] into a chokehold!</span>", \
-							"<span class='userdanger'>[A] puts you into a chokehold!</span>")
-		D.SetSleeping(20)
-		restrained = 0
+	if(restraining)
+		if(D = current_target)
+			D.visible_message("<span class='danger'>[A] puts [D] into a chokehold!</span>", \
+								"<span class='userdanger'>[A] puts you into a chokehold!</span>")
+			D.SetSleeping(20)
+			restraining = 0
+		else
+			restraining = 0
+			return 0
 	return 1
 
 /mob/living/carbon/human/proc/CQC_help()
@@ -746,3 +752,4 @@
 	if(wielded)
 		return ..()
 	return 0
+

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -394,7 +394,7 @@
 #define KICK_COMBO "HH"
 #define RESTRAIN_COMBO "GG"
 #define PRESSURE_COMBO "DG"
-#define CONSECUTIVE_COMBO "HHD"
+#define CONSECUTIVE_COMBO "DDH"
 /datum/martial_art/cqc
 	name = "CQC"
 	help_verb = /mob/living/carbon/human/proc/CQC_help

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -389,7 +389,7 @@
 	usr << "<span class='notice'>Head Kick</span>: Disarm Harm Harm. Decent damage, forces opponent to drop item in hand."
 	usr << "<span class='notice'>Elbow Drop</span>: Harm Disarm Harm Disarm Harm. Opponent must be on the ground. Deals huge damage, instantly kills anyone in critical condition."
 
-//CQC _bman_
+//CQC
 #define SLAM_COMBO "GH"
 #define KICK_COMBO "HH"
 #define RESTRAIN_COMBO "GG"
@@ -402,7 +402,6 @@
 
 /datum/martial_art/cqc/proc/drop_restraining()
 	restraining = 0
-	return 1
 
 /datum/martial_art/cqc/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(findtext(streak,SLAM_COMBO))

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -6,7 +6,6 @@
 	var/temporary = 0
 	var/datum/martial_art/base = null // The permanent style
 	var/deflection_chance = 0 //Chance to deflect projectiles
-	var/block_chance = 0 //Chance to block melee attacks using items while on throw mode.
 	var/help_verb = null
 
 /datum/martial_art/proc/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -397,8 +396,7 @@
 /datum/martial_art/CQC
 	name = "CQC"
 	help_verb = /mob/living/carbon/human/proc/CQC_help
-	var/restraining = 0 //used in CQC's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
-	block_chance = 65
+	var/restrained = 0 //used in CQC's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
 
 /datum/martial_art/CQC/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(findtext(streak,SLAM_COMBO))
@@ -460,14 +458,14 @@
 	return 1
 
 /datum/martial_art/CQC/proc/Restrain(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(restraining)
+	if(restrained)
 		return
 	if(!D.stat)
 		D.visible_message("<span class='warning'>[A] locks [D] into a restraining position!</span>", \
 							"<span class='userdanger'>[A] locks you into a restraining position!</span>")
 		D.adjustStaminaLoss(20)
 		D.Stun(5)
-		restraining = 1
+		restrained = 1
 	return 1
 
 /datum/martial_art/CQC/proc/Consecutive(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -509,7 +507,7 @@
 			add_logs(A, D, "grabbed", addition="aggressively")
 			A.grab_state = GRAB_AGGRESSIVE //Instant aggressive grab
 			if(!A.pulling)
-				restraining = 0
+				restrained = 0
 
 	return 1
 
@@ -558,15 +556,11 @@
 							"<span class='userdanger'>[A] attempted to disarm [D]!</span>")
 		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 	add_logs(A, D, "disarmed with CQC")
-	if(restraining)
-		if(D = current_target)
-			D.visible_message("<span class='danger'>[A] puts [D] into a chokehold!</span>", \
-								"<span class='userdanger'>[A] puts you into a chokehold!</span>")
-			D.SetSleeping(20)
-			restraining = 0
-		else
-			restraining = 0
-			return 0
+	if(restrained)
+		D.visible_message("<span class='danger'>[A] puts [D] into a chokehold!</span>", \
+							"<span class='userdanger'>[A] puts you into a chokehold!</span>")
+		D.SetSleeping(20)
+		restrained = 0
 	return 1
 
 /mob/living/carbon/human/proc/CQC_help()
@@ -752,4 +746,3 @@
 	if(wielded)
 		return ..()
 	return 0
-

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -387,20 +387,20 @@
 	usr << "<span class='notice'>Head Kick</span>: Disarm Harm Harm. Decent damage, forces opponent to drop item in hand."
 	usr << "<span class='notice'>Elbow Drop</span>: Harm Disarm Harm Disarm Harm. Opponent must be on the ground. Deals huge damage, instantly kills anyone in critical condition."
 
-//CQC
+//cqc
 #define SLAM_COMBO "GH"
 #define KICK_COMBO "HDH"
 #define RESTRAIN_COMBO "GG"
 #define PRESSURE_COMBO "DG"
 #define CONSECUTIVE_COMBO "HHD"
 #define STRIKE_COMBO "HG"
-/datum/martial_art/CQC
-	name = "CQC"
+/datum/martial_art/cqc
+	name = "cqc"
 	help_verb = /mob/living/carbon/human/proc/CQC_help
-	var/restraining = 0 //used in CQC's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
+	var/restraining = 0 //used in cqc's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
 	block_chance = 65
 
-/datum/martial_art/CQC/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/cqc/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(findtext(streak,SLAM_COMBO))
 		streak = ""
 		Slam(A,D)
@@ -426,17 +426,17 @@
 		return 1
 	return 0
 
-/datum/martial_art/CQC/proc/Slam(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/cqc/proc/Slam(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!D.stat || !D.weakened)
 		D.visible_message("<span class='warning'>[A] slams [D] into the ground!</span>", \
 						  	"<span class='userdanger'>[A] slams you into the ground!</span>")
 		playsound(get_turf(A), 'sound/weapons/slam.ogg', 50, 1, -1)
 		D.apply_damage(10, BRUTE)
 		D.Weaken(6)
-		add_logs(A, D, "CQC slammed")
+		add_logs(A, D, "cqc slammed")
 	return 1
 
-/datum/martial_art/CQC/proc/Kick(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/cqc/proc/Kick(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!D.stat || !D.weakened)
 		D.visible_message("<span class='warning'>[A] kicks [D] back!</span>", \
 							"<span class='userdanger'>[A] kicks you back!</span>")
@@ -444,7 +444,7 @@
 		var/atom/throw_target = get_edge_target_turf(D, A.dir)
 		D.throw_at(throw_target, 1, 14, A)
 		D.apply_damage(10, BRUTE)
-		add_logs(A, D, "CQC kicked")
+		add_logs(A, D, "cqc kicked")
 	if(D.weakened)
 		D.visible_message("<span class='warning'>[A] kicks [D]'s head, knocking them out!</span>", \
 					  		"<span class='userdanger'>[A] kicks your head, knocking you out!</span>")
@@ -453,13 +453,13 @@
 		D.adjustBrainLoss(25)
 	return 1
 
-/datum/martial_art/CQC/proc/Pressure(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/cqc/proc/Pressure(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	D.visible_message("<span class='warning'>[A] forces their arm on [D]'s neck!</span>")
 	D.adjustStaminaLoss(60)
 	playsound(get_turf(A), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
 	return 1
 
-/datum/martial_art/CQC/proc/Restrain(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/cqc/proc/Restrain(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(restraining)
 		return
 	if(!D.stat)
@@ -470,7 +470,7 @@
 		restraining = 1
 	return 1
 
-/datum/martial_art/CQC/proc/Consecutive(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/cqc/proc/Consecutive(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!D.stat)
 		D.visible_message("<span class='warning'>[A] strikes [D]'s abdomen, neck and back consecutively</span>", \
 							"<span class='userdanger'>[A] strikes your abdomen, neck and back consecutively!</span>")
@@ -483,7 +483,7 @@
 		D.apply_damage(20, BRUTE)
 	return 1
 
-/datum/martial_art/CQC/proc/Strike(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/cqc/proc/Strike(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!D.stat || !D.weakened)
 		var/obj/item/I = D.get_active_held_item()
 		D.visible_message("<span class='warning'>[A] strikes [D]'s jaw with their hand and then disarms them!</span>", \
@@ -496,7 +496,7 @@
 		D.apply_damage(5, BRUTE)
 	return 1
 
-/datum/martial_art/CQC/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/cqc/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("G",D)
 	if(check_streak(A,D))
 		return 1
@@ -513,13 +513,13 @@
 
 	return 1
 
-/datum/martial_art/CQC/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/cqc/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("H",D)
 	if(check_streak(A,D))
 		return 1
-	add_logs(A, D, "CQC'd")
+	add_logs(A, D, "cqc'd")
 	A.do_attack_animation(D)
-	var/picked_hit_type = pick("CQC'd", "Big Bossed")
+	var/picked_hit_type = pick("cqc'd", "Big Bossed")
 	var/bonus_damage = 10
 	if(D.weakened || D.resting || D.lying)
 		bonus_damage += 5
@@ -538,10 +538,10 @@
 		playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 		D.apply_damage(10, BRUTE)
 		D.Weaken(3)
-		add_logs(A, D, "CQC sweeped")
+		add_logs(A, D, "cqc sweeped")
 	return 1
 
-/datum/martial_art/CQC/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/cqc/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return 1
@@ -571,16 +571,16 @@
 
 /mob/living/carbon/human/proc/CQC_help()
 	set name = "Recall Teachings"
-	set desc = "You try to remember some of the basics of CQC."
-	set category = "CQC"
+	set desc = "You try to remember some of the basics of cqc."
+	set category = "cqc"
 
-	usr << "<b><i>You try to remember some of the basics of CQC.</i></b>"
+	usr << "<b><i>You try to remember some of the basics of cqc.</i></b>"
 
 	usr << "<span class='notice'>Slam</span>: Grab Harm. Slam opponent into the ground, weakens and knocks down."
-	usr << "<span class='notice'>CQC Kick</span>: Harm Disarm Harm. Knocks opponent away. Knocks out stunned or weakened opponents."
+	usr << "<span class='notice'>cqc Kick</span>: Harm Disarm Harm. Knocks opponent away. Knocks out stunned or weakened opponents."
 	usr << "<span class='notice'>Restrain</span>: Grab Grab. Locks opponents into a restraining position, disarm to knock them out with a choke hold."
 	usr << "<span class='notice'>Pressure</span>: Disarm Grab. Decent stamina damage."
-	usr << "<span class='notice'>Consecutive CQC</span>: Harm Harm Disarm. Mainly offensive move, huge damage and decent stamina damage."
+	usr << "<span class='notice'>Consecutive cqc</span>: Harm Harm Disarm. Mainly offensive move, huge damage and decent stamina damage."
 	usr << "<span class='notice'>Disorient and Disarm</span>: Harm Grab. Deal a hit to opponent's jaw to disorient them, and then steal what they are holding."
 
 
@@ -655,7 +655,7 @@
 	if(!istype(user) || !user)
 		return
 	user <<"<span class='boldannounce'>You remember the basics of CQC.</span>"
-	var/datum/martial_art/CQC/D = new(null)
+	var/datum/martial_art/cqc/D = new(null)
 	D.teach(user)
 	user.drop_item()
 	visible_message("<span class='warning'>[src] beeps ominously, and a moment later it bursts up in flames.</span>")

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -1,6 +1,13 @@
 /obj/item/weapon/melee
 	needs_permit = 1
 
+/obj/item/weapon/melee/proc/check_martial_counter(mob/living/carbon/human/target, mob/living/carbon/human/user)
+	if(target.check_block())
+		target.visible_message("<span class='danger'>[target.name] blocks [src] and twists [user]'s arm behind their back!</span>",
+					"<span class='userdanger'>You block the attack!</span>")
+		user.Stun(2)
+		return 1
+
 
 /obj/item/weapon/melee/chainofcommand
 	name = "chain of command"
@@ -98,11 +105,8 @@
 				var/mob/living/carbon/human/H = target
 				if (H.check_shields(0, "[user]'s [name]", src, MELEE_ATTACK))
 					return
-				if(H.check_block())
-					H.visible_message("<span class='danger'>[H.name] blocks [src] and twists [user]'s arm behind their back!</span>",
-									"<span class='userdanger'>You block the attack!</span>")
-					user.Stun(2)
-					return 0
+				if(check_martial_counter(H, user))
+					return
 			playsound(get_turf(src), 'sound/effects/woodhit.ogg', 75, 1, -1)
 			target.Weaken(3)
 			add_logs(user, target, "stunned", src)

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -98,6 +98,13 @@
 				var/mob/living/carbon/human/H = target
 				if (H.check_shields(0, "[user]'s [name]", src, MELEE_ATTACK))
 					return
+				if(H.martial_art && H.martial_art.block_chance)
+					if(prob(H.martial_art.block_chance) && H.in_throw_mode && !H.get_active_held_item())
+						if(!H.stat && !H.weakened && !H.stunned)
+							H.visible_message("<span class='danger'>[H.name] blocks the [src] and twists [user]'s arm behind their back!</span>",
+										"<span class='userdanger'>You block the attack!</span>")
+							user.Stun(2)
+							return
 			playsound(get_turf(src), 'sound/effects/woodhit.ogg', 75, 1, -1)
 			target.Weaken(3)
 			add_logs(user, target, "stunned", src)

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -98,13 +98,11 @@
 				var/mob/living/carbon/human/H = target
 				if (H.check_shields(0, "[user]'s [name]", src, MELEE_ATTACK))
 					return
-				if(H.martial_art && H.martial_art.block_chance)
-					if(prob(H.martial_art.block_chance) && H.in_throw_mode && !H.get_active_held_item())
-						if(!H.stat && !H.weakened && !H.stunned)
-							H.visible_message("<span class='danger'>[H.name] blocks the [src] and twists [user]'s arm behind their back!</span>",
-										"<span class='userdanger'>You block the attack!</span>")
-							user.Stun(2)
-							return
+				if(H.check_block())
+					H.visible_message("<span class='danger'>[H.name] blocks [src] and twists [user]'s arm behind their back!</span>",
+									"<span class='userdanger'>You block the attack!</span>")
+					user.Stun(2)
+					return 0
 			playsound(get_turf(src), 'sound/effects/woodhit.ogg', 75, 1, -1)
 			target.Weaken(3)
 			add_logs(user, target, "stunned", src)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -120,7 +120,15 @@
 	if(!isliving(M))
 		return
 
-	var/mob/living/L = M
+	var/mob/living/carbon/human/L = M
+
+	if(L.martial_art && L.martial_art.block_chance)
+		if(prob(L.martial_art.block_chance) && L.in_throw_mode && !L.get_active_held_item())
+			if(!L.stat && !L.weakened && !L.stunned)
+				L.visible_message("<span class='danger'>[L.name] blocks the [src] and twists [user]'s arm behind their back!</span>",
+								"<span class='userdanger'>You block the attack!</span>")
+				user.Stun(2)
+				return 0
 
 	if(user.a_intent != "harm")
 		if(status)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -122,13 +122,11 @@
 
 	var/mob/living/carbon/human/L = M
 
-	if(L.martial_art && L.martial_art.block_chance)
-		if(prob(L.martial_art.block_chance) && L.in_throw_mode && !L.get_active_held_item())
-			if(!L.stat && !L.weakened && !L.stunned)
-				L.visible_message("<span class='danger'>[L.name] blocks the [src] and twists [user]'s arm behind their back!</span>",
-								"<span class='userdanger'>You block the attack!</span>")
-				user.Stun(2)
-				return 0
+	if(L.check_block())
+		L.visible_message("<span class='danger'>[L.name] blocks [src] and twists [user]'s arm behind their back!</span>",
+						"<span class='userdanger'>You block the attack!</span>")
+		user.Stun(2)
+		return 0
 
 	if(user.a_intent != "harm")
 		if(status)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -122,10 +122,7 @@
 
 	var/mob/living/carbon/human/L = M
 
-	if(L.check_block())
-		L.visible_message("<span class='danger'>[L.name] blocks [src] and twists [user]'s arm behind their back!</span>",
-						"<span class='userdanger'>You block the attack!</span>")
-		user.Stun(2)
+	if(check_martial_counter(L, user))
 		return 0
 
 	if(user.a_intent != "harm")

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -120,15 +120,7 @@
 	if(!isliving(M))
 		return
 
-	var/mob/living/carbon/human/L = M
-
-	if(L.martial_art && L.martial_art.block_chance)
-		if(prob(L.martial_art.block_chance) && L.in_throw_mode && !L.get_active_held_item())
-			if(!L.stat && !L.weakened && !L.stunned)
-				L.visible_message("<span class='danger'>[L.name] blocks the [src] and twists [user]'s arm behind their back!</span>",
-								"<span class='userdanger'>You block the attack!</span>")
-				user.Stun(2)
-				return 0
+	var/mob/living/L = M
 
 	if(user.a_intent != "harm")
 		if(status)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -118,11 +118,10 @@
 	return 0
 
 /mob/living/carbon/human/proc/check_block()
-	if(martial_art && martial_art.block_chance)
-		if(prob(martial_art.block_chance) && in_throw_mode)
-			if(!stat && !weakened && !stunned)
-				return TRUE
-
+	if(martial_art && martial_art.block_chance \
+	&& prob(martial_art.block_chance) && in_throw_mode \
+	&& !stat && !weakened && !stunned)
+		return TRUE
 	return FALSE
 
 /mob/living/carbon/human/hitby(atom/movable/AM, skipcatch = 0, hitpush = 1, blocked = 0)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -117,6 +117,13 @@
 			return 1
 	return 0
 
+/mob/living/carbon/human/proc/check_block()
+	if(martial_art && martial_art.block_chance)
+		if(prob(martial_art.block_chance) && in_throw_mode)
+			if(!stat && !weakened && !stunned)
+				return TRUE
+
+	return FALSE
 
 /mob/living/carbon/human/hitby(atom/movable/AM, skipcatch = 0, hitpush = 1, blocked = 0)
 	var/obj/item/I

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -944,9 +944,11 @@
 	else
 		target.grabbedby(user)
 		return 1
-	if(prob(target.martial_art.block_chance) && target.in_throw_mode && !target.get_active_held_item())
-		if(!target.stat && !target.weakened && !target.stunned)
-			target.visible_message("<span class='danger'>[target.name] blocks [user] with their arm!</span>", "<span class='userdanger'>You block the grab attempt!</span>", null, COMBAT_MESSAGE_RANGE, user)
+
+	if(target.martial_art && target.martial_art.block_chance)
+		if(prob(target.martial_art.block_chance) && target.in_throw_mode && !target.get_active_held_item())
+			if(!target.stat && !target.weakened && !target.stunned)
+				target.visible_message("<span class='danger'>[target.name] blocks [user] with their arm!</span>", "<span class='userdanger'>You block the grab attempt!</span>", null, COMBAT_MESSAGE_RANGE, user)
 
 /datum/species/proc/harm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(attacker_style && attacker_style.harm_act(user,target))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -939,18 +939,23 @@
 			user << "<span class='notice'>You do not breathe, so you cannot perform CPR.</span>"
 
 /datum/species/proc/grab(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
+	if(target.check_block())
+		target.visible_message("<span class='warning'>[target] blocks [user]'s grab attempt!</span>")
+		return 0
 	if(attacker_style && attacker_style.grab_act(user,target))
 		return 1
 	else
 		target.grabbedby(user)
 		return 1
 
-	if(target.martial_art && target.martial_art.block_chance)
-		if(prob(target.martial_art.block_chance) && target.in_throw_mode && !target.get_active_held_item())
-			if(!target.stat && !target.weakened && !target.stunned)
-				target.visible_message("<span class='danger'>[target.name] blocks [user] with their arm!</span>", "<span class='userdanger'>You block the grab attempt!</span>", null, COMBAT_MESSAGE_RANGE, user)
+
+
+
 
 /datum/species/proc/harm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
+	if(target.check_block())
+		target.visible_message("<span class='warning'>[target] blocks [user]'s attack!</span>")
+		return 0
 	if(attacker_style && attacker_style.harm_act(user,target))
 		return 1
 	else
@@ -998,13 +1003,13 @@
 			target.forcesay(hit_appends)
 		else if(target.lying)
 			target.forcesay(hit_appends)
-	if(target.martial_art && target.martial_art.block_chance)
-		if(prob(target.martial_art.block_chance) && target.in_throw_mode && !target.get_active_held_item())
-			if(!target.stat && !target.weakened && !target.stunned)
-				target.visible_message("<span class='danger'>[target.name] blocks [user] with their arm!</span>", \
-								"<span class='userdanger'>You block the attack attempt!</span>", null, COMBAT_MESSAGE_RANGE, user)
+
+
 
 /datum/species/proc/disarm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
+	if(target.check_block())
+		target.visible_message("<span class='warning'>[target] blocks [user]'s disarm attempt!</span>")
+		return 0
 	if(attacker_style && attacker_style.disarm_act(user,target))
 		return 1
 	else
@@ -1044,11 +1049,8 @@
 		playsound(target, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		target.visible_message("<span class='danger'>[user] attempted to disarm [target]!</span>", \
 						"<span class='userdanger'>[user] attemped to disarm [target]!</span>", null, COMBAT_MESSAGE_RANGE, user)
-	if(target.martial_art && target.martial_art.block_chance)
-		if(prob(target.martial_art.block_chance) && target.in_throw_mode && !target.get_active_held_item())
-			if(!target.stat && !target.weakened && !target.stunned)
-				target.visible_message("<span class='danger'>[target.name] blocks [user] with their arm!</span>", "<span class='userdanger'>You block the disarm attempt!</span>", null, COMBAT_MESSAGE_RANGE, user)
-				return 0
+
+
 
 /datum/species/proc/spec_attack_hand(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style = M.martial_art)
 	if(!istype(M))
@@ -1080,6 +1082,9 @@
 	if(user != H)
 		if(H.check_shields(I.force, "the [I.name]", I, MELEE_ATTACK, I.armour_penetration))
 			return 0
+	if(H.check_block())
+		H.visible_message("<span class='warning'>[H] blocks [I]!</span>")
+		return 0
 
 	var/hit_area
 	if(!affecting) //Something went wrong. Maybe the limb is missing?

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -944,6 +944,9 @@
 	else
 		target.grabbedby(user)
 		return 1
+	if(prob(target.martial_art.block_chance) && target.in_throw_mode && !target.get_active_held_item())
+		if(!target.stat && !target.weakened && !target.stunned)
+			target.visible_message("<span class='danger'>[target.name] blocks [user] with their arm!</span>", "<span class='userdanger'>You block the grab attempt!</span>", null, COMBAT_MESSAGE_RANGE, user)
 
 /datum/species/proc/harm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(attacker_style && attacker_style.harm_act(user,target))
@@ -993,6 +996,11 @@
 			target.forcesay(hit_appends)
 		else if(target.lying)
 			target.forcesay(hit_appends)
+	if(target.martial_art && target.martial_art.block_chance)
+		if(prob(target.martial_art.block_chance) && target.in_throw_mode && !target.get_active_held_item())
+			if(!target.stat && !target.weakened && !target.stunned)
+				target.visible_message("<span class='danger'>[target.name] blocks [user] with their arm!</span>", \
+								"<span class='userdanger'>You block the attack attempt!</span>", null, COMBAT_MESSAGE_RANGE, user)
 
 /datum/species/proc/disarm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(attacker_style && attacker_style.disarm_act(user,target))
@@ -1034,7 +1042,11 @@
 		playsound(target, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		target.visible_message("<span class='danger'>[user] attempted to disarm [target]!</span>", \
 						"<span class='userdanger'>[user] attemped to disarm [target]!</span>", null, COMBAT_MESSAGE_RANGE, user)
-
+	if(target.martial_art && target.martial_art.block_chance)
+		if(prob(target.martial_art.block_chance) && target.in_throw_mode && !target.get_active_held_item())
+			if(!target.stat && !target.weakened && !target.stunned)
+				target.visible_message("<span class='danger'>[target.name] blocks [user] with their arm!</span>", "<span class='userdanger'>You block the disarm attempt!</span>", null, COMBAT_MESSAGE_RANGE, user)
+				return 0
 
 /datum/species/proc/spec_attack_hand(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style = M.martial_art)
 	if(!istype(M))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -944,9 +944,6 @@
 	else
 		target.grabbedby(user)
 		return 1
-	if(prob(target.martial_art.block_chance) && target.in_throw_mode && !target.get_active_held_item())
-		if(!target.stat && !target.weakened && !target.stunned)
-			target.visible_message("<span class='danger'>[target.name] blocks [user] with their arm!</span>", "<span class='userdanger'>You block the grab attempt!</span>", null, COMBAT_MESSAGE_RANGE, user)
 
 /datum/species/proc/harm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(attacker_style && attacker_style.harm_act(user,target))
@@ -996,11 +993,6 @@
 			target.forcesay(hit_appends)
 		else if(target.lying)
 			target.forcesay(hit_appends)
-	if(target.martial_art && target.martial_art.block_chance)
-		if(prob(target.martial_art.block_chance) && target.in_throw_mode && !target.get_active_held_item())
-			if(!target.stat && !target.weakened && !target.stunned)
-				target.visible_message("<span class='danger'>[target.name] blocks [user] with their arm!</span>", \
-								"<span class='userdanger'>You block the attack attempt!</span>", null, COMBAT_MESSAGE_RANGE, user)
 
 /datum/species/proc/disarm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(attacker_style && attacker_style.disarm_act(user,target))
@@ -1042,11 +1034,7 @@
 		playsound(target, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		target.visible_message("<span class='danger'>[user] attempted to disarm [target]!</span>", \
 						"<span class='userdanger'>[user] attemped to disarm [target]!</span>", null, COMBAT_MESSAGE_RANGE, user)
-	if(target.martial_art && target.martial_art.block_chance)
-		if(prob(target.martial_art.block_chance) && target.in_throw_mode && !target.get_active_held_item())
-			if(!target.stat && !target.weakened && !target.stunned)
-				target.visible_message("<span class='danger'>[target.name] blocks [user] with their arm!</span>", "<span class='userdanger'>You block the disarm attempt!</span>", null, COMBAT_MESSAGE_RANGE, user)
-				return 0
+
 
 /datum/species/proc/spec_attack_hand(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style = M.martial_art)
 	if(!istype(M))

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -535,7 +535,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing."
 	item = /obj/item/weapon/CQC_manual
 	include_modes = list(/datum/game_mode/nuclear)
-	cost = 10
+	cost = 13
 	surplus = 0
 
 /datum/uplink_item/stealthy_weapons/throwingweapons

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -533,7 +533,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 /datum/uplink_item/stealthy_weapons/cqc
 	name = "CQC Manual"
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing."
-	item = /obj/item/weapon/CQC_manual
+	item = /obj/item/weapon/cqc_manual
 	include_modes = list(/datum/game_mode/nuclear)
 	cost = 13
 	surplus = 0


### PR DESCRIPTION
fixes an abusive exploit and makes 2 combos easier to use, increases cqc harm damage, adds martial art block_chance var which is only activated if you have your throw_mode on for active defense.

baton blocks stun the person attempting the attack too, you can now block batons and then throw or chokehold.

:cl: Basilman
add: CQC users can now block attacks by having their throw mode on.
tweak: The CQC kick and Disorient-disarm combos are now much easier to use, CQC harm intent attacks are stronger aswell.
fix: Fixed being able to CQC restrain someone, let him go, then 10 minutes later disarm someone else to instantly chokehold them.
tweak: CQC costs more TC (13)
/:cl:

makes tc cost for CQC 13 with all the buffs.
