### PR TITLE
The station time for silicons and observers now ignores roundstart

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -6,7 +6,7 @@
 	return time2text(world.timeofday, format)
 
 /proc/gameTimestamp(format = "hh:mm:ss") // Get the game time in text
-	return time2text(world.time - timezoneOffset + 432000, format)
+	return time2text(world.time - timezoneOffset + 432000 - round_start_time, format)
 
 /* Returns 1 if it is the selected month and day */
 /proc/isDay(month, day)


### PR DESCRIPTION
It's a sudden jump back for pre-game observers but avoiding that would require adding to ticker fire() and I'd rather not.