### PR TITLE
Cogscarabs can no longer hold slabs to produce components

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -437,12 +437,15 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		if(M.ckey == key)
 			return M
 
-// Returns the atom sitting on the turf.
-// For example, using this on a disk, which is in a bag, on a mob, will return the mob because it's on the turf.
-/proc/get_atom_on_turf(atom/movable/M)
+//Returns the atom sitting on the turf.
+//For example, using this on a disk, which is in a bag, on a mob, will return the mob because it's on the turf.
+//Optional arg 'type' to stop once it reaches a specific type instead of a turf.
+/proc/get_atom_on_turf(atom/movable/M, stop_type)
 	var/atom/loc = M
 	while(loc && loc.loc && !isturf(loc.loc))
 		loc = loc.loc
+		if(stop_type && istype(loc, stop_type))
+			break
 	return loc
 
 // returns the turf located at the map edge in the specified direction relative to A

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
@@ -125,21 +125,16 @@
 		production_slowdown = min(SLAB_SERVANT_SLOWDOWN * servants, SLAB_SLOWDOWN_MAXIMUM) //SLAB_SERVANT_SLOWDOWN additional seconds for each servant above 5, up to SLAB_SLOWDOWN_MAXIMUM
 	production_time = world.time + SLAB_PRODUCTION_TIME + production_slowdown
 	var/mob/living/L
-	if(isliving(loc))
-		L = loc
-	else if(istype(loc, /obj/item/weapon/storage))
-		var/obj/item/weapon/storage/W = loc
-		if(isliving(W.loc)) //Only goes one level down - otherwise it won't produce components
-			L = W.loc
-	if(L)
+	L = get_atom_on_turf(src, /mob/living)
+	if(istype(L) && is_servant_of_ratvar(L) && (nonhuman_usable || ishuman(L)))
 		var/component_to_generate = get_weighted_component_id(src) //more likely to generate components that we have less of
 		stored_components[component_to_generate]++
 		update_slab_info(src)
 		for(var/obj/item/clockwork/slab/S in L.GetAllContents()) //prevent slab abuse today
 			if(L == src)
 				continue
-			S.production_time = world.time + SLAB_PRODUCTION_TIME
-		L << "<span class='warning'>Your slab clunks as it produces a new component.</span>"
+			S.production_time = production_time + 50 //set it to our next production plus five seconds, so that if you hold the same slabs, the same one will always generate
+		L << "<span class='warning'>Your slab cl[pick("ank", "ink", "unk", "ang")]s as it produces a new component.</span>"
 
 /obj/item/clockwork/slab/examine(mob/user)
 	..()


### PR DESCRIPTION
:cl: Joan
rscdel: Cogscarabs can no longer hold slabs to produce components.
rscadd: Slabs will now produce components even if in a box in your backpack inside of a bag of holding on your back; any depth you can hide the slab in will still produce components.
bugfix: Non-Servants in possession of clockwork slabs will also no longer produce components.
/:cl:

This was honestly pretty weird and exploit-y and I never actually intended it, so I'm removing it and giving a small buff to hiding slabs(try a cheese wheel or some bread!)
