### PR TITLE
Replaces ID cards with sniper rifles

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -26,7 +26,7 @@ Captain
 /datum/outfit/job/captain
 	name = "Captain"
 
-	id = /obj/item/weapon/card/id/gold
+	id = /obj/item/weapon/gun/ballistic/automatic/sniper_rifle
 	belt = /obj/item/device/pda/captain
 	glasses = /obj/item/clothing/glasses/sunglasses
 	ears = /obj/item/device/radio/headset/heads/captain/alt
@@ -90,7 +90,7 @@ Head of Personnel
 /datum/outfit/job/hop
 	name = "Head of Personnel"
 
-	id = /obj/item/weapon/card/id/silver
+	id = /obj/item/weapon/gun/ballistic/automatic/sniper_rifle
 	belt = /obj/item/device/pda/heads/hop
 	ears = /obj/item/device/radio/headset/heads/hop
 	uniform = /obj/item/clothing/under/rank/head_of_personnel

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -28,7 +28,7 @@ Chief Engineer
 /datum/outfit/job/ce
 	name = "Chief Engineer"
 
-	id = /obj/item/weapon/card/id/silver
+	id = /obj/item/weapon/gun/ballistic/automatic/sniper_rifle
 	belt = /obj/item/weapon/storage/belt/utility/chief/full
 	l_pocket = /obj/item/device/pda/heads/ce
 	ears = /obj/item/device/radio/headset/heads/ce

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -136,7 +136,7 @@
 	name = "Standard Gear"
 
 	uniform = /obj/item/clothing/under/color/grey
-	id = /obj/item/weapon/card/id
+	id = /obj/item/weapon/gun/ballistic/automatic/sniper_rifle
 	ears = /obj/item/device/radio/headset
 	belt = /obj/item/device/pda
 	back = /obj/item/weapon/storage/backpack

--- a/code/modules/projectiles/boxes_magazines/external_mag.dm
+++ b/code/modules/projectiles/boxes_magazines/external_mag.dm
@@ -229,7 +229,7 @@ obj/item/ammo_box/magazine/tommygunm45
 	desc = "An extremely powerful round capable of passing straight through cover and anyone unfortunate enough to be behind it."
 	ammo_type = /obj/item/ammo_casing/penetrator
 	origin_tech = "combat=6;syndicate=3"
-	max_ammo = 5
+	max_ammo = 50
 
 
 //// SAW MAGAZINES

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -366,7 +366,7 @@
 	w_class = 3
 	zoomable = TRUE
 	zoom_amt = 7 //Long range, enough to see in front of you, but no tiles behind you.
-	slot_flags = SLOT_BACK
+	slot_flags = SLOT_BACK | SLOT_ID
 	actions_types = list()
 
 


### PR DESCRIPTION
People will now spawn with sniper rifles instead of ID cards. Sniper magazines have been increased to hold 50 rounds each in case people miss the doors they are trying to open. Sniper rifles now fit in your ID slot.
