### PR TITLE
Special SnowFood [Food Feature + Food-Related fixes]

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -19,11 +19,11 @@
 	..()
 
 /obj/item/weapon/proc/rename_weapon(mob/M)
-	var/input = stripped_input(M,"What do you want to name the weapon?", ,"", MAX_NAME_LEN)
+	var/input = stripped_input(M,"What do you want to name the [name]?", ,"", MAX_NAME_LEN)
 
 	if(!qdeleted(src) && M.canUseTopic(src, BE_CLOSE) && input != "")
 		name = input
-		M << "You name the weapon [input]. Say hello to your new friend."
+		M << "You have successfully changed the object's name to [input]."
 		return
 	else
 		return

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -19,11 +19,12 @@
 	..()
 
 /obj/item/weapon/proc/rename_weapon(mob/M)
-	var/input = stripped_input(M,"What do you want to name the [name]?", ,"", MAX_NAME_LEN)
+	var/oldname = name
+	var/input = stripped_input(M,"What do you want to name /the [name]?", ,"", MAX_NAME_LEN)
 
 	if(!qdeleted(src) && M.canUseTopic(src, BE_CLOSE) && input != "")
 		name = input
-		M << "You have successfully changed the object's name to [input]."
+		M << "/The [oldname] has successfully been renamed to /the [input]."
 		return
 	else
 		return
@@ -33,7 +34,7 @@
 
 	if(!qdeleted(src) && M.canUseTopic(src, BE_CLOSE) && input != "")
 		desc = input
-		M << "You have successfully changed the object's description."
+		M << "You have successfully changed /the [name]'s description."
 		return
 	else
 		return

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -15,6 +15,7 @@
 	bitesize = 4
 	w_class = 2
 	volume = 80
+	unique_rename = 1
 
 	var/ingMax = 12
 	var/list/ingredients = list()
@@ -56,18 +57,6 @@
 			update_overlays(S)
 			user << "<span class='notice'>You add the [I.name] to the [name].</span>"
 			update_name(S)
-	else if(istype(I, /obj/item/weapon/pen))
-		var/txt = stripped_input(user, "What would you like the food to be called?", "Food Naming", "", 30)
-		if(txt)
-			ingMax = ingredients.len
-			user << "<span class='notice'>You add a last touch to the dish by renaming it.</span>"
-			customname = txt
-			if(istype(src, /obj/item/weapon/reagent_containers/food/snacks/customizable/sandwich))
-				var/obj/item/weapon/reagent_containers/food/snacks/customizable/sandwich/S = src
-				if(S.finished)
-					name = "[customname] sandwich"
-					return
-			name = "[customname] [initial(name)]"
 	else . = ..()
 
 

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -3,6 +3,7 @@
 	desc = "Yummy."
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = null
+	unique_rename = 1
 	var/bitesize = 2
 	var/bitecount = 0
 	var/trash = null
@@ -245,7 +246,7 @@
 		if(M && M.dirty < 100)
 			M.dirty++
 	qdel(src)
-			
+
 /obj/item/weapon/reagent_containers/food/snacks/Destroy()
 	if(contents)
 		for(var/atom/movable/something in contents)


### PR DESCRIPTION
🆑 Cobby
:add: All forms of food is now unique, meaning it can be renamed and its description edited!
:fix: replaces the food renaming with `unique_rename` [consistency!]
:tweak: Changes feedback of renaming / changing description to fit all items [like food!], not just weapons.
/🆑

Check CL for PR description.

Didn't think this needed to be atomized since it's all pertaining to food renaming [the last one is more or less], but I can separate the "food feature" if it's an issue.