### PR TITLE
Fixes a buggy syringe on the map

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -5085,9 +5085,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/obj/item/weapon/reagent_containers/syringe{
-	name = "steel point"
-	},
+/obj/item/weapon/reagent_containers/syringe
 /obj/item/weapon/reagent_containers/glass/bottle/charcoal,
 /obj/item/weapon/reagent_containers/glass/bottle/epinephrine,
 /turf/open/floor/plasteel/whitered/side{

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -3428,9 +3428,7 @@
 	pixel_x = -27;
 	pixel_y = 0
 	},
-/obj/item/weapon/reagent_containers/syringe{
-	name = "steel point"
-	},
+/obj/item/weapon/reagent_containers/syringe,
 /obj/item/weapon/reagent_containers/glass/bottle/charcoal,
 /obj/item/weapon/reagent_containers/glass/bottle/epinephrine,
 /obj/machinery/light{


### PR DESCRIPTION
It's minor but why should it stay? Like really, why is a syringe called steel point instead of syringe?

Generally curious why, if it's so minor that you care to keep a syringe named steel point in the game.