### PR TITLE
[WIP]Mutant bodypart config refactoring and blacklists

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -128,6 +128,7 @@
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
 	var/list/roundstart_races = list()	//races you can play as from the get go. If left undefined the game's roundstart var for species is used
 	var/mutant_humans = 0				//players can pick mutant bodyparts for humans before joining the game
+	var/list/br_parts = list()			//what mutant part types are allowed to be chosen.
 
 	var/no_summon_guns		//No
 	var/no_summon_magic		//Fun
@@ -620,6 +621,9 @@
 							roundstart_species[species_id] = species_list[species_id]
 				if("join_with_mutant_humans")
 					config.mutant_humans			= 1
+				if("blacklist_mutant_parts")
+					var/part_id = lowertext(value)
+					br_parts += part_id
 				if("assistant_cap")
 					config.assistant_cap			= text2num(value)
 				if("starlight")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -250,7 +250,7 @@ var/list/preferences_datums = list()
 
 					dat += "</td>"
 
-				if("tail_lizard" in pref_species.mutant_bodyparts)
+				if("tail_lizard" in pref_species.mutant_bodyparts && tails_list_lizard.len)
 					dat += "<td valign='top' width='7%'>"
 
 					dat += "<h3>Tail</h3>"
@@ -259,7 +259,7 @@ var/list/preferences_datums = list()
 
 					dat += "</td>"
 
-				if("snout" in pref_species.mutant_bodyparts)
+				if("snout" in pref_species.mutant_bodyparts && snouts_list.len)
 					dat += "<td valign='top' width='7%'>"
 
 					dat += "<h3>Snout</h3>"
@@ -268,7 +268,7 @@ var/list/preferences_datums = list()
 
 					dat += "</td>"
 
-				if("horns" in pref_species.mutant_bodyparts)
+				if("horns" in pref_species.mutant_bodyparts && horns_list > 1)
 					dat += "<td valign='top' width='7%'>"
 
 					dat += "<h3>Horns</h3>"
@@ -277,7 +277,7 @@ var/list/preferences_datums = list()
 
 					dat += "</td>"
 
-				if("frills" in pref_species.mutant_bodyparts)
+				if("frills" in pref_species.mutant_bodyparts && frills_list.len > 1)
 					dat += "<td valign='top' width='7%'>"
 
 					dat += "<h3>Frills</h3>"
@@ -286,7 +286,7 @@ var/list/preferences_datums = list()
 
 					dat += "</td>"
 
-				if("spines" in pref_species.mutant_bodyparts)
+				if("spines" in pref_species.mutant_bodyparts && spines_list.len > 1)
 					dat += "<td valign='top' width='7%'>"
 
 					dat += "<h3>Spines</h3>"
@@ -295,7 +295,7 @@ var/list/preferences_datums = list()
 
 					dat += "</td>"
 
-				if("body_markings" in pref_species.mutant_bodyparts)
+				if("body_markings" in pref_species.mutant_bodyparts && body_markings_list.len > 1)
 					dat += "<td valign='top' width='7%'>"
 
 					dat += "<h3>Body Markings</h3>"
@@ -303,7 +303,7 @@ var/list/preferences_datums = list()
 					dat += "<a href='?_src_=prefs;preference=body_markings;task=input'>[features["body_markings"]]</a><BR>"
 
 					dat += "</td>"
-				if("legs" in pref_species.mutant_bodyparts)
+				if("legs" in pref_species.mutant_bodyparts && legs_list.len > 1)
 					dat += "<td valign='top' width='7%'>"
 
 					dat += "<h3>Legs</h3>"
@@ -313,7 +313,7 @@ var/list/preferences_datums = list()
 					dat += "</td>"
 			if(config.mutant_humans)
 
-				if("tail_human" in pref_species.mutant_bodyparts)
+				if("tail_human" in pref_species.mutant_bodyparts && tails_list_human.len > 1)
 					dat += "<td valign='top' width='7%'>"
 
 					dat += "<h3>Tail</h3>"
@@ -322,7 +322,7 @@ var/list/preferences_datums = list()
 
 					dat += "</td>"
 
-				if("ears" in pref_species.mutant_bodyparts)
+				if("ears" in pref_species.mutant_bodyparts && ears_list.len > 1)
 					dat += "<td valign='top' width='7%'>"
 
 					dat += "<h3>Ears</h3>"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -294,9 +294,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(!config.mutant_humans)
 		features["tail_human"] = "none"
 		features["ears"] = "none"
+		features["wings"] = "none"
 	else
 		S["feature_human_tail"]				>> features["tail_human"]
 		S["feature_human_ears"]				>> features["ears"]
+		S["feature_human_wings"]			>> features["wings"]
 	S["clown_name"]			>> custom_names["clown"]
 	S["mime_name"]			>> custom_names["mime"]
 	S["ai_name"]			>> custom_names["ai"]
@@ -350,6 +352,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	features["mcolor"]	= sanitize_hexcolor(features["mcolor"], 3, 0)
 	features["tail_lizard"]	= sanitize_inlist(features["tail_lizard"], tails_list_lizard)
 	features["tail_human"] 	= sanitize_inlist(features["tail_human"], tails_list_human, "None")
+	features["wings"] 	= sanitize_inlist(features["wings"], wings_list, "None")
 	features["snout"]	= sanitize_inlist(features["snout"], snouts_list)
 	features["horns"] 	= sanitize_inlist(features["horns"], horns_list)
 	features["ears"]	= sanitize_inlist(features["ears"], ears_list, "None")
@@ -402,6 +405,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["feature_mcolor"]					<< features["mcolor"]
 	S["feature_lizard_tail"]			<< features["tail_lizard"]
 	S["feature_human_tail"]				<< features["tail_human"]
+	S["feature_human_wings"]			<< features["wings"]
 	S["feature_lizard_snout"]			<< features["snout"]
 	S["feature_lizard_horns"]			<< features["horns"]
 	S["feature_human_ears"]				<< features["ears"]

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -1294,7 +1294,6 @@
 	dimension_x = 46
 	center = TRUE
 	dimension_y = 34
-	locked = TRUE
 
 /datum/sprite_accessory/frills
 	icon = 'icons/mob/mutant_bodyparts.dmi'

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -27,8 +27,12 @@
 	for(var/path in typesof(prototype))
 		if(path == prototype)
 			continue
+
+		var/datum/sprite_accessory/P = path
+		if(config && (lowertext(initial(P.name)) in config.br_parts))
+			continue
+
 		if(roundstart)
-			var/datum/sprite_accessory/P = path
 			if(initial(P.locked))
 				continue
 		var/datum/sprite_accessory/D = new path()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -338,6 +338,10 @@ ROUNDSTART_RACES plasmaman
 ## Uncomment to give players the choice of joining as a human with mutant bodyparts before they join the game
 #JOIN_WITH_MUTANT_HUMANS
 
+## List of any mutant parts you want to blacklist. Place their name after BLACKLIST_MUTANT_PARTS
+## BLACKLIST_MUTANT_PARTS
+
+
 ## Assistant slot cap. Set to -1 for unlimited.
 ASSISTANT_CAP -1
 


### PR DESCRIPTION
Changing how mutant bodyparts are handled so people with remote can manually disable certain ones if they want.
Mostly done, just need to rework the naming so it's unique.
Also fixes some oversights with wing pref handling.