### PR TITLE
Slips Bugfix

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -121,7 +121,7 @@
 	return 1
 
 /turf/open/handle_slip(mob/living/carbon/C, s_amount, w_amount, obj/O, lube)
-	if(C.movement_type & FLYING)
+	if((C.movement_type & FLYING) || C.slipping)
 		return 0
 	if(has_gravity(src))
 		var/obj/buckled_obj
@@ -144,25 +144,30 @@
 			C.accident(I)
 
 		var/olddir = C.dir
-		if(!(lube&SLIDE_ICE))
+		if(!(lube & SLIDE_ICE))
 			C.Stun(s_amount)
 			C.Weaken(w_amount)
 			C.stop_pulling()
 		else
 			C.Stun(1)
+
 		if(buckled_obj)
 			buckled_obj.unbuckle_mob(C)
+			C.slipping = TRUE
 			step(buckled_obj, olddir)
 		else if(lube&SLIDE)
+			C.slipping = TRUE
 			for(var/i=1, i<5, i++)
 				spawn (i)
+					if(i == 4)
+						C.slipping = FALSE
 					step(C, olddir)
 					C.spin(1,1)
 		else if(lube&SLIDE_ICE)
 			C.slipping = TRUE
 			spawn(1)
-				step(C, olddir)
 				C.slipping = FALSE
+				step(C, olddir)
 		return 1
 
 /turf/open/proc/MakeSlippery(wet_setting = TURF_WET_WATER, min_wet_time = 0, wet_time_to_add = 0) // 1 = Water, 2 = Lube, 3 = Ice, 4 = Permafrost, 5 = Slide

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -153,7 +153,6 @@
 
 		if(buckled_obj)
 			buckled_obj.unbuckle_mob(C)
-			C.slipping = TRUE
 			step(buckled_obj, olddir)
 		else if(lube&SLIDE)
 			C.slipping = TRUE

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -129,6 +129,8 @@
 		return 0
 	if(isliving(mob))
 		var/mob/living/L = mob
+		if(L.slipping)
+			return 0
 		if(L.incorporeal_move)	//Move though walls
 			Process_Incorpmove(direct)
 			return 0


### PR DESCRIPTION
```
<Cyberboss> what exactly is causing the lag with slips? im dead serious
...
<%oranges> Cyberboss: it queues up too many moves
...
<%oranges> I suspect an edge case where someone is slipping
<%oranges> failing to be moved to the new tile
<%oranges> and then slipping again
```

Just because I'm tired of hearing people bitching about freon/slips without actually doing anything

:cl: Cyberboss
fix: The slips bug (which made freon laggy) is fixed
/:cl:

Testmerge it, prove me wrong!

