### PR TITLE
Adds pre-calling the shuttle

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -7,8 +7,9 @@
 #define SHUTTLE_STRANDED	"stranded"
 #define SHUTTLE_ESCAPE		"escape"
 #define SHUTTLE_ENDGAME		"endgame: game over"
+#define SHUTTLE_PRECALL     "precall"
 
-#define EMERGENCY_IDLE_OR_RECALLED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_IDLE) || (SSshuttle.emergency.mode == SHUTTLE_RECALL)))
+#define EMERGENCY_IDLE_OR_RECALLED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_IDLE) || (SSshuttle.emergency.mode == SHUTTLE_RECALL) || (SSshuttle.emergency.mode == SHUTTLE_PRECALL)))
 #define EMERGENCY_ESCAPED_OR_ENDGAMED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_ESCAPE) || (SSshuttle.emergency.mode == SHUTTLE_ENDGAME)))
 #define EMERGENCY_AT_LEAST_DOCKED (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_CALL)
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -645,6 +645,8 @@
 			return "RCL"
 		if(SHUTTLE_CALL)
 			return "ETA"
+		if(SHUTTLE_PRECALL)
+			return "PRE"
 		if(SHUTTLE_DOCKED)
 			return "ETD"
 		if(SHUTTLE_ESCAPE)


### PR DESCRIPTION
:cl: coiax
add: It is now possible to pre-call the shuttle when it is refueling,
generating an automatic shuttle call when the refueling period is
complete. Cancelling this pre-call has no penalty.
/:cl:

Reasoning

Lots of time, the singuloth gets loose, or there are nuke ops, and
people are universal in the desire to CALL IT AS SOON AS POSSIBLE, and
spend ages on the bridge just waiting for the time to go down so they
can call it.

Well now, you can just call it, and it'll take care of itself.