### PR TITLE
Fixes a small oversight in timer subsystem

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -75,7 +75,7 @@ var/datum/subsystem/timer/SStimer
 	var/hashlist = args.Copy()
 
 	hashlist[1] = "[thingToCall](\ref[thingToCall])"
-	event.hash = jointext(args, null)
+	event.hash = jointext(hashlist, null)
 
 	var/bad_args = unique != TIMER_NORMAL && unique != TIMER_UNIQUE
 	if(args.len > 4 || bad_args)


### PR DESCRIPTION
hashlist was designed to ensure that timers on different objects with the same name didn't get detected as the same timer, but when I added it, I forgot to make this line actually use the hashlist.

Thanks @Fox-McCloud 