### PR TITLE
Removes safety checks from firelocks

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -20,6 +20,7 @@
 	glass = 1
 	var/nextstate = null
 	sub_door = 1
+	safe = FALSE
 	closingLayer = CLOSED_FIREDOOR_LAYER
 	assemblytype = /obj/structure/firelock_frame
 	armor = list(melee = 30, bullet = 30, laser = 20, energy = 20, bomb = 10, bio = 100, rad = 100, fire = 95, acid = 70)


### PR DESCRIPTION
:cl: Cyberboss
del: Due to budget cuts. Firelocks no longer have safety features
/:cl: