### PR TITLE
Corrects some defs without leading slash

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -199,7 +199,7 @@ mob
 				getFlatIcon(src)
 			Browse_Icon()
 
-obj/effect/overlayTest
+/obj/effect/overlayTest
 	icon = 'old_or_unused.dmi'
 	icon_state = "blue"
 	pixel_x = -24

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1262,7 +1262,7 @@ B --><-- A
 				closest_atom = A
 	return closest_atom
 
-proc/pick_closest_path(value)
+/proc/pick_closest_path(value)
 	var/list/matches = get_fancy_list_of_types()
 	if (!isnull(value) && value!="")
 		matches = filter_fancy_list(matches, value)

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -227,7 +227,7 @@ var/datum/subsystem/garbage_collector/SSgarbage
 
 	find_references(FALSE)
 
-datum/proc/find_references(skip_alert)
+/datum/proc/find_references(skip_alert)
 	set background = 1
 	running_find_references = type
 	if(usr && usr.client)

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -266,7 +266,7 @@
 		return
 	gender = (deconstruct_block(getblock(dna.uni_identity, DNA_GENDER_BLOCK), 2)-1) ? FEMALE : MALE
 
-mob/living/carbon/human/updateappearance(icon_update=1, mutcolor_update=0, mutations_overlay_update=0)
+/mob/living/carbon/human/updateappearance(icon_update=1, mutcolor_update=0, mutations_overlay_update=0)
 	..()
 	var/structure = dna.uni_identity
 	hair_color = sanitize_hexcolor(getblock(structure, DNA_HAIR_COLOR_BLOCK))

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -102,7 +102,7 @@
 	add_logs(A, D, "neck chopped")
 	return 1
 
-datum/martial_art/krav_maga/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+/datum/martial_art/krav_maga/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(check_streak(A,D))
 		return 1
 	add_logs(A, D, "grabbed with krav maga")

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -747,7 +747,7 @@ var/total_borer_hosts_needed = 10
 	chemicals -= 75
 
 
-mob/living/carbon/proc/release_control()
+/mob/living/carbon/proc/release_control()
 
 	set category = "Borer"
 	set name = "Release Control"

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -145,7 +145,7 @@
 /obj/machinery/door/proc/try_to_weld(obj/item/weapon/weldingtool/W, mob/user)
 	return
 
-obj/machinery/door/proc/try_to_crowbar(obj/item/I, mob/user)
+/obj/machinery/door/proc/try_to_crowbar(obj/item/I, mob/user)
 	return
 
 /obj/machinery/door/attackby(obj/item/I, mob/user, params)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -61,6 +61,6 @@
 /obj/machinery/door/poddoor/try_to_activate_door(mob/user)
  	return
 
-obj/machinery/door/poddoor/try_to_crowbar(obj/item/I, mob/user)
+/obj/machinery/door/poddoor/try_to_crowbar(obj/item/I, mob/user)
 	if(stat & NOPOWER)
 		open(1)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -22,7 +22,7 @@ var/list/blacklisted_glowshroom_turfs = typecacheof(list(
 	var/generation = 1
 	var/spreadIntoAdjacentChance = 60
 
-obj/structure/glowshroom/glowcap
+/obj/structure/glowshroom/glowcap
 	name = "glowcap"
 	icon_state = "glowcap"
 

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -246,7 +246,7 @@
 		T.color = null
 		T.maptext = ""
 
-proc/dyn_explosion(turf/epicenter, power, flash_range, adminlog = 1, ignorecap = 1, flame_range = 0 ,silent = 0, smoke = 1)
+/proc/dyn_explosion(turf/epicenter, power, flash_range, adminlog = 1, ignorecap = 1, flame_range = 0 ,silent = 0, smoke = 1)
 	if(!power)
 		return
 	var/range = 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -384,7 +384,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 			A.Grant(user)
 
 //sometimes we only want to grant the item's action if it's equipped in a specific slot.
-obj/item/proc/item_action_slot_check(slot, mob/user)
+/obj/item/proc/item_action_slot_check(slot, mob/user)
 	return 1
 
 //the mob M is attempting to equip this item into the slot passed through as 'slot'. Return 1 if it can do this and 0 if it can't.

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -170,7 +170,7 @@
 		attack_self(usr)
 
 //Bananalamp
-obj/item/device/flashlight/lamp/bananalamp
+/obj/item/device/flashlight/lamp/bananalamp
 	name = "banana lamp"
 	desc = "Only a clown would think to make a ghetto banana-shaped lamp. Even has a goofy pullstring."
 	icon_state = "bananalamp"

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -20,7 +20,7 @@
 	create_reagents(mopcap)
 
 
-obj/item/weapon/mop/proc/clean(turf/A)
+/obj/item/weapon/mop/proc/clean(turf/A)
 	if(reagents.has_reagent("water", 1) || reagents.has_reagent("holywater", 1) || reagents.has_reagent("vodka", 1) || reagents.has_reagent("cleaner", 1))
 		A.clean_blood()
 		for(var/obj/effect/O in A)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -69,7 +69,7 @@
 	user.put_in_active_hand(s_drill)
 	qdel(src)
 
-obj/item/weapon/wrench/power/suicide_act(mob/user)
+/obj/item/weapon/wrench/power/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is pressing [src] against [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!")
 	return (BRUTELOSS)
 
@@ -460,7 +460,7 @@ obj/item/weapon/wrench/power/suicide_act(mob/user)
 	return 1
 
 //Switches the welder on
-obj/item/weapon/weldingtool/proc/switched_on(mob/user)
+/obj/item/weapon/weldingtool/proc/switched_on(mob/user)
 	if(!status)
 		user << "<span class='warning'>[src] can't be turned on while unsecured!</span>"
 		return
@@ -483,7 +483,7 @@ obj/item/weapon/weldingtool/proc/switched_on(mob/user)
 		switched_off(user)
 
 //Switches the welder off
-obj/item/weapon/weldingtool/proc/switched_off(mob/user)
+/obj/item/weapon/weldingtool/proc/switched_off(mob/user)
 	welding = 0
 	if(user == loc) //If player is holding the welder
 		user.AddLuminosity(-light_intensity)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -62,7 +62,7 @@ if rights_required == 0, then it simply checks if they are an admin.
 if it doesn't return 1 and show_msg=1 it will prints a message explaining why the check has failed
 generally it would be used like so:
 
-proc/admin_proc()
+/proc/admin_proc()
 	if(!check_rights(R_ADMIN)) return
 	world << "you have enough rights!"
 

--- a/code/modules/awaymissions/maploader/swapmaps.dm
+++ b/code/modules/awaymissions/maploader/swapmaps.dm
@@ -509,7 +509,7 @@ var/swapmaps_initialized
 var/swapmaps_loaded
 var/swapmaps_byname
 
-proc/InitializeSwapMaps()
+/proc/InitializeSwapMaps()
 	if(swapmaps_initialized) return
 	swapmaps_initialized=1
 	swapmaps_compiled_maxx=world.maxx
@@ -523,16 +523,16 @@ proc/InitializeSwapMaps()
 			// so you can look up an icon file by name or vice-versa
 			swapmaps_iconcache[swapmaps_iconcache[V]]=V
 
-proc/SwapMaps_AddIconToCache(name,icon)
+/proc/SwapMaps_AddIconToCache(name,icon)
 	if(!swapmaps_iconcache) swapmaps_iconcache=list()
 	swapmaps_iconcache[name]=icon
 	swapmaps_iconcache[icon]=name
 
-proc/SwapMaps_Find(id)
+/proc/SwapMaps_Find(id)
 	InitializeSwapMaps()
 	return swapmaps_byname[id]
 
-proc/SwapMaps_Load(id)
+/proc/SwapMaps_Load(id)
 	InitializeSwapMaps()
 	var/swapmap/M=swapmaps_byname[id]
 	if(!M)
@@ -553,29 +553,29 @@ proc/SwapMaps_Load(id)
 		M.mode=text
 	return M
 
-proc/SwapMaps_Save(id)
+/proc/SwapMaps_Save(id)
 	InitializeSwapMaps()
 	var/swapmap/M=swapmaps_byname[id]
 	if(M) M.Save()
 	return M
 
-proc/SwapMaps_Save_All()
+/proc/SwapMaps_Save_All()
 	InitializeSwapMaps()
 	for(var/swapmap/M in swapmaps_loaded)
 		if(M) M.Save()
 
-proc/SwapMaps_Unload(id)
+/proc/SwapMaps_Unload(id)
 	InitializeSwapMaps()
 	var/swapmap/M=swapmaps_byname[id]
 	if(!M) return	// return silently from an error
 	M.Unload()
 	return 1
 
-proc/SwapMaps_DeleteFile(id)
+/proc/SwapMaps_DeleteFile(id)
 	fdel("map_[id].sav")
 	fdel("map_[id].txt")
 
-proc/SwapMaps_CreateFromTemplate(template_id)
+/proc/SwapMaps_CreateFromTemplate(template_id)
 	var/swapmap/M=new
 	var/savefile/S
 	var/text=0
@@ -602,7 +602,7 @@ proc/SwapMaps_CreateFromTemplate(template_id)
 	while(M.locked) sleep(1)
 	return M
 
-proc/SwapMaps_LoadChunk(chunk_id,turf/locorner)
+/proc/SwapMaps_LoadChunk(chunk_id,turf/locorner)
 	var/swapmap/M=new
 	var/savefile/S
 	var/text=0
@@ -629,7 +629,7 @@ proc/SwapMaps_LoadChunk(chunk_id,turf/locorner)
 	qdel(M)
 	return 1
 
-proc/SwapMaps_SaveChunk(chunk_id,turf/corner1,turf/corner2)
+/proc/SwapMaps_SaveChunk(chunk_id,turf/corner1,turf/corner2)
 	if(!corner1 || !corner2)
 		world.log << "SwapMaps error in SwapMaps_SaveChunk():"
 		if(!corner1) world.log << "  corner1 turf is null"
@@ -650,7 +650,7 @@ proc/SwapMaps_SaveChunk(chunk_id,turf/corner1,turf/corner2)
 	qdel(M)
 	return 1
 
-proc/SwapMaps_GetSize(id)
+/proc/SwapMaps_GetSize(id)
 	var/savefile/S
 	var/text=0
 	if(swapmaps_mode==SWAPMAPS_TEXT && fexists("map_[id].txt"))

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -40,7 +40,7 @@
 	shipment of supplies. The snow has really kicked up recently, shits almost like a constant blizzard right now. Maybe it'll drop down soon so we can get a word in.<br><br>
 	<i>The rest of the paper seems to be a mixture of scribbles and smudged ink.</i> "}
 
-obj/item/weapon/paper/snowdin/secnotice
+/obj/item/weapon/paper/snowdin/secnotice
 	name = "Security Notice"
 	info = {"You have been assigned a position on a listening outpost. Here you'll be watching over several crewmembers assigned to watching signals of the general area.
 	 As not much is expected in terms of issues, we've only assigned one guard per outpost. Crewmembers are expected to keep to their regulated work schedules and may be
@@ -48,23 +48,23 @@ obj/item/weapon/paper/snowdin/secnotice
 	 should be punished severely as to prevent future incidients. Mutiny and/or rioting should be reported to central and dealt with swiftly. You're here to secure and protect
 	 Nanotrasen assets, not be a police officer. Do what you must, but make sure it's not messy."}
 
-obj/item/weapon/paper/snowdin/syndienotice
+/obj/item/weapon/paper/snowdin/syndienotice
 	name = "Assignment Notice"
 	info = {"You've been assigned as an agent to listen in on Nanotrasen activities from passing ships and nearby stations. The outpost you've been assigned to is under lays of solid
 	ice and we've supplied you with a scrambler to help avoid Nanotrasen discovery, as they've recently built a listening post of their own aboveground. Get aquainted with your new
 	crewmates, because you're gonna be here for awhile. Enjoy the free syndicakes."}
 
-obj/item/weapon/paper/crumpled/snowdin/syndielava
+/obj/item/weapon/paper/crumpled/snowdin/syndielava
 	name = "scribbled note"
 	info = {"Some cracks in the ice nearby have exposed some sort of hidden magma stream under all this shit ice. I don't know whats worse at this point honestly; freezing to death or
 	burning alive."}
 
-obj/item/weapon/paper/crumpled/snowdin/lootstructures
+/obj/item/weapon/paper/crumpled/snowdin/lootstructures
 	name = "scribbled note"
 	info = {"From what we've seen so far, theres a ton of iced-over ruins down here in the caves. We sent a few men out to check things out and they never came back, so we decided to
 	border up majority of the ruins. We've heard some weird shit coming out of these caves and I'm not gonna find out the hard way myself."}
 
-obj/item/weapon/paper/crumpled/snowdin/shovel
+/obj/item/weapon/paper/crumpled/snowdin/shovel
 	name = "shoveling duties"
 	info = {"Snow piles up bad here all-year round, even worse during the winter months. Keeping a constant rotation of shoveling that shit out of the way of the airlocks and keeping the paths decently clear
 	is a good step towards not getting stuck walking through knee-deep snow."}
@@ -184,7 +184,7 @@ obj/item/weapon/paper/crumpled/snowdin/shovel
 	hidden_uplink.name = "dusty radio"
 	hidden_uplink.telecrystals = 10
 
-obj/effect/mob_spawn/human/syndicatesoldier/coldres
+/obj/effect/mob_spawn/human/syndicatesoldier/coldres
 	name = "Syndicate Snow Operative"
 	uniform = /obj/item/clothing/under/syndicate/coldres
 	shoes = /obj/item/clothing/shoes/combat/coldres
@@ -193,7 +193,7 @@ obj/effect/mob_spawn/human/syndicatesoldier/coldres
 	pocket2 = /obj/item/weapon/card/id/syndicate
 	has_id = 0
 
-obj/effect/mob_spawn/human/syndicatesoldier/coldres/alive
+/obj/effect/mob_spawn/human/syndicatesoldier/coldres/alive
 	name = "sleeper"
 	mob_name = "Syndicate Snow Operative"
 	icon = 'icons/obj/Cryogenic2.dmi'
@@ -205,7 +205,7 @@ obj/effect/mob_spawn/human/syndicatesoldier/coldres/alive
 	flavour_text = {"You are a syndicate operative recently awoken from cyrostatis in an underground outpost. Monitor Nanotrasen communications and record infomation. All intruders should be
 	disposed of swirfly to assure no gathered infomation is stolen or lost. Try not to wander too far from the outpost as the caves can be a deadly place even for a trained operative such as yourself."}
 
-obj/effect/mob_spawn/human/syndicatesoldier/coldres/alive/female
+/obj/effect/mob_spawn/human/syndicatesoldier/coldres/alive/female
 	mob_gender = FEMALE
 
 //mobs//--

--- a/code/modules/awaymissions/mission_code/stationCollision.dm
+++ b/code/modules/awaymissions/mission_code/stationCollision.dm
@@ -36,7 +36,7 @@
  * Guns - I'm making these specifically so that I dont spawn a pile of fully loaded weapons on the map.
  */
 //Captain's retro laser - Fires practice laser shots instead.
-obj/item/weapon/gun/energy/laser/retro/sc_retro
+/obj/item/weapon/gun/energy/laser/retro/sc_retro
 	name ="retro laser"
 	icon_state = "retro"
 	desc = "An older model of the basic lasergun, no longer used by Nanotrasen's security or military forces."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1,4 +1,4 @@
-datum/supply_pack
+/datum/supply_pack
 	var/name = "Crate"
 	var/group = ""
 	var/hidden = FALSE

--- a/code/modules/client/message.dm
+++ b/code/modules/client/message.dm
@@ -1,6 +1,6 @@
 var/list/clientmessages = list()
 
-proc/addclientmessage(var/ckey, var/message)
+/proc/addclientmessage(var/ckey, var/message)
 	ckey = ckey(ckey)
 	if (!ckey || !message)
 		return

--- a/code/modules/games/cas.dm
+++ b/code/modules/games/cas.dm
@@ -125,7 +125,7 @@ var/global/list/cards_against_space
 	flipped = !flipped
 	update_icon()
 
-obj/item/toy/cards/singlecard/cas/AltClick(mob/living/user)
+/obj/item/toy/cards/singlecard/cas/AltClick(mob/living/user)
 	if(!user.canUseTopic(src,1))
 		return
 	Flip()

--- a/code/modules/html_interface/html_interface.dm
+++ b/code/modules/html_interface/html_interface.dm
@@ -68,9 +68,9 @@ You have to use modules/client/asset_cache to ensure they get sent BEFORE the in
 
 	** Sample code **
 
-mob/var/datum/html_interface/hi
+/mob/var/datum/html_interface/hi
 
-mob/verb/test()
+/mob/verb/test()
 	if (!hi) hi = new/datum/html_interface(src, "[src.key]")
 
 	hi.updateLayout("<div id=\"content\"></div>")

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -106,7 +106,7 @@
 	..()
 
 //For alien evolution/promotion/queen finder procs. Checks for an active alien of that type
-proc/get_alien_type(var/alienpath)
+/proc/get_alien_type(var/alienpath)
 	for(var/mob/living/carbon/alien/humanoid/A in living_mob_list)
 		if(!istype(A, alienpath))
 			continue

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -10,7 +10,7 @@
 		return 1
 
 //Overridden so we can handle when it hits a limb that doesn't exist
-mob/living/carbon/bullet_act(obj/item/projectile/P, def_zone)
+/mob/living/carbon/bullet_act(obj/item/projectile/P, def_zone)
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
 	if(!affecting) //that zone is dismembered
 		. = bullet_act(P, "chest")//act on chest instead

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -120,6 +120,6 @@
 		ui = new(user, src, ui_key, "ai_restorer", "Integrity Restorer", 600, 400, master_ui, state)
 		ui.open()
 
-datum/computer_file/program/aidiag/kill_program(forced)
+/datum/computer_file/program/aidiag/kill_program(forced)
 	restoring = FALSE
 	return ..(forced)

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -11,7 +11,7 @@
 	var/locked = FALSE
 
 
-obj/item/weapon/computer_hardware/ai_slot/examine(mob/user)
+/obj/item/weapon/computer_hardware/ai_slot/examine(mob/user)
 	..()
 	if(stored_card)
 		user << "There appears to be an intelliCard loaded. There appears to be a pinhole protecting a manual eject button. A screwdriver could probably press it"

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -240,7 +240,7 @@
 		ui.set_autoupdate(state = 1)
 
 
-obj/machinery/lapvend/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/lapvend/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I,/obj/item/stack/spacecash))
 		var/obj/item/stack/spacecash/c = I
 

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -154,7 +154,7 @@
 	projectile_type = /obj/item/projectile/energy/bolt/large
 	select_name = "heavy bolt"
 
-obj/item/ammo_casing/energy/net
+/obj/item/ammo_casing/energy/net
 	projectile_type = /obj/item/projectile/energy/net
 	select_name = "netting"
 	pellets = 6

--- a/code/modules/projectiles/boxes_magazines/external_mag.dm
+++ b/code/modules/projectiles/boxes_magazines/external_mag.dm
@@ -119,7 +119,7 @@
 	..()
 	icon_state = "c20r45-[round(ammo_count(),2)]"
 
-obj/item/ammo_box/magazine/tommygunm45
+/obj/item/ammo_box/magazine/tommygunm45
 	name = "drum magazine (.45)"
 	icon_state = "drum45"
 	ammo_type = /obj/item/ammo_casing/c45

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -200,7 +200,7 @@
 		user << "<span class='warning'>[src]'s trigger is locked. This weapon doesn't have a firing pin installed!</span>"
 	return 0
 
-obj/item/weapon/gun/proc/recharge_newshot()
+/obj/item/weapon/gun/proc/recharge_newshot()
 	return
 
 /obj/item/weapon/gun/proc/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params, zone_override, bonus_spread = 0)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -322,7 +322,7 @@
 	damage = 7
 	armour_penetration = 0
 
-obj/item/projectile/bullet/saw/incen/Move()
+/obj/item/projectile/bullet/saw/incen/Move()
 	..()
 	var/turf/location = get_turf(src)
 	if(location)

--- a/code/modules/reagents/chem_splash.dm
+++ b/code/modules/reagents/chem_splash.dm
@@ -5,7 +5,7 @@
 // Extra heat affects the temperature of the mixture, and may cause it to react in different ways.
 
 
-proc/chem_splash(turf/epicenter, affected_range = 3, list/datum/reagents/reactants = list(), extra_heat = 0, threatscale = 1, adminlog = 1)
+/proc/chem_splash(turf/epicenter, affected_range = 3, list/datum/reagents/reactants = list(), extra_heat = 0, threatscale = 1, adminlog = 1)
 	if(!isturf(epicenter) || !reactants.len || threatscale <= 0)
 		return
 	var/has_reagents

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -883,7 +883,7 @@
 	..()
 
 //Trek Chems, used primarily by medibots. Only heals a specific damage type, but is very efficient.
-datum/reagent/medicine/bicaridine
+/datum/reagent/medicine/bicaridine
 	name = "Bicaridine"
 	id = "bicaridine"
 	description = "Restores bruising. Overdose causes it instead."
@@ -891,17 +891,17 @@ datum/reagent/medicine/bicaridine
 	color = "#C8A5DC"
 	overdose_threshold = 30
 
-datum/reagent/medicine/bicaridine/on_mob_life(mob/living/M)
+/datum/reagent/medicine/bicaridine/on_mob_life(mob/living/M)
 	M.adjustBruteLoss(-2*REM, 0)
 	..()
 	. = 1
 
-datum/reagent/medicine/bicaridine/overdose_process(mob/living/M)
+/datum/reagent/medicine/bicaridine/overdose_process(mob/living/M)
 	M.adjustBruteLoss(4*REM, 0)
 	..()
 	. = 1
 
-datum/reagent/medicine/dexalin
+/datum/reagent/medicine/dexalin
 	name = "Dexalin"
 	id = "dexalin"
 	description = "Restores oxygen loss. Overdose causes it instead."
@@ -909,17 +909,17 @@ datum/reagent/medicine/dexalin
 	color = "#C8A5DC"
 	overdose_threshold = 30
 
-datum/reagent/medicine/dexalin/on_mob_life(mob/living/M)
+/datum/reagent/medicine/dexalin/on_mob_life(mob/living/M)
 	M.adjustOxyLoss(-2*REM, 0)
 	..()
 	. = 1
 
-datum/reagent/medicine/dexalin/overdose_process(mob/living/M)
+/datum/reagent/medicine/dexalin/overdose_process(mob/living/M)
 	M.adjustOxyLoss(4*REM, 0)
 	..()
 	. = 1
 
-datum/reagent/medicine/kelotane
+/datum/reagent/medicine/kelotane
 	name = "Kelotane"
 	id = "kelotane"
 	description = "Restores fire damage. Overdose causes it instead."
@@ -927,17 +927,17 @@ datum/reagent/medicine/kelotane
 	color = "#C8A5DC"
 	overdose_threshold = 30
 
-datum/reagent/medicine/kelotane/on_mob_life(mob/living/M)
+/datum/reagent/medicine/kelotane/on_mob_life(mob/living/M)
 	M.adjustFireLoss(-2*REM, 0)
 	..()
 	. = 1
 
-datum/reagent/medicine/kelotane/overdose_process(mob/living/M)
+/datum/reagent/medicine/kelotane/overdose_process(mob/living/M)
 	M.adjustFireLoss(4*REM, 0)
 	..()
 	. = 1
 
-datum/reagent/medicine/antitoxin
+/datum/reagent/medicine/antitoxin
 	name = "Anti-Toxin"
 	id = "antitoxin"
 	description = "Heals toxin damage and removes toxins in the bloodstream. Overdose causes toxin damage."
@@ -945,7 +945,7 @@ datum/reagent/medicine/antitoxin
 	color = "#C8A5DC"
 	overdose_threshold = 30
 
-datum/reagent/medicine/antitoxin/on_mob_life(mob/living/M)
+/datum/reagent/medicine/antitoxin/on_mob_life(mob/living/M)
 	M.adjustToxLoss(-2*REM, 0)
 	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
 		if(R != src)
@@ -953,24 +953,24 @@ datum/reagent/medicine/antitoxin/on_mob_life(mob/living/M)
 	..()
 	. = 1
 
-datum/reagent/medicine/antitoxin/overdose_process(mob/living/M)
+/datum/reagent/medicine/antitoxin/overdose_process(mob/living/M)
 	M.adjustToxLoss(4*REM, 0) // End result is 2 toxin loss taken, because it heals 2 and then removes 4.
 	..()
 	. = 1
 
-datum/reagent/medicine/inaprovaline
+/datum/reagent/medicine/inaprovaline
 	name = "Inaprovaline"
 	id = "inaprovaline"
 	description = "Stabilizes the breathing of patients. Good for those in critical condition."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 
-datum/reagent/medicine/inaprovaline/on_mob_life(mob/living/M)
+/datum/reagent/medicine/inaprovaline/on_mob_life(mob/living/M)
 	if(M.losebreath >= 5)
 		M.losebreath -= 5
 	..()
 
-datum/reagent/medicine/tricordrazine
+/datum/reagent/medicine/tricordrazine
 	name = "Tricordrazine"
 	id = "tricordrazine"
 	description = "Has a high chance to heal all types of damage. Overdose instead causes it."
@@ -978,7 +978,7 @@ datum/reagent/medicine/tricordrazine
 	color = "#C8A5DC"
 	overdose_threshold = 30
 
-datum/reagent/medicine/tricordrazine/on_mob_life(mob/living/M)
+/datum/reagent/medicine/tricordrazine/on_mob_life(mob/living/M)
 	if(prob(80))
 		M.adjustBruteLoss(-1*REM, 0)
 		M.adjustFireLoss(-1*REM, 0)
@@ -987,7 +987,7 @@ datum/reagent/medicine/tricordrazine/on_mob_life(mob/living/M)
 		. = 1
 	..()
 
-datum/reagent/medicine/tricordrazine/overdose_process(mob/living/M)
+/datum/reagent/medicine/tricordrazine/overdose_process(mob/living/M)
 	M.adjustToxLoss(2*REM, 0)
 	M.adjustOxyLoss(2*REM, 0)
 	M.adjustBruteLoss(2*REM, 0)
@@ -995,14 +995,14 @@ datum/reagent/medicine/tricordrazine/overdose_process(mob/living/M)
 	..()
 	. = 1
 
-datum/reagent/medicine/syndicate_nanites //Used exclusively by Syndicate medical cyborgs
+/datum/reagent/medicine/syndicate_nanites //Used exclusively by Syndicate medical cyborgs
 	name = "Restorative Nanites"
 	id = "syndicate_nanites"
 	description = "Miniature medical robots that swiftly restore bodily damage."
 	reagent_state = SOLID
 	color = "#555555"
 
-datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/M)
+/datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/M)
 	M.adjustBruteLoss(-5*REM, 0) //A ton of healing - this is a 50 telecrystal investment.
 	M.adjustFireLoss(-5*REM, 0)
 	M.adjustOxyLoss(-15, 0)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1356,7 +1356,7 @@
 
 //Misc reagents
 
-datum/reagent/romerol
+/datum/reagent/romerol
 	name = "romerol"
 	// the REAL zombie powder
 	id = "romerol"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -368,7 +368,7 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/clothing/glasses/hud/security/night
 	category = list("Equipment")
 
-datum/design/diagnostic_hud
+/datum/design/diagnostic_hud
 	name = "Diagnostic HUD"
 	desc = "A HUD used to analyze and determine faults within robotic machinery."
 	id = "dianostic_hud"
@@ -378,7 +378,7 @@ datum/design/diagnostic_hud
 	build_path = /obj/item/clothing/glasses/hud/diagnostic
 	category = list("Equipment")
 
-datum/design/diagnostic_hud_night
+/datum/design/diagnostic_hud_night
 	name = "Night Vision Diagnostic HUD"
 	desc = "Upgraded version of the diagnostic HUD designed to function during a power failure."
 	id = "dianostic_hud_night"

--- a/code/modules/stock_market/articles.dm
+++ b/code/modules/stock_market/articles.dm
@@ -1,13 +1,13 @@
-proc/consonant()
+/proc/consonant()
 	return pick("B","C","D","F","G","H","J","K","L","M","N","P","Q","R","S","T","V","W","X","Y","Z")
 
-proc/vowel()
+/proc/vowel()
 	return pick("A", "E", "I", "O", "U")
 
-proc/ucfirst(var/S)
+/proc/ucfirst(var/S)
 	return "[uppertext(ascii2text(text2ascii(S, 1)))][copytext(S, 2)]"
 
-proc/ucfirsts(var/S)
+/proc/ucfirsts(var/S)
 	var/list/L = splittext(S, " ")
 	var/list/M = list()
 	for (var/P in L)
@@ -16,7 +16,7 @@ proc/ucfirsts(var/S)
 
 var/global/list/FrozenAccounts = list()
 
-proc/list_frozen()
+/proc/list_frozen()
 	for (var/A in FrozenAccounts)
 		usr << "[A]: [length(FrozenAccounts[A])] borrows"
 

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -88,7 +88,7 @@
 
 
 
-proc/get_location_modifier(mob/M)
+/proc/get_location_modifier(mob/M)
 	var/turf/T = get_turf(M)
 	if(locate(/obj/structure/table/optable, T))
 		return 1

--- a/code/modules/surgery/organs/helpers.dm
+++ b/code/modules/surgery/organs/helpers.dm
@@ -1,17 +1,17 @@
-mob/proc/getorgan(typepath)
+/mob/proc/getorgan(typepath)
 	return
 
-mob/proc/getorganszone(zone)
+/mob/proc/getorganszone(zone)
 	return
 
-mob/proc/getorganslot(slot)
+/mob/proc/getorganslot(slot)
 	return
 
 
-mob/living/carbon/getorgan(typepath)
+/mob/living/carbon/getorgan(typepath)
 	return (locate(typepath) in internal_organs)
 
-mob/living/carbon/getorganszone(zone, subzones = 0)
+/mob/living/carbon/getorganszone(zone, subzones = 0)
 	var/list/returnorg = list()
 	if(subzones)
 		// Include subzones - groin for chest, eyes and mouth for head
@@ -26,9 +26,9 @@ mob/living/carbon/getorganszone(zone, subzones = 0)
 			returnorg += O
 	return returnorg
 
-mob/living/carbon/getorganslot(slot)
+/mob/living/carbon/getorganslot(slot)
 	return internal_organs_slot[slot]
 
 
-proc/isorgan(atom/A)
+/proc/isorgan(atom/A)
 	return istype(A, /obj/item/organ)

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -17,7 +17,7 @@
 		atvcover.layer = ABOVE_MOB_LAYER
 
 
-obj/vehicle/atv/post_buckle_mob(mob/living/M)
+/obj/vehicle/atv/post_buckle_mob(mob/living/M)
 	if(has_buckled_mobs())
 		add_overlay(atvcover)
 	else


### PR DESCRIPTION
This is probably stretching the boundary on 'actually useful commit' but ... something something consistency 


```
Search:  ^(proc|datum|atom|obj|turf|area|mob|world|client)/
Replace: /$1/
```