### PR TITLE
Malf AI doomsday countdown is better formatted

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -81,7 +81,7 @@
 	SSshuttle.registerHostileEnvironment(src)
 
 /obj/machinery/doomsday_device/proc/seconds_remaining()
-	. = max(0, (round(detonation_timer - world.time) / 10))
+	. = max(0, (round((detonation_timer - world.time) / 10)))
 
 /obj/machinery/doomsday_device/process()
 	var/turf/T = get_turf(src)

--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -135,10 +135,11 @@
 
 /obj/effect/countdown/doomsday
 	name = "doomsday countdown"
+	text_size = 3
 
 /obj/effect/countdown/doomsday/get_value()
 	var/obj/machinery/doomsday_device/DD = attached_to
 	if(!istype(DD))
 		return
 	else if(DD.timing)
-		. = DD.seconds_remaining()
+		return "<div align='center' valign='middle' style='position:relative; top:0px; left:0px'>[DD.seconds_remaining()]</div>"


### PR DESCRIPTION
:cl: coiax
fix: The observer visible countdown timer for the malfunctioning AI doomsday device is now formatted and rounded appropriately.
/:cl:

It's centred, and no longer has decimals.