### PR TITLE
Locks up Insulated gloves in cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -521,6 +521,7 @@ datum/supply_pack
 /datum/supply_pack/engineering/nowaythiswillendbadly
 	name = "Bootleg Insulated Gloves Crate"
 	cost = 1000 //But its such a good deal!
+	contraband = TRUE
 	contains =  list(/obj/item/clothing/gloves/color/fyellow,
 					/obj/item/clothing/gloves/color/fyellow,
 					/obj/item/clothing/gloves/color/fyellow)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -511,10 +511,12 @@ datum/supply_pack
 /datum/supply_pack/engineering/powergamermitts
 	name = "Insulated Gloves Crate"
 	cost = 2000	//Made of pure-grade bullshittinium
+	access = access_engine_equip
 	contains = list(/obj/item/clothing/gloves/color/yellow,
 					/obj/item/clothing/gloves/color/yellow,
 					/obj/item/clothing/gloves/color/yellow)
 	crate_name = "insulated gloves crate"
+	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/engineering/power
 	name = "Powercell Crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -518,6 +518,14 @@ datum/supply_pack
 	crate_name = "insulated gloves crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 
+/datum/supply_pack/engineering/nowaythiswillendbadly
+	name = "Bootleg Insulated Gloves Crate"
+	cost = 1000 //But its such a good deal!
+	contains =  list(/obj/item/clothing/gloves/color/fyellow,
+					/obj/item/clothing/gloves/color/fyellow,
+					/obj/item/clothing/gloves/color/fyellow)
+	crate_name = "insulated gloves crate"
+
 /datum/supply_pack/engineering/power
 	name = "Powercell Crate"
 	cost = 1000


### PR DESCRIPTION
:cl:
tweak: The insulated gloves crate has been locked
add: Space china's grey market reacted quickly to the news and has attempted to undercut legitimate suppliers. Purchase from such dubious sources is of course prohibited.
/:cl:

These things are supposed to be rare and act as cargo's go to power-gaming item. This change should have happened a long time ago to be honest.