### PR TITLE
Syndicate bomb cost 11 -> 8

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -935,7 +935,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
 			be defused, and some crew may attempt to do so."
 	item = /obj/item/device/sbeacondrop/bomb
-	cost = 11
+	cost = 8
 
 /datum/uplink_item/device_tools/syndicate_detonator
 	name = "Syndicate Detonator"


### PR DESCRIPTION
Ever since durability came into the picture using a large explosion to smash and grab things has become a lot less useful. In this new world the bomb is mostly used for denial rather than theft, so this price change reflects that loss of utility.

Don't think this opens up any "killer combos" as the only real combo with the syndicate bomb is C4/minibomb, which was already well possible and rarely performed.

:cl:
tweak: the cost of syndicate bombs has dropped to 8, from 11. This is mostly due to changes with durability that rendered <b>large explosions</b> less useful for smash and grab jobs.
/:cl:

