### PR TITLE
Fixes turret placement in boxstation's AI core.

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -98443,8 +98443,8 @@ cva
 cva
 cvp
 cwv
-cvp
 cvr
+cvp
 cvl
 cvr
 cwv
@@ -99985,8 +99985,8 @@ cva
 cva
 cvp
 cwB
-cvp
 cvr
+cvp
 cvl
 cvr
 cwB


### PR DESCRIPTION
Fixes #19044 
Moved top two turrets up by one tile. They are now capable of hitting these areas like they used to before pixel projectiles.

![](http://i.imgur.com/AfthKst.png)

:cl: WJohn
fix: AI core turrets can once again hit you if you are standing in front of the glass panes, or in the viewing area's doorway.
/:cl:

