### PR TITLE
Revert "Singularity Gen isn't Exportable"

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -81,10 +81,22 @@
 	unit_name = "pipe dispenser"
 	export_types = list(/obj/machinery/pipedispenser)
 
+
+/datum/export/large/singularitygen
+	cost = 4000 // If you have one left after engine setup, sell it.
+	unit_name = "unused gravitational singularity generator"
+	export_types = list(/obj/machinery/the_singularitygen)
+	include_subtypes = FALSE
+
+/datum/export/large/singularitygen/tesla
+	unit_name = "unused energy ball generator"
+	export_types = list(/obj/machinery/the_singularitygen/tesla)
+
 /datum/export/large/supermatter
 	cost = 9000
 	unit_name = "supermatter shard"
 	export_types = list(/obj/machinery/power/supermatter_shard)
+
 
 // Misc
 /datum/export/large/iv


### PR DESCRIPTION
Reverts tgstation/tgstation#21571

There is absolutely no reason to make singulo generator unexportable. Yes, it's 4000 credits, but you have to actually get it from the engineers to sell it. And 4000 credits is not that much: it's 8 crates (found right in the cargo bay!) or 8 plasma sheets.

Engineering can give a maximum of 3 generators if they decide to go green and use only solars - it's 12000 credits. 30 plasma sheets from engineering secure storage - the ones that are used to fuel PACMAN - sell for 15000 credits, and you don't even have to pull them to cargo.