### PR TITLE
Adds automatic catching and throwing to martial arts

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -7,6 +7,7 @@
 	var/datum/martial_art/base = null // The permanent style
 	var/deflection_chance = 0 //Chance to deflect projectiles
 	var/block_chance = 0 //Chance to block melee attacks using items while on throw mode.
+	var/catch_chance = 0 //Chance to catch and throw back items instantly regardless of throw mode
 	var/restraining = 0 //used in cqc's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
 	var/help_verb = null
 
@@ -248,6 +249,7 @@
 /datum/martial_art/the_sleeping_carp
 	name = "The Sleeping Carp"
 	deflection_chance = 100
+	catch_chance = 100
 	help_verb = /mob/living/carbon/human/proc/sleeping_carp_help
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -156,6 +156,7 @@
 
 /datum/martial_art/plasma_fist
 	name = "Plasma Fist"
+	catch_chance = 30
 	help_verb = /mob/living/carbon/human/proc/plasma_fist_help
 
 
@@ -249,7 +250,7 @@
 /datum/martial_art/the_sleeping_carp
 	name = "The Sleeping Carp"
 	deflection_chance = 100
-	catch_chance = 100
+	catch_chance = 60
 	help_verb = /mob/living/carbon/human/proc/sleeping_carp_help
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -1,5 +1,6 @@
 /datum/martial_art/krav_maga
 	name = "Krav Maga"
+	catch_chance = 30
 	var/datum/action/neck_chop/neckchop = new/datum/action/neck_chop()
 	var/datum/action/leg_sweep/legsweep = new/datum/action/leg_sweep()
 	var/datum/action/lung_punch/lungpunch = new/datum/action/lung_punch()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -140,7 +140,19 @@
 		throwpower = I.throwforce
 		if(I.thrownby == src) //No throwing stuff at yourself to trigger hit reactions
 			return ..()
-	if(check_shields(throwpower, "\the [AM.name]", AM, THROWN_PROJECTILE_ATTACK))
+	if(martial_art && martial_art.catch_chance)
+		if(prob(martial_art.catch_chance))
+			if(canmove && !restrained() && I && isturf(I.loc))
+				var/thrower = I.thrownby
+				if(put_in_hands(I))
+					visible_message("<span class='warning'>[src] catches [I]!</span>")
+					if(!(a_intent == "help") && thrower && thrower in view(src))
+						sleep(1)
+						unEquip(I)
+						visible_message("<span class='danger'>[src] has thrown [I]!</span>")
+						I.throw_at(thrower,I.throw_range,I.throw_speed,src)
+					return 1
+	else if(check_shields(throwpower, "\the [AM.name]", AM, THROWN_PROJECTILE_ATTACK))
 		hitpush = 0
 		skipcatch = 1
 		blocked = 1


### PR DESCRIPTION
:cl: Swindly
add: Some martial arts now grant a chance to catch thrown items regardless of which hand is active or whether throw mode is toggled as long as the user has a free hand. In intents besides help, items caught this way are immediately thrown back. These catch/throw chances are 60% for Sleeping Carp and 30% for Plasma Fist and Krav Maga.
/:cl:
