### PR TITLE
Fixes paper wizard not spawning the loot

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -153,13 +153,16 @@
 	visible_message("<span class='boldannounce'>The wizard cries out in pain as a gate appears behind him, sucking him in!</span>")
 	playsound(get_turf(src),'sound/magic/MandSwap.ogg', 50, 1, 1)
 	playsound(get_turf(src),'sound/hallucinations/wail.ogg', 50, 1, 1)
-	spawn(16)
-		for(var/mob/M in range(7,src))
-			shake_camera(M, 7, 1)
-		playsound(get_turf(src),'sound/magic/Summon_Magic.ogg', 50, 1, 1)
-		new /obj/effect/overlay/temp/paper_scatter(src)
-		new /obj/item/clothing/suit/wizrobe/paper(src)
-		new /obj/item/clothing/head/collectable/paper(src)
+	
+/obj/effect/overlay/temp/paperwiz_dying/Destroy()
+	for(var/mob/M in range(7,src))
+		shake_camera(M, 7, 1)
+	var/turf/T = get_turf(src)
+	playsound(T,'sound/magic/Summon_Magic.ogg', 50, 1, 1)
+	new /obj/effect/overlay/temp/paper_scatter(T)
+	new /obj/item/clothing/suit/wizrobe/paper(T)
+	new /obj/item/clothing/head/collectable/paper(T)
+	return ..()
 
 
 


### PR DESCRIPTION
Also removes spawn() and moves the spawn code to Destroy
:cl: Lzimann
fix: Mjor the Creative will drop his loot correctly now.
/:cl:

I think the new proc was changed so it was spawning inside the effect instead of the turf. Also removes a spawn.