### PR TITLE
Double fixes the sprite issue of the Paper Cutter.

### DIFF
--- a/code/modules/paperwork/paper_cutter.dm
+++ b/code/modules/paperwork/paper_cutter.dm
@@ -2,7 +2,7 @@
 	name = "paper cutter"
 	desc = "Standard office equipment. Precisely cuts paper using a large blade."
 	icon = 'icons/obj/bureaucracy.dmi'
-	icon_state = "papercutter-cutter"
+	icon_state = "papercutter"
 	force = 5
 	throwforce = 5
 	w_class = WEIGHT_CLASS_NORMAL
@@ -15,6 +15,7 @@
 /obj/item/weapon/papercutter/New()
 	..()
 	storedcutter = new /obj/item/weapon/hatchet/cutterblade(src)
+	update_icon()
 
 
 /obj/item/weapon/papercutter/suicide_act(mob/user)


### PR DESCRIPTION
The paper cutter used to go invisible when a piece of paper was inserted(since the icon_state was papercutter-cutter, and the proc was trying to set it to papercutter-cutter-cutter when the paper got added).

After that was fixed, I noticed it didn't spawn with the correct sprite, so I added update_icon as well.

Long story short, the dreaded paper cutter is now 0.00001% more usable.
