### PR TITLE
Added "Sentience" rare random event

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/sentience
-	name = "Sentience"
+	name = "Random Human-level Intelligence"
 	typepath = /datum/round_event/ghost_role/sentience
 	weight = 5
 
@@ -36,7 +36,7 @@
 	SA.health = SA.maxHealth
 	SA.del_on_death = FALSE
 
+	SA << "<span class='userdanger'>Hello world!</span>"
 	SA << "<span class='warning'>Due to freak radiation and/or chemicals \
-		and/or lucky chance, you have gained sentience!</span>"
-	SA << "<span class='userdanger'>Hello world! What you do with your free \
-		will is up to you.</span>"
+		and/or lucky chance, you have gained human level intelligence \
+		and the ability to speak and understand human language!</span>"

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -32,7 +32,7 @@
 	SA.languages_understood |= HUMAN
 	SA.sentience_act()
 
-	SA.maxHealth = min(SA.maxHealth, 200)
+	SA.maxHealth = max(SA.maxHealth, 200)
 	SA.health = SA.maxHealth
 	SA.del_on_death = FALSE
 

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -1,0 +1,42 @@
+/datum/round_event_control/sentience
+	name = "Sentience"
+	typepath = /datum/round_event/ghost_role/sentience
+	weight = 5
+
+/datum/round_event/ghost_role/sentience
+	minimum_required = 1
+	role_name = "random animal"
+
+/datum/round_event/ghost_role/sentience/spawn_role()
+	var/list/mob/dead/observer/candidates
+	candidates = get_candidates(ROLE_ALIEN, null, ROLE_ALIEN)
+
+	// find our chosen mob to breathe life into
+	// Mobs have to be simple animals, mindless and on station
+	var/list/potential = list()
+	for(var/mob/living/simple_animal/L in living_mob_list)
+		var/turf/T = get_turf(L)
+		if(T.z != ZLEVEL_STATION)
+			continue
+		if(!(L in player_list) && !L.mind)
+			potential += L
+
+	var/mob/living/simple_animal/SA = pick(potential)
+	var/mob/dead/observer/SG = pick(candidates)
+
+	if(!SA || !SG)
+		return FALSE
+
+	SA.key = SG.key
+	SA.languages_spoken |= HUMAN
+	SA.languages_understood |= HUMAN
+	SA.sentience_act()
+
+	SA.maxHealth = min(SA.maxHealth, 200)
+	SA.health = SA.maxHealth
+	SA.del_on_death = FALSE
+
+	SA << "<span class='warning'>Due to freak radiation and/or chemicals \
+		and/or lucky chance, you have gained sentience!</span>"
+	SA << "<span class='userdanger'>Hello world! What you do with your free \
+		will is up to you.</span>"

--- a/code/modules/mob/living/simple_animal/friendly/cockroach.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cockroach.dm
@@ -1,5 +1,3 @@
-
-
 /mob/living/simple_animal/cockroach
 	name = "cockroach"
 	desc = "This station is just crawling with bugs."
@@ -16,17 +14,25 @@
 	response_help  = "pokes"
 	response_disarm = "shoos"
 	response_harm   = "splats"
+	speak_emote = list("chitters")
 	density = 0
 	ventcrawler = VENTCRAWLER_ALWAYS
 	gold_core_spawnable = 2
+	verb_say = "chitters"
+	verb_ask = "chitters inquisitively"
+	verb_exclaim = "chitters loudly"
+	verb_yell = "chitters loudly"
 	var/squish_chance = 50
-	loot = list(/obj/effect/decal/cleanable/deadcockroach)
 	del_on_death = 1
 
 /mob/living/simple_animal/cockroach/death(gibbed)
 	if(ticker.cinematic) //If the nuke is going off, then cockroaches are invincible. Keeps the nuke from killing them, cause cockroaches are immune to nukes.
 		return
 	..()
+
+/mob/living/simple_animal/cockroach/proc/squish()
+	adjustBruteLoss(1) // kills a normal cockroach
+	new /obj/effect/decal/cleanable/deadcockroach(get_turf(src))
 
 /mob/living/simple_animal/cockroach/Crossed(var/atom/movable/AM)
 	if(ismob(AM))
@@ -35,14 +41,14 @@
 			if(A.mob_size > MOB_SIZE_SMALL)
 				if(prob(squish_chance))
 					A.visible_message("<span class='notice'>\The [A] squashed \the [name].</span>", "<span class='notice'>You squashed \the [name].</span>")
-					death()
+					squish()
 				else
 					visible_message("<span class='notice'>\The [name] avoids getting crushed.</span>")
 	else
 		if(isobj(AM))
 			if(istype(AM,/obj/structure))
 				visible_message("<span class='notice'>As \the [AM] moved over \the [name], it was crushed.</span>")
-				death()
+				squish()
 
 /mob/living/simple_animal/cockroach/ex_act() //Explosions are a terrible way to handle a cockroach.
 	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1175,6 +1175,7 @@
 #include "code\modules\events\prison_break.dm"
 #include "code\modules\events\processor_overload.dm"
 #include "code\modules\events\radiation_storm.dm"
+#include "code\modules\events\sentience.dm"
 #include "code\modules\events\shuttle_loan.dm"
 #include "code\modules\events\spacevine.dm"
 #include "code\modules\events\spider_infestation.dm"


### PR DESCRIPTION
:cl: coiax
add: Due to a combination of radiation and water supply contamination,
stations have been reporting animals gaining self awareness.
/:cl:

Picks a random /mob/living/simple_animal on station that has no mind,
and gives it to a ghost who signs up, along with giving them a decent
chunk of health so they don't die instantly.

Note that this does include bots, which I've kept because it's hilarious
that the Mulebot spontaneously develops opinions.

Cockroaches now take 1 damage when stepped on, enough to kill a normal
cockroach, but not enough to kill a sentient one.