### PR TITLE
Hot-Tweak for Radstorms, Shuttle Boogaloo

### DIFF
--- a/code/datums/weather/weather_types.dm
+++ b/code/datums/weather/weather_types.dm
@@ -132,7 +132,7 @@
 	end_message = "<span class='notice'>The air seems to be cooling off again.</span>"
 
 	area_type = /area
-	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer, /area/ai_monitored/turret_protected/ai, /area/storage/emergency, /area/storage/emergency2)
+	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer, /area/ai_monitored/turret_protected/ai, /area/storage/emergency, /area/storage/emergency2, /area/shuttle/labor)
 	target_z = ZLEVEL_STATION
 
 	immunity_type = "rad"


### PR DESCRIPTION
:cl: Cobby
tweak: mining/labor shuttles are now radiation proof.
/:cl:

Radstorms would magically teleport to lavaland with the shuttles, so instead of trying to stupidly write L O R E as to why this occurs I just figured to make the mining shuttle [this includes gulag shuttle as well] radproof.