### PR TITLE
Syndicate Base Fixes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -70,108 +70,114 @@
 "br" = (/obj/structure/reagent_dispensers/virusfood{pixel_y = 32},/obj/structure/table/reinforced,/obj/item/device/healthanalyzer,/obj/item/stack/sheet/mineral/plasma{amount = 5; layer = 3.1},/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
 "bs" = (/obj/structure/extinguisher_cabinet{pixel_x = 0; pixel_y = 32},/obj/machinery/computer/pandemic,/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
 "bt" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/box/beakers{pixel_x = 3; pixel_y = 3},/obj/item/weapon/storage/box/syringes,/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"bu" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/obj/item/weapon/reagent_containers/blood/random,/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"bv" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/obj/item/weapon/reagent_containers/blood/APlus,/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"bw" = (/obj/structure/filingcabinet/filingcabinet,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"bx" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plating,/area/ruin/powered/syndicate_lava_base)
-"by" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/mob/living/carbon/monkey,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bz" = (/obj/structure/window/reinforced,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bA" = (/obj/machinery/door/window/brigdoor,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bB" = (/obj/machinery/chem_heater,/obj/structure/extinguisher_cabinet{pixel_x = -26},/turf/open/floor/plasteel/podhatch{dir = 10},/area/ruin/powered/syndicate_lava_base)
-"bC" = (/obj/structure/chair/office/dark{dir = 1},/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"bD" = (/obj/structure/closet/crate/bin,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"bE" = (/turf/open/floor/plasteel/vault,/area/ruin/powered/syndicate_lava_base)
-"bF" = (/obj/item/device/assembly/igniter,/obj/item/device/assembly/igniter,/obj/item/device/assembly/igniter,/obj/item/device/assembly/timer{pixel_x = 3; pixel_y = 3},/obj/item/device/assembly/timer{pixel_x = 3; pixel_y = 3},/obj/item/device/assembly/timer{pixel_x = 3; pixel_y = 3},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bG" = (/obj/structure/table/reinforced,/obj/item/weapon/folder/white,/obj/item/weapon/pen/red,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"bH" = (/obj/structure/chair/office/dark{dir = 8},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bI" = (/obj/structure/table/reinforced,/obj/item/weapon/gun/ballistic/automatic/c20r/toy{pixel_x = 3; pixel_y = 3},/obj/item/weapon/gun/ballistic/automatic/c20r/toy,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bJ" = (/obj/item/weapon/twohanded/required/kirbyplants{icon_state = "plant-21"; layer = 4.1},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bK" = (/obj/structure/table/reinforced,/obj/item/clothing/gloves/color/latex,/obj/item/clothing/gloves/color/latex,/obj/item/clothing/suit/toggle/labcoat,/obj/item/clothing/suit/toggle/labcoat,/obj/item/clothing/glasses/science,/obj/item/clothing/glasses/science,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bL" = (/obj/machinery/smartfridge/chemistry/virology,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"bM" = (/obj/machinery/door/airlock/hatch{name = "Monkey Pen"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bN" = (/mob/living/carbon/monkey,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bO" = (/obj/machinery/iv_drip,/obj/item/weapon/reagent_containers/blood/random,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bP" = (/obj/structure/closet/crate/bin,/turf/open/floor/plasteel/podhatch{dir = 9},/area/ruin/powered/syndicate_lava_base)
-"bQ" = (/obj/structure/chair/office/dark,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"bR" = (/obj/machinery/chem_heater,/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bS" = (/obj/structure/table/reinforced,/obj/item/weapon/reagent_containers/glass/beaker/large,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"bT" = (/obj/structure/chair/office/dark,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bU" = (/obj/structure/table/reinforced,/obj/item/weapon/folder,/obj/item/clothing/ears/earmuffs,/obj/item/clothing/ears/earmuffs,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bV" = (/obj/structure/table/reinforced,/obj/item/weapon/gun/ballistic/automatic/toy/pistol{pixel_x = 3; pixel_y = 3},/obj/item/weapon/gun/ballistic/automatic/toy/pistol,/obj/item/weapon/suppressor/specialoffer,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bW" = (/obj/machinery/chem_master,/turf/open/floor/plasteel/podhatch{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bX" = (/obj/structure/table/reinforced,/obj/item/weapon/reagent_containers/glass/beaker/large,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"bY" = (/obj/machinery/chem_dispenser,/obj/structure/extinguisher_cabinet{pixel_x = 26},/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"bZ" = (/obj/structure/table/reinforced,/obj/item/clothing/suit/bio_suit/general,/obj/item/clothing/mask/surgical,/obj/item/clothing/head/bio_hood/general,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"ca" = (/obj/machinery/shower{dir = 4; icon_state = "shower"; name = "emergency shower"},/obj/machinery/shower{dir = 8; icon_state = "shower"; name = "emergency shower"},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cb" = (/obj/structure/table/reinforced,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"cc" = (/obj/structure/table/reinforced,/obj/item/weapon/folder/white,/obj/item/stack/sheet/mineral/gold{amount = 10},/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"cd" = (/obj/structure/table/reinforced,/obj/item/weapon/book/manual/wiki/infections,/obj/structure/sign/nosmoking_2{pixel_y = -32},/obj/item/stack/sheet/mineral/silver{amount = 10},/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"ce" = (/obj/structure/filingcabinet/chestdrawer,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"cf" = (/obj/structure/sign/securearea,/turf/closed/wall/mineral/plastitanium,/area/ruin/powered/syndicate_lava_base)
-"cg" = (/obj/machinery/door/airlock/hatch{name = "Firing Range"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"ch" = (/obj/machinery/door/airlock/hatch{name = "Chemistry Lab"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"ci" = (/obj/structure/sign/chemistry,/turf/closed/wall/mineral/plastitanium,/area/ruin/powered/syndicate_lava_base)
-"cj" = (/obj/machinery/syndicatebomb/badmin/varplosion{can_unanchor = 0; name = "self destruct device"},/turf/open/floor/plasteel/podhatch{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"ck" = (/obj/structure/sign/biohazard,/turf/closed/wall/mineral/plastitanium,/area/ruin/powered/syndicate_lava_base)
-"cl" = (/obj/machinery/door/airlock/hatch{name = "Virology Lab"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cm" = (/obj/structure/rack,/obj/item/ammo_box/foambox{pixel_x = -3; pixel_y = 3},/obj/item/ammo_box/foambox,/obj/item/ammo_box/foambox{pixel_x = 3; pixel_y = -3},/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cn" = (/obj/item/weapon/twohanded/required/kirbyplants{icon_state = "plant-22"},/turf/open/floor/plasteel/podhatch{dir = 9},/area/ruin/powered/syndicate_lava_base)
-"co" = (/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"cp" = (/turf/open/floor/plasteel/podhatch/corner{tag = "icon-podhatchcorner (EAST)"; icon_state = "podhatchcorner"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"cq" = (/turf/open/floor/plasteel/podhatch/corner{tag = "icon-podhatchcorner (WEST)"; icon_state = "podhatchcorner"; dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cr" = (/obj/item/weapon/twohanded/required/kirbyplants{icon_state = "plant-21"; layer = 4.1},/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cs" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/obj/structure/sign/bluecross_2,/turf/open/floor/plating,/area/ruin/powered/syndicate_lava_base)
-"ct" = (/obj/structure/table,/obj/item/weapon/storage/firstaid/regular{pixel_x = 3; pixel_y = 3},/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/regular{pixel_x = -3; pixel_y = -3},/turf/open/floor/plasteel/vault,/area/ruin/powered/syndicate_lava_base)
-"cu" = (/obj/machinery/sleeper/syndie{dir = 8},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cv" = (/obj/structure/closet/crate/secure,/obj/item/target,/obj/item/target,/obj/item/target/alien,/obj/item/target/alien,/obj/item/target/clown,/obj/item/target/clown,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"cw" = (/turf/open/floor/plasteel/podhatch{dir = 10},/area/ruin/powered/syndicate_lava_base)
-"cx" = (/obj/machinery/syndicatebomb/badmin/varplosion{can_unanchor = 0; name = "self destruct device"},/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"cy" = (/obj/structure/extinguisher_cabinet{pixel_y = -32},/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"cz" = (/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"cA" = (/turf/open/floor/plasteel/podhatch/corner{tag = "icon-podhatchcorner (NORTH)"; icon_state = "podhatchcorner"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"cB" = (/turf/open/floor/plasteel/podhatch/corner,/area/ruin/powered/syndicate_lava_base)
-"cC" = (/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"cD" = (/obj/machinery/door/airlock/hatch{name = "Infirmary"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cE" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/obj/item/weapon/reagent_containers/blood/random,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cF" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/obj/machinery/door/poddoor/preopen{id = "lavalandsyndi"; name = "Syndicate Research Experimentor Shutters"},/turf/open/floor/plating,/area/ruin/powered/syndicate_lava_base)
-"cG" = (/obj/machinery/door/airlock/hatch{name = "Experimentation Room"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cH" = (/obj/machinery/door/airlock/hatch{name = "Telecommunications Control"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cI" = (/turf/open/floor/engine,/area/ruin/powered/syndicate_lava_base)
-"cJ" = (/obj/structure/noticeboard{pixel_y = 32},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cK" = (/obj/structure/table,/obj/item/weapon/storage/toolbox/syndicate,/obj/item/device/multitool,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cL" = (/obj/item/weapon/surgicaldrill,/obj/item/weapon/circular_saw,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cM" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/obj/structure/mirror{pixel_x = 30},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cN" = (/obj/item/stack/cable_coil/white{pixel_x = 3; pixel_y = 3},/obj/structure/table/reinforced,/obj/item/weapon/storage/toolbox/syndicate,/obj/item/stack/cable_coil/white,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cO" = (/obj/structure/table/reinforced,/obj/item/device/flashlight/lamp,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cP" = (/obj/structure/table/reinforced,/obj/item/device/radio/intercom{broadcasting = 0; dir = 8; freerange = 1; listening = 1; name = "Pirate Radio Listening Channel"; pixel_x = 0},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cQ" = (/obj/machinery/computer/camera_advanced,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cR" = (/obj/structure/filingcabinet/chestdrawer,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cS" = (/obj/item/weapon/cautery,/obj/item/weapon/scalpel,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cT" = (/obj/structure/table/optable,/obj/item/weapon/surgical_drapes,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cU" = (/obj/item/weapon/retractor,/obj/item/weapon/hemostat,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cV" = (/obj/structure/sign/nosmoking_2{pixel_x = 32},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cW" = (/obj/item/weapon/twohanded/required/kirbyplants{icon_state = "plant-22"},/obj/structure/extinguisher_cabinet{pixel_x = -26},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cX" = (/obj/structure/table/reinforced,/obj/item/device/radio/intercom{broadcasting = 1; dir = 8; freerange = 1; listening = 0; name = "Pirate Radio Broadcast Channel"; pixel_x = 0},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cY" = (/obj/structure/sign/fire{pixel_x = -32},/turf/open/floor/engine,/area/ruin/powered/syndicate_lava_base)
-"cZ" = (/obj/structure/table/reinforced,/obj/item/device/assembly/signaler,/obj/item/device/assembly/signaler,/obj/item/device/assembly/voice,/obj/item/device/assembly/voice,/obj/item/weapon/screwdriver/nuke,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"da" = (/obj/structure/table/reinforced,/obj/item/stack/sheet/plasteel{amount = 15},/obj/item/device/electropack,/obj/item/device/taperecorder,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"db" = (/obj/structure/filingcabinet/security,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"dc" = (/obj/structure/table/reinforced,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dd" = (/obj/machinery/computer/message_monitor,/obj/item/weapon/paper/monitorkey,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"de" = (/turf/open/floor/plasteel/vault{tag = "icon-vault (NORTHEAST)"; dir = 5},/area/ruin/powered/syndicate_lava_base)
-"df" = (/obj/effect/baseturf_helper,/turf/open/floor/plasteel/vault{tag = "icon-vault (NORTHEAST)"; dir = 5},/area/ruin/powered/syndicate_lava_base)
-"dg" = (/obj/machinery/button/door{id = "lavalandsyndi"; name = "Syndicate Experimentor Lockdown Control"; pixel_x = 26; req_access_txt = "150"},/turf/open/floor/engine,/area/ruin/powered/syndicate_lava_base)
-"dh" = (/obj/machinery/button/door{id = "lavalandsyndi"; name = "Syndicate Experimentor Lockdown Control"; pixel_x = -26; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"di" = (/obj/item/stack/sheet/mineral/plastitanium{amount = 30},/obj/item/stack/rods{amount = 50},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dj" = (/obj/structure/filingcabinet/medical,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"dk" = (/turf/open/floor/plasteel/circuit/gcircuit,/area/ruin/powered/syndicate_lava_base)
-"dl" = (/obj/machinery/door/poddoor/preopen{id = "lavalandsyndi"; name = "Syndicate Research Experimentor Shutters"},/obj/machinery/door/airlock/hatch{name = "Experimentation Room"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dm" = (/obj/item/stack/sheet/metal{amount = 50},/obj/item/weapon/grenade/chem_grenade,/obj/item/weapon/grenade/chem_grenade,/obj/item/weapon/grenade/chem_grenade,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dn" = (/obj/machinery/telecomms/relay/preset/ruskie{use_power = 0},/turf/open/floor/plasteel/vault{tag = "icon-vault (NORTHEAST)"; dir = 5},/area/ruin/powered/syndicate_lava_base)
-"do" = (/obj/machinery/door/airlock/hatch{name = "Syndicate Recon Outpost"; req_access_txt = "150"},/obj/structure/fans/tiny,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dp" = (/obj/structure/sign/vacuum{pixel_x = -32},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dq" = (/obj/structure/sign/xeno_warning_mining{pixel_x = 32},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dr" = (/obj/structure/sign/securearea{pixel_y = 32},/turf/open/floor/plating/lava/smooth/lava_land_surface,/area/lavaland/surface/outdoors)
+"bu" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/obj/item/weapon/reagent_containers/blood/random,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
+"bv" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plating,/area/ruin/powered/syndicate_lava_base)
+"bw" = (/mob/living/carbon/monkey,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"bx" = (/obj/structure/bed/roller,/turf/open/floor/plasteel/vault{dir = 8},/area/space)
+"by" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"bz" = (/obj/structure/bed/roller,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"bA" = (/mob/living/carbon/monkey,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"bB" = (/obj/structure/window/reinforced,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"bC" = (/obj/machinery/door/window/brigdoor,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"bD" = (/obj/machinery/chem_heater,/obj/structure/extinguisher_cabinet{pixel_x = -26},/turf/open/floor/plasteel/podhatch{dir = 10},/area/ruin/powered/syndicate_lava_base)
+"bE" = (/obj/structure/chair/office/dark{dir = 1},/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
+"bF" = (/obj/structure/closet/crate/bin,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
+"bG" = (/turf/open/floor/plasteel/vault,/area/ruin/powered/syndicate_lava_base)
+"bH" = (/obj/item/device/assembly/igniter,/obj/item/device/assembly/igniter,/obj/item/device/assembly/igniter,/obj/item/device/assembly/timer{pixel_x = 3; pixel_y = 3},/obj/item/device/assembly/timer{pixel_x = 3; pixel_y = 3},/obj/item/device/assembly/timer{pixel_x = 3; pixel_y = 3},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"bI" = (/obj/structure/table/reinforced,/obj/item/weapon/book/manual/wiki/infections,/obj/item/stack/sheet/mineral/silver{amount = 10},/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
+"bJ" = (/obj/structure/chair/office/dark{dir = 8},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"bK" = (/obj/machinery/door/airlock/hatch{name = "Monkey Pen"; req_access_txt = "150"},/turf/open/floor/plasteel/black,/area/ruin/powered/syndicate_lava_base)
+"bL" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plasteel/vault{dir = 5},/area/space)
+"bM" = (/obj/structure/table/reinforced,/obj/item/weapon/gun/ballistic/automatic/c20r/toy/unrestricted,/obj/item/weapon/gun/ballistic/automatic/c20r/toy/unrestricted,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"bN" = (/obj/item/weapon/twohanded/required/kirbyplants{icon_state = "plant-21"; layer = 4.1},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"bO" = (/obj/structure/table/reinforced,/obj/item/clothing/gloves/color/latex,/obj/item/clothing/gloves/color/latex,/obj/item/clothing/suit/toggle/labcoat,/obj/item/clothing/suit/toggle/labcoat,/obj/item/clothing/glasses/science,/obj/item/clothing/glasses/science,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"bP" = (/obj/machinery/smartfridge/chemistry/virology,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
+"bQ" = (/obj/machinery/iv_drip,/obj/item/weapon/reagent_containers/blood/random,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"bR" = (/obj/structure/closet/crate/bin,/turf/open/floor/plasteel/podhatch{dir = 9},/area/ruin/powered/syndicate_lava_base)
+"bS" = (/obj/structure/chair/office/dark,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
+"bT" = (/obj/machinery/chem_heater,/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"bU" = (/obj/structure/table/reinforced,/obj/item/weapon/reagent_containers/glass/beaker/large,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
+"bV" = (/obj/structure/chair/office/dark,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"bW" = (/obj/machinery/door/airlock/hatch{name = "Monkey Pen"; req_access_txt = "150"},/turf/open/floor/plasteel/black,/area/space)
+"bX" = (/obj/machinery/door/airlock/hatch{name = "Monkey Pen"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"bY" = (/obj/structure/table/reinforced,/obj/item/weapon/folder,/obj/item/clothing/ears/earmuffs,/obj/item/clothing/ears/earmuffs,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"bZ" = (/obj/structure/table/reinforced,/obj/item/weapon/suppressor/specialoffer,/obj/item/weapon/gun/ballistic/automatic/toy/pistol/unrestricted,/obj/item/weapon/gun/ballistic/automatic/toy/pistol/unrestricted,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"ca" = (/obj/machinery/chem_master,/turf/open/floor/plasteel/podhatch{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cb" = (/obj/structure/table/reinforced,/obj/item/weapon/reagent_containers/glass/beaker/large,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
+"cc" = (/obj/machinery/chem_dispenser,/obj/structure/extinguisher_cabinet{pixel_x = 26},/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
+"cd" = (/obj/structure/table/reinforced,/obj/item/clothing/suit/bio_suit/general,/obj/item/clothing/mask/surgical,/obj/item/clothing/head/bio_hood/general,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
+"ce" = (/obj/machinery/shower{dir = 4; icon_state = "shower"; name = "emergency shower"},/obj/machinery/shower{dir = 8; icon_state = "shower"; name = "emergency shower"},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"cf" = (/obj/structure/table/reinforced,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
+"cg" = (/obj/structure/table/reinforced,/obj/item/weapon/folder/white,/obj/item/stack/sheet/mineral/gold{amount = 10},/obj/item/stack/sheet/mineral/uranium{amount = 10},/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
+"ch" = (/turf/open/floor/plasteel/vault{dir = 8},/area/space)
+"ci" = (/obj/structure/bed/roller,/mob/living/carbon/monkey,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cj" = (/obj/structure/sign/securearea,/turf/closed/wall/mineral/plastitanium,/area/ruin/powered/syndicate_lava_base)
+"ck" = (/obj/machinery/door/airlock/hatch{name = "Firing Range"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cl" = (/obj/machinery/door/airlock/hatch{name = "Chemistry Lab"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cm" = (/obj/structure/sign/chemistry,/turf/closed/wall/mineral/plastitanium,/area/ruin/powered/syndicate_lava_base)
+"cn" = (/obj/machinery/syndicatebomb/badmin/varplosion{can_unanchor = 0; name = "self destruct device"},/turf/open/floor/plasteel/podhatch{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"co" = (/obj/structure/sign/biohazard,/turf/closed/wall/mineral/plastitanium,/area/ruin/powered/syndicate_lava_base)
+"cp" = (/obj/machinery/door/airlock/hatch{name = "Virology Lab"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cq" = (/obj/structure/rack,/obj/item/ammo_box/foambox{pixel_x = -3; pixel_y = 3},/obj/item/ammo_box/foambox,/obj/item/ammo_box/foambox{pixel_x = 3; pixel_y = -3},/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"cr" = (/obj/item/weapon/twohanded/required/kirbyplants{icon_state = "plant-22"},/turf/open/floor/plasteel/podhatch{dir = 9},/area/ruin/powered/syndicate_lava_base)
+"cs" = (/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
+"ct" = (/turf/open/floor/plasteel/podhatch/corner{tag = "icon-podhatchcorner (EAST)"; icon_state = "podhatchcorner"; dir = 4},/area/ruin/powered/syndicate_lava_base)
+"cu" = (/turf/open/floor/plasteel/podhatch/corner{tag = "icon-podhatchcorner (WEST)"; icon_state = "podhatchcorner"; dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cv" = (/obj/item/weapon/twohanded/required/kirbyplants{icon_state = "plant-21"; layer = 4.1},/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"cw" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/obj/structure/sign/bluecross_2,/turf/open/floor/plating,/area/ruin/powered/syndicate_lava_base)
+"cx" = (/obj/structure/table,/obj/item/weapon/storage/firstaid/regular{pixel_x = 3; pixel_y = 3},/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/regular{pixel_x = -3; pixel_y = -3},/turf/open/floor/plasteel/vault,/area/ruin/powered/syndicate_lava_base)
+"cy" = (/obj/machinery/sleeper/syndie{dir = 8},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cz" = (/obj/structure/closet/crate/secure,/obj/item/target,/obj/item/target,/obj/item/target/alien,/obj/item/target/alien,/obj/item/target/clown,/obj/item/target/clown,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
+"cA" = (/turf/open/floor/plasteel/podhatch{dir = 10},/area/ruin/powered/syndicate_lava_base)
+"cB" = (/obj/machinery/syndicatebomb/badmin/varplosion{can_unanchor = 0; name = "self destruct device"},/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
+"cC" = (/obj/structure/extinguisher_cabinet{pixel_y = -32},/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
+"cD" = (/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
+"cE" = (/turf/open/floor/plasteel/podhatch/corner{tag = "icon-podhatchcorner (NORTH)"; icon_state = "podhatchcorner"; dir = 1},/area/ruin/powered/syndicate_lava_base)
+"cF" = (/turf/open/floor/plasteel/podhatch/corner,/area/ruin/powered/syndicate_lava_base)
+"cG" = (/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
+"cH" = (/obj/machinery/door/airlock/hatch{name = "Infirmary"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cI" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/obj/item/weapon/reagent_containers/blood/random,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cJ" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/obj/machinery/door/poddoor/preopen{id = "lavalandsyndi"; name = "Syndicate Research Experimentor Shutters"},/turf/open/floor/plating,/area/ruin/powered/syndicate_lava_base)
+"cK" = (/obj/machinery/door/airlock/hatch{name = "Experimentation Room"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cL" = (/obj/machinery/door/airlock/hatch{name = "Telecommunications Control"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cM" = (/turf/open/floor/engine,/area/ruin/powered/syndicate_lava_base)
+"cN" = (/obj/structure/noticeboard{pixel_y = 32},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"cO" = (/obj/structure/table,/obj/item/weapon/storage/toolbox/syndicate,/obj/item/device/multitool,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cP" = (/obj/item/weapon/surgicaldrill,/obj/item/weapon/circular_saw,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cQ" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/obj/structure/mirror{pixel_x = 30},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"cR" = (/obj/item/stack/cable_coil/white{pixel_x = 3; pixel_y = 3},/obj/structure/table/reinforced,/obj/item/weapon/storage/toolbox/syndicate,/obj/item/stack/cable_coil/white,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cS" = (/obj/structure/table/reinforced,/obj/item/device/flashlight/lamp,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cT" = (/obj/structure/table/reinforced,/obj/item/device/radio/intercom{broadcasting = 0; dir = 8; freerange = 1; listening = 1; name = "Pirate Radio Listening Channel"; pixel_x = 0},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cU" = (/obj/machinery/computer/camera_advanced,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"cV" = (/obj/structure/filingcabinet/chestdrawer,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cW" = (/obj/item/weapon/cautery,/obj/item/weapon/scalpel,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cX" = (/obj/structure/table/optable,/obj/item/weapon/surgical_drapes,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cY" = (/obj/item/weapon/retractor,/obj/item/weapon/hemostat,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"cZ" = (/obj/structure/sign/nosmoking_2{pixel_x = 32},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"da" = (/obj/item/weapon/twohanded/required/kirbyplants{icon_state = "plant-22"},/obj/structure/extinguisher_cabinet{pixel_x = -26},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"db" = (/obj/structure/table/reinforced,/obj/item/device/radio/intercom{broadcasting = 1; dir = 8; freerange = 1; listening = 0; name = "Pirate Radio Broadcast Channel"; pixel_x = 0},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"dc" = (/obj/structure/sign/fire{pixel_x = -32},/turf/open/floor/engine,/area/ruin/powered/syndicate_lava_base)
+"dd" = (/obj/structure/table/reinforced,/obj/item/device/assembly/signaler,/obj/item/device/assembly/signaler,/obj/item/device/assembly/voice,/obj/item/device/assembly/voice,/obj/item/weapon/screwdriver/nuke,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"de" = (/obj/structure/table/reinforced,/obj/item/stack/sheet/plasteel{amount = 15},/obj/item/device/electropack,/obj/item/device/taperecorder,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"df" = (/obj/structure/filingcabinet/security,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"dg" = (/obj/structure/table/reinforced,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"dh" = (/obj/machinery/computer/message_monitor,/obj/item/weapon/paper/monitorkey,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"di" = (/turf/open/floor/plasteel/vault{tag = "icon-vault (NORTHEAST)"; dir = 5},/area/ruin/powered/syndicate_lava_base)
+"dj" = (/obj/effect/baseturf_helper,/turf/open/floor/plasteel/vault{tag = "icon-vault (NORTHEAST)"; dir = 5},/area/ruin/powered/syndicate_lava_base)
+"dk" = (/obj/machinery/button/door{id = "lavalandsyndi"; name = "Syndicate Experimentor Lockdown Control"; pixel_x = 26; req_access_txt = "150"},/turf/open/floor/engine,/area/ruin/powered/syndicate_lava_base)
+"dl" = (/obj/machinery/button/door{id = "lavalandsyndi"; name = "Syndicate Experimentor Lockdown Control"; pixel_x = -26; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"dm" = (/obj/item/stack/sheet/mineral/plastitanium{amount = 30},/obj/item/stack/rods{amount = 50},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"dn" = (/obj/structure/filingcabinet/medical,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
+"do" = (/turf/open/floor/plasteel/circuit/gcircuit,/area/ruin/powered/syndicate_lava_base)
+"dp" = (/obj/machinery/door/poddoor/preopen{id = "lavalandsyndi"; name = "Syndicate Research Experimentor Shutters"},/obj/machinery/door/airlock/hatch{name = "Experimentation Room"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"dq" = (/obj/item/stack/sheet/metal{amount = 50},/obj/item/weapon/grenade/chem_grenade,/obj/item/weapon/grenade/chem_grenade,/obj/item/weapon/grenade/chem_grenade,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"dr" = (/obj/machinery/telecomms/relay/preset/ruskie{use_power = 0},/turf/open/floor/plasteel/vault{tag = "icon-vault (NORTHEAST)"; dir = 5},/area/ruin/powered/syndicate_lava_base)
+"ds" = (/obj/machinery/door/airlock/hatch{name = "Syndicate Recon Outpost"; req_access_txt = "150"},/obj/structure/fans/tiny,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"dt" = (/obj/machinery/door/airlock/hatch{name = "Monkey Pen"; req_access_txt = "150"},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"du" = (/obj/structure/sign/vacuum{pixel_x = -32},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"dv" = (/obj/structure/sign/xeno_warning_mining{pixel_x = 32},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"dw" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/mob/living/carbon/monkey,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
+"dx" = (/obj/structure/sign/securearea{pixel_y = 32},/turf/open/floor/plating/lava/smooth/lava_land_surface,/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 aaaaaaaaabaaaaabababababababababababababababababababababababababababababaaaa
@@ -188,27 +194,27 @@ abababababababacadapapapadaIapaoadadaJaKaLaKaoapadaMaNadaNaOadacabacabababab
 ababababababababadapaPapadaQapaoaRadapaoapaoapaSadadaTadaTadadadadababababab
 abababababacababadapaNapadaUaoapapaVaoapaoapaoapaTapapapapapaWaXadababababab
 abababababababacadaYaNaZadbabbaobcadbdbeapaobcbfadaRapapapaRadbgadacabababab
-abababababababacadapaNapadadadadadadadadbhbhadadadadadadadadadadadadabababab
-abababababababacadaYaNaZadbibjbkblbmbnadbobpadbqbrbsbtbubvbwbxbyaNadabababab
-abababababacabacadbzbAbzadbBbCbDbEbEbFbxaYaZbxbGbHapapapapapbxapapadabababab
-abababababacababadbIaNbJadaRapapapapbKbxaYaZbxbLapaoaoaoaoapbMapbNadabababab
-abababababacabacadapapapadbOaoapbPbQbRbxaYaZbxbSapapapbTapbbbxapapadabababab
-abababababababacadbUapbVadbOapapbWbXbYadaYaZadbZcabPcbcccdcebxbyaNadabababab
-ababababababacabadcfcgadadcfchciadbxadadcjaZadckcladbxbxadadadadadadabababab
-ababababababababadcmapaRbxcncococococococpcqcococococococrcsctapcuadabababab
-aaabababababacacadcvapapcgcwcxcyczczczczcAcBczczczczczczcCcDapapcEadabababab
-aaabababababacadadadcFadadadadadadcGcfadaYaZadadcHcfadadadadapapcuadabababab
-abababababababadcIcIcIcIcIcIcIcfaRapapadaYaZadaRapapcJbbcKadcLapcMadabababab
-abababababababadcIcIcIcIcIcIcIcFcNapapadaYaZadapaocOcPcQcRadcScTcUadabababab
-abababababababadcIcIcIcIcIcIcIcFbFapcVadaYaZadcWaocXbHapaNadadadadadabababab
-ababababababacadcYcIcIcIcIcIcIcFcZapdaadaYaZaddbaodcddapaNcHdedfdeadabababab
-abababababababadcIcIcIcIcIcIdgaddhapdiadaYaZaddjapapapapbJaddkdkdkadabababab
-ababababababacadcIcIcIcIcIcIcIdlapapdmadcwcCadadadadadadadaddkdndkadabababab
-ababababababacadcIcIcIcIcIcIcIadcWapaRaddodoadacacacacacabadadadadadabababab
-ababababababacadadadadadadadadadbxbMbxaddpdqadacacacababababababacacabababab
-ababababababacacacabababacacacadbyaNbyadaNaNadacababababacababababababababab
-ababababababababababababababacadadadadaddodoadababacacababababababababababab
-abababababababababababababababababababdrababdrababababababababababababababab
+abababababababacadapaNapadadadadadadadadbhbhadadadadadadadadadadadadadababab
+abababababababacadaYaNaZadbibjbkblbmbnadbobpadbqbrbsbtbubvbwbxbybzbAadababab
+abababababacabacadbBbCbBadbDbEbFbGbGbHbvaYaZbvbIbJapapapbvbKbLbybKbyadababab
+abababababacababadbMaNbNadaRapapapapbObvaYaZbvbPapaoaoaoaoaoaoaoaoaoadababab
+abababababacabacadapapapadbQaoapbRbSbTbvaYaZbvbUapapbbbVbybWbybybXbyadababab
+abababababababacadbYapbZadbQapapcacbccadaYaZadcdcebRcfcgbychcibyaNciadababab
+ababababababacabadcjckadadcjclcmadbvadadcnaZadcocpadbvbvadadadadadadadababab
+ababababababababadcqapaRbvcrcscscscscscsctcucscscscscscscvcwcxapcyadabababab
+aaabababababacacadczapapckcAcBcCcDcDcDcDcEcFcDcDcDcDcDcDcGcHapapcIadabababab
+aaabababababacadadadcJadadadadadadcKcjadaYaZadadcLcjadadadadapapcyadabababab
+abababababababadcMcMcMcMcMcMcMcjaRapapadaYaZadaRapapcNbbcOadcPapcQadabababab
+abababababababadcMcMcMcMcMcMcMcJcRapapadaYaZadapaocScTcUcVadcWcXcYadabababab
+abababababababadcMcMcMcMcMcMcMcJbHapcZadaYaZaddaaodbbJapaNadadadadadabababab
+ababababababacaddccMcMcMcMcMcMcJddapdeadaYaZaddfaodgdhapaNcLdidjdiadabababab
+abababababababadcMcMcMcMcMcMdkaddlapdmadaYaZaddnapapapapbNaddododoadabababab
+ababababababacadcMcMcMcMcMcMcMdpapapdqadcAcGadadadadadadadaddodrdoadabababab
+ababababababacadcMcMcMcMcMcMcMaddaapaRaddsdsadacacacacacabadadadadadabababab
+ababababababacadadadadadadadadadbvdtbvaddudvadacacacababababababacacabababab
+ababababababacacacabababacacacaddwaNdwadaNaNadacababababacababababababababab
+ababababababababababababababacadadadadaddsdsadababacacababababababababababab
+abababababababababababababababababababdxababdxababababababababababababababab
 abababababababababababababababababababababababababababababababababababababaa
 aaababababababababababababababababababababababababababababababababababababaa
 aaaaabaaababababababababababababababababababababababababababababababaaaaaaaa

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -131,7 +131,7 @@
 	back = /obj/item/weapon/storage/backpack
 	pocket1 = /obj/item/weapon/gun/ballistic/automatic/pistol
 	id_job = "Operative"
-	id_access = "Syndicate"
+	id_access = "syndicate"
 	roundstart = FALSE
 	death = FALSE
 	icon = 'icons/obj/Cryogenic2.dmi'


### PR DESCRIPTION
-Can now use the toy guns in the range
-Can now use the doors
-Adds uranium to viro
-Divides monkey pen up into four rooms so you dont have to infect them all with one disease