### PR TITLE
Changes to drake transformation

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -589,9 +589,10 @@
 			user << "<span class='danger'>Your flesh begins to melt! Miraculously, you seem fine otherwise.</span>"
 			H.set_species(/datum/species/skeleton)
 		if(3)
-			user << "<span class='danger'>You don't feel so good...</span>"
-			message_admins("[key_name_admin(user)](<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) has started transforming into a dragon via dragon's blood.")
-			H.ForceContractDisease(new /datum/disease/transformation/dragon(0))
+			user << "<span class='danger'>Power courses through you! You can now shift your form at will."
+			if(user.mind)
+				var/obj/effect/proc_holder/spell/targeted/shapeshift/dragon/D = new
+				user.mind.AddSpell(D)
 		if(4)
 			user << "<span class='danger'>You feel like you could walk straight through lava now.</span>"
 			H.weather_immunities |= "lava"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -259,8 +259,8 @@ Difficulty: Medium
 
 /mob/living/simple_animal/hostile/megafauna/dragon/lesser
 	name = "lesser ash drake"
-	maxHealth = 300
-	health = 300
+	maxHealth = 200
+	health = 200
 	faction = list("neutral")
 	obj_damage = 80
 	melee_damage_upper = 30

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -75,7 +75,7 @@
 	if(isliving(target))
 		var/mob/living/L = target
 		if(L.stat != DEAD)
-			if(ranged && ranged_cooldown <= world.time)
+			if(!client && ranged && ranged_cooldown <= world.time)
 				OpenFire()
 		else
 			devour(L)

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -71,3 +71,13 @@
 
 	shape.mind.transfer_to(caster)
 	qdel(shape) //Gib it maybe ?
+
+/obj/effect/proc_holder/spell/targeted/shapeshift/dragon
+	name = "Dragon Form"
+	desc = "Take on the shape a lesser ash drake."
+	invocation = "RAAAAAAAAWR!"
+
+	shapeshift_type = /mob/living/simple_animal/hostile/megafauna/dragon/lesser
+	list/current_shapes = list(/mob/living/simple_animal/hostile/megafauna/dragon/lesser)
+	list/current_casters = list()
+	list/possible_shapes = list(/mob/living/simple_animal/hostile/megafauna/dragon/lesser)


### PR DESCRIPTION
-It's now a shapeshift spell, so your options aren't "go afk on lavaland forever" or "walk around on station waiting until someone tries to murder you and then get banned"

-It now has less health, since the shapeshift spell is obviously way stronger

-Player controlled megafauna no longer involuntarily use ranged attacks when trying to melee people