### PR TITLE
Borers can now no longer take control of implanted people or cultists

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -633,6 +633,10 @@ var/total_borer_hosts_needed = 10
 	if(docile)
 		src <<"<span class='warning'>You are feeling far too docile to do that.</span>"
 		return
+	if(is_servant_of_ratvar(C) || iscultist(C) || C.isloyal())
+		src << "<span class='warning'>[C]'s mind seems to be blocked by some unknown force!</span>"
+		return
+
 	else
 
 		log_game("[src]/([src.ckey]) assumed control of [victim]/([victim.ckey] with borer powers.")

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -364,10 +364,6 @@ var/total_borer_hosts_needed = 10
 		src << "<span class='warning'>[C] does not possess the vital systems needed to support us.</span>"
 		return
 
-	if(is_servant_of_ratvar(C) || iscultist(C) || C.isloyal())
-		src << "<span class='warning'>[C]'s mind seems to be blocked by some unknown force!</span>"
-		return
-
 	victim = C
 	forceMove(victim)
 

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -364,6 +364,10 @@ var/total_borer_hosts_needed = 10
 		src << "<span class='warning'>[C] does not possess the vital systems needed to support us.</span>"
 		return
 
+	if(is_servant_of_ratvar(C) || iscultist(C) || C.isloyal())
+		src << "<span class='warning'>[C]'s mind seems to be blocked by some unknown force!</span>"
+		return
+
 	victim = C
 	forceMove(victim)
 

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -629,8 +629,8 @@ var/total_borer_hosts_needed = 10
 	if(docile)
 		src <<"<span class='warning'>You are feeling far too docile to do that.</span>"
 		return
-	if(is_servant_of_ratvar(C) || iscultist(C) || C.isloyal())
-		src << "<span class='warning'>[C]'s mind seems to be blocked by some unknown force!</span>"
+	if(is_servant_of_ratvar(victim) || iscultist(victim) || victim.isloyal())
+		src << "<span class='warning'>[victim]'s mind seems to be blocked by some unknown force!</span>"
 		return
 
 	else


### PR DESCRIPTION
:cl:
tweak: Borers can no longer take control of people who have a mindshield implant or are a member of either cult. This however does not stop them from infesting and controlling them through other means, such as chemicals.
/:cl:

This is to solve the issue of borers ruining cult rounds by revealing
every cultist there is, as well as to stop borers from having instant
access to kill weapons by simply infesting a security officer, HoS, or
the Captain.

They're not supposed to be a primary antagonist, just a secondary nuisance. This will help stop borers from being able to become a primary antagonist which can destroy rounds.