### PR TITLE
Implementing unused hydroponics code and some other botany tweaks.

### DIFF
--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -76,7 +76,7 @@
 	lifespan = 30
 	endurance = 25
 	mutatelist = list()
-	genes = list(/datum/plant_gene/trait/glow/berry)
+	genes = list(/datum/plant_gene/trait/glow/berry , /datum/plant_gene/trait/noreact)
 	reagents_add = list("uranium" = 0.25, "iodine" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -11,7 +11,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	icon_dead = "watermelon-dead"
 	mutatelist = list(/obj/item/seeds/watermelon/holy)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.2)
+	reagents_add = list("water" = 0.2, "vitamin" = 0.04, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/watermelon
 	seed = /obj/item/seeds/watermelon

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -40,7 +40,7 @@
 	plantname = "Blumpkin Vines"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/blumpkin
 	mutatelist = list()
-	reagents_add = list("ammonia" = 0.2, "chlorine" = 0.2, "nutriment" = 0.2)
+	reagents_add = list("ammonia" = 0.2, "chlorine" = 0.1, "nutriment" = 0.2)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/blumpkin

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -93,6 +93,7 @@
 	oneharvest = 1
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	icon_dead = "whitebeet-dead"
+	genes = list(/datum/plant_gene/trait/maxchem)
 	reagents_add = list("vitamin" = 0.05, "nutriment" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/redbeet

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -174,8 +174,8 @@
 	examine_line = "<span class='info'>It has a lot of liquid contents inside.</span>"
 	origin_tech = list("biotech" = 5)
 
-/*/datum/plant_gene/trait/squash/on_slip(obj/item/weapon/reagent_containers/food/snacks/grown/G, mob/living/carbon/target)
-	G.squash(target)*/
+/datum/plant_gene/trait/squash/on_slip(obj/item/weapon/reagent_containers/food/snacks/grown/G, mob/living/carbon/target)
+	G.squash(target)
 
 
 /datum/plant_gene/trait/slip


### PR DESCRIPTION
Added Separated Chemicals trait to glowberries. 
Added Densified Chemicals trait to redbeets. 
Added 0.2 water production to watermelons, because it was quite stupid to have holy water in holymelons but no normal water in watermelons.
Reduced blumpkin chlorine production to 0.1, because it was only causing annoyance when making mutagen blumpkins.
Now plants with Liquid Reagents trait will squash all over you if you slip on them.

:cl: MisterTikva
add: Nanotrasen informs that certain berry and root plants have been infused with additional genetic traits.
add: Watermelons now have water in them!
add: Blumpkin's chlorine production has been reduced for better workplace efficiency.
add: Squishy plants now obey the laws of physics and will squash all over you if fall on them.
/:cl:
