### PR TITLE
Fixes the Electrocution Animation

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -726,11 +726,13 @@
 	//Handle mutant parts if possible
 	if(dna && dna.species)
 		add_atom_colour("#000000", TEMPORARY_COLOUR_PRIORITY)
-		add_overlay("electrocuted_base")
+		var/static/image/electrocution_skeleton_anim = image(icon = icon, icon_state = "electrocuted_base")
+		electrocution_skeleton_anim.appearance_flags = RESET_COLOR
+		add_overlay(electrocution_skeleton_anim)
 		spawn(anim_duration)
 			if(src)
 				remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#000000")
-				overlays -= "electrocuted_base"
+				overlays -= electrocution_skeleton_anim
 
 	else //or just do a generic animation
 		var/list/viewing = list()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -729,10 +729,7 @@
 		var/static/image/electrocution_skeleton_anim = image(icon = icon, icon_state = "electrocuted_base")
 		electrocution_skeleton_anim.appearance_flags = RESET_COLOR
 		add_overlay(electrocution_skeleton_anim)
-		spawn(anim_duration)
-			if(src)
-				remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#000000")
-				overlays -= electrocution_skeleton_anim
+		addtimer(src, "end_electrocution_animation", anim_duration, FALSE, electrocution_skeleton_anim)
 
 	else //or just do a generic animation
 		var/list/viewing = list()
@@ -740,6 +737,10 @@
 			if(M.client)
 				viewing += M.client
 		flick_overlay(image(icon,src,"electrocuted_generic",ABOVE_MOB_LAYER), viewing, anim_duration)
+
+/mob/living/carbon/human/proc/end_electrocution_animation(image/I)
+	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#000000")
+	overlays -= I
 
 /mob/living/carbon/human/canUseTopic(atom/movable/M, be_close = 0)
 	if(incapacitated() || lying )


### PR DESCRIPTION
* The animation's skeleton was being set to black along with the rest of the mob, due to it being an overlay, causing it to appear invisible.

fixes #21413 

Caused by @phil235 (naughty!)'s colour refactor.