### PR TITLE
Cyborgs have a reset module wire

### DIFF
--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -30,6 +30,7 @@
 #define WIRE_POWER2 "Main Power 2"
 #define WIRE_PROCEED "Proceed"
 #define WIRE_RX "Recieve"
+#define WIRE_RESET_MODULE "Reset Module"
 #define WIRE_SAFETY "Safety"
 #define WIRE_SHOCK "High Voltage Ground"
 #define WIRE_SIGNAL "Signal"

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -5,7 +5,8 @@
 /datum/wires/robot/New(atom/holder)
 	wires = list(
 		WIRE_AI, WIRE_CAMERA,
-		WIRE_LAWSYNC, WIRE_LOCKDOWN
+		WIRE_LAWSYNC, WIRE_LOCKDOWN,
+		WIRE_RESET_MODULE
 	)
 	add_duds(2)
 	..()
@@ -22,6 +23,7 @@
 	status += "The intelligence link display shows [R.connected_ai ? R.connected_ai.name : "NULL"]."
 	status += "The camera light is [!isnull(R.camera) && R.camera.status ? "on" : "off"]."
 	status += "The lockdown indicator is [R.lockcharge ? "on" : "off"]."
+	status += "The reset module hardware light is [R.has_module() ? "on" : "off"]."
 	return status
 
 /datum/wires/robot/on_pulse(wire)
@@ -44,6 +46,9 @@
 				R.show_laws()
 		if(WIRE_LOCKDOWN)
 			R.SetLockdown(!R.lockcharge) // Toggle
+		if(WIRE_RESET_MODULE)
+			if(R.has_module())
+				R.ResetModule()
 
 /datum/wires/robot/on_cut(wire, mend)
 	var/mob/living/silicon/robot/R = holder

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -21,20 +21,6 @@
 		usr << "There's no mounting point for the module!"
 		return 1
 
-/obj/item/borg/upgrade/reset
-	name = "cyborg module reset board"
-	desc = "Used to reset a cyborg's module. Destroys any other upgrades applied to the cyborg."
-	icon_state = "cyborg_upgrade1"
-	require_module = 1
-
-/obj/item/borg/upgrade/reset/action(mob/living/silicon/robot/R)
-	if(..())
-		return
-
-	R.ResetModule()
-
-	return 1
-
 /obj/item/borg/upgrade/rename
 	name = "cyborg reclassification board"
 	desc = "Used to rename a cyborg."
@@ -219,6 +205,7 @@
 	var/on = 0
 	var/powercost = 10
 	var/mob/living/silicon/robot/cyborg
+	var/datum/action/toggle_action
 
 /obj/item/borg/upgrade/selfrepair/action(mob/living/silicon/robot/R)
 	if(..())
@@ -231,9 +218,18 @@
 
 	cyborg = R
 	icon_state = "selfrepair_off"
-	var/datum/action/A = new /datum/action/item_action/toggle(src)
-	A.Grant(R)
+	toggle_action = new /datum/action/item_action/toggle(src)
+	toggle_action.Grant(R)
 	return 1
+
+/obj/item/borg/uprgade/selfrepair/dropped()
+	addtimer(src, "check_dropped", 1)
+
+/obj/item/borg/upgrade/selfrepair/proc/check_dropped()
+	if(loc != cyborg)
+		toggle_action.Remove(cyborg)
+		cyborg = null
+		deactivate()
 
 /obj/item/borg/upgrade/selfrepair/ui_action_click()
 	on = !on

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -931,6 +931,12 @@
 
 	return 1
 
+/mob/living/silicon/robot/proc/has_module()
+	if(!module || module.type == /obj/item/weapon/robot_module)
+		. = FALSE
+	else
+		. = TRUE
+
 /mob/living/silicon/robot/proc/update_module_innate()
 	designation = module.name
 	if(hands)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -74,6 +74,8 @@
 	var/updating = 0 //portable camera camerachunk update
 	hud_possible = list(ANTAG_HUD, DIAG_STAT_HUD, DIAG_HUD, DIAG_BATT_HUD)
 
+	var/list/upgrades = list()
+
 /mob/living/silicon/robot/New(loc)
 	spark_system = new /datum/effect_system/spark_spread()
 	spark_system.set_up(5, 0, src)
@@ -475,6 +477,7 @@
 			if(U.action(src))
 				user << "<span class='notice'>You apply the upgrade to [src].</span>"
 				U.loc = src
+				upgrades += U
 			else
 				user << "<span class='danger'>Upgrade error.</span>"
 
@@ -621,7 +624,6 @@
 	else
 		explosion(src.loc,-1,0,2)
 	gib()
-	return
 
 /mob/living/silicon/robot/proc/UnlinkSelf()
 	if(src.connected_ai)
@@ -926,7 +928,13 @@
 		hud_used.update_robot_modules_display()
 	module.transform_to(/obj/item/weapon/robot_module)
 
-	speed = 0 // Remove upgrades.
+	// Remove upgrades.
+	for(var/obj/item/I in upgrades)
+		I.forceMove(get_turf(src))
+
+	upgrades.Cut()
+
+	speed = 0
 	ionpulse = FALSE
 
 	return 1

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -571,15 +571,6 @@
 //////////////Borg Upgrades//////////////
 /////////////////////////////////////////
 
-/datum/design/borg_upgrade_reset
-	name = "Cyborg Upgrade (Module Reset Board)"
-	id = "borg_upgrade_reset"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/reset
-	materials = list(MAT_METAL=10000)
-	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
-
 /datum/design/borg_upgrade_rename
 	name = "Cyborg Upgrade (Rename Board)"
 	id = "borg_upgrade_rename"


### PR DESCRIPTION
:cl: coiax
add: Cyborgs now have a reset module wire, that when pulsed, triggers
the cyborg's reset module hardware.
add: Cyborgs now eject all upgrades when reset, rather than the upgrades being destroyed.
del: Removed redundant reset module.
/:cl:

Because they can't touch it themselves for software reasons. Now you can
ask random assistants to reset you in a pinch, or do it on the FRONTIER.