### PR TITLE
Readds the day the world ended

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -302,6 +302,11 @@
 	begin_day = 14
 	begin_month = DECEMBER
 
+/datum/holiday/doomsday
+	name = "Mayan Doomsday Anniversary"
+	begin_day = 21
+	begin_month = DECEMBER
+
 /datum/holiday/xmas
 	name = CHRISTMAS
 	begin_day = 23


### PR DESCRIPTION
When holidays were moved over to datums last year an important part of our history was left out, and as a result the game did NOT mention it at all when December 21st, 2015 rolled around. We can't forget this important date when people thought the end of the world would come, and were incorrect.
