### PR TITLE
Late joining won't runtime if the emergency shuttle does not exist (dev QoL)

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -66,6 +66,9 @@ var/datum/subsystem/shuttle/SSshuttle
 #endif
 
 /datum/subsystem/shuttle/proc/setup_transit_zone()
+	if(transit_markers.len == 0)
+		WARNING("No /obj/effect/landmark/transit placed on the map!")
+		return
 	// transit zone
 	var/turf/A = get_turf(transit_markers[1])
 	var/turf/B = get_turf(transit_markers[2])
@@ -77,6 +80,9 @@ var/datum/subsystem/shuttle/SSshuttle
 
 #ifdef HIGHLIGHT_DYNAMIC_TRANSIT
 /datum/subsystem/shuttle/proc/color_space()
+	if(transit_markers.len == 0)
+		WARNING("No /obj/effect/landmark/transit placed on the map!")
+		return
 	var/turf/A = get_turf(transit_markers[1])
 	var/turf/B = get_turf(transit_markers[2])
 	for(var/i in block(A, B))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -339,12 +339,13 @@
 	joined_player_list += character.ckey
 
 	if(config.allow_latejoin_antagonists && humanc)	//Borgs aren't allowed to be antags. Will need to be tweaked if we get true latejoin ais.
-		switch(SSshuttle.emergency.mode)
-			if(SHUTTLE_RECALL, SHUTTLE_IDLE)
-				ticker.mode.make_antag_chance(humanc)
-			if(SHUTTLE_CALL)
-				if(SSshuttle.emergency.timeLeft(1) > initial(SSshuttle.emergencyCallTime)*0.5)
+		if(SSshuttle.emergency)
+			switch(SSshuttle.emergency.mode)
+				if(SHUTTLE_RECALL, SHUTTLE_IDLE)
 					ticker.mode.make_antag_chance(humanc)
+				if(SHUTTLE_CALL)
+					if(SSshuttle.emergency.timeLeft(1) > initial(SSshuttle.emergencyCallTime)*0.5)
+						ticker.mode.make_antag_chance(humanc)
 	qdel(src)
 
 /mob/new_player/proc/AnnounceArrival(var/mob/living/carbon/human/character, var/rank)
@@ -380,12 +381,13 @@
 
 	var/dat = "<div class='notice'>Round Duration: [round(hours)]h [round(mins)]m</div>"
 
-	switch(SSshuttle.emergency.mode)
-		if(SHUTTLE_ESCAPE)
-			dat += "<div class='notice red'>The station has been evacuated.</div><br>"
-		if(SHUTTLE_CALL)
-			if(!SSshuttle.canRecall())
-				dat += "<div class='notice red'>The station is currently undergoing evacuation procedures.</div><br>"
+	if(SSshuttle.emergency)
+		switch(SSshuttle.emergency.mode)
+			if(SHUTTLE_ESCAPE)
+				dat += "<div class='notice red'>The station has been evacuated.</div><br>"
+			if(SHUTTLE_CALL)
+				if(!SSshuttle.canRecall())
+					dat += "<div class='notice red'>The station is currently undergoing evacuation procedures.</div><br>"
 
 	var/available_job_count = 0
 	for(var/datum/job/job in SSjob.occupations)


### PR DESCRIPTION
Yo

I've been using a 32 x 32 map for quickly iterating on some ideas for the game. The benefit of this is that the game loads basically instantly after compiling, which is an amazing quality-of-life improvement if you're not altering the station itself. The downside is that the map lacks an emergency shuttle, and this causes the game to throw runtimes on startup and prevents anyone from late-joining. Fixing the late-join issue is great for letting people test ideas quickly on shuttle-less maps.

The shuttle subsystem will throw a warning at startup if `/obj/effect/landmark/transit` is not found on the map.
