### PR TITLE
Mice no longer spawn on grilles

### DIFF
--- a/code/controllers/subsystem/squeak.dm
+++ b/code/controllers/subsystem/squeak.dm
@@ -37,10 +37,8 @@ var/datum/subsystem/squeak/SSsqueak
 	exposed_wires.Cut()
 
 	var/list/all_turfs = block(locate(1,1,1), locate(world.maxx,world.maxy,1))
-	turf_loop:
-		for(var/turf/open/floor/plating/T in all_turfs)
-			if(locate(/obj/structure/cable) in T)
-				for(var/atom/A in T)
-					if(A.density)
-						continue turf_loop
-				exposed_wires += T
+	for(var/turf/open/floor/plating/T in all_turfs)
+		if(is_blocked_turf(T))
+			continue
+		if(locate(/obj/structure/cable) in T)
+			exposed_wires += T

--- a/code/controllers/subsystem/squeak.dm
+++ b/code/controllers/subsystem/squeak.dm
@@ -15,8 +15,10 @@ var/datum/subsystem/squeak/SSsqueak
 	NEW_SS_GLOBAL(SSsqueak)
 
 /datum/subsystem/squeak/Initialize(timeofday)
+	trigger_migration()
+
+/datum/subsystem/squeak/proc/trigger_migration(num_mice=10)
 	find_exposed_wires()
-	var/num_mice = 10
 
 	var/mob/living/simple_animal/mouse/M
 	var/turf/proposed_turf
@@ -35,6 +37,10 @@ var/datum/subsystem/squeak/SSsqueak
 	exposed_wires.Cut()
 
 	var/list/all_turfs = block(locate(1,1,1), locate(world.maxx,world.maxy,1))
-	for(var/turf/open/floor/plating/T in all_turfs)
-		if(locate(/obj/structure/cable) in T)
-			exposed_wires += T
+	turf_loop:
+		for(var/turf/open/floor/plating/T in all_turfs)
+			if(locate(/obj/structure/cable) in T)
+				for(var/atom/A in T)
+					if(A.density)
+						continue turf_loop
+				exposed_wires += T

--- a/code/modules/events/mice_migration.dm
+++ b/code/modules/events/mice_migration.dm
@@ -1,0 +1,15 @@
+/datum/round_event_control/mice_migration
+	name = "Mice Migration"
+	typepath = /datum/round_event/mice_migration
+	weight = 0
+
+/datum/round_event/mice_migration
+	announceWhen = 0
+
+/datum/round_event/mice_migration/announce()
+	priority_announce("Due to space-winter, a number of rodents have \
+		migrated into the maintenance tunnels.", "Migration Alert",
+		'sound/effects/mousesqueek.ogg', 100, 1)
+
+/datum/round_event/mice_migration/start()
+	SSsqueak.trigger_migration(rand(5,15))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1161,6 +1161,7 @@
 #include "code\modules\events\mass_hallucination.dm"
 #include "code\modules\events\meateor_wave.dm"
 #include "code\modules\events\meteor_wave.dm"
+#include "code\modules\events\mice_migration.dm"
 #include "code\modules\events\operative.dm"
 #include "code\modules\events\portal_storm.dm"
 #include "code\modules\events\prison_break.dm"


### PR DESCRIPTION
Fixes #21574. Mice no longer spawn on cables that have dense objects
also on the tile.

Also added the Mice Migration event, used for debug purposes, currently
disabled.