### PR TITLE
Clockwork structures that use power will now handle APC power better

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -149,7 +149,7 @@
 /datum/clockwork_scripture/create_object/interdiction_lens
 	descname = "Structure, Disables Machinery"
 	name = "Interdiction Lens"
-	desc = "Creates a clockwork totem that sabotages nearby machinery and funnels drained power into nearby Sigils of Transmission."
+	desc = "Creates a clockwork totem that sabotages nearby machinery and funnels drained power into nearby Sigils of Transmission or the area's APC."
 	invocations = list("May this totem...", "...shroud the false suns!")
 	channel_time = 80
 	required_components = list("belligerent_eye" = 4, "replicant_alloy" = 1, "hierophant_ansible" = 1)

--- a/code/game/gamemodes/clock_cult/clock_structure.dm
+++ b/code/game/gamemodes/clock_cult/clock_structure.dm
@@ -172,11 +172,14 @@
 				amount -= MIN_CLOCKCULT_POWER
 	var/apcpower = accessable_apc_power()
 	while(apcpower >= MIN_CLOCKCULT_POWER && amount >= MIN_CLOCKCULT_POWER)
-		if(target_apc.cell.use(MIN_CLOCKCULT_POWER))
+		if(target_apc.cell && target_apc.cell.use(MIN_CLOCKCULT_POWER))
 			apcpower -= MIN_CLOCKCULT_POWER
 			amount -= MIN_CLOCKCULT_POWER
+			target_apc.charging = 1
+			target_apc.chargemode = TRUE
 			target_apc.update()
 			target_apc.update_icon()
+			target_apc.updateUsrDialog()
 		else
 			apcpower = 0
 	if(amount)
@@ -184,17 +187,24 @@
 	else
 		return TRUE
 
-/obj/structure/destructible/clockwork/powered/proc/return_power(amount) //returns a given amount of power to all nearby sigils
+/obj/structure/destructible/clockwork/powered/proc/return_power(amount) //returns a given amount of power to all nearby sigils or if there are no sigils, to the APC
 	if(amount <= 0)
 		return FALSE
 	var/list/sigils_in_range = list()
 	for(var/obj/effect/clockwork/sigil/transmission/T in range(1, src))
 		sigils_in_range |= T
-	if(!sigils_in_range.len)
+	if(!sigils_in_range.len && (!target_apc || !target_apc.cell))
 		return FALSE
-	while(amount >= MIN_CLOCKCULT_POWER)
-		for(var/S in sigils_in_range)
-			var/obj/effect/clockwork/sigil/transmission/T = S
-			if(amount >= MIN_CLOCKCULT_POWER && T.modify_charge(-MIN_CLOCKCULT_POWER))
-				amount -= MIN_CLOCKCULT_POWER
+	if(sigils_in_range.len)
+		while(amount >= MIN_CLOCKCULT_POWER)
+			for(var/S in sigils_in_range)
+				var/obj/effect/clockwork/sigil/transmission/T = S
+				if(amount >= MIN_CLOCKCULT_POWER && T.modify_charge(-MIN_CLOCKCULT_POWER))
+					amount -= MIN_CLOCKCULT_POWER
+	if(target_apc && target_apc.cell && target_apc.cell.give(amount))
+		target_apc.charging = 1
+		target_apc.chargemode = TRUE
+		target_apc.update()
+		target_apc.update_icon()
+		target_apc.updateUsrDialog()
 	return TRUE

--- a/code/game/gamemodes/clock_cult/clock_structure.dm
+++ b/code/game/gamemodes/clock_cult/clock_structure.dm
@@ -172,7 +172,7 @@
 				amount -= MIN_CLOCKCULT_POWER
 	var/apcpower = accessable_apc_power()
 	while(apcpower >= MIN_CLOCKCULT_POWER && amount >= MIN_CLOCKCULT_POWER)
-		if(target_apc.cell && target_apc.cell.use(MIN_CLOCKCULT_POWER))
+		if(target_apc.cell.use(MIN_CLOCKCULT_POWER))
 			apcpower -= MIN_CLOCKCULT_POWER
 			amount -= MIN_CLOCKCULT_POWER
 			target_apc.charging = 1

--- a/code/game/gamemodes/clock_cult/clock_structures/interdiction_lens.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/interdiction_lens.dm
@@ -2,7 +2,7 @@
 /obj/structure/destructible/clockwork/powered/interdiction_lens
 	name = "interdiction lens"
 	desc = "An ominous, double-pronged brass totem. There's a strange gemstone clasped between the pincers."
-	clockwork_desc = "A powerful totem that constantly drains nearby electronics and funnels the power drained into nearby Sigils of Transmission."
+	clockwork_desc = "A powerful totem that constantly drains nearby electronics and funnels the power drained into nearby Sigils of Transmission or the area's APC."
 	icon_state = "interdiction_lens"
 	construction_value = 25
 	active_icon = "interdiction_lens_active"
@@ -56,7 +56,7 @@
 
 		for(var/M in atoms_to_test)
 			var/atom/movable/A = M
-			if(!A || qdeleted(A))
+			if(!A || qdeleted(A) || A == target_apc)
 				continue
 			power_drained += A.power_drain(TRUE)
 


### PR DESCRIPTION
:cl: Joan
bugfix: Clockwork structures that return power can now return power to the APC of the area they're in if there happens to be one.
bugfix: Clockwork structures that use power from an APC will cause that APC to start charging and update the tgUI of anyone looking at the APC.
/:cl:
