### PR TITLE
Finally fucking fixed deathgasps

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -16,7 +16,7 @@
 /mob/living/carbon/human/death(gibbed)
 	if(stat == DEAD)
 		return
-	stat = DEAD
+
 	dizziness = 0
 	jitteriness = 0
 	heart_attack = 0
@@ -29,6 +29,7 @@
 	if(!gibbed)
 		emote("deathgasp") //let the world KNOW WE ARE DEAD
 
+	stat = DEAD
 	dna.species.spec_death(gibbed, src)
 
 	if(ticker && ticker.mode)

--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -8,10 +8,10 @@
 	if(stat == DEAD)
 		return
 
-	stat = DEAD
-
 	if(!gibbed)
 		emote("deathgasp")
+
+	stat = DEAD
 
 	if(ticker && ticker.mode)
 		ticker.mode.check_win()


### PR DESCRIPTION
 Fixes #21136

This fix is to beat the stat check in living/emote
Through all my gitlog tracing I cannot figure out what caused this bug in the first place. It was working fine last month

:cl: Cyberboss
fix: Deathgasps are back, fucking finally
/:cl:

