### PR TITLE
Intents can be cycled forward and backwards with hotkeys again

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -616,6 +616,7 @@ var/global/list/ghost_others_options = list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 #define INTENT_GRAB   "grab"
 #define INTENT_DISARM "disarm"
 #define INTENT_HARM   "harm"
-// NOTE: This is not a real intent! It's used to allow
-// the alternate intent selection stlye (clockwise)
-#define INTENT_NEXT   "next"
+// NOTE: INTENT_HOTKEY_* defines are not actual intents!
+// they are here to support hotkeys
+#define INTENT_HOTKEY_LEFT  "left"
+#define INTENT_HOTKEY_RIGHT "right"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -201,7 +201,7 @@
 			usr.a_intent_change(INTENT_DISARM)
 
 	else
-		usr.a_intent_change(INTENT_NEXT)
+		usr.a_intent_change(INTENT_HOTKEY_RIGHT)
 
 /obj/screen/act_intent/alien
 	icon = 'icons/mob/screen_alien.dmi'

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -319,7 +319,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 				a_intent = INTENT_HELP
 			if(INTENT_HARM)
 				a_intent = INTENT_HARM
-			if(INTENT_HOTKEY_RIGHT)
+			if(INTENT_HOTKEY_RIGHT, INTENT_HOTKEY_LEFT)
 				switch (a_intent)
 					if(INTENT_HELP)
 						a_intent = INTENT_HARM

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -289,7 +289,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 		switch(input)
 			if(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
 				a_intent = input
-			if(INTENT_NEXT)
+			if(INTENT_HOTKEY_RIGHT)
 				switch (a_intent)
 					if(INTENT_HELP)
 						a_intent = INTENT_DISARM
@@ -299,6 +299,16 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 						a_intent = INTENT_HARM
 					if(INTENT_HARM)
 						a_intent = INTENT_HELP
+			if(INTENT_HOTKEY_LEFT)
+				switch (a_intent)
+					if(INTENT_HELP)
+						a_intent = INTENT_HARM
+					if(INTENT_DISARM)
+						a_intent = INTENT_HELP
+					if(INTENT_GRAB)
+						a_intent = INTENT_DISARM
+					if(INTENT_HARM)
+						a_intent = INTENT_GRAB
 
 		if(hud_used && hud_used.action_intent)
 			hud_used.action_intent.icon_state = "[a_intent]"
@@ -309,7 +319,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 				a_intent = INTENT_HELP
 			if(INTENT_HARM)
 				a_intent = INTENT_HARM
-			if(INTENT_NEXT)
+			if(INTENT_HOTKEY_RIGHT)
 				switch (a_intent)
 					if(INTENT_HELP)
 						a_intent = INTENT_HARM

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -57,7 +57,7 @@ macro "default"
 		is-disabled = false
 	elem 
 		name = "INSERT"
-		command = "a-intent next"
+		command = "a-intent right"
 		is-disabled = false
 	elem 
 		name = "DELETE"
@@ -97,11 +97,11 @@ macro "default"
 		is-disabled = false
 	elem 
 		name = "CTRL+F"
-		command = "a-intent next"
+		command = "a-intent left"
 		is-disabled = false
 	elem 
 		name = "CTRL+G"
-		command = "a-intent next"
+		command = "a-intent right"
 		is-disabled = false
 	elem 
 		name = "CTRL+H"
@@ -263,7 +263,7 @@ macro "hotkeys"
 		is-disabled = false
 	elem 
 		name = "INSERT"
-		command = "a-intent next"
+		command = "a-intent right"
 		is-disabled = false
 	elem 
 		name = "DELETE"
@@ -335,19 +335,19 @@ macro "hotkeys"
 		is-disabled = false
 	elem 
 		name = "F"
-		command = "a-intent next"
+		command = "a-intent left"
 		is-disabled = false
 	elem 
 		name = "CTRL+F"
-		command = "a-intent next"
+		command = "a-intent left"
 		is-disabled = false
 	elem 
 		name = "G"
-		command = "a-intent next"
+		command = "a-intent right"
 		is-disabled = false
 	elem 
 		name = "CTRL+G"
-		command = "a-intent next"
+		command = "a-intent right"
 		is-disabled = false
 	elem 
 		name = "H"
@@ -549,7 +549,7 @@ macro "robot-default"
 		is-disabled = false
 	elem 
 		name = "INSERT"
-		command = "a-intent next"
+		command = "a-intent right"
 		is-disabled = false
 	elem 
 		name = "DELETE"
@@ -569,7 +569,7 @@ macro "robot-default"
 		is-disabled = false
 	elem 
 		name = "CTRL+4"
-		command = "a-intent next"
+		command = "a-intent left"
 		is-disabled = false
 	elem 
 		name = "CTRL+A+REP"
@@ -589,11 +589,11 @@ macro "robot-default"
 		is-disabled = false
 	elem 
 		name = "CTRL+F"
-		command = "a-intent next"
+		command = "a-intent left"
 		is-disabled = false
 	elem 
 		name = "CTRL+G"
-		command = "a-intent next"
+		command = "a-intent right"
 		is-disabled = false
 	elem 
 		name = "CTRL+Q"
@@ -739,7 +739,7 @@ macro "robot-hotkeys"
 		is-disabled = false
 	elem 
 		name = "INSERT"
-		command = "a-intent next"
+		command = "a-intent right"
 		is-disabled = false
 	elem 
 		name = "DELETE"
@@ -771,11 +771,11 @@ macro "robot-hotkeys"
 		is-disabled = false
 	elem 
 		name = "4"
-		command = "a-intent next"
+		command = "a-intent left"
 		is-disabled = false
 	elem 
 		name = "CTRL+4"
-		command = "a-intent next"
+		command = "a-intent left"
 		is-disabled = false
 	elem 
 		name = "A+REP"
@@ -811,19 +811,19 @@ macro "robot-hotkeys"
 		is-disabled = false
 	elem 
 		name = "F"
-		command = "a-intent next"
+		command = "a-intent left"
 		is-disabled = false
 	elem 
 		name = "CTRL+F"
-		command = "a-intent next"
+		command = "a-intent left"
 		is-disabled = false
 	elem 
 		name = "G"
-		command = "a-intent next"
+		command = "a-intent right"
 		is-disabled = false
 	elem 
 		name = "CTRL+G"
-		command = "a-intent next"
+		command = "a-intent right"
 		is-disabled = false
 	elem 
 		name = "Q"


### PR DESCRIPTION
:cl: Mervill
fix: Intents can be cycled forward and backwards with hotkeys again
/:cl:

After I broke it by refactoring intents

fixes https://github.com/tgstation/tgstation/issues/22111
fixes https://github.com/tgstation/tgstation/issues/21973