### PR TITLE
Adds  5 unstable mutagen bottles to a hacked NutriMax botany vendor

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -850,7 +850,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	icon_deny = "nutri-deny"
 	products = list(/obj/item/weapon/reagent_containers/glass/bottle/nutrient/ez = 30,/obj/item/weapon/reagent_containers/glass/bottle/nutrient/l4z = 20,/obj/item/weapon/reagent_containers/glass/bottle/nutrient/rh = 10,/obj/item/weapon/reagent_containers/spray/pestspray = 20,
 					/obj/item/weapon/reagent_containers/syringe = 5,/obj/item/weapon/storage/bag/plants = 5,/obj/item/weapon/cultivator = 3,/obj/item/weapon/shovel/spade = 3,/obj/item/device/plant_analyzer = 4)
-	contraband = list(/obj/item/weapon/reagent_containers/glass/bottle/ammonia = 10,/obj/item/weapon/reagent_containers/glass/bottle/diethylamine = 5)
+	contraband = list(/obj/item/weapon/reagent_containers/glass/bottle/ammonia = 10,/obj/item/weapon/reagent_containers/glass/bottle/diethylamine = 5,/obj/item/weapon/reagent_containers/glass/bottle/mutagen = 5)
 	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 50)
 	resistance_flags = FIRE_PROOF
 


### PR DESCRIPTION
:cl:
add: Nanotrasen Security Division reports that some bottles with strange green liquid have been contrabanded to the botany vendomat
/:cl:

Enough to kickstart botany if you know what you are doing, but not enough to run longer than a few minutes if you don't.
Because messing with chemists who are too busy making some ClF3/incompetent/braindead is the WORST part of botany and only causes general frustration.
