### PR TITLE
Removes growth serum alternation between size 2 and size 1.5 and adds effects for higher dosages

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -504,7 +504,7 @@
 	for(var/type in subtypesof(/datum/species))
 		var/datum/species/S = type
 		if(initial(S.blacklisted))
-			continue
+			continueu
 		possible_morphs += S
 	race = pick(possible_morphs)
 	..()
@@ -1395,7 +1395,7 @@
 		H.resize = 2.5/current_size
 		current_size = 2.5
 		H.update_transform()
-	else if(volume >= 20 && volume < && current_size != 2)
+	else if(volume >= 20 && volume < 50 && current_size != 2)
 		H.resize = 2/current_size
 		current_size = 2
 		H.update_transform()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1382,11 +1382,24 @@
 	var/current_size = 1
 
 /datum/reagent/growthserum/on_mob_life(mob/living/carbon/H)
-	if(volume >= 20 && current_size != 2)
+	
+	if(volume >=200 && current_size != 5)
+		H.resize = 5/current_size
+		current_size = 5
+		H.update_transform()
+	else if(volume >= 100 && volume < 200 && current_size != 3.5)
+		H.resize = 3.5/current_size
+		current_size = 3.5
+		H.update_transform()
+	else if(volume >= 50 && volume < 100 && current_size != 2.5)
+		H.resize = 2.5/current_size
+		current_size = 2.5
+		H.update_transform()
+	else if(volume >= 20 && volume < && current_size != 2)
 		H.resize = 2/current_size
 		current_size = 2
 		H.update_transform()
-	else if (current_size != 1.5)
+	else if (volume < 20 && current_size != 1.5)
 		H.resize = 1.5/current_size
 		current_size = 1.5
 		H.update_transform()


### PR DESCRIPTION
[
:cl: MisterTikva
add: Nanotrasen Mushroom Studies Division proudly announces that growth serum producing plants were genetically reassebled. You no longer alternate between sizes with doses 20u+ and more effects were added to higher doses.
/:cl:

See title 
at 50u size is 2.5
at 100u size is 3.5
at 200u size is 5