### PR TITLE
Quantum Pads can now be Renamed

### DIFF
--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -7,6 +7,7 @@
 	use_power = 1
 	idle_power_usage = 200
 	active_power_usage = 5000
+	unique_rename = 1
 	var/teleport_cooldown = 400 //30 seconds base due to base parts
 	var/teleport_speed = 50
 	var/last_teleport //to handle the cooldown


### PR DESCRIPTION
:cl: Cobby
:tweak: Allows Quantum Pads to be renamed. Trust these as much as you trust the "try jumping" messages on Dark Souls.
/:cl:

This allows for quick [re]labeling of Quantum pads and was the purpose of setting `unique_rename` to /obj/.

As alluded to in the CL, feel free to use this maliciously as antag ;-)