### PR TITLE
Tweaks the projectile speed to be a bit slower

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -23,7 +23,7 @@
 	var/paused = FALSE //for suspending the projectile midair
 	var/p_x = 16
 	var/p_y = 16			// the pixel location of the tile that the player clicked. Default is the center
-	var/speed = 0.5			//Amount of deciseconds it takes for projectile to travel
+	var/speed = 0.8			//Amount of deciseconds it takes for projectile to travel
 	var/Angle = 0
 	var/spread = 0			//amount (in degrees) of projectile spread
 	var/legacy = 0			//legacy projectile system


### PR DESCRIPTION
This changes the projectile speed from 0.5 to 0.8.

The speed being at 0.5 pretty much makes the projectile to pretty much instantly travel when shot, which is awful. At this value it won't be as fast, leaving a room so you can actually react to the shot.