### PR TITLE
Reverts run/walk toggle hotkey but keeps the target selection

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -203,14 +203,6 @@ macro "default"
 		name = "F12"
 		command = "F12"
 		is-disabled = false
-	elem 
-		name = "SHIFT"
-		command = "toggle-walk-run"
-		is-disabled = false
-	elem 
-		name = "SHIFT+UP"
-		command = "toggle-walk-run"
-		is-disabled = false
 
 macro "hotkeys"
 	elem 
@@ -500,14 +492,6 @@ macro "hotkeys"
 	elem 
 		name = "F12"
 		command = "F12"
-		is-disabled = false
-	elem 
-		name = "SHIFT"
-		command = "toggle-walk-run"
-		is-disabled = false
-	elem 
-		name = "SHIFT+UP"
-		command = "toggle-walk-run"
 		is-disabled = false
 
 macro "robot-default"


### PR DESCRIPTION
:cl: Lzimann
del: You can no longer walk holding shift.
/:cl:

fixes #21343
partial revert of #21039