### PR TITLE
Make emergency storage protect from rad storms

### DIFF
--- a/code/datums/weather/weather_types.dm
+++ b/code/datums/weather/weather_types.dm
@@ -132,7 +132,7 @@
 	end_message = "<span class='notice'>The air seems to be cooling off again.</span>"
 
 	area_type = /area
-	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer, /area/ai_monitored/turret_protected/ai)
+	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer, /area/ai_monitored/turret_protected/ai, /area/storage/emergency, /area/storage/emergency2)
 	target_z = ZLEVEL_STATION
 
 	immunity_type = "rad"


### PR DESCRIPTION
People were dying to radstorms because they didn't realize emergency storage wasn't maint, and well, if it looks like maint and smells like maint then it should be considered maint.

Bonus: There is now no excuse for dying to radstorms because two publicly available safe spaces exist on the station.