### PR TITLE
AI mech pilots are no longer gibbed on mech death + tweaks

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -142,9 +142,11 @@
 
 /obj/mecha/Destroy()
 	go_out()
+	var/mob/living/silicon/ai/AI
 	for(var/mob/M in src) //Let's just be ultra sure
 		if(isAI(M))
-			M.gib() //AIs are loaded into the mech computer itself. When the mech dies, so does the AI. Forever.
+			occupant = null
+			AI = M //AIs are loaded into the mech computer itself. When the mech dies, so does the AI. They can be recovered with an AI card from the wreck.
 		else
 			M.forceMove(loc)
 
@@ -152,7 +154,7 @@
 		explosion(get_turf(loc), 0, 0, 1, 3)
 
 	if(wreckage)
-		var/obj/structure/mecha_wreckage/WR = new wreckage(loc)
+		var/obj/structure/mecha_wreckage/WR = new wreckage(loc, AI)
 		for(var/obj/item/mecha_parts/mecha_equipment/E in equipment)
 			if(E.salvageable && prob(30))
 				WR.crowbar_salvage += E
@@ -176,6 +178,8 @@
 			qdel(cell)
 		if(internal_tank)
 			qdel(internal_tank)
+		if(AI)
+			AI.gib() //No wreck, no AI to recover
 	STOP_PROCESSING(SSobj, src)
 	poi_list.Remove(src)
 	equipment.Cut()
@@ -630,9 +634,6 @@
 			if(!AI || !isAI(occupant)) //Mech does not have an AI for a pilot
 				user << "<span class='warning'>No AI detected in the [name] onboard computer.</span>"
 				return
-			if(AI.mind.special_role) //Malf AIs cannot leave mechs. Except through death.
-				user << "<span class='boldannounce'>ACCESS DENIED.</span>"
-				return
 			AI.ai_restore_power()//So the AI initially has power.
 			AI.control_disabled = 1
 			AI.radio_enabled = 0
@@ -684,9 +685,9 @@
 	AI.remote_control = src
 	AI.canmove = 1 //Much easier than adding AI checks! Be sure to set this back to 0 if you decide to allow an AI to leave a mech somehow.
 	AI.can_shunt = 0 //ONE AI ENTERS. NO AI LEAVES.
-	AI << "[interaction == AI_MECH_HACK ? "<span class='announce'>Takeover of [name] complete! You are now permanently loaded onto the onboard computer. Do not attempt to leave the station sector!</span>" \
+	AI << "[interaction == AI_MECH_HACK ? "<span class='announce'>Takeover of [name] complete! You are now loaded onto the onboard computer. Do not attempt to leave the station sector!</span>" \
 	: "<span class='notice'>You have been uploaded to a mech's onboard computer."]"
-	AI << "<span class='boldnotice'>Use Middle-Mouse to activate mech functions and equipment. Click normally for AI interactions.</span>"
+	AI << "<span class='reallybig boldnotice'>Use Middle-Mouse to activate mech functions and equipment. Click normally for AI interactions.</span>"
 	GrantActions(AI)
 
 

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -14,6 +14,23 @@
 	var/list/wirecutters_salvage = list(/obj/item/stack/cable_coil)
 	var/list/crowbar_salvage = list()
 	var/salvage_num = 5
+	var/mob/living/silicon/ai/AI //AIs to be salvaged
+
+/obj/structure/mecha_wreckage/New(loc, mob/living/silicon/ai/AI_pilot)
+	..()
+	if(AI_pilot) //Type-checking for this is already done in mecha/Destroy()
+		AI = AI_pilot
+		AI.apply_damage(150, BURN) //Give the AI a bit of damage from the "shock" of being suddenly shut down
+		AI.death() //The damage is not enough to kill the AI, but to be 'corrupted files' in need of repair.
+		AI.forceMove(src) //Put the dead AI inside the wreckage for recovery
+		add_overlay(image('icons/obj/projectiles.dmi', icon_state = "green_laser")) //Overlay for the recovery beacon
+		AI.controlled_mech = null
+		AI.remote_control = null
+
+/obj/structure/mecha_wreckage/examine(mob/user)
+	..()
+	if(AI)
+		user << "<span class='notice'>The AI recovery beacon is active.</span>"
 
 /obj/structure/mecha_wreckage/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/weldingtool))
@@ -57,6 +74,25 @@
 			return
 		else
 			user << "<span class='warning'>You don't see anything that can be pried with [I]!</span>"
+
+
+/obj/structure/mecha_wreckage/transfer_ai(interaction, mob/user, null, obj/item/device/aicard/card)
+	if(!..())
+		return
+
+ //Proc called on the wreck by the AI card.
+	if(interaction == AI_TRANS_TO_CARD) //AIs can only be transferred in one direction, from the wreck to the card.
+		if(!AI) //No AI in the wreck
+			user << "<span class='warning'>No AI backups found.</span>"
+			return
+		cut_overlays() //Remove the recovery beacon overlay
+		AI.forceMove(card) //Move the dead AI to the card.
+		card.AI = AI
+		if(AI.client) //AI player is still in the dead AI and is connected
+			AI << "The remains of your file system have been recovered on a mobile storage device."
+		else //Give the AI a heads-up that it is probably going to get fixed.
+			AI.notify_ghost_cloning("You have been recovered from the wreckage!", source = card)
+		user << "<span class='boldnotice'>Backup files recovered</span>: [AI.name] ([rand(1000,9999)].exe) salvaged from [name] and stored within local memory."
 
 	else
 		return ..()


### PR DESCRIPTION
:cl: Gun Hog
add: AIs piloting a mech may now be recovered with an Intellicard from the wreckage if the mech is destroyed. They will be require repair once recovered.
tweak: Instructions for piloting mechs as an AI are now more obvious.
tweak: Traitor and Ratvar AIs may now be carded from mechs, at their discretion.
/:cl:

The following changes are based on player feedback:
**Allows AIs to be recovered from mech wrecks by hitting the mech with
an AI card. The AI will be dead, thus requiring the use of an AI console to revive it.**

- A wreck containing a dead AI will be marked with an overlay and corresponding message on examination. 

**Makes the explanation text of the AI's new control REALLY BIG.** 

- Players complained about missing the instruction text upon being placed in a mech, so it is now much, much larger.

 **Antagonist AIs can now be carded from mechs** 

- Note that all AIs, antagonist or not, must allow maintenance protocols in order to be carded. There is thus no reason to withhold that choice from antag AIs. I have changed the text slightly to reflect this.

![screenshot 2016-11-23 16 38 47](https://cloud.githubusercontent.com/assets/4955510/20581289/8cce4c62-b19d-11e6-893e-1ce056746972.png)

