### PR TITLE
The panic bouncer

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -29,6 +29,7 @@ var/global/comms_allowed = 0 //By default, the server does not allow messages to
 //Cross server communications
 var/global/cross_address = "byond://" //This needs to be global as the message sent contains the comms key.
 var/global/cross_allowed = 0 //Don't bother attempting to send if the address wasn't set.
+var/global/allow_panic_bunker_to_cross = 0 //Reconnect a player to a linked server if this server isn't accepting new players
 
 var/global/medal_hub = null
 var/global/medal_pass = " "

--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -29,7 +29,7 @@ var/global/comms_allowed = 0 //By default, the server does not allow messages to
 //Cross server communications
 var/global/cross_address = "byond://" //This needs to be global as the message sent contains the comms key.
 var/global/cross_allowed = 0 //Don't bother attempting to send if the address wasn't set.
-var/global/allow_panic_bunker_to_cross = 0 //Reconnect a player to a linked server if this server isn't accepting new players
+var/global/panic_address = "byond://" //Reconnect a player this linked server if this server isn't accepting new players
 
 var/global/medal_hub = null
 var/global/medal_pass = " "

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -73,6 +73,9 @@
 
 	var/check_randomizer = 0
 
+	var/allow_panic_bunker_bounce = 0 //Send new players somewhere else
+	var/panic_server_name = "somewhere else"
+
 	//IP Intel vars
 	var/ipintel_email
 	var/ipintel_rating_bad = 1
@@ -386,8 +389,12 @@
 						global.cross_allowed = 1
 				if("cross_comms_name")
 					cross_name = value
-				if("send_panic_bunkered_to_cross_server")
-					global.allow_panic_bunker_to_cross = 1
+				if("panic_server_name")
+					panic_server_name = value
+				if("panic_server_address")
+					global.panic_address = value
+					if(value != "byond:\\address:port")
+						allow_panic_bunker_bounce = 1
 				if("medal_hub_address")
 					global.medal_hub = value
 				if("medal_hub_password")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -386,6 +386,8 @@
 						global.cross_allowed = 1
 				if("cross_comms_name")
 					cross_name = value
+				if("send_panic_bunkered_to_cross_server")
+					global.allow_panic_bunker_to_cross = 1
 				if("medal_hub_address")
 					global.medal_hub = value
 				if("medal_hub_password")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -196,10 +196,10 @@ var/next_external_rsc = 0
 			log_access("Failed Login: [key] - New account attempting to connect during panic bunker")
 			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
 			src << "Sorry but the server is currently not accepting connections from never before seen players."
-			if(global.cross_allowed && global.allow_panic_bunker_to_cross)
-				src << "<span class='notice'>Sending you to [global.cross_address].</span>"
+			if(config.allow_panic_bunker_bounce && tdata != "redirect")
+				src << "<span class='notice'>Sending you to [config.panic_server_name].</span>"
 				winset(src, null, "command=.options")
-				src << link(global.cross_address)
+				src << link("[global.panic_address]?redirect")
 			qdel(src)
 			return 0
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -196,6 +196,10 @@ var/next_external_rsc = 0
 			log_access("Failed Login: [key] - New account attempting to connect during panic bunker")
 			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
 			src << "Sorry but the server is currently not accepting connections from never before seen players."
+			if(global.cross_allowed && global.allow_panic_bunker_to_cross)
+				src << "<span class='notice'>Sending you to [global.cross_address].</span>"
+				winset(src, null, "command=.options")
+				src << link(global.cross_address)
 			qdel(src)
 			return 0
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -241,6 +241,11 @@ NOTIFY_NEW_PLAYER_AGE 0
 ##	Requires database
 #PANIC_BUNKER
 
+## If panic bunker is on and a player is rejected (see above), attempt to send them to the connected server (see CROSS_SERVER_ADDRESS) instead.
+##	Do not use this setting if both servers are bunkered and have this setting, players will just bounce endlessly between rejections.
+##	Requires PANIC_BUNKER and CROSS_SERVER_ADDRESS
+#SEND_PANIC_BUNKERED_TO_CROSS_SERVER
+
 ## Uncomment to have the changelog file automatically open when a user connects and hasn't seen the latest changelog
 #AGGRESSIVE_CHANGELOG
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -241,10 +241,12 @@ NOTIFY_NEW_PLAYER_AGE 0
 ##	Requires database
 #PANIC_BUNKER
 
-## If panic bunker is on and a player is rejected (see above), attempt to send them to the connected server (see CROSS_SERVER_ADDRESS) instead.
-##	Do not use this setting if both servers are bunkered and have this setting, players will just bounce endlessly between rejections.
-##	Requires PANIC_BUNKER and CROSS_SERVER_ADDRESS
-#SEND_PANIC_BUNKERED_TO_CROSS_SERVER
+## If panic bunker is on and a player is rejected (see above), attempt to send them to this connected server (see below) instead.
+##	You probably want this to be the same as CROSS_SERVER_ADDRESS
+PANIC_SERVER_ADDRESS byond:\\address:port
+
+##Name of the place to send people rejected by the bunker
+PANIC_SERVER_NAME [Put the name here]
 
 ## Uncomment to have the changelog file automatically open when a user connects and hasn't seen the latest changelog
 #AGGRESSIVE_CHANGELOG


### PR DESCRIPTION
If a server has the panic bunker on, you can now choose to redirect new players to the linked server instead of denying them outright.

You shouldn't use this if BOTH servers are panic bunkered, obviously.

Disclaimer: I don't see why this wouldn't work, but I have no way to be sure without a test merge.


:cl:
add: Server owners that use the panic bunker feature can now optionally redirect new players to a different server. See config.txt for details.
/:cl: