### PR TITLE
Small Renaming Oversights

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -8,7 +8,16 @@
 	return
 
 /obj/attackby(obj/item/I, mob/living/user, params)
-	return I.attack_obj(src, user)
+	if(unique_rename)
+		if(istype(I, /obj/item/weapon/pen))
+			var/penchoice = alert("What would you like to edit?", "Rename or change description?", "Rename", "Change description", "Cancel")
+			if(!qdeleted(src) && user.canUseTopic(src, BE_CLOSE))
+				if(penchoice == "Rename")
+					rename_obj(user)
+				if(penchoice == "Change description")
+					redesc_obj(user)
+	else
+		return I.attack_obj(src, user)
 
 /mob/living/attackby(obj/item/I, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
@@ -48,8 +57,6 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.do_attack_animation(O)
 	O.attacked_by(src, user)
-
-
 
 /atom/movable/proc/attacked_by()
 	return

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -9,12 +9,12 @@
 
 /obj/attackby(obj/item/I, mob/living/user, params)
 	if(unique_rename && istype(I, /obj/item/weapon/pen))
-			var/penchoice = alert("What would you like to edit?", "Rename or change description?", "Rename", "Change description", "Cancel")
-			if(!qdeleted(src) && user.canUseTopic(src, BE_CLOSE))
-				if(penchoice == "Rename")
-					rename_obj(user)
-				if(penchoice == "Change description")
-					redesc_obj(user)
+		var/penchoice = alert("What would you like to edit?", "Rename or change description?", "Rename", "Change description", "Cancel")
+		if(!qdeleted(src) && user.canUseTopic(src, BE_CLOSE))
+			if(penchoice == "Rename")
+				rename_obj(user)
+			if(penchoice == "Change description")
+				redesc_obj(user)
 	else
 		return I.attack_obj(src, user)
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -8,8 +8,7 @@
 	return
 
 /obj/attackby(obj/item/I, mob/living/user, params)
-	if(unique_rename)
-		if(istype(I, /obj/item/weapon/pen))
+	if(unique_rename && istype(I, /obj/item/weapon/pen))
 			var/penchoice = alert("What would you like to edit?", "Rename or change description?", "Rename", "Change description", "Cancel")
 			if(!qdeleted(src) && user.canUseTopic(src, BE_CLOSE))
 				if(penchoice == "Rename")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -337,6 +337,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 			else if(S.can_be_inserted(src))
 				S.handle_item_insertion(src)
+	else
+		..()
 
 
 // afterattack() and attack() prototypes moved to _onclick/item_attack.dm for consistency

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -337,8 +337,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 			else if(S.can_be_inserted(src))
 				S.handle_item_insertion(src)
-	else
-		..()
+	else ..()
 
 
 // afterattack() and attack() prototypes moved to _onclick/item_attack.dm for consistency

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -337,7 +337,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 			else if(S.can_be_inserted(src))
 				S.handle_item_insertion(src)
-	else ..()
+	else
+		..()
 
 
 // afterattack() and attack() prototypes moved to _onclick/item_attack.dm for consistency

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -194,17 +194,6 @@
 	if(unique_rename)
 		user << "<span class='notice'>Use a pen on it to rename it or change its description.</span>"
 
-/obj/attackby(obj/item/I, mob/user, params)
-	if(unique_rename)
-		if(istype(I, /obj/item/weapon/pen))
-			var/penchoice = alert("What would you like to edit?", "Rename or change description?", "Rename", "Change description", "Cancel")
-			if(!qdeleted(src) && user.canUseTopic(src, BE_CLOSE))
-				if(penchoice == "Rename")
-					rename_obj(user)
-				if(penchoice == "Change description")
-					redesc_obj(user)
-	..()
-
 /obj/proc/rename_obj(mob/M)
 	var/input = stripped_input(M,"What do you want to name \the [name]?", ,"", MAX_NAME_LEN)
 	var/oldname = name

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -143,7 +143,8 @@
 	if(sharp)
 		if(slice(sharp, W, user))
 			return 1
-	else ..()
+	else
+		..()
 
 //Called when you finish tablecrafting a snack.
 /obj/item/weapon/reagent_containers/food/snacks/CheckParts(list/parts_list, datum/crafting_recipe/food/R)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -143,6 +143,7 @@
 	if(sharp)
 		if(slice(sharp, W, user))
 			return 1
+	else ..()
 
 //Called when you finish tablecrafting a snack.
 /obj/item/weapon/reagent_containers/food/snacks/CheckParts(list/parts_list, datum/crafting_recipe/food/R)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -305,6 +305,7 @@
 					verbs -= /obj/item/weapon/gun/proc/toggle_gunlight
 				for(var/datum/action/item_action/toggle_gunlight/TGL in actions)
 					qdel(TGL)
+	else ..()
 
 
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -305,7 +305,8 @@
 					verbs -= /obj/item/weapon/gun/proc/toggle_gunlight
 				for(var/datum/action/item_action/toggle_gunlight/TGL in actions)
 					qdel(TGL)
-	else ..()
+	else
+		..()
 
 
 


### PR DESCRIPTION
:cl: Cobby
fix: Fixes literally everything regarding renaming so far. When adding unique_rename to objects, make sure the attackby checks for inheritance.
/:cl:

If you give an object `unique_rename = 1`, but the `attackby()` doesn't check inheritance, then the object won't rename regardless of the var. go figure.