### PR TITLE
Simplifies some wall code.

### DIFF
--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -108,7 +108,7 @@
 	..()
 
 /turf/closed/wall/mineral/plasma/proc/PlasmaBurn(temperature)
-	new /obj/structure/girder(src)
+	new girder_type(src)
 	src.ChangeTurf(/turf/open/floor/plasteel)
 	var/turf/open/T = src
 	T.atmos_spawn_air("plasma=400;TEMP=1000")

--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -4,17 +4,16 @@
 	icon = 'icons/turf/walls/cult_wall.dmi'
 	icon_state = "cult"
 	canSmoothWith = null
+	sheet_type = /obj/item/stack/sheet/runed_metal
+	sheet_amount = 1
+	girder_type = /obj/structure/girder/cult
 
 /turf/closed/wall/mineral/cult/New()
 	PoolOrNew(/obj/effect/overlay/temp/cult/turf, src)
 	..()
 
-/turf/closed/wall/mineral/cult/break_wall()
-	new/obj/item/stack/sheet/runed_metal(get_turf(src), 1)
-	return (new /obj/structure/girder/cult(src))
-
 /turf/closed/wall/mineral/cult/devastate_wall()
-	new/obj/item/stack/sheet/runed_metal(get_turf(src), 1)
+	new sheet_type(get_turf(src), sheet_amount)
 
 /turf/closed/wall/mineral/cult/narsie_act()
 	return
@@ -45,6 +44,8 @@
 	explosion_block = 2
 	hardness = 10
 	sheet_type = /obj/item/stack/tile/brass
+	sheet_amount = 1
+	girder_type = /obj/structure/destructible/clockwork/wall_gear
 	var/obj/effect/clockwork/overlay/wall/realappearence
 	var/obj/structure/destructible/clockwork/cache/linkedcache
 
@@ -120,9 +121,6 @@
 		else
 			O.loc = src
 
-/turf/closed/wall/clockwork/break_wall()
-	new sheet_type(src)
-	return new/obj/structure/destructible/clockwork/wall_gear(src)
 
 /turf/closed/wall/clockwork/devastate_wall()
 	for(var/i in 1 to 2)

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -9,6 +9,8 @@
 	var/d_state = INTACT
 	hardness = 10
 	sheet_type = /obj/item/stack/sheet/plasteel
+	sheet_amount = 1
+	girder_type = /obj/structure/girder/reinforced
 	explosion_block = 2
 
 /turf/closed/wall/r_wall/examine(mob/user)
@@ -29,12 +31,8 @@
 		if(SHEATH)
 			user << "<span class='notice'>The support rods have been <i>sliced through</i>, and the outer sheath is <b>connected loosely</b> to the girder.</span>"
 
-/turf/closed/wall/r_wall/break_wall()
-	new sheet_type(src)
-	return (new /obj/structure/girder/reinforced(src))
-
 /turf/closed/wall/r_wall/devastate_wall()
-	new sheet_type(src)
+	new sheet_type(src, sheet_amount)
 	new /obj/item/stack/sheet/metal(src, 2)
 
 /turf/closed/wall/r_wall/attack_animal(mob/living/simple_animal/M)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -11,6 +11,8 @@
 	var/hardness = 40 //lower numbers are harder. Used to determine the probability of a hulk smashing through.
 	var/slicing_duration = 100  //default time taken to slice the wall
 	var/sheet_type = /obj/item/stack/sheet/metal
+	var/sheet_amount = 2
+	var/girder_type = /obj/structure/girder
 
 	canSmoothWith = list(
 	/turf/closed/wall,
@@ -43,13 +45,11 @@
 	ChangeTurf(/turf/open/floor/plating)
 
 /turf/closed/wall/proc/break_wall()
-	var/obj/item/stack/sheet/builtin_sheet = new sheet_type(src)
-	builtin_sheet.amount = 2
-	return (new /obj/structure/girder(src))
+	new sheet_type(src, sheet_amount)
+	return new girder_type(src)
 
 /turf/closed/wall/proc/devastate_wall()
-	var/obj/item/stack/sheet/builtin_sheet = new sheet_type(src)
-	builtin_sheet.amount = 2
+	new sheet_type(src, sheet_amount)
 	new /obj/item/stack/sheet/metal(src)
 
 /turf/closed/wall/ex_act(severity, target)


### PR DESCRIPTION
To put it simply, this adds the vars girder_type and sheet_amount to the wall code, and cuts down on a small amount of now unneeded lines.

This simplifies it so adding newer walls and different wall/girder combinations is slightly simpler. It is also easier to adjust how much sheets a wall drops when deconstructed and what type of girder is left behind.

Tested and everything works as intended. Please inform me if I mixed anything.