### PR TITLE
Gives traitorchan a minimum pop limit

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -3,7 +3,7 @@
 	config_tag = "traitorchan"
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 0
+	required_players = 25
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 	reroll_friendly = 1


### PR DESCRIPTION
After many horrific low pop rounds absolutely dominated by 2-3 changelings I've listened to the feedback of sybil and given traitor a minimum population limit of 25. This is roughly the same pop requirement for cult and I feel is a fair number of players to combat the changeling menace. I'll edit the requirement if people think it's too high.


Also, this is the first pr I've made so shit might be broke. point out any mistakes please.


:cl: Durkel
tweak: Recent enemy reports indicate that changelings have grown bored with attacking near desolate stations and have shifted focus to more fertile hunting grounds.
/:cl:

