### PR TITLE
Replaces black magic spawn with addtimers

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -122,7 +122,9 @@
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
 	addtimer(src, "chemical_mob_spawn", 50, TIMER_NORMAL, holder, 5, "Gold Slime")
-	addtimer(src, "delete_extract", 55, TIMER_UNIQUE, holder)
+	var/obj/item/slime_extract/M = holder.my_atom
+	deltimer(M.qdel_timer)
+	M.qdel_timer = addtimer(src, "delete_extract", 55, TIMER_NORMAL, holder)
 
 /datum/chemical_reaction/slime/slimecritlesser
 	name = "Slime Crit Lesser"
@@ -136,7 +138,9 @@
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
 	addtimer(src, "chemical_mob_spawn", 50, TIMER_NORMAL, holder, 3, "Lesser Gold Slime", "neutral")
-	addtimer(src, "delete_extract", 55, TIMER_UNIQUE, holder)
+	var/obj/item/slime_extract/M = holder.my_atom
+	deltimer(M.qdel_timer)
+	M.qdel_timer = addtimer(src, "delete_extract", 55, TIMER_NORMAL, holder)
 
 /datum/chemical_reaction/slime/slimecritfriendly
 	name = "Slime Crit Friendly"
@@ -150,7 +154,9 @@
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
 	addtimer(src, "chemical_mob_spawn", 50, TIMER_NORMAL, holder, 1, "Friendly Gold Slime", "neutral")
-	addtimer(src, "delete_extract", 55, TIMER_UNIQUE, holder)
+	var/obj/item/slime_extract/M = holder.my_atom
+	deltimer(M.qdel_timer)
+	M.qdel_timer = addtimer(src, "delete_extract", 55, TIMER_NORMAL, holder)
 
 //Silver
 /datum/chemical_reaction/slime/slimebork
@@ -311,7 +317,9 @@
 	var/turf/TU = get_turf(holder.my_atom)
 	TU.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
 	addtimer(src, "slime_burn", 50, TIMER_NORMAL, holder)
-	addtimer(src, "delete_extract", 55, TIMER_UNIQUE, holder)
+	var/obj/item/slime_extract/M = holder.my_atom
+	deltimer(M.qdel_timer)
+	M.qdel_timer = addtimer(src, "delete_extract", 55, TIMER_NORMAL, holder)
 
 /datum/chemical_reaction/slime/slimefire/proc/slime_burn(datum/reagents/holder)
 	if(holder && holder.my_atom)
@@ -521,7 +529,9 @@
 	log_game("Slime Explosion reaction started at [T.loc.name] ([T.x],[T.y],[T.z]). Last Fingerprint: [lastkey ? lastkey : "N/A"].")
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
 	addtimer(src, "boom", 50, TIMER_NORMAL, holder)
-	addtimer(src, "delete_extract", 55, TIMER_UNIQUE, holder)
+	var/obj/item/slime_extract/M = holder.my_atom
+	deltimer(M.qdel_timer)
+	M.qdel_timer = addtimer(src, "delete_extract", 55, TIMER_NORMAL, holder)
 
 /datum/chemical_reaction/slime/slimeexplosion/proc/boom(datum/reagents/holder)
 	if(holder && holder.my_atom)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -2,6 +2,9 @@
 /datum/chemical_reaction/slime
 
 /datum/chemical_reaction/slime/on_reaction(datum/reagents/holder)
+	delete_extract(holder)
+
+/datum/chemical_reaction/slime/proc/delete_extract(datum/reagents/holder)
 	var/obj/item/slime_extract/M = holder.my_atom
 	if(M.Uses <= 0)
 		if (!results.len) //if the slime doesn't output chemicals
@@ -119,8 +122,7 @@
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
 	addtimer(src, "chemical_mob_spawn", 50, TIMER_NORMAL, holder, 5, "Gold Slime")
-	spawn(60)
-	..()
+	addtimer(src, "delete_extract", 55, TIMER_UNIQUE, holder)
 
 /datum/chemical_reaction/slime/slimecritlesser
 	name = "Slime Crit Lesser"
@@ -134,8 +136,7 @@
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
 	addtimer(src, "chemical_mob_spawn", 50, TIMER_NORMAL, holder, 3, "Lesser Gold Slime", "neutral")
-	spawn(60)
-	..()
+	addtimer(src, "delete_extract", 55, TIMER_UNIQUE, holder)
 
 /datum/chemical_reaction/slime/slimecritfriendly
 	name = "Slime Crit Friendly"
@@ -149,8 +150,7 @@
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
 	addtimer(src, "chemical_mob_spawn", 50, TIMER_NORMAL, holder, 1, "Friendly Gold Slime", "neutral")
-	spawn(60)
-	..()
+	addtimer(src, "delete_extract", 55, TIMER_UNIQUE, holder)
 
 //Silver
 /datum/chemical_reaction/slime/slimebork
@@ -311,8 +311,7 @@
 	var/turf/TU = get_turf(holder.my_atom)
 	TU.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
 	addtimer(src, "slime_burn", 50, TIMER_NORMAL, holder)
-	spawn(60)
-	..()
+	addtimer(src, "delete_extract", 55, TIMER_UNIQUE, holder)
 
 /datum/chemical_reaction/slime/slimefire/proc/slime_burn(datum/reagents/holder)
 	if(holder && holder.my_atom)
@@ -522,8 +521,7 @@
 	log_game("Slime Explosion reaction started at [T.loc.name] ([T.x],[T.y],[T.z]). Last Fingerprint: [lastkey ? lastkey : "N/A"].")
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
 	addtimer(src, "boom", 50, TIMER_NORMAL, holder)
-	spawn(60)
-	..()
+	addtimer(src, "delete_extract", 55, TIMER_UNIQUE, holder)
 
 /datum/chemical_reaction/slime/slimeexplosion/proc/boom(datum/reagents/holder)
 	if(holder && holder.my_atom)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -13,6 +13,7 @@
 	throw_range = 6
 	origin_tech = "biotech=3"
 	var/Uses = 1 // uses before it goes inert
+	var/qdel_timer = null // deletion timer, for delayed reactions
 
 /obj/item/slime_extract/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/slimepotion/enhancer))


### PR DESCRIPTION
No observed change in behaviour. I still have no idea of how spawns were delaying the ..().
This also fixes the issue where if you consume all the uses of a cerulean-boosted gold slime in one go only one will go off before it gets deleted.
If/when #22181 gets merged it will need this fix as well.