### PR TITLE
Fixes plasmamen spawning with no name

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -1156,6 +1156,12 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 	if(unique)
 		return random_unique_plasmaman_name()
 
+	var/randname = plasmaman_name()
+
+	if(lastname)
+		randname += " [lastname]"
+
+	return randname
 
 /datum/species/synth
 	name = "Synth" //inherited from the real species, for health scanners and things


### PR DESCRIPTION
This PR restores some lines of code that tgstation/tgstation/pull/21708 accidentally deleted. 
The deletion has resulted in plasmaman characters with [Always Random Name: Yes] to spawn with no name! This PR will fix this bug.
In the meantime, on all your plasmaman characters, set [Always Random Name] to No. You can use the [Random Name] button as usual.