### PR TITLE
Random mouse placement

### DIFF
--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -7155,7 +7155,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plating{
 	broken = 1;
 	icon_state = "platingdmg1"
@@ -9277,7 +9276,6 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/incinerator)
 "auf" = (
@@ -10958,7 +10956,6 @@
 	lootcount = 2;
 	name = "random material damage spawner"
 	},
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plating,
 /area/maintenance/asmaint)
 "axw" = (
@@ -29770,7 +29767,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plating{
 	broken = 1;
 	icon_state = "platingdmg3"
@@ -43647,7 +43643,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plating,
 /area/maintenance/fpmaint)
 "bIT" = (
@@ -61475,7 +61470,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plating,
 /area/maintenance/fsmaint)
 "csB" = (
@@ -67964,7 +67958,6 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plasteel/floorgrime,
 /area/toxins/storage)
 "cFj" = (
@@ -86934,7 +86927,7 @@ aaa
 anS
 auo
 avT
-axk
+aqh
 ayG
 aqh
 aBA
@@ -86948,7 +86941,7 @@ aqh
 aqh
 aMH
 aNN
-aPD
+aNN
 aRp
 aqh
 aqh
@@ -91366,7 +91359,7 @@ cgO
 cgO
 crh
 cgO
-cuj
+cdl
 cvT
 cgO
 aaa
@@ -96508,7 +96501,7 @@ cpF
 csV
 cpF
 cpF
-cxB
+cpF
 cpF
 czQ
 cAP
@@ -97489,7 +97482,7 @@ aQi
 aHv
 aHv
 aQl
-aWs
+aWq
 aYc
 aYc
 aYc
@@ -100382,7 +100375,7 @@ cdO
 ckC
 cdO
 cdO
-cMe
+chl
 cdO
 cpP
 cMV
@@ -103967,7 +103960,7 @@ cqd
 cBb
 cCi
 cpP
-cEe
+cfG
 cdO
 cpP
 cpP
@@ -104506,7 +104499,7 @@ cdO
 chl
 cdO
 cfG
-cLD
+cdO
 cdO
 cdO
 cdO
@@ -106034,7 +106027,7 @@ cJV
 cCj
 cKC
 cqd
-cLD
+cdO
 cLR
 cMk
 cMz
@@ -110405,7 +110398,7 @@ cKO
 cLk
 cpP
 ahA
-cMu
+cwt
 cpP
 cLC
 cdO
@@ -114769,7 +114762,7 @@ cIh
 csr
 csq
 ccC
-cKv
+chZ
 ccC
 aaa
 aaa
@@ -115454,7 +115447,7 @@ amb
 amS
 anH
 aol
-apb
+akZ
 apO
 aqI
 arQ
@@ -122677,7 +122670,7 @@ azZ
 azX
 azX
 azX
-aRg
+aRh
 bcp
 bdM
 bfl
@@ -124984,7 +124977,7 @@ aae
 aae
 azZ
 arV
-aRg
+aRh
 aSw
 aTC
 aVu
@@ -128057,7 +128050,7 @@ aaa
 aaa
 aaa
 azY
-aBr
+aBm
 azY
 azY
 azY
@@ -129355,7 +129348,7 @@ aCS
 aPB
 aRn
 aRn
-aTP
+aRn
 aRn
 aRn
 aZj

--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -7489,7 +7489,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/incinerator)
 "anY" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12692,7 +12692,6 @@
 	})
 "awe" = (
 /obj/structure/disposalpipe/segment,
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -64000,7 +63999,6 @@
 	scrub_N2O = 0;
 	scrub_Toxins = 0
 	},
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/incinerator)
 "cgp" = (
@@ -75810,7 +75808,6 @@
 	dir = 9;
 	pixel_y = 0
 	},
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plating,
 /area/maintenance/aft{
 	name = "Aft Maintenance"
@@ -111691,7 +111688,7 @@ amW
 aog
 ahv
 aqm
-asr
+asj
 atE
 alI
 alI
@@ -115051,7 +115048,7 @@ aLV
 awf
 bhD
 aQp
-aRC
+awf
 avY
 aUn
 awf
@@ -132304,7 +132301,7 @@ bRs
 bJs
 bUo
 bVq
-bWI
+apk
 bXO
 apj
 bZm

--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -15401,79 +15401,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"JS" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+"IS" = (
+/turf/closed/mineral/random{
+	mineralSpawnChanceList = list(/turf/closed/mineral/uranium = 5, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 10, /turf/closed/mineral/silver = 12, /turf/closed/mineral/plasma = 20, /turf/closed/mineral/iron = 40, /turf/closed/mineral/titanium = 11, /turf/closed/mineral/gibtonite = 4, /turf/closed/mineral/bscrystal = 1)
 	},
+/area/mine/unexplored)
+"IT" = (
+/turf/closed/wall,
+/area/maintenance/fore)
+"IU" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/mining)
+"IV" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"JR" = (
-/obj/machinery/vending/assist,
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"JQ" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"JP" = (
-/obj/machinery/light/small,
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"JO" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"JN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"JM" = (
-/turf/open/floor/plating/warnplate{
-	dir = 4
-	},
-/area/maintenance/starboard)
-"JL" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "_West APC";
-	pixel_x = -25
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"JK" = (
+/area/shuttle/mining)
+"IW" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/mining)
+"IX" = (
+/obj/machinery/computer/shuttle/mining,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/mining)
+"IY" = (
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1;
@@ -15481,225 +15433,50 @@
 	},
 /obj/machinery/power/apc{
 	auto_name = 1;
-	dir = 8;
-	name = "_West APC";
-	pixel_x = -25
+	dir = 1;
+	name = "_North APC";
+	pixel_y = 24
 	},
 /turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"JJ" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"JI" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"JH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"JG" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"JF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"JE" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"JD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"JC" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"JB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"JA" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"Jz" = (
-/turf/closed/wall,
-/area/maintenance/starboard)
-"Jy" = (
-/turf/closed/wall,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"Jx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"Jw" = (
-/turf/open/floor/plating,
-/area/medical/research{
-	name = "Research Division"
-	})
-"Jv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"Ju" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/area/maintenance/fore)
+"IZ" = (
+/obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
-/turf/open/floor/plasteel/bot,
-/area/quartermaster/storage)
-"Jt" = (
 /turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
-"Js" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"Jr" = (
-/obj/structure/shuttle/engine/propulsion/burst,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/mining)
-"Jq" = (
-/obj/machinery/suit_storage_unit/mining/eva,
-/turf/open/floor/plasteel/brown{
-	dir = 4
-	},
-/area/quartermaster/storage)
-"Jp" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/mining)
-"Jo" = (
-/obj/structure/ore_box,
+/area/maintenance/fore)
+"Ja" = (
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/mining)
-"Jn" = (
-/obj/structure/closet/wardrobe/miner,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"Jm" = (
-/obj/structure/rack,
-/obj/item/weapon/pickaxe,
-/obj/item/weapon/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/weapon/shovel{
-	pixel_x = -5
-	},
-/obj/item/weapon/shovel{
-	pixel_x = -5
-	},
-/turf/open/floor/plasteel/brown{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/quartermaster/storage)
-"Jl" = (
-/obj/structure/closet/secure_closet/miner,
-/turf/open/floor/plasteel/brown{
-	dir = 10
-	},
-/area/quartermaster/storage)
-"Jk" = (
-/turf/open/floor/plasteel/brown{
-	dir = 8
-	},
-/area/quartermaster/storage)
-"Jj" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Shuttle Airlock";
-	req_access_txt = "0"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"Ji" = (
-/obj/machinery/light/small{
+"Jb" = (
+/obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/plasteel/warning{
-	dir = 8
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/mining)
+"Jc" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/plasteel/brown{
+	dir = 9
 	},
 /area/quartermaster/storage)
-"Jh" = (
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/delivery{
-	name = "floor"
+"Jd" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/open/floor/plasteel/brown{
+	dir = 1
 	},
 /area/quartermaster/storage)
-"Jg" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Shuttle Airlock";
-	req_access_txt = "0"
+"Je" = (
+/obj/machinery/computer/shuttle/mining{
+	req_access = "0";
+	req_one_access = "0"
 	},
-/turf/open/floor/plasteel/delivery{
-	name = "floor"
+/obj/machinery/light{
+	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "Jf" = (
 /obj/machinery/door/airlock/shuttle{
@@ -15725,46 +15502,219 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/mining)
-"Je" = (
-/obj/machinery/computer/shuttle/mining{
-	req_access = "0";
-	req_one_access = "0"
+"Jg" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Shuttle Airlock";
+	req_access_txt = "0"
 	},
-/obj/machinery/light{
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/quartermaster/storage)
+"Jh" = (
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/quartermaster/storage)
+"Ji" = (
+/obj/machinery/light/small{
 	dir = 1
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/quartermaster/storage)
+"Jj" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Shuttle Airlock";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"Jd" = (
+"Jk" = (
+/turf/open/floor/plasteel/brown{
+	dir = 8
+	},
+/area/quartermaster/storage)
+"Jl" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel/brown{
-	dir = 1
+	dir = 10
 	},
 /area/quartermaster/storage)
-"Jc" = (
-/obj/machinery/mineral/equipment_vendor,
+"Jm" = (
+/obj/structure/rack,
+/obj/item/weapon/pickaxe,
+/obj/item/weapon/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/weapon/shovel{
+	pixel_x = -5
+	},
+/obj/item/weapon/shovel{
+	pixel_x = -5
+	},
 /turf/open/floor/plasteel/brown{
-	dir = 9
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
 /area/quartermaster/storage)
-"Jb" = (
-/obj/structure/chair{
+"Jn" = (
+/obj/structure/closet/wardrobe/miner,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"Jo" = (
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/mining)
+"Jp" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/plasteel/shuttle,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
 /area/shuttle/mining)
-"Ja" = (
-/turf/open/floor/plasteel/shuttle,
+"Jq" = (
+/obj/machinery/suit_storage_unit/mining/eva,
+/turf/open/floor/plasteel/brown{
+	dir = 4
+	},
+/area/quartermaster/storage)
+"Jr" = (
+/obj/structure/shuttle/engine/propulsion/burst,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/plating/airless,
 /area/shuttle/mining)
-"IZ" = (
-/obj/structure/closet/crate,
+"Js" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"Jt" = (
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"Ju" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
+/turf/open/floor/plasteel/bot,
+/area/quartermaster/storage)
+"Jv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
-"IY" = (
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"Jw" = (
+/turf/open/floor/plating,
+/area/medical/research{
+	name = "Research Division"
+	})
+"Jx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"Jy" = (
+/turf/closed/wall,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"Jz" = (
+/turf/closed/wall,
+/area/maintenance/starboard)
+"JA" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"JB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"JC" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"JD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"JE" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"JF" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"JG" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"JH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"JI" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"JJ" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"JK" = (
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1;
@@ -15772,36 +15722,86 @@
 	},
 /obj/machinery/power/apc{
 	auto_name = 1;
-	dir = 1;
-	name = "_North APC";
-	pixel_y = 24
+	dir = 8;
+	name = "_West APC";
+	pixel_x = -25
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
-"IX" = (
-/obj/machinery/computer/shuttle/mining,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/mining)
-"IW" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/mining)
-"IV" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/mining)
-"IU" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/mining)
-"IT" = (
-/turf/closed/wall,
-/area/maintenance/fore)
-"IS" = (
-/turf/closed/mineral/random{
-	mineralSpawnChanceList = list(/turf/closed/mineral/uranium = 5, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 10, /turf/closed/mineral/silver = 12, /turf/closed/mineral/plasma = 20, /turf/closed/mineral/iron = 40, /turf/closed/mineral/titanium = 11, /turf/closed/mineral/gibtonite = 4, /turf/closed/mineral/bscrystal = 1)
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"JL" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "_West APC";
+	pixel_x = -25
 	},
-/area/mine/unexplored)
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"JM" = (
+/turf/open/floor/plating/warnplate{
+	dir = 4
+	},
+/area/maintenance/starboard)
+"JN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"JO" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"JP" = (
+/obj/machinery/light/small,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"JQ" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"JR" = (
+/obj/machinery/vending/assist,
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
+"JS" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "JT" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -46035,7 +46035,7 @@ un
 vv
 sr
 Av
-wW
+xr
 xr
 xL
 BS
@@ -46789,7 +46789,7 @@ bx
 lW
 my
 Jt
-nE
+Jt
 Jt
 Jt
 pr
@@ -51671,7 +51671,7 @@ Jz
 lt
 JF
 mH
-nf
+JF
 mH
 JF
 JL

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -25173,7 +25173,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plating,
 /area/crew_quarters/locker)
 "bfd" = (
@@ -38360,7 +38359,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plating,
 /area/maintenance/asmaint)
 "bGJ" = (
@@ -52617,7 +52615,6 @@
 	name = "Mix to Incinerator";
 	on = 0
 	},
-/mob/living/simple_animal/mouse,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/incinerator)
 "cle" = (
@@ -74677,7 +74674,7 @@ asc
 atq
 auX
 avS
-axd
+amC
 amC
 alU
 aAM
@@ -81174,7 +81171,7 @@ cdY
 ceY
 bCq
 bHE
-chU
+cgH
 bHE
 bLu
 bCq
@@ -102225,7 +102222,7 @@ bLS
 cbQ
 bLS
 bLS
-bHB
+bKE
 caU
 bNc
 bOj
@@ -104485,7 +104482,7 @@ alO
 aqA
 anf
 alP
-atz
+anf
 anf
 alP
 awJ
@@ -105563,7 +105560,7 @@ bBZ
 bDc
 bEp
 bCX
-bDX
+bEc
 bIA
 bIA
 bJN

--- a/code/controllers/subsystem/squeak.dm
+++ b/code/controllers/subsystem/squeak.dm
@@ -34,7 +34,7 @@ var/datum/subsystem/squeak/SSsqueak
 /datum/subsystem/squeak/proc/find_exposed_wires()
 	exposed_wires.Cut()
 
-	var/all_turfs = block(locate(1,1,1), locate(world.maxx, world.maxy, 1))
+	var/list/all_turfs = block(locate(1,1,1), locate(world.maxx,world.maxy,1))
 	for(var/turf/open/floor/plating/T in all_turfs)
 		if(locate(/obj/structure/cable) in T)
 			exposed_wires += T

--- a/code/controllers/subsystem/squeak.dm
+++ b/code/controllers/subsystem/squeak.dm
@@ -1,0 +1,40 @@
+var/datum/subsystem/squeak/SSsqueak
+
+// The Squeak
+// because this is about placement of mice mobs, and nothing to do with
+// mice - the computer peripheral
+
+/datum/subsystem/squeak
+	name = "Squeak"
+	priority = 40
+	flags = SS_NO_FIRE
+
+	var/list/exposed_wires = list()
+
+/datum/subsystem/squeak/New()
+	NEW_SS_GLOBAL(SSsqueak)
+
+/datum/subsystem/squeak/Initialize(timeofday)
+	find_exposed_wires()
+	var/num_mice = 10
+
+	var/mob/living/simple_animal/mouse/M
+	var/turf/proposed_turf
+
+	while((num_mice > 0) && exposed_wires.len)
+		proposed_turf = pick_n_take(exposed_wires)
+		if(!M)
+			M = new(proposed_turf)
+		else
+			M.forceMove(proposed_turf)
+		if(M.environment_is_safe())
+			num_mice -= 1
+			M = null
+
+/datum/subsystem/squeak/proc/find_exposed_wires()
+	exposed_wires.Cut()
+
+	var/all_turfs = block(locate(1,1,1), locate(world.maxx, world.maxy, 1))
+	for(var/turf/open/floor/plating/T in all_turfs)
+		if(locate(/obj/structure/cable) in T)
+			exposed_wires += T

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -238,13 +238,13 @@
 			bodytemperature += diff
 
 	if(!environment_is_safe(environment))
-		adjustBruteLoss(unsuitable_atmos_damage)
+		adjustHealth(-unsuitable_atmos_damage)
 
 	handle_temperature_damage()
 
 /mob/living/simple_animal/proc/handle_temperature_damage()
 	if((bodytemperature < minbodytemp) || (bodytemperature > maxbodytemp))
-		adjustBruteLoss(unsuitable_atmos_damage)
+		adjustHealth(-unsuitable_atmos_damage)
 
 /mob/living/simple_animal/gib()
 	if(butcher_results)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -182,15 +182,54 @@
 						emote("me", 2, pick(emote_hear))
 
 
-/mob/living/simple_animal/handle_environment(datum/gas_mixture/environment)
-	var/atmos_suitable = 1
+/mob/living/simple_animal/proc/environment_is_safe(datum/gas_mixture/environment, check_temp = FALSE)
+	. = TRUE
 
 	if(pulledby && pulledby.grab_state >= GRAB_KILL && atmos_requirements["min_oxy"])
-		atmos_suitable = 0 //getting choked
+		. = FALSE //getting choked
 
+	if(isturf(src.loc) && isopenturf(src.loc))
+		var/turf/open/ST = src.loc
+		if(ST.air)
+			var/ST_gases = ST.air.gases
+			ST.air.assert_gases(arglist(hardcoded_gases))
+
+			var/tox = ST_gases["plasma"][MOLES]
+			var/oxy = ST_gases["o2"][MOLES]
+			var/n2  = ST_gases["n2"][MOLES]
+			var/co2 = ST_gases["co2"][MOLES]
+
+			ST.air.garbage_collect()
+
+			if(atmos_requirements["min_oxy"] && oxy < atmos_requirements["min_oxy"])
+				. = FALSE
+			else if(atmos_requirements["max_oxy"] && oxy > atmos_requirements["max_oxy"])
+				. = FALSE
+			else if(atmos_requirements["min_tox"] && tox < atmos_requirements["min_tox"])
+				. = FALSE
+			else if(atmos_requirements["max_tox"] && tox > atmos_requirements["max_tox"])
+				. = FALSE
+			else if(atmos_requirements["min_n2"] && n2 < atmos_requirements["min_n2"])
+				. = FALSE
+			else if(atmos_requirements["max_n2"] && n2 > atmos_requirements["max_n2"])
+				. = FALSE
+			else if(atmos_requirements["min_co2"] && co2 < atmos_requirements["min_co2"])
+				. = FALSE
+			else if(atmos_requirements["max_co2"] && co2 > atmos_requirements["max_co2"])
+				. = FALSE
+		else
+			if(atmos_requirements["min_oxy"] || atmos_requirements["min_tox"] || atmos_requirements["min_n2"] || atmos_requirements["min_co2"])
+				. = FALSE
+
+	if(check_temp)
+		var/areatemp = get_temperature(environment)
+		if((areatemp < minbodytemp) || (areatemp > maxbodytemp))
+			. = FALSE
+
+
+/mob/living/simple_animal/handle_environment(datum/gas_mixture/environment)
 	var/atom/A = src.loc
 	if(isturf(A))
-		var/turf/T = A
 		var/areatemp = get_temperature(environment)
 		if( abs(areatemp - bodytemperature) > 40 )
 			var/diff = areatemp - bodytemperature
@@ -198,50 +237,14 @@
 			//world << "changed from [bodytemperature] by [diff] to [bodytemperature + diff]"
 			bodytemperature += diff
 
-		if(isopenturf(T))
-			var/turf/open/ST = T
-			if(ST.air)
-				var/ST_gases = ST.air.gases
-				ST.air.assert_gases(arglist(hardcoded_gases))
-
-				var/tox = ST_gases["plasma"][MOLES]
-				var/oxy = ST_gases["o2"][MOLES]
-				var/n2  = ST_gases["n2"][MOLES]
-				var/co2 = ST_gases["co2"][MOLES]
-
-				ST.air.garbage_collect()
-
-				if(atmos_requirements["min_oxy"] && oxy < atmos_requirements["min_oxy"])
-					atmos_suitable = 0
-				else if(atmos_requirements["max_oxy"] && oxy > atmos_requirements["max_oxy"])
-					atmos_suitable = 0
-				else if(atmos_requirements["min_tox"] && tox < atmos_requirements["min_tox"])
-					atmos_suitable = 0
-				else if(atmos_requirements["max_tox"] && tox > atmos_requirements["max_tox"])
-					atmos_suitable = 0
-				else if(atmos_requirements["min_n2"] && n2 < atmos_requirements["min_n2"])
-					atmos_suitable = 0
-				else if(atmos_requirements["max_n2"] && n2 > atmos_requirements["max_n2"])
-					atmos_suitable = 0
-				else if(atmos_requirements["min_co2"] && co2 < atmos_requirements["min_co2"])
-					atmos_suitable = 0
-				else if(atmos_requirements["max_co2"] && co2 > atmos_requirements["max_co2"])
-					atmos_suitable = 0
-
-				if(!atmos_suitable)
-					adjustBruteLoss(unsuitable_atmos_damage)
-
-		else
-			if(atmos_requirements["min_oxy"] || atmos_requirements["min_tox"] || atmos_requirements["min_n2"] || atmos_requirements["min_co2"])
-				adjustBruteLoss(unsuitable_atmos_damage)
+	if(!environment_is_safe(environment))
+		adjustBruteLoss(unsuitable_atmos_damage)
 
 	handle_temperature_damage()
 
 /mob/living/simple_animal/proc/handle_temperature_damage()
-	if(bodytemperature < minbodytemp)
-		adjustBruteLoss(2)
-	else if(bodytemperature > maxbodytemp)
-		adjustBruteLoss(3)
+	if((bodytemperature < minbodytemp) || (bodytemperature > maxbodytemp))
+		adjustBruteLoss(unsuitable_atmos_damage)
 
 /mob/living/simple_animal/gib()
 	if(butcher_results)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -162,6 +162,7 @@
 #include "code\controllers\subsystem\server_maintenance.dm"
 #include "code\controllers\subsystem\shuttles.dm"
 #include "code\controllers\subsystem\spacedrift.dm"
+#include "code\controllers\subsystem\squeak.dm"
 #include "code\controllers\subsystem\stickyban.dm"
 #include "code\controllers\subsystem\sun.dm"
 #include "code\controllers\subsystem\tgui.dm"


### PR DESCRIPTION
:cl: coiax
add: Mice (the rodent, not the peripheral) now start in random locations.
/:cl:

- Adds the SSsqueak subsystem for initial placement of mice, with some mild changes to /mob/living/simple_animal to allow for environment testing (so mice don't get spawned on the solars)

- [x] Edit the maps to remove all starting mice (apart from the named ones in Perma etc.)