### PR TITLE
nerfs growth serum

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1385,15 +1385,15 @@
 	var/newsize = current_size
 	switch(volume)
 		if(0 to 19)
-			newsize = 1.5
+			newsize = 1.25
 		if(20 to 49)
-			newsize = 2
+			newsize = 1.5
 		if(50 to 99)
-			newsize = 2.5
+			newsize = 2
 		if(100 to 199)
-			newsize = 3.5
+			newsize = 2.5
 		if(200 to INFINITY)
-			newsize = 5
+			newsize = 3.5
 		
 	H.resize = newsize/current_size
 	current_size = newsize


### PR DESCRIPTION
originally the max it would resize you to was 2, then https://github.com/tgstation/tgstation/pull/21962 changed it to 5. this is evidently a bit much, so now the max is 3.5