### PR TITLE
Fixes not being able to fall while standing on a wall

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -119,13 +119,6 @@
 		qdel(hotspot)
 	return 1
 
-/turf/open/handle_fall(mob/faller, forced)
-	faller.lying = pick(90, 270)
-	if(!forced)
-		return
-	if(has_gravity(src))
-		playsound(src, "bodyfall", 50, 1)
-
 /turf/open/handle_slip(mob/living/carbon/C, s_amount, w_amount, obj/O, lube)
 	if(has_gravity(src))
 		var/obj/buckled_obj

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -377,4 +377,9 @@
 		T.setDir(dir)
 	return T
 
-
+/turf/handle_fall(mob/faller, forced)
+	faller.lying = pick(90, 270)
+	if(!forced)
+		return
+	if(has_gravity(src))
+		playsound(src, "bodyfall", 50, 1)


### PR DESCRIPTION
Moves handle_fall() back to /turf instead of /turf/open.
It was moved from /turf to /turf/open in https://github.com/tgstation/tgstation/commit/b9950c43584da8134726ecc3fef7e37189c46e35#diff-2939b84f8f6de56f3b4a70ef33122366L241 without any explanation so I'm assuming this was unintentional.
Fixes #19630

