### PR TITLE
Fixes station goals not generating in extended

### DIFF
--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -18,7 +18,7 @@
 
 /datum/game_mode/extended/announced/generate_station_goals()
 	for(var/T in subtypesof(/datum/station_goal))
-		var/datum/station_goal/G = T
+		var/datum/station_goal/G = new T
 		station_goals += G
 		G.on_report()
 


### PR DESCRIPTION
:cl: Kor
fix: Station goals will once again function in extended.
/:cl:

