### PR TITLE
Fixes Syndicate Medical Cyborg Penetration

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -90,7 +90,7 @@ Borg Hypospray
 		return
 	if(!istype(M))
 		return
-	if(R.total_volume && M.can_inject(user, 1, bypass_protection))
+	if(R.total_volume && M.can_inject(user, 1, user.zone_selected,bypass_protection))
 		M << "<span class='warning'>You feel a tiny prick!</span>"
 		user << "<span class='notice'>You inject [M] with the injector.</span>"
 		var/fraction = min(amount_per_transfer_from_this/R.total_volume, 1)


### PR DESCRIPTION
:cl: Gun Hog
fix: Syndicate Medical Cyborg hyposprays now properly work through Operative hardsuits and other thick clothing.
/:cl:

Syndieborg hyposprays now properly penetrate thick clothing.