### PR TITLE
Limited range abductor telepathy

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -749,7 +749,7 @@
 	mutant_organs = list(/obj/item/organ/tongue/abductor)
 	var/scientist = 0 // vars to not pollute spieces list with castes
 	var/agent = 0
-	var/team = 1
+	var/team = 0 // ayys are default "teamless" turning on their telepathy
 
 var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_state"="plasmaman")
 


### PR DESCRIPTION
:cl: coiax
del: Abductors that are not part of a research team no longer have a
common telepathic channel.
add: Abductors that are not part of a research team now broadcast their
speech to anyone they can see, which bypasses sound and language
barriers.
/:cl:

Teamless abductors now "talk" to anyone they can see. There should be no
change to abductor squads, who have their rangeless telepathy as before
and are still silent.