### PR TITLE
Removes growth serum alternation between size 2 and size 1.5 and adds effects for higher dosages

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1382,11 +1382,23 @@
 	var/current_size = 1
 
 /datum/reagent/growthserum/on_mob_life(mob/living/carbon/H)
-	if(volume >= 20 && current_size != 2)
+	if(volume >=200 && current_size != 5)
+		H.resize = 5/current_size
+		current_size = 5
+		H.update_transform()
+	else if(volume >= 100 && volume < 200 && current_size != 3.5)
+		H.resize = 3.5/current_size
+		current_size = 3.5
+		H.update_transform()
+	else if(volume >= 50 && volume < 100 && current_size != 2.5)
+		H.resize = 2.5/current_size
+		current_size = 2.5
+		H.update_transform()
+	else if(volume >= 20 && volume < 50 && current_size != 2)
 		H.resize = 2/current_size
 		current_size = 2
 		H.update_transform()
-	else if (current_size != 1.5)
+	else if (volume < 20 && current_size != 1.5)
 		H.resize = 1.5/current_size
 		current_size = 1.5
 		H.update_transform()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1382,26 +1382,22 @@
 	var/current_size = 1
 
 /datum/reagent/growthserum/on_mob_life(mob/living/carbon/H)
-	if(volume >=200 && current_size != 5)
-		H.resize = 5/current_size
-		current_size = 5
-		H.update_transform()
-	else if(volume >= 100 && volume < 200 && current_size != 3.5)
-		H.resize = 3.5/current_size
-		current_size = 3.5
-		H.update_transform()
-	else if(volume >= 50 && volume < 100 && current_size != 2.5)
-		H.resize = 2.5/current_size
-		current_size = 2.5
-		H.update_transform()
-	else if(volume >= 20 && volume < 50 && current_size != 2)
-		H.resize = 2/current_size
-		current_size = 2
-		H.update_transform()
-	else if (volume < 20 && current_size != 1.5)
-		H.resize = 1.5/current_size
-		current_size = 1.5
-		H.update_transform()
+	var/newsize = current_size
+	switch(volume)
+	if(0 to 19)
+		newsize = 1.5
+	if(20 to 49)
+		newsize = 2
+	if(50 to 99)
+		newsize = 2.5
+	if(100 to 199)
+		newsize = 3.5
+	if(200 to INFINITY)
+		newsize = 5
+		
+	H.resize = newsize/current_size
+	current_size = newsize
+	H.update_transform()
 	..()
 
 /datum/reagent/growthserum/on_mob_delete(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1384,16 +1384,16 @@
 /datum/reagent/growthserum/on_mob_life(mob/living/carbon/H)
 	var/newsize = current_size
 	switch(volume)
-	if(0 to 19)
-		newsize = 1.5
-	if(20 to 49)
-		newsize = 2
-	if(50 to 99)
-		newsize = 2.5
-	if(100 to 199)
-		newsize = 3.5
-	if(200 to INFINITY)
-		newsize = 5
+		if(0 to 19)
+			newsize = 1.5
+		if(20 to 49)
+			newsize = 2
+		if(50 to 99)
+			newsize = 2.5
+		if(100 to 199)
+			newsize = 3.5
+		if(200 to INFINITY)
+			newsize = 5
 		
 	H.resize = newsize/current_size
 	current_size = newsize


### PR DESCRIPTION
:cl: MisterTikva
add: Nanotrasen Mushroom Studies Division proudly announces that growth serum producing plants were genetically reassembled. You no longer alternate between sizes with doses 20u+ and more effects were added to higher doses.
/:cl:

See title
at 50u size is 2.5
at 100u size is 3.5
at 200u size is 5