### PR TITLE
Adds cycler shotguns to nuke ops

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -158,6 +158,14 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 8
 	surplus = 40
 	include_modes = list(/datum/game_mode/nuclear)
+	
+/datum/uplink_item/dangerous/cycler_shotgun
+       name = "Cycler Shotgun"
+       desc = "An advanced shotgun with two separate magazine tubes, allowing you to quickly toggle between ammo types."
+       item = /obj/item/weapon/gun/ballistic/shotgun/automatic/dual_tube
+       cost = 16
+       Surplus = 0
+       include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/smg
 	name = "C-20r Submachine Gun"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -164,7 +164,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
        desc = "An advanced shotgun with two separate magazine tubes, allowing you to quickly toggle between ammo types."
        item = /obj/item/weapon/gun/ballistic/shotgun/automatic/dual_tube
        cost = 16
-       Surplus = 0
+       surplus = 0
        include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/smg


### PR DESCRIPTION
Adds cycler shotguns for nuke ops for 16 tc cycler shotguns have two tubes which you can carry different ammo types which you can switch between how tactical

:cl: Jughu
add:Nanotrasen officials have reported that rival corporation Blast Co. have developed and mass produced an advanced cycling shotgun capable of swapping between two ammunition types at will. Station crew are advised to be on the lookout for well-armed terrorist teams.
/:cl:

