### PR TITLE
Revert "Hopefully fixes arm replacement not working"

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -245,7 +245,7 @@
 	owner = C
 	C.bodyparts += src
 	if(held_index)
-		C.hand_bodyparts += src
+		C.hand_bodyparts[held_index] = src
 		if(C.hud_used)
 			var/obj/screen/inventory/hand/hand = C.hud_used.hand_slots["[held_index]"]
 			if(hand)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -84,7 +84,7 @@
 	C.bodyparts -= src
 	if(held_index)
 		C.unEquip(owner.get_item_for_held_index(held_index), 1)
-		C.hand_bodyparts -= src
+		C.hand_bodyparts[held_index] = null
 
 	owner = null
 


### PR DESCRIPTION
Reverts tgstation/tgstation#20868

This is meant to actually have nulls in it

The bug will be in the code that fails when the arm replacement item is null.

I will investigate and find the answer.
