### PR TITLE
Makes medibots tricord aware. Changes the tox treatment to charcoal

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -38,6 +38,7 @@
 	var/declare_cooldown = 0 //Prevents spam of critical patient alerts.
 	var/stationary_mode = 0 //If enabled, the Medibot will not move automatically.
 	//Setting which reagents to use to treat what by default. By id.
+	var/treatment_avoid = "tricordrazine"	//will not treat if present
 	var/treatment_brute = "bicaridine"
 	var/treatment_oxy = "dexalin"
 	var/treatment_fire = "kelotane"
@@ -50,6 +51,7 @@
 	name = "\improper Mysterious Medibot"
 	desc = "International Medibot of mystery."
 	skin = "bezerk"
+	treatment_avoid = null
 	treatment_oxy = "tricordrazine"
 	treatment_brute = "tricordrazine"
 	treatment_fire = "tricordrazine"
@@ -61,6 +63,7 @@
 	skin = "bezerk"
 	heal_threshold = 0
 	declare_crit = 0
+	treatment_avoid = null
 	treatment_oxy = "pancuronium"
 	treatment_brute = "pancuronium"
 	treatment_fire = "sodium_thiopental"
@@ -349,18 +352,19 @@
 			if(!C.reagents.has_reagent(R.id))
 				return 1
 
-	//They're injured enough for it!
-	if((C.getBruteLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_brute)))
-		return 1 //If they're already medicated don't bother!
+	if(!C.reagents.has_reagent(treatment_avoid))
+		if((C.getOxyLoss() >= (15 + heal_threshold)) && (!C.reagents.has_reagent(treatment_oxy)))
+			return 1
 
-	if((C.getOxyLoss() >= (15 + heal_threshold)) && (!C.reagents.has_reagent(treatment_oxy)))
-		return 1
+		//They're injured enough for it!
+		if((C.getBruteLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_brute)))
+			return 1 //If they're already medicated don't bother!
 
-	if((C.getFireLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_fire)))
-		return 1
+		if((C.getFireLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_fire)))
+			return 1
 
-	if((C.getToxLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_tox)))
-		return 1
+		if((C.getToxLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_tox)))
+			return 1
 
 	if(treat_virus)
 		for(var/datum/disease/D in C.viruses)
@@ -429,21 +433,22 @@
 				if(!C.reagents.has_reagent(treatment_virus))
 					reagent_id = treatment_virus
 
-		if(!reagent_id && (C.getBruteLoss() >= heal_threshold))
-			if(!C.reagents.has_reagent(treatment_brute))
-				reagent_id = treatment_brute
+		if(!C.reagents.has_reagent(treatment_avoid))
+			if(!reagent_id && (C.getOxyLoss() >= (15 + heal_threshold)))
+				if(!C.reagents.has_reagent(treatment_oxy))
+					reagent_id = treatment_oxy
 
-		if(!reagent_id && (C.getOxyLoss() >= (15 + heal_threshold)))
-			if(!C.reagents.has_reagent(treatment_oxy))
-				reagent_id = treatment_oxy
+			if(!reagent_id && (C.getBruteLoss() >= heal_threshold))
+				if(!C.reagents.has_reagent(treatment_brute))
+					reagent_id = treatment_brute
 
-		if(!reagent_id && (C.getFireLoss() >= heal_threshold))
-			if(!C.reagents.has_reagent(treatment_fire))
-				reagent_id = treatment_fire
+			if(!reagent_id && (C.getFireLoss() >= heal_threshold))
+				if(!C.reagents.has_reagent(treatment_fire))
+					reagent_id = treatment_fire
 
-		if(!reagent_id && (C.getToxLoss() >= heal_threshold))
-			if(!C.reagents.has_reagent(treatment_tox))
-				reagent_id = treatment_tox
+			if(!reagent_id && (C.getToxLoss() >= heal_threshold))
+				if(!C.reagents.has_reagent(treatment_tox))
+					reagent_id = treatment_tox
 
 		//If the patient is injured but doesn't have our special reagent in them then we should give it to them first
 		if(reagent_id && use_beaker && reagent_glass && reagent_glass.reagents.total_volume)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -45,7 +45,7 @@
 	var/treatment_fire_avoid = "tricordrazine"
 	var/treatment_fire = "kelotane"
 	var/treatment_tox_avoid = "tricordrazine"
-	var/treatment_tox = "antitoxin"
+	var/treatment_tox = "charcoal"
 	var/treatment_virus_avoid = null
 	var/treatment_virus = "spaceacillin"
 	var/treat_virus = 1 //If on, the bot will attempt to treat viral infections, curing them if possible.

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -469,7 +469,8 @@
 		C.visible_message("<span class='danger'>[src] is trying to inject [patient]!</span>", \
 			"<span class='userdanger'>[src] is trying to inject you!</span>")
 
-		spawn(30)//replace with do mob
+		var/failed = FALSE;
+		if(do_mob(src, patient, 30))	//Is C == patient? This is so confusing
 			if((get_dist(src, patient) <= 1) && (on) && assess_patient(patient))
 				if(reagent_id == "internal_beaker")
 					if(use_beaker && reagent_glass && reagent_glass.reagents.total_volume)
@@ -481,10 +482,15 @@
 				C.visible_message("<span class='danger'>[src] injects [patient] with its syringe!</span>", \
 					"<span class='userdanger'>[src] injects you with its syringe!</span>")
 			else
-				visible_message("[src] retracts its syringe.")
-			update_icon()
-			soft_reset()
-			return
+				failed = TRUE
+		else
+			failed = TRUE
+
+		if(failed)
+			visible_message("[src] retracts its syringe.")
+		update_icon()
+		soft_reset()
+		return
 
 	reagent_id = null
 	return

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -66,13 +66,12 @@
 	skin = "bezerk"
 	heal_threshold = 0
 	declare_crit = 0
-	treatment_avoid_oxy = null
 	treatment_oxy = "pancuronium"
-	treatment_avoid_brute = null
+	treatment_brute_avoid = null
 	treatment_brute = "pancuronium"
-	treatment_avoid_fire = null
+	treatment_fire_avoid = null
 	treatment_fire = "sodium_thiopental"
-	treatment_avoid_tox = null
+	treatment_tox_avoid = null
 	treatment_tox = "sodium_thiopental"
 
 /mob/living/simple_animal/bot/medbot/update_icon()
@@ -359,29 +358,25 @@
 				return 1
 
 	//They're injured enough for it!
-	if((!C.has_reagent(treatment_brute_avoid)) && (C.getBruteLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_brute)))
+	if((!C.reagents.has_reagent(treatment_brute_avoid)) && (C.getBruteLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_brute)))
 		return 1 //If they're already medicated don't bother!
 
-	if((!C.has_reagent(treatment_oxy_avoid)) && (C.getOxyLoss() >= (15 + heal_threshold)) && (!C.reagents.has_reagent(treatment_oxy)))
+	if((!C.reagents.has_reagent(treatment_oxy_avoid)) && (C.getOxyLoss() >= (15 + heal_threshold)) && (!C.reagents.has_reagent(treatment_oxy)))
 		return 1
 
-	if((!C.has_reagent(treatment_fire_avoid)) && (C.getFireLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_fire)))
+	if((!C.reagents.has_reagent(treatment_fire_avoid)) && (C.getFireLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_fire)))
 		return 1
 
-	if((!C.has_reagent(treatment_tox_avoid)) && (C.getToxLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_tox)))
+	if((!C.reagents.has_reagent(treatment_tox_avoid)) && (C.getToxLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_tox)))
 		return 1
 
-	if(treat_virus && (!C.has_reagent(treatment_virus_avoid)))
+	if(treat_virus && !C.reagents.has_reagent(treatment_virus_avoid) && !C.reagents.has_reagent(treatment_virus))
 		for(var/datum/disease/D in C.viruses)
 			//the medibot can't detect viruses that are undetectable to Health Analyzers or Pandemic machines.
-			if(D.visibility_flags & HIDDEN_SCANNER || D.visibility_flags & HIDDEN_PANDEMIC)
-				return 0
-			if(D.severity == NONTHREAT) // medibot doesn't try to heal truly harmless viruses
-				return 0
-			if((D.stage > 1) || (D.spread_flags & AIRBORNE)) // medibot can't detect a virus in its initial stage unless it spreads airborne.
-
-				if(!C.reagents.has_reagent(treatment_virus))
-					return 1 //STOP DISEASE FOREVER
+			if(!(D.visibility_flags & HIDDEN_SCANNER || D.visibility_flags & HIDDEN_PANDEMIC) \
+			&& D.severity != NONTHREAT \
+			&& (D.stage > 1 || (D.spread_flags & AIRBORNE))) // medibot can't detect a virus in its initial stage unless it spreads airborne.
+				return 1 //STOP DISEASE FOREVER
 
 	return 0
 
@@ -435,23 +430,23 @@
 							virus = 1
 
 			if(!reagent_id && (virus))
-				if(!C.reagents.has_reagent(treatment_virus) && !C.has_reagent(treatment_virus_avoid))
+				if(!C.reagents.has_reagent(treatment_virus) && !C.reagents.has_reagent(treatment_virus_avoid))
 					reagent_id = treatment_virus
 
 		if(!reagent_id && (C.getBruteLoss() >= heal_threshold))
-			if(!C.reagents.has_reagent(treatment_brute) && !C.has_reagent(treatment_brute_avoid))
+			if(!C.reagents.has_reagent(treatment_brute) && !C.reagents.has_reagent(treatment_brute_avoid))
 				reagent_id = treatment_brute
 
 		if(!reagent_id && (C.getOxyLoss() >= (15 + heal_threshold)))
-			if(!C.reagents.has_reagent(treatment_oxy) && !C.has_reagent(treatment_oxy_avoid))
+			if(!C.reagents.has_reagent(treatment_oxy) && !C.reagents.has_reagent(treatment_oxy_avoid))
 				reagent_id = treatment_oxy
 
 		if(!reagent_id && (C.getFireLoss() >= heal_threshold))
-			if(!C.reagents.has_reagent(treatment_fire) && !C.has_reagent(treatment_fire_avoid))
+			if(!C.reagents.has_reagent(treatment_fire) && !C.reagents.has_reagent(treatment_fire_avoid))
 				reagent_id = treatment_fire
 
 		if(!reagent_id && (C.getToxLoss() >= heal_threshold))
-			if(!C.reagents.has_reagent(treatment_tox) && !C.has_reagent(treatment_tox_avoid))
+			if(!C.reagents.has_reagent(treatment_tox) && !C.reagents.has_reagent(treatment_tox_avoid))
 				reagent_id = treatment_tox
 
 		//If the patient is injured but doesn't have our special reagent in them then we should give it to them first

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -55,7 +55,6 @@
 	name = "\improper Mysterious Medibot"
 	desc = "International Medibot of mystery."
 	skin = "bezerk"
-	treatment_oxy = "tricordrazine"
 	treatment_brute = "tricordrazine"
 	treatment_fire = "tricordrazine"
 	treatment_tox = "tricordrazine"


### PR DESCRIPTION
Fixes #21346

:cl: Cyberboss
fix: Medibots, by default, can no longer OD you on tricord
tweak: They will now use charcoal instead of anti-toxin to heal tox damage
/:cl:

