### PR TITLE
Attacking someone with an extinguisher on help intent only stops it if the safety is off

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -50,6 +50,12 @@
 	user << "The safety is [safety ? "on" : "off"]."
 	return
 
+/obj/item/weapon/extinguisher/attack(mob/M, mob/user)
+	if(user.a_intent == "help" && !safety) //If we're on help intent and going to spray people, don't bash them.
+		return 0
+	else
+		return ..()
+
 /obj/item/weapon/extinguisher/examine(mob/user)
 	..()
 	if(reagents.total_volume)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -50,15 +50,6 @@
 	user << "The safety is [safety ? "on" : "off"]."
 	return
 
-/obj/item/weapon/extinguisher/attack(mob/M, mob/user)
-	if(user.a_intent == "help")
-		// If we're in help intent, don't bash anyone with the
-		// extinguisher
-		user.visible_message("[user] targets [M] with \the [src]", "<span class='info'>You target [M] with \the [src].</span>")
-		return 0
-	else
-		return ..()
-
 /obj/item/weapon/extinguisher/examine(mob/user)
 	..()
 	if(reagents.total_volume)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -52,7 +52,7 @@
 
 /obj/item/weapon/extinguisher/attack(mob/M, mob/user)
 	if(user.a_intent == "help" && !safety) //If we're on help intent and going to spray people, don't bash them.
-		return 0
+		return FALSE
 	else
 		return ..()
 


### PR DESCRIPTION
This was such an annoying change. You can hit people with almost any other item in the game on help intent, so this is really inconsistent.

:cl:
del: Removed the restriction on attacking people with a fire extinguisher on help intent if the safety is on.
/:cl:

Edit: changed so the attack is only stopped when the safety is off