### PR TITLE
Fixes the false armblade removal timer. Refactors addtimer

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -585,3 +585,8 @@ var/global/list/ghost_others_options = list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 #define CLOCK_SUMMON 21
 #define CLOCK_SILICONS 22
 #define CLOCK_PROSELYTIZATION 23
+
+//For SSTimer
+
+#define TIMER_NORMAL "normal"
+#define TIMER_UNIQUE "unique"

--- a/code/controllers/subsystem/augury.dm
+++ b/code/controllers/subsystem/augury.dm
@@ -46,7 +46,7 @@ var/datum/subsystem/augury/SSaugury
 		if(O.orbiting)
 			continue
 		else if(biggest_doom)
-			addtimer(O, "orbit", 0, FALSE, biggest_doom)
+			addtimer(O, "orbit", 0, TIMER_NORMAL, biggest_doom)
 
 /datum/action/innate/augury
 	name = "Auto Follow Debris"

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -1,8 +1,5 @@
 var/datum/subsystem/timer/SStimer
 
-#define TIMER_NORMAL "normal"
-#define TIMER_UNIQUE "unique"
-
 /datum/subsystem/timer
 	name = "Timer"
 	wait = 2 //SS_TICKER subsystem, so wait is in ticks

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -1,5 +1,8 @@
 var/datum/subsystem/timer/SStimer
 
+#define TIMER_NORMAL "normal"
+#define TIMER_UNIQUE "unique"
+
 /datum/subsystem/timer
 	name = "Timer"
 	wait = 2 //SS_TICKER subsystem, so wait is in ticks
@@ -62,7 +65,7 @@ var/datum/subsystem/timer/SStimer
 	SStimer.hashes -= hash
 	return QDEL_HINT_IWILLGC
 
-/proc/addtimer(thingToCall, procToCall, wait, unique = FALSE, ...)
+/proc/addtimer(thingToCall, procToCall, wait, unique = TIMER_NORMAL, ...)
 	if (!thingToCall || !procToCall)
 		return
 	if (!SStimer.can_fire)
@@ -76,11 +79,17 @@ var/datum/subsystem/timer/SStimer
 
 	hashlist[1] = "[thingToCall](\ref[thingToCall])"
 	event.hash = jointext(args, null)
-	if(args.len > 4)
-		event.argList = args.Copy(5)
+
+	var/bad_args = unique != TIMER_NORMAL && unique != TIMER_UNIQUE
+	if(args.len > 4 || bad_args)
+		if(bad_args)
+			stack_trace("Invalid arguments in call to addtimer!")
+			event.argList = args.Copy(4)
+		else
+			event.argList = args.Copy(5)
 
 	// Check for dupes if unique = 1.
-	if(unique)
+	if(!bad_args && unique != TIMER_NORMAL)	//faster than checking if(unique == TIMER_UNIQUE)
 		var/datum/timedevent/hash_event = SStimer.hashes[event.hash]
 		if(hash_event)
 			return hash_event.id

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -29,7 +29,7 @@ var/datum/subsystem/weather/SSweather
 		var/datum/weather/W = pickweight(possible_weather_for_this_z)
 		run_weather(W.name, Z)
 		eligible_zlevels -= Z
-		addtimer(src, "make_z_eligible", rand(3000, 6000) + W.weather_duration_upper, TRUE, Z) //Around 5-10 minutes between weathers
+		addtimer(src, "make_z_eligible", rand(3000, 6000) + W.weather_duration_upper, TIMER_UNIQUE, Z) //Around 5-10 minutes between weathers
 
 /datum/subsystem/weather/Initialize(start_timeofday)
 	..()

--- a/code/datums/antagonists/datum_clockcult.dm
+++ b/code/datums/antagonists/datum_clockcult.dm
@@ -40,7 +40,7 @@
 		ticker.mode.servants_of_ratvar += owner.mind
 		ticker.mode.update_servant_icons_added(owner.mind)
 		if(jobban_isbanned(owner, ROLE_SERVANT_OF_RATVAR))
-			addtimer(ticker.mode, "replace_jobbaned_player", 0, FALSE, owner, ROLE_SERVANT_OF_RATVAR, ROLE_SERVANT_OF_RATVAR)
+			addtimer(ticker.mode, "replace_jobbaned_player", 0, TIMER_NORMAL, owner, ROLE_SERVANT_OF_RATVAR, ROLE_SERVANT_OF_RATVAR)
 	if(owner.mind)
 		owner.mind.special_role = "Servant of Ratvar"
 	owner.attack_log += "\[[time_stamp()]\] <span class='brass'>Has been converted to the cult of Ratvar!</span>"

--- a/code/datums/antagonists/datum_cult.dm
+++ b/code/datums/antagonists/datum_cult.dm
@@ -20,7 +20,7 @@
 			var/datum/game_mode/cult/C = ticker.mode
 			C.memorize_cult_objectives(owner.mind)
 		if(jobban_isbanned(owner, ROLE_CULTIST))
-			addtimer(ticker.mode, "replace_jobbaned_player", 0, FALSE, owner, ROLE_CULTIST, ROLE_CULTIST)
+			addtimer(ticker.mode, "replace_jobbaned_player", 0, TIMER_NORMAL, owner, ROLE_CULTIST, ROLE_CULTIST)
 	if(owner.mind)
 		owner.mind.special_role = "Cultist"
 	owner.attack_log += "\[[time_stamp()]\] <span class='cult'>Has been converted to the cult of Nar'Sie!</span>"

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -82,9 +82,9 @@
 /datum/teleport/proc/playSpecials(atom/location,datum/effect_system/effect,sound)
 	if(location)
 		if(effect)
-			addtimer(src, "do_effect", 0, FALSE, location, effect)
+			addtimer(src, "do_effect", 0, TIMER_NORMAL, location, effect)
 		if(sound)
-			addtimer(src, "do_sound", 0, FALSE, location, sound)
+			addtimer(src, "do_sound", 0, TIMER_NORMAL, location, sound)
 
 /datum/teleport/proc/do_effect(atom/location, datum/effect_system/effect)
 	src = null

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -471,7 +471,7 @@
 		D.adjustStaminaLoss(20)
 		D.Stun(5)
 		restraining = 1
-		addtimer(src, "drop_restraining", 50, TRUE)
+		addtimer(src, "drop_restraining", 50, TIMER_UNIQUE)
 	return 1
 
 /datum/martial_art/cqc/proc/Consecutive(mob/living/carbon/human/A, mob/living/carbon/human/D)

--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -237,7 +237,7 @@
 		owner.visible_message("<span class='danger'>[owner] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
 		owner.Paralyse(10)
 		owner.Jitter(1000)
-		addtimer(src, "jitter_less", 90, FALSE, owner)
+		addtimer(src, "jitter_less", 90, TIMER_NORMAL, owner)
 
 /datum/mutation/human/epilepsy/proc/jitter_less(mob/living/carbon/human/owner)
 	if(owner)

--- a/code/datums/wires/airalarm.dm
+++ b/code/datums/wires/airalarm.dm
@@ -31,13 +31,13 @@
 			if(!A.shorted)
 				A.shorted = TRUE
 				A.update_icon()
-			addtimer(A, "reset", 1200, FALSE, wire)
+			addtimer(A, "reset", 1200, TIMER_NORMAL, wire)
 		if(WIRE_IDSCAN) // Toggle lock.
 			A.locked = !A.locked
 		if(WIRE_AI) // Disable AI control for a while.
 			if(!A.aidisabled)
 				A.aidisabled = TRUE
-			addtimer(A, "reset", 100, FALSE, wire)
+			addtimer(A, "reset", 100, TIMER_NORMAL, wire)
 		if(WIRE_PANIC) // Toggle panic siphon.
 			if(!A.shorted)
 				if(A.mode == 1) // AALARM_MODE_SCRUB

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -29,14 +29,14 @@
 		if(WIRE_POWER1, WIRE_POWER2) // Short for a long while.
 			if(!A.shorted)
 				A.shorted = TRUE
-				addtimer(A, "reset", 1200, FALSE, wire)
+				addtimer(A, "reset", 1200, TIMER_NORMAL, wire)
 		if(WIRE_IDSCAN) // Unlock for a little while.
 			A.locked = FALSE
 			addtimer(A, "reset", 300, FALSE, wire)
 		if(WIRE_AI) // Disable AI control for a very short time.
 			if(!A.aidisabled)
 				A.aidisabled = TRUE
-				addtimer(A, "reset", 10, FALSE, wire)
+				addtimer(A, "reset", 10, TIMER_NORMAL, wire)
 
 /datum/wires/apc/on_cut(index, mend)
 	var/obj/machinery/power/apc/A = holder

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -27,13 +27,13 @@
 	switch(wire)
 		if(WIRE_HACK)
 			A.adjust_hacked(!A.hacked)
-			addtimer(A, "reset", 60, FALSE, wire)
+			addtimer(A, "reset", 60, TIMER_NORMAL, wire)
 		if(WIRE_SHOCK)
 			A.shocked = !A.shocked
-			addtimer(A, "reset", 60, FALSE, wire)
+			addtimer(A, "reset", 60, TIMER_NORMAL, wire)
 		if(WIRE_DISABLE)
 			A.disabled = !A.disabled
-			addtimer(A, "reset", 60, FALSE, wire)
+			addtimer(A, "reset", 60, TIMER_NORMAL, wire)
 
 /datum/wires/autolathe/on_cut(wire, mend)
 	var/obj/machinery/autolathe/A = holder

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -255,7 +255,7 @@ var/list/teleportlocs = list()
 	for (var/mob/living/silicon/SILICON in player_list)
 		if(SILICON.triggerAlarm("Burglar", src, cameras, trigger))
 			//Cancel silicon alert after 1 minute
-			addtimer(SILICON, "cancelAlarm", 600, FALSE,"Burglar",src,trigger)
+			addtimer(SILICON, "cancelAlarm", 600, TIMER_NORMAL,"Burglar",src,trigger)
 
 /area/proc/set_fire_alarm_effect()
 	fire = 1

--- a/code/game/gamemodes/changeling/powers/biodegrade.dm
+++ b/code/game/gamemodes/changeling/powers/biodegrade.dm
@@ -25,7 +25,7 @@
 			"<span class='warning'>We vomit acidic ooze onto our \
 			restraints!</span>")
 
-		addtimer(src, "dissolve_handcuffs", 30, FALSE, user, O)
+		addtimer(src, "dissolve_handcuffs", 30, TIMER_NORMAL, user, O)
 		used = TRUE
 
 	if(user.wear_suit && user.wear_suit.breakouttime && !used)
@@ -36,7 +36,7 @@
 			of acid across the front of \his [S]!</span>", \
 			"<span class='warning'>We vomit acidic ooze onto our straight \
 			jacket!</span>")
-		addtimer(src, "dissolve_straightjacket", 30, FALSE, user, S)
+		addtimer(src, "dissolve_straightjacket", 30, TIMER_NORMAL, user, S)
 		used = TRUE
 
 
@@ -48,7 +48,7 @@
 			begin to melt and run!</span>")
 		user << "<span class='warning'>We vomit acidic goop onto the \
 			interior of [C]!</span>"
-		addtimer(src, "open_closet", 70, FALSE, user, C)
+		addtimer(src, "open_closet", 70, TIMER_NORMAL, user, C)
 		used = TRUE
 
 	if(istype(user.loc, /obj/structure/spider/cocoon) && !used)
@@ -57,7 +57,7 @@
 			return 0
 		C.visible_message("<span class='warning'>[src] shifts and starts to fall apart!</span>")
 		user << "<span class='warning'>We secrete acidic enzymes from our skin and begin melting our cocoon...</span>"
-		addtimer(src, "dissolve_cocoon", 25, FALSE, user, C) //Very short because it's just webs
+		addtimer(src, "dissolve_cocoon", 25, TIMER_NORMAL, user, C) //Very short because it's just webs
 		used = TRUE
 
 	if(used)

--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -18,7 +18,7 @@
 	user.update_stat()
 	user.update_canmove()
 
-	addtimer(src, "ready_to_regenerate", LING_FAKEDEATH_TIME, FALSE, user)
+	addtimer(src, "ready_to_regenerate", LING_FAKEDEATH_TIME, TIMER_NORMAL, user)
 
 	feedback_add_details("changeling_powers","FD")
 	return 1

--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -36,7 +36,7 @@
 			by quick repeated use!</span>"
 
 	recent_uses++
-	addtimer(src, "fleshmend", 0, FALSE, user)
+	addtimer(src, "fleshmend", 0, TIMER_NORMAL, user)
 
 	feedback_add_details("changeling_powers","RR")
 	return 1

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -149,7 +149,7 @@
 	target.visible_message("<span class='warning'>A grotesque blade forms around [target.name]\'s arm!</span>", "<span class='userdanger'>Your arm twists and mutates, transforming into a horrific monstrosity!</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
 	playsound(target, 'sound/effects/blobattack.ogg', 30, 1)
 
-	addtimer(src, "remove_fake", 600, target, blade)
+	addtimer(src, "remove_fake", 600, FALSE, target, blade)
 
 	feedback_add_details("changeling_powers","AS")
 	return 1

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -149,7 +149,7 @@
 	target.visible_message("<span class='warning'>A grotesque blade forms around [target.name]\'s arm!</span>", "<span class='userdanger'>Your arm twists and mutates, transforming into a horrific monstrosity!</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
 	playsound(target, 'sound/effects/blobattack.ogg', 30, 1)
 
-	addtimer(src, "remove_fake", 600, FALSE, target, blade)
+	addtimer(src, "remove_fake", 600, TIMER_NORMAL, target, blade)
 
 	feedback_add_details("changeling_powers","AS")
 	return 1
@@ -224,7 +224,7 @@
 
 /obj/effect/proc_holder/changeling/sting/LSD/sting_action(mob/user, mob/living/carbon/target)
 	add_logs(user, target, "stung", "LSD sting")
-	addtimer(src, "hallucination_time", rand(300,600), target)
+	addtimer(src, "hallucination_time", rand(300,600), TIMER_NORMAL, target)
 	feedback_add_details("changeling_powers","HS")
 	return 1
 

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_overlay.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_overlay.dm
@@ -30,7 +30,7 @@
 /obj/effect/clockwork/overlay/wall/New()
 	..()
 	queue_smooth_neighbors(src)
-	addtimer(GLOBAL_PROC, "queue_smooth", 1, FALSE, src)
+	addtimer(GLOBAL_PROC, "queue_smooth", 1, TIMER_NORMAL, src)
 
 /obj/effect/clockwork/overlay/wall/Destroy()
 	queue_smooth_neighbors(src)

--- a/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
@@ -142,7 +142,7 @@
 	if(reinf)
 		prosel_cost -= REPLICANT_ROD
 	for(var/obj/structure/grille/G in get_turf(src))
-		addtimer(proselytizer, "proselytize", 0, FALSE, G, user)
+		addtimer(proselytizer, "proselytize", 0, TIMER_NORMAL, G, user)
 	return list("operation_time" = prosel_time, "new_obj_type" = windowtype, "alloy_cost" = prosel_cost, "spawn_dir" = dir, "dir_in_new" = new_dir)
 
 /obj/structure/window/reinforced/clockwork/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)

--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -47,7 +47,7 @@
 			clockwork_say(ranged_ability_user, text2ratvar("Be bound, heathen!"))
 			remove_mousepointer(ranged_ability_user.client)
 			ranged_ability_user.notransform = TRUE
-			addtimer(src, "reset_user_notransform", 5, FALSE, ranged_ability_user) //stop us moving for a little bit so we don't break the scripture following this
+			addtimer(src, "reset_user_notransform", 5, TIMER_NORMAL, ranged_ability_user) //stop us moving for a little bit so we don't break the scripture following this
 			slab.busy = null
 			var/datum/clockwork_scripture/geis/conversion = new
 			conversion.slab = slab

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_armor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_armor.dm
@@ -31,7 +31,7 @@
 			user.emote("scream")
 			user.apply_damage(30, BRUTE, "head")
 			user.adjustBrainLoss(30)
-		addtimer(user, "unEquip", 1, FALSE, src, 1) //equipped happens before putting stuff on(but not before picking items up). thus, we need to wait for it to be on before forcing it off.
+		addtimer(user, "unEquip", 1, TIMER_NORMAL, src, 1) //equipped happens before putting stuff on(but not before picking items up). thus, we need to wait for it to be on before forcing it off.
 
 /obj/item/clothing/head/helmet/clockwork/mob_can_equip(mob/M, mob/equipper, slot, disable_warning = 0)
 	if(equipper && !is_servant_of_ratvar(equipper))
@@ -78,7 +78,7 @@
 			user.apply_damage(15, BURN, "chest")
 			user.adjust_fire_stacks(2)
 			user.IgniteMob()
-		addtimer(user, "unEquip", 1, FALSE, src, 1)
+		addtimer(user, "unEquip", 1, TIMER_NORMAL, src, 1)
 
 /obj/item/clothing/gloves/clockwork
 	name = "clockwork gauntlets"
@@ -123,7 +123,7 @@
 			user.emote("scream")
 			user.apply_damage(7, BRUTE, "l_arm")
 			user.apply_damage(7, BRUTE, "r_arm")
-		addtimer(user, "unEquip", 1, FALSE, src, 1)
+		addtimer(user, "unEquip", 1, TIMER_NORMAL, src, 1)
 
 /obj/item/clothing/shoes/clockwork
 	name = "clockwork treads"
@@ -163,4 +163,4 @@
 			user.emote("scream")
 			user.apply_damage(7, BURN, "l_leg")
 			user.apply_damage(7, BURN, "r_leg")
-		addtimer(user, "unEquip", 1, FALSE, src, 1)
+		addtimer(user, "unEquip", 1, TIMER_NORMAL, src, 1)

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
@@ -92,7 +92,7 @@
 
 /obj/item/clockwork/slab/dropped(mob/user)
 	. = ..()
-	addtimer(src, "check_on_mob", 1, FALSE, user) //dropped is called before the item is out of the slot, so we need to check slightly later
+	addtimer(src, "check_on_mob", 1, TIMER_NORMAL, user) //dropped is called before the item is out of the slot, so we need to check slightly later
 
 /obj/item/clockwork/slab/proc/check_on_mob(mob/user)
 	if(user && !(src in user.held_items) && slab_ability && slab_ability.ranged_ability_user) //if we happen to check and we AREN'T in user's hands, remove whatever ability we have
@@ -424,7 +424,7 @@
 
 	if(href_list["Recite"])
 		href_list["Recite"] = text2path(href_list["Recite"])
-		addtimer(src, "recite_scripture", 0, FALSE, href_list["Recite"], usr, FALSE)
+		addtimer(src, "recite_scripture", 0, TIMER_NORMAL, href_list["Recite"], usr, FALSE)
 		return
 
 	if(href_list["Quickbindone"])

--- a/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
@@ -52,7 +52,7 @@
 
 /obj/item/clothing/glasses/judicial_visor/dropped(mob/user)
 	. = ..()
-	addtimer(src, "check_on_mob", 1, FALSE, user) //dropped is called before the item is out of the slot, so we need to check slightly later
+	addtimer(src, "check_on_mob", 1, TIMER_NORMAL, user) //dropped is called before the item is out of the slot, so we need to check slightly later
 
 /obj/item/clothing/glasses/judicial_visor/proc/check_on_mob(mob/user)
 	if(user && src != user.get_item_by_slot(slot_glasses)) //if we happen to check and we AREN'T in the slot, we need to remove our shit from whoever we got dropped from
@@ -131,7 +131,7 @@
 				continue
 			V.recharging = TRUE //To prevent exploiting multiple visors to bypass the cooldown
 			V.update_status()
-			addtimer(V, "recharge_visor", (ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown) * 2, FALSE, ranged_ability_user)
+			addtimer(V, "recharge_visor", (ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown) * 2, TIMER_NORMAL, ranged_ability_user)
 		clockwork_say(ranged_ability_user, text2ratvar("Kneel, heathens!"))
 		ranged_ability_user.visible_message("<span class='warning'>[ranged_ability_user]'s judicial visor fires a stream of energy at [target], creating a strange mark!</span>", "<span class='heavy_brass'>You direct [visor]'s power to [target]. You must wait for some time before doing this again.</span>")
 		var/turf/targetturf = get_turf(target)
@@ -139,7 +139,7 @@
 		add_logs(ranged_ability_user, targetturf, "created a judicial marker")
 		ranged_ability_user.update_action_buttons_icon()
 		ranged_ability_user.update_inv_glasses()
-		addtimer(visor, "recharge_visor", ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown, FALSE, ranged_ability_user)//Cooldown is reduced by 10x if Ratvar is up
+		addtimer(visor, "recharge_visor", ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown, TIMER_NORMAL, ranged_ability_user)//Cooldown is reduced by 10x if Ratvar is up
 		remove_ranged_ability()
 
 		return TRUE
@@ -161,12 +161,12 @@
 	user = caster
 	playsound(src, 'sound/magic/MAGIC_MISSILE.ogg', 50, 1, 1, 1)
 	flick("judicial_marker", src)
-	addtimer(src, "burstanim", 16, FALSE)
+	addtimer(src, "burstanim", 16, TIMER_NORMAL)
 
 /obj/effect/clockwork/judicial_marker/proc/burstanim()
 	layer = ABOVE_ALL_MOB_LAYER
 	flick("judicial_explosion", src)
-	addtimer(src, "judicialblast", 13, FALSE)
+	addtimer(src, "judicialblast", 13, TIMER_NORMAL)
 
 /obj/effect/clockwork/judicial_marker/proc/judicialblast()
 	var/targetsjudged = 0

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
@@ -214,10 +214,10 @@
 	if(!ratvar_awakens)
 		R.clockwork_desc = "A powerful spear of Ratvarian making. It's more effective against enemy cultists and silicons, though it won't last for long."
 		owner << "<span class='warning'>Your spear begins to break down in this plane of existence. You can't use it for long!</span>"
-		addtimer(R, "break_spear", base_cooldown, FALSE)
+		addtimer(R, "break_spear", base_cooldown, TIMER_NORMAL)
 	cooldown = base_cooldown + world.time
 	owner.update_action_buttons_icon()
-	addtimer(src, "update_actions", base_cooldown, FALSE)
+	addtimer(src, "update_actions", base_cooldown, TIMER_NORMAL)
 	return TRUE
 
 /datum/action/innate/function_call/proc/update_actions()

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -194,7 +194,7 @@
 					sleep(3)
 					new/obj/structure/destructible/clockwork/massive/ratvar(startpoint)
 				else
-					addtimer(SSshuttle.emergency, "request", 0, FALSE, null, 0) //call the shuttle immediately
+					addtimer(SSshuttle.emergency, "request", 0, TIMER_NORMAL, null, 0) //call the shuttle immediately
 					sleep(3)
 					send_to_playing_players("<span class='ratvar'>\"[text2ratvar("Behold")]!\"</span>\n<span class='inathneq_large'>\"[text2ratvar("See Engine's mercy")]!\"</span>\n\
 					<span class='sevtug_large'>\"[text2ratvar("Observe Engine's design skills")]!\"</span>\n<span class='nezbere_large'>\"[text2ratvar("Behold Engine's light")]!!\"</span>\n\

--- a/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
@@ -24,7 +24,7 @@
 	var/image/alert_overlay = image('icons/effects/clockwork_effects.dmi', "ratvar_alert")
 	var/area/A = get_area(src)
 	notify_ghosts("The Justiciar's light calls to you! Reach out to Ratvar in [A.name] to be granted a shell to spread his glory!", null, source = src, alert_overlay = alert_overlay)
-	addtimer(SSshuttle.emergency, "request", 50, FALSE, null, 0.1)
+	addtimer(SSshuttle.emergency, "request", 50, TIMER_NORMAL, null, 0.1)
 
 /obj/structure/destructible/clockwork/massive/ratvar/Destroy()
 	ratvar_awakens--

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -179,7 +179,7 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 
 	G.add_gang_hud(gangster_mind)
 	if(jobban_isbanned(gangster_mind.current, ROLE_GANG))
-		addtimer(src, "replace_jobbaned_player", 0, FALSE, gangster_mind.current, ROLE_GANG, ROLE_GANG)
+		addtimer(src, "replace_jobbaned_player", 0, TIMER_NORMAL, gangster_mind.current, ROLE_GANG, ROLE_GANG)
 	return 2
 ////////////////////////////////////////////////////////////////////
 //Deals with players reverting to neutral (Not a gangster anymore)//

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -162,7 +162,7 @@
 	for(var/obj/machinery/door/D in airlocks)
 		if(D.z != ZLEVEL_STATION)
 			continue
-		addtimer(D, "hostile_lockdown", 0, FALSE, src)
+		addtimer(D, "hostile_lockdown", 0, TIMER_NORMAL, src)
 		addtimer(D, "disable_lockdown", 900)
 
 	var/obj/machinery/computer/communications/C = locate() in machines
@@ -172,7 +172,7 @@
 	verbs -= /mob/living/silicon/ai/proc/lockdown
 	minor_announce("Hostile runtime detected in door controllers. Isolation Lockdown protocols are now in effect. Please remain calm.","Network Alert:", 1)
 	src << "<span class = 'warning'>Lockdown Initiated. Network reset in 90 seconds.</span>"
-	addtimer(GLOBAL_PROC, "minor_announce", 900, FALSE,
+	addtimer(GLOBAL_PROC, "minor_announce", 900, TIMER_NORMAL,
 		"Automatic system reboot complete. Have a secure day.",
 		"Network reset:")
 

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -41,7 +41,7 @@
 	B.victim << "<span class='danger'>You feel the captive mind of [src] begin to resist your control.</span>"
 
 	var/delay = rand(150,250) + B.victim.brainloss
-	addtimer(src, "return_control", delay, FALSE, src.loc)
+	addtimer(src, "return_control", delay, TIMER_NORMAL, src.loc)
 
 /mob/living/captive_brain/proc/return_control(mob/living/simple_animal/borer/B)
     if(!B || !B.controlling)
@@ -272,7 +272,7 @@ var/total_borer_hosts_needed = 10
 					else
 						src << "<span class='warning'>You start shaking off your lethargy as the sugar leaves your host's blood. This will take about 10 seconds...</span>"
 
-					waketimerid = addtimer(src,"wakeup",10,FALSE)
+					waketimerid = addtimer(src,"wakeup",10,TIMER_NORMAL)
 			if(controlling)
 
 				if(docile)
@@ -514,7 +514,7 @@ var/total_borer_hosts_needed = 10
 
 	leaving = TRUE
 
-	addtimer(src, "release_host", 100, FALSE)
+	addtimer(src, "release_host", 100, TIMER_NORMAL)
 
 /mob/living/simple_animal/borer/proc/release_host()
 	if(!victim || !src || qdeleted(victim) || qdeleted(src))
@@ -638,7 +638,7 @@ var/total_borer_hosts_needed = 10
 	bonding = TRUE
 
 	var/delay = 200+(victim.brainloss*5)
-	addtimer(src, "assume_control", delay, FALSE)
+	addtimer(src, "assume_control", delay, TIMER_NORMAL)
 
 /mob/living/simple_animal/borer/proc/assume_control()
 	if(!victim || !src || controlling || victim.stat == DEAD)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -186,7 +186,7 @@
 		adjustBruteLoss(25) //hella effective
 		inhibited = 1
 		update_action_buttons_icon()
-		addtimer(src, "reset_inhibit", 30, FALSE)
+		addtimer(src, "reset_inhibit", 30, TIMER_NORMAL)
 
 /mob/living/simple_animal/revenant/proc/reset_inhibit()
 	if(src)
@@ -331,7 +331,7 @@
 
 /obj/item/weapon/ectoplasm/revenant/New()
 	..()
-	addtimer(src, "try_reform", 600, FALSE)
+	addtimer(src, "try_reform", 600, TIMER_NORMAL)
 
 /obj/item/weapon/ectoplasm/revenant/proc/try_reform()
 	if(src)

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -202,7 +202,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/overload/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(src, "overload", 0, FALSE, T, user)
+			addtimer(src, "overload", 0, TIMER_NORMAL, T, user)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/overload/proc/overload(turf/T, mob/user)
 	for(var/obj/machinery/light/L in T)
@@ -242,7 +242,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(src, "defile", 0, FALSE, T)
+			addtimer(src, "defile", 0, TIMER_NORMAL, T)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile/proc/defile(turf/T)
 	if(T.flags & NOJAUNT)
@@ -289,7 +289,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(src, "malfunction", 0, FALSE, T, user)
+			addtimer(src, "malfunction", 0, TIMER_NORMAL, T, user)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction/proc/malfunction(turf/T, mob/user)
 	for(var/mob/living/simple_animal/bot/bot in T)
@@ -333,7 +333,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/blight/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(src, "blight", 0, FALSE, T, user)
+			addtimer(src, "blight", 0, TIMER_NORMAL, T, user)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/blight/proc/blight(turf/T, mob/user)
 	for(var/mob/living/mob in T)

--- a/code/game/gamemodes/miniantags/revenant/revenant_blight.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_blight.dm
@@ -62,6 +62,6 @@
 					affected_mob.dna.species.handle_hair(affected_mob,"#1d2953")
 				affected_mob.visible_message("<span class='warning'>[affected_mob] looks terrifyingly gaunt...</span>", "<span class='revennotice'>You suddenly feel like your skin is <i>wrong</i>...</span>")
 				affected_mob.add_atom_colour("#1d2953", TEMPORARY_COLOUR_PRIORITY)
-				addtimer(src, "cure", 100, FALSE)
+				addtimer(src, "cure", 100, TIMER_NORMAL)
 		else
 			return

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -76,7 +76,7 @@
 	scan_for_target()
 	point_to_target()
 	my_god_jc_a_bomb()
-	addtimer(src, "refresh_target", 50, TRUE)
+	addtimer(src, "refresh_target", 50, TIMER_UNIQUE)
 
 /obj/item/weapon/pinpointer/proc/scan_for_target() //Looks for whatever it's tracking
 	if(target)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -275,7 +275,7 @@
 	rev_mind.special_role = "Revolutionary"
 	update_rev_icons_added(rev_mind)
 	if(jobban_isbanned(rev_mind.current, ROLE_REV))
-		addtimer(src, "replace_jobbaned_player", 0, FALSE, rev_mind.current, ROLE_REV, ROLE_REV)
+		addtimer(src, "replace_jobbaned_player", 0, TIMER_NORMAL, rev_mind.current, ROLE_REV, ROLE_REV)
 	return 1
 //////////////////////////////////////////////////////////////////////////////
 //Deals with players being converted from the revolution (Not a rev anymore)//  // Modified to handle borged MMIs.  Accepts another var if the target is being borged at the time  -- Polymorph.

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -134,7 +134,7 @@
 		if(!G)
 			return FALSE
 	if(clonemind.damnation_type) //Can't clone the damned.
-		addtimer(0, "horrifyingsound", src)
+		addtimer(src, "horrifyingsound", 0)
 		mess = 1
 		icon_state = "pod_g"
 		update_icon()

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -114,7 +114,7 @@
 			user.clear_fullscreen("flash", 5)
 		watchers[user] = C
 		use_power(50)
-		addtimer(src, "use_camera_console", 5, FALSE, user)
+		addtimer(src, "use_camera_console", 5, TIMER_NORMAL, user)
 	else
 		user.unset_machine()
 

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -260,7 +260,7 @@ var/global/datum/crewmonitor/crewmonitor = new
 		return ..()
 
 /datum/crewmonitor/proc/queueUpdate(z)
-	addtimer(crewmonitor, "update", 5, TRUE, z)
+	addtimer(crewmonitor, "update", 5, TIMER_UNIQUE, z)
 
 /datum/crewmonitor/proc/sendResources(var/client/client)
 	send_asset(client, "crewmonitor.js")

--- a/code/game/machinery/computer/gulag_teleporter.dm
+++ b/code/game/machinery/computer/gulag_teleporter.dm
@@ -124,7 +124,7 @@
 		if("teleport")
 			if(!teleporter || !beacon)
 				return
-			addtimer(src, "teleport", 5, FALSE, usr)
+			addtimer(src, "teleport", 5, TIMER_NORMAL, usr)
 
 /obj/machinery/computer/gulag_teleporter_computer/proc/scan_machinery()
 	teleporter = findteleporter()

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -29,9 +29,9 @@
 /obj/machinery/door/poddoor/shuttledock/proc/check()
 	var/turf/T = get_step(src, checkdir)
 	if(!isspaceturf(T))
-		addtimer(src, "open", 0, TRUE)
+		addtimer(src, "open", 0, TIMER_UNIQUE)
 	else
-		addtimer(src, "close", 0, TRUE)
+		addtimer(src, "close", 0, TIMER_UNIQUE)
 
 /obj/machinery/door/poddoor/Bumped(atom/AM)
 	if(density)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -93,7 +93,7 @@
 	playsound(src.loc, 'sound/ambience/signal.ogg', 75, 0)
 
 /obj/machinery/firealarm/proc/alarm_in(time)
-	addtimer(src, "alarm", time, FALSE)
+	addtimer(src, "alarm", time, TIMER_NORMAL)
 
 /obj/machinery/firealarm/proc/reset()
 	if(!is_operational())
@@ -102,7 +102,7 @@
 	A.firereset(src)
 
 /obj/machinery/firealarm/proc/reset_in(time)
-	addtimer(src, "reset", time, FALSE)
+	addtimer(src, "reset", time, TIMER_NORMAL)
 
 /obj/machinery/firealarm/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, \
 									datum/tgui/master_ui = null, datum/ui_state/state = default_state)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -217,7 +217,7 @@
 				occupant.adjustFireLoss(rand(10, 16))
 			if(iscarbon(occupant))
 				occupant.emote("scream")
-		addtimer(src, "cook", 50, FALSE)
+		addtimer(src, "cook", 50, TIMER_NORMAL)
 	else
 		uv_cycles = initial(uv_cycles)
 		uv = FALSE
@@ -263,7 +263,7 @@
 	add_fingerprint(user)
 	if(locked)
 		visible_message("<span class='notice'>You see [user] kicking against the doors of [src]!</span>", "<span class='notice'>You start kicking against the doors...</span>")
-		addtimer(src, "resist_open", 300, FALSE, user)
+		addtimer(src, "resist_open", 300, TIMER_NORMAL, user)
 	else
 		open_machine()
 		dump_contents()

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -103,7 +103,7 @@
 
  	// So he can't jump out the gate right away.
 	R.SetLockdown()
-	addtimer(src, "unlock_new_robot", 50, FALSE, R)
+	addtimer(src, "unlock_new_robot", 50, TIMER_NORMAL, R)
 
 /obj/machinery/transformer/proc/unlock_new_robot(mob/living/silicon/robot/R)
 	playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -87,7 +87,7 @@
 /obj/item/mecha_parts/mecha_equipment/proc/start_cooldown()
 	set_ready_state(0)
 	chassis.use_power(energy_drain)
-	addtimer(src, "set_ready_state", equip_cooldown, FALSE, 1)
+	addtimer(src, "set_ready_state", equip_cooldown, TIMER_NORMAL, 1)
 
 /obj/item/mecha_parts/mecha_equipment/proc/do_after_cooldown(atom/target)
 	if(!chassis)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -68,7 +68,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/start_cooldown()
 	set_ready_state(0)
 	chassis.use_power(energy_drain*get_shot_amount())
-	addtimer(src, "set_ready_state", equip_cooldown, FALSE, 1)
+	addtimer(src, "set_ready_state", equip_cooldown, TIMER_NORMAL, 1)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	equip_cooldown = 8


### PR DESCRIPTION
Fixes #21023

Basically the refactor is for preventing/locating bad arg calls on addtimer which happen way too often
Found 2 just while doing this

:cl: Cyberboss
fix: False armblades are now removed after one minute. Start feeling the P A R A N O I A when you see em
/:cl:

