### PR TITLE
Pens can now be placed on top of paper bins :shock: :rocket:

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -113,7 +113,7 @@
 "ci" = (/obj/structure/lattice,/obj/structure/disposalpipe/broken{tag = "icon-pipe-b (EAST)"; icon_state = "pipe-b"; dir = 4},/obj/structure/disposalpipe/broken{tag = "icon-pipe-b (WEST)"; icon_state = "pipe-b"; dir = 8},/obj/item/stack/rods,/turf/open/space,/area/ruin/onehalf/hallway)
 "cj" = (/obj/structure/lattice,/obj/structure/disposalpipe/segment{dir = 4},/obj/item/weapon/shard{icon_state = "small"},/turf/open/space,/area/space)
 "ck" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/door/poddoor/preopen{id = "bridge_onehalf"; name = "bridge blast door"},/turf/open/floor/plating,/area/ruin/onehalf/bridge)
-"cl" = (/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/obj/structure/table/reinforced,/obj/item/weapon/paper_bin{amount = 12},/turf/open/floor/plasteel,/area/ruin/onehalf/bridge)
+"cl" = (/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/obj/structure/table/reinforced,/obj/item/weapon/paper_bin{total_paper = 12},/turf/open/floor/plasteel,/area/ruin/onehalf/bridge)
 "cm" = (/obj/structure/chair/office{dir = 8},/turf/open/floor/plasteel,/area/ruin/onehalf/bridge)
 "cn" = (/turf/open/floor/plasteel,/area/ruin/onehalf/bridge)
 "co" = (/obj/structure/chair/office{tag = "icon-chair (NORTH)"; icon_state = "chair"; dir = 1},/turf/open/floor/plasteel,/area/ruin/onehalf/bridge)

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -57,7 +57,7 @@
 		user.visible_message("<span class='notice'>[user] throws [T] into \
 			[src].</span>", "<span class='notice'>You add [T] to [src].\
 			</span>")
-		adjust_fuel_timer(PAPER_BURN_TIMER * paper_bin.amount)
+		adjust_fuel_timer(PAPER_BURN_TIMER * paper_bin.total_paper)
 		qdel(paper_bin)
 	else if(istype(T, /obj/item/weapon/paper))
 		user.visible_message("<span class='notice'>[user] throws [T] into \


### PR DESCRIPTION
:cl: Mervill
fix: Paper bins can now have pens placed on top of them
/:cl:

Clicking a paper bin with a pen will put the pen on top of it. If you click the paper bin again (with an empty hand) you'll take the pen out. If the bin has a pen on it, you can still insert paper, but you cannot remove paper unless you move the pen.

When a paper bin is init'd, it checks if there is a pen on the same tile an eats it, issuing a warning (but only ever once!) if this happens.

I could expand this so that once of many items (like stamps, hand labeler, folders) could also be placed on top of the paper in in this way (but only one at a time).