### PR TITLE
stop_procress now attempts to remove even if its not processing

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -6,7 +6,7 @@
 #define NEW_SS_GLOBAL(varname) if(varname != src){if(istype(varname)){Recover();qdel(varname);}varname = src;}
 
 #define START_PROCESSING(Processor, Datum) if (!Datum.isprocessing) {Datum.isprocessing = 1;Processor.processing += Datum}
-#define STOP_PROCESSING(Processor, Datum) if (Datum.isprocessing) {Datum.isprocessing = 0;Processor.processing -= Datum}
+#define STOP_PROCESSING(Processor, Datum) Datum.isprocessing = 0;Processor.processing -= Datum
 
 //SubSystem flags (Please design any new flags so that the default is off, to make adding flags to subsystems easier)
 


### PR DESCRIPTION
fixes #21171

Basically some things will attempt to remove from both fast process and normal process on destroy because they don't know what process its in.

I don't care to figure out if this is the case for nukes or if there is some other bug where its getting added to process without setting that var.
