### PR TITLE
Hulks now take longer to break clockwork windows and doors

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -449,6 +449,9 @@
 		animate(src, color = previouscolor, time = 8)
 		addtimer(src, "update_atom_colour", 8)
 
+/obj/machinery/door/airlock/clockwork/hulk_damage()
+	return 50
+
 /obj/machinery/door/airlock/clockwork/attackby(obj/item/I, mob/living/user, params)
 	if(!attempt_construction(I, user))
 		return ..()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -326,6 +326,9 @@
 	change_construction_value(-2)
 	return ..()
 
+/obj/machinery/door/window/clockwork/hulk_damage()
+	return 30
+
 /obj/machinery/door/window/clockwork/ratvar_act()
 	obj_integrity = max_integrity
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -475,6 +475,9 @@
 	change_construction_value(fulltile ? -2 : -1)
 	return ..()
 
+/obj/structure/window/reinforced/clockwork/hulk_damage()
+	return 60
+
 /obj/structure/window/reinforced/clockwork/ratvar_act()
 	obj_integrity = max_integrity
 	update_icon()


### PR DESCRIPTION
:cl: Joan
tweak: Hulks now take longer to break clockwork windows and doors.
/:cl:

5 hits for directional brass windows, 7 for full-tile brass windows, 7 for brass windoors, and 8 for pinion airlocks.