### PR TITLE
The Ark's mass proselytization now converts all silicons after finishing

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -213,6 +213,13 @@
 							dist = FALSE
 						T.ratvar_act(dist)
 						CHECK_TICK
+					for(var/mob/living/silicon/robot/R in silicon_mobs)
+						if(R && R.stat != DEAD && !is_servant_of_ratvar(R))
+							add_servant_of_ratvar(R)
+					for(var/i in ai_list)
+						var/mob/living/silicon/ai/A = i
+						if(A && A.stat != DEAD && !is_servant_of_ratvar(A))
+							add_servant_of_ratvar(A)
 					for(var/I in all_clockwork_mobs)
 						var/mob/M = I
 						if(M.stat == CONSCIOUS)


### PR DESCRIPTION
:cl: Joan
rscadd: The Ark of the Clockwork Justicar now converts all silicons once it finishes proselytizing the station.
/:cl:

>Win condition
>Fail because one silicon was off-station

SHITTY DESIGN