### PR TITLE
Fixes clicking on clothing with pockets.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -58,7 +58,8 @@
 
 /obj/item/clothing/attack_hand(mob/user)
 	if(pockets && pockets.priority && ismob(loc))
-		pockets.show_to(user)
+		pockets.loc = loc //Set the pocket's loc to ours so the player can access it like it's in the real inventory.
+		pockets.attack_hand(user)
 	else
 		return ..()
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -58,8 +58,15 @@
 
 /obj/item/clothing/attack_hand(mob/user)
 	if(pockets && pockets.priority && ismob(loc))
-		pockets.loc = loc //Set the pocket's loc to ours so the player can access it like it's in the real inventory.
-		pockets.attack_hand(user)
+		//If we already have the pockets open, close them.
+		if (user.s_active == pockets)
+			pockets.close(user)
+		//Close whatever the user has open and show them the pockets.
+		else
+			if (user.s_active)
+				user.s_active.close(user)
+			pockets.orient2hud(user)
+			pockets.show_to(user)
 	else
 		return ..()
 

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -153,8 +153,7 @@ Detective
 	r_pocket = /obj/item/weapon/lighter
 	backpack_contents = list(/obj/item/weapon/storage/box/evidence=1,\
 		/obj/item/device/detective_scanner=1,\
-		/obj/item/weapon/melee/classic_baton=1,\
-		/obj/item/weapon/reagent_containers/food/drinks/flask/det=1)
+		/obj/item/weapon/melee/classic_baton=1)
 	mask = /obj/item/clothing/mask/cigarette
 
 /datum/outfit/job/detective/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)


### PR DESCRIPTION
Fixed clicking on clothing with pockets (such as detective's fedora) not working.

This should fix bugs https://github.com/tgstation/tgstation/issues/22094 and https://github.com/tgstation/tgstation/issues/20676.

The storage object was supposed to have its "orient2hud" method called, but it was being skipped.

:cl: spudboy
fix: Fixed items not appearing in the detective's fedora.
/:cl:

With this fix the detective starts with 2 detective flasks. Idk if that's intended but it'd be an easy fix if not.