### PR TITLE
Medibot healing fix

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -497,6 +497,8 @@
 
 /mob/living/simple_animal/bot/medbot/proc/check_overdose(mob/living/carbon/patient,reagent_id,injection_amount)
 	var/datum/reagent/R  = chemical_reagents_list[reagent_id]
+	if(!R.overdose_threshold) //Some chems do not have an OD threshold
+		return 0
 	var/current_volume = patient.reagents.get_reagent_amount(reagent_id)
 	if(current_volume + injection_amount > R.overdose_threshold)
 		return 1


### PR DESCRIPTION
:cl: Gun Hog
fix: Medibots now heal toxin damage again.
/:cl:

When Medibots were switched to charcoal, which lacks an OD threshold, they were unable to use it for healing due to it having an OD threshold of zero, which the medibot will think that any injection amount is over the threshold, thus refusing to inject.