### PR TITLE
Refactors scripture quickbind

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -128,7 +128,7 @@
 		return 0
 	if(target)
 		var/obj/item/I = target
-		I.ui_action_click(owner, src.type)
+		I.ui_action_click(owner, src)
 	return 1
 
 /datum/action/item_action/ApplyIcon(obj/screen/movable/action_button/current_button)
@@ -253,13 +253,10 @@
 	desc = "Allows you to communicate with other Servants."
 	button_icon_state = "hierophant_slab"
 
-/datum/action/item_action/clock/quickbind_one
+/datum/action/item_action/clock/quickbind
 	name = "Quickbind"
 	desc = "If you're seeing this, file a bug report."
-
-/datum/action/item_action/clock/quickbind_two
-	name = "Quickbind"
-	desc = "If you're seeing this, file a bug report."
+	var/scripture_index = 0 //the index of the scripture we're associated with
 
 /datum/action/item_action/toggle_helmet_flashlight
 	name = "Toggle Helmet Flashlight"

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
@@ -417,7 +417,7 @@
 		qdel(Q)
 	if(LAZYLEN(quickbound))
 		for(var/i in 1 to quickbound.len)
-			var/datum/action/item_action/clock/quickbind/Q  new /datum/action/item_action/clock/quickbind(src)
+			var/datum/action/item_action/clock/quickbind/Q = new /datum/action/item_action/clock/quickbind(src)
 			Q.scripture_index = i
 			var/datum/clockwork_scripture/quickbind_slot = quickbound[i]
 			Q.name = initial(quickbind_slot.name)

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
@@ -9,14 +9,14 @@
 	var/busy //If the slab is currently being used by something
 	var/production_time = 0
 	var/no_cost = FALSE //If the slab is admin-only and needs no components and has no scripture locks
+	var/speed_multiplier = 1 //multiples how fast this slab recites scripture
 	var/nonhuman_usable = FALSE //if the slab can be used by nonhumans, defaults to off
 	var/produces_components = TRUE //if it produces components at all
 	var/list/shown_scripture = list(SCRIPTURE_DRIVER = TRUE, SCRIPTURE_SCRIPT = FALSE, SCRIPTURE_APPLICATION = FALSE, SCRIPTURE_REVENANT = FALSE, SCRIPTURE_JUDGEMENT = FALSE)
 	var/compact_scripture = FALSE
 	var/obj/effect/proc_holder/slab/slab_ability //the slab's current bound ability, for certain scripture
-	var/datum/clockwork_scripture/quickbind_slot_one //these are paths, not instances
-	var/datum/clockwork_scripture/quickbind_slot_two //accordingly, use initial() for non-list vars
-	actions_types = list(/datum/action/item_action/clock/hierophant, /datum/action/item_action/clock/quickbind_one, /datum/action/item_action/clock/quickbind_two)
+	var/list/quickbound = list(/datum/clockwork_scripture/ranged_ability/geis_prep, /datum/clockwork_scripture/vanguard) //quickbound scripture, accessed by index
+	actions_types = list(/datum/action/item_action/clock/hierophant)
 
 /obj/item/clockwork/slab/starter
 	stored_components = list(BELLIGERENT_EYE = 1, VANGUARD_COGWHEEL = 1, GEIS_CAPACITOR = 1, REPLICANT_ALLOY = 1, HIEROPHANT_ANSIBLE = 1)
@@ -30,6 +30,7 @@
 	nonhuman_usable = TRUE
 
 /obj/item/clockwork/slab/debug
+	speed_multiplier = 0
 	no_cost = TRUE
 	nonhuman_usable = TRUE
 
@@ -40,8 +41,7 @@
 
 /obj/item/clockwork/slab/New()
 	..()
-	quickbind_to_one(/datum/clockwork_scripture/ranged_ability/geis_prep)
-	quickbind_to_two(/datum/clockwork_scripture/vanguard)
+	update_quickbind()
 	START_PROCESSING(SSobj, src)
 	production_time = world.time + SLAB_PRODUCTION_TIME
 
@@ -97,10 +97,10 @@
 		user << "Use the <span class='brass'>Hierophant Network</span> action button to communicate with other servants."
 		user << "Clockwork slabs will only make components if held or if inside an item held by a human, and when making a component will prevent all other slabs held from making components."
 		user << "Hitting a slab, a Servant with a slab, or a cache will <b>transfer</b> this slab's components into the target, the target's slab, or the global cache, respectively."
-		if(quickbind_slot_one)
-			user << "Quickbind button One: <span class='[get_component_span(initial(quickbind_slot_one.primary_component))]'>[initial(quickbind_slot_one.name)]</span>"
-		if(quickbind_slot_two)
-			user << "Quickbind button Two: <span class='[get_component_span(initial(quickbind_slot_two.primary_component))]'>[initial(quickbind_slot_two.name)]</span>"
+		if(LAZYLEN(quickbound))
+			for(var/i in 1 to quickbound.len)
+				var/datum/clockwork_scripture/quickbind_slot = quickbound[i]
+				user << "<b>Quickbind</b> button: <span class='[get_component_span(initial(quickbind_slot.primary_component))]'>[initial(quickbind_slot.name)]</span>."
 		if(clockwork_caches)
 			user << "<b>Stored components (with global cache):</b>"
 			for(var/i in stored_components)
@@ -158,15 +158,13 @@
 	else
 		return ..()
 
-//Slab actions; Hierophant, Quickbind One and Two
-/obj/item/clockwork/slab/ui_action_click(mob/user, actiontype)
-	switch(actiontype)
-		if(/datum/action/item_action/clock/hierophant)
-			show_hierophant(user)
-		if(/datum/action/item_action/clock/quickbind_one)
-			recite_scripture(quickbind_slot_one, user, FALSE)
-		if(/datum/action/item_action/clock/quickbind_two)
-			recite_scripture(quickbind_slot_two, user, FALSE)
+//Slab actions; Hierophant, Quickbind
+/obj/item/clockwork/slab/ui_action_click(mob/user, action)
+	if(istype(action, /datum/action/item_action/clock/hierophant))
+		show_hierophant(user)
+	else if(istype(action, /datum/action/item_action/clock/quickbind))
+		var/datum/action/item_action/clock/quickbind/Q = action
+		recite_scripture(quickbound[Q.scripture_index], user, FALSE)
 
 /obj/item/clockwork/slab/proc/show_hierophant(mob/living/user)
 	var/message = stripped_input(user, "Enter a message to send to your fellow servants.", "Hierophant")
@@ -274,7 +272,10 @@
 						break //we want this to only show up if the scripture has a cost of some sort
 				scripture_text += "<br><b>Tip:</b> [initial(S.usage_tip)]"
 			if(initial(S.quickbind))
-				scripture_text += "<br><font color=#BE8700 size=1>[S == quickbind_slot_one || S == quickbind_slot_two ? "Currently Quickbound":\
+				var/is_bound = FALSE
+				if(S in quickbound)
+					is_bound = TRUE
+				scripture_text += "<br><font color=#BE8700 size=1>[is_bound ? "Currently Quickbound":\
 				"<A href='?src=\ref[src];Quickbindone=[S]'>Quickbind to button One</A>| <A href='?src=\ref[src];Quickbindtwo=[S]'>Quickbind to button Two</A>"]</font>"
 			scripture_text += "<br><b><A href='?src=\ref[src];Recite=[S]'>Recite</A></b><br>"
 			switch(initial_tier)
@@ -361,10 +362,12 @@
 		of scripture.<br><br>\
 		\
 		The third to fifth functions are three buttons in the top left while holding the slab.<br>From left to right, they are:<br>\
-		<b><font color=#DAAA18>Hierophant Network</font></b>, which allows communication to other Servants.<br>\
-		<b>Quickbind slot One</b>, currently set to <b><font color=[get_component_color_brightalloy(initial(quickbind_slot_one.primary_component))]>[initial(quickbind_slot_one.name)]</font></b>.<br>\
-		<b>Quickbind slot Two</b>, currently set to <b><font color=[get_component_color_brightalloy(initial(quickbind_slot_two.primary_component))]>[initial(quickbind_slot_two.name)]</font></b>.<br><br>\
-		\
+		<b><font color=#DAAA18>Hierophant Network</font></b>, which allows communication to other Servants.<br>"
+		if(LAZYLEN(quickbound))
+			for(var/i in 1 to quickbound.len)
+				var/datum/clockwork_scripture/quickbind_slot = quickbound[i]
+				text += "A <b>Quickbind</b> slot, currently set to <b><font color=[get_component_color_brightalloy(initial(quickbind_slot.primary_component))]>[initial(quickbind_slot.name)]</font></b>.<br>"
+		text += "<br>\
 		Examine the slab to check the number of components it has available.<br><br>\
 		\
 		<font color=#BE8700 size=3><b><center>Purge all untruths and honor Ratvar.</center></b></font>"
@@ -387,10 +390,10 @@
 		return
 
 	if(href_list["Quickbindone"])
-		quickbind_to_one(href_list["Quickbindone"])
+		quickbind_to_slot(href_list["Quickbindone"], 1)
 
 	if(href_list["Quickbindtwo"])
-		quickbind_to_two(href_list["Quickbindtwo"])
+		quickbind_to_slot(href_list["Quickbindtwo"], 2)
 
 	if(href_list["compactscripture"])
 		compact_scripture = !compact_scripture
@@ -401,26 +404,25 @@
 
 	interact(usr)
 
-/obj/item/clockwork/slab/proc/quickbind_to_one(datum/clockwork_scripture/scripture) //takes a typepath(typecast for initial()) and binds it to slot 1
+/obj/item/clockwork/slab/proc/quickbind_to_slot(datum/clockwork_scripture/scripture, index) //takes a typepath(typecast for initial()) and binds it to a slot
 	if(!ispath(scripture) && istext(scripture))
 		scripture = text2path(scripture) //if given as a href, the scripture will be a string and not a path. obviously, we need a path and not a string
-	if(!scripture || quickbind_slot_two == scripture)
+	if(!scripture || (scripture in quickbound))
 		return
-	quickbind_slot_one = scripture
-	for(var/datum/action/item_action/clock/quickbind_one/O in actions)
-		O.name = initial(quickbind_slot_one.name)
-		O.desc = initial(quickbind_slot_one.quickbind_desc)
-		O.button_icon_state = initial(quickbind_slot_one.name)
-		O.UpdateButtonIcon()
+	quickbound[index] = scripture
+	update_quickbind()
 
-/obj/item/clockwork/slab/proc/quickbind_to_two(datum/clockwork_scripture/scripture) //takes a typepath(typecast for initial()) and binds it to slot 2
-	if(!ispath(scripture) && istext(scripture))
-		scripture = text2path(scripture) //if given as a href, the scripture will be a string and not a path. obviously, we need a path and not a string
-	if(!scripture || quickbind_slot_one == scripture)
-		return
-	quickbind_slot_two = scripture
-	for(var/datum/action/item_action/clock/quickbind_two/O in actions)
-		O.name = initial(quickbind_slot_two.name)
-		O.desc = initial(quickbind_slot_two.quickbind_desc)
-		O.button_icon_state = initial(quickbind_slot_two.name)
-		O.UpdateButtonIcon()
+/obj/item/clockwork/slab/proc/update_quickbind()
+	for(var/datum/action/item_action/clock/quickbind/Q in actions)
+		qdel(Q)
+	if(LAZYLEN(quickbound))
+		for(var/i in 1 to quickbound.len)
+			var/datum/action/item_action/clock/quickbind/Q  new /datum/action/item_action/clock/quickbind(src)
+			Q.scripture_index = i
+			var/datum/clockwork_scripture/quickbind_slot = quickbound[i]
+			Q.name = initial(quickbind_slot.name)
+			Q.desc = initial(quickbind_slot.quickbind_desc)
+			Q.button_icon_state = initial(quickbind_slot.name)
+			Q.UpdateButtonIcon()
+			if(isliving(loc))
+				Q.Grant(loc)

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -52,7 +52,9 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 			invoker << "<span class='warning'>[slab] refuses to work, displaying the message: \"[slab.busy]!\"</span>"
 			return FALSE
 		slab.busy = "Invocation ([name]) in progress"
-		if(!ratvar_awakens && !slab.no_cost)
+		if(ratvar_awakens)
+			channel_time *= 0.5 //if ratvar has awoken, half channel time and no cost
+		else if(!slab.no_cost)
 			for(var/i in consumed_components)
 				if(consumed_components[i])
 					for(var/j in 1 to consumed_components[i])
@@ -62,8 +64,7 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 						else
 							clockwork_component_cache[i]--
 							used_cache_components[i]++
-		else
-			channel_time *= 0.5 //if ratvar has awoken or the slab has no cost, half channel time
+		channel_time *= slab.speed_multiplier
 		if(!recital() || !check_special_requirements() || !scripture_effects()) //if we fail any of these, refund components used
 			for(var/i in used_slab_components)
 				if(used_slab_components[i])
@@ -74,7 +75,7 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 			for(var/i in used_cache_components)
 				if(used_cache_components[i])
 					clockwork_component_cache[i] += consumed_components[i]
-		else if(slab && !slab.no_cost) //if the slab exists and isn't debug, log the scripture as being used
+		else if(slab && !slab.no_cost && !ratvar_awakens) //if the slab exists and isn't debug and ratvar isn't up, log the scripture as being used
 			feedback_add_details("clockcult_scripture_recited", name)
 	if(slab)
 		slab.busy = null

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -20,10 +20,10 @@
 	ion_trail = new
 	ion_trail.set_up(src)
 
-/obj/item/weapon/tank/jetpack/ui_action_click(mob/user, actiontype)
-	if(actiontype == /datum/action/item_action/toggle_jetpack)
+/obj/item/weapon/tank/jetpack/ui_action_click(mob/user, action)
+	if(istype(action, /datum/action/item_action/toggle_jetpack))
 		cycle(user)
-	else if(actiontype == /datum/action/item_action/jetpack_stabilization)
+	else if(istype(action, /datum/action/item_action/jetpack_stabilization))
 		if(on)
 			stabilizers = !stabilizers
 			user << "<span class='notice'>You turn the jetpack stabilization [stabilizers ? "on" : "off"].</span>"

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -56,8 +56,8 @@
 	else
 		..()
 
-/obj/item/clothing/mask/gas/sechailer/ui_action_click(mob/user, actiontype)
-	if(actiontype == /datum/action/item_action/halt)
+/obj/item/clothing/mask/gas/sechailer/ui_action_click(mob/user, action)
+	if(istype(action, /datum/action/item_action/halt))
 		halt()
 	else
 		adjustmask(user)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -176,7 +176,7 @@
 	var/recharging_time = 0 //time until next dash
 	var/jumping = FALSE //are we mid-jump?
 
-/obj/item/clothing/shoes/bhop/ui_action_click(mob/user, actiontype)
+/obj/item/clothing/shoes/bhop/ui_action_click(mob/user, action)
 	if(!isliving(usr))
 		return
 

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -154,7 +154,7 @@
 	actions_types = list(/datum/action/item_action/stickmen)
 
 
-/obj/item/clothing/suit/wizrobe/paper/ui_action_click(mob/user, actiontype)
+/obj/item/clothing/suit/wizrobe/paper/ui_action_click(mob/user, action)
 	stickmen()
 
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -804,8 +804,8 @@
 		else
 			user << "<span class='warning'>That target is out of range!</span>" //too far away
 
-/obj/item/weapon/hierophant_staff/ui_action_click(mob/user, actiontype)
-	if(actiontype == /datum/action/item_action/toggle_unfriendly_fire) //toggle friendly fire...
+/obj/item/weapon/hierophant_staff/ui_action_click(mob/user, action)
+	if(istype(action, /datum/action/item_action/toggle_unfriendly_fire)) //toggle friendly fire...
 		friendly_fire_check = !friendly_fire_check
 		user << "<span class='warning'>You toggle friendly fire [friendly_fire_check ? "off":"on"]!</span>"
 		return


### PR DESCRIPTION
ui_action_click now sends the action button itself instead of the button's type(god damn it)
quickbound scripture is now a list; update_quickbind() regenerates the number of quickbind buttons to match the number of scripture in the list, to allow for arbitrary amounts of buttons
unrelated; all slabs have a speed_multiplier var to multiply the invoke time of scripture
scripture used while ratvar is alive no longer log, ha ha that wasn't a good choice