### PR TITLE
Species Mutation toxins can no longer be mass synthesized.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -364,6 +364,7 @@
 	metabolization_rate = INFINITY //So it instantly removes all of itself
 	var/datum/species/race = /datum/species/human
 	var/mutationtext = "<span class='danger'>The pain subsides. You feel... human.</span>"
+	can_synth = 0 //no fun allowed
 
 /datum/reagent/stableslimetoxin/on_mob_life(mob/living/carbon/human/H)
 	..()
@@ -391,6 +392,7 @@
 	color = "#13BC5E" // rgb: 19, 188, 94
 	race = /datum/species/jelly/slime
 	mutationtext = "<span class='danger'>The pain subsides. Your whole body feels like slime.</span>"
+	can_synth = 1 //honk honk
 
 /datum/reagent/stableslimetoxin/lizard
 	name = "Lizard Mutation Toxin"


### PR DESCRIPTION
:cl: optional name here
tweak: Species mutation toxin has been blacklisted from the mech syringe gun. Slime transformation toxin has been left
/:cl:

xeno needs to make more than one to go on their grif spree. the slime toxin is a(deadly and b(makes you able to robust the guy who did it later.