### PR TITLE
Removes Build Your Own shuttle, bannable to use it

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -33,13 +33,6 @@
 
 // Shuttles start here:
 
-/datum/map_template/shuttle/emergency/airless
-	suffix = "airless"
-	name = "Build your own shuttle kit"
-	description = "Save money by building your own shuttle! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Interior and atmosphere not included."
-	admin_notes = "No brig, no medical facilities, no air."
-	credit_cost = -7500
-
 /datum/map_template/shuttle/emergency/asteroid
 	suffix = "asteroid"
 	name = "Asteroid Station Emergency Shuttle"


### PR DESCRIPTION
:cl: Ausops
del: Removes the build-a-shuttle from the game.
/:cl:

https://tgstation13.org/phpBB/viewtopic.php?f=7&t=8761

Might as well remove it, can't have players getting banned for improper escalation by buying it.

If I can't buy the build-a-shuttle as the guy in charge of building things with the intent to proceed to build a shuttle without getting banned for defending myself while building the shuttle, why should I keep the shuttle in the game?