### PR TITLE
[DNM] Tweaks security and silicon player age restrictions

### DIFF
--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -18,7 +18,7 @@ Head of Security
 	supervisors = "the captain"
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
-	minimal_player_age = 14
+	minimal_player_age = 30
 
 	outfit = /datum/outfit/job/hos
 
@@ -76,7 +76,7 @@ Warden
 	spawn_positions = 1
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
-	minimal_player_age = 7
+	minimal_player_age = 21
 
 	outfit = /datum/outfit/job/warden
 
@@ -132,7 +132,7 @@ Detective
 	spawn_positions = 1
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
-	minimal_player_age = 7
+	minimal_player_age = 21
 
 	outfit = /datum/outfit/job/detective
 
@@ -181,7 +181,7 @@ Security Officer
 	spawn_positions = 5 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
 	supervisors = "the head of security, and the head of your assigned department (if applicable)"
 	selection_color = "#ffeeee"
-	minimal_player_age = 7
+	minimal_player_age = 21
 
 	outfit = /datum/outfit/job/security
 

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -18,7 +18,7 @@ Head of Security
 	supervisors = "the captain"
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
-	minimal_player_age = 30
+	minimal_player_age = 21
 
 	outfit = /datum/outfit/job/hos
 
@@ -76,7 +76,7 @@ Warden
 	spawn_positions = 1
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
-	minimal_player_age = 21
+	minimal_player_age = 14
 
 	outfit = /datum/outfit/job/warden
 
@@ -132,7 +132,7 @@ Detective
 	spawn_positions = 1
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
-	minimal_player_age = 21
+	minimal_player_age = 14
 
 	outfit = /datum/outfit/job/detective
 
@@ -181,7 +181,7 @@ Security Officer
 	spawn_positions = 5 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
 	supervisors = "the head of security, and the head of your assigned department (if applicable)"
 	selection_color = "#ffeeee"
-	minimal_player_age = 21
+	minimal_player_age = 14
 
 	outfit = /datum/outfit/job/security
 

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -11,7 +11,7 @@ AI
 	selection_color = "#ccffcc"
 	supervisors = "your laws"
 	req_admin_notify = 1
-	minimal_player_age = 14
+	minimal_player_age = 30
 
 /datum/job/ai/equip(mob/living/carbon/human/H)
 	if(!H)

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -11,7 +11,7 @@ AI
 	selection_color = "#ccffcc"
 	supervisors = "your laws"
 	req_admin_notify = 1
-	minimal_player_age = 30
+	minimal_player_age = 14
 
 /datum/job/ai/equip(mob/living/carbon/human/H)
 	if(!H)
@@ -34,7 +34,7 @@ Cyborg
 	spawn_positions = 1
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#ddffdd"
-	minimal_player_age = 21
+	minimal_player_age = 7
 
 /datum/job/cyborg/equip(mob/living/carbon/human/H)
 	if(!H)


### PR DESCRIPTION
Values probably/almost certainly subject to tweaking.
In general, I feel that the age requirement for silicons is way too high, compared to the difficulty of following silicon laws (plus, you can just get borged and bypass it anyways) and sec officer has a way too low age requirement compared to the skill level expected and how you're supposed to act as sec.

:cl:
experiment: Security and Silicon minimum player ages have been tweaked.
experiment: Security officer, Warden, and Detective take 14 days to unlock, while HOS takes 21 days
experiment: Cyborg now takes 7 days to unlock
/:cl: