### PR TITLE
Makes borer event admin only

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer_event.dm
+++ b/code/game/gamemodes/miniantags/borer/borer_event.dm
@@ -2,7 +2,7 @@
 	name = "Borer"
 	typepath = /datum/round_event/borer
 	weight = 20
-	max_occurrences = 1
+	max_occurrences = 0
 	min_players = 15
 	earliest_start = 12000
 


### PR DESCRIPTION
Our policy at the moment about borers is kind of a mess. Headmins recommended we disable them until we figure it out

:cl:
del: The cortical borer event is now admin only
/:cl:

