### PR TITLE
Ore satchel auto empties into ore box when dragged

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -39,6 +39,12 @@
 					break
 		if(OB)
 			F.attackby(OB, AM)
+			// Then, if the user is dragging an ore box, empty the satchel
+			// into the box.
+			var/mob/living/L = AM
+			if(istype(L.pulling, /obj/structure/ore_box))
+				var/obj/structure/ore_box/box = L.pulling
+				box.attackby(OB, AM)
 	return ..()
 
 /obj/item/weapon/ore/uranium


### PR DESCRIPTION
:cl: coiax
add: Whenever you automatically pick up ore with an ore satchel, if you
are dragging a wooden ore box, the satchel automatically empties into
the box.
/:cl:

Because convinience. Streamlining. Less pointless clicking.