### PR TITLE
Lizards are now restricted to janitorial positions.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -64,6 +64,11 @@
 	if(H)
 		H.endTailWag()
 
+/datum/species/lizard/qualifies_for_rank(rank, list/features)
+	if(rank == "Janitor")
+		return TRUE
+	return FALSE
+
 /*
  Lizard subspecies: ASHWALKERS
 */


### PR DESCRIPTION
Lizards started as janitors, then they were given more rights. Now they are taking those rights for granted, so it's time to put them back in their place.

:cl:
fix: After a recent diplomatic incident, Nanotrasen has restricted lizardsmen to janitorial positions again.
/:cl:

