### PR TITLE
Runtime Station - Quick loading developer sandbox

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1,0 +1,255 @@
+"aa" = (/turf/open/space,/area/space)
+"ab" = (/obj/structure/lattice,/turf/open/space,/area/space)
+"ac" = (/turf/open/space,/area/space/nearstation)
+"ad" = (/turf/closed/wall/r_wall,/area/maintenance/maintcentral)
+"ae" = (/obj/structure/lattice,/obj/structure/grille,/turf/open/space,/area/space/nearstation)
+"af" = (/turf/open/floor/plating,/area/maintenance/maintcentral)
+"ag" = (/obj/structure/lattice,/turf/open/space,/area/space/nearstation)
+"ah" = (/turf/closed/wall/r_wall,/area/atmos)
+"ai" = (/obj/machinery/power/rtg/advanced,/turf/open/floor/plating/airless,/area/space/nearstation)
+"aj" = (/turf/closed/wall/r_wall,/area/engine/engineering)
+"ak" = (/turf/closed/wall/r_wall,/area/engine/gravity_generator)
+"al" = (/obj/machinery/airalarm{frequency = 1439; locked = 0; pixel_y = 23},/obj/structure/closet/secure_closet/atmospherics,/turf/open/floor/plating,/area/atmos)
+"am" = (/obj/machinery/atmospherics/components/unary/tank/air,/turf/open/floor/plating,/area/atmos)
+"an" = (/obj/structure/lattice/catwalk,/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/open/space,/area/space/nearstation)
+"ao" = (/obj/structure/lattice/catwalk,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"; tag = ""},/turf/open/space,/area/space/nearstation)
+"ap" = (/obj/machinery/airalarm{frequency = 1439; locked = 0; pixel_y = 23},/obj/machinery/power/apc{dir = 8; pixel_x = -24},/obj/structure/closet/secure_closet/engineering_electrical,/obj/structure/cable{icon_state = "0-4"; d2 = 4},/turf/open/floor/plating,/area/engine/engineering)
+"aq" = (/obj/machinery/computer/monitor,/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"; tag = ""},/turf/open/floor/plating,/area/engine/engineering)
+"ar" = (/obj/structure/closet/secure_closet/engineering_welding,/turf/open/floor/plating,/area/engine/engineering)
+"as" = (/obj/machinery/power/smes{charge = 5e+006},/obj/machinery/airalarm{frequency = 1439; locked = 0; pixel_y = 23},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/turf/open/floor/plasteel/warning{dir = 9},/area/engine/gravity_generator)
+"at" = (/obj/machinery/power/apc{dir = 1; name = "Gravity Generator APC"; pixel_x = 0; pixel_y = 25},/obj/structure/cable{icon_state = "0-8"; step_x = 0; step_y = 0; d2 = 8},/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/open/floor/plasteel/warning{dir = 5},/area/engine/gravity_generator)
+"au" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 32},/turf/open/floor/plating,/area/engine/gravity_generator)
+"av" = (/turf/open/floor/plasteel/black,/area/engine/gravity_generator)
+"aw" = (/turf/open/floor/plating,/area/atmos)
+"ax" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 5},/turf/open/floor/plating,/area/atmos)
+"ay" = (/obj/machinery/atmospherics/pipe/manifold/supply/hidden,/turf/open/floor/plating,/area/atmos)
+"az" = (/obj/machinery/atmospherics/pipe/manifold/supply/hidden{dir = 4},/obj/machinery/meter,/turf/open/floor/plating,/area/atmos)
+"aA" = (/obj/structure/lattice/catwalk,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/open/space,/area/space/nearstation)
+"aB" = (/obj/structure/lattice/catwalk,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/open/space,/area/space/nearstation)
+"aC" = (/obj/machinery/door/airlock,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/open/floor/plating,/area/engine/engineering)
+"aD" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/open/floor/plating,/area/engine/engineering)
+"aE" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"; tag = ""},/turf/open/floor/plating,/area/engine/engineering)
+"aF" = (/turf/open/floor/plating,/area/engine/engineering)
+"aG" = (/obj/machinery/power/terminal{icon_state = "term"; dir = 1},/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/open/floor/plasteel/warning{dir = 8},/area/engine/gravity_generator)
+"aH" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/open/floor/plasteel/warning{dir = 4},/area/engine/gravity_generator)
+"aI" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plating,/area/engine/gravity_generator)
+"aJ" = (/turf/open/floor/plasteel/vault{dir = 1},/area/engine/gravity_generator)
+"aK" = (/turf/open/floor/plasteel/vault{dir = 8},/area/engine/gravity_generator)
+"aL" = (/turf/open/floor/plasteel/vault{dir = 4},/area/engine/gravity_generator)
+"aM" = (/obj/machinery/suit_storage_unit/ce,/turf/open/floor/plating,/area/atmos)
+"aN" = (/obj/machinery/atmospherics/components/unary/portables_connector/visible{dir = 4},/obj/machinery/portable_atmospherics/canister/nitrous_oxide,/turf/open/floor/plasteel/bot{dir = 2},/area/atmos)
+"aO" = (/obj/machinery/atmospherics/components/binary/pump{dir = 4; on = 1},/turf/open/floor/plasteel,/area/atmos)
+"aP" = (/obj/machinery/atmospherics/pipe/manifold/supply/hidden{dir = 4},/turf/open/floor/plating,/area/atmos)
+"aQ" = (/obj/structure/lattice/catwalk,/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/open/space,/area/space/nearstation)
+"aR" = (/obj/structure/lattice/catwalk,/obj/structure/cable{icon_state = "1-8"},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/open/space,/area/space/nearstation)
+"aS" = (/obj/structure/table,/obj/item/device/flashlight{pixel_y = 5},/obj/item/weapon/airlock_painter,/turf/open/floor/plating,/area/engine/engineering)
+"aT" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/open/floor/plating,/area/engine/engineering)
+"aU" = (/obj/machinery/door/airlock/glass_engineering{name = "Gravity Generator"; req_access_txt = "11"; req_one_access_txt = "0"},/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/open/floor/plasteel,/area/engine/gravity_generator)
+"aV" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/open/floor/plasteel/warning{dir = 8},/area/engine/gravity_generator)
+"aW" = (/obj/structure/cable{icon_state = "1-8"},/turf/open/floor/plasteel/warning{dir = 4},/area/engine/gravity_generator)
+"aX" = (/obj/machinery/door/airlock/glass_engineering{name = "Gravity Generator"; req_access_txt = "11"; req_one_access_txt = "0"},/turf/open/floor/plasteel/black,/area/engine/gravity_generator)
+"aY" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/black,/area/engine/gravity_generator)
+"aZ" = (/obj/structure/tank_dispenser{pixel_x = -1},/turf/open/floor/plating,/area/atmos)
+"ba" = (/obj/machinery/atmospherics/components/unary/vent_pump{on = 1},/turf/open/floor/plating,/area/atmos)
+"bb" = (/obj/machinery/atmospherics/components/unary/portables_connector/visible{dir = 4},/obj/machinery/portable_atmospherics/canister,/turf/open/floor/plasteel/bot{dir = 2},/area/atmos)
+"bc" = (/obj/machinery/atmospherics/components/binary/pump{dir = 8; on = 1},/turf/open/floor/plasteel,/area/atmos)
+"bd" = (/obj/structure/table,/obj/item/weapon/weldingtool/experimental,/turf/open/floor/plating,/area/engine/engineering)
+"be" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/open/floor/plating,/area/engine/engineering)
+"bf" = (/obj/structure/closet/secure_closet/engineering_chief,/turf/open/floor/plating,/area/engine/engineering)
+"bg" = (/turf/open/floor/plasteel/warning{dir = 8},/area/engine/gravity_generator)
+"bh" = (/turf/open/floor/plasteel/warning{dir = 4},/area/engine/gravity_generator)
+"bi" = (/obj/machinery/gravity_generator/main/station,/turf/open/floor/plasteel/vault{dir = 8},/area/engine/gravity_generator)
+"bj" = (/obj/machinery/power/apc{dir = 8; pixel_x = -24},/obj/structure/cable{icon_state = "0-2"; pixel_y = 1; d2 = 2},/obj/machinery/light,/obj/structure/table,/obj/item/device/analyzer,/obj/item/weapon/wrench,/turf/open/floor/plating,/area/atmos)
+"bk" = (/obj/machinery/atmospherics/pipe/manifold/supply/hidden{dir = 8},/turf/open/floor/plating,/area/atmos)
+"bl" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/machinery/meter,/turf/open/floor/plating,/area/atmos)
+"bm" = (/obj/machinery/atmospherics/components/binary/valve/open{icon_state = "mvalve_map"; dir = 4},/turf/open/floor/plating,/area/atmos)
+"bn" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 9; pixel_y = 0},/obj/machinery/light,/turf/open/floor/plating,/area/atmos)
+"bo" = (/obj/machinery/atmospherics/components/unary/vent_pump{on = 1},/obj/structure/table,/obj/item/weapon/screwdriver/power,/obj/item/weapon/wirecutters/power,/turf/open/floor/plating,/area/engine/engineering)
+"bp" = (/obj/machinery/light,/obj/item/weapon/storage/box/lights/mixed,/obj/item/device/lightreplacer,/turf/open/floor/plating,/area/engine/engineering)
+"bq" = (/turf/open/floor/plasteel/warning{dir = 10},/area/engine/gravity_generator)
+"br" = (/obj/structure/closet/radiation,/turf/open/floor/plasteel/warning{dir = 6},/area/engine/gravity_generator)
+"bs" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/closed/wall/r_wall,/area/hallway/primary/central)
+"bt" = (/obj/machinery/door/airlock,/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/open/floor/plasteel,/area/atmos)
+"bu" = (/turf/closed/wall/r_wall,/area/bridge)
+"bv" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plating,/area/bridge)
+"bw" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/closed/wall/r_wall,/area/engine/engineering)
+"bx" = (/obj/machinery/door/airlock,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/open/floor/plating,/area/engine/engineering)
+"by" = (/turf/closed/wall/r_wall,/area/hallway/secondary/entry)
+"bz" = (/obj/machinery/light{dir = 8},/turf/open/floor/plating,/area/maintenance/maintcentral)
+"bA" = (/turf/closed/wall/r_wall,/area/hallway/primary/central)
+"bB" = (/obj/machinery/power/apc{dir = 8; pixel_x = -24},/obj/structure/cable,/obj/structure/cable{icon_state = "0-2"; pixel_y = 1; d2 = 2},/obj/machinery/airalarm{frequency = 1439; locked = 0; pixel_y = 23},/obj/structure/closet/jcloset,/turf/open/floor/plasteel,/area/hallway/primary/central)
+"bC" = (/obj/machinery/atmospherics/pipe/manifold/supply/hidden{dir = 8},/turf/open/floor/plasteel,/area/hallway/primary/central)
+"bD" = (/obj/machinery/atmospherics/components/unary/vent_pump{dir = 8; on = 1},/turf/open/floor/plasteel,/area/hallway/primary/central)
+"bE" = (/turf/open/floor/plasteel,/area/hallway/primary/central)
+"bF" = (/obj/structure/closet/secure_closet/CMO,/turf/open/floor/plasteel,/area/hallway/primary/central)
+"bG" = (/obj/machinery/airalarm{frequency = 1439; locked = 0; pixel_y = 23},/obj/machinery/power/apc{dir = 8; pixel_x = -24},/obj/structure/cable{icon_state = "0-2"; pixel_y = 1; d2 = 2},/obj/structure/closet/secure_closet/captains,/turf/open/floor/plasteel/blue/side{dir = 8},/area/bridge)
+"bH" = (/obj/structure/table,/obj/item/ammo_box/c10mm,/obj/item/weapon/gun/projectile,/turf/open/floor/plasteel,/area/bridge)
+"bI" = (/obj/structure/table,/turf/open/floor/plasteel,/area/bridge)
+"bJ" = (/obj/structure/table,/obj/item/weapon/card/id/captains_spare,/turf/open/floor/plasteel,/area/bridge)
+"bK" = (/obj/structure/table,/obj/item/weapon/storage/backpack/holding,/turf/open/floor/plasteel,/area/bridge)
+"bL" = (/obj/structure/table,/obj/item/weapon/rcd_ammo/large,/obj/item/weapon/rcd_ammo/large,/obj/item/weapon/rcd_ammo/large,/obj/item/weapon/rcd,/turf/open/floor/plasteel,/area/bridge)
+"bM" = (/obj/structure/closet/secure_closet/hop,/turf/open/floor/plasteel/blue/side{dir = 4},/area/bridge)
+"bN" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/open/floor/plasteel,/area/hallway/primary/central)
+"bO" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/open/floor/plasteel,/area/hallway/primary/central)
+"bP" = (/obj/machinery/vending/cigarette,/turf/open/floor/plasteel/black,/area/hallway/primary/central)
+"bQ" = (/obj/machinery/vending/coffee,/turf/open/floor/plasteel/black,/area/hallway/primary/central)
+"bR" = (/obj/machinery/vending/cola,/turf/open/floor/plasteel/black,/area/hallway/primary/central)
+"bS" = (/obj/machinery/vending/snack,/turf/open/floor/plasteel/black,/area/hallway/primary/central)
+"bT" = (/obj/machinery/computer/arcade,/turf/open/floor/plasteel/black,/area/hallway/primary/central)
+"bU" = (/obj/machinery/airalarm{frequency = 1439; locked = 0; pixel_y = 23},/obj/machinery/power/apc{dir = 8; pixel_x = -24},/obj/structure/cable{icon_state = "0-2"; pixel_y = 1; d2 = 2},/obj/structure/closet/firecloset/full,/turf/open/floor/plasteel/arrival{tag = "icon-arrival (NORTHWEST)"; icon_state = "arrival"; dir = 9},/area/hallway/secondary/entry)
+"bV" = (/obj/machinery/light{dir = 1},/obj/structure/closet/emcloset,/turf/open/floor/plasteel/arrival{dir = 1},/area/hallway/secondary/entry)
+"bW" = (/obj/structure/closet/secure_closet/hos,/turf/open/floor/plasteel/arrival{dir = 1},/area/hallway/secondary/entry)
+"bX" = (/obj/structure/closet/emcloset,/turf/open/floor/plasteel/arrival{dir = 1},/area/hallway/secondary/entry)
+"bY" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plating,/area/maintenance/maintcentral)
+"bZ" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plating,/area/hallway/primary/central)
+"ca" = (/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/open/floor/plasteel,/area/hallway/primary/central)
+"cb" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/open/floor/plasteel,/area/hallway/primary/central)
+"cc" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/open/floor/plasteel,/area/hallway/primary/central)
+"cd" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/open/floor/plating,/area/bridge)
+"ce" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/open/floor/plasteel/blue/side{dir = 8},/area/bridge)
+"cf" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/open/floor/plasteel,/area/bridge)
+"cg" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/open/floor/plasteel/blue/side{dir = 4},/area/bridge)
+"ch" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/open/floor/plating,/area/bridge)
+"ci" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/turf/open/floor/plasteel,/area/hallway/primary/central)
+"cj" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0},/obj/structure/cable{icon_state = "1-8"},/turf/open/floor/plasteel,/area/hallway/primary/central)
+"ck" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/closed/wall/r_wall,/area/hallway/secondary/entry)
+"cl" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/open/floor/plasteel/arrival{dir = 8},/area/hallway/secondary/entry)
+"cm" = (/turf/open/floor/plasteel,/area/hallway/secondary/entry)
+"cn" = (/obj/machinery/door/airlock,/turf/open/floor/plating,/area/hallway/secondary/entry)
+"co" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel,/area/hallway/primary/central)
+"cp" = (/obj/machinery/light,/obj/machinery/atmospherics/components/unary/vent_pump{on = 1},/turf/open/floor/plasteel/blue/side{dir = 10},/area/bridge)
+"cq" = (/turf/open/floor/plasteel/blue/side,/area/bridge)
+"cr" = (/obj/machinery/light,/turf/open/floor/plasteel/blue/side{dir = 6},/area/bridge)
+"cs" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/closed/wall/r_wall,/area/bridge)
+"ct" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/open/floor/plasteel,/area/hallway/primary/central)
+"cu" = (/turf/open/floor/plasteel/arrival{dir = 8},/area/hallway/secondary/entry)
+"cv" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/closed/wall/r_wall,/area/bridge)
+"cw" = (/obj/machinery/door/airlock,/turf/open/floor/plasteel,/area/bridge)
+"cx" = (/obj/machinery/door/airlock/glass,/turf/open/floor/plasteel,/area/hallway/secondary/entry)
+"cy" = (/turf/open/floor/plasteel/loadingarea{dir = 8},/area/hallway/secondary/entry)
+"cz" = (/turf/open/floor/plating,/area/hallway/secondary/entry)
+"cA" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/turf/open/floor/plasteel,/area/hallway/primary/central)
+"cB" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/blue/corner{dir = 4},/area/hallway/primary/central)
+"cC" = (/obj/machinery/atmospherics/pipe/manifold/supply/hidden,/turf/open/floor/plasteel/blue/side{dir = 1},/area/hallway/primary/central)
+"cD" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/turf/open/floor/plasteel/blue/side{dir = 1},/area/hallway/primary/central)
+"cE" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/blue/corner{dir = 1},/area/hallway/primary/central)
+"cF" = (/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,/turf/open/floor/plasteel,/area/hallway/primary/central)
+"cG" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/turf/closed/wall/r_wall,/area/hallway/secondary/entry)
+"cH" = (/obj/machinery/atmospherics/components/unary/vent_pump{dir = 8; on = 1},/turf/open/floor/plasteel/arrival{dir = 8},/area/hallway/secondary/entry)
+"cI" = (/obj/structure/table,/obj/item/weapon/storage/fancy/donut_box,/turf/open/floor/plasteel/arrival{dir = 8},/area/hallway/secondary/entry)
+"cJ" = (/obj/structure/table,/obj/item/weapon/storage/fancy/donut_box,/turf/open/floor/plasteel/arrival{dir = 10},/area/hallway/secondary/entry)
+"cK" = (/obj/structure/table,/obj/item/stack/sheet/glass{amount = 50},/obj/item/stack/rods{amount = 50},/obj/machinery/light,/turf/open/floor/plasteel/arrival,/area/hallway/secondary/entry)
+"cL" = (/obj/structure/table,/obj/item/weapon/paper_bin{pixel_x = -3; pixel_y = 7},/obj/item/weapon/pen,/turf/open/floor/plasteel/arrival,/area/hallway/secondary/entry)
+"cM" = (/obj/structure/table,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/storage/firstaid/regular,/obj/item/device/healthanalyzer,/turf/open/floor/plasteel/arrival,/area/hallway/secondary/entry)
+"cN" = (/turf/closed/wall/r_wall,/area/construction)
+"cO" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/closed/wall/r_wall,/area/construction)
+"cP" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/closed/wall/r_wall,/area/construction)
+"cQ" = (/obj/machinery/door/airlock/glass,/turf/open/floor/plasteel,/area/construction)
+"cR" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plating,/area/construction)
+"cS" = (/turf/closed/wall/r_wall,/area/storage/primary)
+"cT" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/closed/wall/r_wall,/area/storage/primary)
+"cU" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/closed/wall/r_wall,/area/storage/primary)
+"cV" = (/obj/machinery/door/airlock/glass,/turf/open/floor/plasteel,/area/storage/primary)
+"cW" = (/obj/machinery/airalarm{frequency = 1439; locked = 0; pixel_y = 23},/obj/structure/cable,/obj/machinery/power/apc{dir = 8; pixel_x = -24},/turf/open/floor/plasteel/warning/corner,/area/construction)
+"cX" = (/obj/machinery/atmospherics/components/unary/vent_pump{dir = 1; on = 1},/turf/open/floor/plasteel/warning,/area/construction)
+"cY" = (/turf/open/floor/plasteel/warning,/area/construction)
+"cZ" = (/turf/open/floor/plasteel/warning/corner{dir = 1},/area/construction)
+"da" = (/obj/machinery/airalarm{frequency = 1439; locked = 0; pixel_y = 23},/obj/machinery/power/apc{dir = 8; pixel_x = -24},/obj/structure/cable,/turf/open/floor/plating,/area/storage/primary)
+"db" = (/obj/machinery/atmospherics/components/unary/vent_pump{dir = 1; on = 1},/turf/open/floor/plating,/area/storage/primary)
+"dc" = (/turf/open/floor/plasteel/warning{dir = 8},/area/storage/primary)
+"dd" = (/turf/open/floor/plasteel{icon_state = "L1"},/area/storage/primary)
+"de" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel{icon_state = "L3"},/area/storage/primary)
+"df" = (/turf/open/floor/plasteel{icon_state = "L5"},/area/storage/primary)
+"dg" = (/turf/open/floor/plasteel{icon_state = "L7"},/area/storage/primary)
+"dh" = (/turf/open/floor/plasteel{icon_state = "L9"},/area/storage/primary)
+"di" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel{icon_state = "L11"},/area/storage/primary)
+"dj" = (/turf/open/floor/plasteel{icon_state = "L13"; name = "floor"},/area/storage/primary)
+"dk" = (/turf/open/floor/plasteel/warning{dir = 4},/area/storage/primary)
+"dl" = (/turf/open/floor/plating,/area/storage/primary)
+"dm" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/open/floor/plasteel/warning{dir = 4},/area/construction)
+"dn" = (/turf/open/floor/plating,/area/construction)
+"do" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/open/floor/plasteel/warning{dir = 8},/area/construction)
+"dp" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/open/floor/plating,/area/storage/primary)
+"dq" = (/turf/open/floor/plasteel{icon_state = "L2"},/area/storage/primary)
+"dr" = (/turf/open/floor/plasteel{icon_state = "L4"},/area/storage/primary)
+"ds" = (/turf/open/floor/plasteel{icon_state = "L6"},/area/storage/primary)
+"dt" = (/turf/open/floor/plasteel{icon_state = "L8"},/area/storage/primary)
+"du" = (/turf/open/floor/plasteel{icon_state = "L10"},/area/storage/primary)
+"dv" = (/turf/open/floor/plasteel{icon_state = "L12"},/area/storage/primary)
+"dw" = (/turf/open/floor/plasteel{icon_state = "L14"},/area/storage/primary)
+"dx" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/open/floor/plating,/area/storage/primary)
+"dy" = (/turf/open/floor/plasteel/warning{dir = 4},/area/construction)
+"dz" = (/turf/open/floor/plasteel/warning{dir = 8},/area/construction)
+"dA" = (/turf/open/floor/plasteel/warning{dir = 10},/area/storage/primary)
+"dB" = (/turf/open/floor/plasteel/warning,/area/storage/primary)
+"dC" = (/turf/open/floor/plasteel/warning{dir = 6},/area/storage/primary)
+"dD" = (/turf/open/floor/plasteel/warning{dir = 9},/area/storage/primary)
+"dE" = (/turf/open/floor/plasteel/warning{dir = 1},/area/storage/primary)
+"dF" = (/turf/open/floor/plasteel/warning{dir = 5},/area/storage/primary)
+"dG" = (/obj/machinery/door/airlock,/turf/open/floor/plasteel,/area/storage/primary)
+"dH" = (/obj/effect/landmark/start,/turf/open/floor/plasteel,/area/storage/primary)
+"dI" = (/obj/effect/landmark{name = "JoinLate"},/turf/open/floor/plasteel,/area/storage/primary)
+"dJ" = (/turf/open/floor/plasteel,/area/storage/primary)
+"dK" = (/turf/open/floor/plasteel/warning/corner{dir = 8},/area/construction)
+"dL" = (/turf/open/floor/plasteel/warning{dir = 1},/area/construction)
+"dM" = (/turf/open/floor/plasteel/warning/corner{dir = 4},/area/construction)
+"dN" = (/obj/structure/table,/turf/open/floor/plasteel,/area/storage/primary)
+"dO" = (/obj/structure/table,/obj/machinery/light,/obj/item/weapon/twohanded/fireaxe,/obj/item/weapon/extinguisher,/turf/open/floor/plasteel,/area/storage/primary)
+"dP" = (/obj/structure/table,/obj/item/device/lightreplacer,/turf/open/floor/plasteel,/area/storage/primary)
+"dQ" = (/obj/structure/table,/obj/item/weapon/storage/box/lights/mixed,/obj/item/weapon/storage/box/lights/tubes,/obj/machinery/light,/turf/open/floor/plasteel,/area/storage/primary)
+"dR" = (/obj/structure/table,/obj/item/device/flashlight{pixel_y = 5},/turf/open/floor/plasteel,/area/storage/primary)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaababababababababababababababababababababababababababababababababababababaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadadadadadadadadadaeaeaeaeaeaeaeadadadadadadadadadadadadadadadadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafafafafafafafadagagagagacacacadafafafafafafafafafafafafafafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafahahahahahahahagaiaiagacacacajajajajakakakakakakakakakakafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafahalamamamamahaganaoagagajajajapaqarakasatauavavavavavakafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafahawaxayayazahagaiaAaBaBaCaDaCaDaEaFakaGaHaIavaJaKaLavakafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafahaMawaNaOaPahagaQaRagagajajajaSaTaDaUaVaWaXavaKavaKaYakafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafahaZbabbbcaPahagaiaiagacacacajbdbebfakbgbhaIavaLbiaJavakafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafahbjbkblbmbnahagagagagacacacajbobebpakbqbraIavavavavavakafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafahbsbtahahahbububvbvbvbvbvbububwbxajakakakakbybybybybybyafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadbzbAbBbCbDbEbFbubGbHbIbJbKbLbMbubNbObPbQbRbSbTbybUbVbWbXbyafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacbYafbZcacbcccccccdcecfcfcfcfcfcgchcicjccccccccccckclcmcmcmcnafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacbYafbZbObNbEbEcobucpcqcqcqcqcqcrcsctbEbEbEbEbEcobycucmcmcmbybybyacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacbYafbZbObNbEbEbEbucvbvbucwbubvbucsbNbEbEbEbEbEbEcxcucmcmcycnczcnacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacbYafbZbObCcAcAcAcBcCcDcDcDcDcDcDcEcFcAcAcAcAcAcAcGcHcmcmcmbybybyacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacbYafbZbObNbEbEbEbEbEbEbEbEbEbEbEbObNbEbEbEbEbEbEbycIcmcmcmcnafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadbzbAbObNbEbEbEbEbEbEbEbEbEbEbEbObNbEbEbEbEbEbEbycJcKcLcMbyafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNcOcPcQcQcNcRcRcRcNcQcQcNcScTcUcScScScVcVcVbybybybybybyafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNcWcXcYcYcYcYcYcYcYcYcYcZcSdadbdcdddedfdgdhdidjdkdldlcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNdmdndndndndndndndndndndocSdpdldcdqdrdsdtdudvdwdkdldxcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNdydndndndndndndndndndndzcSdldldAdBdBdBdBdBdBdBdCdldlcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNdydndndndndndndndndndndzcSdldldldldldldldldldldldldlcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNdydndndndndndndndndndndzcSdldldDdEdEdEdEdEdEdEdFdldlcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNdydndndndndndndndndndndzdGdldldcdHdHdHdHdHdHdHdkdldlcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNdydndndndndndndndndndndzdGdldldcdIdIdIdIdIdIdIdkdldlcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNdydndndndndndndndndndndzcSdldldAdBdBdBdBdBdBdBdCdldlcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNdydndndndndndndndndndndzcSdldldldldldldldldldldldldlcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNdydndndndndndndndndndndzcSdldldDdEdEdEdEdEdEdEdFdldlcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNdmdndndndndndndndndndndocSdpdldcdJdJdJdJdJdJdJdkdldxcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNdKdLdLdLdLdLdLdLdLdLdLdMcSdldldcdNdOdNdNdPdQdRdkdldlcSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafcNcNcNcNcNcNcNcNcNcNcNcNcNcScScScScScScScScScScScScScScSafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacabaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaababababababababababababababababababababababababababababababababababababaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"}

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -17,7 +17,7 @@
 "aq" = (/obj/machinery/computer/monitor,/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"; tag = ""},/turf/open/floor/plating,/area/engine/engineering)
 "ar" = (/obj/structure/closet/secure_closet/engineering_welding,/turf/open/floor/plating,/area/engine/engineering)
 "as" = (/obj/machinery/power/smes{charge = 5e+006},/obj/machinery/airalarm{frequency = 1439; locked = 0; pixel_y = 23},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/turf/open/floor/plasteel/warning{dir = 9},/area/engine/gravity_generator)
-"at" = (/obj/machinery/power/apc{dir = 1; name = "Gravity Generator APC"; pixel_x = 0; pixel_y = 25},/obj/structure/cable{icon_state = "0-8"; step_x = 0; step_y = 0; d2 = 8},/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/open/floor/plasteel/warning{dir = 5},/area/engine/gravity_generator)
+"at" = (/obj/machinery/power/apc{dir = 1; name = "Gravity Generator APC"; pixel_x = 0; pixel_y = 25},/obj/structure/cable{icon_state = "0-8"; d2 = 8},/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/open/floor/plasteel/warning{dir = 5},/area/engine/gravity_generator)
 "au" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 32},/turf/open/floor/plating,/area/engine/gravity_generator)
 "av" = (/turf/open/floor/plasteel/black,/area/engine/gravity_generator)
 "aw" = (/turf/open/floor/plating,/area/atmos)

--- a/_maps/runtimestation.dm
+++ b/_maps/runtimestation.dm
@@ -1,0 +1,23 @@
+#if !defined(MAP_FILE)
+
+		// Runtime Station
+		// This is a developer sandbox map that will compile and
+		// load quickly. Not intended for production deployment.
+
+		#define TITLESCREEN "title"
+
+		#define MINETYPE "lavaland"
+
+        #include "map_files\debug\runtimestation.dmm"
+
+		#define MAP_PATH "map_files/debug"
+        #define MAP_FILE "runtimestation.dmm"
+        #define MAP_NAME "Runtime Station"
+
+		#define MAP_TRANSITION_CONFIG DEFAULT_MAP_TRANSITION_CONFIG
+
+#elif !defined(MAP_OVERRIDE)
+
+	#warn a map has already been included, ignoring Runtime Station.
+
+#endif


### PR DESCRIPTION
Heyo!

As previously described in #21320, making an extremely small map (and eliminating all other z levels) reduces compile time (somewhat) and launch time (significantly). This is great for when developers need to quickly iterate on their designs.

This is Runtime Station, a quick-loading developer sandbox:

![](http://i.imgur.com/e4pGKW9.png)

The screenshot is only missing a small bit of maintenance at both ends. The map is 52 x 52 with the station occupying the center 32 x 32 block (including outer walls). All other z-levels (lava land, centcom etc) are excluded from the build.

Along the top of the station (from left to right) is Atmos, the RTG array, Engineering & the Gravity Generator. The 'Operations Room' is situated in the middle of the main hallway. At the extreme right end of the main hallway is the airlock and arrivals area. The lower right hand room is the spawn area, it has lots of space for spawning any items you need. The lower left room in the station is a construction area with a 10 x 10 chunk of empty plating.
 
The station is stocked with some essentials, plus a few items I thought would be useful (or just handy to have lying around). There are no airlock permissions so that moving around is easy.

Compiling Runtime Station takes about 1 - 3 minutes, verses a compile time of 3 - 6 minutes when compiling tgstation2 and the other z-levels (side note: 'Generating Object Trees' is by far the longest part of the compiling process). It usually takes _less then 10 secconds_ to load Runtime Station, versus a 1 - 2 minute load time for tgstation2. These numbers aren't very scientific ... look it loads faster ok? trust me.

Known Issues
- Scripts related to populating the other z-levels will runtime on startup. They seem to crash with no side-effects.
- The gravity generator will complain at startup, everything is fine though.
- Going outside the lattice ring will cause a runtime related to moving to z-levels that don't exist.