### PR TITLE
Fix duplicate species id's

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -65,7 +65,8 @@
 */
 /datum/species/lizard/ashwalker
 	name = "Ash Walker"
-	id = "lizard"
+	id = "ashlizard"
+	limbs_id = "lizard"
 	specflags = list(MUTCOLORS,EYECOLOR,LIPS,NOBREATH,NOGUNS,DIGITIGRADE)
 /*
  PODPEOPLE
@@ -669,6 +670,8 @@
 
 /datum/species/zombie/infectious
 	name = "Infectious Zombie"
+	id = "memezombies"
+	limbs_id = "zombie"
 	no_equip = list(slot_wear_mask, slot_head)
 	armor = 20 // 120 damage to KO a zombie, which kills it
 	speedmod = 2
@@ -705,7 +708,8 @@
 // Your skin falls off
 /datum/species/krokodil_addict
 	name = "Human"
-	id = "zombie"
+	id = "goofzombies"
+	limbs_id = "zombie" //They look like zombies
 	sexes = 0
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/zombie
 	mutant_organs = list(/obj/item/organ/tongue/zombie)


### PR DESCRIPTION
Unique id's for both krokodil humans and infectious zombies
Unique id for the ashwalker lizard subspecies

Uses the correct limbs_id var to ensure their icons reuse the
appropriate icons of correct species
