### PR TITLE
Sets abduction mode's suggested maximum players to 50

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -9,6 +9,7 @@
 	antag_flag = ROLE_ABDUCTOR
 	recommended_enemies = 2
 	required_players = 15
+	maximum_players = 45
 	var/max_teams = 4
 	abductor_teams = 1
 	var/list/datum/mind/scientists = list()

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -9,7 +9,7 @@
 	antag_flag = ROLE_ABDUCTOR
 	recommended_enemies = 2
 	required_players = 15
-	maximum_players = 45
+	maximum_players = 50
 	var/max_teams = 4
 	abductor_teams = 1
 	var/list/datum/mind/scientists = list()


### PR DESCRIPTION
Back when abductors was a mode people ran the big complaint was that the abductors weren't a practical threat against giant stations. This resolves the problem by limiting the mode to 15 to 50 players. 

With default scaling there will be one team at 15, and three at 50. The fourth slot remaining open for the random event (or in case someone changed the abductor scaling coeff). I feel like this will make abductor mode relevant again and hopefully get it back in rotation, bringing a little life back to low-med pop round selection.
