### PR TITLE
Allows dice to be rigged and adds microwave_act()

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -144,9 +144,6 @@
 /atom/proc/emp_act(severity)
 	return
 
-/atom/proc/microwave_act(obj/machinery/microwave/M)
-	return
-
 /atom/proc/bullet_act(obj/item/projectile/P, def_zone)
 	. = P.on_hit(src, 0, def_zone)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -144,6 +144,9 @@
 /atom/proc/emp_act(severity)
 	return
 
+/atom/proc/microwave_act(obj/machinery/microwave/M)
+	return
+
 /atom/proc/bullet_act(obj/item/projectile/P, def_zone)
 	. = P.on_hit(src, 0, def_zone)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -599,3 +599,7 @@ obj/item/proc/item_action_slot_check(slot, mob/user)
 		MO.pixel_y = rand(-16,16)
 		MO.desc = "Looks like this was \an [src] some time ago."
 		..()
+
+/obj/item/proc/microwave_act(obj/machinery/microwave/M)
+	if(M && M.dirty < 100)
+		M.dirty++

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -33,6 +33,8 @@
 	var/sides = 6
 	var/result = null
 	var/list/special_faces = list() //entries should match up to sides var if used
+	var/can_be_rigged = TRUE
+	var/rigged = -1
 
 /obj/item/weapon/dice/New()
 	result = rand(1, sides)
@@ -115,6 +117,9 @@
 
 /obj/item/weapon/dice/proc/diceroll(mob/user)
 	result = rand(1, sides)
+	if(rigged > 0 && result != rigged)
+		if(prob(Clamp(1/(sides - 1) * 100, 25, 80)))
+			result = rigged
 	var/fake_result = rand(1, sides)//Daredevil isn't as good as he used to be
 	var/comment = ""
 	if(sides == 20 && result == 20)

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -34,7 +34,7 @@
 	var/result = null
 	var/list/special_faces = list() //entries should match up to sides var if used
 	var/can_be_rigged = TRUE
-	var/rigged = -1
+	var/rigged = FALSE
 
 /obj/item/weapon/dice/New()
 	result = rand(1, sides)
@@ -117,7 +117,7 @@
 
 /obj/item/weapon/dice/proc/diceroll(mob/user)
 	result = rand(1, sides)
-	if(rigged > 0 && result != rigged)
+	if(rigged && result != rigged)
 		if(prob(Clamp(1/(sides - 1) * 100, 25, 80)))
 			result = rigged
 	var/fake_result = rand(1, sides)//Daredevil isn't as good as he used to be

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -149,3 +149,8 @@
 /obj/item/weapon/dice/update_icon()
 	cut_overlays()
 	add_overlay("[src.icon_state][src.result]")
+	
+/obj/item/weapon/dice/microwave_act(obj/machinery/microwave/M)
+	if(can_be_rigged)
+		rigged = result
+	..(M)

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -123,9 +123,9 @@
 	desc = "A die with twenty sides. You can feel unearthly energies radiating from it. Using this might be VERY risky."
 	icon_state = "d20"
 	sides = 20
+	can_be_rigged = FALSE
 	var/reusable = 1
 	var/used = 0
-	var/rigged = -1
 
 /obj/item/weapon/dice/d20/fate/one_use
 	reusable = 0

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -136,7 +136,7 @@
 		if(!ishuman(user) || !user.mind || (user.mind in ticker.mode.wizards))
 			user << "<span class='warning'>You feel the magic of the dice is restricted to ordinary humans!</span>"
 			return
-		if(rigged > 0)
+		if(rigged)
 			effect(user,rigged)
 		else
 			effect(user,result)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -229,6 +229,21 @@
 			var/amount = S.bonus_reagents[r_id] * cooking_efficiency
 			S.reagents.add_reagent(r_id, amount)
 
+/obj/item/weapon/reagent_containers/food/snacks/microwave_act(obj/machinery/microwave/M)
+	if(cooked_type)
+		var/obj/item/weapon/reagent_containers/food/snacks/S = new cooked_type(get_turf(src))
+		if(M)
+			initialize_cooked_food(S, M.efficiency)
+		else
+			initialize_cooked_food(S, 1)
+		feedback_add_details("food_made","[type]")
+	else
+		new /obj/item/weapon/reagent_containers/food/snacks/badrecipe(src)
+		if(M && M.dirty < 100)
+			M.dirty++
+	qdel(src)
+	..(M)
+			
 /obj/item/weapon/reagent_containers/food/snacks/Destroy()
 	if(contents)
 		for(var/atom/movable/something in contents)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -242,7 +242,6 @@
 		if(M && M.dirty < 100)
 			M.dirty++
 	qdel(src)
-	..(M)
 			
 /obj/item/weapon/reagent_containers/food/snacks/Destroy()
 	if(contents)

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -240,11 +240,8 @@
 			return
 		stop()
 
-		for(var/obj/O in contents)
+		for(var/obj/item/O in contents)
 			O.microwave_act(src)
-			if(!istype(O,/obj/item/weapon/reagent_containers/food) && !istype(O, /obj/item/weapon/grown))
-				if(dirty < 100)
-					dirty++
 			
 		return
 

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -149,7 +149,7 @@
 			user << "<span class='notice'>You insert [loaded] items into [src].</span>"
 
 
-	else if(istype(O,/obj/item/weapon/reagent_containers/food/snacks))
+	else if(istype(O,/obj/item/weapon/reagent_containers/food/snacks) || istype(O,/obj/item/weapon/dice))
 		if (contents.len>=max_n_of_items)
 			user << "<span class='warning'>[src] is full, you cannot put more!</span>"
 			return 1
@@ -256,6 +256,11 @@
 					dirty++
 			qdel(F)
 
+		for(var/obj/item/weapon/dice/D in contents)
+			if(D.can_be_rigged)
+				D.rigged = D.result
+			if(dirty < 100)
+				dirty++
 		return
 
 /obj/machinery/microwave/proc/microwaving(seconds as num)
@@ -270,7 +275,8 @@
 	for (var/obj/O in contents)
 		if ( \
 				!istype(O,/obj/item/weapon/reagent_containers/food) && \
-				!istype(O, /obj/item/weapon/grown) \
+				!istype(O, /obj/item/weapon/grown) && \
+				!istype(O, /obj/item/weapon/dice) \
 			)
 			return 1
 	return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -230,37 +230,22 @@
 		muck_finish()
 		return
 
-	else if (has_extra_item())
-		if (!microwaving(4))
+	else
+		if(has_extra_item() && prob(min(dirty*5,100)) && !microwaving(4))
 			broke()
 			return
-
-		broke()
-		return
-
-	else
-
+				
 		if(!microwaving(10))
 			abort()
 			return
 		stop()
 
-		for(var/obj/item/weapon/reagent_containers/food/snacks/F in contents)
-			if(F.cooked_type)
-				var/obj/item/weapon/reagent_containers/food/snacks/S = new F.cooked_type (get_turf(src))
-				F.initialize_cooked_food(S, efficiency)
-				feedback_add_details("food_made","[F.type]")
-			else
-				new /obj/item/weapon/reagent_containers/food/snacks/badrecipe(src)
+		for(var/obj/O in contents)
+			O.microwave_act(src)
+			if(!istype(O,/obj/item/weapon/reagent_containers/food) && !istype(O, /obj/item/weapon/grown))
 				if(dirty < 100)
 					dirty++
-			qdel(F)
-
-		for(var/obj/item/weapon/dice/D in contents)
-			if(D.can_be_rigged)
-				D.rigged = D.result
-			if(dirty < 100)
-				dirty++
+			
 		return
 
 /obj/machinery/microwave/proc/microwaving(seconds as num)
@@ -275,8 +260,7 @@
 	for (var/obj/O in contents)
 		if ( \
 				!istype(O,/obj/item/weapon/reagent_containers/food) && \
-				!istype(O, /obj/item/weapon/grown) && \
-				!istype(O, /obj/item/weapon/dice) \
+				!istype(O, /obj/item/weapon/grown) \
 			)
 			return 1
 	return 0

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -78,3 +78,6 @@
 		if(G)
 			user.AddLuminosity(-G.get_lum(seed))
 			SetLuminosity(G.get_lum(seed))
+			
+/obj/item/weapon/grown/microwave_act(obj/machine/microwave/M)
+	return


### PR DESCRIPTION
:cl: Swindly
add: Dice can now be rigged by microwaving them.
/:cl:

Dice can be rigged to increase the chances of them landing on the result they were put in the microwave with. The probability of landing on the rigged value is doubled and clamped between 25% (for dice with at least 10 sides) and 80% (for d2s). Dice of fate cannot be rigged.

The microwave_act() proc is added for objects. The microwave calls this for its contents instead of handling microwaving itself. It is overridden for snacks and dice.