### PR TITLE
[DNM] Adds a null check for APC recharger

### DIFF
--- a/code/modules/modular_computers/hardware/recharger.dm
+++ b/code/modules/modular_computers/hardware/recharger.dm
@@ -31,7 +31,7 @@
 	origin_tech = "programming=2;engineering=2;powerstorage=3"
 
 /obj/item/weapon/computer_hardware/recharger/APC/use_power(amount, charging=0)
-	if(istype(holder.physical, /obj/machinery))
+	if(holder && istype(holder.physical, /obj/machinery))
 		var/obj/machinery/M = holder.physical
 		if(M.powered())
 			M.use_power(amount)


### PR DESCRIPTION
The following runtime has occurred 118 time(s).
runtime error: Cannot read null.physical
proc name: use power (/obj/item/weapon/computer_hardware/recharger/APC/use_power)
  source file: recharger.dm,34
  usr: Allen Guess (/mob/living/carbon/human)
  src: the area power connector (/obj/item/weapon/computer_hardware/recharger/APC)