### PR TITLE
Adds a config file to enable/disable shuttles from being bought

### DIFF
--- a/code/datums/helper_datums/map_template.dm
+++ b/code/datums/helper_datums/map_template.dm
@@ -117,12 +117,16 @@
 
 
 /proc/preloadShuttleTemplates()
+	var/list/unbuyable = generateMapList("config/unbuyableShuttles.txt")
+
 	for(var/item in subtypesof(/datum/map_template/shuttle))
 		var/datum/map_template/shuttle/shuttle_type = item
 		if(!(initial(shuttle_type.suffix)))
 			continue
 
 		var/datum/map_template/shuttle/S = new shuttle_type()
+		if(unbuyable.Find(S.mappath))
+			S.can_be_bought = FALSE
 
 		shuttle_templates[S.shuttle_id] = S
 		map_templates[S.shuttle_id] = S

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -9,7 +9,7 @@
 	var/admin_notes
 
 	var/credit_cost = INFINITY
-	var/can_be_bought = TRUE // shuttle config
+	var/can_be_bought = TRUE
 
 /datum/map_template/shuttle/New()
 	shuttle_id = "[port_id]_[suffix]"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -9,6 +9,7 @@
 	var/admin_notes
 
 	var/credit_cost = INFINITY
+	var/can_be_bought = TRUE // shuttle config
 
 /datum/map_template/shuttle/New()
 	shuttle_id = "[port_id]_[suffix]"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -527,7 +527,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 			dat += "Budget: [SSshuttle.points] Credits.<BR>"
 			for(var/shuttle_id in shuttle_templates)
 				var/datum/map_template/shuttle/S = shuttle_templates[shuttle_id]
-				if(S.credit_cost < INFINITY)
+				if(S.can_be_bought && S.credit_cost < INFINITY)
 					dat += "[S.name] | [S.credit_cost] Credits<BR>"
 					dat += "[S.description]<BR>"
 					dat += "<A href='?src=\ref[src];operation=buyshuttle;chosen_shuttle=\ref[S]'>(<font color=red><i>Purchase</i></font>)</A><BR><BR>"

--- a/config/unbuyableShuttles.txt
+++ b/config/unbuyableShuttles.txt
@@ -1,0 +1,18 @@
+#Listing maps here will make the shuttle not available to buy in comms console.
+#Maps must be the full path to them
+#Only shuttles with a price in the code will work with this!
+#SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
+
+#_maps/shuttles/emergency_asteroid.dmm
+#_maps/shuttles/emergency_bar.dmm
+#_maps/shuttles/emergency_meteor.dmm
+#_maps/shuttles/emergency_luxury.dmm
+#_maps/shuttles/emergency_birdboat.dmm
+#_maps/shuttles/emergency_box.dmm
+#_maps/shuttles/emergency_clown.dmm
+#_maps/shuttles/emergency_cramped.dmm
+#_maps/shuttles/emergency_meta.dmm
+#_maps/shuttles/emergency_mini.dmm
+#_maps/shuttles/emergency_imfedupwiththisworld.dmm
+#_maps/shuttles/emergency_goon.dmm
+#_maps/shuttles/emergency_wabbajack.dmm


### PR DESCRIPTION
Works like ruin blacklisting where uncommented paths in config/unbuyableShuttles.txt won't show up in the purchase shuttle menu.

This will only make a difference for shuttles that have a price set in the code(I really don't want to go in balance things by setting a price in all of them so if anyone ever does that, remember to add the path to the txt file).