### PR TITLE
You can now actually drag people over Vitality Matrices

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -330,4 +330,5 @@
 		animation_number = initial(animation_number)
 		sigil_active = FALSE
 		visible_message("<span class='warning'>[src] slowly stops glowing!</span>")
+	if(sigil_active || alpha == 255)
 		animate(src, alpha = initial(alpha), time = 20)

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -236,9 +236,9 @@
 	visible_message("<span class='warning'>[src] begins to glow bright blue!</span>")
 	animate(src, alpha = 255, time = 10)
 	sleep(10)
-	sigil_active = TRUE
 //as long as they're still on the sigil and are either not a servant or they're a servant AND it has remaining vitality
 	while(L && (!is_servant_of_ratvar(L) || (is_servant_of_ratvar(L) && vitality)) && get_turf(L) == get_turf(src))
+		sigil_active = TRUE
 		if(animation_number >= 4)
 			PoolOrNew(/obj/effect/overlay/temp/ratvar/sigil/vitality, get_turf(src))
 			animation_number = 0

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -326,7 +326,8 @@
 				vitality -= vitality_used
 		sleep(2)
 
-	animation_number = initial(animation_number)
-	sigil_active = FALSE
-	animate(src, alpha = initial(alpha), time = 20)
-	visible_message("<span class='warning'>[src] slowly stops glowing!</span>")
+	if(sigil_active)
+		animation_number = initial(animation_number)
+		sigil_active = FALSE
+		visible_message("<span class='warning'>[src] slowly stops glowing!</span>")
+		animate(src, alpha = initial(alpha), time = 20)


### PR DESCRIPTION
:cl: Joan
bugfix: Dragging people over a Vitality Matrix will actually cause the Matrix to start working on them instead of failing to start draining because it's "active" from when the dragging person crossed it.
/:cl: