### PR TITLE
Fixes Resist Fire Stuns

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -264,7 +264,7 @@
 
 /mob/living/carbon/resist_fire()
 	fire_stacks -= 5
-	Weaken(3,1)
+	Weaken(3, 1, 1)
 	spin(32,2)
 	visible_message("<span class='danger'>[src] rolls on the floor, trying to put themselves out!</span>", \
 		"<span class='notice'>You stop, drop, and roll!</span>")


### PR DESCRIPTION
When the conditional life update happened, `resist_fire` wasn't properly updated to factor in the new argument order, as such, stopping, dropping, and rolling results in someone not being weakened, but the flames still being extinguished.

This fixes that by correcting the arguments to ensure that even stun immune mobs are properly weakened for the duration of the the roll.

🆑Fox McCloud
fix: Fixes stopping, dropping, and rolling not properly stunning all mobs
/:cl: