### PR TITLE
Internally track shifts since containment failure

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -9,10 +9,17 @@ var/datum/subsystem/persistence/SSpersistence
 	var/list/new_secret_satchels 	= list() //these are objects
 	var/old_secret_satchels 		= ""
 
+	var/savefile/containment_failure_save
+	var/containment_failure_counter
+
 /datum/subsystem/persistence/New()
 	NEW_SS_GLOBAL(SSpersistence)
 
 /datum/subsystem/persistence/Initialize()
+	initialize_secret_satchels()
+	initialize_shifts_since_containment_failure()
+
+/datum/subsystem/persistence/proc/initialize_secret_satchels()
 	secret_satchels = new /savefile("data/npc_saves/SecretSatchels.sav")
 	satchel_blacklist = typecacheof(list(/obj/item/stack/tile/plasteel, /obj/item/weapon/crowbar))
 	secret_satchels[MAP_NAME] >> old_secret_satchels
@@ -36,8 +43,24 @@ var/datum/subsystem/persistence/SSpersistence
 
 	..()
 
+/datum/subsystem/persistence/proc/initialize_shifts_since_containment_failure()
+	containment_failure_save = new("data/npc_saves/ContainmentFailure.sav")
+	containment_failure_save["counter"] >> containment_failure_counter
+
+/datum/subsystem/persistence/proc/notify_containment_failure()
+	containment_failure_counter = -1
+
 /datum/subsystem/persistence/proc/CollectData()
 	CollectSecretSatchels()
+	CollectContainmentFailure()
+
+/datum/subsystem/persistence/proc/CollectContainmentFailure()
+	if(containment_failure_counter < 0)
+		containment_failure_counter = 0
+	else
+		containment_failure_counter++
+
+	containment_failure_save["counter"] << containment_failure_counter
 
 /datum/subsystem/persistence/proc/PlaceSecretSatchel(list/expanded_old_satchels)
 	var/satchel_string

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -329,6 +329,7 @@ field_generator power level display
 	spawn(1)
 		var/temp = 1 //stops spam
 		for(var/obj/singularity/O in world)
+			SSpersistence.notify_containment_failure()
 			if(O.last_warning && temp)
 				if((world.time - O.last_warning) > 50) //to stop message-spam
 					temp = 0

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -119,9 +119,6 @@
 	dissipate()
 	check_energy()
 
-	return
-
-
 /obj/singularity/attack_ai() //to prevent ais from gibbing themselves when they click on one.
 	return
 
@@ -131,6 +128,7 @@
 	var/count = locate(/obj/machinery/field/containment) in urange(30, src, 1)
 	if(!count)
 		message_admins("A singulo has been created without containment fields active ([x],[y],[z])",1)
+		SSpersistence.notify_containment_failure()
 	investigate_log("was created. [count?"":"<font color='red'>No containment fields were active</font>"]","singulo")
 
 /obj/singularity/proc/dissipate()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -83,6 +83,7 @@
 	. = ..()
 
 /obj/machinery/power/supermatter_shard/proc/explode()
+	SSpersistence.notify_containment_failure()
 	investigate_log("has exploded.", "supermatter")
 	explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1, 1)
 	qdel(src)


### PR DESCRIPTION
Since I don't want to add a full item without sprites, here is the code
work to tally the number of shifts since an engine was created loose, or
containment failed while an engine was active. (Note that the detection
isn't exact, so I've just piggybacked on the admin messages.)

Then later, we can actually have a X SHIFTS SINCE CONTAINMENT FAILURE
sign, and use this number.