### PR TITLE
Smartfridge improvements

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -3274,7 +3274,7 @@
 /turf/closed/wall,
 /area/ruin/hotel/power)
 "if" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/food,
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/hotel/bar)
 "ig" = (

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -29,6 +29,12 @@
 	build_path = /obj/machinery/smartfridge
 	origin_tech = "programming=1"
 	req_components = list(/obj/item/weapon/stock_parts/matter_bin = 1)
+	var/list/fridges = list(/obj/machinery/smartfridge = "plant produce",
+							/obj/machinery/smartfridge/food = "food",
+							/obj/machinery/smartfridge/drinks = "drinks",
+							/obj/machinery/smartfridge/extract = "slimes",
+							/obj/machinery/smartfridge/chemistry = "chems",
+							/obj/machinery/smartfridge/chemistry/virology = "viruses")
 
 /obj/item/weapon/circuitboard/machine/smartfridge/New(loc, new_type)
 	if(new_type)
@@ -37,18 +43,16 @@
 
 /obj/item/weapon/circuitboard/machine/smartfridge/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/screwdriver))
-		var/list/fridges = list(/obj/machinery/smartfridge = "default",
-								/obj/machinery/smartfridge/drinks = "drinks",
-								/obj/machinery/smartfridge/extract = "slimes",
-								/obj/machinery/smartfridge/chemistry = "chems",
-								/obj/machinery/smartfridge/chemistry/virology = "viruses")
-
 		var/position = fridges.Find(build_path, fridges)
 		position = (position == fridges.len) ? 1 : (position + 1)
 		build_path = fridges[position]
 		user << "<span class='notice'>You set the board to [fridges[build_path]].</span>"
 	else
 		return ..()
+
+/obj/item/weapon/circuitboard/machine/smartfridge/examine/(mob/user)
+	..()
+	user << "<span class='info'>[src] is set to [fridges[build_path]]. You can use a screwdriver to reconfigure it.</span>"
 
 /obj/machinery/smartfridge/RefreshParts()
 	for(var/obj/item/weapon/stock_parts/matter_bin/B in component_parts)
@@ -231,6 +235,7 @@
 // ----------------------------
 /obj/machinery/smartfridge/drying_rack
 	name = "drying rack"
+	desc = "A wooden contraption, used to dry plant products, food and leather."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "drying_rack_on"
 	use_power = 1
@@ -352,6 +357,16 @@
 	if(istype(O,/obj/item/weapon/reagent_containers/glass) || istype(O,/obj/item/weapon/reagent_containers/food/drinks) || istype(O,/obj/item/weapon/reagent_containers/food/condiment))
 		return 1
 
+// ----------------------------
+//  Food smartfridge
+// ----------------------------
+/obj/machinery/smartfridge/food
+	desc = "A refrigerated storage unit for food."
+
+/obj/machinery/smartfridge/food/accept_check(obj/item/O)
+	if(istype(O,/obj/item/weapon/reagent_containers/food/snacks/))
+		return 1
+	return 0
 
 // -------------------------------------
 // Xenobiology Slime-Extract Smartfridge

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -29,7 +29,7 @@
 	build_path = /obj/machinery/smartfridge
 	origin_tech = "programming=1"
 	req_components = list(/obj/item/weapon/stock_parts/matter_bin = 1)
-	var/list/fridges = list(/obj/machinery/smartfridge = "plant produce",
+	var/static/list/fridges = list(/obj/machinery/smartfridge = "plant produce",
 							/obj/machinery/smartfridge/food = "food",
 							/obj/machinery/smartfridge/drinks = "drinks",
 							/obj/machinery/smartfridge/extract = "slimes",


### PR DESCRIPTION
The only way you'd know about the smartfridge board settings is by code-diving.  Just today I added a wiki entry for smartfridge machines. This PR adds information about the board's reconfigurability.

Examining a smartfridge circuit board tells you its setting, and it tells you that you can use a screwdriver to change its setting.
The fridges list is moved to machine/smartfridge so that it can be used by both attackby screwdriver and by examine.

The default setting for the fridge is renamed 'plant produce', which better indicates the strictness of that setting. 
I've added a new type of smartfridge. The food smartfridge has the same name as the default, but stores food and has a different description. To make one, set the board to 'food'.
The Space Hotel's smartfridge is changed to be a food smartfridge. This allows players to keep excess food in the fridge as well as the meat and veg from the back room.
