### PR TITLE
Replaces ID cards with combat RCD

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -90,7 +90,7 @@ Head of Personnel
 /datum/outfit/job/hop
 	name = "Head of Personnel"
 
-	id = /obj/item/weapon/card/id/silver
+	id = /obj/item/weapon/rcd/combat
 	belt = /obj/item/device/pda/heads/hop
 	ears = /obj/item/device/radio/headset/heads/hop
 	uniform = /obj/item/clothing/under/rank/head_of_personnel

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -26,7 +26,7 @@ Captain
 /datum/outfit/job/captain
 	name = "Captain"
 
-	id = /obj/item/weapon/card/id/gold
+	id = /obj/item/weapon/rcd/combat
 	belt = /obj/item/device/pda/captain
 	glasses = /obj/item/clothing/glasses/sunglasses
 	ears = /obj/item/device/radio/headset/heads/captain/alt

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -28,7 +28,7 @@ Chief Engineer
 /datum/outfit/job/ce
 	name = "Chief Engineer"
 
-	id = /obj/item/weapon/card/id/silver
+	id = /obj/item/weapon/rcd/combat
 	belt = /obj/item/weapon/storage/belt/utility/chief/full
 	l_pocket = /obj/item/device/pda/heads/ce
 	ears = /obj/item/device/radio/headset/heads/ce

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -136,7 +136,7 @@
 	name = "Standard Gear"
 
 	uniform = /obj/item/clothing/under/color/grey
-	id = /obj/item/weapon/card/id
+	id = /obj/item/weapon/rcd/combat
 	ears = /obj/item/device/radio/headset
 	belt = /obj/item/device/pda
 	back = /obj/item/weapon/storage/backpack


### PR DESCRIPTION
:cl: ma44
tweak: Centcomm realized that the crew is having a rough time dealing with airlocks, so now they have supplied you and your fellow crewmembers with RCDs so you can remove airlocks or make your own with very little effort. 
/:cl:
