### PR TITLE
Better addtimer logging

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -80,7 +80,7 @@ var/datum/subsystem/timer/SStimer
 	var/bad_args = unique != TIMER_NORMAL && unique != TIMER_UNIQUE
 	if(args.len > 4 || bad_args)
 		if(bad_args)
-			stack_trace("Invalid arguments in call to addtimer!")
+			stack_trace("Invalid arguments in call to addtimer! Attempt to call [thingToCall] proc [procToCall]")
 			event.argList = args.Copy(4)
 		else
 			event.argList = args.Copy(5)


### PR DESCRIPTION
Should make the condensed server logs different for each crappy call

Also works as a backup for when BYOND DOESN'T STACK TRACE