### PR TITLE
Adds multiple upgrades for Medical cyborgs

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -199,6 +199,9 @@
 	if(!R.module)
 		return
 
+	if(!R.client)
+		return
+
 	if(R.shown_robot_modules && screenmob.hud_used.hud_shown)
 		//Modules display is shown
 		screenmob.client.screen += module_store_icon	//"store" icon

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -340,7 +340,7 @@
 		log_game("[user.ckey]([user]) used an emagged Cyborg Harm Alarm in ([user.x],[user.y],[user.z])")
 
 /obj/item/borg/lollipop
-	name = "Lollipop Fabricator"
+	name = "lollipop fabricator"
 	desc = "Reward good humans with this. Toggle in-module to switch between dispensing and high velocity ejection modes."
 	icon_state = "lollipop"
 	var/candy = 30

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -367,7 +367,7 @@
 	if(..())
 		return
 
-	var/obj/item/weapon/twohanded/shockpaddles/S = new(R.module)
+	var/obj/item/weapon/twohanded/shockpaddles/cyborg/S = new(R.module)
 	R.module.basic_modules += S
 	R.module.add_module(S, FALSE, TRUE)
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -296,3 +296,79 @@
 			msg_cooldown = world.time
 	else
 		deactivate()
+
+/obj/item/borg/upgrade/hypospray
+	name = "medical cyborg hypospray advanced synthesiser"
+	desc = "An upgrade to the Medical module cyborg's hypospray, allowing it \
+		to produce more advanced and complex medical reagents."
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	module_type = /obj/item/weapon/robot_module/medical
+	origin_tech = null
+	var/list/additional_reagents = list()
+
+/obj/item/borg/upgrade/hypospray/action(mob/living/silicon/robot/R)
+	if(..())
+		return
+	for(var/obj/item/weapon/reagent_containers/borghypo/H in R.module)
+		if(H.accepts_reagent_upgrades)
+			for(var/re in additional_reagents)
+				H.add_reagent(re)
+
+	return 1
+
+/obj/item/borg/upgrade/hypospray/expanded
+	name = "medical cyborg expanded hypospray"
+	desc = "An upgrade to the Medical module's hypospray, allowing it \
+		to treat a wider range of conditions and problems."
+	additional_reagents = list("mannitol", "oculine", "inacusiate",
+		"mutadone", "haloperidol")
+	origin_tech = "programming=5;engineering=4;biotech=5"
+
+/obj/item/borg/upgrade/hypospray/high_strength
+	name = "medical cyborg high-strength hypospray"
+	desc = "An upgrade to the Medical module's hypospray, containing \
+		stronger versions of existing chemicals."
+	additional_reagents = list("oxandrolone", "sal_acid", "rezadone",
+		"pen_acid")
+	origin_tech = "programming=5;engineering=5;biotech=6"
+
+/obj/item/borg/upgrade/piercing_hypospray
+	name = "cyborg piercing hypospray"
+	desc = "An upgrade to a cyborg's hypospray, allowing it to \
+		pierce armor and thick material."
+	origin_tech = "materials=5;engineering=7;combat=3"
+	icon_state = "cyborg_upgrade3"
+
+/obj/item/borg/upgrade/piercing_hypospray/action(mob/living/silicon/robot/R)
+	if(..())
+		return
+
+	var/found_hypo = FALSE
+	for(var/obj/item/weapon/reagent_containers/borghypo/H in R.module)
+		H.bypass_protection = TRUE
+		found_hypo = TRUE
+
+	if(!found_hypo)
+		return
+
+	return 1
+
+/obj/item/borg/upgrade/defib
+	name = "medical cyborg defibrillator"
+	desc = "An upgrade to the Medical module, installing a builtin \
+		defibrillator, for on the scene revival."
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	module_type = /obj/item/weapon/robot_module/medical
+	origin_tech = "programming=4;engineering=6;materials=5;powerstorage=5;biotech=5"
+
+/obj/item/borg/upgrade/defib/action(mob/living/silicon/robot/R)
+	if(..())
+		return
+
+	var/obj/item/weapon/twohanded/shockpaddles/S = new(R.module)
+	R.module.basic_modules += S
+	R.module.add_module(S, FALSE, TRUE)
+
+	return 1

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -306,7 +306,6 @@
 		loc = defib
 		busy = 0
 		update_icon()
-	return
 
 /obj/item/weapon/twohanded/shockpaddles/update_icon()
 	icon_state = "defibpaddles[wielded]"
@@ -557,11 +556,30 @@
 	busy = 0
 	update_icon()
 
-/obj/item/weapon/twohanded/shockpaddles/syndicate
-	name = "syndicate defibrillator paddles"
-	desc = "A pair of paddles used to revive deceased operatives. It possesses both the ability to penetrate armor and to deliver powerful shocks offensively."
-	combat = 1
+/obj/item/weapon/twohanded/shockpaddles/cyborg
+	name = "cyborg defibrillator paddles"
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "defibpaddles0"
 	item_state = "defibpaddles0"
-	req_defib = 0
+	req_defib = FALSE
+
+/obj/item/weapon/twohanded/shockpaddles/cyborg/attack(mob/M, mob/user)
+	if(iscyborg(user))
+		var/mob/living/silicon/robot/R = user
+		if(R.emagged)
+			combat = TRUE
+		else
+			combat = FALSE
+	else
+		combat = FALSE
+
+	. = ..()
+
+/obj/item/weapon/twohanded/shockpaddles/syndicate
+	name = "syndicate defibrillator paddles"
+	desc = "A pair of paddles used to revive deceased operatives. It possesses both the ability to penetrate armor and to deliver powerful shocks offensively."
+	combat = TRUE
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "defibpaddles0"
+	item_state = "defibpaddles0"
+	req_defib = FALSE

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -25,6 +25,7 @@ Borg Hypospray
 
 	var/list/datum/reagents/reagent_list = list()
 	var/list/reagent_ids = list("dexalin", "kelotane", "bicaridine", "antitoxin", "epinephrine", "spaceacillin")
+	var/accepts_reagent_upgrades = TRUE //If upgrades can increase number of reagents dispensed.
 	var/list/modes = list() //Basically the inverse of reagent_ids. Instead of having numbers as "keys" and strings as values it has strings as keys and numbers as values.
 								//Used as list for input() in shakers.
 
@@ -32,11 +33,8 @@ Borg Hypospray
 /obj/item/weapon/reagent_containers/borghypo/New()
 	..()
 
-	var/iteration = 1
 	for(var/R in reagent_ids)
 		add_reagent(R)
-		modes[R] = iteration
-		iteration++
 
 	START_PROCESSING(SSobj, src)
 
@@ -72,6 +70,8 @@ Borg Hypospray
 
 	var/datum/reagents/R = reagent_list[reagent_list.len]
 	R.add_reagent(reagent, 30)
+
+	modes[reagent] = modes.len + 1
 
 /obj/item/weapon/reagent_containers/borghypo/proc/regenerate_reagents()
 	if(iscyborg(src.loc))
@@ -134,6 +134,7 @@ Borg Hypospray
 /obj/item/weapon/reagent_containers/borghypo/hacked
 	icon_state = "borghypo_s"
 	reagent_ids = list ("facid", "mutetoxin", "cyanide", "sodium_thiopental", "heparin", "lexorin")
+	accepts_reagent_upgrades = FALSE
 
 /obj/item/weapon/reagent_containers/borghypo/syndicate
 	name = "syndicate cyborg hypospray"
@@ -143,6 +144,7 @@ Borg Hypospray
 	recharge_time = 2
 	reagent_ids = list("syndicate_nanites", "potass_iodide", "morphine")
 	bypass_protection = 1
+	accepts_reagent_upgrades = FALSE
 
 /*
 Borg Shaker
@@ -155,6 +157,7 @@ Borg Shaker
 	possible_transfer_amounts = list(5,10,20)
 	charge_cost = 20 //Lots of reagents all regenerating at once, so the charge cost is lower. They also regenerate faster.
 	recharge_time = 3
+	accepts_reagent_upgrades = FALSE
 
 	reagent_ids = list("beer", "orangejuice", "limejuice", "tomatojuice", "cola", "tonic", "sodawater", "ice", "cream", "whiskey", "vodka", "rum", "gin", "tequila", "vermouth", "wine", "kahlua", "cognac", "ale")
 
@@ -209,6 +212,7 @@ Borg Shaker
 	possible_transfer_amounts = list(5,10,20)
 	charge_cost = 20 //Lots of reagents all regenerating at once, so the charge cost is lower. They also regenerate faster.
 	recharge_time = 3
+	accepts_reagent_upgrades = FALSE
 
 	reagent_ids = list("beer2")
 
@@ -216,13 +220,16 @@ Borg Shaker
 	name = "Peace Hypospray"
 
 	reagent_ids = list("dizzysolution","tiresolution")
+	accepts_reagent_upgrades = FALSE
 
 /obj/item/weapon/reagent_containers/borghypo/peace/hacked
 	desc = "Everything's peaceful in death!"
 	icon_state = "borghypo_s"
 	reagent_ids = list("dizzysolution","tiresolution","tirizene","sulfonal","sodium_thiopental","cyanide","neurotoxin2")
+	accepts_reagent_upgrades = FALSE
 
 /obj/item/weapon/reagent_containers/borghypo/epi
 	name = "epinephrine injector"
 	desc = "An advanced chemical synthesizer and injection system, designed to stabilize patients.."
 	reagent_ids = list("epinephrine")
+	accepts_reagent_upgrades = FALSE

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -675,7 +675,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/hypospray/expanded
 	req_tech = list("programming" = 5, "engineering" = 4, "biotech" = 5)
-	materials = list(MAT_METAL=15000, MAT_GLASS=15000)
+	materials = list(MAT_METAL=15000, MAT_GLASS=15000, MAT_PLASMA=5000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
@@ -685,7 +685,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/hypospray/high_strength
 	req_tech = list("programming" = 5, "engineering" = 5, "biotech" = 6)
-	materials = list(MAT_METAL=15000, MAT_GLASS=15000)
+	materials = list(MAT_METAL=15000, MAT_GLASS=15000, MAT_PLASMA=10000, MAT_URANIUM=5000
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
@@ -695,7 +695,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/piercing_hypospray
 	req_tech = list("materials" = 5, "engineering" = 7, "combat" = 3)
-	materials = list(MAT_METAL=15000, MAT_GLASS=15000)
+	materials = list(MAT_METAL=15000, MAT_GLASS=15000, MAT_TITANIUM=10000, MAT_DIAMOND=5000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
@@ -704,8 +704,8 @@
 	id = "borg_upgrade_defibrillator"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/defib
-	req_tech = list("programming" = 4, "engineering" = 6, "materials" = 5, "powerstorage" = 5, "biotech" = 5)
-	materials = list(MAT_METAL=15000, MAT_GLASS=15000)
+	req_tech = list("programming" = 4, "engineering" = 5, "materials" = 5, "powerstorage" = 5, "biotech" = 5)
+	materials = list(MAT_METAL=15000, MAT_GLASS=15000, MAT_SILVER=10000, MAT_GOLD=10000, MAT_TITANIUM=5000, MAT_DIAMOND=5000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -669,6 +669,46 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_expandedsynthesiser
+	name = "Cyborg Upgrade (Hypospray Expanded Synthesiser)"
+	id = "borg_upgrade_expandedsynthesiser"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/hypospray/expanded
+	req_tech = list("programming" = 5, "engineering" = 4, "biotech" = 5)
+	materials = list(MAT_METAL=15000, MAT_GLASS=15000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_highstrengthsynthesiser
+	name = "Cyborg Upgrade (Hypospray High-Strength Synthesiser)"
+	id = "borg_upgrade_highstrengthsynthesiser"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/hypospray/high_strength
+	req_tech = list("programming" = 5, "engineering" = 5, "biotech" = 6)
+	materials = list(MAT_METAL=15000, MAT_GLASS=15000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_piercinghypospray
+	name = "Cyborg Upgrade (Piercing Hypospray)"
+	id = "borg_upgrade_piercinghypospray"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/piercing_hypospray
+	req_tech = list("materials" = 5, "engineering" = 7, "combat" = 3)
+	materials = list(MAT_METAL=15000, MAT_GLASS=15000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_defibrillator
+	name = "Cyborg Upgrade (Defibrillator)"
+	id = "borg_upgrade_defibrillator"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/defib
+	req_tech = list("programming" = 4, "engineering" = 6, "materials" = 5, "powerstorage" = 5, "biotech" = 5)
+	materials = list(MAT_METAL=15000, MAT_GLASS=15000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
 //Misc
 /datum/design/mecha_tracking
 	name = "Exosuit Tracking Beacon"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -685,7 +685,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/hypospray/high_strength
 	req_tech = list("programming" = 5, "engineering" = 5, "biotech" = 6)
-	materials = list(MAT_METAL=15000, MAT_GLASS=15000, MAT_PLASMA=10000, MAT_URANIUM=5000
+	materials = list(MAT_METAL=15000, MAT_GLASS=15000, MAT_PLASMA=10000, MAT_URANIUM=5000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 


### PR DESCRIPTION
:cl: coiax
add: Adds upgrades for the medical cyborg!
add: The Hypospray Expanded Synthesiser that adds chemicals to treat
blindness, deafness, brain damage, genetic corruption and drug abuse.
add: The Hypospray High-Strength Synthesiser, containing stronger
versions of drugs to treat brute, burn, oxyloss and toxic damage.
add: The Piercing Hypospray (also applicable to the Standard and
Peacekeeper borgs) that allows a hypospray to pierce thick clothing and
hardsuits.
add: The Defibrillator, giving the medical cyborg an onboard
defibrillator.
/:cl:

- [x] Price the material cost of the boards appropriately
- [x] Get the defib upgrade working