### PR TITLE
Using a clockwork proselytizer offstation is significantly less efficient

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
@@ -168,6 +168,12 @@
 			return FALSE
 		proselytize_values["alloy_cost"] = 0
 
+	var/turf/T = get_turf(user)
+	if(!T || (T.z != ZLEVEL_STATION && T.z != ZLEVEL_CENTCOM && T.z != ZLEVEL_MINING && T.z != ZLEVEL_LAVALAND))
+		proselytize_values["operation_time"] *= 2
+		if(proselytize_values["alloy_cost"] > 0)
+			proselytize_values["alloy_cost"] *= 2
+
 	if(!can_use_alloy(proselytize_values["alloy_cost"]))
 		if(stored_alloy - proselytize_values["alloy_cost"] < 0)
 			user << "<span class='warning'>You need <b>[proselytize_values["alloy_cost"]]</b> liquified alloy to proselytize [target]!</span>"
@@ -181,7 +187,6 @@
 		proselytize_values["operation_time"] *= 0.5
 
 	proselytize_values["operation_time"] *= speed_multiplier
-
 
 	playsound(target, 'sound/machines/click.ogg', 50, 1)
 	if(proselytize_values["operation_time"])

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
@@ -168,8 +168,8 @@
 			return FALSE
 		proselytize_values["alloy_cost"] = 0
 
-	var/turf/T = get_turf(user)
-	if(!T || (T.z != ZLEVEL_STATION && T.z != ZLEVEL_CENTCOM && T.z != ZLEVEL_MINING && T.z != ZLEVEL_LAVALAND))
+	var/turf/Y = get_turf(user)
+	if(!Y || (Y.z != ZLEVEL_STATION && Y.z != ZLEVEL_CENTCOM && Y.z != ZLEVEL_MINING && Y.z != ZLEVEL_LAVALAND))
 		proselytize_values["operation_time"] *= 2
 		if(proselytize_values["alloy_cost"] > 0)
 			proselytize_values["alloy_cost"] *= 2

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -130,23 +130,24 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 		switch(primary_component)
 			if(BELLIGERENT_EYE)
 				message = pick(neovgre_penalty)
-				ratvarian_prob = 80
+				ratvarian_prob = 55
 			if(VANGUARD_COGWHEEL)
 				message = pick(inathneq_penalty)
-				ratvarian_prob = 30
+				ratvarian_prob = 25
 			if(GEIS_CAPACITOR)
 				message = pick(sevtug_penalty)
-				ratvarian_prob = 50
+				ratvarian_prob = 40
 			if(REPLICANT_ALLOY)
 				message = pick(nezbere_penalty)
 				ratvarian_prob = 10
 			if(HIEROPHANT_ANSIBLE)
 				message = pick(nzcrentr_penalty)
-				ratvarian_prob = 100
+				ratvarian_prob = 70
 		if(message)
 			if(prob(ratvarian_prob))
 				message = text2ratvar(message)
-			invoker << "<span class='[get_component_span(primary_component)]'>\"[message]\"</span>"
+			invoker << "<span class='[get_component_span(primary_component)]_large'>\"[message]\"</span>"
+			invoker << 'sound/magic/clockwork/invoke_general.ogg'
 	return TRUE
 
 /datum/clockwork_scripture/proc/check_offstation_penalty()


### PR DESCRIPTION
:cl: Joan
experiment: Clockwork proselytizers suffer doubled cost and proselytization time when not on the station, mining, or centcom.
soundadd: Trying to recite scripture offstation is more clearly disapproved of.
/:cl: