### PR TITLE
[READY] AI hologram can move seamlessly between holopads

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1253,7 +1253,7 @@ B --><-- A
 		if(!istype(A, type))
 			continue
 		var/distance = get_dist(source, A)
-		if(!closest_distance)
+		if(!closest_atom)
 			closest_distance = distance
 			closest_atom = A
 		else

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -235,10 +235,9 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/holopad/proc/move_hologram(mob/living/silicon/ai/user)
 	if(masters[user])
-		step_to(masters[user], user.eyeobj) // So it turns.
 		var/obj/effect/overlay/holo_pad_hologram/H = masters[user]
 		H.loc = get_turf(user.eyeobj)
-		masters[user] = H
+		H.setDir(user.eyeobj.dir)
 	return 1
 
 /obj/effect/overlay/holo_pad_hologram/Process_Spacemove(movement_dir = 0)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -159,8 +159,6 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 						if(get_dist(master.eyeobj, src) <= holo_range)
 							return 1
 						else
-							var/turf/T = master.eyeobj.loc
-
 							var/obj/machinery/holopad/pad_close = get_closest_atom(/obj/machinery/holopad, holopads, master.eyeobj)
 							world << "[pad_close] [get_dist(pad_close, master.eyeobj)]"
 							if(get_dist(pad_close, master.eyeobj) <= holo_range)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -160,7 +160,6 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 							return 1
 						else
 							var/obj/machinery/holopad/pad_close = get_closest_atom(/obj/machinery/holopad, holopads, master.eyeobj)
-							world << "[pad_close] [get_dist(pad_close, master.eyeobj)]"
 							if(get_dist(pad_close, master.eyeobj) <= holo_range)
 								var/obj/effect/overlay/holo_pad_hologram/h = masters[master]
 								unset_holo(master)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -31,7 +31,7 @@ Possible to do for anyone motivated enough:
 
 var/const/HOLOPAD_MODE = RANGE_BASED
 
-/var/list/holopads = list()
+var/list/holopads = list()
 
 /obj/machinery/holopad
 	name = "\improper AI holopad"
@@ -232,9 +232,9 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/holopad/proc/move_hologram(mob/living/silicon/ai/user)
 	if(masters[user])
+		step_to(masters[user], user.eyeobj)
 		var/obj/effect/overlay/holo_pad_hologram/H = masters[user]
 		H.loc = get_turf(user.eyeobj)
-		H.setDir(user.eyeobj.dir)
 	return 1
 
 /obj/effect/overlay/holo_pad_hologram/Process_Spacemove(movement_dir = 0)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -157,14 +157,14 @@ var/list/holopads = list()
 				if(!(stat & NOPOWER))//If the  machine has power.
 					if(HOLOPAD_MODE == RANGE_BASED)
 						if(get_dist(master.eyeobj, src) <= holo_range)
-							return 1
+							return TRUE
 						else
 							var/obj/machinery/holopad/pad_close = get_closest_atom(/obj/machinery/holopad, holopads, master.eyeobj)
 							if(get_dist(pad_close, master.eyeobj) <= holo_range)
 								var/obj/effect/overlay/holo_pad_hologram/h = masters[master]
 								unset_holo(master)
 								pad_close.set_holo(master, h)
-								return 1
+								return TRUE
 
 					else if (HOLOPAD_MODE == AREA_BASED)
 
@@ -172,10 +172,10 @@ var/list/holopads = list()
 						var/area/eye_area = get_area(master.eyeobj)
 
 						if(eye_area in holo_area.master.related)
-							return 1
+							return TRUE
 
 			clear_holo(master)//If not, we want to get rid of the hologram.
-	return 1
+	return TRUE
 
 /obj/machinery/holopad/proc/activate_holo(mob/living/silicon/ai/user)
 	if(!(stat & NOPOWER) && user.eyeobj.loc == src.loc)//If the projector has power and client eye is on it
@@ -204,7 +204,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	h.name = "[A.name] (Hologram)"//If someone decides to right click.
 	h.SetLuminosity(2)	//hologram lighting
 	set_holo(A, h)
-	return 1
+	return TRUE
 
 /obj/machinery/holopad/proc/set_holo(mob/living/silicon/ai/A, var/obj/effect/overlay/holo_pad_hologram/h)
 	masters[A] = h
@@ -212,12 +212,12 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	icon_state = "holopad1"
 	A.current = src
 	use_power += HOLOGRAM_POWER_USAGE
-	return 1
+	return TRUE
 
 /obj/machinery/holopad/proc/clear_holo(mob/living/silicon/ai/user)
 	qdel(masters[user]) // Get rid of user's hologram
 	unset_holo(user)
-	return 1
+	return TRUE
 
 /obj/machinery/holopad/proc/unset_holo(mob/living/silicon/ai/user)
 	if(user.current == src)
@@ -228,14 +228,14 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		SetLuminosity(0) // pad lighting (hologram lighting will be handled automatically since its owner was deleted)
 		icon_state = "holopad0"
 		use_power = HOLOPAD_PASSIVE_POWER_USAGE
-	return 1
+	return TRUE
 
 /obj/machinery/holopad/proc/move_hologram(mob/living/silicon/ai/user)
 	if(masters[user])
 		step_to(masters[user], user.eyeobj)
 		var/obj/effect/overlay/holo_pad_hologram/H = masters[user]
 		H.loc = get_turf(user.eyeobj)
-	return 1
+	return TRUE
 
 /obj/effect/overlay/holo_pad_hologram/Process_Spacemove(movement_dir = 0)
 	return 1


### PR DESCRIPTION
:cl: Mervill
add: AI hologram can move seamlessly between holopads
/:cl:

If the AI hologram moves out of range of it's holopad, search all holopads and check if any _are_ in range. If  there is a holopad in range, "transfer" the hologram from one pad to another. If no closer holopad exists, cancel hologram as normal

The one blocker at the moment is that after the _new_ hologram is moved to the position of the old one, the rotation of the new hologram is incorrect.