### PR TITLE
Makes minor changes to BoxStation to reduce atmos problems

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -8604,9 +8604,7 @@
 /area/space/nearstation)
 "asD" = (
 /turf/open/floor/plating/warnplate{
-	dir = 4;
-	luminosity = 2;
-	initial_gas_mix = "o2=0.01;n2=0.01"
+	dir = 4
 	},
 /area/shuttle/auxillary_base)
 "asE" = (
@@ -42268,9 +42266,6 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bON" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -54464,9 +54459,6 @@
 /obj/item/weapon/gun/energy/laser{
 	pixel_x = 3;
 	pixel_y = -3
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /turf/open/floor/plasteel/bot{
 	dir = 2
@@ -86260,7 +86252,7 @@ asj
 asU
 ats
 atY
-awg
+auo
 axy
 ayN
 azP
@@ -86517,7 +86509,7 @@ arS
 apU
 atu
 cCi
-auo
+awg
 axy
 ayM
 azs


### PR DESCRIPTION
This removes a few problems with boxstation pipes, and removes about a dozen roundstart active turfs.  Nothing major.  There are still four active turfs left that I couldn't figure out.

They MIGHT have something to do with transit tube stations, though I could be wrong.
