### PR TITLE
Plasmaman random name adjustments

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -109,7 +109,7 @@
 
 /proc/random_unique_plasmaman_name(attempts_to_find_unique_name=10)
 	for(var/i=1, i<=attempts_to_find_unique_name, i++)
-		. = capitalize(plasmaman_name()) + " " + "\Roman[rand(1,99)]"
+		. = capitalize(plasmaman_name())
 
 		if(i != attempts_to_find_unique_name && !findname(.))
 			break

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -5,7 +5,7 @@
 		return "[pick(lizard_names_female)]-[pick(lizard_names_female)]"
 
 /proc/plasmaman_name()
-	return "[pick(plasmaman_names)]"
+	return "[pick(plasmaman_names)] \Roman[rand(1,99)]"
 
 var/church_name = null
 /proc/church_name()

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -802,7 +802,7 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 		return 0
 	return ..()
 
-/datum/species/plasmaman/random_name(unique,lastname)
+/datum/species/plasmaman/random_name(gender,unique,lastname)
 	if(unique)
 		return random_unique_plasmaman_name()
 


### PR DESCRIPTION
A space and roman numeral are added in the proc _plasmaman_name_ instead of _random_unique_plasmaman_name_.

_random_name_ proc for plasmaman characters gets a gender parameter; as the game calls _random_name_ with 3 parameters it needs to be like the other _random_name_ procs.

I've seen plasmaman players have names, likely randomized, that don't have a space between their first and last names (e.g. _IronX_). I don't know if these tweaks will fix this.