### PR TITLE
Fixes russian revolver ammo displaying incorrectly

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal_mag.dm
+++ b/code/modules/projectiles/boxes_magazines/internal_mag.dm
@@ -144,7 +144,7 @@
 	caliber = "speargun"
 	max_ammo = 1
 
-/obj/item/ammo_box/magazine/internal/rus357
+/obj/item/ammo_box/magazine/internal/cylinder/rus357
 	name = "russian revolver cylinder"
 	ammo_type = /obj/item/ammo_casing/a357
 	caliber = "357"

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -169,50 +169,30 @@
 	name = "\improper russian revolver"
 	desc = "A Russian-made revolver for drinking games. Uses .357 ammo, and has a mechanism requiring you to spin the chamber before each trigger pull."
 	origin_tech = "combat=2;materials=2"
-	mag_type = /obj/item/ammo_box/magazine/internal/rus357
-	var/spun = 0
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rus357
+	var/spun = FALSE
 
 /obj/item/weapon/gun/ballistic/revolver/russian/New()
 	..()
-	Spin()
+	spin()
+	spun = TRUE
 	update_icon()
 
-/obj/item/weapon/gun/ballistic/revolver/russian/proc/Spin()
-	chambered = null
-	var/random = rand(1, magazine.max_ammo)
-	if(random <= get_ammo(0,0))
-		chamber_round()
-	spun = 1
-
 /obj/item/weapon/gun/ballistic/revolver/russian/attackby(obj/item/A, mob/user, params)
-	var/num_loaded = ..()
-	if(num_loaded)
-		user.visible_message("[user] loads a single bullet into the revolver and spins the chamber.", "<span class='notice'>You load a single bullet into the chamber and spin it.</span>")
-	else
-		user.visible_message("[user] spins the chamber of the revolver.", "<span class='notice'>You spin the revolver's chamber.</span>")
+	..()
 	if(get_ammo() > 0)
-		Spin()
+		spin()
+		spun = TRUE
 	update_icon()
 	A.update_icon()
 	return
 
 /obj/item/weapon/gun/ballistic/revolver/russian/attack_self(mob/user)
 	if(!spun && can_shoot())
-		user.visible_message("[user] spins the chamber of the revolver.", "<span class='notice'>You spin the revolver's chamber.</span>")
-		Spin()
-	else
-		var/num_unloaded = 0
-		while (get_ammo() > 0)
-			var/obj/item/ammo_casing/CB
-			CB = magazine.get_round()
-			chambered = null
-			CB.loc = get_turf(src.loc)
-			CB.update_icon()
-			num_unloaded++
-		if (num_unloaded)
-			user << "<span class='notice'>You unload [num_unloaded] shell\s from [src].</span>"
-		else
-			user << "<span class='notice'>[src] is empty.</span>"
+		spin()
+		spun = TRUE
+		return
+	..()
 
 /obj/item/weapon/gun/ballistic/revolver/russian/afterattack(atom/target, mob/living/user, flag, params)
 	if(flag)
@@ -234,7 +214,7 @@
 			user << "<span class='warning'>You need to spin the revolver's chamber first!</span>"
 			return
 
-		spun = 0
+		spun = FALSE
 
 		if(chambered)
 			var/obj/item/ammo_casing/AC = chambered
@@ -246,6 +226,7 @@
 					shoot_self(user, affecting)
 				else
 					user.visible_message("<span class='danger'>[user.name] cowardly fires [src] at [user.p_their()] [affecting.name]!</span>", "<span class='userdanger'>You cowardly fire [src] at your [affecting.name]!</span>", "<span class='italics'>You hear a gunshot!</span>")
+				chambered = null
 				return
 
 		user.visible_message("<span class='danger'>*click*</span>")
@@ -266,8 +247,6 @@
 		qdel(SS)
 		return
 	user.visible_message("<span class='danger'>[user.name]'s soul is captured by \the [src]!</span>", "<span class='userdanger'>You've lost the gamble! Your soul is forfiet!</span>")
-
-
 
 /////////////////////////////
 // DOUBLE BARRELED SHOTGUN //
@@ -321,9 +300,6 @@
 		user << "<span class='notice'>You break open \the [src] and unload [num_unloaded] shell\s.</span>"
 	else
 		user << "<span class='warning'>[src] is empty!</span>"
-
-
-
 
 // IMPROVISED SHOTGUN //
 


### PR DESCRIPTION
:cl: Mervill
fix: Russian revolver ammo display works correctly
/:cl:

Authors note: boy did I have to shoot myself a lot to fix this

- magazine is properly a cylinder
- `revolver/russian` was handling spin itself when it's a verb on `revolver`
- also doing it's own reload code when the same exists the base class
- weird loading text that was never called removed

fixes https://github.com/tgstation/tgstation/issues/20155