### PR TITLE
Fixed a few bugs with clockwork proselytizers

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
@@ -41,42 +41,51 @@
 /obj/item/stack/rods/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
 	if(get_amount() >= 10)
 		var/sheets_to_make = round(get_amount() * 0.1)
-		var/remainder = get_amount() - (sheets_to_make * 10)
-		if(remainder)
-			new type(loc, remainder)
-		return list("operation_time" = 0, "new_obj_type" = /obj/item/stack/sheet/brass, "alloy_cost" = 0, "spawn_dir" = sheets_to_make, "dir_in_new" = TRUE)
+		var/used = sheets_to_make * 10
+		user.visible_message("<span class='warning'>[user]'s [name] rips into [src], converting it to brass!</span>", \
+		"<span class='brass'>You convert [get_amount() - used > 0 ? "part of ":""][src] into brass...</span>")
+		playsound(src, 'sound/machines/click.ogg', 50, 1)
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
+		new /obj/item/stack/sheet/brass(get_turf(src), sheets_to_make)
+		use(used)
 	else
 		user << "<span class='warning'>You need at least 10 rods to convert into brass.</span>"
-		return TRUE
+	return TRUE
 
 /obj/item/stack/sheet/metal/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
-	if(src.get_amount() >= 5)
+	if(get_amount() >= 5)
 		var/sheets_to_make = round(src.get_amount() * 0.2)
-		var/remainder = src.get_amount() - (sheets_to_make * 5)
-		if(remainder)
-			new type(loc, remainder)
-		return list("operation_time" = 0, "new_obj_type" = /obj/item/stack/sheet/brass, "alloy_cost" = 0, "spawn_dir" = sheets_to_make, "dir_in_new" = TRUE)
+		var/used = sheets_to_make * 5
+		user.visible_message("<span class='warning'>[user]'s [name] rips into [src], converting it to brass!</span>", \
+		"<span class='brass'>You convert [get_amount() - used > 0 ? "part of ":""][src] into brass...</span>")
+		playsound(src, 'sound/machines/click.ogg', 50, 1)
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
+		new /obj/item/stack/sheet/brass(get_turf(src), sheets_to_make)
+		use(used)
 	else
 		user << "<span class='warning'>You need at least 5 sheets of metal to convert into brass.</span>"
-		return TRUE
+	return TRUE
 
 /obj/item/stack/sheet/plasteel/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
-	if(get_amount() >= 10)
-		var/sheets_to_make = round(get_amount() * 0.4)
-		var/remainder = get_amount() - (sheets_to_make * 2.5)
-		if(remainder)
-			new type(loc, remainder)
-		return list("operation_time" = 0, "new_obj_type" = /obj/item/stack/sheet/brass, "alloy_cost" = 0, "spawn_dir" = sheets_to_make, "dir_in_new" = TRUE)
+	if(get_amount() >= 2)
+		var/sheets_to_make = round(get_amount() * 0.5)
+		var/used = sheets_to_make * 2
+		user.visible_message("<span class='warning'>[user]'s [name] rips into [src], converting it to brass!</span>", \
+		"<span class='brass'>You convert [get_amount() - used > 0 ? "part of ":""][src] into brass...</span>")
+		playsound(src, 'sound/machines/click.ogg', 50, 1)
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
+		new /obj/item/stack/sheet/brass(get_turf(src), sheets_to_make)
+		use(used)
 	else
-		user << "<span class='warning'>You need at least 10 sheets of plasteel to convert into brass.</span>"
-		return TRUE
+		user << "<span class='warning'>You need at least 2 sheets of plasteel to convert into brass.</span>"
+	return TRUE
 
 //Brass directly to alloy; scarab only
 /obj/item/stack/sheet/brass/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
 	if(!proselytizer.metal_to_alloy)
 		return FALSE
-	var/prosel_cost = -amount*10
-	var/prosel_time = -amount*1
+	var/prosel_cost = -amount*REPLICANT_FLOOR
+	var/prosel_time = -amount
 	return list("operation_time" = -prosel_time, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "alloy_cost" = prosel_cost, "spawn_dir" = SOUTH)
 
 //Airlock conversion
@@ -127,9 +136,6 @@
 //Hitting a clockwork structure will try to repair it.
 /obj/structure/destructible/clockwork/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
 	. = TRUE
-	if(proselytizer.repairing) //no spamclicking for fast repairs, bucko
-		user << "<span class='warning'>You are already repairing [proselytizer.repairing] with [proselytizer]!</span>"
-		return
 	if(!can_be_repaired)
 		user << "<span class='warning'>[src] cannot be repaired with a proselytizer!</span>"
 		return
@@ -187,6 +193,7 @@
 	if(!clockwork_component_cache["replicant_alloy"])
 		user << "<span class='warning'>There is no Replicant Alloy in the global component cache!</span>"
 		return
+	proselytizer.refueling = TRUE
 	user.visible_message("<span class='notice'>[user] places the end of [proselytizer] in the hole in [src]...</span>", \
 	"<span class='notice'>You start filling [proselytizer] with liquified alloy...</span>")
 	//hugeass check because we need to re-check after the do_after
@@ -196,15 +203,18 @@
 		proselytizer.modify_stored_alloy(REPLICANT_ALLOY_UNIT)
 		clockwork_component_cache["replicant_alloy"]--
 		playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
-	if(proselytizer && user)
-		user.visible_message("<span class='notice'>[user] removes [proselytizer] from the hole in [src], apparently satisfied.</span>", \
+	if(proselytizer)
+		proselytizer.refueling = FALSE
+		if(user)
+			user.visible_message("<span class='notice'>[user] removes [proselytizer] from the hole in [src], apparently satisfied.</span>", \
 		"<span class='brass'>You finish filling [proselytizer] with liquified alloy. It now contains <b>[proselytizer.stored_alloy]/[proselytizer.max_alloy]</b> units of liquified alloy.</span>")
 	return
 
-//Convert shards, wall gears, and replicant alloy directly to liquid alloy
+//convert wall gears back to brass sheets
 /obj/structure/destructible/clockwork/wall_gear/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
-	return list("operation_time" = 10, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "alloy_cost" = -REPLICANT_GEAR, "spawn_dir" = SOUTH)
+	return list("operation_time" = 10, "new_obj_type" = /obj/item/stack/sheet/brass, "alloy_cost" = 0, "spawn_dir" = 3, "dir_in_new" = TRUE)
 
+//Convert shards and replicant alloy directly to liquid alloy
 /obj/item/clockwork/alloy_shards/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
 	return list("operation_time" = 5, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "alloy_cost" = -REPLICANT_STANDARD, "spawn_dir" = SOUTH)
 

--- a/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
@@ -42,7 +42,7 @@
 	if(get_amount() >= 10)
 		var/sheets_to_make = round(get_amount() * 0.1)
 		var/used = sheets_to_make * 10
-		user.visible_message("<span class='warning'>[user]'s [name] rips into [src], converting it to brass!</span>", \
+		user.visible_message("<span class='warning'>[user]'s [proselytizer.name] rips into [src], converting it to brass!</span>", \
 		"<span class='brass'>You convert [get_amount() - used > 0 ? "part of ":""][src] into brass...</span>")
 		playsound(src, 'sound/machines/click.ogg', 50, 1)
 		playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
@@ -54,9 +54,9 @@
 
 /obj/item/stack/sheet/metal/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
 	if(get_amount() >= 5)
-		var/sheets_to_make = round(src.get_amount() * 0.2)
+		var/sheets_to_make = round(get_amount() * 0.2)
 		var/used = sheets_to_make * 5
-		user.visible_message("<span class='warning'>[user]'s [name] rips into [src], converting it to brass!</span>", \
+		user.visible_message("<span class='warning'>[user]'s [proselytizer.name] rips into [src], converting it to brass!</span>", \
 		"<span class='brass'>You convert [get_amount() - used > 0 ? "part of ":""][src] into brass...</span>")
 		playsound(src, 'sound/machines/click.ogg', 50, 1)
 		playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
@@ -70,7 +70,7 @@
 	if(get_amount() >= 2)
 		var/sheets_to_make = round(get_amount() * 0.5)
 		var/used = sheets_to_make * 2
-		user.visible_message("<span class='warning'>[user]'s [name] rips into [src], converting it to brass!</span>", \
+		user.visible_message("<span class='warning'>[user]'s [proselytizer.name] rips into [src], converting it to brass!</span>", \
 		"<span class='brass'>You convert [get_amount() - used > 0 ? "part of ":""][src] into brass...</span>")
 		playsound(src, 'sound/machines/click.ogg', 50, 1)
 		playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)

--- a/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
@@ -150,8 +150,8 @@
 	var/healing_for_cycle = min(amount_to_heal, repair_amount)
 	var/proselytizer_cost = 0
 	if(!proselytizer.can_use_alloy(RATVAR_ALLOY_CHECK))
-		healing_for_cycle = min(healing_for_cycle, proselytizer.stored_alloy)
-		proselytizer_cost = healing_for_cycle*2
+		healing_for_cycle = min(healing_for_cycle, proselytizer.stored_alloy * 0.5)
+		proselytizer_cost = healing_for_cycle * 2
 	if(!proselytizer.can_use_alloy(proselytizer_cost))
 		user << "<span class='warning'>You need more liquified alloy to repair [src]!</span>"
 		return
@@ -165,8 +165,8 @@
 			break
 		healing_for_cycle = min(amount_to_heal, repair_amount)
 		if(!proselytizer.can_use_alloy(RATVAR_ALLOY_CHECK))
-			healing_for_cycle = min(healing_for_cycle, proselytizer.stored_alloy)
-			proselytizer_cost = healing_for_cycle*2
+			healing_for_cycle = min(healing_for_cycle, proselytizer.stored_alloy * 0.5)
+			proselytizer_cost = healing_for_cycle * 2
 			if(!proselytizer.can_use_alloy(proselytizer_cost))
 				break
 		else
@@ -178,13 +178,13 @@
 			break
 		healing_for_cycle = min(amount_to_heal, repair_amount)
 		if(!proselytizer.can_use_alloy(RATVAR_ALLOY_CHECK))
-			healing_for_cycle = min(healing_for_cycle, proselytizer.stored_alloy)
-			proselytizer_cost = healing_for_cycle*2
+			healing_for_cycle = min(healing_for_cycle, proselytizer.stored_alloy * 0.5)
+			proselytizer_cost = healing_for_cycle * 2
 			if(!proselytizer.can_use_alloy(proselytizer_cost))
 				break
 		else
 			proselytizer_cost = 0
-		obj_integrity += healing_for_cycle
+		obj_integrity = Clamp(obj_integrity + healing_for_cycle, 0, max_integrity)
 		proselytizer.modify_stored_alloy(-proselytizer_cost)
 		playsound(src, 'sound/machines/click.ogg', 50, 1)
 

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
@@ -1,5 +1,5 @@
-
-/obj/item/clockwork/clockwork_proselytizer //Clockwork proselytizer (yes, that's a real word): Converts applicable objects to Ratvarian variants.
+//Clockwork proselytizer (yes, that's a real word): Converts applicable objects to Ratvarian variants.
+/obj/item/clockwork/clockwork_proselytizer
 	name = "clockwork proselytizer"
 	desc = "An odd, L-shaped device that hums with energy."
 	clockwork_desc = "A device that allows the replacing of mundane objects with Ratvarian variants. It requires liquified Replicant Alloy to function."
@@ -39,9 +39,9 @@
 	..()
 	if(is_servant_of_ratvar(user) || isobserver(user))
 		user << "<span class='brass'>Can be used to convert walls, floors, windows, airlocks, windoors, and grilles to clockwork variants.</span>"
-		user << "<span class='brass'>Can also form some objects into Replicant Alloy, as well as reform Clockwork Walls into Clockwork Floors, and vice versa.</span>"
+		user << "<span class='brass'>Can also form some objects into Brass sheets, as well as reform Clockwork Walls into Clockwork Floors, and vice versa.</span>"
 		if(metal_to_alloy)
-			user << "<span class='alloy'>It can convert brass to liquified replicant alloy at a rate of <b>1 sheet to [REPLICANT_FLOOR] alloy</b>.</span>"
+			user << "<span class='alloy'>It can convert Brass sheets to liquified replicant alloy at a rate of <b>1</b> sheet to <b>[REPLICANT_FLOOR]</b> alloy.</span>"
 		if(uses_alloy)
 			user << "<span class='alloy'>It has <b>[stored_alloy]/[max_alloy]</b> units of liquified alloy stored.</span>"
 			user << "<span class='alloy'>Use it on a Tinkerer's Cache, strike it with Replicant Alloy, or attack Replicant Alloy with it to add additional liquified alloy.</span>"
@@ -131,11 +131,7 @@
 	playsound(target, 'sound/machines/click.ogg', 50, 1)
 	if(proselytize_values["operation_time"] && !do_after(user, proselytize_values["operation_time"], target = target))
 		return FALSE
-	if(!can_use_alloy(proselytize_values["alloy_cost"])) //Check again to prevent bypassing via spamclick
-		return FALSE
-	if(!target || target.type != target_type)
-		return FALSE
-	if(repairing)
+	if(repairing || refueling || !can_use_alloy(proselytize_values["alloy_cost"]) || !target || target.type != target_type) //Check again to prevent bypassing via spamclick
 		return FALSE
 	user.visible_message("<span class='warning'>[user]'s [name] disgorges a chunk of metal and shapes it over what's left of [target]!</span>", \
 	"<span class='brass'>You proselytize [target].</span>")

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
@@ -12,6 +12,7 @@
 	var/uses_alloy = TRUE
 	var/metal_to_alloy = FALSE
 	var/repairing = null //what we're currently repairing, if anything
+	var/refueling = FALSE //if we're currently refueling from a cache
 
 /obj/item/clockwork/clockwork_proselytizer/preloaded
 	stored_alloy = REPLICANT_WALL_MINUS_FLOOR+REPLICANT_WALL_TOTAL
@@ -40,7 +41,7 @@
 		user << "<span class='brass'>Can be used to convert walls, floors, windows, airlocks, windoors, and grilles to clockwork variants.</span>"
 		user << "<span class='brass'>Can also form some objects into Replicant Alloy, as well as reform Clockwork Walls into Clockwork Floors, and vice versa.</span>"
 		if(metal_to_alloy)
-			user << "<span class='alloy'>It can convert rods, metal, and plasteel to liquified replicant alloy at a low rate.</span>"
+			user << "<span class='alloy'>It can convert brass to liquified replicant alloy at a rate of <b>1 sheet to [REPLICANT_FLOOR] alloy</b>.</span>"
 		if(uses_alloy)
 			user << "<span class='alloy'>It has <b>[stored_alloy]/[max_alloy]</b> units of liquified alloy stored.</span>"
 			user << "<span class='alloy'>Use it on a Tinkerer's Cache, strike it with Replicant Alloy, or attack Replicant Alloy with it to add additional liquified alloy.</span>"
@@ -80,10 +81,8 @@
 	proselytize(target, user)
 
 /obj/item/clockwork/clockwork_proselytizer/proc/modify_stored_alloy(amount)
-	if(can_use_alloy(RATVAR_ALLOY_CHECK)) //Ratvar makes it free
-		amount = 0
 	stored_alloy = Clamp(stored_alloy + amount, 0, max_alloy)
-	return 1
+	return TRUE
 
 /obj/item/clockwork/clockwork_proselytizer/proc/can_use_alloy(amount)
 	if(amount == RATVAR_ALLOY_CHECK)
@@ -99,17 +98,23 @@
 
 /obj/item/clockwork/clockwork_proselytizer/proc/proselytize(atom/target, mob/living/user)
 	if(!target || !user)
-		return 0
+		return FALSE
+	if(repairing)
+		user << "<span class='warning'>You are currently repairing [repairing] with [src]!</span>"
+		return FALSE
+	if(refueling)
+		user << "<span class='warning'>You are currently refueling [src]!</span>"
+		return FALSE
 	var/target_type = target.type
 	var/list/proselytize_values = target.proselytize_vals(user, src) //relevant values for proselytizing stuff, given as an associated list
 	if(!islist(proselytize_values))
 		if(proselytize_values != TRUE) //if we get true, fail, but don't send a message for whatever reason
 			user << "<span class='warning'>[target] cannot be proselytized!</span>"
-		return 0
-	if(repairing)
-		user << "<span class='warning'>You are currently repairing [repairing] with [src]!</span>"
-		return 0
-	if(!uses_alloy)
+		return FALSE
+	if(can_use_alloy(RATVAR_ALLOY_CHECK))
+		if(proselytize_values["alloy_cost"] < 0) //if it's less than 0, it's trying to refuel from whatever this is, and we don't need to refuel right now!
+			user << "<span class='warning'>[target] cannot be proselytized!</span>"
+			return FALSE
 		proselytize_values["alloy_cost"] = 0
 
 	if(!can_use_alloy(proselytize_values["alloy_cost"]))
@@ -117,7 +122,7 @@
 			user << "<span class='warning'>You need <b>[proselytize_values["alloy_cost"]]</b> liquified alloy to proselytize [target]!</span>"
 		else if(stored_alloy - proselytize_values["alloy_cost"] > max_alloy)
 			user << "<span class='warning'>You have too much liquified alloy stored to proselytize [target]!</span>"
-		return 0
+		return FALSE
 
 	if(can_use_alloy(RATVAR_ALLOY_CHECK)) //Ratvar makes it faster
 		proselytize_values["operation_time"] *= 0.5
@@ -125,13 +130,13 @@
 	user.visible_message("<span class='warning'>[user]'s [name] begins tearing apart [target]!</span>", "<span class='brass'>You begin proselytizing [target]...</span>")
 	playsound(target, 'sound/machines/click.ogg', 50, 1)
 	if(proselytize_values["operation_time"] && !do_after(user, proselytize_values["operation_time"], target = target))
-		return 0
+		return FALSE
 	if(!can_use_alloy(proselytize_values["alloy_cost"])) //Check again to prevent bypassing via spamclick
-		return 0
+		return FALSE
 	if(!target || target.type != target_type)
-		return 0
+		return FALSE
 	if(repairing)
-		return 0
+		return FALSE
 	user.visible_message("<span class='warning'>[user]'s [name] disgorges a chunk of metal and shapes it over what's left of [target]!</span>", \
 	"<span class='brass'>You proselytize [target].</span>")
 	playsound(target, 'sound/items/Deconstruct.ogg', 50, 1)
@@ -147,4 +152,4 @@
 			A.setDir(proselytize_values["spawn_dir"])
 		qdel(target)
 	modify_stored_alloy(-proselytize_values["alloy_cost"])
-	return 1
+	return TRUE

--- a/code/game/gamemodes/clock_cult/clock_structures/wall_gear.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/wall_gear.dm
@@ -5,8 +5,9 @@
 	climbable = TRUE
 	max_integrity = 50
 	obj_integrity = 50
+	construction_value = 3
 	desc = "A massive brass gear. You could probably secure or unsecure it with a wrench, or just climb over it."
-	clockwork_desc = "A massive brass gear. You could probably secure or unsecure it with a wrench, just climb over it, or proselytize it into replicant alloy."
+	clockwork_desc = "A massive brass gear. You could probably secure or unsecure it with a wrench, just climb over it, or proselytize it into brass sheets."
 	break_message = "<span class='warning'>The gear breaks apart into shards of alloy!</span>"
 	debris = list(/obj/item/clockwork/alloy_shards/large = 1, \
 	/obj/item/clockwork/alloy_shards/medium = 4, \

--- a/code/game/gamemodes/clock_cult/clock_structures/wall_gear.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/wall_gear.dm
@@ -5,6 +5,7 @@
 	climbable = TRUE
 	max_integrity = 50
 	obj_integrity = 50
+	layer = BELOW_OBJ_LAYER
 	construction_value = 3
 	desc = "A massive brass gear. You could probably secure or unsecure it with a wrench, or just climb over it."
 	clockwork_desc = "A massive brass gear. You could probably secure or unsecure it with a wrench, just climb over it, or proselytize it into brass sheets."

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -432,15 +432,15 @@
 
 /obj/machinery/door/airlock/clockwork/examine(mob/user)
 	..()
-	var/gear_text = "Its gear is glitching the fuck out, report this to a coder."
+	var/gear_text = "The cogwheel is flickering and twisting wildly. Report this to a coder."
 	switch(construction_state)
 		if(GEAR_SECURE)
-			gear_text = "Its gear is firmly secured."
+			gear_text = "<span class='brass'>The cogwheel is solidly secured to the brass around it.</span>"
 		if(GEAR_UNFASTENED)
-			gear_text = "Its gear is slightly loose."
+			gear_text = "<span class='brass'>The cogwheel is slightly raised, enough to see a thin gap between it and the brass.</span>"
 		if(GEAR_LOOSE)
-			gear_text = "Its gear is barely attached to the door!"
-	user << "<span class='brass'>[gear_text]</span>"
+			gear_text = "<span class='heavy_alloy'>There is a wide gap between the cogwheel and the door!</span>"
+	user << gear_text
 
 /obj/machinery/door/airlock/clockwork/canAIControl(mob/user)
 	return (is_servant_of_ratvar(user) && !isAllPowerCut())
@@ -475,7 +475,7 @@
 	if(!(flags & NODECONSTRUCT))
 		var/turf/T = get_turf(src)
 		if(disassembled)
-			new/obj/item/stack/sheet/brass(T, 2)
+			new/obj/item/stack/sheet/brass(T, 4)
 		else
 			new/obj/item/clockwork/alloy_shards(T)
 		new/obj/item/clockwork/component/vanguard_cogwheel/pinion_lock(T)
@@ -486,19 +486,19 @@
 		return 0
 	if(istype(I, /obj/item/weapon/screwdriver))
 		if(construction_state == GEAR_SECURE)
-			user.visible_message("<span class='notice'>[user] begins unfastening [src]'s gear...</span>", "<span class='notice'>You begin unfastening [src]'s gear...</span>")
+			user.visible_message("<span class='notice'>[user] begins unfastening [src]'s cogwheel...</span>", "<span class='notice'>You begin unfastening [src]'s cogwheel...</span>")
 			playsound(src, I.usesound, 50, 1)
-			if(!do_after(user, 75 / I.toolspeed, target = src))
+			if(!do_after(user, 100 / I.toolspeed, target = src))
 				return 1 //Returns 1 so as not to have extra interactions with the tools used (i.e. prying open)
-			user.visible_message("<span class='notice'>[user] unfastens [src]'s gear!</span>", "<span class='notice'>[src]'s gear shifts slightly with a pop.</span>")
+			user.visible_message("<span class='notice'>[user] unfastens [src]'s cogwheel!</span>", "<span class='notice'>[src]'s cogwheel shifts slightly with a pop.</span>")
 			playsound(src, 'sound/items/Screwdriver2.ogg', 50, 1)
 			construction_state = GEAR_UNFASTENED
 		else if(construction_state == GEAR_UNFASTENED)
-			user.visible_message("<span class='notice'>[user] begins fastening [src]'s gear...</span>", "<span class='notice'>You begin fastening [src]'s gear...</span>")
+			user.visible_message("<span class='notice'>[user] begins fastening [src]'s cogwheel...</span>", "<span class='notice'>You begin fastening [src]'s cogwheel...</span>")
 			playsound(src, I.usesound, 50, 1)
 			if(!do_after(user, 75 / I.toolspeed, target = src))
 				return 1
-			user.visible_message("<span class='notice'>[user] fastens [src]'s gear!</span>", "<span class='notice'>[src]'s gear shifts back into place.</span>")
+			user.visible_message("<span class='notice'>[user] fastens [src]'s cogwheel!</span>", "<span class='notice'>[src]'s cogwheel shifts back into place.</span>")
 			playsound(src, 'sound/items/Screwdriver2.ogg', 50, 1)
 			construction_state = GEAR_SECURE
 		else if(construction_state == GEAR_LOOSE)
@@ -506,36 +506,36 @@
 		return 1
 	else if(istype(I, /obj/item/weapon/wrench))
 		if(construction_state == GEAR_SECURE)
-			user << "<span class='warning'>[src] is too tightly secured! Your [I.name] can't get a solid grip!</span>"
+			user << "<span class='warning'>[src]'s cogwheel is too tightly secured! Your [I.name] can't get a solid grip!</span>"
 			return 0
 		else if(construction_state == GEAR_UNFASTENED)
-			user.visible_message("<span class='notice'>[user] begins loosening [src]'s gear...</span>", "<span class='notice'>You begin loosening [src]'s gear...</span>")
+			user.visible_message("<span class='notice'>[user] begins loosening [src]'s cogwheel...</span>", "<span class='notice'>You begin loosening [src]'s cogwheel...</span>")
 			playsound(src, I.usesound, 50, 1)
-			if(!do_after(user, 80 / I.toolspeed, target = src))
+			if(!do_after(user, 100 / I.toolspeed, target = src))
 				return 1
-			user.visible_message("<span class='notice'>[user] loosens [src]'s gear!</span>", "<span class='notice'>[src]'s gear pops off and dangles loosely.</span>")
+			user.visible_message("<span class='notice'>[user] loosens [src]'s cogwheel!</span>", "<span class='notice'>[src]'s cogwheel pops off and dangles loosely.</span>")
 			playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
 			construction_state = GEAR_LOOSE
 		else if(construction_state == GEAR_LOOSE)
-			user.visible_message("<span class='notice'>[user] begins tightening [src]'s gear...</span>", "<span class='notice'>You begin tightening [src]'s gear into place...</span>")
+			user.visible_message("<span class='notice'>[user] begins tightening [src]'s cogwheel...</span>", "<span class='notice'>You begin tightening [src]'s cogwheel into place...</span>")
 			playsound(src, I.usesound, 50, 1)
-			if(!do_after(user, 80 / I.toolspeed, target = src))
+			if(!do_after(user, 75 / I.toolspeed, target = src))
 				return 1
-			user.visible_message("<span class='notice'>[user] tightens [src]'s gear!</span>", "<span class='notice'>You firmly tighten [src]'s gear into place.</span>")
+			user.visible_message("<span class='notice'>[user] tightens [src]'s cogwheel!</span>", "<span class='notice'>You firmly tighten [src]'s cogwheel into place.</span>")
 			playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
 			construction_state = GEAR_UNFASTENED
 		return 1
 	else if(istype(I, /obj/item/weapon/crowbar))
 		if(construction_state == GEAR_SECURE || construction_state == GEAR_UNFASTENED)
-			user << "<span class='warning'>[src]'s gear is too tightly secured! Your [I.name] can't reach under it!</span>"
+			user << "<span class='warning'>[src]'s cogwheel is too tightly secured! Your [I.name] can't reach under it!</span>"
 			return 1
 		else if(construction_state == GEAR_LOOSE)
-			user.visible_message("<span class='notice'>[user] begins slowly lifting off [src]'s gear...</span>", "<span class='notice'>You slowly begin lifting off [src]'s gear...</span>")
+			user.visible_message("<span class='notice'>[user] begins slowly lifting off [src]'s cogwheel...</span>", "<span class='notice'>You slowly begin lifting off [src]'s cogwheel...</span>")
 			playsound(src, I.usesound, 50, 1)
-			if(!do_after(user, 85 / I.toolspeed, target = src))
+			if(!do_after(user, 100 / I.toolspeed, target = src))
 				return 1
-			user.visible_message("<span class='notice'>[user] lifts off [src]'s gear, causing it to fall apart!</span>", "<span class='notice'>You lift off [src]'s gear, causing it to fall \
-			apart!</span>")
+			user.visible_message("<span class='notice'>[user] lifts off [src]'s cogwheel, causing it to fall apart!</span>", \
+			"<span class='notice'>You lift off [src]'s cogwheel, causing it to fall apart!</span>")
 			deconstruct(TRUE)
 		return 1
 	return 0

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -17,6 +17,7 @@
 	origin_tech = "materials=1"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 100)
 	resistance_flags = ACID_PROOF
+	merge_type = /obj/item/stack/sheet/glass
 
 /obj/item/stack/sheet/glass/cyborg
 	materials = list()
@@ -141,6 +142,7 @@
 	origin_tech = "materials=2"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 70, acid = 100)
 	resistance_flags = ACID_PROOF
+	merge_type = /obj/item/stack/sheet/rglass
 
 /obj/item/stack/sheet/rglass/cyborg
 	materials = list()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -62,6 +62,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 	flags = CONDUCT
 	origin_tech = "materials=1"
 	resistance_flags = FIRE_PROOF
+	merge_type = /obj/item/stack/sheet/metal
 
 /obj/item/stack/sheet/metal/ratvar_act()
 	new /obj/item/stack/sheet/brass(loc, amount)
@@ -107,6 +108,7 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 	origin_tech = "materials=2"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 80)
 	resistance_flags = FIRE_PROOF
+	merge_type = /obj/item/stack/sheet/plasteel
 
 /obj/item/stack/sheet/plasteel/New(var/loc, var/amount=null)
 	recipes = plasteel_recipes
@@ -152,6 +154,7 @@ var/global/list/datum/stack_recipe/wood_recipes = list ( \
 	sheettype = "wood"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 0)
 	resistance_flags = FLAMMABLE
+	merge_type = /obj/item/stack/sheet/mineral/wood
 
 /obj/item/stack/sheet/mineral/wood/New(var/loc, var/amount=null)
 	recipes = wood_recipes
@@ -191,6 +194,7 @@ var/global/list/datum/stack_recipe/cloth_recipes = list ( \
 	resistance_flags = FLAMMABLE
 	force = 0
 	throwforce = 0
+	merge_type = /obj/item/stack/sheet/cloth
 
 /obj/item/stack/sheet/cloth/New(var/loc, var/amount=null)
 	recipes = cloth_recipes
@@ -222,6 +226,7 @@ var/global/list/datum/stack_recipe/cardboard_recipes = list ( \
 	icon_state = "sheet-card"
 	origin_tech = "materials=1"
 	resistance_flags = FLAMMABLE
+	merge_type = /obj/item/stack/sheet/cardboard
 
 /obj/item/stack/sheet/cardboard/New(var/loc, var/amount=null)
 		recipes = cardboard_recipes
@@ -250,6 +255,7 @@ var/global/list/datum/stack_recipe/runed_metal_recipes = list ( \
 	icon_state = "sheet-runed"
 	icon = 'icons/obj/items.dmi'
 	sheettype = "runed"
+	merge_type = /obj/item/stack/sheet/runed_metal
 
 /obj/item/stack/sheet/runed_metal/ratvar_act()
 	new /obj/item/stack/sheet/brass(loc, amount)

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -285,13 +285,15 @@ var/global/list/datum/stack_recipe/runed_metal_recipes = list ( \
  */
 var/global/list/datum/stack_recipe/brass_recipes = list ( \
 	new/datum/stack_recipe("wall gear", /obj/structure/destructible/clockwork/wall_gear, 3, time = 30, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("brass floor tile", /obj/item/stack/tile/brass, 1, 1, 50), \
+	null,
 	new/datum/stack_recipe("pinion airlock", /obj/machinery/door/airlock/clockwork, 5, time = 50, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("brass pinion airlock", /obj/machinery/door/airlock/clockwork/brass, 5, time = 50, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("brass windoor", /obj/machinery/door/window/clockwork, 2, time = 30, one_per_turf = 1, on_floor = 1), \
+	null,
 	new/datum/stack_recipe("directional brass window", /obj/structure/window/reinforced/clockwork, time = 15, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("brass window", /obj/structure/window/reinforced/clockwork/fulltile, 2, time = 30, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("brass table frame", /obj/structure/table_frame/brass, 1, time = 5, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("brass floor tile", /obj/item/stack/tile/brass, 1, 1, 50) \
+	new/datum/stack_recipe("brass table frame", /obj/structure/table_frame/brass, 1, time = 5, one_per_turf = 1, on_floor = 1) \
 )
 
 /obj/item/stack/sheet/brass

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -110,6 +110,7 @@
 	icon_state = "tile_space"
 	turf_type = /turf/open/floor/fakespace
 	resistance_flags = FLAMMABLE
+	merge_type = /obj/item/stack/tile/fakespace
 
 /obj/item/stack/tile/fakespace/loaded
 	amount = 30
@@ -122,6 +123,7 @@
 	icon_state = "tile_noslip"
 	turf_type = /turf/open/floor/noslip
 	origin_tech = "materials=3"
+	merge_type = /obj/item/stack/tile/noslip
 
 /obj/item/stack/tile/noslip/thirty
 	amount = 30

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -133,6 +133,14 @@
 	framestack = /obj/item/stack/sheet/brass
 	framestackamount = 1
 
+/obj/structure/table_frame/brass/New()
+	change_construction_value(1)
+	..()
+
+/obj/structure/table_frame/brass/Destroy()
+	change_construction_value(-1)
+	return ..()
+
 /obj/structure/table_frame/brass/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/stack/sheet/brass))
 		var/obj/item/stack/sheet/brass/W = I

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -330,6 +330,15 @@
 	buildstackamount = 1
 	canSmoothWith = list(/obj/structure/table/reinforced/brass)
 
+/obj/structure/table/reinforced/brass/New()
+	change_construction_value(2)
+	..()
+
+/obj/structure/table/reinforced/brass/Destroy()
+	change_construction_value(-2)
+	return ..()
+
+
 /obj/structure/table/reinforced/brass/narsie_act()
 	take_damage(rand(15, 45), BRUTE)
 	if(src) //do we still exist?

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -14,8 +14,8 @@
 	var/reinf = 0
 	var/wtype = "glass"
 	var/fulltile = 0
-//	var/silicate = 0 // number of units of silicate
-//	var/icon/silicateIcon = null // the silicated icon
+	var/glass_type = /obj/item/stack/sheet/glass
+	var/glass_amount = 1
 	var/image/crack_overlay
 	var/list/debris = list()
 	can_be_unanchored = 1
@@ -182,19 +182,8 @@
 				if(qdeleted(src))
 					return
 
-				if(reinf)
-					var/obj/item/stack/sheet/rglass/RG = new (user.loc)
-					RG.add_fingerprint(user)
-					if(fulltile) //fulltiles drop two panes
-						RG = new (user.loc)
-						RG.add_fingerprint(user)
-
-				else
-					var/obj/item/stack/sheet/glass/G = new (user.loc)
-					G.add_fingerprint(user)
-					if(fulltile)
-						G = new (user.loc)
-						G.add_fingerprint(user)
+				var/obj/item/stack/sheet/G = new glass_type(user.loc, glass_amount)
+				G.add_fingerprint(user)
 
 				playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 				user << "<span class='notice'>You successfully disassemble [src].</span>"
@@ -297,21 +286,6 @@
 	else
 		revrotate()
 
-/*
-/obj/structure/window/proc/updateSilicate() what do you call a syndicate silicon?
-	if(silicateIcon && silicate)
-		icon = initial(icon)
-
-		var/icon/I = icon(icon,icon_state,dir)
-
-		var/r = (silicate / 100) + 1
-		var/g = (silicate / 70) + 1
-		var/b = (silicate / 50) + 1
-		I.SetIntensity(r,g,b)
-		icon = I
-		silicateIcon = I
-*/
-
 /obj/structure/window/Destroy()
 	density = 0
 	air_update_turf(1)
@@ -379,6 +353,7 @@
 	armor = list(melee = 50, bullet = 0, laser = 0, energy = 0, bomb = 25, bio = 100, rad = 100, fire = 80, acid = 100)
 	max_integrity = 50
 	explosion_block = 1
+	glass_type = /obj/item/stack/sheet/rglass
 
 /obj/structure/window/reinforced/tinted
 	name = "tinted window"
@@ -400,6 +375,7 @@
 	fulltile = 1
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(/obj/structure/window/fulltile, /obj/structure/window/reinforced/fulltile, /obj/structure/window/reinforced/tinted/fulltile)
+	glass_amount = 2
 
 /obj/structure/window/reinforced/fulltile
 	icon = 'icons/obj/smooth_structures/reinforced_window.dmi'
@@ -410,6 +386,7 @@
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(/obj/structure/window/fulltile, /obj/structure/window/reinforced/fulltile, /obj/structure/window/reinforced/tinted/fulltile)
 	level = 3
+	glass_amount = 2
 
 /obj/structure/window/reinforced/tinted/fulltile
 	icon = 'icons/obj/smooth_structures/tinted_window.dmi'
@@ -419,6 +396,7 @@
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(/obj/structure/window/fulltile, /obj/structure/window/reinforced/fulltile, /obj/structure/window/reinforced/tinted/fulltile/)
 	level = 3
+	glass_amount = 2
 
 /obj/structure/window/reinforced/fulltile/ice
 	icon = 'icons/obj/smooth_structures/rice_window.dmi'
@@ -426,6 +404,7 @@
 	max_integrity = 150
 	canSmoothWith = list(/obj/structure/window/fulltile, /obj/structure/window/reinforced/fulltile, /obj/structure/window/reinforced/tinted/fulltile, /obj/structure/window/reinforced/fulltile/ice)
 	level = 3
+	glass_amount = 2
 
 /obj/structure/window/shuttle
 	name = "shuttle window"
@@ -442,6 +421,8 @@
 	canSmoothWith = null
 	explosion_block = 1
 	level = 3
+	glass_type = /obj/item/stack/sheet/rglass
+	glass_amount = 2
 
 /obj/structure/window/shuttle/narsie_act()
 	color = "#3C3434"
@@ -457,6 +438,8 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	max_integrity = 100
 	explosion_block = 2 //fancy AND hard to destroy. the most useful combination.
+	glass_type = /obj/item/stack/sheet/brass
+	glass_amount = 1
 	var/made_glow = FALSE
 
 /obj/structure/window/reinforced/clockwork/New(loc, direct)
@@ -475,7 +458,7 @@
 		PoolOrNew(/obj/effect/overlay/temp/ratvar/window, get_turf(src))
 		made_glow = TRUE
 		debris += new/obj/item/stack/sheet/brass(src, 2)
-	change_construction_value(fulltile ? 3 : 2)
+	change_construction_value(fulltile ? 2 : 1)
 
 /obj/structure/window/reinforced/clockwork/setDir(direct)
 	if(!made_glow)
@@ -485,7 +468,7 @@
 	..()
 
 /obj/structure/window/reinforced/clockwork/Destroy()
-	change_construction_value(fulltile ? -3 : -2)
+	change_construction_value(fulltile ? -2 : -1)
 	return ..()
 
 /obj/structure/window/reinforced/clockwork/ratvar_act()
@@ -507,3 +490,4 @@
 	fulltile = 1
 	dir = NORTHEAST
 	max_integrity = 150
+	glass_amount = 2


### PR DESCRIPTION
:cl: Joan
bugfix: Converting metal, rods, or plasteel to brass with a clockwork proselytizer while holding it will no longer leave a remainder inside of you.
tweak: Plasteel to brass is now a 2:1 ratio, from a 2.5:1 ratio. Accordingly, you now only need 2 sheets of plasteel to convert it to brass instead of 10 sheets.
tweak: Wall gears are now converted to brass sheets instead of directly to alloy.
rscdel: You can no longer do other proselytizer actions while refueling from a cache.
bugfix: Fixed a bug where certain stacks wouldn't merge with other stacks, even when they should have been.
bugfix: Clockwork structures constructed from brass sheets now all have appropriate construction value to replicant alloy ratios.
/:cl:
