### PR TITLE
Fixes a warning

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -135,7 +135,6 @@
 		M.visible_message("<span class='warning'>[src] snaps into glowing pieces and dissipates!</span>")
 		for(var/obj/item/geis_binding/GB in M.held_items)
 			M.unEquip(GB, TRUE)
-		qdel(src)
 
 /obj/structure/destructible/clockwork/geis_binding/relaymove(mob/user, direction)
 	if(isliving(user))

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
@@ -149,7 +149,8 @@
 	var/obj/structure/destructible/clockwork/geis_binding/binding
 
 /datum/clockwork_scripture/geis/Destroy()
-	qdel(binding)
+	if(binding && !qdeleted(binding))
+		qdel(binding)
 	return ..()
 
 /datum/clockwork_scripture/geis/can_recite()


### PR DESCRIPTION
There were two possible things happening to cause this:

A: The scripture finishes properly; it calls Destroy on itself, calling qdel() on the binding, which eventually called post_buckle_mob() and calling qdel() on the binding again. The qdel() in post_buckle_mob() wasn't required, so it needed to go.

B: Someone breaks the binding,  calling qdel() on the binding, which caused the scripture to qdel() the binding again, assuming that the binding still existed/wasn't being deleted at the point the scripture was trying to delete it. Both qdel()s were needed, so the scripture makes sure the binding isn't being deleted.