### PR TITLE
Minor tweaks to lizard skin and lizard skin crafting

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -60,9 +60,17 @@ var/global/list/datum/stack_recipe/monkey_recipes = list ( \
 
 /obj/item/stack/sheet/animalhide/lizard
 	name = "lizard skin"
-	desc = "Sssssss..."
+	desc = "Extremely valuable lizard hide. People kill for this stuff. Especially valued if colored blue, or has a footlike-odor."
 	singular_name = "lizard skin piece"
 	icon_state = "sheet-lizard"
+	
+var/global/list/datum/stack_recipe/lizard_recipes = list ( \
+	new/datum/stack_recipe("lizard cloche hat", /obj/item/clothing/head/lizard, 1, on_floor=1), \
+	)
+
+/obj/item/stack/sheet/animalhide/lizard/New(var/loc, var/amount=null)
+	recipes = lizard_recipes
+	return ..()
 
 /obj/item/stack/sheet/animalhide/xeno
 	name = "alien hide"

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -60,7 +60,7 @@ var/global/list/datum/stack_recipe/monkey_recipes = list ( \
 
 /obj/item/stack/sheet/animalhide/lizard
 	name = "lizard skin"
-	desc = "Extremely valuable lizard hide. People kill for this stuff. Especially valued if colored blue, or has a footlike-odor."
+	desc = "Extremely valuable lizard hide. Smells like stinky feet. Legend has it the blue skin is the most valuable."
 	singular_name = "lizard skin piece"
 	icon_state = "sheet-lizard"
 	

--- a/code/modules/cargo/exports/gear.dm
+++ b/code/modules/cargo/exports/gear.dm
@@ -4,6 +4,7 @@
 
 /datum/export/gear/liz_hat
 	cost = 2000
+	contraband = TRUE
 	unit_name = "lizard cloche hat"
 	export_types = list(/obj/item/clothing/head/lizard)
 

--- a/code/modules/cargo/exports/gear.dm
+++ b/code/modules/cargo/exports/gear.dm
@@ -2,6 +2,11 @@
 
 /datum/export/gear
 
+/datum/export/gear/liz_hat
+	cost = 2000
+	unit_name = "lizard cloche hat"
+	export_types = list(/obj/item/clothing/head/lizard)
+
 // Security gear
 /datum/export/gear/sec_helmet
 	cost = 100

--- a/code/modules/cargo/exports/organs.dm
+++ b/code/modules/cargo/exports/organs.dm
@@ -77,6 +77,15 @@
 	return ..()
 
 
+/datum/export/organ/lizard
+	contraband = TRUE
+	include_subtypes = FALSE
+	
+/datum/export/organ/lizard/skin
+	cost = 1000 //lizard hide costs a pretty penny
+	unit_name = "lizard hide"
+	export_types = list(/obj/item/stack/sheet/animalhide/lizard)
+
 // Human organs.
 
 // Do not put human brains here, they are not sellable for a purpose.


### PR DESCRIPTION
:cl: NanoTrasen Species Equality Division
add: Lizard hats are now craftable by using lizard skin in-hand
add: Lizard skin and lizard hats can now be sold in cargo if contraband is enabled
/:cl:

they can now be crafted like other items, without opening the crafting menu.
they also can be sold like human organs.