### PR TITLE
You can't resist out of Geis below 5 servants

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
@@ -143,7 +143,7 @@
 /datum/clockwork_scripture/geis
 	name = "Geis Conversion"
 	invocations = list("Enlighten this heathen!", "All are insects before Engine!", "Purge all untruths and honor Engine.")
-	channel_time = 50
+	channel_time = 49
 	tier = SCRIPTURE_PERIPHERAL
 	var/mob/living/target
 	var/obj/structure/destructible/clockwork/geis_binding/binding


### PR DESCRIPTION
Player input is faster than byond apparently????
As in, the binding ring appears and on the same tick the caster starts reciting it, they start resisting out, and they resist out BEFORE it finishes reciting, even though in theory recital should start before they can start resisting, and should thus finish first.

Honestly, byond makes me want to start drinking.
I swear I did this pr already???