### PR TITLE
Changes size of custom food items

### DIFF
--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -13,7 +13,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable
 	bitesize = 4
-	w_class = 3
+	w_class = 2
 	volume = 80
 
 	var/ingMax = 12

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -36,12 +36,14 @@
 	user << "It contains [ingredients.len?"[ingredients_listed]":"no ingredient, "]making a [size]-sized [initial(name)]."
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/attackby(obj/item/I, mob/user, params)
-	if(istype(I,/obj/item/weapon/reagent_containers/food/snacks))
+	if(!istype(I, /obj/item/weapon/reagent_containers/food/snacks/customizable) && istype(I,/obj/item/weapon/reagent_containers/food/snacks))
 		var/obj/item/weapon/reagent_containers/food/snacks/S = I
 		if(I.w_class > 2)
 			user << "<span class='warning'>The ingredient is too big for [src]!</span>"
 		else if((ingredients.len >= ingMax) || (reagents.total_volume >= volume))
 			user << "<span class='warning'>You can't add more ingredients to [src]!</span>"
+		else if(istype(I, /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/custom) || istype(I, /obj/item/weapon/reagent_containers/food/snacks/cakeslice/custom))
+			user << "<span class='warning'>Adding [I.name] to [src] would make a mess.</span>"
 		else
 			if(!user.unEquip(I))
 				return
@@ -67,7 +69,6 @@
 					name = "[customname] sandwich"
 					return
 			name = "[customname] [initial(name)]"
-
 	else . = ..()
 
 

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -139,7 +139,7 @@
 			if(S.w_class > 2)
 				user << "<span class='warning'>[S] is too big for [src]!</span>"
 				return 0
-			if(!S.customfoodfilling)
+			if(!S.customfoodfilling || istype(W, /obj/item/weapon/reagent_containers/food/snacks/customizable) || istype(W, /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/custom) || istype(W, /obj/item/weapon/reagent_containers/food/snacks/cakeslice/custom))
 				user << "<span class='warning'>[src] can't be filled with [S]!</span>"
 				return 0
 			if(contents.len >= 20)


### PR DESCRIPTION
:cl:
tweak: Custom food items can now fit inside of smaller containers, such as paper sacks.
/:cl:

Custom food items are now w_class 2, allowing them to fit in papersacks.
Prevents you from putting custom food items into other custom food items. A minor bugfix that existed before that allowed for infinipizzas and infinicakes. 
Gone are the days of:
_That's a custom cake slice cake slice cake slice cake slice cake slice cake slice cake slice cake slice cake slice cake slice cake slice cake slice cake slice cake slice cake slice cake._ (Feature? You decide.)

It bothered me that a crafted sandwich can fit inside a paper sack, but a custom sandwich that's just two slices of bread put together is suddenly too big. On the other side of this, you can now fit entire custom cakes into paper sacks, which doesn't make a whole lot of sense. If this bothers anybody, it's easily fixed.
