### PR TITLE
Cleans up some init procs from world start.

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -948,9 +948,8 @@ var/global/list/friendly_animal_types = list()
 	overlays += priority_overlays
 
 /atom/proc/add_overlay(image, priority = 0)
-	if(image in overlays)
-		return
 	var/list/new_overlays = overlays.Copy()
+	new_overlays -= image
 	if(priority)
 		if(!priority_overlays)
 			priority_overlays = list()

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -407,3 +407,9 @@
 
 //Picks from the list, with some safeties, and returns the "default" arg if it fails
 #define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
+
+#define LAZYINITLIST(L) if (!L) L = list()
+
+#define UNSETEMPTY(L) if (L && !L.len) L = null
+
+#define LAZYLEN(L) ( L ? L.len : 0 )

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1189,7 +1189,8 @@ B --><-- A
 	var/list/L = block(locate(T.x - range, T.y - range, T.z), locate(T.x + range, T.y + range, T.z))
 	for(var/B in L)
 		var/turf/C = B
-		C.proximity_checkers |= A
+		LAZYINITLIST(C.proximity_checkers)
+		C.proximity_checkers[A] = TRUE
 	return L
 
 /proc/remove_from_proximity_list(atom/A, range)
@@ -1197,7 +1198,11 @@ B --><-- A
 	var/list/L = block(locate(T.x - range, T.y - range, T.z), locate(T.x + range, T.y + range, T.z))
 	for(var/B in L)
 		var/turf/C = B
+		if (!C.proximity_checkers)
+			continue
 		C.proximity_checkers.Remove(A)
+		UNSETEMPTY(C.proximity_checkers)
+
 
 /proc/shift_proximity(atom/checker, atom/A, range, atom/B, newrange)
 	var/turf/T = get_turf(A)
@@ -1210,10 +1215,14 @@ B --><-- A
 	var/list/O = M - L
 	for(var/C in N)
 		var/turf/D = C
+		if (!D.proximity_checkers)
+			continue
 		D.proximity_checkers.Remove(checker)
+		UNSETEMPTY(D.proximity_checkers)
 	for(var/E in O)
 		var/turf/F = E
-		F.proximity_checkers |= checker
+		LAZYINITLIST(F.proximity_checkers)
+		F.proximity_checkers[checker] = TRUE
 	return 1
 
 /proc/flick_overlay_static(image/I, atom/A, duration)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -9,7 +9,7 @@
 	var/damtype = "brute"
 	var/force = 0
 
-	var/list/armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
+	var/list/armor
 	var/obj_integrity = 500
 	var/max_integrity = 500
 	var/integrity_failure = 0 //0 if we have no special broken behavior
@@ -29,7 +29,8 @@
 
 /obj/New()
 	..()
-
+	if (!armor)
+		armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 	if(on_blueprints && isturf(loc))
 		var/turf/T = loc
 		if(force_blueprints)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -43,7 +43,7 @@
 
 /turf/open/space/AfterChange()
 	..()
-	atmos_overlay_types.Cut()
+	atmos_overlay_types = null
 
 /turf/open/space/Assimilate_Air()
 	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -15,7 +15,7 @@
 
 	flags = CAN_BE_DIRTY
 
-	var/list/proximity_checkers = list()
+	var/list/proximity_checkers
 
 	var/image/obscured	//camerachunks
 
@@ -172,7 +172,7 @@
 
 	var/datum/gas_mixture/total = new//Holders to assimilate air from nearby turfs
 	var/list/total_gases = total.gases
-	var/turf_count = atmos_adjacent_turfs.len
+	var/turf_count = LAZYLEN(atmos_adjacent_turfs)
 
 	for(var/T in atmos_adjacent_turfs)
 		var/turf/open/S = T

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -53,24 +53,39 @@
 	return 0
 
 /turf/proc/CalculateAdjacentTurfs()
+	var/list/atmos_adjacent_turfs = src.atmos_adjacent_turfs
 	for(var/direction in cardinal)
 		var/turf/open/T = get_step(src, direction)
 		if(!istype(T))
 			continue
 		if(CanAtmosPass(T))
-			atmos_adjacent_turfs |= T
-			T.atmos_adjacent_turfs |= src
+			LAZYINITLIST(atmos_adjacent_turfs)
+			LAZYINITLIST(T.atmos_adjacent_turfs)
+			atmos_adjacent_turfs[T] = TRUE
+			T.atmos_adjacent_turfs[src] = TRUE
 		else
-			atmos_adjacent_turfs -= T
-			T.atmos_adjacent_turfs -= src
+			if (atmos_adjacent_turfs)
+				atmos_adjacent_turfs -= T
+			if (T.atmos_adjacent_turfs)
+				T.atmos_adjacent_turfs -= src
+			UNSETEMPTY(T.atmos_adjacent_turfs)
+	UNSETEMPTY(atmos_adjacent_turfs)
+	if (atmos_adjacent_turfs)
+		src.atmos_adjacent_turfs = atmos_adjacent_turfs
 
 //returns a list of adjacent turfs that can share air with this one.
 //alldir includes adjacent diagonal tiles that can share
 //	air with both of the related adjacent cardinal tiles
 /turf/proc/GetAtmosAdjacentTurfs(alldir = 0)
-	var/adjacent_turfs = atmos_adjacent_turfs.Copy()
+	var/adjacent_turfs
+	if (atmos_adjacent_turfs)
+		adjacent_turfs = atmos_adjacent_turfs.Copy()
+	else
+		adjacent_turfs = list()
+
 	if (!alldir)
 		return adjacent_turfs
+
 	var/turf/curloc = src
 
 	for (var/direction in diagonals)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -5,7 +5,7 @@
 	var/temperature_archived
 
 	//list of open turfs adjacent to us
-	var/list/atmos_adjacent_turfs = list()
+	var/list/atmos_adjacent_turfs
 	//bitfield of dirs in which we are superconducitng
 	var/atmos_supeconductivity = 0
 
@@ -33,7 +33,7 @@
 	var/atmos_cooldown  = 0
 	var/planetary_atmos = FALSE //air will revert to initial_gas_mix over time
 
-	var/list/atmos_overlay_types = list() //gas IDs of current active gas overlays
+	var/list/atmos_overlay_types //gas IDs of current active gas overlays
 
 /turf/open/New()
 	..()
@@ -98,13 +98,17 @@
 /turf/open/proc/update_visuals()
 	var/list/new_overlay_types = tile_graphic()
 
-	for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
-		overlays -= overlay
-		atmos_overlay_types -= overlay
+	if (atmos_overlay_types)
+		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
+			overlays -= overlay
 
-	for(var/overlay in new_overlay_types-atmos_overlay_types) //doesn't add overlays that already exist
-		add_overlay(overlay)
+	if (new_overlay_types.len)
+		var/overlays_to_add = new_overlay_types
+		if (atmos_overlay_types)
+			overlays_to_add -= atmos_overlay_types //doesn't add overlays that already exist
+		add_overlay(overlays_to_add) //add_overlay works with lists because it uses +=
 
+	UNSETEMPTY(new_overlay_types)
 	atmos_overlay_types = new_overlay_types
 
 /turf/open/proc/tile_graphic()
@@ -130,7 +134,7 @@
 	//cache for sanic speed
 	var/list/adjacent_turfs = atmos_adjacent_turfs
 	var/datum/excited_group/our_excited_group = excited_group
-	var/adjacent_turfs_length = adjacent_turfs.len
+	var/adjacent_turfs_length = LAZYLEN(adjacent_turfs)
 	atmos_cooldown++
 	if (planetary_atmos)
 		adjacent_turfs_length++


### PR DESCRIPTION
`/turf`, `/turf/open`, `/turf/open/space`, `/obj` should now no longer have an `init[]` proc in byond.

This mostly abuses the fact that `for (var/thing in null)` works exactly the same as `for (var/thing in emptylist)`

`atmos_adjacent_turfs` is lazy init'ed and set back to null when empty. `GetAtmosAdjacentTurfs()` will always return a list for code that doesn't want to care.

`atmos_overlay_types`, and `proximity_checkers` lazy init and reset back to null when empty.

`armor` is now init'ed in `/obj`'s `New()` if it's blank. This could also be set to some lazy init system if somebody is feeling masochistic enough.

`/obj`s that both don't call parent in `New()` and don't set their own armor will have a null armor list. This might cause bugs so this change may get removed if that becomes an issue. I did a `select /obj where armor = null` and the only round start objects that came up were the abstract objects used to display clickable stat entries for the subsystems in the mc tab.

Minor slightly unrelated change that made doing this change easier, `add_overlay()` now _technically_ works properly if given a list

PoI: @RemieRichards @duncathan @phil235 @optimumtact 

This change lead to a **5-10s** reduction in world start time, as well as a non-trivial reduction in memory usage (**562mb** vs **681mb**)
