### PR TITLE
[s] Clock Cult items that suffered off station penalties no longer work off station.

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
@@ -169,10 +169,9 @@
 		proselytize_values["alloy_cost"] = 0
 
 	var/turf/Y = get_turf(user)
-	if(!Y || (Y.z != ZLEVEL_STATION && Y.z != ZLEVEL_CENTCOM && Y.z != ZLEVEL_MINING && Y.z != ZLEVEL_LAVALAND))
-		proselytize_values["operation_time"] *= 2
-		if(proselytize_values["alloy_cost"] > 0)
-			proselytize_values["alloy_cost"] *= 2
+	if(!Y || Y.z != ZLEVEL_STATION)
+		user << "<span class='warning'>You need to be on the station to do this!"
+		return FALSE
 
 	if(!can_use_alloy(proselytize_values["alloy_cost"]))
 		if(stored_alloy - proselytize_values["alloy_cost"] < 0)


### PR DESCRIPTION
:cl: Iamgoofball
fix: You can't work off-station as clock cult anymore.
/:cl:

>CLOCK CULT ROUND
>Step 1. Go to off station point ASAP
>Step 2. Wait out the grind to get resources to build
>Step 3. Come back to the station an hour later and win the game

>coder: oh let's double the time it takes them that'll work

>Step 4. Wait a bit extra for your free greentext because instead of actually fixing the problem(clockcult spends entire round off station circlejerking instead of being an active antag force), we applied a bandaid and let the extended-until-5-minutes-before-end rounds continue.

remember kids, when you don't want players to do stuff, just stop them from doing it, don't just make it take longer because they'll just do it anyways and bore everyone else out too

also even if it's fun for the clock cultists to play base building tycoon 2016, the players aren't enjoying it