### PR TITLE
PAI notifications no longer flood people who are not observers (admins who can hear dchat) and people who have pAI off in their preferences

### DIFF
--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -139,11 +139,13 @@ var/list/obj/item/device/paicard/pai_card_list = list()
 /datum/subsystem/pai/proc/findPAI(obj/item/device/paicard/p, mob/user)
 	if(!ghost_spam)
 		ghost_spam = TRUE
-		deadchat_broadcast("<span class='ghostalert'>Someone is requesting a pAI personality! Use the pAI button to submit yourself as one.</span>")
 		for(var/mob/dead/observer/G in player_list)
 			if(!G.key || !G.client)
 				continue
+			if(!(ROLE_PAI in G.client.prefs.be_special))
+				continue
 			G << 'sound/misc/server-ready.ogg' //Alerting them to their consideration
+			G << "<span class='ghostalert'>Someone is requesting a pAI personality! Use the pAI button to submit yourself as one.</span>"
 		addtimer(src, "spam_again", spam_delay)
 	var/list/available = list()
 	for(var/datum/paiCandidate/c in SSpai.candidates)


### PR DESCRIPTION
:cl: Mekhi Anderson
bugfix: PAI notifications no longer flood those who do not wish to be flooded.
/:cl: