### PR TITLE
Facehuggers can no longer latch onto mobs without a head

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -111,6 +111,9 @@ var/const/MAX_ACTIVE_TIME = 400
 		return 0
 	if((!iscorgi(M) && !iscarbon(M)) || isalien(M))
 		return 0
+	var/mob/living/carbon/Carb = M
+	if(!Carb.head)
+		return 0
 	if(attached)
 		return 0
 	else

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -109,10 +109,11 @@ var/const/MAX_ACTIVE_TIME = 400
 /obj/item/clothing/mask/facehugger/proc/Attach(mob/living/M)
 	if(!isliving(M))
 		return 0
-	if((!iscorgi(M) && !iscarbon(M)) || isalien(M))
+	var/Corgi = iscorgi(M)
+	if((!Corgi && !iscarbon(M)) || isalien(M))
 		return 0
 	var/mob/living/carbon/Carb = M
-	if(!Carb.head)
+	if(!Corgi && !Carb.head)
 		return 0
 	if(attached)
 		return 0


### PR DESCRIPTION
Fixes #21437

:cl: Cyberboss
fix: Facehuggers can no longer latch onto mobs without a head... How the fuck did you get a living mob without a head?
/:cl:

