### PR TITLE
Fixes ghost vision breaking randomly

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -495,10 +495,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	updateghostimages()
 
 /proc/updateallghostimages()
-	remove_nulls(ghost_images_full)
-	remove_nulls(ghost_images_default)
-	remove_nulls(ghost_images_simple)
-	remove_nulls(ghost_darkness_images)
+	listclearnulls(ghost_images_full)
+	listclearnulls(ghost_images_default)
+	listclearnulls(ghost_images_simple)
+	listclearnulls(ghost_darkness_images)
 	
 	for (var/mob/dead/observer/O in player_list)
 		O.updateghostimages()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -495,13 +495,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	updateghostimages()
 
 /proc/updateallghostimages()
+	remove_nulls(ghost_images_full)
+	remove_nulls(ghost_images_default)
+	remove_nulls(ghost_images_simple)
+	remove_nulls(ghost_darkness_images)
+	
 	for (var/mob/dead/observer/O in player_list)
 		O.updateghostimages()
 
 /mob/dead/observer/proc/updateghostimages()
 	if (!client)
 		return
-
+	
 	if(lastsetting)
 		switch(lastsetting) //checks the setting we last came from, for a little efficiency so we don't try to delete images from the client that it doesn't have anyway
 			if(GHOST_OTHERS_THEIR_SETTING)


### PR DESCRIPTION
There is a fine line between not wanting to hide bugs, and just making a system to fragile and finicky.

The fact that things keep leaving nulls in this list is showing that not supporting this edge case is making shit too finicky