### PR TITLE
Reverts roundstart airlock reinforcement from security and command doors.

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -5,13 +5,11 @@
 	icon = 'icons/obj/doors/airlocks/station/command.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_com
 	normal_integrity = 450
-	security_level = 1
 
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_sec
 	normal_integrity = 450
-	security_level = 1
 
 /obj/machinery/door/airlock/engineering
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
@@ -65,7 +63,6 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_com/glass
 	glass = 1
 	normal_integrity = 400
-	security_level = 1
 
 /obj/machinery/door/airlock/glass_engineering
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
@@ -79,7 +76,6 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_sec/glass
 	glass = 1
 	normal_integrity = 400
-	security_level = 1
 
 /obj/machinery/door/airlock/glass_medical
 	icon = 'icons/obj/doors/airlocks/station/medical.dmi'


### PR DESCRIPTION
It was said that airlock "security levels" wouldn't be added into the map roundstart but it was. This takes out security levels from security/command doors so they can be hacked normally unless someone manually reinforces them. However, vault and AI airlocks will still have reinforcement, as if you're breaking into those areas you probably should have to deal with the extra time involved anyways.