### PR TITLE
Rebalances non-hybrid tasers and disablers

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -117,6 +117,12 @@
 	select_name  = "disable"
 	e_cost = 50
 	fire_sound = "sound/weapons/taser2.ogg"
+	
+/obj/item/ammo_casing/energy/small_disabler
+	projectile_type = /obj/item/projectile/beam/disabler
+	select_name = "pulse disabler"
+	e_cost = 142
+	fire_sound = "sound/weapons/taser2.ogg"
 
 /obj/item/ammo_casing/energy/plasma
 	projectile_type = /obj/item/projectile/plasma

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -119,7 +119,7 @@
 	fire_sound = "sound/weapons/taser2.ogg"
 	
 /obj/item/ammo_casing/energy/small_disabler
-	projectile_type = /obj/item/projectile/beam/disabler
+	projectile_type = /obj/item/projectile/beam/pulse_disabler
 	select_name = "pulse disabler"
 	e_cost = 142
 	fire_sound = "sound/weapons/taser2.ogg"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -4,6 +4,7 @@
 	icon_state = "taser"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
+	cell_type = /obj/item/weapon/stock_parts/cell{charge = 800; maxcharge = 800}
 	origin_tech = "combat=3"
 	ammo_x_offset = 3
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -38,6 +38,7 @@
 	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse."
 	icon_state = "disabler"
 	item_state = "combat=3"
+	cell_type = /obj/item/weapon/stock_parts/cell{charge = 350; maxcharge = 350}
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 3
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -4,7 +4,7 @@
 	icon_state = "taser"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
-	cell_type = /obj/item/weapon/stock_parts/cell{charge = 800; maxcharge = 800}
+	//cell_type = /obj/item/weapon/stock_parts/cell{charge = 800; maxcharge = 800}
 	origin_tech = "combat=3"
 	ammo_x_offset = 3
 
@@ -39,7 +39,7 @@
 	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse."
 	icon_state = "disabler"
 	item_state = "combat=3"
-	cell_type = /obj/item/weapon/stock_parts/cell{charge = 350; maxcharge = 350}
+	//cell_type = /obj/item/weapon/stock_parts/cell{charge = 350; maxcharge = 350}
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 3
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -35,12 +35,12 @@
 	use_cyborg_cell = 1
 
 /obj/item/weapon/gun/energy/disabler
-	name = "disabler"
+	name = "pulse disabler"
 	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse."
 	icon_state = "disabler"
 	item_state = "combat=3"
 	//cell_type = /obj/item/weapon/stock_parts/cell{charge = 350; maxcharge = 350}
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
+	ammo_type = list(/obj/item/ammo_casing/energy/small_disabler)
 	ammo_x_offset = 3
 
 /obj/item/weapon/gun/energy/disabler/cyborg

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -56,6 +56,16 @@
 	hitsound = 'sound/weapons/tap.ogg'
 	eyeblur = 0
 	impact_effect_type = /obj/effect/overlay/temp/impact_effect/blue_laser
+	
+/obj/item/projectile/beam/pulse_disabler
+	name = "pulse disabler beam"
+	icon_state = "u_laser"
+	damage = 45
+	damage_type = STAMINA
+	flag = "energy"
+	hitsound = 'sound/weapons/tap.ogg'
+	eyeblur = 0
+	impact_effect_type = /obj/effect/overlay/temp/impact_effect/blue_laser
 
 /obj/item/projectile/beam/pulse
 	name = "pulse"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -60,7 +60,7 @@
 /obj/item/projectile/beam/pulse_disabler
 	name = "pulse disabler beam"
 	icon_state = "u_laser"
-	damage = 45
+	damage = 42
 	damage_type = STAMINA
 	flag = "energy"
 	hitsound = 'sound/weapons/tap.ogg'


### PR DESCRIPTION
:cl: Tacolizard
tweak: Non-hybrid tasers have enough charge for 4 shots; non-hybrid disablers have 7 shots
/:cl:


i hope this will fill a good self-defense niche so that i may make these weapons obtainable in-game.

also just saying, a four shot taser is still very powerful for anyone non-sec. I'm more interested in the lower-power disabler.

**egun, the thing you are familiar with != disabler**
**disablers don't spawn on any map other than dream**