### PR TITLE
Teslium can no longer destory nukes

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -399,9 +399,10 @@ var/bomb_set
 		return
 	qdel(src)
 
-/obj/machinery/nuclearbomb/tesla_act(var/power)
+/obj/machinery/nuclearbomb/tesla_act(power, explosive)
 	..()
-	qdel(src)//like the singulo, tesla deletes it. stops it from exploding over and over
+	if(explosive)
+		qdel(src)//like the singulo, tesla deletes it. stops it from exploding over and over
 
 #define NUKERANGE 127
 /obj/machinery/nuclearbomb/proc/explode()

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -36,9 +36,10 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	if(prob(20))
 		set_broken()
 
-/obj/machinery/gravity_generator/tesla_act(var/power)
+/obj/machinery/gravity_generator/tesla_act(power, explosive)
 	..()
-	qdel(src)//like the singulo, tesla deletes it. stops it from exploding over and over
+	if(explosive)
+		qdel(src)//like the singulo, tesla deletes it. stops it from exploding over and over
 
 /obj/machinery/gravity_generator/update_icon()
 	..()


### PR DESCRIPTION
Fixes #21382

:cl: Cyberboss
fix: Tesla zaps that don't come from an energy ball can no longer destroy nukes and gravity generators
/:cl:

