### PR TITLE
Improves Geis binding resist

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -29,31 +29,40 @@
 	if(!isturf(T))
 		return TRUE
 
-	if(isliving(target) && ranged_ability_user.Adjacent(target))
-		var/mob/living/L = target
-		if(is_servant_of_ratvar(L))
-			if(L != ranged_ability_user)
-				ranged_ability_user << "<span class='sevtug'>\"[L.p_they(TRUE)] already serve[L.p_s()] Ratvar. [text2ratvar("Perhaps [ranged_ability_user.p_theyre()] into bondage?")]\"</span>"
-			return TRUE
-		if(L.stat == DEAD)
-			ranged_ability_user << "<span class='sevtug'>\"[L.p_theyre(TRUE)] dead, idiot.\"</span>"
-			return TRUE
+	var/target_is_binding = istype(target, /obj/structure/destructible/clockwork/geis_binding)
 
-		if(istype(L.buckled, /obj/structure/destructible/clockwork/geis_binding)) //if they're already bound, just stun them
-			L.Stun(1)
+	if((target_is_binding || isliving(target)) && ranged_ability_user.Adjacent(target))
+		if(target_is_binding)
+			var/obj/structure/destructible/clockwork/geis_binding/GB = target
+			GB.repair_and_interrupt()
 			successful = TRUE
 		else
-			in_progress = TRUE
-			clockwork_say(ranged_ability_user, text2ratvar("Be bound, heathen!"))
-			remove_mousepointer(ranged_ability_user.client)
-			ranged_ability_user.notransform = TRUE
-			addtimer(src, "reset_user_notransform", 5, TIMER_NORMAL, ranged_ability_user) //stop us moving for a little bit so we don't break the scripture following this
-			slab.busy = null
-			var/datum/clockwork_scripture/geis/conversion = new
-			conversion.slab = slab
-			conversion.invoker = ranged_ability_user
-			conversion.target = target
-			successful = conversion.run_scripture()
+			var/mob/living/L = target
+			if(is_servant_of_ratvar(L))
+				if(L != ranged_ability_user)
+					ranged_ability_user << "<span class='sevtug'>\"[L.p_they(TRUE)] already serve[L.p_s()] Ratvar. [text2ratvar("Perhaps [ranged_ability_user.p_theyre()] into bondage?")]\"</span>"
+				return TRUE
+			if(L.stat == DEAD)
+				ranged_ability_user << "<span class='sevtug'>\"[L.p_theyre(TRUE)] dead, idiot.\"</span>"
+				return TRUE
+
+			if(istype(L.buckled, /obj/structure/destructible/clockwork/geis_binding)) //if they're already bound, just stun them
+				var/obj/structure/destructible/clockwork/geis_binding/GB = L.buckled
+				GB.repair_and_interrupt()
+				successful = TRUE
+			else
+				in_progress = TRUE
+				clockwork_say(ranged_ability_user, text2ratvar("Be bound, heathen!"))
+				remove_mousepointer(ranged_ability_user.client)
+				if(slab.speed_multiplier >= 0.5) //excuse my debug...
+					ranged_ability_user.notransform = TRUE
+					addtimer(src, "reset_user_notransform", 5, TIMER_NORMAL, ranged_ability_user) //stop us moving for a little bit so we don't break the scripture following this
+				slab.busy = null
+				var/datum/clockwork_scripture/geis/conversion = new
+				conversion.slab = slab
+				conversion.invoker = ranged_ability_user
+				conversion.target = target
+				successful = conversion.run_scripture()
 
 		remove_ranged_ability()
 
@@ -71,12 +80,14 @@
 	obj_integrity = 30
 	density = 0
 	icon = 'icons/effects/clockwork_effects.dmi'
-	icon_state = "geisbinding"
-	break_message = "<span class='warning'>The glowing ring shatters!</span>"
+	icon_state = "geisbinding_full"
+	break_message = null
 	break_sound = 'sound/magic/Repulse.ogg'
 	debris = list()
 	can_buckle = TRUE
 	buckle_lying = 0
+	var/resisting = FALSE
+	var/mob_layer = MOB_LAYER
 
 /obj/structure/destructible/clockwork/geis_binding/examine(mob/user)
 	icon_state = "geisbinding_full"
@@ -90,6 +101,8 @@
 	if(M.buckled == src)
 		desc = "A flickering, glowing purple ring around [M]."
 		clockwork_desc = "A binding ring around [M], preventing [M.p_them()] from taking action while [M.p_theyre()] being converted."
+		icon_state = "geisbinding"
+		mob_layer = M.layer
 		layer = M.layer - 0.01
 		var/image/GB = new('icons/effects/clockwork_effects.dmi', src, "geisbinding_top", M.layer + 0.01)
 		add_overlay(GB)
@@ -102,18 +115,65 @@
 		M.visible_message("<span class='warning'>A [name] appears around [M]!</span>", \
 		"<span class='warning'>A [name] appears around you!</span>\n<span class='userdanger'>Resist!</span>")
 	else
+		var/obj/effect/overlay/temp/ratvar/geis_binding/G = PoolOrNew(/obj/effect/overlay/temp/ratvar/geis_binding, M.loc)
+		var/obj/effect/overlay/temp/ratvar/geis_binding/T = PoolOrNew(/obj/effect/overlay/temp/ratvar/geis_binding/top, M.loc)
+		G.layer = mob_layer - 0.01
+		T.layer = mob_layer + 0.01
+		G.alpha = alpha
+		T.alpha = alpha
+		animate(G, transform = matrix()*2, alpha = 0, time = 8, easing = EASE_OUT)
+		animate(T, transform = matrix()*2, alpha = 0, time = 8, easing = EASE_OUT)
 		M.visible_message("<span class='warning'>[src] snaps into glowing pieces and dissipates!</span>")
-		for(var/obj/item/geis_binding/G in M.held_items)
-			M.unEquip(G, TRUE)
+		for(var/obj/item/geis_binding/GB in M.held_items)
+			M.unEquip(GB, TRUE)
 		qdel(src)
+
+/obj/structure/destructible/clockwork/geis_binding/relaymove(mob/user, direction)
+	if(isliving(user))
+		var/mob/living/L = user
+		L.resist()
+
+/obj/structure/destructible/clockwork/geis_binding/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+	playsound(src, 'sound/effects/EMPulse.ogg', 50, 1)
+
+/obj/structure/destructible/clockwork/geis_binding/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+	. = ..()
+	if(.)
+		update_icon()
+
+/obj/structure/destructible/clockwork/geis_binding/update_icon()
+	alpha = min(initial(alpha) + ((obj_integrity - max_integrity) * 5), 255)
+
+/obj/structure/destructible/clockwork/geis_binding/proc/repair_and_interrupt()
+	obj_integrity = max_integrity
+	update_icon()
+	resisting = FALSE
+	visible_message("<span class='sevtug'>[src] flares brightly!</span>")
+	var/obj/effect/overlay/temp/ratvar/geis_binding/G1 = PoolOrNew(/obj/effect/overlay/temp/ratvar/geis_binding, loc)
+	var/obj/effect/overlay/temp/ratvar/geis_binding/G2 = PoolOrNew(/obj/effect/overlay/temp/ratvar/geis_binding, loc)
+	var/obj/effect/overlay/temp/ratvar/geis_binding/T1 = PoolOrNew(/obj/effect/overlay/temp/ratvar/geis_binding/top, loc)
+	var/obj/effect/overlay/temp/ratvar/geis_binding/T2 = PoolOrNew(/obj/effect/overlay/temp/ratvar/geis_binding/top, loc)
+	G1.layer = mob_layer - 0.01
+	G2.layer = mob_layer - 0.01
+	T1.layer = mob_layer + 0.01
+	T2.layer = mob_layer + 0.01
+	animate(G1, pixel_y = pixel_y + 9, alpha = 0, time = 8, easing = EASE_IN)
+	animate(G2, pixel_y = pixel_y - 9, alpha = 0, time = 8, easing = EASE_IN)
+	animate(T1, pixel_y = pixel_y + 9, alpha = 0, time = 8, easing = EASE_IN)
+	animate(T2, pixel_y = pixel_y - 9, alpha = 0, time = 8, easing = EASE_IN)
 
 /obj/structure/destructible/clockwork/geis_binding/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
 	if(buckled_mob == user)
-		user.visible_message("<span class='warning'>[user] starts struggling against [src]...</span>", "<span class='userdanger'>You start breaking out of [src]...</span>")
-		if(do_after(user, 40, target = src))
-			user.visible_message("<span class='warning'>[user] breaks [src]!</span>", "<span class='userdanger'>You break [src]!</span>")
-			unbuckle_mob(user, TRUE)
-			return user
+		if(!resisting)
+			resisting = TRUE
+			user.visible_message("<span class='warning'>[user] starts struggling against [src]...</span>", "<span class='userdanger'>You start breaking out of [src]...</span>")
+			while(do_after(user, 7.5, target = src) && resisting && obj_integrity)
+				if(obj_integrity - 5 <= 0)
+					user.visible_message("<span class='warning'>[user] breaks [src]!</span>", "<span class='userdanger'>You break [src]!</span>")
+					take_damage(5)
+					return user
+				take_damage(5)
+			resisting = FALSE
 	else
 		return ..()
 

--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -86,6 +86,7 @@
 	debris = list()
 	can_buckle = TRUE
 	buckle_lying = 0
+	buckle_prevents_pull = TRUE
 	var/resisting = FALSE
 	var/mob_layer = MOB_LAYER
 

--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -147,7 +147,10 @@
 /obj/structure/destructible/clockwork/geis_binding/proc/repair_and_interrupt()
 	obj_integrity = max_integrity
 	update_icon()
-	resisting = FALSE
+	for(var/m in buckled_mobs)
+		var/mob/living/L = m
+		if(L)
+			L.Stun(1, 1, 1)
 	visible_message("<span class='sevtug'>[src] flares brightly!</span>")
 	var/obj/effect/overlay/temp/ratvar/geis_binding/G1 = PoolOrNew(/obj/effect/overlay/temp/ratvar/geis_binding, loc)
 	var/obj/effect/overlay/temp/ratvar/geis_binding/G2 = PoolOrNew(/obj/effect/overlay/temp/ratvar/geis_binding, loc)

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
@@ -111,7 +111,7 @@
 	descname = "Melee Convert Attack"
 	name = "Geis"
 	desc = "Charges your slab with divine energy, allowing you to bind a nearby heretic for conversion. This is very obvious and will make your slab visible in-hand."
-	invocations = list("Divinity, grant me strength...", "...to enlighten the heathen!")
+	invocations = list("Divinity, grant...", "...me strength...", "...to enlighten...", "...the heathen!")
 	whispered = TRUE
 	channel_time = 20
 	required_components = list(GEIS_CAPACITOR = 1)
@@ -135,6 +135,8 @@
 			servants++
 	if(servants > SCRIPT_SERVANT_REQ)
 		whispered = FALSE
+		servants -= SCRIPT_SERVANT_REQ
+		channel_time = min(channel_time + servants*3, 50)
 	return ..()
 
 //The scripture that does the converting.
@@ -162,7 +164,7 @@
 			servants++
 	if(servants > SCRIPT_SERVANT_REQ)
 		servants -= SCRIPT_SERVANT_REQ
-		channel_time = min(channel_time + servants*5, 100)
+		channel_time = min(channel_time + servants*7, 120)
 	if(target.buckled)
 		target.buckled.unbuckle_mob(target, TRUE)
 	binding = new(get_turf(target))

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -49,12 +49,14 @@
 			usr << "<span class='warning'>You are unable to buckle [M] to the [src]!</span>"
 		return 0
 
+	if(M.pulledby && anchored)
+		M.pulledby.stop_pulling()
 	M.buckled = src
 	M.setDir(dir)
 	buckled_mobs |= M
 	M.update_canmove()
-	post_buckle_mob(M)
 	M.throw_alert("buckled", /obj/screen/alert/restrained/buckled, new_master = src)
+	post_buckle_mob(M)
 
 	return 1
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -6,6 +6,7 @@
 	var/buckle_requires_restraints = 0 //require people to be handcuffed before being able to buckle. eg: pipes
 	var/list/mob/living/buckled_mobs = null //list()
 	var/max_buckled_mobs = 1
+	var/buckle_prevents_pull = FALSE
 
 //Interaction
 /atom/movable/attack_hand(mob/living/user)
@@ -49,7 +50,7 @@
 			usr << "<span class='warning'>You are unable to buckle [M] to the [src]!</span>"
 		return 0
 
-	if(M.pulledby && anchored)
+	if(M.pulledby && buckle_prevents_pull)
 		M.pulledby.stop_pulling()
 	M.buckled = src
 	M.setDir(dir)

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -306,6 +306,12 @@
 	pixel_y = -16
 	pixel_x = -16
 
+/obj/effect/overlay/temp/ratvar/geis_binding
+	icon_state = "geisbinding"
+
+/obj/effect/overlay/temp/ratvar/geis_binding/top
+	icon_state = "geisbinding_top"
+
 /obj/effect/overlay/temp/ratvar/component
 	icon = 'icons/obj/clockwork_objects.dmi'
 	icon_state = "belligerent_eye"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -304,7 +304,7 @@ var/next_mob_id = 0
 		return
 	if(isliving(AM))
 		var/mob/living/L = AM
-		if(L.buckled && L.buckled.anchored)
+		if(L.buckled && L.buckled.buckle_prevents_pull)
 			return
 	if(throwing || incapacitated())
 		return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -302,6 +302,10 @@ var/next_mob_id = 0
 		return
 	if(AM.anchored || AM.throwing)
 		return
+	if(isliving(AM))
+		var/mob/living/L = AM
+		if(L.buckled && L.buckled.anchored)
+			return
 	if(throwing || incapacitated())
 		return
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -316,7 +316,7 @@
 		return
 	if(isliving(pulling))
 		var/mob/living/L = pulling
-		if(L.buckled && L.buckled.anchored) //if they're buckled to something anchored, we can't move them and should stop trying
+		if(L.buckled && L.buckled.buckle_prevents_pull) //if they're buckled to something that disallows pulling, prevent it
 			stop_pulling()
 			return
 	if(A == loc && pulling.density)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -309,14 +309,19 @@
 
 //moves the mob/object we're pulling
 /mob/proc/Move_Pulled(atom/A)
-	if (!pulling)
+	if(!pulling)
 		return
-	if (pulling.anchored || !pulling.Adjacent(src))
+	if(pulling.anchored || !pulling.Adjacent(src))
 		stop_pulling()
 		return
-	if (A == loc && pulling.density)
+	if(isliving(pulling))
+		var/mob/living/L = pulling
+		if(L.buckled && L.buckled.anchored) //if they're buckled to something anchored, we can't move them and should stop trying
+			stop_pulling()
+			return
+	if(A == loc && pulling.density)
 		return
-	if (!Process_Spacemove(get_dir(pulling.loc, A)))
+	if(!Process_Spacemove(get_dir(pulling.loc, A)))
 		return
 	step(pulling, get_dir(pulling.loc, A))
 


### PR DESCRIPTION
:cl: Joan
rscadd: Trying to move while bound by Geis will cause you to start resisting, but the time required to resist is up by half a second.
experiment: Resisting out of Geis now does damage to the binding, and as such being stunned while bound will no longer totally reset your resist progress.
rscadd: Using Geis on someone already bound by Geis will interrupt them resisting out of it and will fully repair the binding.
tweak: Geis's pre-binding channel now takes longer for each servant above 5. Geis's conversion channel also takes slightly longer for each servant above 5.
/:cl:

Yes, this means mending motors are eeeeven beeetter because they'll repair the binding.
In exchange, the pre-binding channel is longer and more obvious when above 5 servants, and it's easier for people to resist out(but also easier to see how close they are to getting out, and the actual resist time is slightly higher)

And yes, you can use a proselytizer on the glowing ring. Don't ask me HOW that works, exactly.