### PR TITLE
Fixes Unicode CL tags breaking changelogs.

### DIFF
--- a/tools/github_webhook_processor.php
+++ b/tools/github_webhook_processor.php
@@ -155,14 +155,14 @@ function checkchangelog($payload, $merge = false) {
 	$foundcltag = false;
 	foreach ($body as $line) {
 		$line = trim($line);
-		if (substr($line,0,4) == ':cl:') {
+		if (substr($line,0,4) == ':cl:' || substr($line,0,4) == '🆑') {
 			$incltag = true;
 			$foundcltag = true;
 			$pos = strpos($line, " ");
 			if ($pos)
 				$username = substr($line, $pos+1);
 			continue;
-		} else if (substr($line,0,5) == '/:cl:' || substr($line,0,6) == '/ :cl:' || substr($line,0,5) == ':/cl:') {
+		} else if (substr($line,0,5) == '/:cl:' || substr($line,0,6) == '/ :cl:' || substr($line,0,5) == ':/cl:' || substr($line,0,5) == '/🆑' || substr($line,0,6) == '/ 🆑' ) {
 			$incltag = false;
 			$changelogbody = array_merge($changelogbody, $currentchangelogblock);
 			continue;


### PR DESCRIPTION
This seemed to be a problem on Yogstation where some coders were using the Unicode CL character instead of the Github emoji, and its impossible to tell the difference unless you try to edit the PR.

For some reason PHP still considers the Unicode character to be 4 characters long.

:cl:
^Github Emoji
🆑
^Unicode Emoji