### PR TITLE
Fix a qdel loop in two handed weapons

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -80,6 +80,7 @@
 	var/obj/item/weapon/twohanded/offhand/O = new(user) ////Let's reserve his other hand~
 	O.name = "[name] - offhand"
 	O.desc = "Your second grip on [src]."
+	O.wielded = TRUE 
 	user.put_in_inactive_hand(O)
 	return
 
@@ -121,10 +122,14 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/item/weapon/twohanded/offhand/unwield()
-	qdel(src)
+	if(wielded)//Only delete if we're wielded
+		wielded = FALSE
+		qdel(src)
 
 /obj/item/weapon/twohanded/offhand/wield()
-	qdel(src)
+	if(wielded)//Only delete if we're wielded
+		wielded = FALSE
+		qdel(src)
 
 ///////////Two hand required objects///////////////
 //This is for objects that require two hands to even pick up


### PR DESCRIPTION
The offhand was deleted in unwield which can be called by dropped, which
can be called by unequip, which can be called by Destroy

By explicitly using wield as a guard, we avoid this
