### PR TITLE
The time left on a shuttle call/recall modifies with security level.

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -234,12 +234,17 @@ var/datum/subsystem/shuttle/SSshuttle
 		return
 	if(ticker.mode.name == "meteor")
 		return
-	if(seclevel2num(get_security_level()) == SEC_LEVEL_RED)
-		if(emergency.timeLeft(1) < emergencyCallTime * 0.25)
-			return
-	else
-		if(emergency.timeLeft(1) < emergencyCallTime * 0.5)
-			return
+	var/security_num = seclevel2num(get_security_level())
+	switch(security_num)
+		if(SEC_LEVEL_GREEN)
+			if(emergency.timeLeft(1) < emergencyCallTime)
+				return
+		if(SEC_LEVEL_BLUE)
+			if(emergency.timeLeft(1) < emergencyCallTime * 0.5)
+				return
+		else
+			if(emergency.timeLeft(1) < emergencyCallTime * 0.25)
+				return
 	return 1
 
 /datum/subsystem/shuttle/proc/autoEvac()

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -197,16 +197,20 @@ var/datum/subsystem/shuttle/SSshuttle
 
 	call_reason = trim(html_encode(call_reason))
 
-	if(length(call_reason) < CALL_SHUTTLE_REASON_LENGTH)
+	if(length(call_reason) < CALL_SHUTTLE_REASON_LENGTH && seclevel2num(get_security_level()) > SEC_LEVEL_GREEN)
 		user << "You must provide a reason."
 		return
 
 	var/area/signal_origin = get_area(user)
 	var/emergency_reason = "\nNature of emergency:\n\n[call_reason]"
-	if(seclevel2num(get_security_level()) == SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
-		emergency.request(null, 0.5, signal_origin, html_decode(emergency_reason), 1)
-	else
-		emergency.request(null, 1, signal_origin, html_decode(emergency_reason), 0)
+	var/security_num = seclevel2num(get_security_level())
+	switch(security_num)
+		if(SEC_LEVEL_GREEN)
+			emergency.request(null, 2, signal_origin, html_decode(emergency_reason), 0)
+		if(SEC_LEVEL_BLUE)
+			emergency.request(null, 1, signal_origin, html_decode(emergency_reason), 0)
+		else
+			emergency.request(null, 0.5, signal_origin, html_decode(emergency_reason), 1) // There is a serious threat we gotta move no time to give them five minutes.
 
 	log_game("[key_name(user)] has called the shuttle.")
 	message_admins("[key_name_admin(user)] has called the shuttle.")

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -22,6 +22,11 @@
 		switch(level)
 			if(SEC_LEVEL_GREEN)
 				minor_announce(config.alert_desc_green, "Attention! Security level lowered to green:")
+				if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
+					if(security_level >= SEC_LEVEL_RED)
+						SSshuttle.emergency.modTimer(4)
+					else
+						SSshuttle.emergency.modTimer(2)
 				security_level = SEC_LEVEL_GREEN
 				for(var/obj/machinery/firealarm/FA in machines)
 					if(FA.z == ZLEVEL_STATION)
@@ -29,8 +34,12 @@
 			if(SEC_LEVEL_BLUE)
 				if(security_level < SEC_LEVEL_BLUE)
 					minor_announce(config.alert_desc_blue_upto, "Attention! Security level elevated to blue:",1)
+					if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
+						SSshuttle.emergency.modTimer(0.5)
 				else
 					minor_announce(config.alert_desc_blue_downto, "Attention! Security level lowered to blue:")
+					if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
+						SSshuttle.emergency.modTimer(2)
 				security_level = SEC_LEVEL_BLUE
 				for(var/obj/machinery/firealarm/FA in machines)
 					if(FA.z == ZLEVEL_STATION)
@@ -38,6 +47,11 @@
 			if(SEC_LEVEL_RED)
 				if(security_level < SEC_LEVEL_RED)
 					minor_announce(config.alert_desc_red_upto, "Attention! Code red!",1)
+					if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
+						if(security_level == SEC_LEVEL_GREEN)
+							SSshuttle.emergency.modTimer(0.25)
+						else
+							SSshuttle.emergency.modTimer(0.5)
 				else
 					minor_announce(config.alert_desc_red_downto, "Attention! Code red!")
 				security_level = SEC_LEVEL_RED
@@ -54,6 +68,11 @@
 					pod.admin_controlled = 0
 			if(SEC_LEVEL_DELTA)
 				minor_announce(config.alert_desc_delta, "Attention! Delta security level reached!",1)
+				if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
+					if(security_level == SEC_LEVEL_GREEN)
+						SSshuttle.emergency.modTimer(0.25)
+					else if(security_level == SEC_LEVEL_BLUE)
+						SSshuttle.emergency.modTimer(0.5)
 				security_level = SEC_LEVEL_DELTA
 				for(var/obj/machinery/firealarm/FA in machines)
 					if(FA.z == ZLEVEL_STATION)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -602,6 +602,14 @@
 	timer = world.time + wait
 	last_timer_length = wait
 
+/obj/docking_port/mobile/proc/modTimer(multiple)
+	var/time_remaining = timer - world.time
+	if(time_remaining < 0 || !last_timer_length)
+		return
+	time_remaining *= multiple
+	last_timer_length *= multiple
+	setTimer(time_remaining)
+
 /obj/docking_port/mobile/proc/invertTimer()
 	if(!last_timer_length)
 		return


### PR DESCRIPTION
The time left on a shuttle call/recall will now correctly modify with changes to the security code.

Fixes #21897 

As added functionality Code Green shuttle calls no longer need a reason (though you can still give one) and take 20 minutes to arrive. You can recall a timer in Code Green up to the <s>5</s> 10 minutes remaining mark.

<s>You may have noticed that this allows you to recall a shuttle, any shuttle, up to the 3/4ths mark of that shuttle's timer by first converting to code green. This is intentional.</s>

For review:

Code Green:
20 minute call/recall, can be recalled for <s>15</s> 10 minutes.

Code Blue
10 minute call/recall, can be recalled for 5 minutes.

Code Red/Code Delta
5 minute call/recall, can be recalled for 2.5 minutes.

:cl:
bugfix: The timer for shuttle calls/recalls now scales with the security level of the station (Code Red/Green, etc.). You no longer have to feel dumb if you forget to call Code Red before you call the shuttle!
add: Shuttles called in Code Green (the lowest level) now take 20 minutes to arrive, but may be recalled for up to 10 minutes. They also don't require a reason to be called.
experiment: That doesn't mean you should call a code green shuttle every round the moment it finishes refueling.
/:cl: