### PR TITLE
Fixes deleting items in storages not updating the HUD

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -367,10 +367,10 @@
 	W.plane = initial(W.plane)
 	W.loc = new_location
 
-	if(usr)
-		orient2hud(usr)
-		if(usr.s_active)
-			usr.s_active.show_to(usr)
+	for(var/mob/M in can_see_contents())
+		orient2hud(M)
+		show_to(M)
+
 	if(W.maptext)
 		W.maptext = ""
 	W.on_exit_storage(src)


### PR DESCRIPTION
Thanks @RemieRichards! Turns out that handle_atom_del _already_ called remove_from_storage, but it only updated the usr's hud instead of everyone with the storage open.