### PR TITLE
Set iv_drip density to 0

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/obj/iv_drip.dmi'
 	icon_state = "iv_drip"
 	anchored = 0
-	density = 1
 	var/mob/living/carbon/attached = null
 	var/mode = 1 // 1 is injecting, 0 is taking blood.
 	var/obj/item/weapon/reagent_containers/beaker = null


### PR DESCRIPTION
It's inconsistent for players to be able to run over chairs, stools, beds, and potted plants, but not over thin metal IV drips. It's also inconsistent to have 0-density IV drips exist on Meta and Pubby, but not on Box and the other maps.

So let's just have 0-density IV drips everywhere and throw a party to celebrate.