### PR TITLE
Fixes a couple of kudzu bugs

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -30,12 +30,6 @@
 
 	if(color)
 		add_atom_colour(color, FIXED_COLOUR_PRIORITY)
-
-	if(!atom_colours)
-		atom_colours = list(ADMIN_COLOUR_PRIORITY = null, \
-		TEMPORARY_COLOUR_PRIORITY = null, \
-		WASHABLE_COLOUR_PRIORITY = null, \
-		FIXED_COLOUR_PRIORITY = null)
 	. = ..()
 
 /atom/Destroy()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -30,6 +30,12 @@
 
 	if(color)
 		add_atom_colour(color, FIXED_COLOUR_PRIORITY)
+
+	if(!atom_colours)
+		atom_colours = list(ADMIN_COLOUR_PRIORITY = null, \
+		TEMPORARY_COLOUR_PRIORITY = null, \
+		WASHABLE_COLOUR_PRIORITY = null, \
+		FIXED_COLOUR_PRIORITY = null)
 	. = ..()
 
 /atom/Destroy()

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -306,7 +306,7 @@
 		new/obj/structure/alien/resin/flower_bud_enemy(get_turf(holder))
 
 /datum/spacevine_mutation/flowering/on_cross(obj/structure/spacevine/holder, mob/living/crosser)
-	if(prob(25)
+	if(prob(25))
 		holder.entangle(crosser)
 
 

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -347,7 +347,7 @@
 		if(!master.vines.len)
 			var/obj/item/seeds/kudzu/KZ = new(loc)
 			KZ.mutations |= mutations
-			KZ.potency = min(100, master.mutativness * 10)
+			KZ.potency = min(100, master.mutativeness * 10)
 			KZ.production = (master.spread_cap / initial(master.spread_cap)) * 50
 	mutations = list()
 	SetOpacity(0)
@@ -430,17 +430,17 @@
 	var/spread_multiplier = 5
 	var/spread_cap = 30
 	var/list/mutations_list = list()
-	var/mutativness = 1
+	var/mutativeness = 1
 
-/obj/effect/spacevine_controller/New(loc, list/muts, mttv, spreading)
+/obj/effect/spacevine_controller/New(loc, list/muts, potency, production)
 	spawn_spacevine_piece(loc, , muts)
 	START_PROCESSING(SSobj, src)
 	init_subtypes(/datum/spacevine_mutation/, mutations_list)
-	if(mttv != null)
-		mutativness = mttv / 10
-	if(spreading != null)
-		spread_cap *= spreading / 50
-		spread_multiplier /= spreading / 50
+	if(potency != null)
+		mutativeness = potency / 10
+	if(production != null)
+		spread_cap *= production / 50
+		spread_multiplier /= production / 50
 
 /obj/effect/spacevine_controller/ex_act() //only killing all vines will end this suffering
 	return
@@ -466,9 +466,10 @@
 		return
 	if(parent)
 		SV.mutations |= parent.mutations
-		var/parentcolor = parent.atom_colours[FIXED_COLOUR_PRIORITY]
-		SV.add_atom_colour(parentcolor, FIXED_COLOUR_PRIORITY)
-		if(prob(mutativness))
+		if(parent.atom_colours)
+			var/parentcolor = parent.atom_colours[FIXED_COLOUR_PRIORITY]
+			SV.add_atom_colour(parentcolor, FIXED_COLOUR_PRIORITY)
+		if(prob(mutativeness))
 			var/datum/spacevine_mutation/randmut = pick(mutations_list - SV.mutations)
 			randmut.add_mutation_to_vinepiece(SV)
 

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -306,7 +306,8 @@
 		new/obj/structure/alien/resin/flower_bud_enemy(get_turf(holder))
 
 /datum/spacevine_mutation/flowering/on_cross(obj/structure/spacevine/holder, mob/living/crosser)
-	holder.entangle(crosser)
+	if(prob(25)
+		holder.entangle(crosser)
 
 
 // SPACE VINES (Note that this code is very similar to Biomass code)
@@ -325,6 +326,10 @@
 	var/energy = 0
 	var/obj/effect/spacevine_controller/master = null
 	var/list/mutations = list()
+
+/obj/structure/spacevine/New()
+	..()
+	add_atom_colour("#ffffff", FIXED_COLOUR_PRIORITY)
 
 /obj/structure/spacevine/examine(mob/user)
 	..()
@@ -433,14 +438,15 @@
 	var/mutativeness = 1
 
 /obj/effect/spacevine_controller/New(loc, list/muts, potency, production)
+	add_atom_colour("#ffffff", FIXED_COLOUR_PRIORITY)
 	spawn_spacevine_piece(loc, , muts)
 	START_PROCESSING(SSobj, src)
 	init_subtypes(/datum/spacevine_mutation/, mutations_list)
 	if(potency != null)
 		mutativeness = potency / 10
 	if(production != null)
-		spread_cap *= production / 50
-		spread_multiplier /= production / 50
+		spread_cap *= production / 5
+		spread_multiplier /= production / 5
 	..()
 
 /obj/effect/spacevine_controller/ex_act() //only killing all vines will end this suffering
@@ -538,7 +544,7 @@
 		SM.on_buckle(src, V)
 	if((V.stat != DEAD) && (V.buckled != src)) //not dead or captured
 		V << "<span class='danger'>The vines [pick("wind", "tangle", "tighten")] around you!</span>"
-		buckle_mob(V)
+		buckle_mob(V, 1)
 
 /obj/structure/spacevine/proc/spread()
 	var/direction = pick(cardinal)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -441,6 +441,7 @@
 	if(production != null)
 		spread_cap *= production / 50
 		spread_multiplier /= production / 50
+	..()
 
 /obj/effect/spacevine_controller/ex_act() //only killing all vines will end this suffering
 	return
@@ -466,9 +467,8 @@
 		return
 	if(parent)
 		SV.mutations |= parent.mutations
-		if(parent.atom_colours)
-			var/parentcolor = parent.atom_colours[FIXED_COLOUR_PRIORITY]
-			SV.add_atom_colour(parentcolor, FIXED_COLOUR_PRIORITY)
+		var/parentcolor = parent.atom_colours[FIXED_COLOUR_PRIORITY]
+		SV.add_atom_colour(parentcolor, FIXED_COLOUR_PRIORITY)
 		if(prob(mutativeness))
 			var/datum/spacevine_mutation/randmut = pick(mutations_list - SV.mutations)
 			randmut.add_mutation_to_vinepiece(SV)

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -57,6 +57,7 @@
 		if(prob(20))
 			mutations.Remove(pick(temp_mut_list))
 		temp_mut_list.Cut()
+
 	if(S.has_reagent("welding_fuel", 5))
 		for(var/datum/spacevine_mutation/SM in mutations)
 			if(SM.quality == POSITIVE)
@@ -64,20 +65,26 @@
 		if(prob(20))
 			mutations.Remove(pick(temp_mut_list))
 		temp_mut_list.Cut()
+
 	if(S.has_reagent("phenol", 5))
 		for(var/datum/spacevine_mutation/SM in mutations)
 			if(SM.quality == MINOR_NEGATIVE)
 				temp_mut_list += SM
 		if(prob(20))
 			mutations.Remove(pick(temp_mut_list))
+		temp_mut_list.Cut()
+
 	if(S.has_reagent("blood", 15))
-		production += rand(15, -5)
+		production = Clamp(production + rand(15, -5),1,10)
+
 	if(S.has_reagent("amatoxin", 5))
-		production += rand(5, -15)
+		production = Clamp(production + rand(5, -15),1,10)
+
 	if(S.has_reagent("plasma", 5))
-		potency += rand(5, -15)
+		potency = Clamp(potency + rand(5, -15),0,100)
+
 	if(S.has_reagent("holywater", 10))
-		potency += rand(15, -5)
+		potency = Clamp(potency + rand(15, -5),0,100)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/kudzupod


### PR DESCRIPTION
Kuzdu now works and doesn't runtime on every spread.

Mutating kudzu stats via kudzu-specific chems now clamps the value to the normal limits.

Kudzu now scales properly with production speed. Higher production means more maximum vines per seed but less spread speed (i think?) and viceversa.

Kudzu now buckles properly when entangling. Flowering vines' entangling has been nerfed because it's very fucking OP, and i hope to god nobody spreads an aggressive spreading flowering vine while i'm online.

Fixes  #21881 and #21879.