### PR TITLE
Hydroponic Trays can now be Renamed

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -4,7 +4,8 @@
 	icon_state = "hydrotray"
 	density = 1
 	anchored = 1
-	pixel_y=8
+	pixel_y = 8
+	unique_rename = 1
 	var/waterlevel = 100	//The amount of water in the tray (max 100)
 	var/maxwater = 100		//The maximum amount of water in the tray
 	var/nutrilevel = 10		//The amount of nutrient in the tray (max 10)


### PR DESCRIPTION
:cl: Cobby
:tweak: Hydroponic Trays can now be renamed with a pen. Careful not to eat from the apple tray labeled "Super Healing Apples", Snow White!
/:cl:

For the daisy holmes botanists in all of us, this is useful for public trays. Especially with the gene manipulation device, it can be hard to tell what the purpose of the plant is [healing plant, death plant, etc.]. This hopes to alleviate [or, if antag, purport] that issue.

Also spaced out that pixel_y because it was bothering me.