### PR TITLE
Lich phylacteries are now points of interest

### DIFF
--- a/code/modules/spells/spell_types/lichdom.dm
+++ b/code/modules/spells/spell_types/lichdom.dm
@@ -124,9 +124,11 @@
 			charge_max = 1800 //3 minute cooldown, if you rise in sight of someone and killed again, you're probably screwed.
 			charge_counter = 1800
 			stat_allowed = 1
-			marked_item.name = "Ensouled [marked_item.name]"
-			marked_item.desc = "A terrible aura surrounds this item, its very existence is offensive to life itself..."
+			marked_item.name = "ensouled [marked_item.name]"
+			marked_item.desc += "\nA terrible aura surrounds this item, its very existence is offensive to life itself..."
 			marked_item.add_atom_colour("#003300", ADMIN_COLOUR_PRIORITY)
+			poi_list |= marked_item
+
 			M << "<span class='userdanger'>With a hideous feeling of emptiness you watch in horrified fascination as skin sloughs off bone! Blood boils, nerves disintegrate, eyes boil in their sockets! As your organs crumble to dust in your fleshless chest you come to terms with your choice. You're a lich!</span>"
 			M.set_species(/datum/species/skeleton)
 			current_body = M.mind.current


### PR DESCRIPTION
:cl: coiax
add: Lich phylacteries are now in the "points of interest" for ghosts.
/:cl:

Also, a phylactery just appends to the description of the item, rather
than clobbering it.

Balance consideration: if a lich summons magic and a crewmember get a
scrying orb, they'll be able to locate the phylactery immediately. So I
guess this is a lich nerf?