### PR TITLE
Fixes Revolver not being able to be redescribed

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -32,10 +32,6 @@
 		update_icon()
 		chamber_round(0)
 
-	if(unique_rename)
-		if(istype(A, /obj/item/weapon/pen))
-			rename_weapon(user)
-
 /obj/item/weapon/gun/ballistic/revolver/attack_self(mob/living/user)
 	var/num_unloaded = 0
 	chambered = null


### PR DESCRIPTION
/obj/item/weapon already covers this so not sure why the revolver had its own.