### PR TITLE
[s]fixes ai turf click admin spam

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -33,11 +33,11 @@
 
 	if(control_disabled || stat)
 		return
-
-	if(!cameranet.checkTurfVis(get_turf_pixel(A)))
-		log_admin("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click)")
-		message_admins("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click)")
-		send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click)")
+	
+	if(!cameranet.checkTurfVis(get_turf_pixel(A) || get_turf(A)))
+		log_admin("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(A)])")
+		message_admins("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([ADMIN_COORDJMP(A)]))")
+		send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(A)]))")
 		return
 
 	var/list/modifiers = params2list(params)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -34,10 +34,11 @@
 	if(control_disabled || stat)
 		return
 	
-	if(!cameranet.checkTurfVis(get_turf_pixel(A) || get_turf(A)))
-		log_admin("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(A)])")
-		message_admins("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([ADMIN_COORDJMP(A)]))")
-		send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(A)]))")
+	var/turf/pixel_turf = get_turf_pixel(A)
+	if(pixel_turf && !cameranet.checkTurfVis(pixel_turf))
+		log_admin("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(pixel_turf)])")
+		message_admins("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([ADMIN_COORDJMP(pixel_turf)]))")
+		send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(pixel_turf)]))")
 		return
 
 	var/list/modifiers = params2list(params)


### PR DESCRIPTION
`get_turf_pixel` returns null if handed anything that's not a `movable`. I could `istype` it before I call that, but this looks cooler and it's about the same result since `get_turf_pixel` already `istype`s it.

fixes #21955 

I also added a bit of info on what was clicked to the admin logs because that's kind of important to validate bugs and edge cases from cheats. (and because it would have made debugging this much easier)