### PR TITLE
Mending Motors are overall more powerful

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures/mending_motor.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/mending_motor.dm
@@ -1,3 +1,10 @@
+var/list/mending_motor_typecache = typecacheof(list(
+	/obj/structure/destructible/clockwork,
+	/obj/machinery/door/airlock/clockwork,
+	/obj/machinery/door/window/clockwork,
+	/obj/structure/window/reinforced/clockwork,
+	/obj/structure/table/reinforced/brass))
+
 //Mending Motor: A prism that consumes replicant alloy or power to repair nearby mechanical servants at a quick rate.
 /obj/structure/destructible/clockwork/powered/mending_motor
 	name = "mending motor"
@@ -16,9 +23,7 @@
 	/obj/item/clockwork/component/vanguard_cogwheel = 1)
 	var/stored_alloy = 0
 	var/max_alloy = REPLICANT_ALLOY_POWER * 10
-	var/mob_cost = 200
-	var/structure_cost = 250
-	var/cyborg_cost = 300
+	var/heal_attempts = 4
 
 /obj/structure/destructible/clockwork/powered/mending_motor/prefilled
 	stored_alloy = REPLICANT_ALLOY_POWER //starts with 1 replicant alloy's worth of power
@@ -44,46 +49,52 @@
 	if(is_servant_of_ratvar(user) || isobserver(user))
 		user << "<span class='alloy'>It contains <b>[stored_alloy*CLOCKCULT_POWER_TO_ALLOY_MULTIPLIER]/[max_alloy*CLOCKCULT_POWER_TO_ALLOY_MULTIPLIER]</b> units of liquified alloy, \
 		which is equivalent to <b>[stored_alloy]W/[max_alloy]W</b> of power.</span>"
-		user << "<span class='inathneq_small'>It requires <b>[mob_cost]W</b> to heal clockwork mobs, <b>[structure_cost]W</b> for clockwork structures, and <b>[cyborg_cost]W</b> for cyborgs.</span>"
+		user << "<span class='inathneq_small'>It requires at least <b>[MIN_CLOCKCULT_POWER]W</b> to attempt to repair clockwork mobs, structures, or converted silicons.</span>"
 
 /obj/structure/destructible/clockwork/powered/mending_motor/process()
-	if(..() < mob_cost)
+	. = ..()
+	if(. < MIN_CLOCKCULT_POWER)
 		visible_message("<span class='warning'>[src] emits an airy chuckling sound and falls dark!</span>")
 		toggle()
 		return
-	for(var/atom/movable/M in range(5, src))
+	for(var/atom/movable/M in range(7, src))
 		if(isclockmob(M) || istype(M, /mob/living/simple_animal/drone/cogscarab))
-			var/mob/living/simple_animal/hostile/clockwork/W = M
-			var/fatigued = FALSE
-			if(istype(M, /mob/living/simple_animal/hostile/clockwork/marauder))
-				var/mob/living/simple_animal/hostile/clockwork/marauder/E = M
-				if(E.fatigue)
-					fatigued = TRUE
-			if((!fatigued && W.health == W.maxHealth) || W.stat)
+			var/mob/living/simple_animal/hostile/clockwork/marauder/E = M
+			var/is_marauder = istype(E)
+			if(E.health == E.maxHealth || E.stat == DEAD || (is_marauder && !E.fatigue))
 				continue
-			if(!try_use_power(mob_cost))
-				break
-			W.adjustHealth(-20)
-		else if(istype(M, /obj/structure/destructible/clockwork))
-			var/obj/structure/destructible/clockwork/C = M
+			for(var/i in 1 to heal_attempts)
+				if(E.health <= E.maxhealth || (is_marauder && E.fatigue))
+					if(try_use_power(MIN_CLOCKCULT_POWER))
+						E.adjustHealth(-8)
+					else
+						break
+		else if(is_type_in_typecache(M, mending_motor_typecache))
+			var/obj/structure/C = M
 			if(C.obj_integrity == C.max_integrity)
 				continue
-			if(!try_use_power(structure_cost))
-				break
-			C.obj_integrity = min(C.obj_integrity + 20, C.max_integrity)
+			for(var/i in 1 to heal_attempts)
+				if(C.obj_integrity <= C.max_integrity)
+					if(try_use_power(MIN_CLOCKCULT_POWER))
+						C.obj_integrity = min(C.obj_integrity + 8, C.max_integrity)
+					else
+						break
 		else if(issilicon(M))
 			var/mob/living/silicon/S = M
 			if(S.health == S.maxHealth || S.stat == DEAD || !is_servant_of_ratvar(S))
 				continue
-			if(!try_use_power(cyborg_cost))
-				break
-			S.adjustBruteLoss(-20)
-			S.adjustFireLoss(-10)
-	return 1
+			for(var/i in 1 to heal_attempts)
+				if(S.health <= S.maxHealth)
+					if(try_use_power(MIN_CLOCKCULT_POWER))
+						S.adjustBruteLoss(-5)
+						S.adjustFireLoss(-3)
+					else
+						break
+
 
 /obj/structure/destructible/clockwork/powered/mending_motor/attack_hand(mob/living/user)
 	if(user.canUseTopic(src, BE_CLOSE))
-		if(total_accessable_power() < mob_cost)
+		if(total_accessable_power() < MIN_CLOCKCULT_POWER)
 			user << "<span class='warning'>[src] needs more power or replicant alloy to function!</span>"
 			return 0
 		toggle(0, user)

--- a/code/game/gamemodes/clock_cult/clock_structures/mending_motor.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/mending_motor.dm
@@ -1,10 +1,3 @@
-var/list/mending_motor_typecache = typecacheof(list(
-	/obj/structure/destructible/clockwork,
-	/obj/machinery/door/airlock/clockwork,
-	/obj/machinery/door/window/clockwork,
-	/obj/structure/window/reinforced/clockwork,
-	/obj/structure/table/reinforced/brass))
-
 //Mending Motor: A prism that consumes replicant alloy or power to repair nearby mechanical servants at a quick rate.
 /obj/structure/destructible/clockwork/powered/mending_motor
 	name = "mending motor"
@@ -24,6 +17,12 @@ var/list/mending_motor_typecache = typecacheof(list(
 	var/stored_alloy = 0
 	var/max_alloy = REPLICANT_ALLOY_POWER * 10
 	var/heal_attempts = 4
+	var/static/list/mending_motor_typecache = typecacheof(list(
+	/obj/structure/destructible/clockwork,
+	/obj/machinery/door/airlock/clockwork,
+	/obj/machinery/door/window/clockwork,
+	/obj/structure/window/reinforced/clockwork,
+	/obj/structure/table/reinforced/brass))
 
 /obj/structure/destructible/clockwork/powered/mending_motor/prefilled
 	stored_alloy = REPLICANT_ALLOY_POWER //starts with 1 replicant alloy's worth of power
@@ -64,7 +63,7 @@ var/list/mending_motor_typecache = typecacheof(list(
 			if(E.health == E.maxHealth || E.stat == DEAD || (is_marauder && !E.fatigue))
 				continue
 			for(var/i in 1 to heal_attempts)
-				if(E.health <= E.maxhealth || (is_marauder && E.fatigue))
+				if(E.health < E.maxHealth || (is_marauder && E.fatigue))
 					if(try_use_power(MIN_CLOCKCULT_POWER))
 						E.adjustHealth(-8)
 					else
@@ -74,7 +73,7 @@ var/list/mending_motor_typecache = typecacheof(list(
 			if(C.obj_integrity == C.max_integrity)
 				continue
 			for(var/i in 1 to heal_attempts)
-				if(C.obj_integrity <= C.max_integrity)
+				if(C.obj_integrity < C.max_integrity)
 					if(try_use_power(MIN_CLOCKCULT_POWER))
 						C.obj_integrity = min(C.obj_integrity + 8, C.max_integrity)
 					else
@@ -84,13 +83,12 @@ var/list/mending_motor_typecache = typecacheof(list(
 			if(S.health == S.maxHealth || S.stat == DEAD || !is_servant_of_ratvar(S))
 				continue
 			for(var/i in 1 to heal_attempts)
-				if(S.health <= S.maxHealth)
+				if(S.health < S.maxHealth)
 					if(try_use_power(MIN_CLOCKCULT_POWER))
 						S.adjustBruteLoss(-5)
 						S.adjustFireLoss(-3)
 					else
 						break
-
 
 /obj/structure/destructible/clockwork/powered/mending_motor/attack_hand(mob/living/user)
 	if(user.canUseTopic(src, BE_CLOSE))


### PR DESCRIPTION
:cl: Joan
tweak: Mending Motors have an increased range and heal for more.
experiment: Mending Motors will no longer waste massive amounts of power on slightly damaged objects; instead, they will heal a small amount, use a small amount of power, and stop if the object is fully healed.
wip: Mending Motors can now heal all clockwork objects, including pinion airlocks, brass windows, and anything else you can think of.
/:cl:
