### PR TITLE
Reverted F8 to be Invismin and F7 to be build-mode

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -193,11 +193,11 @@ macro "default"
 		is-disabled = false
 	elem 
 		name = "F7"
-		command = "Stealth-Mode"
+		command = "Toggle-Build-Mode-Self"
 		is-disabled = false
 	elem 
 		name = "F8"
-		command = "Toggle-Build-Mode-Self"
+		command = "Invisimin"
 		is-disabled = false
 	elem 
 		name = "F12"


### PR DESCRIPTION
:cl: PeopleAreStrange
tweak: Changed F7 to buildmode, F8 to Invismin (again). Removed stealthmin toggle
/:cl:

Having F8 as a Invisimin toggle key is incredibly useful for events and the like (it has always been that key as well, so reverted to that key for legacy issues).
F7 will be build mode (because having it on a key is actually really useful).
Having "Stealthmin" on a hot key REALLY isnt necessary. Its not something you toggle on and off frequently. Its something you set and leave and honestly only a few admins utilise it anyway.

(Also my first PR woo!)