### PR TITLE
Alternatively, last ditch attempt to fix hardlight bows.

### DIFF
--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -186,4 +186,4 @@
 	qdel(src)
 
 /obj/item/ammo_casing/caseless/arrow/hardlight/dropped()
-	qdel(src)
+	QDEL_IN(200,src)

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -124,7 +124,7 @@
 	name = "bow hardlight magazine"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/hardlight
 
-/obj/item/projectile/bullet/reusable/arrow/hardlight
+/obj/item/projectile/bullet/hardlight_arrow
 	name = "hardlight arrow"
 	icon_state = "arrow_hardlight"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/hardlight
@@ -139,7 +139,7 @@
 	desc = "An arrow made out of hardlight."
 	icon_state = "arrow_hardlight"
 	force = 7
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/hardlight
+	projectile_type = /obj/item/projectile/bullet/hardlight_arrow
 	delay = 10
 
 /obj/item/weapon/storage/backpack/quiver/hardlight
@@ -182,6 +182,10 @@
 		else
 			icon_amount = 3
 	icon_state = "hlquiver[icon_amount]"
+
+/obj/item/projectile/bullet/hardlight_arrow/on_hit()
+	..()
+	qdel(src)
 
 /obj/item/ammo_casing/caseless/arrow/hardlight/dropped()
 	qdel(src)

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -127,12 +127,10 @@
 /obj/item/projectile/bullet/hardlight_arrow
 	name = "hardlight arrow"
 	icon_state = "arrow_hardlight"
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/hardlight
 	range = 30
 	damage = 30
 	damage_type = BRUTE		//I give the fuck up untill someone makes projectiles able to multi-damage I'm not going to risk experimenting with multi-hit projectiles.
 	flag = "bullet"
-	dropped = 1
 
 /obj/item/ammo_casing/caseless/arrow/hardlight
 	name = "hardlight arrow"


### PR DESCRIPTION
Does some stuff that I should of did the last time.
Repathed to normal bullets, and not reusable, as it's not meant to be reusable.
Immediately deleted after hitting. Shouldn't allow for multi-hits.
