### PR TITLE
Easy fixes/tweaks.

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -154,7 +154,7 @@
 
 		else if(istype(W, /obj/item/weapon/weldingtool))
 			if(weld(W, user))
-				visible_message("<span class='warning'>[user] unwelds [src], leaving it as just a frame screwed to the wall.</span>", "<span class='warning'>You unweld [src], leaving it as just a frame screwed to the wall</span>")
+				visible_message("<span class='warning'>[user] unwelds [src], leaving it as just a frame attached to the wall.</span>", "<span class='warning'>You unweld [src], leaving it as just a frame attached to the wall</span>")
 				deconstruct(TRUE)
 			return
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -154,7 +154,7 @@
 
 		else if(istype(W, /obj/item/weapon/weldingtool))
 			if(weld(W, user))
-				visible_message("<span class='warning'>[user] unwelds [src], leaving it as just a frame attached to the wall.</span>", "<span class='warning'>You unweld [src], leaving it as just a frame attached to the wall</span>")
+				visible_message("<span class='warning'>[user] unwelds [src], leaving it as just a frame bolted to the wall.</span>", "<span class='warning'>You unweld [src], leaving it as just a frame bolted to the wall</span>")
 				deconstruct(TRUE)
 			return
 

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -32,9 +32,6 @@
 	if(AI)
 		user << "<span class='notice'>The AI recovery beacon is active.</span>"
 
-/obj/structure/mecha_wreckage/examine_status() // it's wreckage what more do you need to know
-	..()
-
 /obj/structure/mecha_wreckage/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/weldingtool))
 		if(salvage_num <= 0)

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -5,7 +5,7 @@
 
 /obj/structure/mecha_wreckage
 	name = "exosuit wreckage"
-	desc = "Remains of some unfortunate mecha. Completely unrepairable."
+	desc = "Remains of some unfortunate mecha. Completely unrepairable, but perhaps something can be salvaged."
 	icon = 'icons/mecha/mecha.dmi'
 	density = 1
 	anchored = 0
@@ -31,6 +31,9 @@
 	..()
 	if(AI)
 		user << "<span class='notice'>The AI recovery beacon is active.</span>"
+
+/obj/structure/mecha_wreckage/examine_status() // it's wreckage what more do you need to know
+	..()
 
 /obj/structure/mecha_wreckage/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/weldingtool))
@@ -139,6 +142,7 @@
 	name = "\improper Reticence wreckage"
 	icon_state = "reticence-broken"
 	color = "#87878715"
+	desc = "..."
 
 /obj/structure/mecha_wreckage/ripley
 	name = "\improper Ripley wreckage"
@@ -185,6 +189,7 @@
 /obj/structure/mecha_wreckage/honker
 	name = "\improper H.O.N.K wreckage"
 	icon_state = "honker-broken"
+	desc = "All is right in the universe."
 
 /obj/structure/mecha_wreckage/honker/New()
 	..()

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -42,6 +42,10 @@
 
 		H.update_hair()
 
+/obj/structure/mirror/examine_status()
+	if(broken)
+		return // no message spam
+	..()
 
 /obj/structure/mirror/obj_break(damage_flag)
 	if(!broken && !(flags & NODECONSTRUCT))

--- a/code/modules/holodeck/mobs.dm
+++ b/code/modules/holodeck/mobs.dm
@@ -17,4 +17,4 @@
 	butcher_results = list()
 	response_help = "pets"
 	response_disarm = "pushes aside"
-	response_harm = "bites"
+	response_harm = "kicks"


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/21830.

Fixes https://github.com/tgstation/tgstation/issues/22356.

Fixes https://github.com/tgstation/tgstation/issues/22148.

 I personally think it is badly designed to have both a broken flag and an object damage system, but the proc did say it was overrideable, so...

Adds some flavor and/or guidance text to mecha wreckage