### PR TITLE
EMPs will generally fuck up clockwork structures

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -106,6 +106,9 @@
 /obj/structure/destructible/clockwork/geis_binding/attack_hand(mob/living/user)
 	return
 
+/obj/structure/destructible/clockwork/geis_binding/emp_act(severity)
+	qdel(src)
+
 /obj/structure/destructible/clockwork/geis_binding/post_buckle_mob(mob/living/M)
 	if(M.buckled == src)
 		desc = "A flickering, glowing purple ring around [M]."

--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -107,6 +107,7 @@
 	return
 
 /obj/structure/destructible/clockwork/geis_binding/emp_act(severity)
+	PoolOrNew(/obj/effect/overlay/temp/emp, loc)
 	qdel(src)
 
 /obj/structure/destructible/clockwork/geis_binding/post_buckle_mob(mob/living/M)

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -99,6 +99,12 @@
 /mob/living/simple_animal/hostile/clockwork/fragment/Process_Spacemove(movement_dir = 0)
 	return 1
 
+/mob/living/simple_animal/hostile/clockwork/fragment/emp_act(severity)
+	if(movement_delay_time > world.time)
+		movement_delay_time = movement_delay_time + (50/severity)
+	else
+		movement_delay_time = world.time + (50/severity)
+
 /mob/living/simple_animal/hostile/clockwork/fragment/movement_delay()
 	. = ..()
 	if(movement_delay_time > world.time && !ratvar_awakens)

--- a/code/game/gamemodes/clock_cult/clock_structure.dm
+++ b/code/game/gamemodes/clock_cult/clock_structure.dm
@@ -79,15 +79,24 @@
 /obj/structure/destructible/clockwork/attackby(obj/item/I, mob/user, params)
 	if(is_servant_of_ratvar(user) && istype(I, /obj/item/weapon/wrench) && unanchored_icon)
 		if(default_unfasten_wrench(user, I, 50) == SUCCESSFUL_UNFASTEN)
-			if(anchored)
-				icon_state = initial(icon_state)
-			else
-				icon_state = unanchored_icon
-				playsound(src, break_sound, 10 * get_efficiency_mod(TRUE), 1)
-				take_damage(round(max_integrity * 0.25, 1), BRUTE)
-				user << "<span class='warning'>As you unsecure [src] from the floor, you see cracks appear in its surface!</span>"
+			update_anchored(user, TRUE)
 		return 1
 	return ..()
+
+/obj/structure/destructible/clockwork/proc/update_anchored(mob/user, do_damage)
+	if(anchored)
+		icon_state = initial(icon_state)
+	else
+		icon_state = unanchored_icon
+		if(do_damage)
+			playsound(src, break_sound, 10 * get_efficiency_mod(TRUE), 1)
+			take_damage(round(max_integrity * 0.25, 1), BRUTE)
+		user << "<span class='warning'>As you unsecure [src] from the floor, you see cracks appear in its surface!</span>"
+
+/obj/structure/destructible/clockwork/emp_act(severity)
+	if(anchored && unanchored_icon)
+		anchored = FALSE
+		update_anchored(null, obj_integrity > max_integrity * 0.25)
 
 
 //for the ark and Ratvar
@@ -166,6 +175,12 @@
 			STOP_PROCESSING(SSobj, src)
 	return TRUE
 
+/obj/structure/destructible/clockwork/powered/proc/forced_disable(bad_effects)
+	if(active)
+		toggle()
+
+/obj/structure/destructible/clockwork/powered/emp_act(severity)
+	forced_disable(TRUE)
 
 /obj/structure/destructible/clockwork/powered/proc/total_accessable_power() //how much power we have and can use
 	if(!needs_power || ratvar_awakens)

--- a/code/game/gamemodes/clock_cult/clock_structure.dm
+++ b/code/game/gamemodes/clock_cult/clock_structure.dm
@@ -97,6 +97,7 @@
 	if(anchored && unanchored_icon)
 		anchored = FALSE
 		update_anchored(null, obj_integrity > max_integrity * 0.25)
+		PoolOrNew(/obj/effect/overlay/temp/emp, loc)
 
 
 //for the ark and Ratvar
@@ -180,7 +181,8 @@
 		toggle()
 
 /obj/structure/destructible/clockwork/powered/emp_act(severity)
-	forced_disable(TRUE)
+	if(forced_disable(TRUE))
+		PoolOrNew(/obj/effect/overlay/temp/emp, loc)
 
 /obj/structure/destructible/clockwork/powered/proc/total_accessable_power() //how much power we have and can use
 	if(!needs_power || ratvar_awakens)

--- a/code/game/gamemodes/clock_cult/clock_structures/clockwork_obelisk.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/clockwork_obelisk.dm
@@ -31,17 +31,11 @@
 		return FAILED_UNFASTEN
 	return ..()
 
-/obj/structure/destructible/clockwork/powered/clockwork_obelisk/process()
-	if(!anchored)
-		return
-	if(locate(/obj/effect/clockwork/spatial_gateway) in loc)
-		icon_state = active_icon
-		density = 0
-		active = TRUE
-	else
-		icon_state = inactive_icon
-		density = 1
-		active = FALSE
+/obj/structure/destructible/clockwork/powered/clockwork_obelisk/forced_disable(bad_effects)
+	for(var/obj/effect/clockwork/spatial_gateway/SG in loc)
+		SG.ex_act(1)
+	if(bad_effects)
+		try_use_power(MIN_CLOCKCULT_POWER*5)
 
 /obj/structure/destructible/clockwork/powered/clockwork_obelisk/attack_hand(mob/living/user)
 	if(!is_servant_of_ratvar(user) || !total_accessable_power() >= hierophant_cost || !anchored)
@@ -75,3 +69,15 @@
 				clockwork_say(user, text2ratvar("Spatial Gateway, activate!"))
 			else
 				return_power(gateway_cost)
+
+/obj/structure/destructible/clockwork/powered/clockwork_obelisk/process()
+	if(!anchored)
+		return
+	if(locate(/obj/effect/clockwork/spatial_gateway) in loc)
+		icon_state = active_icon
+		density = 0
+		active = TRUE
+	else
+		icon_state = inactive_icon
+		density = 1
+		active = FALSE

--- a/code/game/gamemodes/clock_cult/clock_structures/clockwork_obelisk.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/clockwork_obelisk.dm
@@ -32,10 +32,13 @@
 	return ..()
 
 /obj/structure/destructible/clockwork/powered/clockwork_obelisk/forced_disable(bad_effects)
+	var/affected = 0
 	for(var/obj/effect/clockwork/spatial_gateway/SG in loc)
 		SG.ex_act(1)
+		affected++
 	if(bad_effects)
-		try_use_power(MIN_CLOCKCULT_POWER*5)
+		affected += try_use_power(MIN_CLOCKCULT_POWER*2)
+	return affected
 
 /obj/structure/destructible/clockwork/powered/clockwork_obelisk/attack_hand(mob/living/user)
 	if(!is_servant_of_ratvar(user) || !total_accessable_power() >= hierophant_cost || !anchored)

--- a/code/game/gamemodes/clock_cult/clock_structures/interdiction_lens.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/interdiction_lens.dm
@@ -37,6 +37,19 @@
 			return 0
 		toggle(0, user)
 
+/obj/structure/destructible/clockwork/powered/interdiction_lens/forced_disable(bad_effects)
+	if(disabled)
+		return FALSE
+	if(!active)
+		toggle(0)
+	visible_message("<span class='warning'>The gemstone suddenly turns horribly dark, writhing tendrils covering it!</span>")
+	recharging = world.time + recharge_time
+	flick("interdiction_lens_discharged", src)
+	icon_state = "interdiction_lens_inactive"
+	SetLuminosity(2,1)
+	disabled = TRUE
+	return TRUE
+
 /obj/structure/destructible/clockwork/powered/interdiction_lens/process()
 	. = ..()
 	if(recharging > world.time)
@@ -104,9 +117,4 @@
 			playsound(src, 'sound/items/PSHOOM.ogg', 50 * efficiency, 1, interdiction_range-7, 1)
 
 		if(!successfulprocess)
-			visible_message("<span class='warning'>The gemstone suddenly turns horribly dark, writhing tendrils covering it!</span>")
-			recharging = world.time + recharge_time
-			flick("interdiction_lens_discharged", src)
-			icon_state = "interdiction_lens_inactive"
-			SetLuminosity(2,1)
-			disabled = TRUE
+			forced_disable()

--- a/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
@@ -35,6 +35,28 @@
 	if(is_servant_of_ratvar(user) || isobserver(user))
 		user << "<span class='sevtug_small'>It requires <b>[mania_cost]W</b> to run, and <b>[convert_attempt_cost + convert_cost]W</b> to convert humans adjecent to it.</span>"
 
+/obj/structure/destructible/clockwork/powered/mania_motor/forced_disable(bad_effects)
+	if(active)
+		if(bad_effects)
+			try_use_power(MIN_CLOCKCULT_POWER*5)
+		visible_message("<span class='warning'>[src] hums loudly, then the sockets at its base fall dark!</span>")
+		playsound(src, 'sound/effects/screech.ogg', 40, 1)
+		toggle(0)
+
+/obj/structure/destructible/clockwork/powered/mania_motor/attack_hand(mob/living/user)
+	if(user.canUseTopic(src, !issilicon(user)) && is_servant_of_ratvar(user))
+		if(!total_accessable_power() >= mania_cost)
+			user << "<span class='warning'>[src] needs more power to function!</span>"
+			return 0
+		toggle(0, user)
+
+/obj/structure/destructible/clockwork/powered/mania_motor/toggle(fast_process, mob/living/user)
+	. = ..()
+	if(active)
+		SetLuminosity(2, 1)
+	else
+		SetLuminosity(0)
+
 /obj/structure/destructible/clockwork/powered/mania_motor/process()
 	if(try_use_power(mania_cost))
 		var/turf/T = get_turf(src)
@@ -126,20 +148,4 @@
 						H.confused = min(H.confused + (5 * efficiency), 60)
 
 	else
-		visible_message("<span class='warning'>[src] hums loudly, then the sockets at its base fall dark!</span>")
-		playsound(src, 'sound/effects/screech.ogg', 40, 1)
-		toggle(0)
-
-/obj/structure/destructible/clockwork/powered/mania_motor/attack_hand(mob/living/user)
-	if(user.canUseTopic(src, !issilicon(user)) && is_servant_of_ratvar(user))
-		if(!total_accessable_power() >= mania_cost)
-			user << "<span class='warning'>[src] needs more power to function!</span>"
-			return 0
-		toggle(0, user)
-
-/obj/structure/destructible/clockwork/powered/mania_motor/toggle(fast_process, mob/living/user)
-	. = ..()
-	if(active)
-		SetLuminosity(2, 1)
-	else
-		SetLuminosity(0)
+		forced_disable(FALSE)

--- a/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
@@ -38,10 +38,11 @@
 /obj/structure/destructible/clockwork/powered/mania_motor/forced_disable(bad_effects)
 	if(active)
 		if(bad_effects)
-			try_use_power(MIN_CLOCKCULT_POWER*5)
+			try_use_power(MIN_CLOCKCULT_POWER*2)
 		visible_message("<span class='warning'>[src] hums loudly, then the sockets at its base fall dark!</span>")
 		playsound(src, 'sound/effects/screech.ogg', 40, 1)
-		toggle(0)
+		toggle()
+		return TRUE
 
 /obj/structure/destructible/clockwork/powered/mania_motor/attack_hand(mob/living/user)
 	if(user.canUseTopic(src, !issilicon(user)) && is_servant_of_ratvar(user))

--- a/code/game/gamemodes/clock_cult/clock_structures/mending_motor.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/mending_motor.dm
@@ -55,6 +55,36 @@
 		which is equivalent to <b>[stored_alloy]W/[max_alloy]W</b> of power.</span>"
 		user << "<span class='inathneq_small'>It requires at least <b>[MIN_CLOCKCULT_POWER]W</b> to attempt to repair clockwork mobs, structures, or converted silicons.</span>"
 
+/obj/structure/destructible/clockwork/powered/mending_motor/forced_disable(bad_effects)
+	if(active)
+		if(bad_effects)
+			try_use_power(MIN_CLOCKCULT_POWER*5)
+		visible_message("<span class='warning'>[src] emits an airy chuckling sound and falls dark!</span>")
+		toggle()
+
+/obj/structure/destructible/clockwork/powered/mending_motor/attack_hand(mob/living/user)
+	if(user.canUseTopic(src, !issilicon(user)) && is_servant_of_ratvar(user))
+		if(total_accessable_power() < MIN_CLOCKCULT_POWER)
+			user << "<span class='warning'>[src] needs more power or replicant alloy to function!</span>"
+			return 0
+		toggle(0, user)
+
+/obj/structure/destructible/clockwork/powered/mending_motor/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/clockwork/component/replicant_alloy) && is_servant_of_ratvar(user))
+		if(stored_alloy + REPLICANT_ALLOY_POWER > max_alloy)
+			user << "<span class='warning'>[src] is too full to accept any more alloy!</span>"
+			return 0
+		playsound(user, 'sound/machines/click.ogg', 50, 1)
+		clockwork_say(user, text2ratvar("Transmute into fuel."), TRUE)
+		user << "<span class='brass'>You force [I] to liquify and pour it into [src]'s compartments. \
+		It now contains <b>[stored_alloy*CLOCKCULT_POWER_TO_ALLOY_MULTIPLIER]/[max_alloy*CLOCKCULT_POWER_TO_ALLOY_MULTIPLIER]</b> units of liquified alloy.</span>"
+		stored_alloy = stored_alloy + REPLICANT_ALLOY_POWER
+		user.drop_item()
+		qdel(I)
+		return 1
+	else
+		return ..()
+
 /obj/structure/destructible/clockwork/powered/mending_motor/process()
 	var/efficiency = get_efficiency_mod()
 	for(var/atom/movable/M in range(7, src))
@@ -112,29 +142,4 @@
 					break
 	. = ..()
 	if(. < MIN_CLOCKCULT_POWER)
-		visible_message("<span class='warning'>[src] emits an airy chuckling sound and falls dark!</span>")
-		toggle()
-		return
-
-/obj/structure/destructible/clockwork/powered/mending_motor/attack_hand(mob/living/user)
-	if(user.canUseTopic(src, !issilicon(user)) && is_servant_of_ratvar(user))
-		if(total_accessable_power() < MIN_CLOCKCULT_POWER)
-			user << "<span class='warning'>[src] needs more power or replicant alloy to function!</span>"
-			return 0
-		toggle(0, user)
-
-/obj/structure/destructible/clockwork/powered/mending_motor/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/clockwork/component/replicant_alloy) && is_servant_of_ratvar(user))
-		if(stored_alloy + REPLICANT_ALLOY_POWER > max_alloy)
-			user << "<span class='warning'>[src] is too full to accept any more alloy!</span>"
-			return 0
-		playsound(user, 'sound/machines/click.ogg', 50, 1)
-		clockwork_say(user, text2ratvar("Transmute into fuel."), TRUE)
-		user << "<span class='brass'>You force [I] to liquify and pour it into [src]'s compartments. \
-		It now contains <b>[stored_alloy*CLOCKCULT_POWER_TO_ALLOY_MULTIPLIER]/[max_alloy*CLOCKCULT_POWER_TO_ALLOY_MULTIPLIER]</b> units of liquified alloy.</span>"
-		stored_alloy = stored_alloy + REPLICANT_ALLOY_POWER
-		user.drop_item()
-		qdel(I)
-		return 1
-	else
-		return ..()
+		forced_disable(FALSE)

--- a/code/game/gamemodes/clock_cult/clock_structures/mending_motor.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/mending_motor.dm
@@ -58,9 +58,10 @@
 /obj/structure/destructible/clockwork/powered/mending_motor/forced_disable(bad_effects)
 	if(active)
 		if(bad_effects)
-			try_use_power(MIN_CLOCKCULT_POWER*5)
+			try_use_power(MIN_CLOCKCULT_POWER*2)
 		visible_message("<span class='warning'>[src] emits an airy chuckling sound and falls dark!</span>")
 		toggle()
+		return TRUE
 
 /obj/structure/destructible/clockwork/powered/mending_motor/attack_hand(mob/living/user)
 	if(user.canUseTopic(src, !issilicon(user)) && is_servant_of_ratvar(user))

--- a/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
@@ -40,6 +40,16 @@
 		for(var/i in clockwork_component_cache)
 			user << "<span class='[get_component_span(i)]_small'><i>[get_component_name(i)]:</i> <b>[get_component_cost(i)]W</b> <i>([clockwork_component_cache[i]] exist[clockwork_component_cache[i] == 1 ? "s" : ""])</i></span>"
 
+/obj/structure/destructible/clockwork/powered/tinkerers_daemon/forced_disable(bad_effects)
+	if(active)
+		if(bad_effects)
+			try_use_power(MIN_CLOCKCULT_POWER*10)
+			visible_message("<span class='warning'>[src] shuts down with a horrible grinding noise!</span>")
+			playsound(src, 'sound/magic/clockwork/anima_fragment_attack.ogg', 50, 1)
+		else
+			visible_message("<span class='warning'>[src] shuts down!</span>")
+		toggle()
+
 /obj/structure/destructible/clockwork/powered/tinkerers_daemon/attack_hand(mob/living/user)
 	if(!is_servant_of_ratvar(user))
 		user << "<span class='warning'>You place your hand on the daemon, but nothing happens.</span>"
@@ -133,8 +143,7 @@
 	else
 		min_power_usable = get_component_cost(component_id_to_produce)
 	if(!clockwork_caches || servants * 0.2 < clockwork_daemons || . < min_power_usable) //if we don't have enough to produce the lowest or what we chose to produce, cancel out
-		visible_message("<span class='warning'>[src] shuts down!</span>")
-		toggle()
+		forced_disable(FALSE)
 		return
 	if(production_time <= world.time)
 		var/component_to_generate = component_id_to_produce
@@ -152,5 +161,4 @@
 			production_time = world.time + (production_cooldown * get_efficiency_mod(TRUE)) //go on cooldown
 			visible_message("<span class='warning'>[src] hums as it produces a [get_component_name(component_to_generate)].</span>")
 		else
-			visible_message("<span class='warning'>[src] shuts down!</span>") //we shouldn't actually ever get here, as we should cancel out way before this
-			toggle()
+			forced_disable(FALSE) //we shouldn't actually ever get here, as we should cancel out way before this

--- a/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
@@ -43,12 +43,13 @@
 /obj/structure/destructible/clockwork/powered/tinkerers_daemon/forced_disable(bad_effects)
 	if(active)
 		if(bad_effects)
-			try_use_power(MIN_CLOCKCULT_POWER*10)
+			try_use_power(MIN_CLOCKCULT_POWER*2)
 			visible_message("<span class='warning'>[src] shuts down with a horrible grinding noise!</span>")
 			playsound(src, 'sound/magic/clockwork/anima_fragment_attack.ogg', 50, 1)
 		else
 			visible_message("<span class='warning'>[src] shuts down!</span>")
 		toggle()
+		return TRUE
 
 /obj/structure/destructible/clockwork/powered/tinkerers_daemon/attack_hand(mob/living/user)
 	if(!is_servant_of_ratvar(user))

--- a/code/game/gamemodes/clock_cult/clock_structures/wall_gear.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/wall_gear.dm
@@ -21,6 +21,9 @@
 	..()
 	PoolOrNew(/obj/effect/overlay/temp/ratvar/gear, get_turf(src))
 
+/obj/structure/destructible/clockwork/wall_gear/emp_act(severity)
+	return
+
 /obj/structure/destructible/clockwork/wall_gear/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/wrench))
 		default_unfasten_wrench(user, I, 10)

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -111,7 +111,7 @@
 	verb_exclaim = "proclaims"
 	verb_yell = "harangues"
 	bubble_icon = "clock"
-	heavy_emp_damage = 10
+	heavy_emp_damage = 0
 	laws = "0. Purge all untruths and honor Ratvar."
 	default_storage = /obj/item/weapon/storage/toolbox/brass/prefilled
 	seeStatic = 0


### PR DESCRIPTION
:cl: Joan
rscadd: EMPs will generally fuck up clockwork structures.
/:cl:

Geis bindings will break, powered structures will disable and consume power, clockwork obelisks will cut off gateways, interdiction lenses will disable for a long time, caches and ocular wardens will force-unanchor and take some damage, and anima fragments will slow down briefly. Cogscarabs no longer actually DIE to emps, but are still stunned by them.

Basically, I want you to throw EMP grenades at the machine cult, because that seems like a thing you should be able to do, right?
