### PR TITLE
Fixes Sigils of Transmission trying to charge cyborgs with less than the minimum amount to charge missing

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -226,7 +226,7 @@
 	if(!power_charge)
 		cyborg << "<span class='warning'>The [sigil_name] has no stored power!</span>"
 		return FALSE
-	if(cyborg.cell.charge == cyborg.cell.maxcharge)
+	if(cyborg.cell.charge > cyborg.cell.maxcharge - MIN_CLOCKCULT_POWER)
 		cyborg << "<span class='warning'>You are already at maximum charge!</span>"
 		return FALSE
 	if(cyborg.has_status_effect(STATUS_EFFECT_POWERREGEN))


### PR DESCRIPTION
I mean, using the sigil to get 5 power a second is not worth it, but it should at least fail if you're above that.