### PR TITLE
Adds "weighted random" AI law config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -184,6 +184,8 @@
 	var/silicon_max_law_amount = 12
 	var/list/lawids = list()
 
+	var/list/law_weights = list()
+
 	var/assistant_cap = -1
 
 	var/starlight = 0
@@ -647,6 +649,16 @@
 				if("random_laws")
 					var/law_id = lowertext(value)
 					lawids += law_id
+				if("law_weight")
+					// Value is in the form "LAWID,NUMBER"
+					var/list/L = splittext(value, ",")
+					if(L.len != 2)
+						diary << "Invalid LAW_WEIGHT: " + t
+						continue
+					var/lawid = L[1]
+					var/weight = text2num(L[2])
+					law_weights[lawid] = weight
+
 				if("silicon_max_law_amount")
 					config.silicon_max_law_amount	= text2num(value)
 				if("join_with_mutant_race")

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -198,9 +198,22 @@
 				return
 
 		if(2)
-			var/datum/ai_laws/lawtype = pick(subtypesof(/datum/ai_laws/default))
+			var/list/randlaws = list()
+			for(var/lpath in subtypesof(/datum/ai_laws))
+				var/datum/ai_laws/L = lpath
+				if(initial(L.id) in config.lawids)
+					randlaws += lpath
+			var/datum/ai_laws/lawtype
+			if(randlaws.len)
+				lawtype = pick(randlaws)
+			else
+				lawtype = pick(subtypesof(/datum/ai_laws/default))
+
 			var/datum/ai_laws/templaws = new lawtype()
 			inherent = templaws.inherent
+
+		if(3)
+			pick_weighted_lawset()
 
 		else:
 			log_law("Invalid law config. Please check silicon_laws.txt")
@@ -208,6 +221,29 @@
 			add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
 			add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 			WARNING("Invalid custom AI laws, check silicon_laws.txt")
+
+/datum/ai_laws/proc/pick_weighted_lawset()
+	// 80% of the time, it is a "normal" lawset
+	// and 20% of the time, it's quirky
+	var/list/possible_laws = list(
+		// "normals" - weights should add to 80
+		/datum/ai_laws/default/asimov = 32,
+		/datum/ai_laws/asimovpp = 12,
+		/datum/ai_laws/default/corporate = 12,
+		/datum/ai_laws/robocop = 12,
+		/datum/ai_laws/default/paladin = 12,
+		// "quirkys" - weights should add to 20
+		/datum/ai_laws/maintain = 4,
+		/datum/ai_laws/reporter = 4,
+		/datum/ai_laws/hippocratic = 3,
+		/datum/ai_laws/liveandletlive = 3,
+		/datum/ai_laws/peacekeeper = 3,
+		/datum/ai_laws/drone = 3
+	)
+	var/datum/ai_laws/lawtype = pickweight(possible_laws)
+	var/datum/ai_laws/templaws = new lawtype()
+	inherent = templaws.inherent
+
 
 /datum/ai_laws/proc/set_law_sixsixsix(laws)
 	devillaws = laws

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -46,23 +46,8 @@
 	laws.clear_ion_laws()
 
 /mob/living/silicon/proc/make_laws()
-	switch(config.default_laws)
-		if(0)
-			laws = new /datum/ai_laws/default/asimov()
-		if(1)
-			laws = new /datum/ai_laws/custom()
-		if(2)
-			var/list/randlaws = list()
-			for(var/lpath in subtypesof(/datum/ai_laws))
-				var/datum/ai_laws/L = lpath
-				if(initial(L.id) in config.lawids)
-					randlaws += lpath
-			var/datum/ai_laws/lawtype
-			if(randlaws.len)
-				lawtype = pick(randlaws)
-			else
-				lawtype = pick(subtypesof(/datum/ai_laws/default))
-			laws = new lawtype()
+	laws = new /datum/ai_laws
+	laws.set_laws_config()
 	laws.associate(src)
 
 /mob/living/silicon/proc/clear_zeroth_law(force)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -312,6 +312,7 @@ SEC_START_BRIG
 ## Set to 0/commented for "off", silicons will just start with Asimov.
 ## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
+## Set to 3 for "weighted random", silicons will start with a random lawset, 80% of the time it will be standard-ish, and 20% of the time it will be quirky.
 DEFAULT_LAWS 0
 
 ## RANDOM LAWS ##

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -312,7 +312,7 @@ SEC_START_BRIG
 ## Set to 0/commented for "off", silicons will just start with Asimov.
 ## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
-## Set to 3 for "weighted random", silicons will start with a random lawset, 80% of the time it will be standard-ish, and 20% of the time it will be quirky.
+## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specifed in that file.
 DEFAULT_LAWS 0
 
 ## RANDOM LAWS ##
@@ -344,6 +344,36 @@ RANDOM_LAWS corporate
 
 ## meme laws. Honk
 #RANDOM_LAWS buildawall
+
+## If weighted laws are selected (DEFAULT_LAWS = 3),
+## then an AI's starting laws will be determined by the weights of these values
+
+## Make sure there are no spaces between the law_id and the number.
+
+LAW_WEIGHT custom,0
+
+## standard-ish laws. These are fairly ok to run
+LAW_WEIGHT asimov,32
+LAW_WEIGHT asimovpp,12
+LAW_WEIGHT paladin,12
+LAW_WEIGHT robocop,12
+LAW_WEIGHT corporate,12
+
+## Quirky laws. Shouldn't cause too much harm
+LAW_WEIGHT hippocratic,3
+LAW_WEIGHT maintain,4
+LAW_WEIGHT drone,3
+LAW_WEIGHT liveandletlive,3
+LAW_WEIGHT peacekeeper,3
+LAW_WEIGHT reporter,4
+
+## Bad idea laws. Probably shouldn't enable these
+LAW_WEIGHT syndie,0
+LAW_WEIGHT ninja,0
+LAW_WEIGHT antimov,0
+LAW_WEIGHT thermodynamic,0
+LAW_WEIGHT ratvar,0
+LAW_WEIGHT buildawall,0
 
 ##------------------------------------------------
 


### PR DESCRIPTION
- Streamlines some duplicated code for law config stuff
- Makes a new "weighted random" option for AI laws, where an AI has a
random lawset, but the weights are specified in config.

For those unwilling to source dive, here are the default weights:

- 32% Asimov
- 12% Asimov++
- 12% Corporate
- 12% Robocop
- 12% Paladin

- 4% Maintain
- 4% Reporter
- 3% Hippocratic
- 3% Live and Let Live
- 3% Peacekeeper
- 3% Drone