### PR TITLE
Adds nitrous oxide reagent

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -994,6 +994,23 @@
 		T.atmos_spawn_air("co2=[reac_volume/5];TEMP=[T20C]")
 	return
 
+/datum/reagent/nitrous_oxide
+	name = "Nitrous Oxide"
+	id = "nitrous_oxide"
+	description = "A potent oxidizer used as fuel in rockets and as an anaesthetic during surgery."
+	reagent_state = LIQUID
+	color = "#808080"
+	
+/datum/reagent/nitrous_oxide/reaction_obj(obj/O, reac_volume)
+	if((!O) || (!reac_volume))
+		return 0
+	O.atmos_spawn_air("n2o=[reac_volume/5];TEMP=[T20C]")
+
+/datum/reagent/nitrous_oxide/reaction_turf(turf/open/T, reac_volume)
+	if(istype(T))
+		T.atmos_spawn_air("n2o=[reac_volume/5];TEMP=[T20C]")
+	return
+
 
 
 /////////////////////////Coloured Crayon Powder////////////////////////////

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -223,10 +223,3 @@
 		M.electrocute_act(rand(5,20), "Teslium in their body", 1, 1) //Override because it's caused from INSIDE of you
 		playsound(M, "sparks", 50, 1)
 	..()
-
-/datum/reagent/nitrous_oxide
-	name = "Nitrous Oxide"
-	id = "nitrous_oxide"
-	description = "A potent oxidizer used to fuel rockets and race cars and to anesthetize patients during surgery."
-	reagent_state = LIQUID
-	color = "#808080"

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -224,3 +224,19 @@
 		playsound(M, "sparks", 50, 1)
 	..()
 
+/datum/reagent/nitrous_oxide
+	name = "Nitrous Oxide"
+	id = "nitrous_oxide"
+	description = "A potent oxidizer used to fuel rockets and race cars and to anesthetize patients during surgery."
+	reagent_state = LIQUID
+	color = "#808080"
+	
+/datum/reagent/nitrous_oxide/reaction_obj(obj/O, reac_volume)
+	if((!O) || (!reac_volume))
+		return 0
+	O.atmos_spawn_air("n2o=[reac_volume/5];TEMP=[T20C]")
+
+/datum/reagent/nitrous_oxide/reaction_turf(turf/open/T, reac_volume)
+	if(istype(T))
+		T.atmos_spawn_air("n2o=[reac_volume/5];TEMP=[T20C]")
+	return

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -230,13 +230,3 @@
 	description = "A potent oxidizer used to fuel rockets and race cars and to anesthetize patients during surgery."
 	reagent_state = LIQUID
 	color = "#808080"
-	
-/datum/reagent/nitrous_oxide/reaction_obj(obj/O, reac_volume)
-	if((!O) || (!reac_volume))
-		return 0
-	O.atmos_spawn_air("n2o=[reac_volume/5];TEMP=[T20C]")
-
-/datum/reagent/nitrous_oxide/reaction_turf(turf/open/T, reac_volume)
-	if(istype(T))
-		T.atmos_spawn_air("n2o=[reac_volume/5];TEMP=[T20C]")
-	return

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -118,6 +118,13 @@
 	required_reagents = list("carbon" = 1, "oxygen" = 2)
 	required_temp = 777 // pure carbon isn't especially reactive.
 
+/datum/chemical_reaction/nitrous_oxide
+	name = "Nitrous Oxide"
+	id = "nitrous_oxide"
+	results = list("nitrous_oxide" = 2, "water" = 4)
+	required_reagents = list("ammonia" = 3, "nitrogen" = 1, "oxygen" = 2)
+	required_temp = 525
+	
 ////////////////////////////////// Mutation Toxins ///////////////////////////////////
 
 /datum/chemical_reaction/stable_mutation_toxin

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -393,3 +393,18 @@
 	id = "teslium_lightning2"
 	required_temp = 474
 	required_reagents = list("teslium" = 1)
+	
+/datum/chemical_reaction/nitrous_oxide
+	name = "Nitrous Oxide"
+	id = "nitrous_oxide"
+	results = list("nitrous_oxide" = 2, "water" = 4)
+	required_reagents = list("ammonia" = 3, "nitrogen" = 1, "oxygen" = 2)
+	required_temp = 525
+	
+/datum/chemical_reaction/reagent_explosion/nitrous_oxide
+	name = "N2O explosion"
+	id = "n2o_explosion"
+	required_reagents = list("nitrous_oxide" = 1)
+	strengthdiv = 7
+	required_temp = 575
+	modifier = 1

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -394,13 +394,6 @@
 	required_temp = 474
 	required_reagents = list("teslium" = 1)
 	
-/datum/chemical_reaction/nitrous_oxide
-	name = "Nitrous Oxide"
-	id = "nitrous_oxide"
-	results = list("nitrous_oxide" = 2, "water" = 4)
-	required_reagents = list("ammonia" = 3, "nitrogen" = 1, "oxygen" = 2)
-	required_temp = 525
-	
 /datum/chemical_reaction/reagent_explosion/nitrous_oxide
 	name = "N2O explosion"
 	id = "n2o_explosion"


### PR DESCRIPTION
:cl: Swindly
add: Added a nitrous oxide reagent. It can be created by heating 3 parts ammonia, 1 part nitrogen, and 2 parts oxygen to 525K. The process produces water as a by-product and will cause an explosion if too much heat is applied.
/:cl:

Like nitrogen, oxygen, carbon dioxide, and plasma, nitrous oxide now has a reagent form. It is created by heating ammonium nitrate and produces water as a side product. This process requires someone to spend several minutes making hundreds of units of N2O to make enough gas to make a room uninhabitable. The explosion has a strength divider of 7, which is between meth and holy water-potassium.