### PR TITLE
Fixes Delta shuttle template (and backup shuttle)

### DIFF
--- a/_maps/map_files/generic/z2.dmm
+++ b/_maps/map_files/generic/z2.dmm
@@ -489,7 +489,7 @@
 "ju" = (/turf/open/floor/plasteel/darkwarning{tag = "icon-warndark (EAST)"; dir = 4},/area/centcom/ferry)
 "jv" = (/turf/open/floor/plasteel/delivery,/area/centcom/ferry)
 "jw" = (/obj/machinery/door/airlock/external{name = "Backup Emergency Escape Shuttle"},/turf/open/floor/plasteel/delivery,/area/centcom/ferry)
-"jx" = (/obj/machinery/door/airlock/shuttle,/obj/docking_port/stationary{dir = 4; dwidth = 3; height = 8; id = "backup_away"; name = "Backup Shuttle Dock"; width = 8},/obj/docking_port/mobile/emergency/backup{dwidth = 3},/turf/open/floor/plating,/area/shuttle/escape)
+"jx" = (/obj/machinery/door/airlock/shuttle,/obj/docking_port/stationary{dir = 4; dwidth = 2; height = 8; id = "backup_away"; name = "Backup Shuttle Dock"; width = 8},/obj/docking_port/mobile/emergency/backup,/turf/open/floor/plating,/area/shuttle/escape)
 "jy" = (/obj/structure/chair/office/light{dir = 4},/turf/open/floor/mineral/titanium,/area/shuttle/escape)
 "jz" = (/obj/structure/table/wood,/obj/item/weapon/paper{info = "Due to circumstances beyond our control, your Emergency Evacuation Shuttle is out of service.<br><br>We apologise for the inconvinience this may cause you.<br><br>Please enjoy the use of this complementary book.<br><br>Sincerely,<br>Centcom Operations Demolitions Examination Retribution Bugfixing Underlining Services"},/turf/open/floor/mineral/titanium,/area/shuttle/escape)
 "jA" = (/obj/structure/table/wood,/obj/item/weapon/book/manual/random,/turf/open/floor/mineral/titanium,/area/shuttle/escape)

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -46,7 +46,7 @@
 "aT" = (/obj/structure/sign/nanotrasen,/turf/closed/wall/mineral/titanium,/area/shuttle/escape)
 "aU" = (/turf/open/floor/plasteel/bot,/area/shuttle/escape)
 "aV" = (/obj/machinery/door/airlock/glass_medical{id_tag = null; name = "Escape Shuttle Infirmary"; req_access_txt = "0"},/turf/open/floor/plasteel/warning/side{tag = "icon-plasteel_warn_side (EAST)"; icon_state = "plasteel_warn_side"; dir = 4},/area/shuttle/escape)
-"aW" = (/obj/machinery/door/airlock/shuttle{name = "Emergency Shuttle Airlock"},/obj/docking_port/mobile/emergency{dheight = 0; dwidth = 11; height = 18; name = "Delta emergency shuttle"; timid = 0; width = 30},/turf/open/floor/plating,/area/shuttle/escape)
+"aW" = (/obj/machinery/door/airlock/shuttle{name = "Emergency Shuttle Airlock"},/obj/docking_port/mobile/emergency{dheight = 0; dwidth = 11; height = 18; name = "Delta emergency shuttle"; timid = 1; width = 30},/turf/open/floor/plating,/area/shuttle/escape)
 "aX" = (/obj/structure/flora/ausbushes/grassybush,/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/sunnybush,/obj/structure/window/shuttle,/turf/open/floor/grass,/area/shuttle/escape)
 "aY" = (/obj/structure/extinguisher_cabinet{pixel_x = -26},/obj/machinery/shieldgen,/turf/open/floor/plasteel/bot,/area/shuttle/escape)
 "aZ" = (/obj/structure/rack,/obj/item/weapon/storage/toolbox/electrical{pixel_x = -3; pixel_y = 1},/obj/item/weapon/storage/toolbox/mechanical{pixel_x = 0; pixel_y = -1},/obj/item/weapon/storage/toolbox/emergency{pixel_x = 3; pixel_y = -5},/turf/open/floor/plasteel/bot,/area/shuttle/escape)


### PR DESCRIPTION
The Delta shuttle template was not timid, causing the shuttle
manipulator to freak out and delete it immediately, making the backup
shuttle arrive at the station instead.

Another bug was that the backup shuttle's dwidth was 1 off, making it
arrive to the station with a wall missing.