### PR TITLE
Constant, consistent starlight

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -1,0 +1,16 @@
+//Arbitrary lighting related stuff
+
+#define LIGHTING_CIRCULAR 1									//Comment this out to use old square lighting effects.
+#define LIGHTING_CAP 10										//The lumcount level at which alpha is 0 and we're fully lit.
+#define LIGHTING_CAP_FRAC (255/LIGHTING_CAP)				//A precal'd variable we'll use in turf/redraw_lighting()
+#define LIGHTING_ICON 'icons/effects/alphacolors.dmi'
+#define LIGHTING_ICON_STATE ""
+#define LIGHTING_TIME 2									//Time to do any lighting change. Actual number pulled out of my ass
+#define LIGHTING_DARKEST_VISIBLE_ALPHA 250					//Anything darker than this is so dark, we'll just consider the whole tile unlit
+#define LIGHTING_LUM_FOR_FULL_BRIGHT 6						//Anything who's lum is lower then this starts off less bright.
+#define LIGHTING_MIN_RADIUS 4								//Lowest radius a light source can effect.
+
+
+//different modes that lights can operate in
+#define LIGHTING_REGULAR 1									//Apply all effects additively
+#define LIGHTING_STARLIGHT 2								//Track all starlight but only apply brightest

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -54,7 +54,8 @@
 			if(isspaceturf(t))
 				//let's NOT update this that much pls
 				continue
-			SetLuminosity(4,1)
+			SetLuminosity(4,5)
+			light.mode = LIGHTING_STARLIGHT
 			return
 		SetLuminosity(0)
 

--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -26,23 +26,13 @@
 		Colored lights
 */
 
-#define LIGHTING_CIRCULAR 1									//Comment this out to use old square lighting effects.
-//#define LIGHTING_LAYER 15									//Drawing layer for lighting, moved to layers.dm
-#define LIGHTING_CAP 10										//The lumcount level at which alpha is 0 and we're fully lit.
-#define LIGHTING_CAP_FRAC (255/LIGHTING_CAP)				//A precal'd variable we'll use in turf/redraw_lighting()
-#define LIGHTING_ICON 'icons/effects/alphacolors.dmi'
-#define LIGHTING_ICON_STATE ""
-#define LIGHTING_TIME 2									//Time to do any lighting change. Actual number pulled out of my ass
-#define LIGHTING_DARKEST_VISIBLE_ALPHA 250					//Anything darker than this is so dark, we'll just consider the whole tile unlit
-#define LIGHTING_LUM_FOR_FULL_BRIGHT 6						//Anything who's lum is lower then this starts off less bright.
-#define LIGHTING_MIN_RADIUS 4								//Lowest radius a light source can effect.
-
 /datum/light_source
 	var/atom/owner
 	var/radius = 0
 	var/luminosity = 0
 	var/cap = 0
 	var/changed = 0
+	var/mode = LIGHTING_REGULAR
 	var/list/effect = list()
 	var/__x = 0		//x coordinate at last update
 	var/__y = 0		//y coordinate at last update
@@ -104,10 +94,8 @@
 //Remove current effect
 /datum/light_source/proc/remove_effect().
 	for(var/turf/T in effect)
-		T.update_lumcount(-effect[T])
-
-		if(T.affecting_lights && T.affecting_lights.len)
-			T.affecting_lights -= src
+		LAZYREMOVE(T.affecting_lights, src)
+		T.update_lumcount(-effect[T], mode)
 
 	effect.Cut()
 
@@ -151,10 +139,9 @@
 
 		if(delta_lumcount > 0)
 			effect[T] = delta_lumcount
-			T.update_lumcount(delta_lumcount)
+			T.update_lumcount(delta_lumcount, mode)
 
-			if(!T.affecting_lights)
-				T.affecting_lights = list()
+			LAZYINITLIST(T.affecting_lights)
 			T.affecting_lights |= src
 
 	return 1
@@ -259,7 +246,8 @@
 	var/lighting_lumcount = 0
 	var/lighting_changed = 0
 	var/atom/movable/light/lighting_object //Will be null for space turfs and anything in a static lighting area
-	var/list/affecting_lights			//not initialised until used (even empty lists reserve a fair bit of memory)
+	var/list/affecting_lights			//all /light_source affecting this turf, lazy initialized
+	var/starlight = 0					//Amount of starlight hitting this turf
 
 /turf/ChangeTurf(path)
 	if(!path || (!use_preloader && path == type)) //Sucks this is here but it would cause problems otherwise.
@@ -295,14 +283,34 @@
 	for(var/turf/open/space/S in RANGE_TURFS(1,src)) //RANGE_TURFS is in code\__HELPERS\game.dm
 		S.update_starlight()
 
-/turf/proc/update_lumcount(amount)
-	lighting_lumcount += amount
+/turf/proc/update_lumcount(amount, mode)
+	switch(mode)
+		if(LIGHTING_REGULAR)
+			lighting_lumcount += amount
+		if(LIGHTING_STARLIGHT)
+			if(amount > starlight)
+				lighting_lumcount -= starlight
+				starlight = amount
+				lighting_lumcount += amount
+			else if(amount && amount == -starlight)
+				lighting_lumcount -= starlight
+				starlight = 0
+				for(var/thing in affecting_lights)
+					var/datum/light_source/LS = thing
+					if(LS.mode == LIGHTING_STARLIGHT)
+						var/starlight_test = LS.effect[src]
+						if(starlight < starlight_test)
+							starlight = starlight_test
+				lighting_lumcount += starlight
+
 	if(!lighting_changed)
 		SSlighting.changed_turfs += src
 		lighting_changed = 1
 
-/turf/open/space/update_lumcount(amount) //Keep track in case the turf becomes a floor at some point, but don't process.
-	lighting_lumcount += amount
+/turf/open/space/update_lumcount(amount, mode) //Keep track in case the turf becomes a floor at some point, but don't process.
+	lighting_changed = TRUE
+	..()
+	lighting_changed = FALSE
 
 /turf/proc/init_lighting()
 	var/area/A = loc
@@ -373,17 +381,6 @@
 	for(var/turf/T in src.contents)
 		T.init_lighting()
 		T.update_lumcount(0)
-
-#undef LIGHTING_CIRCULAR
-#undef LIGHTING_ICON
-#undef LIGHTING_ICON_STATE
-#undef LIGHTING_TIME
-#undef LIGHTING_CAP
-#undef LIGHTING_CAP_FRAC
-#undef LIGHTING_DARKEST_VISIBLE_ALPHA
-#undef LIGHTING_LUM_FOR_FULL_BRIGHT
-#undef LIGHTING_MIN_RADIUS
-
 
 //set the changed status of all lights which could have possibly lit this atom.
 //We don't need to worry about lights which lit us but moved away, since they will have change status set already

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -35,6 +35,7 @@
 #include "code\__DEFINES\hud.dm"
 #include "code\__DEFINES\is_helpers.dm"
 #include "code\__DEFINES\layers.dm"
+#include "code\__DEFINES\lighting.dm"
 #include "code\__DEFINES\machines.dm"
 #include "code\__DEFINES\math.dm"
 #include "code\__DEFINES\MC.dm"


### PR DESCRIPTION
Currently starlight applies multiple times for each space turf. This is stupid. Instead we'll only apply the brightest starlight to each tile. Looks much better.

Also I moved all the lighting defines into the defines folder.

Picture of after, I don't have a before of this situation. If people really really want one I'll get one.

![dreamseeker_2016-12-17_01-08-34](https://cloud.githubusercontent.com/assets/1389934/21285827/535e9bfe-c3f8-11e6-8651-b939da81af13.png)

:cl:
add: Starlight will have more of a gradient and generally shine a more constant amount of light regardless of how many tiles are touching space. In dark places with long borders to space, starlight will be much darker.
/:cl: