### PR TITLE
Disabled multiverse sword in bullshit mages

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -500,13 +500,14 @@
 /datum/spellbook_entry/summon/multisword/IsAvailible()
 	if(!ticker.mode) // In case spellbook is placed on map
 		return 0
-	return (ticker.mode.name != "ragin' mages" && !config.no_summon_magic)
+	return (ticker.mode.name != "ragin' mages" && ticker.mode.name != "very ragin' bullshit mages" && !config.no_summon_magic)
 
 /datum/spellbook_entry/summon/multisword/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book)
 	feedback_add_details("wizard_spell_learned",log_name)
 	only_me()
 	new /obj/item/weapon/multisword(get_turf(user)) //Because the proc skips special roles
-	SSshuttle.emergency.request()
+	if(SSshuttle.emergency.mode == SHUTTLE_IDLE)
+		SSshuttle.emergency.request()
 	playsound(get_turf(user),"sound/magic/CastSummon.ogg",50,1)
 	user << "<span class='notice'>You have triggerd a multiverse war!</span>"
 


### PR DESCRIPTION
You can no longer purchase the multiverse sword in bullshit mages

The multiverse sword will not call the shuttle if it's already called.