### PR TITLE
Cid Randomizer Detector will not check webclients

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -335,6 +335,8 @@ var/next_external_rsc = 0
 
 /client/proc/check_randomizer(topic)
 	. = FALSE
+	if (connection != "seeker")
+		return
 	topic = params2list(topic)
 	if (!config.check_randomizer)
 		return


### PR DESCRIPTION
or any client type that isn't seeker.

The randomizer doesn't work on the webclient, and it wouldn't matter anyways because the webclient's cid is worthless.