### PR TITLE
Adds Anacea as a makeable toxin

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -684,7 +684,20 @@
 			animate(whole_screen, transform = matrix(), time = 5, easing = QUAD_EASING)
 	..()
 
-
+/datum/reagent/toxin/anacea
+	name = "Anacea"
+	id = "anacea"
+	description = "A toxin that quickly purges medicines and metabolizes very slowly."
+	reagent_state = LIQUID
+	color = "#3C5133"
+	metabolization_rate = 0.08 * REAGENTS_METABOLISM
+	toxpwr = 0.15
+	
+/datum/reagent/toxin/anacea/on_mob_life(mob/living/M)
+	for(var/datum/reagent/medicine/R in M.reagents.reagent_list)
+		M.reagents.remove_reagent(R.id,6)
+	return ..()
+	
 //ACID
 
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -694,8 +694,11 @@
 	toxpwr = 0.15
 	
 /datum/reagent/toxin/anacea/on_mob_life(mob/living/M)
+	var/remove_amt = 5
+	if(holder.has_reagent("calomel") || holder.has_reagent("pen_acid"))
+		remove_amt = 0.5
 	for(var/datum/reagent/medicine/R in M.reagents.reagent_list)
-		M.reagents.remove_reagent(R.id,6)
+		M.reagents.remove_reagent(R.id,remove_amt)
 	return ..()
 	
 //ACID

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -94,3 +94,9 @@
 	results = list("rotatium" = 3)
 	required_reagents = list("mindbreaker" = 1, "teslium" = 1, "neurotoxin2" = 1)
 	mix_message = "<span class='danger'>After sparks, fire, and the smell of mindbreaker, the mix is constantly spinning with no stop in sight.</span>"
+	
+/datum/chemical_reaction/anacea
+	name = "Anacea"
+	id = "anacea"
+	results = list("anacea" = 3)
+	required_reagents = list("haloperidol" = 1, "impedrezene" = 1, "radium" = 1)


### PR DESCRIPTION
:cl: Swindly
add: Adds a new toxin: Anacea. It metabolizes very slowly and quickly purges medicines in the victim while dealing light toxin damage. Its recipe is 1 part Haloperidol, 1 part Impedrezene, 1 part Radium.
/:cl:

It's still a better tator toxin than formaldehyde.