### PR TITLE
Makes golems different, also fixes a couple of bugs

### DIFF
--- a/code/game/objects/radiation.dm
+++ b/code/game/objects/radiation.dm
@@ -32,7 +32,10 @@
 /mob/living/rad_act(amount, silent = 0)
 	if(amount)
 		var/blocked = getarmor(null, "rad")
-
+		if(iscarbon(src))
+			var/mob/living/carbon/C = src
+			if(C.dna && (RADIMMUNE in C.dna.species.specflags))
+				silent = TRUE
 		if(!silent)
 			src << "Your skin feels warm."
 

--- a/code/game/objects/radiation.dm
+++ b/code/game/objects/radiation.dm
@@ -32,16 +32,16 @@
 /mob/living/rad_act(amount, silent = 0)
 	if(amount)
 		var/blocked = getarmor(null, "rad")
-		if(iscarbon(src))
-			var/mob/living/carbon/C = src
-			if(C.dna && (RADIMMUNE in C.dna.species.specflags))
-				silent = TRUE
 		if(!silent)
 			src << "Your skin feels warm."
-
 		apply_effect(amount, IRRADIATE, blocked)
 		for(var/obj/I in src) //Radiation is also applied to items held by the mob
 			I.rad_act(amount)
+
+/mob/living/carbon/rad_act(amount, silent = 0)
+	if(C.dna && (RADIMMUNE in C.dna.species.specflags))
+		silent = TRUE
+	..()
 
 //Silicons will inherently not get irradiated due to having an empty handle_mutations_and_radiation, but they need to not hear this
 /mob/living/silicon/rad_act(amount)

--- a/code/game/objects/radiation.dm
+++ b/code/game/objects/radiation.dm
@@ -41,7 +41,7 @@
 			I.rad_act(amount)
 
 /mob/living/carbon/rad_act(amount, silent = 0)
-	if(C.dna && (RADIMMUNE in C.dna.species.specflags))
+	if(dna && (RADIMMUNE in dna.species.specflags))
 		silent = TRUE
 	..()
 

--- a/code/game/objects/radiation.dm
+++ b/code/game/objects/radiation.dm
@@ -32,8 +32,10 @@
 /mob/living/rad_act(amount, silent = 0)
 	if(amount)
 		var/blocked = getarmor(null, "rad")
+
 		if(!silent)
 			src << "Your skin feels warm."
+
 		apply_effect(amount, IRRADIATE, blocked)
 		for(var/obj/I in src) //Radiation is also applied to items held by the mob
 			I.rad_act(amount)

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -582,7 +582,7 @@
 	fixed_mut_color = "a3d"
 
 /datum/species/golem/plasma/spec_death(gibbed, mob/living/carbon/human/H)
-	explosion(get_turf(H),0,2,3,flame_range = 5)
+	explosion(get_turf(H),0,1,2,flame_range = 5)
 	if(H)
 		H.gib()
 
@@ -590,20 +590,20 @@
 	name = "Diamond Golem"
 	id = "diamond"
 	fixed_mut_color = "0ff"
-	armor = 70
+	armor = 70 //up from 55
 
 /datum/species/golem/gold
 	name = "Gold Golem"
 	id = "gold"
 	fixed_mut_color = "ee0"
 	speedmod = 1
-	armor = 25
+	armor = 25 //down from 55
 
 /datum/species/golem/silver
 	name = "Silver Golem"
 	id = "silver"
 	fixed_mut_color = "ddd"
-	punchstunthreshold = 8 //heavy
+	punchstunthreshold = 9 //60% chance, from 40%
 
 /datum/species/golem/uranium
 	name = "Uranium Golem"
@@ -614,9 +614,9 @@
 
 /datum/species/golem/uranium/spec_life(mob/living/carbon/human/H)
 	if(!active)
-		if(world.time > last_event+15)
+		if(world.time > last_event+30)
 			active = 1
-			radiation_pulse(get_turf(H), 3, 3, 8, 0)
+			radiation_pulse(get_turf(H), 3, 3, 5, 0)
 			last_event = world.time
 			active = null
 	..()

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -581,25 +581,45 @@
 	id = "plasma"
 	fixed_mut_color = "a3d"
 
+/datum/species/golem/plasma/spec_death(gibbed, mob/living/carbon/human/H)
+	explosion(get_turf(H),0,2,3,flame_range = 5)
+	if(H)
+		H.gib()
+
 /datum/species/golem/diamond
 	name = "Diamond Golem"
 	id = "diamond"
 	fixed_mut_color = "0ff"
+	armor = 70
 
 /datum/species/golem/gold
 	name = "Gold Golem"
 	id = "gold"
 	fixed_mut_color = "ee0"
+	speedmod = 1
+	armor = 25
 
 /datum/species/golem/silver
 	name = "Silver Golem"
 	id = "silver"
 	fixed_mut_color = "ddd"
+	punchstunthreshold = 8 //heavy
 
 /datum/species/golem/uranium
 	name = "Uranium Golem"
 	id = "uranium"
 	fixed_mut_color = "7f0"
+	var/last_event = 0
+	var/active = null
+
+/datum/species/golem/uranium/spec_life(mob/living/carbon/human/H)
+	if(!active)
+		if(world.time > last_event+15)
+			active = 1
+			radiation_pulse(get_turf(H), 3, 3, 8, 0)
+			last_event = world.time
+			active = null
+	..()
 
 
 /*

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -569,6 +569,7 @@
 	name = initial(golem_type.name)
 	id = initial(golem_type.id)
 	meat = initial(golem_type.meat)
+	fixed_mut_color = initial(golem_type.fixed_mut_color)
 
 /datum/species/golem/adamantine
 	name = "Adamantine Golem"


### PR DESCRIPTION
:cl: XDTM
add: Golems now have special properties based on the mineral they're made of:
add: Silver golems have a higher chance of stun when punching
add: Gold golems are faster but less armoured
add: Diamond golems are more armoured
add: Uranium golems are radioactive
add: Plasma golems explode on death
add: Iron and adamantine golems are unchanged.
/:cl:

Additionally, RADIMMUNE species no longer receive the "Your skin feels warm" message, and random golems now properly receive their species color when created. 
Random golems do NOT, however, receive the special traits listed above due to how they're handled, so they're cosmetic only. This should only affect golems made with xenobiology green slimes.
