### PR TITLE
Fixes bug with secondary Chaplain Null Rods not being morphable.

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -24,7 +24,8 @@
 	var/obj/item/weapon/nullrod/holy_weapon
 
 	if(SSreligion.holy_weapon)
-		holy_weapon = SSreligion.holy_weapon
+		holy_weapon = new SSreligion.holy_weapon
+		M << "<span class='notice'>The null rod suddenly morphs into your religions already chosen holy weapon.</span>"
 	else
 		var/list/holy_weapons_list = typesof(/obj/item/weapon/nullrod)
 		var/list/display_names = list()

--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -40,6 +40,8 @@ Chaplain
 	if(SSreligion.Bible_deity_name)
 		B.deity_name = SSreligion.Bible_deity_name
 		B.name = SSreligion.Bible_name
+		B.icon_state = SSreligion.Bible_icon_state
+		B.item_state = SSreligion.Bible_item_state
 		H << "There is already an established religion onboard the station. You are an acolyte of [SSreligion.Bible_deity_name]. Defer to the Chaplain."
 		H.equip_to_slot_or_del(B, slot_in_backpack)
 		var/obj/item/weapon/nullrod/N = new(H)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -14,7 +14,7 @@
 
 // BEGIN_INCLUDE
 #include "_maps\__MAP_DEFINES.dm"
-#include "_maps\tgstation2.dm"
+#include "_maps\runtimestation.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DATASTRUCTURES\heap.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -14,7 +14,7 @@
 
 // BEGIN_INCLUDE
 #include "_maps\__MAP_DEFINES.dm"
-#include "_maps\runtimestation.dm"
+#include "_maps\tgstation2.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DATASTRUCTURES\heap.dm"


### PR DESCRIPTION
Previously, when there were multiple chaplains on the station, and one of them already morphed their null rod, their own null rods would runtime when used. This fixes that issue, and their null rod will now morph into the holy weapon which was already established.

This also adds a message for the user when the secondary null rods morphs, so they are less confused about the null rod automatically picking a form.

This PR also makes it so the bible in the backpacks of chaplains who join later after more job slots were opened, are also now similar to the already established religions bible theme. Though it did already pick the bible name and deity name, but didn't change the icon_state and item_state.

PS: Thanks to @XDTM  for helping spot where the issue was.