### PR TITLE
Makes sleeping carp less bad to use (Fixes sleeping carp auto-aggrograbbing on pull)

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -349,8 +349,12 @@
 		if(A.pulling)
 			D.drop_all_held_items()
 			D.stop_pulling()
-			add_logs(A, D, "grabbed", addition="aggressively")
-			A.grab_state = GRAB_AGGRESSIVE //Instant aggressive grab
+			if(A.a_intent == "grab")
+				add_logs(A, D, "grabbed", addition="aggressively")
+				A.grab_state = GRAB_AGGRESSIVE //Instant aggressive grab
+			else
+				add_logs(A, D, "grabbed", addition="passively")
+				A.grab_state = GRAB_PASSIVE
 	return 1
 
 /datum/martial_art/the_sleeping_carp/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)


### PR DESCRIPTION
You no longer automatically aggressively grab someone unless you're on grab intent, letting you pull properly if you're not on grab intent.
:cl: Mekhi
tweak: Sleeping Carp will no longer automatically turn your grabs into aggressive grabs unless you are on grab intent, meaning you can pull properly again.
\:cl: