### PR TITLE
Extended will now tell you that it is extended

### DIFF
--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -1,6 +1,6 @@
 /datum/game_mode/extended
-	name = "extended"
-	config_tag = "extended"
+	name = "secret extended"
+	config_tag = "secret extended"
 	required_players = 0
 
 	announce_span = "notice"
@@ -12,5 +12,15 @@
 /datum/game_mode/extended/post_setup()
 	..()
 
-/datum/game_mode/extended/send_intercept(report = 0)
-	priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. Have a secure shift!", "Central Command Update", 'sound/AI/commandreport.ogg')
+/datum/game_mode/extended/announced
+	name = "extended"
+	config_tag = "extended"
+
+/datum/game_mode/extended/announced/generate_station_goals()
+	for(var/T in subtypesof(/datum/station_goal))
+		var/datum/station_goal/G = T
+		station_goals += G
+		G.on_report()
+
+/datum/game_mode/extended/announced/send_intercept(report = 0)
+	priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", 'sound/AI/commandreport.ogg')

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -11,3 +11,6 @@
 
 /datum/game_mode/extended/post_setup()
 	..()
+
+/datum/game_mode/extended/send_intercept(report = 0)
+	priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. Have a secure shift!", "Central Command Update", 'sound/AI/commandreport.ogg')

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -546,8 +546,6 @@
 		var/datum/station_goal/G = T
 		if(config_tag in initial(G.gamemode_blacklist))
 			continue
-		//if(num_players() < initial(G.required_crew))
-		//	continue
 		possible += T
 	var/goal_weights = 0
 	while(possible.len && goal_weights < STATION_GOAL_BUDGET)


### PR DESCRIPTION
:cl: Kor
add: Extended mode now has a special command report that tells you the round type. This is to let people know they have time to start on large scale projects rather than milling about waiting for antagonists to attack.
add: All station goals are now unlocked during extended.
/:cl:

Extended will be more fun if players know it's actually extended and are able to take advantage of the time rather than waiting for something that will never happen.

Debate me.

Poll:

http://www.ss13.eu/tgdb/tg/ingamepolls.php#p153