### PR TITLE
Changes a few cargo pack prices (BZ can, Egun Tag pins, combat shotgun)

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -345,8 +345,8 @@
 
 /datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
-	cost = 2500
-	contains = list(/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
+	cost = 4000	
+contains = list(/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/weapon/storage/belt/bandolier,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -342,10 +342,10 @@
 					/obj/item/clothing/suit/armor/laserproof)
 	crate_name = "reflector vest crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
-
+	
 /datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
-	cost = 4000	
+	cost = 4000
 contains = list(/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -345,7 +345,7 @@
 
 /datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
-	cost = 2000
+	cost = 2500
 	contains = list(/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
@@ -356,7 +356,7 @@
 
 /datum/supply_pack/security/armory/energy
 	name = "Energy Guns Crate"
-	cost = 2500
+	cost = 2000
 	contains = list(/obj/item/weapon/gun/energy/e_gun,
 					/obj/item/weapon/gun/energy/e_gun)
 	crate_name = "energy gun crate"
@@ -909,7 +909,7 @@
 
 /datum/supply_pack/science/bz_canister
 	name = "BZ Canister"
-	cost = 4000
+	cost = 2000
 	access_any = list(access_rd, access_atmospherics)
 	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
 	crate_name = "bz canister crate"
@@ -1336,7 +1336,7 @@
 
 /datum/supply_pack/misc/lasertag/pins
 	name = "Laser Tag Firing Pins Crate"
-	cost = 2000
+	cost = 3000
 	contraband = TRUE
 	contains = list(/obj/item/weapon/storage/box/lasertagpins)
 	crate_name = "laser tag crate"


### PR DESCRIPTION
:smirk:

:cl: Hyena
tweak: Changes combat shotgun price from 2000 to 2500
tweak: Changes Energy gun price from 2500 to 2000
tweak: Changes bz canister from 3000 to 2000
tweak: Changes laser tag firing pins from 2000 to 3000
/:cl:

-Reasoning-
Tweak 1: Combat shotguns are technically the strongest weapon there is even stronger then a egun yet its cheaper then a egun
Tweak 2:Energy guns are more expensive then combat shotguns yet they are weaker then them even tasers are cheaper in price and these have instastuns
Tweak 3:BZ rarely get used as how useless it is and overpriced this will make it worth buying it when theres a slime outbreak or braindamage shenigans
Tweak 4:Laser tags are basically electronic firing pins for weaponry that requires you to wear something and it doesn't come in a locked crate either so it be a easy gun producing in rev cult and other gamemodes 
-End-