### PR TITLE
Removes roundstart airlock security on most...

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -5,13 +5,11 @@
 	icon = 'icons/obj/doors/airlocks/station/command.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_com
 	normal_integrity = 450
-	security_level = 1
 
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_sec
 	normal_integrity = 450
-	security_level = 1
 
 /obj/machinery/door/airlock/engineering
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
@@ -65,7 +63,6 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_com/glass
 	glass = 1
 	normal_integrity = 400
-	security_level = 1
 
 /obj/machinery/door/airlock/glass_engineering
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
@@ -79,7 +76,6 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_sec/glass
 	glass = 1
 	normal_integrity = 400
-	security_level = 1
 
 /obj/machinery/door/airlock/glass_medical
 	icon = 'icons/obj/doors/airlocks/station/medical.dmi'


### PR DESCRIPTION
:cl: Cobby
tweak: Airlock security is only given to vault doors, centcomm, and Secure Tech [Secure Tech just requires a welder]
/:cl:

Vault and Centcomm are still a pain, and SecTech requires a welder.

https://tgstation13.org/phpBB/viewtopic.php?f=10&t=8590&p=227839#p227839

@optimumtact 
> They weren't supposed to be on by default

Partially Reverts #21519