### PR TITLE
Fixes hardlight bows

### DIFF
--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -192,13 +192,13 @@
 	icon_state = "hlquiver[icon_amount]"
 
 /obj/item/projectile/bullet/reusable/arrow/hardlight/on_hit(atom/target, blocked = 0)
-	if(L.mob_size >= MOB_SIZE_LARGE)
-		damage = 30	//ALMOST as effective as a KA.
-	else
-		var/obj/item/projectile/bullet/reusable/arrow/hardlight2/A = new /obj/item/projectile/bullet/reusable/arrow/hardlight2(src.loc)
-		A.Bump(target, 1)
-		qdel(A)
+	if(ismob(target))
+		if(target.mob_size >= MOB_SIZE_LARGE)
+			damage = 29	//ALMOST as effective as a KA.
 	..()
+	var/obj/item/projectile/bullet/reusable/arrow/hardlight2/A = new /obj/item/projectile/bullet/reusable/arrow/hardlight2(src.loc)
+	A.Bump(target, 1)
+	qdel(A)
 	qdel(src)	//NO INFINITE-HITTING!
 
 /obj/item/ammo_casing/caseless/arrow/hardlight/dropped()

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -144,8 +144,8 @@
 /obj/item/projectile/bullet/reusable/arrow/hardlight2
 	name = "hardlight arrow"
 	range = 30
-	damage = 18
-	damage_type = BURN
+	damage = 30
+	damage_type = BRUTE
 	flag = "laser"
 	dropped = 1
 
@@ -192,8 +192,7 @@
 
 /obj/item/projectile/bullet/reusable/arrow/hardlight/on_hit(atom/target, blocked = 0)
 	..()
-	var/obj/item/projectile/bullet/reusable/arrow/hardlight2/A = new /obj/item/projectile/bullet/reusable/arrow/hardlight2(src.loc)
-	A.Bump(target, 1)
+	qdel(src)
 
 /obj/item/ammo_casing/caseless/arrow/hardlight/dropped()
 	QDEL_IN(src,200)

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -148,6 +148,7 @@
 	damage_type = BURN
 	flag = "laser"
 	dropped = 1
+	suppressed = 1
 
 /obj/item/weapon/storage/backpack/quiver/hardlight
 	name = "hardlight quiver"
@@ -191,10 +192,13 @@
 	icon_state = "hlquiver[icon_amount]"
 
 /obj/item/projectile/bullet/reusable/arrow/hardlight/on_hit(atom/target, blocked = 0)
+	if(L.mob_size >= MOB_SIZE_LARGE)
+		damage = 30	//ALMOST as effective as a KA.
+	else
+		var/obj/item/projectile/bullet/reusable/arrow/hardlight2/A = new /obj/item/projectile/bullet/reusable/arrow/hardlight2(src.loc)
+		A.Bump(target, 1)
+		qdel(A)
 	..()
-	var/obj/item/projectile/bullet/reusable/arrow/hardlight2/A = new /obj/item/projectile/bullet/reusable/arrow/hardlight2(src.loc)
-	A.Bump(target, 1)
-	qdel(A)
 	qdel(src)	//NO INFINITE-HITTING!
 
 /obj/item/ammo_casing/caseless/arrow/hardlight/dropped()

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -130,8 +130,8 @@
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/hardlight
 	range = 30
 	damage = 30
-	damage_type = BURN		//I give the fuck up untill someone makes projectiles able to multi-damage I'm not going to risk experimenting with multi-hit projectiles.
-	flag = "burn"
+	damage_type = BRUTE		//I give the fuck up untill someone makes projectiles able to multi-damage I'm not going to risk experimenting with multi-hit projectiles.
+	flag = "bullet"
 	dropped = 1
 
 /obj/item/ammo_casing/caseless/arrow/hardlight

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -129,9 +129,9 @@
 	icon_state = "arrow_hardlight"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/hardlight
 	range = 30
-	damage = 12
-	damage_type = BRUTE
-	flag = "bullet"
+	damage = 30
+	damage_type = BURN		//I give the fuck up untill someone makes projectiles able to multi-damage I'm not going to risk experimenting with multi-hit projectiles.
+	flag = "burn"
 	dropped = 1
 
 /obj/item/ammo_casing/caseless/arrow/hardlight
@@ -140,15 +140,6 @@
 	icon_state = "arrow_hardlight"
 	force = 7
 	projectile_type = /obj/item/projectile/bullet/reusable/arrow/hardlight
-
-/obj/item/projectile/bullet/reusable/arrow/hardlight2
-	name = "hardlight arrow"
-	range = 30
-	damage = 18
-	damage_type = BURN
-	flag = "laser"
-	dropped = 1
-	suppressed = 1
 
 /obj/item/weapon/storage/backpack/quiver/hardlight
 	name = "hardlight quiver"
@@ -192,14 +183,7 @@
 	icon_state = "hlquiver[icon_amount]"
 
 /obj/item/projectile/bullet/reusable/arrow/hardlight/on_hit(atom/target, blocked = 0)
-	if(isliving(target))
-		var/mob/living/L = target
-		if(L.mob_size >= MOB_SIZE_LARGE)
-			damage = 29	//ALMOST as effective as a KA.
 	..()
-	var/obj/item/projectile/bullet/reusable/arrow/hardlight2/A = new /obj/item/projectile/bullet/reusable/arrow/hardlight2(src.loc)
-	A.Bump(target, 1)
-	qdel(A)
 	qdel(src)	//NO INFINITE-HITTING!
 
 /obj/item/ammo_casing/caseless/arrow/hardlight/dropped()

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -144,8 +144,8 @@
 /obj/item/projectile/bullet/reusable/arrow/hardlight2
 	name = "hardlight arrow"
 	range = 30
-	damage = 30
-	damage_type = BRUTE
+	damage = 18
+	damage_type = BURN
 	flag = "laser"
 	dropped = 1
 
@@ -192,7 +192,10 @@
 
 /obj/item/projectile/bullet/reusable/arrow/hardlight/on_hit(atom/target, blocked = 0)
 	..()
-	qdel(src)
+	var/obj/item/projectile/bullet/reusable/arrow/hardlight2/A = new /obj/item/projectile/bullet/reusable/arrow/hardlight2(src.loc)
+	A.Bump(target, 1)
+	qdel(A)
+	qdel(src)	//NO INFINITE-HITTING!
 
 /obj/item/ammo_casing/caseless/arrow/hardlight/dropped()
 	QDEL_IN(src,200)

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -192,8 +192,9 @@
 	icon_state = "hlquiver[icon_amount]"
 
 /obj/item/projectile/bullet/reusable/arrow/hardlight/on_hit(atom/target, blocked = 0)
-	if(ismob(target))
-		if(target.mob_size >= MOB_SIZE_LARGE)
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.mob_size >= MOB_SIZE_LARGE)
 			damage = 29	//ALMOST as effective as a KA.
 	..()
 	var/obj/item/projectile/bullet/reusable/arrow/hardlight2/A = new /obj/item/projectile/bullet/reusable/arrow/hardlight2(src.loc)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -151,6 +151,7 @@
 /obj/item/projectile/magic/change/on_hit(atom/change)
 	. = ..()
 	wabbajack(change)
+	qdel(src)
 
 /proc/wabbajack(mob/living/M)
 	if(!istype(M) || M.stat == DEAD || M.notransform || (GODMODE & M.status_flags))


### PR DESCRIPTION
Prevents them from infinite-hitting things by deleting them after they apply hit effects.
Also removes the secondary hit for a 30 brute primary hit instead of attempting to split damage as that's not working well.
