### PR TITLE
Seperates shuttle purchasing feedback from admin shuttle loading

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -172,7 +172,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 								SSshuttle.points -= S.credit_cost
 								minor_announce("[usr.name] has purchased [S.name] for [S.credit_cost] credits." , "Shuttle Purchase")
 								message_admins("[key_name_admin(usr)] purchased [S.name].")
-								feedback_add_details("shuttle_manipulator", S.name)
+								feedback_add_details("shuttle_purchase", S.name)
 							else
 								usr << "Something went wrong! The shuttle exchange system seems to be down."
 						else


### PR DESCRIPTION
Bundling them together didn't seem to make much sense to me, since admins loading a shuttle doesn't really reflect what the station is buying for stat tracking.