### PR TITLE
Removes the possibility of a head of staff being selected as a revhead.

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -79,9 +79,14 @@
 				var/datum/mind/lenin = M
 				antag_candidates -= lenin
 				newcandidates -= lenin
-				if(istype(lenin.current,/mob/new_player))
+				if(istype(lenin.current,/mob/new_player)) //We don't want to make the same mistake again
 					continue
 				else
+					var/mob/Nm = lenin.current
+					if(Nm.job in restricted_jobs)	//Don't make the HOS a replacement revhead
+						antag_candidates += lenin	//Let's let them keep antag chance for other antags
+						continue
+
 					head_revolutionaries += lenin
 					break
 


### PR DESCRIPTION
Fixes #21150

:cl:
del: The HOS and other heads of staff no longer have a chance to be revheads
/:cl:
