### PR TITLE
Advanced Mop can now make its own water

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -92,7 +92,7 @@
 		START_PROCESSING(SSobj, src)
 	else
 		STOP_PROCESSING(SSobj,src)
-	user << "<span class='notice'>You turn [refill_enabled ? "on" : "off"] the condenser.</span>"
+	user << "<span class='notice'>You set the condenser switch to the '[refill_enabled ? "ON" : "OFF"]' position.</span>"
 	playsound(user, 'sound/machines/click.ogg', 30, 1)
 
 /obj/item/weapon/mop/advanced/process()
@@ -102,9 +102,9 @@
 
 /obj/item/weapon/mop/advanced/examine(mob/user)
 	..()
-	user << "<span class='notice'>The condenser switch is set to <b>[refill_enabled ? "ON" : "off"]</b>.</span>"
+	user << "<span class='notice'>The condenser switch is set to <b>[refill_enabled ? "ON" : "OFF"]</b>.</span>"
 
 /obj/item/weapon/mop/advanced/Destroy()
 	if(refill_enabled)
 		STOP_PROCESSING(SSobj, src)
-	..()
+	return ..()

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -68,7 +68,7 @@
 	return
 
 /obj/item/weapon/mop/advanced
-	desc = "The most advanced tool in a custodian's arsenal. Just think of all the viscera you will clean up with this!"
+	desc = "The most advanced tool in a custodian's arsenal, complete with a condenser for self-wetting! Just think of all the viscera you will clean up with this!"
 	name = "advanced mop"
 	mopcap = 10
 	icon_state = "advmop"
@@ -78,3 +78,33 @@
 	throwforce = 8
 	throw_range = 4
 	mopspeed = 20
+	var/refill_enabled = TRUE //Self-refill toggle for when a janitor decides to mop with something other than water.
+	var/refill_rate = 1 //Rate per process() tick mop refills itself
+	var/refill_reagent = "water" //Determins what reagent to use for refilling, just in case someone wanted to make a HOLY MOP OF PURGING
+
+/obj/item/weapon/mop/advanced/New()
+	..()
+	START_PROCESSING(SSobj, src)
+
+/obj/item/weapon/mop/advanced/attack_self(mob/user)
+	refill_enabled = !refill_enabled
+	if(refill_enabled)
+		START_PROCESSING(SSobj, src)
+	else
+		STOP_PROCESSING(SSobj,src)
+	user << "<span class='notice'>You turn [refill_enabled ? "on" : "off"] the condenser.</span>"
+	playsound(user, 'sound/machines/click.ogg', 30, 1)
+
+/obj/item/weapon/mop/advanced/process()
+
+	if(reagents.total_volume < mopcap)
+		reagents.add_reagent(refill_reagent, refill_rate)
+
+/obj/item/weapon/mop/advanced/examine(mob/user)
+	..()
+	user << "<span class='notice'>The condenser switch is set to <b>[refill_enabled ? "ON" : "off"]</b>.</span>"
+
+/obj/item/weapon/mop/advanced/Destroy()
+	if(refill_enabled)
+		STOP_PROCESSING(SSobj, src)
+	..()


### PR DESCRIPTION
:cl: Gun Hog
add: Nanotrasen Janitorial Sciences Division is proud to announce a new concept for the Advanced Mop prototype; It now includes a built-in condenser for self re-hydration! See your local Scientist today! In the event that janitorial staff wish to use more expensive solutions, the condenser may be shut off with a handy handle switch!
/:cl:

- The Advanced Mop can now produce its own water at a rate of 1 unit per
`process()` tick, up to 10 units of water.

- The advanced mop includes a switch on `attack_self()` to toggle wetting itself.