### PR TITLE
Adds explaining the rationale behind your PR as a requirement in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,6 +287,8 @@ There is no strict process when it comes to merging pull requests, pull requests
 
 * If your pull request is accepted, the code you add no longer belongs exclusively to you but to everyone; everyone is free to work on it, but you are also free to object to any changes being made, which will be noted by a Project Lead or Project Manager. It is a shame this has to be explicitly said, but there have been cases where this would've saved some trouble.
 
+* Please explain why you are submitting the pull request, and how you think your change will be beneficial to the game. Failure to do so will be grounds for rejecting the PR.
+
 ## Banned content
 Do not add any of the following in a Pull Request or risk getting the PR closed:
 * National Socialist Party of Germany content, National Socialist Party of Germany related content, or National Socialist Party of Germany references

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -16,3 +16,5 @@ imagedel: deleted some icons and images
 spellcheck: fixed a few typos
 experiment: added an experimental thingy
 /:cl:
+
+Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding: 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,4 @@ spellcheck: fixed a few typos
 experiment: added an experimental thingy
 /:cl:
 
-Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding: 
+[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)


### PR DESCRIPTION
Why I think this would be good for the game: Lots of pull requests are just things randomly being added, taken away, or having their balance tweaked without much of an explanation from the person making the PR. If you can't write even a couple sentences justifying your change, the game might not need it. 

**I think the burden is often on maintainers to prove a PR is bad, rather than than the person making it to prove it is good, and this might help shift things slightly.**