### PR TITLE
Fix cyclelinked airlocks

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -21598,7 +21598,7 @@
 	d2 = 4
 	},
 /obj/machinery/door/airlock/glass_command{
-	crit_fail = 4;
+	cyclelinkeddir = 4;
 	name = "Bridge";
 	req_access_txt = "19"
 	},

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -75,6 +75,7 @@ var/list/airlock_overlays = list()
 	var/cyclelinkeddir = 0
 	var/obj/machinery/door/airlock/cyclelinkedairlock
 	var/shuttledocked = 0
+	var/delayed_close_requested = 0 // 1 means the door will automatically close the next time it's opened.
 
 	explosion_block = 1
 
@@ -203,7 +204,10 @@ var/list/airlock_overlays = list()
 			return
 	if (cyclelinkedairlock)
 		if (!shuttledocked && !emergency && !cyclelinkedairlock.shuttledocked && !cyclelinkedairlock.emergency && allowed(user))
-			addtimer(cyclelinkedairlock, "close", ( cyclelinkedairlock.operating ? 2 : 0 ))
+			if(cyclelinkedairlock.operating)
+				cyclelinkedairlock.delayed_close_requested = 1
+			else
+				addtimer(cyclelinkedairlock, "close", 2)
 	..()
 
 
@@ -1064,6 +1068,9 @@ var/list/airlock_overlays = list()
 	operating = 0
 	air_update_turf(1)
 	update_freelook_sight()
+	if(delayed_close_requested)
+		delayed_close_requested = 0
+		addtimer(src, "close", 2)
 	return 1
 
 
@@ -1105,6 +1112,7 @@ var/list/airlock_overlays = list()
 	if(visible && !glass)
 		SetOpacity(1)
 	operating = 0
+	delayed_close_requested = 0
 	air_update_turf(1)
 	update_freelook_sight()
 	if(safe)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -75,7 +75,7 @@ var/list/airlock_overlays = list()
 	var/cyclelinkeddir = 0
 	var/obj/machinery/door/airlock/cyclelinkedairlock
 	var/shuttledocked = 0
-	var/delayed_close_requested = 0 // 1 means the door will automatically close the next time it's opened.
+	var/delayed_close_requested = FALSE // TRUE means the door will automatically close the next time it's opened.
 
 	explosion_block = 1
 
@@ -205,7 +205,7 @@ var/list/airlock_overlays = list()
 	if (cyclelinkedairlock)
 		if (!shuttledocked && !emergency && !cyclelinkedairlock.shuttledocked && !cyclelinkedairlock.emergency && allowed(user))
 			if(cyclelinkedairlock.operating)
-				cyclelinkedairlock.delayed_close_requested = 1
+				cyclelinkedairlock.delayed_close_requested = TRUE
 			else
 				addtimer(cyclelinkedairlock, "close", 2)
 	..()
@@ -1069,7 +1069,7 @@ var/list/airlock_overlays = list()
 	air_update_turf(1)
 	update_freelook_sight()
 	if(delayed_close_requested)
-		delayed_close_requested = 0
+		delayed_close_requested = FALSE
 		addtimer(src, "close", 2)
 	return 1
 
@@ -1112,7 +1112,7 @@ var/list/airlock_overlays = list()
 	if(visible && !glass)
 		SetOpacity(1)
 	operating = 0
-	delayed_close_requested = 0
+	delayed_close_requested = FALSE
 	air_update_turf(1)
 	update_freelook_sight()
 	if(safe)


### PR DESCRIPTION
This fixes cyclelinked airlocks so that they close behind you even when running through at full speed. Previously they only worked if you paused between the airlocks and waited for the door-open animation to finish.

This also fixes an improperly defined cyclelinked airlock on Boxstation's bridge. 

:cl: Pubby
fix: cyclelinked airlock pairs now close behind you even when running through at full speed.
/:cl:

