### PR TITLE
Improves stunbaton code to prevent runtimes and a miscount in charge

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -6,7 +6,7 @@
 		target.visible_message("<span class='danger'>[target.name] blocks [src] and twists [user]'s arm behind their back!</span>",
 					"<span class='userdanger'>You block the attack!</span>")
 		user.Stun(2)
-		return 1
+		return TRUE
 
 
 /obj/item/weapon/melee/chainofcommand

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -39,14 +39,14 @@
 
 /obj/item/weapon/melee/baton/proc/deductcharge(chrgdeductamt)
 	if(bcell)
+		//Note this value returned is significant, as it will determine
+		//if a stun is applied or not
 		. = bcell.use(chrgdeductamt)
-		if(bcell.charge >= hitcost) // If after the deduction the baton doesn't have enough charge for a stun hit it turns off.
-			return
-	if(status)
-		status = 0
-		update_icon()
-		playsound(loc, "sparks", 75, 1, -1)
-	return 0
+		if(status && bcell.charge < hitcost)
+			//we're below minimum, turn off
+			status = 0
+			update_icon()
+			playsound(loc, "sparks", 75, 1, -1)
 
 
 /obj/item/weapon/melee/baton/update_icon()
@@ -117,13 +117,12 @@
 		..()
 		return
 
-	if(!isliving(M))
+	var/mob/living/carbon/human/L = M
+	if(!istype(L))
 		return
 
-	var/mob/living/carbon/human/L = M
-
 	if(check_martial_counter(L, user))
-		return 0
+		return 
 
 	if(user.a_intent != "harm")
 		if(status)


### PR DESCRIPTION
Fixes #21403 
Fixes #13209

    Previously if the final stun from a stunbaton used all the power in the
    cell (putting it below hitcost) it would not properly return the actual
    value of the cell.use call, so you would use the energy but not properly
    get the stun
    
    The logic of the deductcharge proc has been refactor to avoid this by
    explicitly returning the value of cell.use call no matter if the stun
    baton is switched off or not
    
    The code was also cleaned slightly to improve readability
