### PR TITLE
glass and sand fixes and code improvements (and chem dispensers)

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -359,8 +359,6 @@
 			if(!istype(O))
 				return
 			if(!H.shoes)
-				H.apply_damage(5, BRUTE, picked_def_zone)
-				H.Weaken(3)
 				if(cooldown < world.time - 10) //cooldown to avoid message spam.
 					if(!H.incapacitated())
 						H.visible_message("<span class='danger'>[H] steps in the broken glass!</span>", \
@@ -368,5 +366,6 @@
 					else
 						H.visible_message("<span class='danger'>[H] slides on the broken glass!</span>", \
 								"<span class='userdanger'>You slide on the broken glass!</span>")
-
 					cooldown = world.time
+				H.apply_damage(5, BRUTE, picked_def_zone)
+				H.Weaken(3)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -91,26 +91,18 @@
 		return
 	var/mob/living/carbon/human/C = hit_atom
 	if(C.head && C.head.flags_cover & HEADCOVERSEYES)
-		if(cooldown < world.time - 10)
-			visible_message("<span class='danger'>[C]'s headgear blocks the [src]!</span>")
-			cooldown = world.time
+		visible_message("<span class='danger'>[C]'s headgear blocks the sand!</span>")
 		return
 	if(C.wear_mask && C.wear_mask.flags_cover & MASKCOVERSEYES)
-		if(cooldown < world.time - 10)
-			visible_message("<span class='danger'>[C]'s mask blocks the [src]!</span>")
-			cooldown = world.time
-			return
+		visible_message("<span class='danger'>[C]'s mask blocks the sand!</span>")
+		return
 	if(C.glasses && C.glasses.flags_cover & GLASSESCOVERSEYES)
-		if(cooldown < world.time - 10)
-			visible_message("<span class='danger'>[C]'s glasses block the [src]!</span>")
-			cooldown = world.time
+		visible_message("<span class='danger'>[C]'s glasses block the sand!</span>")
 		return
 	C.adjust_blurriness(6)
 	C.adjustStaminaLoss(15)//the pain from your eyes burning does stamina damage
 	C.confused += 5
-	if(cooldown < world.time - 10)
-		C << "<span class='userdanger'>\The [src] gets into your eyes! The pain, it burns!</span>"
-		cooldown = world.time
+	C << "<span class='userdanger'>\The [src] gets into your eyes! The pain, it burns!</span>"
 	qdel(src)
 
 /obj/item/weapon/ore/glass/basalt

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -65,6 +65,7 @@
 	materials = list(MAT_GLASS=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/glass
 	w_class = WEIGHT_CLASS_TINY
+	var/cooldown = 0
 
 /obj/item/weapon/ore/glass/attack_self(mob/living/user)
 	user << "<span class='notice'>You use the sand to make sandstone.</span>"
@@ -90,18 +91,26 @@
 		return
 	var/mob/living/carbon/human/C = hit_atom
 	if(C.head && C.head.flags_cover & HEADCOVERSEYES)
-		visible_message("<span class='danger'>[C]'s headgear blocks the sand!</span>")
+		if(cooldown < world.time - 10)
+			visible_message("<span class='danger'>[C]'s headgear blocks the [src]!</span>")
+			cooldown = world.time
 		return
 	if(C.wear_mask && C.wear_mask.flags_cover & MASKCOVERSEYES)
-		visible_message("<span class='danger'>[C]'s mask blocks the sand!</span>")
-		return
+		if(cooldown < world.time - 10)
+			visible_message("<span class='danger'>[C]'s mask blocks the [src]!</span>")
+			cooldown = world.time
+			return
 	if(C.glasses && C.glasses.flags_cover & GLASSESCOVERSEYES)
-		visible_message("<span class='danger'>[C]'s glasses block the sand!</span>")
+		if(cooldown < world.time - 10)
+			visible_message("<span class='danger'>[C]'s glasses block the [src]!</span>")
+			cooldown = world.time
 		return
 	C.adjust_blurriness(6)
 	C.adjustStaminaLoss(15)//the pain from your eyes burning does stamina damage
 	C.confused += 5
-	C << "<span class='userdanger'>\The [src] gets into your eyes! The pain, it burns!</span>"
+	if(cooldown < world.time - 10)
+		C << "<span class='userdanger'>\The [src] gets into your eyes! The pain, it burns!</span>"
+		cooldown = world.time
 	qdel(src)
 
 /obj/item/weapon/ore/glass/basalt

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -167,7 +167,11 @@
 				. = TRUE
 
 /obj/machinery/chem_dispenser/attackby(obj/item/I, mob/user, params)
-	if(default_unfasten_wrench(user, I))
+	if(istype(I, /obj/item/weapon/wrench))
+		anchored = !anchored
+		power_change()
+		user << "<span class='notice'>You [anchored ? "attached" : "detached"] [src].</span>"
+		playsound(loc, I.usesound, 75, 1)
 		return
 
 	if(istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER))


### PR DESCRIPTION
- adds a cooldown to the sand-in-your-eyes messages.
- properly fixes the step-on-glass message.
- fixes you automatically re-wrenching the chem dispenser after you unwrench it.
- makes the sand-in-your-eyes message use [src] so that's that.

yeah sure

edit: dubs get.

edit: fixes #22258