### PR TITLE
crate price changes improved edition

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -243,7 +243,7 @@
 
 /datum/supply_pack/security/laser
 	name = "Lasers Crate"
-	cost = 1500
+	cost = 2000
 	contains = list(/obj/item/weapon/gun/energy/laser,
 					/obj/item/weapon/gun/energy/laser,
 					/obj/item/weapon/gun/energy/laser)
@@ -251,7 +251,7 @@
 
 /datum/supply_pack/security/taser
 	name = "Taser Crate"
-	cost = 1500
+	cost = 3000
 	contains = list(/obj/item/weapon/gun/energy/e_gun/advtaser,
 					/obj/item/weapon/gun/energy/e_gun/advtaser,
 					/obj/item/weapon/gun/energy/e_gun/advtaser)
@@ -259,7 +259,7 @@
 
 /datum/supply_pack/security/disabler
 	name = "Disabler Crate"
-	cost = 1000
+	cost = 1500
 	contains = list(/obj/item/weapon/gun/energy/disabler,
 					/obj/item/weapon/gun/energy/disabler,
 					/obj/item/weapon/gun/energy/disabler)
@@ -345,7 +345,7 @@
 
 /datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
-	cost = 2000
+	cost = 4000
 	contains = list(/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
@@ -428,7 +428,7 @@
 
 /datum/supply_pack/security/firingpins
 	name = "Standard Firing Pins Crate"
-	cost = 1000
+	cost = 2000
 	contains = list(/obj/item/weapon/storage/box/firingpins,
 					/obj/item/weapon/storage/box/firingpins)
 	crate_name = "firing pins crate"
@@ -909,7 +909,7 @@
 
 /datum/supply_pack/science/bz_canister
 	name = "BZ Canister"
-	cost = 4000
+	cost = 2000
 	access_any = list(access_rd, access_atmospherics)
 	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
 	crate_name = "bz canister crate"
@@ -1336,7 +1336,7 @@
 
 /datum/supply_pack/misc/lasertag/pins
 	name = "Laser Tag Firing Pins Crate"
-	cost = 2000
+	cost = 3000
 	contraband = TRUE
 	contains = list(/obj/item/weapon/storage/box/lasertagpins)
 	crate_name = "laser tag crate"


### PR DESCRIPTION
🆑 Hyena
tweak: Changes combat shotgun price from 2000 to 4000
tweak: Changes bz canister from 4000 to 2000
tweak: Changes laser tag firing pins from 2000 to 3000
tweak: Changes laser gun from 1500 to 2000
tweak: Changes disabler guns from 1000 to 1500
tweak: Changes tasers from 1500 to 3000
tweak: Changes firing pins from 1000 to 2000
/🆑

-Reasoning-
Tweak 1: Combat shotguns are technically the strongest weapon there is even stronger then a egun yet its cheaper then a egun
Tweak 2:BZ rarely get used as how useless it is and overpriced this will make it worth buying it when theres a slime outbreak or braindamage shenigans
Tweak 3:Laser tags are basically electronic firing pins for weaponry that requires you to wear something and it doesn't come in a locked crate either so it be a easy gun producing in rev cult and other gamemodes
Tweak 4:Lasers gun are lethal and go trough windows plus they hold more ammo then eguns lasers
Tweak 5:Because lasers but with stamina damage
Tweak 6:Tasers are also one of the strongest weapons in the game and we shouldnt make it that cheap
Tweak:7:comes with 2 boxes 1 box 7 pins 14 guns 
-End-