### PR TITLE
Fixes syndicate ID access for mob_spawn effect spawned mobs

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1052,7 +1052,7 @@
 	back = /obj/item/weapon/storage/backpack
 	has_id = 1
 	id_job = "Officer"
-	id_access = "Syndicate"
+	id_access_list = list(access_syndicate)
 
 /obj/item/weapon/orion_ship
 	name = "model settler ship"

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -118,6 +118,7 @@
 	var/has_id = 0     //Just set to 1 if you want them to have an ID
 	var/id_job = null // Needs to be in quotes, such as "Clown" or "Chef." This just determines what the ID reads as, not their access
 	var/id_access = null //This is for access. See access.dm for which jobs give what access. Again, put in quotes. Use "Captain" if you want it to be all access.
+	var/id_access_list = null //Allows you to manually add access to an ID card.
 	var/id_icon = null //For setting it to be a gold, silver, centcom etc ID
 	var/husk = null
 	var/outfit_type = null // Will start with this if exists then apply specific slots
@@ -175,6 +176,10 @@
 				W.access = jobdatum.get_access()
 			else
 				W.access = list()
+			if(id_access_list)
+				if(!W.access)
+					W.access = list()
+				W.access |= id_access_list
 		if(id_job)
 			W.assignment = id_job
 		W.registered_name = H.real_name
@@ -261,7 +266,7 @@
 	back = /obj/item/weapon/storage/backpack
 	has_id = 1
 	id_job = "Operative"
-	id_access = "Syndicate"
+	id_access_list = list(access_syndicate)
 
 /obj/effect/mob_spawn/human/syndicatecommando
 	name = "Syndicate Commando"
@@ -276,7 +281,7 @@
 	pocket1 = /obj/item/weapon/tank/internals/emergency_oxygen
 	has_id = 1
 	id_job = "Operative"
-	id_access = "Syndicate"
+	id_access_list = list(access_syndicate)
 
 ///////////Civilians//////////////////////
 

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -20,7 +20,7 @@
 	back = /obj/item/weapon/storage/backpack
 	has_id = 1
 	id_job = "Operative"
-	id_access = "Syndicate"
+	id_access_list = list(access_syndicate)
 
 /obj/effect/mob_spawn/human/corpse/syndicatecommando
 	name = "Syndicate Commando"
@@ -35,7 +35,7 @@
 	pocket1 = /obj/item/weapon/tank/internals/emergency_oxygen
 	has_id = 1
 	id_job = "Operative"
-	id_access = "Syndicate"
+	id_access_list = list(access_syndicate)
 
 /obj/effect/mob_spawn/human/corpse/syndicatestormtrooper
 	name = "Syndicate Stormtrooper"
@@ -49,7 +49,7 @@
 	back = /obj/item/weapon/tank/jetpack/oxygen/harness
 	has_id = 1
 	id_job = "Operative"
-	id_access = "Syndicate"
+	id_access_list = list(access_syndicate)
 
 
 

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -131,7 +131,7 @@
 	back = /obj/item/weapon/storage/backpack
 	pocket1 = /obj/item/weapon/gun/ballistic/automatic/pistol
 	id_job = "Operative"
-	id_access = "syndicate"
+	id_access_list = list(access_syndicate)
 	roundstart = FALSE
 	death = FALSE
 	icon = 'icons/obj/Cryogenic2.dmi'


### PR DESCRIPTION
The previous code was looking for a job datum with the title "Syndicate".
There is no such datum.

I added an override that allows using the access defines as a list to manually set access.
If the mob already fetched access from a datum, it will simply add on to those accesses.

:cl:
fix: The lavaland syndicate agents, as well as the ID for all simple_animal syndicate corpses should have their ID actually have syndicate access on it now!
/:cl:

