### PR TITLE
Adds in-game explanation of the morgue lights

### DIFF
--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -27121,6 +27121,10 @@
 	tag = "every single paper bin is edited to this"
 	},
 /obj/item/weapon/folder/white,
+/obj/item/weapon/paper/morguereminder{
+	pixel_x = 4;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/black,
 /area/medical/morgue)
 "bev" = (

--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -26652,11 +26652,17 @@
 /turf/open/floor/plasteel/black,
 /area/medical/morgue)
 "aZI" = (
-/obj/item/weapon/pen,
+/obj/item/weapon/pen{
+	pixel_x = 6;
+	pixel_y = 7
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/table,
+/obj/item/weapon/paper/morguereminder{
+	pixel_x = -4
+	},
 /turf/open/floor/plasteel/black,
 /area/medical/morgue)
 "aZJ" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -78465,8 +78465,11 @@
 	},
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
-	pixel_x = -2;
+	pixel_x = 6;
 	pixel_y = 4
+	},
+/obj/item/weapon/paper/morguereminder{
+	pixel_x = -4
 	},
 /obj/effect/landmark{
 	name = "revenantspawn"

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -28712,6 +28712,10 @@
 /area/quartermaster/office)
 "bmR" = (
 /obj/structure/table,
+/obj/item/weapon/paper/morguereminder{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/black,
 /area/medical/morgue)
 "bmS" = (

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -135,6 +135,10 @@
 					icon_state = "morgue4" // Cloneable
 					break
 
+/obj/item/weapon/paper/morguereminder
+	name = "morgue memo"
+	info = "<font size='2'>Since this station's medbay never seems to fail to be staffed by the mindless monkeys meant for genetics experiments, I'm leaving a reminder here for anyone handling the pile of cadavers the quacks are sure to leave.</font><BR><BR><font size='4'><font color=red>Red lights mean there's a plain ol' dead body inside.</font><BR><BR><font color=orange>Yellow lights mean there's non-body objects inside.</font><BR><font size='2'>Probably stuff pried off a corpse someone grabbed, or if you're lucky it's stashed booze.</font><BR><BR><font color=green>Green lights mean the morgue system detects the body may be able to be cloned.</font></font><BR><font size='2'>I don't know how that works, but keep it away from the kitchen and go yell at the geneticists.</font><BR><BR>- Centcom medical inspector"
+
 /*
  * Crematorium
  */


### PR DESCRIPTION
:cl:
add: An instruction paper has been added to the morgue on most maps, because somehow it's needed.
/:cl:

Because non-antag chefs and chaplains still pull clone-able bodies out of the morgue for burgers/spacing.

![paper](https://cloud.githubusercontent.com/assets/6583225/20384298/258e04f0-ac68-11e6-8e26-01ae7364e73d.png)
