### PR TITLE
Transforming borgs cannot be moved

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -196,12 +196,14 @@
 	animate(R, alpha = 255, time = 50)
 	var/prev_lockcharge = R.lockcharge
 	R.SetLockdown(1)
+	R.anchored = TRUE
 	sleep(2)
 	for(var/i in 1 to 4)
 		playsound(R, pick('sound/items/drill_use.ogg', 'sound/items/jaws_cut.ogg', 'sound/items/jaws_pry.ogg', 'sound/items/Welder.ogg', 'sound/items/Ratchet.ogg'), 80, 1, -1)
 		sleep(12)
 	if(!prev_lockcharge)
 		R.SetLockdown(0)
+	R.anchored = FALSE
 	R.notify_ai(2)
 	R.update_module_innate()
 	if(R.hud_used)


### PR DESCRIPTION
Because it's weird having the old borg module fading out, and the new one
fading in on a different tile, and also smoke that's not connected to
the cyborg.