### PR TITLE
Makes ninja stealth make you mostly transparent instead of 100% invisible

### DIFF
--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
@@ -18,9 +18,9 @@ Contents:
 			U << "<span class='warning'>You don't have enough power to enable Stealth!</span>"
 			return
 		s_active=!s_active
-		animate(U, alpha = 0,time = 15)
+		animate(U, alpha = 50,time = 15)
 		U.visible_message("<span class='warning'>[U.name] vanishes into thin air!</span>", \
-						"<span class='notice'>You are now invisible to normal detection.</span>")
+						"<span class='notice'>You are now mostly invisible to normal detection.</span>")
 	return
 
 


### PR DESCRIPTION
:cl: XDTM
tweak: Ninjas are now slightly visible when stealthing.
/:cl:

Total invisibility was pretty shitty, especially if you don't even drop it after attacking.
