### PR TITLE
Fixes roundstart airlocks not properly generating airlock electronics access list

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1490,7 +1490,8 @@ var/list/airlock_overlays = list()
 			var/obj/item/weapon/electronics/airlock/ae
 			if(!electronics)
 				ae = new/obj/item/weapon/electronics/airlock( src.loc )
-				if(req_one_access)
+				gen_access()
+				if(req_one_access.len)
 					ae.one_access = 1
 					ae.accesses = src.req_one_access
 				else

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -134,7 +134,8 @@
 /obj/item/proc/GetID()
 	return null
 
-/obj/proc/check_access(obj/item/I)
+//Call this before using req_access or req_one_access directly
+/obj/proc/gen_access()
 	//These generations have been moved out of /obj/New() because they were slowing down the creation of objects that never even used the access system.
 	if(!src.req_access)
 		src.req_access = list()
@@ -153,6 +154,9 @@
 				var/n = text2num(x)
 				if(n)
 					req_one_access += n
+
+/obj/proc/check_access(obj/item/I)
+	gen_access()
 
 	if(!istype(src.req_access, /list)) //something's very wrong
 		return 1


### PR DESCRIPTION
Fixes #21789

:cl: Cyberboss
fix: Roundstart airlock electronics now properly generate the correct accesses
/:cl:

