### PR TITLE
Allows traitors/operatives to buy cheapo fake nuke disks

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -754,7 +754,14 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/storage/box/syndie_kit/cutouts
 	cost = 1
 	surplus = 20
-
+	
+/datum/uplink_item/stealthy_tools/fakenucleardisk
+	name = "Decoy Nuclear Authentication Disk"
+	desc = "It's just a normal disk. Visually it's identical to the real deal, but it won't hold up under closer scrutiny. Don't try to give this to us to complete your objective, we know better!"
+	item = /obj/item/weapon/disk/fakenucleardisk
+	cost = 1
+	surplus = 10
+	
 //Space Suits and Hardsuits
 /datum/uplink_item/suits
 	category = "Space Suits and Hardsuits"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -760,7 +760,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "It's just a normal disk. Visually it's identical to the real deal, but it won't hold up under closer scrutiny. Don't try to give this to us to complete your objective, we know better!"
 	item = /obj/item/weapon/disk/fakenucleardisk
 	cost = 1
-	surplus = 10
+	surplus = 1
 	
 //Space Suits and Hardsuits
 /datum/uplink_item/suits


### PR DESCRIPTION
Adds the existing cheap plastic imitation of the nuclear authentication disk item to the uplink so antags can attempt to switcharoo the real deal under inattentive eyes.

The fake disk doesn't have any special features for a disk, it just LOOKS like the nuke disk. Its name and desc are different so really unless the person looking at the disk is really not paying attention it's likely they'll figure out what's happened.

:cl:
add: Recently we've been receiving reports of cheap knock off nuclear authentication disks circulating among the syndicate network. Don't be fooled by these decoys, only the real deal can be used to destroy the station!
experiment: Please don't destroy the station in an attempt to make sure the disk is real.
/:cl: