### PR TITLE
Fixes ED-209 Crafting Recipe Cost

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -108,12 +108,11 @@
 				/obj/item/clothing/suit/armor/vest = 1,
 				/obj/item/bodypart/l_leg/robot = 1,
 				/obj/item/bodypart/r_leg/robot = 1,
-				/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/cable_coil = 5,
+				/obj/item/stack/sheet/metal = 1,
+				/obj/item/stack/cable_coil = 1,
 				/obj/item/weapon/gun/energy/e_gun/advtaser = 1,
 				/obj/item/weapon/stock_parts/cell = 1,
-				/obj/item/device/assembly/prox_sensor = 1,
-				/obj/item/bodypart/r_arm/robot = 1)
+				/obj/item/device/assembly/prox_sensor = 1)
 	tools = list(/obj/item/weapon/weldingtool, /obj/item/weapon/screwdriver)
 	time = 60
 	category = CAT_ROBOT


### PR DESCRIPTION
Fixes and oversight with the cost of ED-209's.

Construction only requires 1 metal, as demonstrated here: https://github.com/tgstation/tgstation/blob/ce13143d9d9d2d3690ab2f05e01d33c72ee7f51b/code/game/objects/items/robot/robot_parts.dm#L57

Not 5

Construction also only requires 1 cable coil, as demonstrated here: https://github.com/tgstation/tgstation/blob/master/code/modules/mob/living/simple_animal/bot/construction.dm#L144

not 5

ED-209 Construction has also never required a robotic arm

:cl: Fox McCloud
fix: Fixes the personal crafting cost of ED-209's being too expensive
/:cl: