### PR TITLE
Adds imprinter design for limb grower board

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -402,3 +402,11 @@
 	req_tech = list("programming" = 2, "engineering" = 2, "bluespace" = 2)
 	build_path = /obj/item/weapon/circuitboard/machine/ntnet_relay
 	category = list("Subspace Telecomms")
+
+/datum/design/board/limbgrower
+	name = "Machine Design (Limb Grower Board)"
+	desc = "The circuit board for a limb grower."
+	id = "limbgrower"
+	req_tech = list("programming" = 3, "biotech" = 2)
+	build_path = /obj/item/weapon/circuitboard/machine/limbgrower
+	category = list("Medical Machinery")


### PR DESCRIPTION
:cl: Erwgd
add: Limb Grower circuit boards can now be made in Research and Development, requiring level 3 in data theory and level 2 in biological technology.
/:cl:

