### PR TITLE
Reduces tool speed

### DIFF
--- a/code/game/objects/items/nuke_tools.dm
+++ b/code/game/objects/items/nuke_tools.dm
@@ -70,7 +70,7 @@
 	desc = "A screwdriver with an ultra thin tip."
 	icon = 'icons/obj/nuke_tools.dmi'
 	icon_state = "screwdriver_nuke"
-	toolspeed = 0.5
+	toolspeed = 0.6
 
 /obj/item/weapon/paper/nuke_instructions
 	info = "How to break into a Nanotrasen self-destruct terminal and remove its plutonium core:<br>\

--- a/code/game/objects/items/nuke_tools.dm
+++ b/code/game/objects/items/nuke_tools.dm
@@ -70,7 +70,7 @@
 	desc = "A screwdriver with an ultra thin tip."
 	icon = 'icons/obj/nuke_tools.dmi'
 	icon_state = "screwdriver_nuke"
-	toolspeed = 0.6
+	toolspeed = 0.5
 
 /obj/item/weapon/paper/nuke_instructions
 	info = "How to break into a Nanotrasen self-destruct terminal and remove its plutonium core:<br>\

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -39,13 +39,13 @@
 /obj/item/weapon/wrench/cyborg
 	name = "automatic wrench"
 	desc = "An advanced robotic wrench. Can be found in construction cyborgs."
-	toolspeed = 0.75
+	toolspeed = 0.7
 
 /obj/item/weapon/wrench/brass
 	name = "brass wrench"
 	desc = "A brass wrench. It's faintly warm to the touch."
 	icon_state = "wrench_brass"
-	toolspeed = 0.6
+	toolspeed = 0.7
 
 /obj/item/weapon/wrench/power
 	name = "Hand Drill"
@@ -160,7 +160,7 @@
 	name = "brass screwdriver"
 	desc = "A screwdriver made of brass. The handle feels freezing cold."
 	icon_state = "screwdriver_brass"
-	toolspeed = 0.6
+	toolspeed = 0.7
 
 /obj/item/weapon/screwdriver/power
 	name = "Hand Drill"
@@ -194,7 +194,7 @@
 	name = "powered screwdriver"
 	desc = "An electrical screwdriver, designed to be both precise and quick."
 	usesound = 'sound/items/drill_use.ogg'
-	toolspeed = 0.75
+	toolspeed = 0.7
 
 /*
  * Wirecutters
@@ -245,12 +245,12 @@
 	name = "brass wirecutters"
 	desc = "A pair of wirecutters made of brass. The handle feels freezing cold to the touch."
 	icon_state = "cutters_brass"
-	toolspeed = 0.6
+	toolspeed = 0.7
 
 /obj/item/weapon/wirecutters/cyborg
 	name = "wirecutters"
 	desc = "This cuts wires."
-	toolspeed = 0.75
+	toolspeed = 0.7
 
 /obj/item/weapon/wirecutters/power
 	name = "Jaws of Life"
@@ -562,7 +562,7 @@
 /obj/item/weapon/weldingtool/largetank/cyborg
 	name = "integrated welding tool"
 	desc = "An advanced welder designed to be used in robotic systems."
-	toolspeed = 0.75
+	toolspeed = 0.7
 
 /obj/item/weapon/weldingtool/largetank/flamethrower_screwdriver()
 	return
@@ -602,7 +602,7 @@
 	change_icons = 0
 	can_off_process = 1
 	light_intensity = 1
-	toolspeed = 0.75
+	toolspeed = 0.7
 	var/nextrefueltick = 0
 
 /obj/item/weapon/weldingtool/experimental/brass
@@ -653,7 +653,7 @@
 	name = "brass crowbar"
 	desc = "A brass crowbar. It feels faintly warm to the touch."
 	icon_state = "crowbar_brass"
-	toolspeed = 0.6
+	toolspeed = 0.7
 
 /obj/item/weapon/crowbar/large
 	name = "crowbar"
@@ -665,14 +665,14 @@
 	materials = list(MAT_METAL=70)
 	icon_state = "crowbar_large"
 	item_state = "crowbar"
-	toolspeed = 0.75
+	toolspeed = 0.7
 
 /obj/item/weapon/crowbar/cyborg
 	name = "hydraulic crowbar"
 	desc = "A hydraulic prying tool, compact but powerful. Designed to replace crowbar in construction cyborgs."
 	usesound = 'sound/items/jaws_pry.ogg'
 	force = 10
-	toolspeed = 0.75
+	toolspeed = 0.7
 
 /obj/item/weapon/crowbar/power
 	name = "Jaws of Life"

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -39,13 +39,13 @@
 /obj/item/weapon/wrench/cyborg
 	name = "automatic wrench"
 	desc = "An advanced robotic wrench. Can be found in construction cyborgs."
-	toolspeed = 0.5
+	toolspeed = 0.75
 
 /obj/item/weapon/wrench/brass
 	name = "brass wrench"
 	desc = "A brass wrench. It's faintly warm to the touch."
 	icon_state = "wrench_brass"
-	toolspeed = 0.5
+	toolspeed = 0.6
 
 /obj/item/weapon/wrench/power
 	name = "Hand Drill"
@@ -58,7 +58,7 @@
 	force = 8 //might or might not be too high, subject to change
 	throwforce = 8
 	attack_verb = list("drilled", "screwed", "jabbed")
-	toolspeed = 0.25
+	toolspeed = 0.4
 
 /obj/item/weapon/wrench/power/attack_self(mob/user)
 	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
@@ -160,7 +160,7 @@
 	name = "brass screwdriver"
 	desc = "A screwdriver made of brass. The handle feels freezing cold."
 	icon_state = "screwdriver_brass"
-	toolspeed = 0.5
+	toolspeed = 0.6
 
 /obj/item/weapon/screwdriver/power
 	name = "Hand Drill"
@@ -176,7 +176,7 @@
 	attack_verb = list("drilled", "screwed", "jabbed","whacked")
 	hitsound = 'sound/items/drill_hit.ogg'
 	usesound = 'sound/items/drill_use.ogg'
-	toolspeed = 0.25
+	toolspeed = 0.4
 
 /obj/item/weapon/screwdriver/power/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is putting [src] to [user.p_their()] temple. It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -194,7 +194,7 @@
 	name = "powered screwdriver"
 	desc = "An electrical screwdriver, designed to be both precise and quick."
 	usesound = 'sound/items/drill_use.ogg'
-	toolspeed = 0.5
+	toolspeed = 0.75
 
 /*
  * Wirecutters
@@ -245,12 +245,12 @@
 	name = "brass wirecutters"
 	desc = "A pair of wirecutters made of brass. The handle feels freezing cold to the touch."
 	icon_state = "cutters_brass"
-	toolspeed = 0.5
+	toolspeed = 0.6
 
 /obj/item/weapon/wirecutters/cyborg
 	name = "wirecutters"
 	desc = "This cuts wires."
-	toolspeed = 0.5
+	toolspeed = 0.75
 
 /obj/item/weapon/wirecutters/power
 	name = "Jaws of Life"
@@ -260,7 +260,7 @@
 	origin_tech = "materials=2;engineering=2"
 	materials = list(MAT_METAL=150,MAT_SILVER=50,MAT_TITANIUM=25)
 	usesound = 'sound/items/jaws_cut.ogg'
-	toolspeed = 0.25
+	toolspeed = 0.4
 
 /obj/item/weapon/wirecutters/power/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!</span>")
@@ -562,7 +562,7 @@
 /obj/item/weapon/weldingtool/largetank/cyborg
 	name = "integrated welding tool"
 	desc = "An advanced welder designed to be used in robotic systems."
-	toolspeed = 0.5
+	toolspeed = 0.75
 
 /obj/item/weapon/weldingtool/largetank/flamethrower_screwdriver()
 	return
@@ -602,7 +602,7 @@
 	change_icons = 0
 	can_off_process = 1
 	light_intensity = 1
-	toolspeed = 0.5
+	toolspeed = 0.75
 	var/nextrefueltick = 0
 
 /obj/item/weapon/weldingtool/experimental/brass
@@ -653,7 +653,7 @@
 	name = "brass crowbar"
 	desc = "A brass crowbar. It feels faintly warm to the touch."
 	icon_state = "crowbar_brass"
-	toolspeed = 0.5
+	toolspeed = 0.6
 
 /obj/item/weapon/crowbar/large
 	name = "crowbar"
@@ -665,14 +665,14 @@
 	materials = list(MAT_METAL=70)
 	icon_state = "crowbar_large"
 	item_state = "crowbar"
-	toolspeed = 0.5
+	toolspeed = 0.75
 
 /obj/item/weapon/crowbar/cyborg
 	name = "hydraulic crowbar"
 	desc = "A hydraulic prying tool, compact but powerful. Designed to replace crowbar in construction cyborgs."
 	usesound = 'sound/items/jaws_pry.ogg'
 	force = 10
-	toolspeed = 0.5
+	toolspeed = 0.75
 
 /obj/item/weapon/crowbar/power
 	name = "Jaws of Life"
@@ -683,7 +683,7 @@
 	origin_tech = "materials=2;engineering=2"
 	usesound = 'sound/items/jaws_pry.ogg'
 	force = 15
-	toolspeed = 0.25
+	toolspeed = 0.4
 
 /obj/item/weapon/crowbar/power/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!</span>")


### PR DESCRIPTION
:cl: Joan
tweak: Faster-than-normal tools are somewhat slower than before.
/:cl:

Specifically;
Standard tools; 1 ➡️ 1
Cyborg tools, large crowbar, experimental welder, brass tools; 0.5 ➡️ 0.7
Nuke screwdriver; 0.5 ➡️ 0.5
CE's fancy double tools; 0.25 ➡️ 0.4

Level "one" tools literally halving speed is silly as heck.
Construction times might be too long right now, but super fast tools is probably not the solution.