### PR TITLE
Adds Replicant and Tinkerer's Cache to the default slab quickbind

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
@@ -18,7 +18,8 @@
 	var/selected_scripture = SCRIPTURE_DRIVER
 	var/recollecting = FALSE //if we're looking at fancy recollection
 	var/obj/effect/proc_holder/slab/slab_ability //the slab's current bound ability, for certain scripture
-	var/list/quickbound = list(/datum/clockwork_scripture/ranged_ability/geis_prep) //quickbound scripture, accessed by index
+	var/list/quickbound = list(/datum/clockwork_scripture/ranged_ability/geis_prep, /datum/clockwork_scripture/create_object/replicant, \
+	/datum/clockwork_scripture/create_object/tinkerers_cache) //quickbound scripture, accessed by index
 	actions_types = list(/datum/action/item_action/clock/hierophant)
 
 /obj/item/clockwork/slab/starter


### PR DESCRIPTION
:cl: Joan
rscadd: Adds Replicant and Tinkerer's Cache to the default slab quickbind.
/:cl:

In theory, they might hand out slabs or make caches if they're new!
Hmm!