### PR TITLE
Removes over ONE MILLION proc calls from world init.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -27,10 +27,18 @@
 	//atom creation method that preloads variables at creation
 	if(use_preloader && (src.type == _preloader.target_path))//in case the instanciated atom is creating other atoms in New()
 		_preloader.load(src)
-
+	//atom color stuff
 	if(color)
 		add_atom_colour(color, FIXED_COLOUR_PRIORITY)
-	. = ..()
+
+	//lighting stuff
+	if(opacity && isturf(loc))
+		loc.UpdateAffectingLights()
+
+	if(luminosity)
+		light = new(src)
+
+	//. = ..() //uncomment if you are dumb enough to add a /datum/New() proc
 
 /atom/Destroy()
 	if(alternate_appearances)

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -29,7 +29,6 @@
 	var/obj/machinery/atmospherics/pipe/P = A
 	P.add_atom_colour(modes[mode], FIXED_COLOUR_PRIORITY)
 	P.pipe_color = modes[mode]
-	P.stored.add_atom_colour(modes[mode], FIXED_COLOUR_PRIORITY)
 	user.visible_message("<span class='notice'>[user] paints \the [P] [mode].</span>","<span class='notice'>You paint \the [P] [mode].</span>")
 	P.update_node_icon() //updates the neighbors
 

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -544,7 +544,6 @@ var/global/list/RPD_recipes=list(
 			playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
 			P.add_atom_colour(paint_colors[paint_color], FIXED_COLOUR_PRIORITY)
 			P.pipe_color = paint_colors[paint_color]
-			P.stored.add_atom_colour(paint_colors[paint_color], FIXED_COLOUR_PRIORITY)
 			user.visible_message("<span class='notice'>[user] paints \the [P] [paint_color].</span>","<span class='notice'>You paint \the [P] [paint_color].</span>")
 			//P.update_icon()
 			P.update_node_icon()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -30,10 +30,14 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 	var/broken = 0
 	var/burnt = 0
 	var/floor_tile = null //tile that this floor drops
-	var/list/broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
-	var/list/burnt_states = list()
+	var/list/broken_states
+	var/list/burnt_states
 
 /turf/open/floor/New()
+	if (!broken_states)
+		broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
+	if (!burnt_states)
+		burnt_states = list()
 	..()
 	if(icon_state in icons_to_ignore_at_floor_init) //so damaged/burned tiles or plating icons aren't saved as the default
 		icon_regular_floor = "floor"

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -12,13 +12,16 @@
 /turf/open/floor/mineral
 	name = "mineral floor"
 	icon_state = ""
-	var/list/icons = list()
+	var/list/icons
 
 
 
 /turf/open/floor/mineral/New()
-	..()
 	broken_states = list("[initial(icon_state)]_dam")
+	..()
+	if (!icons)
+		icons = list()
+
 
 /turf/open/floor/mineral/update_icon()
 	if(!..())

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -12,10 +12,12 @@
 	name = "plating"
 	icon_state = "plating"
 	intact = 0
-	broken_states = list("platingdmg1", "platingdmg2", "platingdmg3")
-	burnt_states = list("panelscorched")
 
 /turf/open/floor/plating/New()
+	if (!broken_states)
+		broken_states = list("platingdmg1", "platingdmg2", "platingdmg3")
+	if (!burnt_states)
+		burnt_states = list("panelscorched")
 	..()
 	icon_plating = icon_state
 

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -149,10 +149,9 @@
 
 /turf/open/floor/plating/asteroid/airless/cave
 	var/length = 100
-	var/mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 1, /mob/living/simple_animal/hostile/asteroid/goliath = 5, /mob/living/simple_animal/hostile/asteroid/basilisk = 4, /mob/living/simple_animal/hostile/asteroid/hivelord = 3)
-	var/megafauna_spawn_list = list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, \
-	/mob/living/simple_animal/hostile/megafauna/bubblegum = SPAWN_BUBBLEGUM)
-	var/flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
+	var/mob_spawn_list
+	var/megafauna_spawn_list
+	var/flora_spawn_list
 	var/sanity = 1
 	var/forward_cave_dir = 1
 	var/backward_cave_dir = 2
@@ -178,6 +177,13 @@
 	has_data = TRUE
 
 /turf/open/floor/plating/asteroid/airless/cave/New(loc)
+	if (!mob_spawn_list)
+		mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 1, /mob/living/simple_animal/hostile/asteroid/goliath = 5, /mob/living/simple_animal/hostile/asteroid/basilisk = 4, /mob/living/simple_animal/hostile/asteroid/hivelord = 3)
+	if (!megafauna_spawn_list)
+		megafauna_spawn_list = list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = SPAWN_BUBBLEGUM)
+	if (!flora_spawn_list)
+		flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
+
 	if(!has_data)
 		produce_tunnel_from_data()
 	..()

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -6,7 +6,7 @@
 	icon_state = "rock"
 	var/smooth_icon = 'icons/turf/smoothrocks.dmi'
 	smooth = SMOOTH_MORE|SMOOTH_BORDER
-	canSmoothWith = list (/turf/closed)
+	canSmoothWith
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	initial_gas_mix = "TEMP=2.7"
 	opacity = 1
@@ -25,6 +25,8 @@
 	var/defer_change = 0
 
 /turf/closed/mineral/New()
+	if (!canSmoothWith)
+		canSmoothWith = list(/turf/closed)
 	pixel_y = -4
 	pixel_x = -4
 	icon = smooth_icon

--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -3,7 +3,6 @@
 	desc = "A cold metal wall engraved with indecipherable symbols. Studying them causes your head to pound."
 	icon = 'icons/turf/walls/cult_wall.dmi'
 	icon_state = "cult"
-	builtin_sheet = null
 	canSmoothWith = null
 
 /turf/closed/wall/mineral/cult/New()

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -30,11 +30,11 @@
 			user << "<span class='notice'>The support rods have been <i>sliced through</i>, and the outer sheath is <b>connected loosely</b> to the girder.</span>"
 
 /turf/closed/wall/r_wall/break_wall()
-	builtin_sheet.loc = src
+	new sheet_type(loc)
 	return (new /obj/structure/girder/reinforced(src))
 
 /turf/closed/wall/r_wall/devastate_wall()
-	builtin_sheet.loc = src
+	new sheet_type(loc)
 	new /obj/item/stack/sheet/metal(src, 2)
 
 /turf/closed/wall/r_wall/attack_animal(mob/living/simple_animal/M)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -11,7 +11,7 @@
 	var/hardness = 40 //lower numbers are harder. Used to determine the probability of a hulk smashing through.
 	var/slicing_duration = 100  //default time taken to slice the wall
 	var/sheet_type = /obj/item/stack/sheet/metal
-	var/obj/item/stack/sheet/builtin_sheet = null
+	//var/obj/item/stack/sheet/builtin_sheet = null
 
 	canSmoothWith = list(
 	/turf/closed/wall,
@@ -26,7 +26,7 @@
 
 /turf/closed/wall/New()
 	..()
-	builtin_sheet = new sheet_type
+	//builtin_sheet = new sheet_type
 
 /turf/closed/wall/attack_tk()
 	return
@@ -48,13 +48,13 @@
 	ChangeTurf(/turf/open/floor/plating)
 
 /turf/closed/wall/proc/break_wall()
+	var/obj/item/stack/sheet/builtin_sheet = new sheet_type(loc)
 	builtin_sheet.amount = 2
-	builtin_sheet.loc = src
 	return (new /obj/structure/girder(src))
 
 /turf/closed/wall/proc/devastate_wall()
+	var/obj/item/stack/sheet/builtin_sheet = new sheet_type(loc)
 	builtin_sheet.amount = 2
-	builtin_sheet.loc = src
 	new /obj/item/stack/sheet/metal(src)
 
 /turf/closed/wall/ex_act(severity, target)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -16,7 +16,7 @@
 
 
 /turf/open/space/New()
-	update_icon()
+	icon_state = SPACE_ICON_STATE
 	air = space_gas
 
 /turf/open/space/Destroy(force)
@@ -167,9 +167,6 @@
 	if(locate(/obj/structure/lattice/catwalk, src))
 		return 1
 	return 0
-
-/turf/open/space/proc/update_icon()
-	icon_state = SPACE_ICON_STATE
 
 /turf/open/space/is_transition_turf()
 	if(destination_x || destination_y || destination_z)

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -67,7 +67,7 @@
 		throw_atom(AM)
 	..()
 
-/turf/open/space/transit/update_icon()
+/turf/open/space/transit/proc/update_icon()
 	var/p = 9
 	var/angle = 0
 	var/state = 1

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -24,32 +24,29 @@ Pipelines + Other Objects -> Pipe network
 	var/can_unwrench = 0
 	var/initialize_directions = 0
 	var/pipe_color
-	var/obj/item/pipe/stored
+
+	//var/obj/item/pipe/stored
 	var/global/list/iconsetids = list()
 	var/global/list/pipeimages = list()
 
 	var/image/pipe_vision_img = null
 
 	var/device_type = 0
-	var/list/obj/machinery/atmospherics/nodes = list()
+	var/list/obj/machinery/atmospherics/nodes
 
 /obj/machinery/atmospherics/New(loc, process = TRUE)
+	nodes = list()
 	nodes.len = device_type
 	..()
 	if(process)
 		SSair.atmos_machinery += src
 	SetInitDirections()
-	if(can_unwrench)
-		stored = new(src, make_from=src)
 
 /obj/machinery/atmospherics/Destroy()
 	for(DEVICE_TYPE_LOOP)
 		nullifyNode(I)
 
 	SSair.atmos_machinery -= src
-	if(stored)
-		qdel(stored)
-		stored = null
 
 	dropContents()
 	if(pipe_vision_img)
@@ -185,12 +182,10 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))
 		if(can_unwrench)
-			if(stored)
-				stored.forceMove(loc)
-				if(!disassembled)
-					stored.obj_integrity = stored.max_integrity * 0.5
-				transfer_fingerprints_to(stored)
-				stored = null
+			var/obj/item/pipe/stored = new(loc, make_from=src)
+			if(!disassembled)
+				stored.obj_integrity = stored.max_integrity * 0.5
+			transfer_fingerprints_to(stored)
 	..()
 
 /obj/machinery/atmospherics/proc/getpipeimage(iconset, iconstate, direction, col=rgb(255,255,255))
@@ -218,9 +213,6 @@ Pipelines + Other Objects -> Pipe network
 	if(can_unwrench)
 		add_atom_colour(obj_color, FIXED_COLOUR_PRIORITY)
 		pipe_color = obj_color
-		stored.setDir(src.dir		  )//need to define them here, because the obj directions...
-		stored.pipe_type = pipe_type  //... were not set at the time the stored pipe was created
-		stored.add_atom_colour(obj_color, FIXED_COLOUR_PRIORITY)
 	var/turf/T = loc
 	level = T.intact ? 2 : 1
 	atmosinit()

--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -162,23 +162,6 @@
 /atom
 	var/datum/light_source/light
 
-
-//Turfs with opacity when they are constructed will trigger nearby lights to update
-//Turfs and atoms with luminosity when they are constructed will create a light_source automatically
-/turf/New()
-	..()
-	if(luminosity)
-		light = new(src)
-
-//Movable atoms with opacity when they are constructed will trigger nearby lights to update
-//Movable atoms with luminosity when they are constructed will create a light_source automatically
-/atom/movable/New()
-	..()
-	if(opacity && isturf(loc))
-		loc.UpdateAffectingLights()
-	if(luminosity)
-		light = new(src)
-
 //Objects with opacity will trigger nearby lights to update at next SSlighting fire
 /atom/movable/Destroy()
 	qdel(light)


### PR DESCRIPTION
:cl:
tweak: Made the server startup and reboot faster
/:cl:

(Number entirely guesstimated from exaggerated ideas of how many atoms we have at world start.)

I have removed 2 proc calls from every atom, 1 proc call from every space turf, a few proc calls from every floor, 1 proc call + 1 object creation from every wall, 1 proc call + 1 object creation from every pipe... and more!

~~I can't really do too much more until lummox fixes the profiler not showing map object's New() during world init so I know what big ticket items to tackle.~~ nvm, figured out that i can just load the map as an away mission to profile it. item, structure, machinery, in that order, are the 3 biggest [init] procs by call count. I'll work on those sometime this weekend.

