### PR TITLE
Allows the biogenerator in Hydroponics to print paper and fake space cash

### DIFF
--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -61,38 +61,32 @@
 	throw_range = 2
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
+	value = 0
 	
 /obj/item/stack/spacecash/fake/c10
 	icon_state = "spacecash10"
 	desc = "It's worth 10 credits."
-	value = 0
 
 /obj/item/stack/spacecash/fake/c20
 	icon_state = "spacecash20"
 	desc = "It's worth 20 credits."
-	value = 0
 
 /obj/item/stack/spacecash/fake/c50
 	icon_state = "spacecash50"
 	desc = "It's worth 50 credits."
-	value = 0
 
 /obj/item/stack/spacecash/fake/c100
 	icon_state = "spacecash100"
 	desc = "It's worth 100 credits."
-	value = 0
 
 /obj/item/stack/spacecash/fake/c200
 	icon_state = "spacecash200"
 	desc = "It's worth 200 credits."
-	value = 0
 
 /obj/item/stack/spacecash/fake/c500
 	icon_state = "spacecash500"
 	desc = "It's worth 500 credits."
-	value = 0
 
 /obj/item/stack/spacecash/fake/c1000
 	icon_state = "spacecash1000"
 	desc = "It's worth 1000 credits."
-	value = 0

--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -47,3 +47,53 @@
 	icon_state = "spacecash1000"
 	desc = "It's worth 1000 credits."
 	value = 1000
+	
+/obj/item/stack/spacecash/fake //Always has a value of 0
+	name = "space cash" //Even though it's fake, the name and desc is still the same, you can tell if it's fake by trying to use it on a ATM
+	desc = "It's worth 1 credit."
+	singular_name = "bill"
+	icon = 'icons/obj/economy.dmi'
+	icon_state = "spacecash"
+	amount = 1
+	max_amount = 20
+	throwforce = 0
+	throw_speed = 2
+	throw_range = 2
+	w_class = WEIGHT_CLASS_TINY
+	resistance_flags = FLAMMABLE
+	var/value = 0
+	
+/obj/item/stack/spacecash/fake/c10
+	icon_state = "spacecash10"
+	desc = "It's worth 10 credits."
+	value = 0
+
+/obj/item/stack/spacecash/fake/c20
+	icon_state = "spacecash20"
+	desc = "It's worth 20 credits."
+	value = 0
+
+/obj/item/stack/spacecash/fake/c50
+	icon_state = "spacecash50"
+	desc = "It's worth 50 credits."
+	value = 0
+
+/obj/item/stack/spacecash/fake/c100
+	icon_state = "spacecash100"
+	desc = "It's worth 100 credits."
+	value = 0
+
+/obj/item/stack/spacecash/fake/c200
+	icon_state = "spacecash200"
+	desc = "It's worth 200 credits."
+	value = 0
+
+/obj/item/stack/spacecash/fake/c500
+	icon_state = "spacecash500"
+	desc = "It's worth 500 credits."
+	value = 0
+
+/obj/item/stack/spacecash/fake/c1000
+	icon_state = "spacecash1000"
+	desc = "It's worth 1000 credits."
+	value = 0

--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -61,7 +61,6 @@
 	throw_range = 2
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
-	var/value = 0
 	
 /obj/item/stack/spacecash/fake/c10
 	icon_state = "spacecash10"

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -127,7 +127,7 @@
 	name = "Fake c10 bill"
 	id ="fakec10"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 10)
+	materials = list(MAT_BIOMASS = 50)
 	build_path = /obj/item/stack/spacecash/fake/c10
 	category = list("initial","Leather and Cloth")
 
@@ -135,7 +135,7 @@
 	name = "Fake c20 bill"
 	id ="fakec20"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 20)
+	materials = list(MAT_BIOMASS = 50)
 	build_path = /obj/item/stack/spacecash/fake/c20
 	category = list("initial","Leather and Cloth")
 	
@@ -151,7 +151,7 @@
 	name = "Fake c100 bill"
 	id ="fakec100"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 100)
+	materials = list(MAT_BIOMASS = 50)
 	build_path = /obj/item/stack/spacecash/fake/c100
 	category = list("initial","Leather and Cloth")
 	
@@ -159,7 +159,7 @@
 	name = "Fake c200 bill"
 	id ="fakec200"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 200)
+	materials = list(MAT_BIOMASS = 50)
 	build_path = /obj/item/stack/spacecash/fake/c200
 	category = list("initial","Leather and Cloth")
 	
@@ -167,7 +167,7 @@
 	name = "Fake c500 bill"
 	id ="fakec500"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 500)
+	materials = list(MAT_BIOMASS = 125)
 	build_path = /obj/item/stack/spacecash/fake/c500
 	category = list("initial","Leather and Cloth")
 
@@ -175,7 +175,7 @@
 	name = "Fake c1000 bill"
 	id ="fakec1000"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 1000)
+	materials = list(MAT_BIOMASS = 250)
 	build_path = /obj/item/stack/spacecash/fake/c1000
 	category = list("initial","Leather and Cloth")
 

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -127,55 +127,55 @@
 	name = "Fake c10 bill"
 	id ="fakec10"
 	build_type = BIOGENERATOR
-	Mmaterials = list(MAT_BIOMASS = 10)
+	materials = list(MAT_BIOMASS = 10)
 	build_path = /obj/item/stack/spacecash/fake/c10
 	category = list("initial","Leather and Cloth")
 
-/datum/design/fakec1
+/datum/design/fakec20
 	name = "Fake c20 bill"
-	id ="fakec10"
+	id ="fakec20"
 	build_type = BIOGENERATOR
-	Mmaterials = list(MAT_BIOMASS = 20)
+	materials = list(MAT_BIOMASS = 20)
 	build_path = /obj/item/stack/spacecash/fake/c20
 	category = list("initial","Leather and Cloth")
 	
-/datum/design/fakec1
+/datum/design/fakec50
 	name = "Fake c50 bill"
-	id ="fakec10"
+	id ="fakec50"
 	build_type = BIOGENERATOR
-	Mmaterials = list(MAT_BIOMASS = 50)
+	materials = list(MAT_BIOMASS = 50)
 	build_path = /obj/item/stack/spacecash/fake/c50
 	category = list("initial","Leather and Cloth")
 	
-/datum/design/fakec1
+/datum/design/fakec100
 	name = "Fake c100 bill"
-	id ="fakec10"
+	id ="fakec100"
 	build_type = BIOGENERATOR
-	Mmaterials = list(MAT_BIOMASS = 100)
+	materials = list(MAT_BIOMASS = 100)
 	build_path = /obj/item/stack/spacecash/fake/c100
 	category = list("initial","Leather and Cloth")
 	
-/datum/design/fakec1
+/datum/design/fakec200
 	name = "Fake c200 bill"
-	id ="fakec10"
+	id ="fakec200"
 	build_type = BIOGENERATOR
-	Mmaterials = list(MAT_BIOMASS = 200)
+	materials = list(MAT_BIOMASS = 200)
 	build_path = /obj/item/stack/spacecash/fake/c200
 	category = list("initial","Leather and Cloth")
 	
-/datum/design/fakec1
+/datum/design/fake500
 	name = "Fake c500 bill"
-	id ="fakec10"
+	id ="fakec500"
 	build_type = BIOGENERATOR
-	Mmaterials = list(MAT_BIOMASS = 500)
+	materials = list(MAT_BIOMASS = 500)
 	build_path = /obj/item/stack/spacecash/fake/c500
 	category = list("initial","Leather and Cloth")
 
-/datum/design/fakec1
+/datum/design/fakec1000
 	name = "Fake c1000 bill"
-	id ="fakec10"
+	id ="fakec1000"
 	build_type = BIOGENERATOR
-	Mmaterials = list(MAT_BIOMASS = 1000)
+	materials = list(MAT_BIOMASS = 1000)
 	build_path = /obj/item/stack/spacecash/fake/c1000
 	category = list("initial","Leather and Cloth")
 

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -115,6 +115,70 @@
 	build_path = /obj/item/stack/sheet/cloth
 	category = list("initial","Leather and Cloth")
 
+/datum/design/paper
+	name = "Paper"
+	id = "paper"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 20)
+	build_path = /obj/item/weapon/paper
+	category = list("initial","Leather and Cloth")
+	
+/datum/design/fakec10
+	name = "Fake c10 bill"
+	id ="fakec10"
+	build_type = BIOGENERATOR
+	Mmaterials = list(MAT_BIOMASS = 10)
+	build_path = /obj/item/stack/spacecash/fake/c10
+	category = list("initial","Leather and Cloth")
+
+/datum/design/fakec1
+	name = "Fake c20 bill"
+	id ="fakec10"
+	build_type = BIOGENERATOR
+	Mmaterials = list(MAT_BIOMASS = 20)
+	build_path = /obj/item/stack/spacecash/fake/c20
+	category = list("initial","Leather and Cloth")
+	
+/datum/design/fakec1
+	name = "Fake c50 bill"
+	id ="fakec10"
+	build_type = BIOGENERATOR
+	Mmaterials = list(MAT_BIOMASS = 50)
+	build_path = /obj/item/stack/spacecash/fake/c50
+	category = list("initial","Leather and Cloth")
+	
+/datum/design/fakec1
+	name = "Fake c100 bill"
+	id ="fakec10"
+	build_type = BIOGENERATOR
+	Mmaterials = list(MAT_BIOMASS = 100)
+	build_path = /obj/item/stack/spacecash/fake/c100
+	category = list("initial","Leather and Cloth")
+	
+/datum/design/fakec1
+	name = "Fake c200 bill"
+	id ="fakec10"
+	build_type = BIOGENERATOR
+	Mmaterials = list(MAT_BIOMASS = 200)
+	build_path = /obj/item/stack/spacecash/fake/c200
+	category = list("initial","Leather and Cloth")
+	
+/datum/design/fakec1
+	name = "Fake c500 bill"
+	id ="fakec10"
+	build_type = BIOGENERATOR
+	Mmaterials = list(MAT_BIOMASS = 500)
+	build_path = /obj/item/stack/spacecash/fake/c500
+	category = list("initial","Leather and Cloth")
+
+/datum/design/fakec1
+	name = "Fake c1000 bill"
+	id ="fakec10"
+	build_type = BIOGENERATOR
+	Mmaterials = list(MAT_BIOMASS = 1000)
+	build_path = /obj/item/stack/spacecash/fake/c1000
+	category = list("initial","Leather and Cloth")
+
 /datum/design/wallet
 	name = "Wallet"
 	id = "wallet"

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -167,7 +167,7 @@
 	name = "Fake c500 bill"
 	id ="fakec500"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 125)
+	materials = list(MAT_BIOMASS = 50)
 	build_path = /obj/item/stack/spacecash/fake/c500
 	category = list("initial","Leather and Cloth")
 
@@ -175,7 +175,7 @@
 	name = "Fake c1000 bill"
 	id ="fakec1000"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 250)
+	materials = list(MAT_BIOMASS = 50)
 	build_path = /obj/item/stack/spacecash/fake/c1000
 	category = list("initial","Leather and Cloth")
 


### PR DESCRIPTION
**FAKE CASH IS NOT WORTH ANYTHING**

:cl: ma44
add: Biogenerator can now make paper by using biomatter. 
add: A researcher has discovered you can make space cash bills that look exactly like the original ones, these can be made in the Biogenerator in hydroponics with biomatter. 
add: In response to this, the Centcomm in your sector has upgraded the ATM to prevent the fake space cash being used as money, exported money will also be checked to make sure they are not fake. 
/:cl:

This change is good

1. You can print dosh which doesn't effect game balance
2. Antags can use this to bribe or trade for items if the crew can roleplay
3. You can make a fun economy
4. Makes ma44 satisfy his space cash fetish