### PR TITLE
Fixes chronosuit not checking if held items are chronosafe

### DIFF
--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -121,10 +121,15 @@
 		teleport_now.UpdateButtonIcon()
 
 		var/list/nonsafe_slots = list(slot_belt, slot_back)
+		var/list/exposed = list()
 		for(var/slot in nonsafe_slots)
 			var/obj/item/slot_item = user.get_item_by_slot(slot)
-			if(slot_item && !(slot_item.type in chronosafe_items) && user.unEquip(slot_item))
-				user << "<span class='notice'>Your [slot_item.name] got left behind.</span>"
+			exposed += slot_item
+		exposed += user.held_items
+		for(var/exposed_item in exposed)
+			var/obj/item/exposed_I = exposed_item
+			if(exposed_I && !(exposed_I.type in chronosafe_items) && user.unEquip(exposed_I))
+				user << "<span class='notice'>Your [exposed_I.name] got left behind.</span>"
 
 		user.ExtinguishMob()
 


### PR DESCRIPTION
This was broken ever since remi's multihand PR at #20283, where it would only check back and belt.

I have no reason to believe she did this on purpose, she edited a lot of files, a LOT of files.