### PR TITLE
Increases mech-mounted plasma cutter effectiveness

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -111,15 +111,15 @@
 	fire_sound = 'sound/weapons/marauder.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma
-	equip_cooldown = 20
+	equip_cooldown = 10
 	name = "217-D Heavy Plasma Cutter"
 	desc = "A device that shoots resonant plasma bursts at extreme velocity. The blasts are capable of crushing rock and demloishing solid obstacles."
 	icon_state = "mecha_plasmacutter"
 	item_state = "plasmacutter"
-	energy_drain = 60
+	energy_drain = 30
 	origin_tech = "materials=3;plasmatech=4;engineering=3"
 	projectile = /obj/item/projectile/plasma/adv/mech
-	fire_sound = 'sound/weapons/Laser.ogg'
+	fire_sound = 'sound/weapons/plasma_cutter.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma/can_attach(obj/mecha/working/M)
 	if(..()) //combat mech


### PR DESCRIPTION
:cl: Gun Hog

tweak: The mech mounted plasma cutter now fires faster and costs less per
shot.
soundadd: Changed the mech plasma cutter's sound to match the other cutters.
/:cl:

**Values are open to suggestion.**

The mech plasma cutter now fires faster, and costs less per shot to maintain the current average energy usage. I have also corrected the firing sound to match the hand versions.

The plasma cutter is a decent weapon, except being very slow. I have tested the changes on Lavaland, and found that I can engage an Ash Drake if I have at least a super-cap cell, a repair droid and Goliath carapace installed. I did not succeed with the other bosses, though.

With this, it is my hope that the Ripley mech will be a beloved treasure for the miners, one that can survive and eventually thrive in the harshness of Lavaland.