### PR TITLE
Lavaland(Asteroid) mobs no longer appears alive again after a few seconds

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -25,6 +25,8 @@
 
 /mob/living/simple_animal/hostile/asteroid/LoseAggro()
 	..()
+	if(stat == DEAD)
+		return
 	icon_state = icon_living
 
 /mob/living/simple_animal/hostile/asteroid/bullet_act(obj/item/projectile/P)//Reduces damage from most projectiles to curb off-screen kills


### PR DESCRIPTION
This fixes the issue where the sprite of lavaland(and asteroid) mobs switches back to their living sprites after a few seconds of being killed.

Fixes #21895 