### PR TITLE
Fixes errors with cyborg reclassification announcements

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -174,6 +174,7 @@
 		qdel(RM)
 		return
 	R.module = RM
+	R.update_module_innate()
 	RM.rebuild_modules()
 	addtimer(RM, "do_transform_animation", 0)
 	qdel(src)
@@ -203,7 +204,6 @@
 	if(!prev_lockcharge)
 		R.SetLockdown(0)
 	R.notify_ai(2)
-	R.update_module_innate()
 	if(R.hud_used)
 		R.hud_used.update_robot_modules_display()
 	if(feedback_key && !did_feedback)


### PR DESCRIPTION
Moves the updating of the classification/name/etc to before the announcement to the AI instead of after

Fixes #21997