### PR TITLE
Pipelines fail more loudly when they have null gas mixtures

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -194,6 +194,12 @@ var/pipenetwarnings = 10
 			air.temperature -= heat/total_heat_capacity
 	update = 1
 
+/datum/pipeline/proc/return_air()
+	. = other_airs + air
+	if(null in .)
+		stack_trace("[src] has one or more null gas mixtures, which may cause bugs. Null mixtures will not be considered in reconcile_air().")
+		return removeNullsFromList(.)
+
 /datum/pipeline/proc/reconcile_air()
 	var/list/datum/gas_mixture/GL = list()
 	var/list/datum/pipeline/PL = list()
@@ -201,8 +207,7 @@ var/pipenetwarnings = 10
 
 	for(var/i = 1; i <= PL.len; i++) //can't do a for-each here because we may add to the list within the loop
 		var/datum/pipeline/P = PL[i]
-		GL += P.air
-		GL += P.other_airs
+		GL += P.return_air()
 		for(var/obj/machinery/atmospherics/components/binary/valve/V in P.other_atmosmch)
 			if(V.open)
 				PL |= V.PARENT1


### PR DESCRIPTION
Will help debug runtimes similar to this:

```
The following runtime has occurred 8051 time(s).
runtime error: Cannot read null.volume
proc name: reconcile air (/datum/pipeline/proc/reconcile_air)
  source file: datum_pipeline.dm,220
  usr: null
  src: /datum/pipeline (/datum/pipeline)
```

Expect more PRs like this while I try to gather enough useful data to actually track down and fix the causes of various atmos and turf runtimes

btw @Cheridan gib maintainer pls
