### PR TITLE
Fixes disposals belt directions in Box and Meta

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -7331,8 +7331,9 @@
 	dir = 8
 	},
 /obj/machinery/conveyor{
-	dir = 2;
-	id = "garbage"
+	dir = 9;
+	id = "garbage";
+	verted = -1
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -7345,7 +7346,7 @@
 /area/maintenance/disposal)
 "amW" = (
 /obj/machinery/conveyor{
-	dir = 4;
+	dir = 6;
 	id = "garbage"
 	},
 /obj/machinery/door/window/eastright{
@@ -7950,7 +7951,7 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/conveyor{
-	dir = 2;
+	dir = 10;
 	id = "garbage"
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -25094,7 +25094,7 @@
 /obj/machinery/conveyor{
 	dir = 6;
 	id = "garbage";
-	verted = 1
+	verted = -1
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)


### PR DESCRIPTION
Pubby has map errors and fuck the rest
Fixes #21218

:cl: Cyberboss
fix: Objects will no longer get stuck behind the recycler on Boxstation
/:cl:
