### PR TITLE
Fixes a negative sqrt

### DIFF
--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -43,12 +43,12 @@ Bonus
 	return
 
 /datum/symptom/choking/proc/Choke_stage_3_4(mob/living/M, datum/disease/advance/A)
-	var/get_damage = sqrt(21+A.totalStageSpeed()*0.5)+sqrt(16+A.totalStealth())
+	var/get_damage = sqrt(21+A.totalStageSpeed()*0.5)+sqrt(max(16+A.totalStealth(),0))
 	M.adjustOxyLoss(get_damage)
 	return 1
 
 /datum/symptom/choking/proc/Choke(mob/living/M, datum/disease/advance/A)
-	var/get_damage = sqrt(21+A.totalStageSpeed()*0.5)+sqrt(16+A.totalStealth()*5)
+	var/get_damage = sqrt(21+A.totalStageSpeed()*0.5)+sqrt(max(16+A.totalStealth()*5,0))
 	M.adjustOxyLoss(get_damage)
 	return 1
 


### PR DESCRIPTION
The following runtime has occurred 4 time(s).
runtime error: illegal: sqrt(-14.000000)
proc name: Choke (/datum/symptom/choking/proc/Choke)
  source file: choking.dm,51
  usr: null
  src: Choking (/datum/symptom/choking)