### PR TITLE
Correct call to addtimer, preventing runtime

### DIFF
--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -67,7 +67,7 @@
 	playsound(src.loc, 'sound/machines/airlock_alien_prying.ogg', 100, 1)
 	A.audible_message("<span class='italics'>You hear a loud metallic grinding sound.</span>")
 
-	addtimer(src, "growl", 20, unique=FALSE, target=user)
+	addtimer(src, "growl", 20, FALSE, user)
 
 	if(do_after(user, delay=160, needhand=FALSE, target=A, progress=TRUE))
 		playsound(src.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)


### PR DESCRIPTION
All the arguments passed into the arglist appear to be required to not
be named arguments, so this simply strips out the named arguments and
passes them in as the base format.

This is confusing