### PR TITLE
makes rad crates a little more usefull

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -121,7 +121,10 @@
 					/obj/item/clothing/suit/radiation,
 					/obj/item/clothing/suit/radiation,
 					/obj/item/device/geiger_counter,
-					/obj/item/device/geiger_counter)
+					/obj/item/device/geiger_counter
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
+					/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
+					/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass)
 	crate_name = "radiation protection crate"
 	crate_type = /obj/structure/closet/crate/radiation
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -121,7 +121,7 @@
 					/obj/item/clothing/suit/radiation,
 					/obj/item/clothing/suit/radiation,
 					/obj/item/device/geiger_counter,
-					/obj/item/device/geiger_counter
+					/obj/item/device/geiger_counter,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
 					/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
 					/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -119,7 +119,9 @@
 	contains = list(/obj/item/clothing/head/radiation,
 					/obj/item/clothing/head/radiation,
 					/obj/item/clothing/suit/radiation,
-					/obj/item/clothing/suit/radiation)
+					/obj/item/clothing/suit/radiation,
+					/obj/item/device/geiger_counter,
+					/obj/item/device/geiger_counter)
 	crate_name = "radiation protection crate"
 	crate_type = /obj/structure/closet/crate/radiation
 


### PR DESCRIPTION
Because i want to know with how much radition i got struck with and it would make sense if centcom ships it with the suits so you can check the radition if the area is safe so you can take your suit off


:cl: Hyena
Tweak: adds 2 geiger counters to radition protection crates and a gift from the russians
/:cl:

