### PR TITLE
Makes the checks used by bibles better

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -61,7 +61,8 @@
 	var/datum/devilinfo/devilinfo //Information about the devil, if any.
 	var/damnation_type = 0
 	var/datum/mind/soulOwner //who owns the soul.  Under normal circumstances, this will point to src
-
+	var/isholy == 0 //is this person a chaplen or specail role allowed to use bibles
+	
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
 
 /datum/mind/New(var/key)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -61,7 +61,7 @@
 	var/datum/devilinfo/devilinfo //Information about the devil, if any.
 	var/damnation_type = 0
 	var/datum/mind/soulOwner //who owns the soul.  Under normal circumstances, this will point to src
-	var/isholy == 0 //is this person a chaplen or specail role allowed to use bibles
+	var/isholy = FALSE //is this person a chaplen or specail role allowed to use bibles
 	
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -61,7 +61,7 @@
 	var/datum/devilinfo/devilinfo //Information about the devil, if any.
 	var/damnation_type = 0
 	var/datum/mind/soulOwner //who owns the soul.  Under normal circumstances, this will point to src
-	var/isholy = FALSE //is this person a chaplen or specail role allowed to use bibles
+	var/isholy = FALSE //is this person a chaplain or admin role allowed to use bibles
 	
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
 

--- a/code/game/gamemodes/clock_cult/clock_items/clock_components.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clock_components.dm
@@ -14,7 +14,7 @@
 	if(iscultist(user) || (user.mind && user.mind.isholy))
 		user << "<span class='[message_span]'>[cultist_message]</span>"
 		if(user.mind && user.mind.isholy)
-			user << "<span class='boldannounce'>[SSreligion.Bible_deity_name]'s voice thunders: BEGONE FALSE THING!</span>"
+			user << "<span class='boldannounce'>The power of your faith melts away the [src]!</span>"
 			var/obj/item/weapon/ore/slag/wrath = new /obj/item/weapon/ore/slag
 			user.unEquip(src)
 			user.put_in_active_hand(wrath)

--- a/code/game/gamemodes/clock_cult/clock_items/clock_components.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clock_components.dm
@@ -15,8 +15,7 @@
 		user << "<span class='[message_span]'>[cultist_message]</span>"
 		if(user.mind && user.mind.isholy)
 			user << "<span class='boldannounce'>[SSreligion.Bible_deity_name]'s voice thunders: BEGONE FALSE THING!</span>"
-			var//obj/item/weapon/ore/slag/wrath = new /obj/item/weapon/ore/slag
-			visible_message("<span class='danger'>The [src] dissolves into an unrecognisable mass!</span>")
+			var/obj/item/weapon/ore/slag/wrath = new /obj/item/weapon/ore/slag
 			user.unEquip(src)
 			user.put_in_active_hand(wrath)
 			qdel(src)

--- a/code/game/gamemodes/clock_cult/clock_items/clock_components.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clock_components.dm
@@ -11,8 +11,15 @@
 
 /obj/item/clockwork/component/pickup(mob/living/user)
 	..()
-	if(iscultist(user) || (user.mind && user.mind.assigned_role == "Chaplain"))
+	if(iscultist(user) || (user.mind && user.mind.isholy == 1))
 		user << "<span class='[message_span]'>[cultist_message]</span>"
+		if(user.mind && user.mind.isholy == 1)
+			user << "<span class='boldannounce'>[SSreligion.Bible_deity_name]'s voice thunders: BEGONE FALSE THING!</span>"
+			var//obj/item/weapon/ore/slag/wrath = new /obj/item/weapon/ore/slag
+			visible_message("<span class='danger'>The [src] desolves into an unrecognisable mass!</span>")
+			user.unEquip(src)
+			user.put_in_active_hand(wrath)
+			qdel(src)
 	if(is_servant_of_ratvar(user) && prob(20))
 		var/pickedmessage = pick(servant_of_ratvar_messages)
 		user << "<span class='[message_span]'>[servant_of_ratvar_messages[pickedmessage] ? "[text2ratvar(pickedmessage)]" : pickedmessage]</span>"

--- a/code/game/gamemodes/clock_cult/clock_items/clock_components.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clock_components.dm
@@ -11,9 +11,9 @@
 
 /obj/item/clockwork/component/pickup(mob/living/user)
 	..()
-	if(iscultist(user) || (user.mind && user.mind.isholy == 1))
+	if(iscultist(user) || (user.mind && user.mind.isholy))
 		user << "<span class='[message_span]'>[cultist_message]</span>"
-		if(user.mind && user.mind.isholy == 1)
+		if(user.mind && user.mind.isholy)
 			user << "<span class='boldannounce'>[SSreligion.Bible_deity_name]'s voice thunders: BEGONE FALSE THING!</span>"
 			var//obj/item/weapon/ore/slag/wrath = new /obj/item/weapon/ore/slag
 			visible_message("<span class='danger'>The [src] dissolves into an unrecognisable mass!</span>")

--- a/code/game/gamemodes/clock_cult/clock_items/clock_components.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clock_components.dm
@@ -16,7 +16,7 @@
 		if(user.mind && user.mind.isholy == 1)
 			user << "<span class='boldannounce'>[SSreligion.Bible_deity_name]'s voice thunders: BEGONE FALSE THING!</span>"
 			var//obj/item/weapon/ore/slag/wrath = new /obj/item/weapon/ore/slag
-			visible_message("<span class='danger'>The [src] desolves into an unrecognisable mass!</span>")
+			visible_message("<span class='danger'>The [src] dissolves into an unrecognisable mass!</span>")
 			user.unEquip(src)
 			user.put_in_active_hand(wrath)
 			qdel(src)

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -17,7 +17,7 @@
 /obj/item/weapon/nullrod/attack_self(mob/user)
 	if(reskinned)
 		return
-	if(user.mind && (user.mind.assigned_role == "Chaplain"))
+	if(user.mind && (user.mind.isholy == 1))
 		reskin_holy_weapon(user)
 
 /obj/item/weapon/nullrod/proc/reskin_holy_weapon(mob/M)
@@ -322,12 +322,10 @@
 
 /obj/item/weapon/nullrod/carp/attack_self(mob/living/user)
 	if(used_blessing)
-		return
-	if(user.mind && (user.mind.assigned_role != "Chaplain"))
-		return
-	user << "You are blessed by Carp-Sie. Wild space carp will no longer attack you."
-	user.faction |= "carp"
-	used_blessing = TRUE
+	else if(user.mind && (user.mind.isholy == 1))
+		user << "You are blessed by Carp-Sie. Wild space carp will no longer attack you."
+		user.faction |= "carp"
+		used_blessing = TRUE
 
 /obj/item/weapon/nullrod/claymore/bostaff //May as well make it a "claymore" and inherit the blocking
 	name = "monk's staff"

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -17,7 +17,7 @@
 /obj/item/weapon/nullrod/attack_self(mob/user)
 	if(reskinned)
 		return
-	if(user.mind && (user.mind.isholy == 1))
+	if(user.mind && (user.mind.isholy))
 		reskin_holy_weapon(user)
 
 /obj/item/weapon/nullrod/proc/reskin_holy_weapon(mob/M)
@@ -322,7 +322,7 @@
 
 /obj/item/weapon/nullrod/carp/attack_self(mob/living/user)
 	if(used_blessing)
-	else if(user.mind && (user.mind.isholy == 1))
+	else if(user.mind && (user.mind.isholy))
 		user << "You are blessed by Carp-Sie. Wild space carp will no longer attack you."
 		user.faction |= "carp"
 		used_blessing = TRUE

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -139,7 +139,7 @@ var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "
 /obj/item/weapon/storage/book/bible/attack(mob/living/M, mob/living/carbon/human/user)
 
 	var/chaplain = 0
-	if(user.mind && (user.mind.assigned_role == "Chaplain"))
+	if(user.mind && (user.mind.isholy == 1))
 		chaplain = 1
 
 
@@ -189,10 +189,10 @@ var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "
 		return
 	if(isfloorturf(A))
 		user << "<span class='notice'>You hit the floor with the bible.</span>"
-		if(user.mind && (user.mind.assigned_role == "Chaplain"))
+		if(user.mind && (user.mind.isholy == 1))
 			for(var/obj/effect/rune/R in orange(2,user))
 				R.invisibility = 0
-	if(user.mind && (user.mind.assigned_role == "Chaplain"))
+	if(user.mind && (user.mind.isholy == 1))
 		if(A.reagents && A.reagents.has_reagent("water")) //blesses all the water in the holder
 			user << "<span class='notice'>You bless [A].</span>"
 			var/water2holy = A.reagents.get_reagent_amount("water")

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -139,7 +139,7 @@ var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "
 /obj/item/weapon/storage/book/bible/attack(mob/living/M, mob/living/carbon/human/user)
 
 	var/chaplain = 0
-	if(user.mind && (user.mind.isholy == 1))
+	if(user.mind && (user.mind.isholy))
 		chaplain = 1
 
 
@@ -189,10 +189,10 @@ var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "
 		return
 	if(isfloorturf(A))
 		user << "<span class='notice'>You hit the floor with the bible.</span>"
-		if(user.mind && (user.mind.isholy == 1))
+		if(user.mind && (user.mind.isholy))
 			for(var/obj/effect/rune/R in orange(2,user))
 				R.invisibility = 0
-	if(user.mind && (user.mind.isholy == 1))
+	if(user.mind && (user.mind.isholy))
 		if(A.reagents && A.reagents.has_reagent("water")) //blesses all the water in the holder
 			user << "<span class='notice'>You bless [A].</span>"
 			var/water2holy = A.reagents.get_reagent_amount("water")

--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -33,7 +33,8 @@ Chaplain
 
 	if(visualsOnly)
 		return
-
+	
+	H.mind.isholy = 1
 
 	var/obj/item/weapon/storage/book/bible/B = new /obj/item/weapon/storage/book/bible/booze(H)
 

--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -34,7 +34,7 @@ Chaplain
 	if(visualsOnly)
 		return
 	
-	H.mind.isholy = 1
+	H.mind.isholy = TRUE
 
 	var/obj/item/weapon/storage/book/bible/B = new /obj/item/weapon/storage/book/bible/booze(H)
 


### PR DESCRIPTION
:cl:
add: Clockwork components the chaplain picks up are now destroyed.
/:cl:

This is to allow for a holy ERT later (deusvult).  It also makes it possible make someone holy mid-round for admin gimmicks without making them a chaplain.