### PR TITLE
Projectile bugfix

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -225,7 +225,7 @@
 				pixel_x = pixel_x_offset
 				pixel_y = pixel_y_offset
 			else
-				animate(src, pixel_x = pixel_x_offset, pixel_y = pixel_y_offset, time = max(1, (delay <= 3 ? delay - 1 : delay)))
+				animate(src, pixel_x = pixel_x_offset, pixel_y = pixel_y_offset, time = max(1, (delay <= 3 ? delay - 1 : delay)), flags = ANIMATION_END_NOW)
 
 			if(original && (original.layer>=2.75) || ismob(original))
 				if(loc == get_turf(original))


### PR DESCRIPTION
Фикс дергающихся пуль.
Флаг ANIMATION_END_NOW  при начале новой анимации, завершает предыдущую в конечной точке. 

Fixes twitchy bullets.
ANIMATION_END_NOW terminates previous animation with its endpoint at the start of new one.