### PR TITLE
Deconstructed airlock assemblies keep their original name when rebuilt.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1476,6 +1476,7 @@ var/list/airlock_overlays = list()
 		else
 			A = new /obj/structure/door_assembly/door_assembly_0(src.loc)
 			//If you come across a null assemblytype, it will produce the default assembly instead of disintegrating.
+		A.created_name = name
 
 		if(!disassembled)
 			if(A)


### PR DESCRIPTION
:cl: RandomMarine
tweak: Airlocks will keep their original name when their electronics are removed and replaced. You may still use a pen to rename the assembly if desired.
/:cl:

