### PR TITLE
Fixes Vitality Matrices and Raise Dead runes not reviving if the target happened to be in their body already

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -271,8 +271,9 @@
 				if(ratvar_awakens)
 					revival_cost = 0
 				var/mob/dead/observer/ghost = L.get_ghost(TRUE)
-				if(ghost && vitality >= revival_cost)
-					ghost.reenter_corpse()
+				if(vitality >= revival_cost && (ghost || (L.mind && L.mind.active)))
+					if(ghost)
+						ghost.reenter_corpse()
 					L.revive(1, 1)
 					playsound(L, 'sound/magic/Staff_Healing.ogg', 50, 1)
 					L.visible_message("<span class='warning'>[L] suddenly gets back up, [L.p_their()] mouth dripping blue ichor!</span>", \

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -595,7 +595,7 @@ var/list/teleport_runes = list()
 		log_game("Raise Dead rune failed - revival target moved")
 		return 0
 	var/mob/dead/observer/ghost = target_mob.get_ghost(TRUE)
-	if(!ghost)
+	if(!ghost && (!target_mob.mind || !target_mob.mind.active))
 		user << "<span class='cultitalic'>The corpse to revive has no spirit!</span>"
 		fail_invoke()
 		log_game("Raise Dead rune failed - revival target has no ghost")


### PR DESCRIPTION
:cl: Joan
bugfix: Fixed Vitality Matrices and Raise Dead runes not reviving if the target happened to be in their body already.
/:cl: