### PR TITLE
[I am dead therefore I must go to github and make bugfixes to not die again.]I am a sore loser

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -551,7 +551,7 @@
 			if(bumpsmash && occupant) //Need a pilot to push the PUNCH button.
 				if(nextsmash < world.time)
 					obstacle.mech_melee_attack(src)
-					if(!obstacle || (obstacle && !obstacle.density))
+					if(!obstacle || !obstacle.density))
 						step(src,dir)
 					nextsmash = world.time + smashcooldown
 			if(isobj(obstacle))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -551,7 +551,7 @@
 			if(bumpsmash && occupant) //Need a pilot to push the PUNCH button.
 				if(nextsmash < world.time)
 					obstacle.mech_melee_attack(src)
-					if(!obstacle || !obstacle.density))
+					if(!obstacle || !obstacle.density)
 						step(src,dir)
 					nextsmash = world.time + smashcooldown
 			if(isobj(obstacle))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -551,7 +551,7 @@
 					obstacle.mech_melee_attack(src)
 					if(!obstacle || (obstacle && !obstacle.density))
 						step(src,dir)
-					nextsmash = world.time + melee_cooldown
+					nextsmash = world.time + (melee_cooldown/1.5)
 			if(isobj(obstacle))
 				var/obj/O = obstacle
 				if(!O.anchored)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -111,6 +111,8 @@
 	var/phase_state = "" //icon_state when phasing
 	var/strafe = FALSE //If we are strafing
 
+	var/nextsmash = 0
+
 	var/occupant_sight_flags = 0 //sight flags to give to the occupant (e.g. mech mining scanner gives meson-like vision)
 
 	hud_possible = list (DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD)
@@ -545,9 +547,11 @@
 			if(..()) //mech was thrown
 				return
 			if(bumpsmash && occupant) //Need a pilot to push the PUNCH button.
-				obstacle.mech_melee_attack(src)
-				if(!obstacle || (obstacle && !obstacle.density))
-					step(src,dir)
+				if(nextsmash < world.time)
+					obstacle.mech_melee_attack(src)
+					if(!obstacle || (obstacle && !obstacle.density))
+						step(src,dir)
+					nextsmash = world.time + melee_cooldown
 			if(isobj(obstacle))
 				var/obj/O = obstacle
 				if(!O.anchored)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -29,6 +29,7 @@
 	var/step_in = 10 //make a step in step_in/10 sec.
 	var/dir_in = 2//What direction will the mech face when entered/powered on? Defaults to South.
 	var/step_energy_drain = 10
+	var/melee_energy_drain = 15
 	obj_integrity = 300 //obj_integrity is health
 	max_integrity = 300
 	var/deflect_chance = 10 //chance to deflect the incoming projectiles, hits, or lesser the effect of ex_act.
@@ -112,6 +113,7 @@
 	var/strafe = FALSE //If we are strafing
 
 	var/nextsmash = 0
+	var/smashcooldown = 3	//deciseconds
 
 	var/occupant_sight_flags = 0 //sight flags to give to the occupant (e.g. mech mining scanner gives meson-like vision)
 
@@ -551,7 +553,7 @@
 					obstacle.mech_melee_attack(src)
 					if(!obstacle || (obstacle && !obstacle.density))
 						step(src,dir)
-					nextsmash = world.time + (melee_cooldown/1.5)
+					nextsmash = world.time + smashcooldown
 			if(isobj(obstacle))
 				var/obj/O = obstacle
 				if(!O.anchored)

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -282,6 +282,9 @@
 
 
 /obj/mecha/mech_melee_attack(obj/mecha/M)
+	if(!has_charge(melee_energy_drain))
+		return 0
+	use_power(melee_energy_drain)
 	if(M.damtype == BRUTE || M.damtype == BURN)
 		add_logs(M.occupant, src, "attacked", M, "(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 		. = ..()


### PR DESCRIPTION
Fixes mech smashing on bump ignoring melee cooldown, as well as not requiring power.
All shitposting/jokes aside, without the fix mechs can smash walls down way faster than they can normally run aka if you use a mech to smash shit down you'll travel faster then your normal overload runspeed and not use power. Rediculous >:[

Actually, this may be a nerf, but I don't know of any other ways to fix the problem of mechs being instantly deadly to anything that can't be stunned if they're charging as they'll do enough damage to kill another combat mech in a fraction of a second, and destroy walls/stuff near instantly. @GunHog suggestions please.