### PR TITLE
Adds automatic highlighting of syndicate codewords for traitors and !!!GHOSTS!!!

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -220,7 +220,6 @@ var/list/syndicate_code_response = list()//Code response for traitors.
 
 //Phrases are green, responses are blue.
 /proc/parse_for_code_words(text)
-	world << "DEBUG: PARSING..."
 	var/parse = text
 	for(var/word in syndicate_code_phrase)
 		var/indexl = 0
@@ -230,7 +229,6 @@ var/list/syndicate_code_response = list()//Code response for traitors.
 		var/insertword = "<span class='codephrase'>[word]</span>"
 		if(!findtext(parse, word))
 			continue
-		world << "DEBUG: CODEPHRASE PARSED."
 		indexl = findtext(parse, word)
 		indexu = (indexl + lentext(word))
 		parse1 = copytext(parse, 1, indexl)
@@ -244,7 +242,6 @@ var/list/syndicate_code_response = list()//Code response for traitors.
 		var/insertword = "<span class='coderesponse'>[word]</span>"
 		if(!findtext(parse, word))
 			continue
-		world << "DEBUG: CODERESPONSE PARSED."
 		indexl = findtext(parse, word)
 		indexu = (indexl + lentext(word))
 		parse1 = copytext(parse, 1, indexl)

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -216,15 +216,38 @@ var/list/syndicate_code_response = list()//Code response for traitors.
 					if(3)
 						code_phrase += pick(verbs)
 
-	world << "DEBUG: GENERATED CODE PHRASE."
-	world << "[english_list(code_phrase, final_comma_text = ", ", and_text = "")]"
 	return code_phrase
 
-/proc/parse_for_code_word(text)
+//Phrases are green, responses are blue.
+/proc/parse_for_code_words(text)
+	world << "DEBUG: PARSING..."
+	var/parse = text
 	for(var/word in syndicate_code_phrase)
-
+		var/indexl = 0
+		var/indexu = 0
+		var/parse1
+		var/parse2
+		var/insertword = "<span class='codephrase'>[word]</span>"
+		if(!findtext(parse, word))
+			continue
+		world << "DEBUG: CODEPHRASE PARSED."
+		indexl = findtext(parse, word)
+		indexu = (indexl + lentext(word))
+		parse1 = copytext(parse, 1, indexl)
+		parse2 = copytext(parse, indexu)
+		parse = "[parse1][insertword][parse2]"
 	for(var/word in syndicate_code_response)
-
-
-
-if mind.special_role == "traitor"
+		var/indexl = 0
+		var/indexu = 0
+		var/parse1
+		var/parse2
+		var/insertword = "<span class='coderesponse'>[word]</span>"
+		if(!findtext(parse, word))
+			continue
+		world << "DEBUG: CODERESPONSE PARSED."
+		indexl = findtext(parse, word)
+		indexu = (indexl + lentext(word))
+		parse1 = copytext(parse, 1, indexl)
+		parse2 = copytext(parse, indexu)
+		parse = "[parse1][insertword][parse2]"
+	return parse

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -168,10 +168,10 @@ var/list/syndicate_code_response = list()//Code response for traitors.
 		25; 5
 	)
 
-	var/safety[] = list(1,2,3)//Tells the proc which options to remove later on.
-	var/nouns[] = list("love","hate","anger","peace","pride","sympathy","bravery","loyalty","honesty","integrity","compassion","charity","success","courage","deceit","skill","beauty","brilliance","pain","misery","beliefs","dreams","justice","truth","faith","liberty","knowledge","thought","information","culture","trust","dedication","progress","education","hospitality","leisure","trouble","friendships", "relaxation")
-	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepsky Smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
-	var/locations[] = teleportlocs.len ? teleportlocs : drinks//if null, defaults to drinks instead.
+	var/list/safety = list(1,2,3)//Tells the proc which options to remove later on.
+	var/list/nouns = list("love","hate","anger","peace","pride","sympathy","bravery","loyalty","honesty","integrity","compassion","charity","success","courage","deceit","skill","beauty","brilliance","pain","misery","beliefs","dreams","justice","truth","faith","liberty","knowledge","thought","information","culture","trust","dedication","progress","education","hospitality","leisure","trouble","friendships", "relaxation")
+	var/list/drinks = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepsky Smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
+	var/list/locations = teleportlocs.len ? teleportlocs : drinks//if null, defaults to drinks instead.
 
 	var/names[] = list()
 	for(var/datum/data/record/t in data_core.general)//Picks from crew manifest.
@@ -222,29 +222,7 @@ var/list/syndicate_code_response = list()//Code response for traitors.
 /proc/parse_for_code_words(text)
 	var/parse = text
 	for(var/word in syndicate_code_phrase)
-		var/indexl = 0
-		var/indexu = 0
-		var/parse1
-		var/parse2
-		var/insertword = "<span class='codephrase'>[word]</span>"
-		if(!findtext(parse, word))
-			continue
-		indexl = findtext(parse, word)
-		indexu = (indexl + lentext(word))
-		parse1 = copytext(parse, 1, indexl)
-		parse2 = copytext(parse, indexu)
-		parse = "[parse1][insertword][parse2]"
+		parse = replacetext(parse, word, "<span class='codephrase'>[word]</span>")
 	for(var/word in syndicate_code_response)
-		var/indexl = 0
-		var/indexu = 0
-		var/parse1
-		var/parse2
-		var/insertword = "<span class='coderesponse'>[word]</span>"
-		if(!findtext(parse, word))
-			continue
-		indexl = findtext(parse, word)
-		indexu = (indexl + lentext(word))
-		parse1 = copytext(parse, 1, indexl)
-		parse2 = copytext(parse, indexu)
-		parse = "[parse1][insertword][parse2]"
+		parse = replacetext(parse, word, "<span class='coderesponse'>[word]</span>")
 	return parse

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -141,8 +141,8 @@ var/syndicate_name = null
 
 
 //Traitors and traitor silicons will get these. Revs will not.
-var/syndicate_code_phrase//Code phrase for traitors.
-var/syndicate_code_response//Code response for traitors.
+var/list/syndicate_code_phrase = list()//Code phrase for traitors.
+var/list/syndicate_code_response = list()//Code response for traitors.
 
 	/*
 	Should be expanded.
@@ -160,7 +160,7 @@ var/syndicate_code_response//Code response for traitors.
 
 /proc/generate_code_phrase()//Proc is used for phrase and response in master_controller.dm
 
-	var/code_phrase = ""//What is returned when the proc finishes.
+	var/list/code_phrase = list()//What is returned when the proc finishes.
 	var/words = pick(//How many words there will be. Minimum of two. 2, 4 and 5 have a lesser chance of being selected. 3 is the most likely.
 		50; 2,
 		200; 3,
@@ -170,7 +170,7 @@ var/syndicate_code_response//Code response for traitors.
 
 	var/safety[] = list(1,2,3)//Tells the proc which options to remove later on.
 	var/nouns[] = list("love","hate","anger","peace","pride","sympathy","bravery","loyalty","honesty","integrity","compassion","charity","success","courage","deceit","skill","beauty","brilliance","pain","misery","beliefs","dreams","justice","truth","faith","liberty","knowledge","thought","information","culture","trust","dedication","progress","education","hospitality","leisure","trouble","friendships", "relaxation")
-	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepksy Smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
+	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepsky Smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
 	var/locations[] = teleportlocs.len ? teleportlocs : drinks//if null, defaults to drinks instead.
 
 	var/names[] = list()
@@ -196,9 +196,7 @@ var/syndicate_code_response//Code response for traitors.
 							if(prob(10))
 								code_phrase += pick(lizard_name(MALE),lizard_name(FEMALE))
 							else
-								code_phrase += pick(pick(first_names_male,first_names_female))
-								code_phrase += " "
-								code_phrase += pick(last_names)
+								code_phrase += "[pick(pick(first_names_male,first_names_female))] [pick(last_names)]"
 					if(2)
 						code_phrase += pick(get_all_jobs())//Returns a job.
 				safety -= 1
@@ -217,9 +215,16 @@ var/syndicate_code_response//Code response for traitors.
 						code_phrase += pick(adjectives)
 					if(3)
 						code_phrase += pick(verbs)
-		if(words==1)
-			code_phrase += "."
-		else
-			code_phrase += ", "
 
+	world << "DEBUG: GENERATED CODE PHRASE."
+	world << "[english_list(code_phrase, final_comma_text = ", ", and_text = "")]"
 	return code_phrase
+
+/proc/parse_for_code_word(text)
+	for(var/word in syndicate_code_phrase)
+
+	for(var/word in syndicate_code_response)
+
+
+
+if mind.special_role == "traitor"

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -63,9 +63,9 @@ var/datum/subsystem/ticker/ticker
 		login_music = 'sound/ambience/clown.ogg'
 
 /datum/subsystem/ticker/Initialize(timeofday)
-	if(!syndicate_code_phrase)
+	if(!syndicate_code_phrase.len)
 		syndicate_code_phrase	= generate_code_phrase()
-	if(!syndicate_code_response)
+	if(!syndicate_code_response.len)
 		syndicate_code_response	= generate_code_phrase()
 	..()
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -214,11 +214,11 @@
 
 /proc/give_codewords(mob/living/traitor_mob)
 	traitor_mob << "<U><B>The Syndicate provided you with the following information on how to identify their agents:</B></U>"
-	traitor_mob << "<B>Code Phrase</B>: <span class='danger'>[syndicate_code_phrase]</span>"
-	traitor_mob << "<B>Code Response</B>: <span class='danger'>[syndicate_code_response]</span>"
+	traitor_mob << "<B>Code Phrase</B>: <span class='danger'>[english_list(syndicate_code_phrase), final_comma_text = ", ", and_text = "")]</span>"
+	traitor_mob << "<B>Code Response</B>: <span class='danger'>[english_list(syndicate_code_response), final_comma_text = ", ", and_text = "")]</span>"
 
-	traitor_mob.mind.store_memory("<b>Code Phrase</b>: [syndicate_code_phrase]")
-	traitor_mob.mind.store_memory("<b>Code Response</b>: [syndicate_code_response]")
+	traitor_mob.mind.store_memory("<b>Code Phrase</b>: [english_list(syndicate_code_phrase), final_comma_text = ", ", and_text = "")]")
+	traitor_mob.mind.store_memory("<b>Code Response</b>: [english_list(syndicate_code_response), final_comma_text = ", ", and_text = "")]")
 
 	traitor_mob << "Use the code words in the order provided, during regular conversation, to identify other agents. Proceed with caution, however, as everyone is a potential foe."
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -216,9 +216,11 @@
 	traitor_mob << "<U><B>The Syndicate provided you with the following information on how to identify their agents:</B></U>"
 	traitor_mob << "<B>Code Phrase</B>: <span class='danger'>[english_list(syndicate_code_phrase, final_comma_text = "", and_text = " and ")]</span>"
 	traitor_mob << "<B>Code Response</B>: <span class='danger'>[english_list(syndicate_code_response, final_comma_text = "", and_text = " and ")]</span>"
+	traitor_mob << "<U><B>You have been mentally conditioned to be able to recognize Syndicate codewords quickly during normal conversations. They will... stand out to your perception.</B></U>"
 
 	traitor_mob.mind.store_memory("<b>Code Phrase</b>: [english_list(syndicate_code_phrase, final_comma_text = "", and_text = " and ")]")
 	traitor_mob.mind.store_memory("<b>Code Response</b>: [english_list(syndicate_code_response, final_comma_text = "", and_text = " and ")]")
+	traitor_mob.mind.store_memory("<U><B>You have been mentally conditioned to be able to recognize Syndicate codewords quickly during normal conversations. They will... stand out to your perception.</B></U>")
 
 	traitor_mob << "Use the code words in the order provided, during regular conversation, to identify other agents. Proceed with caution, however, as everyone is a potential foe."
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -214,12 +214,12 @@
 
 /proc/give_codewords(mob/living/traitor_mob)
 	traitor_mob << "<U><B>The Syndicate provided you with the following information on how to identify their agents:</B></U>"
-	traitor_mob << "<B>Code Phrase</B>: <span class='danger'>[english_list(syndicate_code_phrase, final_comma_text = "", and_text = " and ")]</span>"
-	traitor_mob << "<B>Code Response</B>: <span class='danger'>[english_list(syndicate_code_response, final_comma_text = "", and_text = " and ")]</span>"
+	traitor_mob << "<B>Code Phrase</B>: <span class='danger'>[english_list(syndicate_code_phrase)]</span>"
+	traitor_mob << "<B>Code Response</B>: <span class='danger'>[english_list(syndicate_code_response)]</span>"
 	traitor_mob << "<U><B>You have been mentally conditioned to be able to recognize Syndicate codewords quickly during normal conversations. They will... stand out to your perception.</B></U>"
 
-	traitor_mob.mind.store_memory("<b>Code Phrase</b>: [english_list(syndicate_code_phrase, final_comma_text = "", and_text = " and ")]")
-	traitor_mob.mind.store_memory("<b>Code Response</b>: [english_list(syndicate_code_response, final_comma_text = "", and_text = " and ")]")
+	traitor_mob.mind.store_memory("<b>Code Phrase</b>: [english_list(syndicate_code_phrase)]")
+	traitor_mob.mind.store_memory("<b>Code Response</b>: [english_list(syndicate_code_response)]")
 	traitor_mob.mind.store_memory("<U><B>You have been mentally conditioned to be able to recognize Syndicate codewords quickly during normal conversations. They will... stand out to your perception.</B></U>")
 
 	traitor_mob << "Use the code words in the order provided, during regular conversation, to identify other agents. Proceed with caution, however, as everyone is a potential foe."

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -214,11 +214,11 @@
 
 /proc/give_codewords(mob/living/traitor_mob)
 	traitor_mob << "<U><B>The Syndicate provided you with the following information on how to identify their agents:</B></U>"
-	traitor_mob << "<B>Code Phrase</B>: <span class='danger'>[english_list(syndicate_code_phrase), final_comma_text = ", ", and_text = "")]</span>"
-	traitor_mob << "<B>Code Response</B>: <span class='danger'>[english_list(syndicate_code_response), final_comma_text = ", ", and_text = "")]</span>"
+	traitor_mob << "<B>Code Phrase</B>: <span class='danger'>[english_list(syndicate_code_phrase, final_comma_text = "", and_text = " and ")]</span>"
+	traitor_mob << "<B>Code Response</B>: <span class='danger'>[english_list(syndicate_code_response, final_comma_text = "", and_text = " and ")]</span>"
 
-	traitor_mob.mind.store_memory("<b>Code Phrase</b>: [english_list(syndicate_code_phrase), final_comma_text = ", ", and_text = "")]")
-	traitor_mob.mind.store_memory("<b>Code Response</b>: [english_list(syndicate_code_response), final_comma_text = ", ", and_text = "")]")
+	traitor_mob.mind.store_memory("<b>Code Phrase</b>: [english_list(syndicate_code_phrase, final_comma_text = "", and_text = " and ")]")
+	traitor_mob.mind.store_memory("<b>Code Response</b>: [english_list(syndicate_code_response, final_comma_text = "", and_text = " and ")]")
 
 	traitor_mob << "Use the code words in the order provided, during regular conversation, to identify other agents. Proceed with caution, however, as everyone is a potential foe."
 

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -18,5 +18,6 @@
 		else
 			speaker = V.source
 	var/link = FOLLOW_LINK(src, speaker)
+	message = parse_for_code_words(message)
 	src << "[link] [message]"
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -139,6 +139,8 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 		deaf_type = 2 // Since you should be able to hear yourself without looking
 	if(!(message_langs & languages_understood) || force_compose) //force_compose is so AIs don't end up without their hrefs.
 		message = compose_message(speaker, message_langs, raw_message, radio_freq, spans)
+	if(mind && mind.special_role && mind.special_role == "traitor")
+		message = parse_for_code_words(message)
 	show_message(message, 2, deaf_message, deaf_type)
 	return message
 

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-traitor
+extended

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-extended
+traitor

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -132,6 +132,8 @@ h1.alert, h2.alert		{color: #000000;}
 .greentext				{color: #00FF00;	font-size: 3;}
 .redtext				{color: #FF0000;	font-size: 3;}
 .clown					{color: #FF69Bf;	font-size: 3; font-family: "Comic Sans MS", cursive, sans-serif; font-weight: bold;}
+.codephrase				{color: #000099;	font-size: 3; font-family: "Comic Sans MS", cursive, sans-serif; font-weight: bold;}
+.coderesponse			{color: #00FF00;	font-size: 3; font-family: "Comic Sans MS", cursive, sans-serif; font-weight: bold;}
 
 BIG IMG.icon 			{width: 32px; height: 32px;}
 


### PR DESCRIPTION
Syndicate codewords are highlighted in SLIGHTLY LARGER BLUE WAVY CURSIVE CLUWNE FONT.
Syndicate code responses are highlighted in the same way, but green instead!
Only other traitors, and ghosts can see this.
Ghosts being able to see this might lead to metagame problems, but uh, feedback would be nice.
Removes the excuse of "I DIDNT READ MY CODEWORDS"
Adds teamwork. Maybe too much of it.
IF THERE IS ANY OTHER ANTAG TYPE THAT GETS CODEWORDS PLEASE LET ME KNOW SO I CAN ADD THEM TO THE LIST.
I originally wanted to add this to PDA messages but I think that would be too much effort. Besides, it's a PDA message, you should have plenty of time (and actually think) to scan it for codewords.
Oh, and I guess traitors can rat each other out easier now, but they could do it anyways!
:cl: Mekhi Anderson
rscadd: Syndicate Agents who are provided with codewords are now mentally conditioned to instantly recognize them during normal vocal conversations, after complaints that agents either didn't bother or did not think of analyzing their conversations for these codewords.
tweak: Syndicate code words and responses will be highlighted cursive-blue or green, respectively, to Traitors.
experimental: Ghosts can also recognize codewords/responses in chat as autohighlighted.
fix: Syndicate Command apologizes for spelling "Beepsky Smash" "BeepKSY Smash".
:cl:
