### PR TITLE
Fixes grape soda

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -488,7 +488,7 @@
 /datum/chemical_reaction/grape_soda
 	name = "grape soda"
 	id = "grapesoda"
-	results = list("grape_soda" = 2)
+	results = list("grapesoda" = 2)
 	required_reagents = list("grapejuice" = 1, "sodawater" = 1)
 
 /datum/chemical_reaction/grappa


### PR DESCRIPTION
Grape soda can now be made. Apparently nobody tried to make it since 15 october 2015, since the bug was only noticed today.

Fixes #21877
