### PR TITLE
[READY]Fixes movement speeds

### DIFF
--- a/code/modules/clothing/spacesuits/flightsuit.dm
+++ b/code/modules/clothing/spacesuits/flightsuit.dm
@@ -425,7 +425,7 @@
 	wearer.adjustBruteLoss(userdamage)
 	usermessage("WARNING: Stabilizers taking damage!", 2)
 	wearer.visible_message(crashmessagesrc)
-	crash_damage = Clamp(crash_damage + 3, 0, crash_disable_threshold*1.5)
+	crash_damage = Clamp(crash_damage + crash_damage_high, 0, crash_disable_threshold*1.5)
 
 /obj/item/device/flightpack/proc/userknockback(density, anchored, speed, dir)
 	var/angle = dir2angle(dir)

--- a/code/modules/clothing/spacesuits/flightsuit.dm
+++ b/code/modules/clothing/spacesuits/flightsuit.dm
@@ -329,10 +329,6 @@
 	if(!flight)
 		suit.slowdown = slowdown_ground
 		return
-	if(brake)
-		suit.slowdown = slowdown_brake
-	else if(boost)
-		suit.slowdown = -boost_speed
 	else
 		suit.slowdown = slowdown_air
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -1,7 +1,8 @@
 /mob/living/carbon/human/movement_delay()
-	. += dna.species.movement_delay(src)
+	. = 0
 	. += ..()
 	. += config.human_delay
+	. += dna.species.movement_delay(src)
 
 /mob/living/carbon/human/slip(s_amount, w_amount, obj/O, lube)
 	if(isobj(shoes) && (shoes.flags&NOSLIP) && !(lube&GALOSHES_DONT_HELP))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -915,7 +915,7 @@
 				. += (health_deficiency / 25)
 		if((hungry >= 70) && !flight)		//Being hungry won't stop you from using flightpack controls/flapping your wings although it probably will in the wing case but who cares.
 			. += hungry / 50
-			if((H.disabilities & FAT))
+		if(H.disabilities & FAT)
 			. += (1.5 - flight)
 		if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
 			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -866,15 +866,11 @@
 	. = 0	//We start at 0.
 	var/flight = 0	//Check for flight and flying items
 	var/flightpack = 0
-	var/slowcarry = 1
-	var/ignoreslow = 0
 	var/obj/item/device/flightpack/F = H.get_flightpack()
 	if(istype(F) && F.flight)
 		flightpack = 1
 	if(H.movement_type & FLYING)
 		flight = 1
-	if(H.status_flags & IGNORESLOWDOWN)
-		ignoreslow = 1
 
 	if(!flightpack)	//Check for chemicals and innate speedups and slowdowns if we're moving using our body and not a flying suit
 		if(H.status_flags & GOTTAGOFAST)
@@ -900,7 +896,7 @@
 	else if(flightpack && F.brake)
 		. += 2
 
-	if(!ignoreslow && !flightpack)
+	if(!(H.status_flags & IGNORESLOWDOWN) && !flightpack)
 		if(H.wear_suit)
 			. += H.wear_suit.slowdown
 		if(H.shoes)
@@ -911,12 +907,12 @@
 			if(I.flags & HANDSLOW)
 				. += I.slowdown
 		var/health_deficiency = (100 - H.health + H.staminaloss)
+		var/hungry = (500 - H.nutrition) / 5 // So overeat would be 100 and default level would be 80
 		if(health_deficiency >= 40)
 			if(flight)
 				. += (health_deficiency / 75)
 			else
 				. += (health_deficiency / 25)
-			var/hungry = (500 - H.nutrition) / 5 // So overeat would be 100 and default level would be 80
 		if((hungry >= 70) && !flight)		//Being hungry won't stop you from using flightpack controls/flapping your wings although it probably will in the wing case but who cares.
 			. += hungry / 50
 			if((H.disabilities & FAT))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -884,7 +884,7 @@
 	if(H.status_flags & IGNORESLOWDOWN)
 		ignoreslow = 1
 	
-	if(H.has_gravity()
+	if(H.has_gravity())
 		gravity = 1
 
 	if(!gravity)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -866,6 +866,8 @@
 	. = 0	//We start at 0.
 	var/flight = 0	//Check for flight and flying items
 	var/flightpack = 0
+	var/ignoreslow = 0
+	var/gravity = 0
 	var/obj/item/device/flightpack/F = H.get_flightpack()
 	if(istype(F) && F.flight)
 		flightpack = 1
@@ -878,8 +880,14 @@
 		if(H.status_flags & GOTTAGOREALLYFAST)
 			. -= 2
 		. += speedmod
+	
+	if(H.status_flags & IGNORESLOWDOWN)
+		ignoreslow = 1
+	
+	if(H.has_gravity()
+		gravity = 1
 
-	if(!H.has_gravity())
+	if(!gravity)
 		var/obj/item/weapon/tank/jetpack/J = H.back
 		var/obj/item/clothing/suit/space/hardsuit/C = H.wear_suit
 		var/obj/item/organ/cyberimp/chest/thrusters/T = H.getorganslot("thrusters")
@@ -891,12 +899,13 @@
 			. -= 2
 		else if(flightpack && F.allow_thrust(0.01, src))
 			. -= 1
+
 	if(flightpack && F.boost)
 		. -= F.boost_speed
 	else if(flightpack && F.brake)
 		. += 2
 
-	if(!(H.status_flags & IGNORESLOWDOWN) && !flightpack)
+	if(!ignoreslow && !flightpack && gravity)
 		if(H.wear_suit)
 			. += H.wear_suit.slowdown
 		if(H.shoes)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -863,42 +863,44 @@
 ////////////////
 
 /datum/species/proc/movement_delay(mob/living/carbon/human/H)
-	. = 0
-	var/obj/item/device/flightpack/F = H.get_flightpack()
+	. = 0	//We start at 0.
+	var/flight = 0	//Check for flight and flying items
 	var/flightpack = 0
+	var/slowcarry = 1
+	var/ignoreslow = 0
+	var/obj/item/device/flightpack/F = H.get_flightpack()
 	if(istype(F) && F.flight)
 		flightpack = 1
-	var/flight = 0
 	if(H.movement_type & FLYING)
 		flight = 1
+	if(H.status_flags & IGNORESLOWDOWN)
+		ignoreslow = 1
 
-	if(!flightpack)
+	if(!flightpack)	//Check for chemicals and innate speedups and slowdowns if we're moving using our body and not a flying suit
 		if(H.status_flags & GOTTAGOFAST)
 			. -= 1
 		if(H.status_flags & GOTTAGOREALLYFAST)
 			. -= 2
+		. += speedmod
 
-	if(!(H.status_flags & IGNORESLOWDOWN))
-		if(!H.has_gravity())
-			if((H.movement_type & FLYING) && !flightpack)	//No hyperstacking angel wings!
-				. += speedmod
-				return
-			// If there's no gravity we have the sanic speed of jetpack.
-			var/obj/item/weapon/tank/jetpack/J = H.back
-			var/obj/item/clothing/suit/space/hardsuit/C = H.wear_suit
-			if(!istype(J) && istype(C))
-				J = C.jetpack
+	if(!H.has_gravity())
+		var/obj/item/weapon/tank/jetpack/J = H.back
+		var/obj/item/clothing/suit/space/hardsuit/C = H.wear_suit
+		var/obj/item/organ/cyberimp/chest/thrusters/T = H.getorganslot("thrusters")
+		if(!istype(J) && istype(C))
+			J = C.jetpack
+		if(istype(J) && J.allow_thrust(0.01, H))	//Prevents stacking
+			. -= 2
+		else if(istype(T) && T.allow_thrust(0.01, H))
+			. -= 2
+		else if(flightpack && F.allow_thrust(0.01, src))
+			. -= 1
+	if(flightpack && F.boost)
+		. -= F.boost_speed
+	else if(flightpack && F.brake)
+		. += 2
 
-			if(istype(J) && J.allow_thrust(0.01, H))
-				. -= 2
-			else
-				var/obj/item/organ/cyberimp/chest/thrusters/T = H.getorganslot("thrusters")
-				if(istype(T) && T.allow_thrust(0.01, H))
-					. -= 2
-
-				else if(flightpack && F.allow_thrust(0.01, src))	//No jetpack/flightsuit hyperstacking!
-					. -= 1
-
+	if(!ignoreslow && !flightpack)
 		if(H.wear_suit)
 			. += H.wear_suit.slowdown
 		if(H.shoes)
@@ -908,24 +910,20 @@
 		for(var/obj/item/I in H.held_items)
 			if(I.flags & HANDSLOW)
 				. += I.slowdown
-		if(!(flightpack))
-			var/health_deficiency = (100 - H.health + H.staminaloss)
-			if(health_deficiency >= 40)
-				if(flight)
-					. += (health_deficiency / 75)
-				else
-					. += (health_deficiency / 25)
-
+		var/health_deficiency = (100 - H.health + H.staminaloss)
+		if(health_deficiency >= 40)
+			if(flight)
+				. += (health_deficiency / 75)
+			else
+				. += (health_deficiency / 25)
 			var/hungry = (500 - H.nutrition) / 5 // So overeat would be 100 and default level would be 80
-			if((hungry >= 70) && !flight)		//Being hungry won't stop you from using flightpack controls/flapping your wings although it probably will in the wing case but who cares.
-				. += hungry / 50
-
+		if((hungry >= 70) && !flight)		//Being hungry won't stop you from using flightpack controls/flapping your wings although it probably will in the wing case but who cares.
+			. += hungry / 50
 			if((H.disabilities & FAT))
-				. += (1.5 - flight)
-			if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
-				. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
-
- 			. += speedmod
+			. += (1.5 - flight)
+		if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
+			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
+	return .
 
 //////////////////
 // ATTACK PROCS //

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -443,7 +443,7 @@
 	if(isopenturf(loc) && !is_flying())
 		var/turf/open/T = loc
 		. += T.slowdown
-	if(!ignorewalk)
+	if(ignorewalk)
 		. += config.run_speed
 	else
 		switch(m_intent)


### PR DESCRIPTION
:cl: Mekhi
bugfix: Walking now slows again
bugfix: Flightpacks no longer crash harder than they were intended to
bugfix: Species and other slowdowns work again
experimental: Movement speed calculation for humans have been moved around a bit, but should work as intended.
rscadd: Notable changes: Anything that prevents slowdowns will no longer prevent species speedups and slowdowns.
\:cl:
Ignoreslowdown no longer impacts species speedmods. Makes no sense that angels slow down and golems speed up after getting morphine.
P.S. See I'm a good coder I actually fix game-breaking bugs that I made. :^(