### PR TITLE
Cyborg upgrade board tweaks

### DIFF
--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -96,7 +96,7 @@
 	sleep(5)
 
 	use_power(5000) // Use a lot of power.
-	var/mob/living/silicon/robot/R = H.Robotize(1) // Delete the items or they'll all pile up in a single tile and lag
+	var/mob/living/silicon/robot/R = H.Robotize()
 
 	R.cell.maxcharge = robot_cell_charge
 	R.cell.charge = robot_cell_charge

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -163,11 +163,11 @@
 
 			var/mob/living/brain/BM = M.brainmob
 			if(!BM.key || !BM.mind)
-				user << "<span class='warning'>The mmi indicates that their mind is completely unresponsive; there's no point!</span>"
+				user << "<span class='warning'>The MMI indicates that their mind is completely unresponsive; there's no point!</span>"
 				return
 
 			if(!BM.client) //braindead
-				user << "<span class='warning'>The mmi indicates that their mind is currently inactive; it might change!</span>"
+				user << "<span class='warning'>The MMI indicates that their mind is currently inactive; it might change!</span>"
 				return
 
 			if(BM.stat == DEAD || (M.brain && M.brain.damaged_brain))

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -43,7 +43,7 @@
 	R.custom_name = heldname
 	R.updatename()
 	if(oldname == R.real_name)
-		R.notify_ai(3, oldname, R.realname)
+		R.notify_ai(3, oldname, R.real_name)
 
 	return 1
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -39,12 +39,10 @@
 		return
 
 	if(heldname == initial(heldname))
-		R << "<span class='error'>Rename error! No name specified!</span>"
-		usr << "<span class='error'>No name has been specified. \
-			Upgrade rejected.</span>"
-		return FALSE
-
-	R.fully_replace_character_name(R.name, heldname)
+		// Use cyborg name from settings or randomly generated
+		R.rename_self("cyborg")
+	else
+		R.fully_replace_character_name(R.name, heldname)
 
 	return 1
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -28,7 +28,7 @@
 	name = "cyborg reclassification board"
 	desc = "Used to rename a cyborg."
 	icon_state = "cyborg_upgrade1"
-	var/heldname = "default name"
+	var/heldname = ""
 	one_use = TRUE
 
 /obj/item/borg/upgrade/rename/attack_self(mob/user)
@@ -38,11 +38,12 @@
 	if(..())
 		return
 
-	if(heldname == initial(heldname))
-		// Use cyborg name from settings or randomly generated
-		R.rename_self("cyborg")
-	else
-		R.fully_replace_character_name(R.name, heldname)
+	var/oldname = R.real_name
+
+	R.custom_name = heldname
+	R.updatename()
+	if(oldname == R.real_name)
+		R.notify_ai(3, oldname, R.realname)
 
 	return 1
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -11,6 +11,9 @@
 	var/installed = 0
 	var/require_module = 0
 	var/module_type = null
+	// if true, is not stored in the robot to be ejected
+	// if module is reset
+	var/one_use = FALSE
 
 /obj/item/borg/upgrade/proc/action(mob/living/silicon/robot/R)
 	if(R.stat == DEAD)
@@ -26,6 +29,7 @@
 	desc = "Used to rename a cyborg."
 	icon_state = "cyborg_upgrade1"
 	var/heldname = "default name"
+	one_use = TRUE
 
 /obj/item/borg/upgrade/rename/attack_self(mob/user)
 	heldname = stripped_input(user, "Enter new robot name", "Cyborg Reclassification", heldname, MAX_NAME_LEN)
@@ -33,6 +37,12 @@
 /obj/item/borg/upgrade/rename/action(mob/living/silicon/robot/R)
 	if(..())
 		return
+
+	if(heldname == initial(heldname))
+		R << "<span class='error'>Rename error! No name specified!</span>"
+		usr << "<span class='error'>No name has been specified. \
+			Upgrade rejected.</span>"
+		return FALSE
 
 	R.fully_replace_character_name(R.name, heldname)
 
@@ -43,6 +53,7 @@
 	name = "cyborg emergency reboot module"
 	desc = "Used to force a reboot of a disabled-but-repaired cyborg, bringing it back online."
 	icon_state = "cyborg_upgrade1"
+	one_use = TRUE
 
 /obj/item/borg/upgrade/restart/action(mob/living/silicon/robot/R)
 	if(R.health < 0)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -194,8 +194,11 @@
 	var/changed_name = ""
 	if(custom_name)
 		changed_name = custom_name
-	else
+	if(changed_name == "" && client)
+		changed_name = client.prefs.custom_names["cyborg"]
+	if(changed_name == "")
 		changed_name = "[(designation ? "[designation] " : "")][mmi.braintype]-[num2text(ident)]"
+
 	real_name = changed_name
 	name = real_name
 	if(camera)
@@ -479,7 +482,7 @@
 				if(U.one_use)
 					qdel(U)
 				else
-					U.loc = src
+					U.forceMove(src)
 					upgrades += U
 			else
 				user << "<span class='danger'>Upgrade error.</span>"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -197,12 +197,15 @@
 	if(changed_name == "" && client)
 		changed_name = client.prefs.custom_names["cyborg"]
 	if(changed_name == "")
-		changed_name = "[(designation ? "[designation] " : "")][mmi.braintype]-[num2text(ident)]"
+		changed_name = get_standard_name()
 
 	real_name = changed_name
 	name = real_name
 	if(camera)
 		camera.c_tag = real_name	//update the camera name too
+
+/mob/living/silicon/robot/proc/get_standard_name()
+	return "[(designation ? "[designation] " : "")][mmi.braintype]-[ident]"
 
 /mob/living/silicon/robot/verb/cmd_robot_alerts()
 	set category = "Robot Commands"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -476,8 +476,11 @@
 				return
 			if(U.action(src))
 				user << "<span class='notice'>You apply the upgrade to [src].</span>"
-				U.loc = src
-				upgrades += U
+				if(U.one_use)
+					qdel(U)
+				else
+					U.loc = src
+					upgrades += U
 			else
 				user << "<span class='danger'>Upgrade error.</span>"
 


### PR DESCRIPTION
:cl: coiax
add: Cyborg renaming boards cannot be used if no name has been entered.
del: Cyborg rename and emergency reboot modules are destroyed upon use,
and not stored inside the cyborg to be ejected if modules are reset.
/:cl:

Reasons: Because being renamed "default name" isn't fun, and it means
you have to hang around to be renamed AGAIN. And for lore/balance/sanity
reasons, you don't get to get the reboot board back after you used it;
try dying less.