### PR TITLE
Allows adding prerequisites to purchasing shuttles

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -41,6 +41,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	var/datum/round_event/shuttle_loan/shuttle_loan
 
 	var/shuttle_purchased = FALSE //If the station has purchased a replacement escape shuttle this round
+	var/list/shuttle_purchase_requirements_met = list() //For keeping track of ingame events that would unlock new shuttles, such as defeating a boss or discovering a secret item
 
 /datum/subsystem/shuttle/New()
 	NEW_SS_GLOBAL(SSshuttle)

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -6,10 +6,15 @@
 	var/shuttle_id
 
 	var/description
+	var/prerequisites
 	var/admin_notes
 
 	var/credit_cost = INFINITY
 	var/can_be_bought = TRUE
+
+
+/datum/map_template/shuttle/proc/prerequisites_met()
+	return TRUE
 
 /datum/map_template/shuttle/New()
 	shuttle_id = "[port_id]_[suffix]"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -160,6 +160,8 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 						return
 					if(SSshuttle.shuttle_purchased)
 						usr << "A replacement shuttle has already been purchased."
+					if(!S.prerequisites_met())
+						usr << "You have not met the requirements for purchasing this shuttle."
 					else
 						if(SSshuttle.points >= S.credit_cost)
 							var/obj/machinery/shuttle_manipulator/M  = locate() in machines
@@ -527,6 +529,8 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 				if(S.can_be_bought && S.credit_cost < INFINITY)
 					dat += "[S.name] | [S.credit_cost] Credits<BR>"
 					dat += "[S.description]<BR>"
+					if(S.prerequisites)
+						dat += "Prerequisites: [S.prerequisites]<BR>"
 					dat += "<A href='?src=\ref[src];operation=buyshuttle;chosen_shuttle=\ref[S]'>(<font color=red><i>Purchase</i></font>)</A><BR><BR>"
 
 	dat += "<BR><BR>\[ [(src.state != STATE_DEFAULT) ? "<A HREF='?src=\ref[src];operation=main'>Main Menu</A> | " : ""]<A HREF='?src=\ref[user];mach_close=communications'>Close</A> \]"


### PR DESCRIPTION
Added some very simple checks/tracking to allow for shuttles to have requirements for purchase.

For example, killing a drake could let you buy a lavaland themed shuttle, or maxing out illegal and AI tech could let you buy an assimilation cube.

I'll be adding a couple of shuttles using the system either to this PR or in a follow up one depending on how quickly it gets merged.
