### PR TITLE
Throwing tweaks / indirect floor tile+rod buff

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -527,6 +527,9 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	. = ..()
 	throw_speed = initial(throw_speed) //explosions change this.
 
+//Called before a mob throws something. Optionally return a replacement object to throw instead of src.
+/obj/item/proc/pre_throw_by_mob(mob/tosser)
+	return src
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/weapon/storage
 	if(!newLoc)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -99,7 +99,8 @@
 
 	use(1)
 
-
+/obj/item/stack/medical/pre_throw_by_mob(mob/tosser)
+	return src
 
 /obj/item/stack/medical/bruise_pack
 	name = "bruise pack"

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -272,10 +272,15 @@
 	src.fingerprintslast  = from.fingerprintslast
 	//TODO bloody overlay
 
+/obj/item/stack/pre_throw_by_mob(mob/tosser)
+	if(get_amount() > 1)
+		return change_stack(tosser, 1)
+	return src
+
 /obj/item/stack/microwave_act(obj/machinery/microwave/M)
 	if(M && M.dirty < 100)
 		M.dirty += amount
-		
+
 /*
  * Recipe datum
  */

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -25,3 +25,6 @@
 			I.hidden_uplink.telecrystals += 1
 			use(1)
 			user << "<span class='notice'>You slot [src] into the [I] and charge its internal uplink.</span>"
+
+/obj/item/stack/telecrystal/pre_throw_by_mob(mob/tosser)
+	return src

--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -19,6 +19,8 @@
 		new /obj/item/weapon/c_tube(get_turf(src))
 	return ..()
 
+/obj/item/stack/wrapping_paper/pre_throw_by_mob(mob/tosser)
+	return src
 
 /*
  * Package Wrap
@@ -102,6 +104,9 @@
 	if(!amount)
 		new /obj/item/weapon/c_tube(get_turf(src))
 	return ..()
+
+/obj/item/stack/packageWrap/pre_throw_by_mob(mob/tosser)
+	return src
 
 /obj/item/weapon/c_tube
 	name = "cardboard tube"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -154,6 +154,7 @@
 					add_logs(src, throwable_mob, "thrown", addition="from [start_T_descriptor] with the target [end_T_descriptor]")
 
 	else if(!(I.flags & (NODROP|ABSTRACT)))
+		I = I.pre_throw_by_mob(src) || I
 		thrown_thing = I
 		unEquip(I)
 

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -27,14 +27,6 @@
 		internalPaper = new /obj/item/weapon/paper(src)
 	update_icon()
 
-/obj/item/weapon/paperplane/suicide_act(mob/user)
-	user.Stun(10)
-	user.visible_message("<span class='suicide'>[user] jams the [src] in [user.p_their()] nose. It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	user.adjust_blurriness(6)
-	user.adjust_eye_damage(rand(6,8))
-	sleep(10)
-	return (BRUTELOSS)
-
 /obj/item/weapon/paperplane/update_icon()
 	cut_overlays()
 	if(!stamped)
@@ -45,9 +37,8 @@
 			var/image/stampoverlay = image('icons/obj/bureaucracy.dmi', "paperplane_[initial(stamp.icon_state)]")
 			add_overlay(stampoverlay)
 
-/obj/item/weapon/paperplane/attack_self(mob/user)
-	user << "<span class='notice'>You unfold [src].</span>"
-	user.unEquip(src)
+/obj/item/weapon/paperplane/equipped(mob/user)
+	user.unEquip(src) //hacky since we're midway through equipping by this point
 	user.put_in_hands(internalPaper)
 	qdel(src)
 
@@ -103,10 +94,6 @@
 		H.Weaken(2)
 		H.emote("scream")
 
-/obj/item/weapon/paper/AltClick(mob/living/carbon/user, obj/item/I,)
-	if((!in_range(src, user)) || usr.stat || usr.restrained())
-		return
-	user << "<span class='notice'>You fold [src] into the shape of a plane!</span>"
-	user.unEquip(src)
-	I = new /obj/item/weapon/paperplane(loc, src)
-	user.put_in_hands(I)
+/obj/item/weapon/paper/pre_throw_by_mob(mob/tosser)
+	tosser.unEquip(src, 1)
+	return new /obj/item/weapon/paperplane(tosser.loc, src)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -530,6 +530,9 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 		new_cable.item_color = item_color
 		new_cable.update_icon()
 
+/obj/item/stack/cable_coil/pre_throw_by_mob(mob/tosser)
+	return src
+
 //add cables to the stack
 /obj/item/stack/cable_coil/proc/give(extra)
 	if(amount + extra > max_amount)


### PR DESCRIPTION
Throwing a stack only throws one item in that stack instead of the whole stack. This will obviously make a stack of floor tiles very deadly because you can just keep throwing them very quickly. This mechanic does not apply to the following stacks: Telecrystals, medical stuff, wrapping paper, and cable coil.

Throwing paper automatically turns it into a paper plane. Picking up a paper plane turns it back into paper.

:cl:
add: Throwing a stack will throw one item in the stack instead of the whole stack. The rest of that stack of floor tiles will remain in your hand.
/:cl: