### PR TITLE
Revenants will be revealed by ocular wardens when targeted

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -64,6 +64,8 @@
 //Simple animals
 #define isanimal(A) (istype(A, /mob/living/simple_animal))
 
+#define isrevenant(A) (istype(A, /mob/living/simple_animal/revenant))
+
 #define isborer(A) (istype(A, /mob/living/simple_animal/borer))
 
 #define isbot(A) (istype(A, /mob/living/simple_animal/bot))

--- a/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
@@ -64,6 +64,12 @@
 			if(isliving(target))
 				var/mob/living/L = target
 				if(!L.null_rod_check())
+					if(isrevenant(L))
+						var/mob/living/simple_animal/revenant/R = L
+						if(R.revealed)
+							R.unreveal_time += 2
+						else
+							R.reveal(10)
 					L.adjustFireLoss((!iscultist(L) ? damage_per_tick : damage_per_tick * 2) * get_efficiency_mod()) //Nar-Sian cultists take additional damage
 					if(ratvar_awakens && L)
 						L.adjust_fire_stacks(damage_per_tick)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -150,9 +150,9 @@
 	log_say("[key_name(src)] : [message]")
 	var/rendered = "<span class='revennotice'><b>[src]</b> says, \"[message]\"</span>"
 	for(var/mob/M in mob_list)
-		if(istype(M, /mob/living/simple_animal/revenant))
+		if(isrevenant(M))
 			M << rendered
-		if(isobserver(M))
+		else if(isobserver(M))
 			var/link = FOLLOW_LINK(M, src)
 			M << "[link] [rendered]"
 	return
@@ -420,7 +420,7 @@
 	..()
 
 /datum/objective/revenant/check_completion()
-	if(!istype(owner.current, /mob/living/simple_animal/revenant))
+	if(!isrevenant(owner.current))
 		return 0
 	var/mob/living/simple_animal/revenant/R = owner.current
 	if(!R || R.stat == DEAD)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -253,7 +253,7 @@
 			var/turf/open/floor/stepTurf = get_step(L, direct)
 			for(var/obj/effect/decal/cleanable/salt/S in stepTurf)
 				L << "<span class='warning'>[S] bars your passage!</span>"
-				if(istype(L, /mob/living/simple_animal/revenant))
+				if(isrevenant(L))
 					var/mob/living/simple_animal/revenant/R = L
 					R.reveal(20)
 					R.stun(20)


### PR DESCRIPTION
:cl: Joan
rscadd: Revenants will be revealed by ocular wardens when targeted.
/:cl:

Ocular wardens can't damage hidden revenants, but would still target them. So, instead of preventing them from attacking revenants, they'll reveal the revenant as long as it's a target for them.