### PR TITLE
Adds a new toxin to the Poison Kit

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -266,6 +266,7 @@
 	new /obj/item/weapon/reagent_containers/glass/bottle/coniine(src)
 	new /obj/item/weapon/reagent_containers/glass/bottle/curare(src)
 	new /obj/item/weapon/reagent_containers/glass/bottle/amanitin(src)
+	new /obj/item/weapon/reagent_containers/glass/bottle/anacea(src)
 	new /obj/item/weapon/reagent_containers/syringe(src)
 	return
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -684,7 +684,20 @@
 			animate(whole_screen, transform = matrix(), time = 5, easing = QUAD_EASING)
 	..()
 
-
+/datum/reagent/toxin/anacea
+	name = "Anacea"
+	id = "anacea"
+	description = "A toxin that quickly purges medicines and metabolizes very slowly."
+	reagent_state = LIQUID
+	color = "#3C5133"
+	metabolization_rate = 0.08 * REAGENTS_METABOLISM
+	toxpwr = 0.1
+	
+/datum/reagent/toxin/anacea/on_mob_life(mob/living/M)
+	for(var/datum/reagent/medicine/R in M.reagents.reagent_list)
+		M.reagents.remove_reagent(R.id,6)
+	return ..()
+	
 //ACID
 
 

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -209,6 +209,12 @@
 	desc = "A small bottle. Contains Histamine."
 	icon_state = "bottle16"
 	list_reagents = list("histamine" = 30)
+	
+/obj/item/weapon/reagent_containers/glass/bottle/anacea
+	name = "anacea bottle"
+	desc = "A small bottle. Contains anacea."
+	icon_state = "bottle16"
+	list_reagents = list("anacea" = 30)
 
 /obj/item/weapon/reagent_containers/glass/bottle/diphenhydramine
 	name = "antihistamine bottle"


### PR DESCRIPTION
:cl: Swindly
add: Adds a new toxin, Anacea, to the traitor poison kit.
add: Anacea metabolizies very slowly and quickly purges medicines in the victim while dealing light toxin damage.
/:cl:

Because according to my SwindleStats<sup>tm</sup>, poison kits are bought by less than 3% of traitors besides me who buy at least one item and the official stats list the kits at 0% popularity. Anacea purges medicines at a rate of 6 units per tick and has a metabolism rate of 0.032 (lower than sulfonal, higher than coniine). It purges medicine fast enough to make sleepers and cryotubes take significantly longer to heal and makes them inefficient "fire and forget" healing methods, but doesn't make them useless. Anacea deals 0.1 toxin damage per tick so that it is not completely stealthy. It is meant to be mixed with a more lethal poison to make it harder to treat at the cost of fitting less of it into the syringe/hypospray/grenade.