### PR TITLE
Prevent runtime station from attempting to move objects between z levels

### DIFF
--- a/_maps/runtimestation.dm
+++ b/_maps/runtimestation.dm
@@ -14,7 +14,7 @@
         #define MAP_FILE "runtimestation.dmm"
         #define MAP_NAME "Runtime Station"
 
-		#define MAP_TRANSITION_CONFIG DEFAULT_MAP_TRANSITION_CONFIG
+		#define MAP_TRANSITION_CONFIG list(MAIN_STATION = UNAFFECTED)
 
 #elif !defined(MAP_OVERRIDE)
 


### PR DESCRIPTION
Title says it all really. Replaced `DEFAULT_MAP_TRANSITION_CONFIG` with `list(MAIN_STATION = UNAFFECTED)`. Prevents the runtime associated with approaching the edge of the map.