### PR TITLE
Speeds up world init. (93s -> 49s)

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -163,3 +163,10 @@
 #define TANK_MAX_RELEASE_PRESSURE (ONE_ATMOSPHERE*3)
 #define TANK_MIN_RELEASE_PRESSURE 0
 #define TANK_DEFAULT_RELEASE_PRESSURE 16
+
+
+#define ATMOS_PASS_YES 1
+#define ATMOS_PASS_NO 0
+#define ATMOS_PASS_PROC -1 //ask CanAtmosPass()
+#define ATMOS_PASS_DENSITY -2 //just check density
+#define CANATMOSPASS(A, O) ( A.CanAtmosPass == ATMOS_PASS_PROC ? A.CanAtmosPass(O) : ( A.CanAtmosPass == ATMOS_PASS_DENSITY ? !A.density : A.CanAtmosPass ) )

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -108,19 +108,19 @@
 
 	return adjacencies
 
+//do not use, use queue_smooth(atom)
 /proc/smooth_icon(atom/A)
+	if(!A || !A.smooth || !A.z)
+		return
 	if(qdeleted(A))
 		return
-	if(!A || !A.smooth)
-		return
-	spawn(0)
-		if((A.smooth & SMOOTH_TRUE) || (A.smooth & SMOOTH_MORE))
-			var/adjacencies = calculate_adjacencies(A)
+	if((A.smooth & SMOOTH_TRUE) || (A.smooth & SMOOTH_MORE))
+		var/adjacencies = calculate_adjacencies(A)
 
-			if(A.smooth & SMOOTH_DIAGONAL)
-				A.diagonal_smooth(adjacencies)
-			else
-				cardinal_smooth(A, adjacencies)
+		if(A.smooth & SMOOTH_DIAGONAL)
+			A.diagonal_smooth(adjacencies)
+		else
+			cardinal_smooth(A, adjacencies)
 
 /atom/proc/diagonal_smooth(adjacencies)
 	switch(adjacencies)
@@ -153,12 +153,12 @@
 /turf/closed/wall/diagonal_smooth(adjacencies)
 	adjacencies = reverse_ndir(..())
 	if(adjacencies)
-		underlays.Cut()
+		var/list/U = list()
 		if(fixed_underlay)
 			if(fixed_underlay["space"])
-				underlays += image('icons/turf/space.dmi', SPACE_ICON_STATE, layer=TURF_LAYER)
+				U += image('icons/turf/space.dmi', SPACE_ICON_STATE, layer=TURF_LAYER)
 			else
-				underlays += image(fixed_underlay["icon"], fixed_underlay["icon_state"], layer=TURF_LAYER)
+				U += image(fixed_underlay["icon"], fixed_underlay["icon_state"], layer=TURF_LAYER)
 		else
 			var/turf/T = get_step(src, turn(adjacencies, 180))
 			if(T && (T.density || T.smooth))
@@ -167,13 +167,15 @@
 					T = get_step(src, turn(adjacencies, 225))
 
 			if(isspaceturf(T) && !istype(T, /turf/open/space/transit))
-				underlays += image('icons/turf/space.dmi', SPACE_ICON_STATE, layer=TURF_LAYER)
+				U += image('icons/turf/space.dmi', SPACE_ICON_STATE, layer=TURF_LAYER)
 			else if(T && !T.density && !T.smooth)
-				underlays += T
+				U += T
 			else if(baseturf && !initial(baseturf.density) && !initial(baseturf.smooth))
-				underlays += image(initial(baseturf.icon), initial(baseturf.icon_state), layer=TURF_LAYER)
+				U += image(initial(baseturf.icon), initial(baseturf.icon_state), layer=TURF_LAYER)
 			else
-				underlays += DEFAULT_UNDERLAY_IMAGE
+				U += DEFAULT_UNDERLAY_IMAGE
+		underlays = U
+
 
 /proc/cardinal_smooth(atom/A, adjacencies)
 	//NW CORNER
@@ -228,25 +230,31 @@
 		else if(adjacencies & N_EAST)
 			se = "4-e"
 
+	var/list/New = list()
+
 	if(A.top_left_corner != nw)
 		A.overlays -= A.top_left_corner
 		A.top_left_corner = nw
-		A.add_overlay(nw)
+		New += nw
 
 	if(A.top_right_corner != ne)
 		A.overlays -= A.top_right_corner
 		A.top_right_corner = ne
-		A.add_overlay(ne)
+		New += ne
 
 	if(A.bottom_right_corner != sw)
 		A.overlays -= A.bottom_right_corner
 		A.bottom_right_corner = sw
-		A.add_overlay(sw)
+		New += sw
 
 	if(A.bottom_left_corner != se)
 		A.overlays -= A.bottom_left_corner
 		A.bottom_left_corner = se
-		A.add_overlay(se)
+		New += se
+
+	if(New.len)
+		A.add_overlay(New)
+
 
 /proc/find_type_in_direction(atom/source, direction)
 	var/turf/target_turf = get_step(source, direction)
@@ -307,14 +315,16 @@
 
 /atom/proc/replace_smooth_overlays(nw, ne, sw, se)
 	clear_smooth_overlays()
+	var/list/O = list()
 	top_left_corner = nw
-	add_overlay(nw)
+	O += nw
 	top_right_corner = ne
-	add_overlay(ne)
+	O += ne
 	bottom_left_corner = sw
-	add_overlay(sw)
+	O += sw
 	bottom_right_corner = se
-	add_overlay(se)
+	O += se
+	add_overlay(O)
 
 /proc/reverse_ndir(ndir)
 	switch(ndir)
@@ -352,19 +362,6 @@
 			return SOUTHEAST
 		else
 			return 0
-
-//SSicon_smooth
-/proc/ss_smooth_icon(atom/A)
-	if(qdeleted(A))
-		return
-	if(!istype(A) || (A && !A.smooth))
-		return
-	if((A.smooth & SMOOTH_TRUE) || (A.smooth & SMOOTH_MORE))
-		var/adjacencies = calculate_adjacencies(A)
-		if(A.smooth & SMOOTH_DIAGONAL)
-			A.diagonal_smooth(adjacencies)
-		else
-			cardinal_smooth(A, adjacencies)
 
 //SSicon_smooth
 /proc/queue_smooth_neighbors(atom/A)

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -16,7 +16,7 @@ var/datum/subsystem/icon_smooth/SSicon_smooth
 	while(smooth_queue.len)
 		var/atom/A = smooth_queue[smooth_queue.len]
 		smooth_queue.len--
-		ss_smooth_icon(A)
+		smooth_icon(A)
 		if (MC_TICK_CHECK)
 			return
 	if (!smooth_queue.len)
@@ -25,8 +25,12 @@ var/datum/subsystem/icon_smooth/SSicon_smooth
 /datum/subsystem/icon_smooth/Initialize()
 	smooth_zlevel(1,TRUE)
 	smooth_zlevel(2,TRUE)
-	for(var/V in smooth_queue)
+	var/queue = smooth_queue
+	smooth_queue = list()
+	for(var/V in queue)
 		var/atom/A = V
-		if(A.z == 1 || A.z == 2)
-			smooth_queue -= A
+		if(!A || A.z <= 2)
+			continue
+		smooth_icon(A)
+
 	..()

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -124,11 +124,13 @@
 /datum/action/item_action/New(Target)
 	..()
 	var/obj/item/I = target
+	LAZYINITLIST(I.actions)
 	I.actions += src
 
 /datum/action/item_action/Destroy()
 	var/obj/item/I = target
 	I.actions -= src
+	UNSETEMPTY(I.actions)
 	return ..()
 
 /datum/action/item_action/Trigger()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -27,10 +27,18 @@
 	//atom creation method that preloads variables at creation
 	if(use_preloader && (src.type == _preloader.target_path))//in case the instanciated atom is creating other atoms in New()
 		_preloader.load(src)
-
+	//atom color stuff
 	if(color)
 		add_atom_colour(color, FIXED_COLOUR_PRIORITY)
-	. = ..()
+
+	//lighting stuff
+	if(opacity && isturf(loc))
+		loc.UpdateAffectingLights()
+
+	if(luminosity)
+		light = new(src)
+
+	//. = ..() //uncomment if you are dumb enough to add a /datum/New() proc
 
 /atom/Destroy()
 	if(alternate_appearances)
@@ -45,6 +53,8 @@
 				AA.hide(list(src))
 	return ..()
 
+/atom/proc/CanPass(atom/movable/mover, turf/target, height=1.5)
+	return (!density || !height)
 
 /atom/proc/onCentcom()
 	var/turf/T = get_turf(src)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -31,6 +31,7 @@
 	..()
 	ConsumeTile()
 	if(atmosblock)
+		CanAtmosPass = ATMOS_PASS_NO
 		air_update_turf(1)
 
 /obj/structure/blob/proc/creation_action() //When it's created by the overmind, do this.
@@ -61,9 +62,6 @@
 					if(C)
 						result++
 		. -= result - 1
-
-/obj/structure/blob/CanAtmosPass(turf/T)
-	return !atmosblock
 
 /obj/structure/blob/BlockSuperconductivity()
 	return atmosblock

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -725,6 +725,7 @@ var/list/wall_runes = list()
 	invocation = "Khari'd! Eske'te tannin!"
 	icon_state = "1"
 	color = "#C80000"
+	CanAtmosPass = ATMOS_PASS_DENSITY
 	var/density_timer
 	var/recharging = FALSE
 
@@ -742,9 +743,6 @@ var/list/wall_runes = list()
 	wall_runes -= src
 	air_update_turf(1)
 	return ..()
-
-/obj/effect/rune/wall/CanAtmosPass(turf/T)
-	return !density
 
 /obj/effect/rune/wall/BlockSuperconductivity()
 	return density

--- a/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
@@ -14,6 +14,7 @@
 	return rgb(rand(0,255),rand(0,255),rand(0,255))
 
 /obj/machinery/abductor/gland_dispenser/New()
+	..()
 	gland_types = subtypesof(/obj/item/organ/gland)
 	gland_types = shuffle(gland_types)
 	gland_colors = new/list(gland_types.len)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -11,7 +11,7 @@
 	obj_integrity = 350
 	max_integrity = 350
 	armor = list(melee = 30, bullet = 30, laser = 20, energy = 20, bomb = 10, bio = 100, rad = 100, fire = 80, acid = 70)
-
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 	var/secondsElectrified = 0
 	var/shockedby = list()
@@ -95,9 +95,6 @@
 /obj/machinery/door/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return !opacity
-	return !density
-
-/obj/machinery/door/CanAtmosPass()
 	return !density
 
 /obj/machinery/door/proc/bumpopen(mob/user)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -24,7 +24,7 @@
 	closingLayer = CLOSED_FIREDOOR_LAYER
 	assemblytype = /obj/structure/firelock_frame
 	armor = list(melee = 30, bullet = 30, laser = 20, energy = 20, bomb = 10, bio = 100, rad = 100, fire = 95, acid = 70)
-
+	CanAtmosPass = ATMOS_PASS_PROC
 
 /obj/machinery/door/firedoor/Bumped(atom/AM)
 	if(panel_open || operating)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -12,6 +12,7 @@
 	visible = 0
 	flags = ON_BORDER
 	opacity = 0
+	CanAtmosPass = ATMOS_PASS_PROC
 	var/obj/item/weapon/electronics/airlock/electronics = null
 	var/reinf = 0
 	var/shards = 2

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -101,7 +101,6 @@ Class Procs:
 	pressure_resistance = 15
 	obj_integrity = 200
 	max_integrity = 200
-	armor = list(melee = 25, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70)
 
 	var/stat = 0
 	var/emagged = 0
@@ -126,6 +125,8 @@ Class Procs:
 	var/speed_process = 0 // Process as fast as possible?
 
 /obj/machinery/New()
+	if (!armor)
+		armor = list(melee = 25, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70)
 	..()
 	machines += src
 	if(!speed_process)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -9,6 +9,7 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	max_integrity = 200
 	obj_integrity = 200 //The shield can only take so much beating (prevents perma-prisons)
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/structure/emergency_shield/New()
 	src.setDir(pick(1,2,3,4))
@@ -29,9 +30,6 @@
 /obj/structure/emergency_shield/CanPass(atom/movable/mover, turf/target, height)
 	if(!height) return 0
 	else return ..()
-
-/obj/structure/emergency_shield/CanAtmosPass(turf/T)
-	return !density
 
 /obj/structure/emergency_shield/emp_act(severity)
 	switch(severity)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -187,6 +187,7 @@
 	gender = PLURAL
 	obj_integrity = 20
 	max_integrity = 20
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/structure/foamedmetal/New()
 	..()
@@ -218,9 +219,6 @@
 /obj/structure/foamedmetal/CanPass(atom/movable/mover, turf/target, height=1.5)
 	return !density
 
-
-/obj/structure/foamedmetal/CanAtmosPass()
-	return !density
 /obj/structure/foamedmetal/iron
 	obj_integrity = 50
 	max_integrity = 50

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -5,9 +5,7 @@
 	anchored = 1
 	opacity = 0
 	density = 1
-
-/obj/effect/forcefield/CanAtmosPass(turf/T)
-	return !density
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/effect/forcefield/cult
 	desc = "An unholy shield that blocks all attacks."

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -22,7 +22,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 	obj_integrity = 200
 	max_integrity = 200
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
+
 
 	var/hitsound = null
 	var/usesound = null
@@ -38,8 +38,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	var/max_heat_protection_temperature //Set this variable to determine up to which temperature (IN KELVIN) the item protects against heat damage. Keep at null to disable protection. Only protects areas set by heat_protection flags
 	var/min_cold_protection_temperature //Set this variable to determine down to which temperature (IN KELVIN) the item protects against cold damage. 0 is NOT an acceptable number due to if(varname) tests!! Keep at null to disable protection. Only protects areas set by cold_protection flags
 
-	var/list/actions = list() //list of /datum/action's that this item has.
-	var/list/actions_types = list() //list of paths of action datums to give to the item on New().
+	var/list/actions //list of /datum/action's that this item has.
+	var/list/actions_types //list of paths of action datums to give to the item on New().
 
 	//Since any item can now be a piece of clothing, this has to be put here so all items share it.
 	var/flags_inv //This flag is used to determine when items in someone's inventory cover others. IE helmets making it so you can't see glasses, etc.
@@ -58,11 +58,11 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	var/strip_delay = 40
 	var/put_on_delay = 20
 	var/breakouttime = 0
-	var/list/materials = list()
+	var/list/materials
 	var/origin_tech = null	//Used by R&D to determine what research bonuses it grants.
 	var/needs_permit = 0			//Used by security bots to determine if this item is safe for public use.
 
-	var/list/attack_verb = list() //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
+	var/list/attack_verb //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
 	var/list/species_exception = null	// list() of species types, if a species cannot put items in a certain slot, but species type is in list, it will be able to wear that item
 
 	var/suittoggled = 0
@@ -98,20 +98,15 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	// non-clothing items
 	var/datum/dog_fashion/dog_fashion = null
 
-
-/obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
-	if(((src in target) && !target_self) || (!isturf(target.loc) && !isturf(target) && not_inside))
-		return 0
-	else
-		return 1
-
-/obj/item/device
-	icon = 'icons/obj/device.dmi'
-
 /obj/item/New()
+	if (!armor)
+		armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
+	if (!materials)
+		materials = list()
 	..()
 	for(var/path in actions_types)
 		new path(src)
+	actions_types = null
 
 /obj/item/Destroy()
 	if(ismob(loc))
@@ -120,6 +115,15 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	for(var/X in actions)
 		qdel(X)
 	return ..()
+
+/obj/item/device
+	icon = 'icons/obj/device.dmi'
+
+/obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
+	if(((src in target) && !target_self) || (!isturf(target.loc) && !isturf(target) && not_inside))
+		return 0
+	else
+		return 1
 
 /obj/item/blob_act(obj/structure/blob/B)
 	if(B && B.loc == loc)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -277,7 +277,7 @@
 
 /turf/open/check_tile_is_border()
 	for(var/atom/movable/AM in src)
-		if(!AM.CanAtmosPass(src))
+		if(!CANATMOSPASS(AM, src))
 			return BORDER_2NDTILE
 
 	return BORDER_NONE

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -11,6 +11,7 @@
 /obj/item/device/instrument/New()
 	song = new(instrumentId, src)
 	song.instrumentExt = instrumentExt
+	..()
 
 /obj/item/device/instrument/Destroy()
 	qdel(song)

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -29,7 +29,6 @@
 	var/obj/machinery/atmospherics/pipe/P = A
 	P.add_atom_colour(modes[mode], FIXED_COLOUR_PRIORITY)
 	P.pipe_color = modes[mode]
-	P.stored.add_atom_colour(modes[mode], FIXED_COLOUR_PRIORITY)
 	user.visible_message("<span class='notice'>[user] paints \the [P] [mode].</span>","<span class='notice'>You paint \the [P] [mode].</span>")
 	P.update_node_icon() //updates the neighbors
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -22,6 +22,7 @@
 /obj/item/device/taperecorder/New()
 	mytape = new /obj/item/device/tape/random(src)
 	update_icon()
+	..()
 
 
 /obj/item/device/taperecorder/examine(mob/user)
@@ -282,3 +283,4 @@
 //Random colour tapes
 /obj/item/device/tape/random/New()
 	icon_state = "tape_[pick("white", "blue", "red", "yellow", "purple")]"
+	..()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -43,6 +43,7 @@
 
 /obj/item/toy/balloon/New()
 	create_reagents(10)
+	..()
 
 /obj/item/toy/balloon/attack(mob/living/carbon/human/M, mob/user)
 	return
@@ -649,9 +650,6 @@
 	var/card_throw_range = 7
 	var/list/card_attack_verb = list("attacked")
 
-/obj/item/toy/cards/New()
-	..()
-
 /obj/item/toy/cards/proc/apply_card_vars(obj/item/toy/cards/newobj, obj/item/toy/cards/sourceobj) // Applies variables for supporting multiple types of card deck
 	if(!istype(sourceobj))
 		return
@@ -1178,6 +1176,7 @@
 
 /obj/item/toy/figure/New()
     desc = "A \"Space Life\" brand [src]."
+    ..()
 
 /obj/item/toy/figure/attack_self(mob/user as mob)
 	if(cooldown <= world.time)

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -544,7 +544,6 @@ var/global/list/RPD_recipes=list(
 			playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
 			P.add_atom_colour(paint_colors[paint_color], FIXED_COLOUR_PRIORITY)
 			P.pipe_color = paint_colors[paint_color]
-			P.stored.add_atom_colour(paint_colors[paint_color], FIXED_COLOUR_PRIORITY)
 			user.visible_message("<span class='notice'>[user] paints \the [P] [paint_color].</span>","<span class='notice'>You paint \the [P] [paint_color].</span>")
 			//P.update_icon()
 			P.update_node_icon()

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -27,8 +27,10 @@
 	name = "lipstick"
 
 /obj/item/weapon/lipstick/random/New()
+	..()
 	colour = pick("red","purple","lime","black","green","blue","white")
 	name = "[colour] lipstick"
+
 
 
 /obj/item/weapon/lipstick/attack_self(mob/user)

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -45,6 +45,7 @@
 /obj/item/weapon/dice/New()
 	result = rand(1, sides)
 	update_icon()
+	..()
 
 /obj/item/weapon/dice/d1
 	name = "d1"

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -189,7 +189,7 @@
 	for(var/turf/T in turflist)
 		if(T == previousturf)
 			continue	//so we don't burn the tile we be standin on
-		if(!T.CanAtmosPass(previousturf))
+		if(!T.atmos_adjacent_turfs || !T.atmos_adjacent_turfs[previousturf])
 			break
 		ignite_turf(T)
 		sleep(1)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -21,7 +21,7 @@
 /obj/item/weapon/grenade/chem_grenade/New()
 	create_reagents(1000)
 	stage_change() // If no argument is set, it will change the stage to the current stage, useful for stock grenades that start READY.
-
+	..()
 
 /obj/item/weapon/grenade/chem_grenade/examine(mob/user)
 	display_timer = (stage == READY && !nadeassembly)	//show/hide the timer based on assembly state

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -226,12 +226,13 @@
 	var/nanofrost_cooldown = 0
 
 /obj/item/weapon/extinguisher/mini/nozzle/New(parent_tank)
+	..()
 	if(check_tank_exists(parent_tank, src))
 		tank = parent_tank
 		reagents = tank.reagents
 		max_water = tank.volume
 		loc = tank
-	return ..()
+
 
 /obj/item/weapon/extinguisher/mini/nozzle/Move()
 	..()

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -231,7 +231,7 @@
 		reagents = tank.reagents
 		max_water = tank.volume
 		loc = tank
-	return
+	return ..()
 
 /obj/item/weapon/extinguisher/mini/nozzle/Move()
 	..()

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -556,12 +556,14 @@ var/highlander_claymores = 0
 	var/list/strong_against
 
 /obj/item/weapon/melee/flyswatter/New()
+	..()
 	strong_against = typecacheof(list(
 					/mob/living/simple_animal/hostile/poison/bees/,
 					/mob/living/simple_animal/butterfly,
 					/mob/living/simple_animal/cockroach,
 					/obj/item/queen_bee
 	))
+
 
 /obj/item/weapon/melee/flyswatter/afterattack(atom/target, mob/user, proximity_flag)
 	if(proximity_flag)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -1,7 +1,6 @@
 /obj/structure
 	icon = 'icons/obj/structures.dmi'
 	pressure_resistance = 8
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 50)
 	obj_integrity = 300
 	max_integrity = 300
 	var/climb_time = 20
@@ -11,6 +10,8 @@
 	var/broken = 0 //similar to machinery's stat BROKEN
 
 /obj/structure/New()
+	if (!armor)
+		armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 50)
 	..()
 	if(smooth)
 		queue_smooth(src)

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -63,7 +63,7 @@
 	max_integrity = 200
 	smooth = SMOOTH_TRUE
 	var/resintype = null
-
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 
 /obj/structure/alien/resin/New(location)
@@ -75,9 +75,6 @@
 	var/turf/T = loc
 	..()
 	move_update_air(T)
-
-/obj/structure/alien/resin/CanAtmosPass()
-	return !density
 
 /obj/structure/alien/resin/wall
 	name = "resin wall"

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -20,6 +20,7 @@
 
 /obj/structure/door_assembly/New()
 	update_icon()
+	..()
 
 /obj/structure/door_assembly/door_assembly_0
 	name = "airlock assembly"

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -28,6 +28,7 @@
 	/turf/closed/wall/clockwork)
 	smooth = SMOOTH_TRUE
 	can_be_unanchored = 0
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/structure/falsewall/New(loc)
 	..()
@@ -37,9 +38,6 @@
 	density = 0
 	air_update_turf(1)
 	return ..()
-
-/obj/structure/falsewall/CanAtmosPass(turf/T)
-	return !density
 
 /obj/structure/falsewall/ratvar_act()
 	new /obj/structure/falsewall/brass(loc)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -18,6 +18,7 @@
 
 /obj/structure/janitorialcart/New()
 	create_reagents(100)
+	..()
 
 
 /obj/structure/janitorialcart/proc/wet_mop(obj/item/weapon/mop, mob/user)

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -21,6 +21,7 @@
 	var/sheetAmount = 7
 	var/openSound = 'sound/effects/stonedoor_openclose.ogg'
 	var/closeSound = 'sound/effects/stonedoor_openclose.ogg'
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/structure/mineral_door/New(location)
 	..()
@@ -58,9 +59,6 @@
 /obj/structure/mineral_door/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover, /obj/effect/beam))
 		return !opacity
-	return !density
-
-/obj/structure/mineral_door/CanAtmosPass()
 	return !density
 
 /obj/structure/mineral_door/proc/TryToSwitchState(atom/user)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -10,6 +10,7 @@
 
 /obj/structure/mopbucket/New()
 	create_reagents(100)
+	..()
 
 /obj/structure/mopbucket/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/mop))

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -308,6 +308,7 @@
 
 
 /obj/structure/piano/New()
+	..()
 	song = new("piano", src)
 
 	if(prob(50))

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -49,13 +49,11 @@
 /obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
 	name = "airtight plastic flaps"
 	desc = "Heavy duty, airtight, plastic flaps."
+	CanAtmosPass = ATMOS_PASS_NO
 
 /obj/structure/plasticflaps/mining/New()
 	air_update_turf(1)
 	. = ..()
-
-/obj/structure/plasticflaps/mining/CanAtmosPass()
-	return FALSE
 
 /obj/structure/plasticflaps/mining/Destroy()
 	var/atom/oldloc = loc

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -24,6 +24,7 @@ FLOOR SAFES
 
 
 /obj/structure/safe/New()
+	..()
 	tumbler_1_pos = rand(0, 71)
 	tumbler_1_open = rand(0, 71)
 

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -12,6 +12,7 @@
 	max_integrity = 100
 	var/oreAmount = 7
 	var/material_drop_type = /obj/item/stack/sheet/metal
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/structure/statue/attackby(obj/item/weapon/W, mob/living/user, params)
 	add_fingerprint(user)
@@ -80,9 +81,6 @@
 	add_fingerprint(user)
 	user.visible_message("[user] rubs some dust off from the [name]'s surface.", \
 						 "<span class='notice'>You rub some dust off from the [name]'s surface.</span>")
-
-/obj/structure/statue/CanAtmosPass()
-	return !density
 
 /obj/structure/statue/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -24,7 +24,7 @@
 	for(var/i in 1 to plasmatanks)
 		new /obj/item/weapon/tank/internals/plasma(src)
 	update_icon()
-
+	..()
 /obj/structure/tank_dispenser/update_icon()
 	cut_overlays()
 	switch(oxygentanks)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -14,6 +14,7 @@
 /obj/structure/toilet/New()
 	open = round(rand(0, 1))
 	update_icon()
+	..()
 
 
 /obj/structure/toilet/attack_hand(mob/living/user)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -26,6 +26,7 @@
 	var/facing = "l"	//Does the windoor open to the left or right?
 	var/secure = 0		//Whether or not this creates a secure windoor
 	var/state = "01"	//How far the door assembly has progressed
+	CanAtmosPass = ATMOS_PASS_PROC
 
 /obj/structure/windoor_assembly/examine(mob/user)
 	..()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -21,6 +21,7 @@
 	can_be_unanchored = 1
 	resistance_flags = ACID_PROOF
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 80, acid = 100)
+	CanAtmosPass = ATMOS_PASS_PROC
 
 /obj/structure/window/examine(mob/user)
 	..()

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -53,7 +53,7 @@
 
 		//only check this turf, if it didn't check us when it was initalized
 		if(enemy_tile.current_cycle < times_fired)
-			if(CanAtmosPass(enemy_tile))
+			if(CANATMOSPASS(src, enemy_tile))
 				LAZYINITLIST(atmos_adjacent_turfs)
 				LAZYINITLIST(enemy_tile.atmos_adjacent_turfs)
 				atmos_adjacent_turfs[enemy_tile] = TRUE

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -30,10 +30,14 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 	var/broken = 0
 	var/burnt = 0
 	var/floor_tile = null //tile that this floor drops
-	var/list/broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
-	var/list/burnt_states = list()
+	var/list/broken_states
+	var/list/burnt_states
 
 /turf/open/floor/New()
+	if (!broken_states)
+		broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
+	if (!burnt_states)
+		burnt_states = list()
 	..()
 	if(icon_state in icons_to_ignore_at_floor_init) //so damaged/burned tiles or plating icons aren't saved as the default
 		icon_regular_floor = "floor"

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -12,13 +12,16 @@
 /turf/open/floor/mineral
 	name = "mineral floor"
 	icon_state = ""
-	var/list/icons = list()
+	var/list/icons
 
 
 
 /turf/open/floor/mineral/New()
-	..()
 	broken_states = list("[initial(icon_state)]_dam")
+	..()
+	if (!icons)
+		icons = list()
+
 
 /turf/open/floor/mineral/update_icon()
 	if(!..())

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -12,10 +12,12 @@
 	name = "plating"
 	icon_state = "plating"
 	intact = 0
-	broken_states = list("platingdmg1", "platingdmg2", "platingdmg3")
-	burnt_states = list("panelscorched")
 
 /turf/open/floor/plating/New()
+	if (!broken_states)
+		broken_states = list("platingdmg1", "platingdmg2", "platingdmg3")
+	if (!burnt_states)
+		burnt_states = list("panelscorched")
 	..()
 	icon_plating = icon_state
 

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -149,10 +149,9 @@
 
 /turf/open/floor/plating/asteroid/airless/cave
 	var/length = 100
-	var/mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 1, /mob/living/simple_animal/hostile/asteroid/goliath = 5, /mob/living/simple_animal/hostile/asteroid/basilisk = 4, /mob/living/simple_animal/hostile/asteroid/hivelord = 3)
-	var/list/megafauna_spawn_list = list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, \
-	/mob/living/simple_animal/hostile/megafauna/bubblegum = SPAWN_BUBBLEGUM)
-	var/flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
+	var/list/mob_spawn_list
+	var/list/megafauna_spawn_list
+	var/list/flora_spawn_list
 	var/sanity = 1
 	var/forward_cave_dir = 1
 	var/backward_cave_dir = 2
@@ -178,6 +177,13 @@
 	has_data = TRUE
 
 /turf/open/floor/plating/asteroid/airless/cave/New(loc)
+	if (!mob_spawn_list)
+		mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 1, /mob/living/simple_animal/hostile/asteroid/goliath = 5, /mob/living/simple_animal/hostile/asteroid/basilisk = 4, /mob/living/simple_animal/hostile/asteroid/hivelord = 3)
+	if (!megafauna_spawn_list)
+		megafauna_spawn_list = list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = SPAWN_BUBBLEGUM)
+	if (!flora_spawn_list)
+		flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
+
 	if(!has_data)
 		produce_tunnel_from_data()
 	..()

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -6,7 +6,7 @@
 	icon_state = "rock"
 	var/smooth_icon = 'icons/turf/smoothrocks.dmi'
 	smooth = SMOOTH_MORE|SMOOTH_BORDER
-	canSmoothWith = list (/turf/closed)
+	canSmoothWith
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	initial_gas_mix = "TEMP=2.7"
 	opacity = 1
@@ -25,6 +25,8 @@
 	var/defer_change = 0
 
 /turf/closed/mineral/New()
+	if (!canSmoothWith)
+		canSmoothWith = list(/turf/closed)
 	pixel_y = -4
 	pixel_x = -4
 	icon = smooth_icon
@@ -133,16 +135,20 @@
 	T.ChangeTurf(type)
 
 /turf/closed/mineral/random
-	var/mineralSpawnChanceList = list(
-		/turf/closed/mineral/uranium = 5, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 10,
-		/turf/closed/mineral/silver = 12, /turf/closed/mineral/plasma = 20, /turf/closed/mineral/iron = 40, /turf/closed/mineral/titanium = 11,
-		/turf/closed/mineral/gibtonite = 4, /turf/open/floor/plating/asteroid/airless/cave = 2, /turf/closed/mineral/bscrystal = 1)
+	var/mineralSpawnChanceList
 		//Currently, Adamantine won't spawn as it has no uses. -Durandan
 	var/mineralChance = 13
+	var/display_icon_state = "rock"
 
 /turf/closed/mineral/random/New()
+	if (!mineralSpawnChanceList)
+		mineralSpawnChanceList = list(
+			/turf/closed/mineral/uranium = 5, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 10,
+			/turf/closed/mineral/silver = 12, /turf/closed/mineral/plasma = 20, /turf/closed/mineral/iron = 40, /turf/closed/mineral/titanium = 11,
+			/turf/closed/mineral/gibtonite = 4, /turf/open/floor/plating/asteroid/airless/cave = 2, /turf/closed/mineral/bscrystal = 1)
+	if (display_icon_state)
+		icon_state = display_icon_state
 	..()
-
 	if (prob(mineralChance))
 		var/path = pickweight(mineralSpawnChanceList)
 		var/turf/T = ChangeTurf(path,FALSE,TRUE)
@@ -164,10 +170,6 @@
 		/turf/closed/mineral/uranium = 35, /turf/closed/mineral/diamond = 30, /turf/closed/mineral/gold = 45, /turf/closed/mineral/titanium = 45,
 		/turf/closed/mineral/silver = 50, /turf/closed/mineral/plasma = 50, /turf/closed/mineral/bscrystal = 20)
 
-/turf/closed/mineral/random/high_chance/New()
-	icon_state = "rock"
-	..()
-
 /turf/closed/mineral/random/high_chance/volcanic
 	environment_type = "basalt"
 	turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
@@ -188,10 +190,6 @@
 		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40,
 		/turf/closed/mineral/gibtonite = 2, /turf/closed/mineral/bscrystal = 1)
 
-/turf/closed/mineral/random/low_chance/New()
-	icon_state = "rock"
-	..()
-
 
 /turf/closed/mineral/random/volcanic
 	environment_type = "basalt"
@@ -206,15 +204,13 @@
 		/turf/closed/mineral/silver/volcanic = 12, /turf/closed/mineral/plasma/volcanic = 20, /turf/closed/mineral/iron/volcanic = 40,
 		/turf/closed/mineral/gibtonite/volcanic = 4, /turf/open/floor/plating/asteroid/airless/cave/volcanic = 1, /turf/closed/mineral/bscrystal/volcanic = 1)
 
+
 /turf/closed/mineral/random/labormineral
 	mineralSpawnChanceList = list(
 		/turf/closed/mineral/iron = 100, /turf/closed/mineral/uranium = 1, /turf/closed/mineral/diamond = 1,
 		/turf/closed/mineral/gold = 1, /turf/closed/mineral/silver = 1, /turf/closed/mineral/plasma = 1)
 	icon_state = "rock_labor"
 
-/turf/closed/mineral/random/labormineral/New()
-	icon_state = "rock"
-	..()
 
 /turf/closed/mineral/random/labormineral/volcanic
 	environment_type = "basalt"

--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -3,7 +3,6 @@
 	desc = "A cold metal wall engraved with indecipherable symbols. Studying them causes your head to pound."
 	icon = 'icons/turf/walls/cult_wall.dmi'
 	icon_state = "cult"
-	builtin_sheet = null
 	canSmoothWith = null
 
 /turf/closed/wall/mineral/cult/New()

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -30,11 +30,11 @@
 			user << "<span class='notice'>The support rods have been <i>sliced through</i>, and the outer sheath is <b>connected loosely</b> to the girder.</span>"
 
 /turf/closed/wall/r_wall/break_wall()
-	builtin_sheet.loc = src
+	new sheet_type(loc)
 	return (new /obj/structure/girder/reinforced(src))
 
 /turf/closed/wall/r_wall/devastate_wall()
-	builtin_sheet.loc = src
+	new sheet_type(loc)
 	new /obj/item/stack/sheet/metal(src, 2)
 
 /turf/closed/wall/r_wall/attack_animal(mob/living/simple_animal/M)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -11,7 +11,6 @@
 	var/hardness = 40 //lower numbers are harder. Used to determine the probability of a hulk smashing through.
 	var/slicing_duration = 100  //default time taken to slice the wall
 	var/sheet_type = /obj/item/stack/sheet/metal
-	var/obj/item/stack/sheet/builtin_sheet = null
 
 	canSmoothWith = list(
 	/turf/closed/wall,
@@ -23,10 +22,6 @@
 	/turf/closed/wall/r_wall/rust,
 	/turf/closed/wall/clockwork)
 	smooth = SMOOTH_TRUE
-
-/turf/closed/wall/New()
-	..()
-	builtin_sheet = new sheet_type
 
 /turf/closed/wall/attack_tk()
 	return
@@ -48,13 +43,13 @@
 	ChangeTurf(/turf/open/floor/plating)
 
 /turf/closed/wall/proc/break_wall()
+	var/obj/item/stack/sheet/builtin_sheet = new sheet_type(loc)
 	builtin_sheet.amount = 2
-	builtin_sheet.loc = src
 	return (new /obj/structure/girder(src))
 
 /turf/closed/wall/proc/devastate_wall()
+	var/obj/item/stack/sheet/builtin_sheet = new sheet_type(loc)
 	builtin_sheet.amount = 2
-	builtin_sheet.loc = src
 	new /obj/item/stack/sheet/metal(src)
 
 /turf/closed/wall/ex_act(severity, target)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -16,7 +16,7 @@
 
 
 /turf/open/space/New()
-	update_icon()
+	icon_state = SPACE_ICON_STATE
 	air = space_gas
 
 /turf/open/space/Destroy(force)
@@ -167,9 +167,6 @@
 	if(locate(/obj/structure/lattice/catwalk, src))
 		return 1
 	return 0
-
-/turf/open/space/proc/update_icon()
-	icon_state = SPACE_ICON_STATE
 
 /turf/open/space/is_transition_turf()
 	if(destination_x || destination_y || destination_z)

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -67,7 +67,7 @@
 		throw_atom(AM)
 	..()
 
-/turf/open/space/transit/update_icon()
+/turf/open/space/transit/proc/update_icon()
 	var/p = 9
 	var/angle = 0
 	var/state = 1

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -62,10 +62,12 @@
 	return
 
 /turf/open/space/transit/New()
+	..()
 	update_icon()
 	for(var/atom/movable/AM in src)
 		throw_atom(AM)
-	..()
+
+
 
 /turf/open/space/transit/proc/update_icon()
 	var/p = 9

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -25,7 +25,7 @@
 
 	levelupdate()
 	if(smooth)
-		smooth_icon(src)
+		queue_smooth(src)
 	visibilityChanged()
 
 	for(var/atom/movable/AM in src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -54,6 +54,25 @@
 
 	return 0
 
+/turf/CanPass(atom/movable/mover, turf/target, height=1.5)
+	if(!target) return 0
+
+	if(istype(mover)) // turf/Enter(...) will perform more advanced checks
+		return !density
+
+	else // Now, doing more detailed checks for air movement and air group formation
+		if(target.blocks_air||blocks_air)
+			return 0
+
+		for(var/obj/obstacle in src)
+			if(!obstacle.CanPass(mover, target, height))
+				return 0
+		for(var/obj/obstacle in target)
+			if(!obstacle.CanPass(mover, src, height))
+				return 0
+
+		return 1
+
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	if (!mover)
 		return 1

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -16,7 +16,6 @@ Pipelines + Other Objects -> Pipe network
 	power_channel = ENVIRON
 	on_blueprints = TRUE
 	layer = GAS_PIPE_LAYER //under wires
-	armor = list(melee = 25, bullet = 10, laser = 10, energy = 100, bomb = 0, bio = 100, rad = 100, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
 	obj_integrity = 200
 	max_integrity = 200
@@ -24,32 +23,29 @@ Pipelines + Other Objects -> Pipe network
 	var/can_unwrench = 0
 	var/initialize_directions = 0
 	var/pipe_color
-	var/obj/item/pipe/stored
+
 	var/global/list/iconsetids = list()
 	var/global/list/pipeimages = list()
 
 	var/image/pipe_vision_img = null
 
 	var/device_type = 0
-	var/list/obj/machinery/atmospherics/nodes = list()
+	var/list/obj/machinery/atmospherics/nodes
 
 /obj/machinery/atmospherics/New(loc, process = TRUE)
-	nodes.len = device_type
+	nodes = new(device_type)
+	if (!armor)
+		armor = list(melee = 25, bullet = 10, laser = 10, energy = 100, bomb = 0, bio = 100, rad = 100, fire = 100, acid = 70)
 	..()
 	if(process)
 		SSair.atmos_machinery += src
 	SetInitDirections()
-	if(can_unwrench)
-		stored = new(src, make_from=src)
 
 /obj/machinery/atmospherics/Destroy()
 	for(DEVICE_TYPE_LOOP)
 		nullifyNode(I)
 
 	SSair.atmos_machinery -= src
-	if(stored)
-		qdel(stored)
-		stored = null
 
 	dropContents()
 	if(pipe_vision_img)
@@ -185,12 +181,10 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))
 		if(can_unwrench)
-			if(stored)
-				stored.forceMove(loc)
-				if(!disassembled)
-					stored.obj_integrity = stored.max_integrity * 0.5
-				transfer_fingerprints_to(stored)
-				stored = null
+			var/obj/item/pipe/stored = new(loc, make_from=src)
+			if(!disassembled)
+				stored.obj_integrity = stored.max_integrity * 0.5
+			transfer_fingerprints_to(stored)
 	..()
 
 /obj/machinery/atmospherics/proc/getpipeimage(iconset, iconstate, direction, col=rgb(255,255,255))
@@ -218,9 +212,6 @@ Pipelines + Other Objects -> Pipe network
 	if(can_unwrench)
 		add_atom_colour(obj_color, FIXED_COLOUR_PRIORITY)
 		pipe_color = obj_color
-		stored.setDir(src.dir		  )//need to define them here, because the obj directions...
-		stored.pipe_type = pipe_type  //... were not set at the time the stored pipe was created
-		stored.add_atom_colour(obj_color, FIXED_COLOUR_PRIORITY)
 	var/turf/T = loc
 	level = T.intact ? 2 : 1
 	atmosinit()

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -7,12 +7,12 @@ On top of that, now people can add component-speciic procs/vars if they want!
 	var/welded = 0 //Used on pumps and scrubbers
 	var/showpipe = 0
 
-	var/list/datum/pipeline/parents = list()
-	var/list/datum/gas_mixture/airs = list()
+	var/list/datum/pipeline/parents
+	var/list/datum/gas_mixture/airs
 
 /obj/machinery/atmospherics/components/New()
-	parents.len = device_type
-	airs.len = device_type
+	parents = new(device_type)
+	airs = new(device_type)
 	..()
 
 	for(DEVICE_TYPE_LOOP)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -1,13 +1,16 @@
 /datum/pipeline
 	var/datum/gas_mixture/air
-	var/list/datum/gas_mixture/other_airs = list()
+	var/list/datum/gas_mixture/other_airs
 
-	var/list/obj/machinery/atmospherics/pipe/members = list()
-	var/list/obj/machinery/atmospherics/components/other_atmosmch = list()
+	var/list/obj/machinery/atmospherics/pipe/members
+	var/list/obj/machinery/atmospherics/components/other_atmosmch
 
 	var/update = 1
 
 /datum/pipeline/New()
+	other_airs = list()
+	members = list()
+	other_atmosmch = list()
 	SSair.networks += src
 
 /datum/pipeline/Destroy()

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -28,6 +28,7 @@
 	var/reset_path = /obj/effect/ctf/flag_reset
 
 /obj/item/weapon/twohanded/required/ctf/New()
+	..()
 	if(!reset)
 		reset = new reset_path(get_turf(src))
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1,7 +1,7 @@
 	////////////
 	//SECURITY//
 	////////////
-#define UPLOAD_LIMIT		100048576	//Restricts client uploads to the server to 1MB //Could probably do with being lower.
+#define UPLOAD_LIMIT		1048576	//Restricts client uploads to the server to 1MB //Could probably do with being lower.
 
 	/*
 	When somebody clicks a link in game, this Topic is called first.

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1,7 +1,7 @@
 	////////////
 	//SECURITY//
 	////////////
-#define UPLOAD_LIMIT		1048576	//Restricts client uploads to the server to 1MB //Could probably do with being lower.
+#define UPLOAD_LIMIT		100048576	//Restricts client uploads to the server to 1MB //Could probably do with being lower.
 
 	/*
 	When somebody clicks a link in game, this Topic is called first.

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -26,6 +26,7 @@
 	create_reagents(100)
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/microwave(null)
 	B.apply_default_parts(src)
+	..()
 
 /obj/item/weapon/circuitboard/machine/microwave
 	name = "circuit board (Microwave)"

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -33,6 +33,7 @@
 /obj/item/weapon/circuitboard/machine/smartfridge/New(loc, new_type)
 	if(new_type)
 		build_path = new_type
+	..()
 
 /obj/item/weapon/circuitboard/machine/smartfridge/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/screwdriver))

--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -28,6 +28,7 @@
 
 /obj/item/pizzabox/New()
 	update_icon()
+	..()
 
 /obj/item/pizzabox/Destroy()
 	unprocess()

--- a/code/modules/games/cas.dm
+++ b/code/modules/games/cas.dm
@@ -29,6 +29,7 @@ var/global/list/cards_against_space
 	card_text_file = "strings/cas_black.txt"
 
 /obj/item/toy/cards/deck/cas/New()
+	..()
 	if(!cards_against_space)  //saves loading from the files every single time a new deck is created, but still lets each deck have a random assortment, it's purely an optimisation
 		cards_against_space = list("cas_white" = file2list("strings/cas_white.txt"),"cas_black" = file2list("strings/cas_black.txt"))
 	allcards = cards_against_space[card_face]

--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -24,9 +24,12 @@
 	var/active = 0
 
 /obj/item/weapon/holo/esword/green/New()
+	..()
 	item_color = "green"
 
+
 /obj/item/weapon/holo/esword/red/New()
+	..()
 	item_color = "red"
 
 /obj/item/weapon/holo/esword/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
@@ -39,6 +42,7 @@
 
 /obj/item/weapon/holo/esword/New()
 	item_color = pick("red","blue","green","purple")
+	..()
 
 /obj/item/weapon/holo/esword/attack_self(mob/living/user as mob)
 	active = !active

--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -162,23 +162,6 @@
 /atom
 	var/datum/light_source/light
 
-
-//Turfs with opacity when they are constructed will trigger nearby lights to update
-//Turfs and atoms with luminosity when they are constructed will create a light_source automatically
-/turf/New()
-	..()
-	if(luminosity)
-		light = new(src)
-
-//Movable atoms with opacity when they are constructed will trigger nearby lights to update
-//Movable atoms with luminosity when they are constructed will create a light_source automatically
-/atom/movable/New()
-	..()
-	if(opacity && isturf(loc))
-		loc.UpdateAffectingLights()
-	if(luminosity)
-		light = new(src)
-
 //Objects with opacity will trigger nearby lights to update at next SSlighting fire
 /atom/movable/Destroy()
 	qdel(light)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -421,6 +421,7 @@
 	var/arbitraryatmosblockingvar = TRUE
 	var/buildstacktype = /obj/item/stack/sheet/metal
 	var/buildstackamount = 5
+	CanAtmosPass = ATMOS_PASS_NO
 
 /obj/structure/fans/deconstruct()
 	if(!(flags & NODECONSTRUCT))
@@ -450,12 +451,10 @@
 	air_update_turf(1)
 
 /obj/structure/fans/Destroy()
-	arbitraryatmosblockingvar = FALSE
-	air_update_turf(1)
-	return ..()
+	var/turf/T = loc
+	. = ..()
+	T.air_update_turf(1)
 
-/obj/structure/fans/CanAtmosPass(turf/T)
-	return !arbitraryatmosblockingvar
 
 //Signs
 /obj/structure/sign/mining

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -301,6 +301,7 @@ var/global/chicken_count = 0
 	reagents = new(50)
 	reagents.my_atom = src
 	reagents.add_reagent("milk", 20)
+	..()
 
 /obj/item/udder/proc/generateMilk()
 	if(prob(5))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -351,7 +351,7 @@ Difficulty: Hard
 		J = get_step(previousturf, targetdir)
 		PoolOrNew(/obj/effect/overlay/temp/dir_setting/bloodsplatter, list(previousturf, get_dir(previousturf, J)))
 		playsound(previousturf,'sound/effects/splat.ogg', 100, 1, -1)
-		if(!J || !previousturf.CanAtmosPass(J))
+		if(!J || !previousturf.atmos_adjacent_turfs || !previousturf.atmos_adjacent_turfs[J])
 			break
 		new /obj/effect/decal/cleanable/blood/bubblegum(J)
 		previousturf = J

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -171,7 +171,7 @@ Difficulty: Medium
 	var/range = 10
 	var/turf/previousturf = get_turf(src)
 	for(var/turf/J in getline(src,E))
-		if(!range || !previousturf.CanAtmosPass(J))
+		if(!range || !previousturf.atmos_adjacent_turfs || !previousturf.atmos_adjacent_turfs[J])
 			break
 		range--
 		PoolOrNew(/obj/effect/hotspot,J)

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -14,6 +14,7 @@
 
 /obj/item/weapon/clipboard/New()
 	update_icon()
+	..()
 
 
 /obj/item/weapon/clipboard/update_icon()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -47,11 +47,10 @@
 	icon_state = "apc0"
 	anchored = 1
 	use_power = 0
-	req_access = list(access_engine_equip)
+	req_access = null
 	obj_integrity = 200
 	max_integrity = 200
 	integrity_failure = 50
-	armor = list(melee = 20, bullet = 20, laser = 10, energy = 100, bomb = 30, bio = 100, rad = 100, fire = 90, acid = 50)
 	var/area/area
 	var/areastring = null
 	var/obj/item/weapon/stock_parts/cell/cell
@@ -92,7 +91,6 @@
 	var/update_state = -1
 	var/update_overlay = -1
 	var/global/status_overlays = 0
-	var/updating_icon = 0
 	var/global/list/status_overlays_lock
 	var/global/list/status_overlays_charging
 	var/global/list/status_overlays_equipment
@@ -109,6 +107,10 @@
 		terminal.connect_to_network()
 
 /obj/machinery/power/apc/New(turf/loc, var/ndir, var/building=0)
+	if (!req_access)
+		req_access = list(access_engine_equip)
+	if (!armor)
+		armor = list(melee = 20, bullet = 20, laser = 10, energy = 100, bomb = 30, bio = 100, rad = 100, fire = 90, acid = 50)
 	..()
 	apcs_list += src
 
@@ -125,17 +127,14 @@
 
 	pixel_x = (src.tdir & 3)? 0 : (src.tdir == 4 ? 24 : -24)
 	pixel_y = (src.tdir & 3)? (src.tdir ==1 ? 24 : -24) : 0
-	if (building==0)
-		init()
-	else
+	if (building)
 		area = src.loc.loc:master
 		opened = 1
 		operating = 0
 		name = "[area.name] APC"
 		stat |= MAINT
 		src.update_icon()
-		spawn(5)
-			src.update()
+		addtimer(src, "update", 5)
 
 /obj/machinery/power/apc/Destroy()
 	apcs_list -= src
@@ -170,7 +169,7 @@
 	terminal.setDir(tdir)
 	terminal.master = src
 
-/obj/machinery/power/apc/proc/init()
+/obj/machinery/power/apc/initialize()
 	has_electronics = 2 //installed and secured
 	// is starting with a power cell installed, create it and set its charge level
 	if(cell_type)
@@ -189,8 +188,7 @@
 
 	make_terminal()
 
-	spawn(5)
-		src.update()
+	addtimer(src, "update", 5)
 
 /obj/machinery/power/apc/examine(mob/user)
 	..()
@@ -363,13 +361,7 @@
 
 // Used in process so it doesn't update the icon too much
 /obj/machinery/power/apc/proc/queue_icon_update()
-
-	if(!updating_icon)
-		updating_icon = 1
-		// Start the update
-		spawn(APC_UPDATE_ICON_COOLDOWN)
-			update_icon()
-			updating_icon = 0
+	addtimer(src, "update_icon", APC_UPDATE_ICON_COOLDOWN, TIMER_UNIQUE)
 
 //attack with an item - open/close cover, insert cell, or (un)lock interface
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -217,17 +217,11 @@
 /obj/machinery/power/apc/update_icon()
 	if (!status_overlays)
 		status_overlays = 1
-		status_overlays_lock = new
-		status_overlays_charging = new
-		status_overlays_equipment = new
-		status_overlays_lighting = new
-		status_overlays_environ = new
-
-		status_overlays_lock.len = 2
-		status_overlays_charging.len = 3
-		status_overlays_equipment.len = 4
-		status_overlays_lighting.len = 4
-		status_overlays_environ.len = 4
+		status_overlays_lock = new(2)
+		status_overlays_charging = new(3)
+		status_overlays_equipment = new(4)
+		status_overlays_lighting = new(4)
+		status_overlays_environ = new(4)
 
 		status_overlays_lock[1] = image(icon, "apcox-0")    // 0=blue 1=red
 		status_overlays_lock[2] = image(icon, "apcox-1")
@@ -281,18 +275,20 @@
 
 	if(!(update_state & UPSTATE_ALLGOOD))
 		if(overlays.len)
-			overlays = 0
+			cut_overlays()
 
 	if(update & 2)
 		if(overlays.len)
-			overlays.len = 0
+			cut_overlays()
 		if(!(stat & (BROKEN|MAINT)) && update_state & UPSTATE_ALLGOOD)
-			add_overlay(status_overlays_lock[locked+1])
-			add_overlay(status_overlays_charging[charging+1])
+			var/list/O = list(
+				status_overlays_lock[locked+1],
+				status_overlays_charging[charging+1])
 			if(operating)
-				add_overlay(status_overlays_equipment[equipment+1])
-				add_overlay(status_overlays_lighting[lighting+1])
-				add_overlay(status_overlays_environ[environ+1])
+				O += status_overlays_equipment[equipment+1]
+				O += status_overlays_lighting[lighting+1]
+				O += status_overlays_environ[environ+1]
+			add_overlay(O)
 
 
 /obj/machinery/power/apc/proc/check_updates()

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -30,6 +30,7 @@
 	anchored = 1
 	density = 1
 	resistance_flags = FIRE_PROOF
+	CanAtmosPass = ATMOS_PASS_DENSITY
 	var/obj/machinery/power/turbine/turbine
 	var/datum/gas_mixture/gas_contained
 	var/turf/inturf
@@ -49,6 +50,7 @@
 	anchored = 1
 	density = 1
 	resistance_flags = FIRE_PROOF
+	CanAtmosPass = ATMOS_PASS_DENSITY
 	var/opened = 0
 	var/obj/machinery/power/compressor/compressor
 	var/turf/outturf
@@ -132,9 +134,6 @@
 		return
 
 	default_deconstruction_crowbar(I)
-
-/obj/machinery/power/compressor/CanAtmosPass(turf/T)
-	return !density
 
 /obj/machinery/power/compressor/process()
 	if(!turbine)
@@ -220,9 +219,6 @@
 	compressor = locate() in get_step(src, get_dir(outturf, src))
 	if(compressor)
 		compressor.locate_machinery()
-
-/obj/machinery/power/turbine/CanAtmosPass(turf/T)
-	return !density
 
 /obj/machinery/power/turbine/process()
 

--- a/code/modules/projectiles/boxes_magazines/internal_mag.dm
+++ b/code/modules/projectiles/boxes_magazines/internal_mag.dm
@@ -153,6 +153,7 @@
 
 /obj/item/ammo_box/magazine/internal/rus357/New()
 	stored_ammo += new ammo_type(src)
+	..()
 
 /obj/item/ammo_box/magazine/internal/boltaction
 	name = "bolt action rifle internal magazine"

--- a/code/modules/reagents/chem_splash.dm
+++ b/code/modules/reagents/chem_splash.dm
@@ -46,12 +46,12 @@
 					turflist.Remove(T)
 					turflist.Add(T) // we move the purely diagonal turfs to the end of the list.
 			for(var/turf/T in turflist)
-				if(T in accessible) continue
-				for(var/turf/NT in orange(1, T))
+				if(accessible[T]) continue
+				for(var/thing in T.GetAtmosAdjacentTurfs(alldir = TRUE))
+					var/turf/NT = thing
 					if(!(NT in accessible)) continue
 					if(!(get_dir(T,NT) in cardinal)) continue
-					if(!NT.CanAtmosPass(T)) continue
-					accessible |= T
+					accessible[T] = 1
 					break
 		var/list/reactable = accessible
 		for(var/turf/T in accessible)
@@ -63,7 +63,8 @@
 		if(!reactable.len) //Nothing to react with. Probably means we're in nullspace.
 			return
 		var/fraction = 0.5/accessible.len // In a 100u mix. A small grenade spreads ~1.5u units per affected tile. A large grenade spreads ~0.75u, and a bomb spreads ~0.4u
-		for(var/atom/A in reactable)
+		for(var/thing in reactable)
+			var/atom/A = thing
 			splash_holder.reaction(A, TOUCH, fraction)
 
 	qdel(splash_holder)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -21,6 +21,7 @@
 	add_overlay("waitlight")
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/chem_master(null)
 	B.apply_default_parts(src)
+	..()
 
 /obj/item/weapon/circuitboard/machine/chem_master
 	name = "circuit board (ChemMaster 3000)"
@@ -303,7 +304,7 @@
 				var/name = stripped_input(usr, "Name:","Name your bottle!", (reagents.total_volume ? reagents.get_master_reagent_name() : " "), MAX_NAME_LEN)
 				if(!name || !reagents.total_volume || !src || qdeleted(src) || !usr.canUseTopic(src, be_close=TRUE))
 					return
-				
+
 				var/obj/item/weapon/reagent_containers/glass/bottle/P
 				for(var/i = 0; i < amount_full; i++)
 					P = new/obj/item/weapon/reagent_containers/glass/bottle(src.loc)
@@ -311,7 +312,7 @@
 					P.pixel_y = rand(-7, 7)
 					P.name = trim("[name] bottle")
 					reagents.trans_to(P, 30)
-					
+
 				if(vol_part)
 					P = new/obj/item/weapon/reagent_containers/glass/bottle(src.loc)
 					P.name = trim("[name] bottle")

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -55,6 +55,7 @@ other types of metals and chemistry for reagents).
 	var/max_blueprints = 1
 
 /obj/item/weapon/disk/design_disk/New()
+	..()
 	src.pixel_x = rand(-5, 5)
 	src.pixel_y = rand(-5, 5)
 	for(var/i in 1 to max_blueprints)

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -201,6 +201,7 @@ var/obj/machinery/blackbox_recorder/blackbox
 	use_power = 1
 	idle_power_usage = 10
 	active_power_usage = 100
+	armor = list(melee = 25, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70)
 	var/list/messages = list()		//Stores messages of non-standard frequencies
 	var/list/messages_admin = list()
 
@@ -223,6 +224,7 @@ var/obj/machinery/blackbox_recorder/blackbox
 		if (istype(blackbox,/obj/machinery/blackbox_recorder))
 			qdel(src)
 	blackbox = src
+
 
 /obj/machinery/blackbox_recorder/Destroy()
 	var/turf/T = locate(1,1,2)

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -307,10 +307,12 @@ research holder datum.
 	var/max_tech_stored = 1
 
 /obj/item/weapon/disk/tech_disk/New()
+	..()
 	src.pixel_x = rand(-5, 5)
 	src.pixel_y = rand(-5, 5)
 	for(var/i in 1 to max_tech_stored)
 		tech_stored += null
+
 
 /obj/item/weapon/disk/tech_disk/adv
 	name = "advanced technology disk"


### PR DESCRIPTION
:cl:
tweak: world initialization is now faster.
/:cl:

* Armor is now new inited for obj and the first level of subpaths.
* Actions is now lazyinited and deleted with empty.
* Actiontypes is now only inited when actually used and deleted once it pre-fills actions with the action buttons.
* Pipes now prefill their node list(s) in new() using new /list/ (count) syntax to speed up the list initaliztions and remove the init proc.
* Pipes no longer store their item version, instead creating it on the fly when deconned
* Walls no longer store their metal stacks, instead creating it on the fly when deconned.
* obj, walls, floor, plating, item, machinery, structure, pipe, pipenet, atom, and movable no longer have an (init) proc. (along with a few other smaller examples)
* Atmos can pass checking is now a var with the ability to have a proc be called in advance cases.
  * (as a side effect, I had to fix a few things that were calling atmosCanPass rather then using the pre-calculated list, this should speed up chemfoam and flame effects greatly)
* Fixed turfs smoothing twice at world init.  (please smack down anybody using `smooth_icon` and not `queue_smooth`) (this alone shaved off 8 seconds)
* Made smoothing batch overlay updates to lower on appearance churn (this alone shaved off 5 seconds)

Top is old, bottom is new (ruin generation disabled to avoid noise)
![image](https://cloud.githubusercontent.com/assets/7069733/20990712/19f789cc-bc8f-11e6-8ff7-54d54ac4c0d4.png)

(93 seconds -> 49 seconds)

We are hitting the point of diminishing returns. there are now less big ticket things to fix, and instead a whole lot of small ticket things to fix.