### PR TITLE
Added a shot logging override for kinetic crusher

### DIFF
--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -507,6 +507,7 @@
 	flag = "bomb"
 	range = 6
 	var/obj/item/weapon/twohanded/required/mining_hammer/hammer_synced =  null
+	log_override = TRUE
 
 /obj/item/projectile/destabilizer/on_hit(atom/target, blocked = 0)
 	if(hammer_synced)


### PR DESCRIPTION
Adds an exception for the Kinetic Crusher destabilizer to the logging implemented by #21433, consistency with the Kinetic Accelerator & de-cluttering.

