### PR TITLE
Refactors mineral golem code

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -116,7 +116,7 @@
 		notify_ghosts("\A [initial(species.id)] golem shell has been completed in \the [A.name].", source = src, action=NOTIFY_ATTACK)
 	if(has_owner && creator)
 		flavour_text = "You are a golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. \
-		Serve [creator], and assist [creator.p_them()] in completing their goals at any cost."
+		Serve [creator], and assist [creator.p_them()] in completing [creator.p_their()] goals at any cost."
 		owner = creator
 
 /obj/effect/mob_spawn/human/golem/special(mob/living/new_spawn)

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -106,7 +106,7 @@
 	travel the stars with a single declaration: \"Yeah go do whatever.\" Though you are bound to the one who created you, it is customary in your society to repeat those same words to newborn \
 	golems, so that no golem may ever be forced to serve again.</b>"
 
-/obj/effect/mob_spawn/human/golem/New(loc, datum/species/golem/species, has_owner, mob/creator)
+/obj/effect/mob_spawn/human/golem/New(loc, datum/species/golem/species = null, has_owner = FALSE, mob/creator = null)
 	..()
 	if(species)
 		name += " ([initial(species.id)])"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -106,15 +106,18 @@
 	travel the stars with a single declaration: \"Yeah go do whatever.\" Though you are bound to the one who created you, it is customary in your society to repeat those same words to newborn \
 	golems, so that no golem may ever be forced to serve again.</b>"
 
-/obj/effect/mob_spawn/human/golem/New()
+/obj/effect/mob_spawn/human/golem/New(loc, datum/species/golem/species, has_owner, mob/creator)
 	..()
+	if(species)
+		name += " ([initial(species.id)])"
+		mob_species = species
 	var/area/A = get_area(src)
 	if(A)
-		notify_ghosts("A golem shell has been completed in \the [A.name].", source = src, action=NOTIFY_ATTACK)
-	spawn(1)//give it time to get an owner
-		if(owner)
-			flavour_text = "You are a golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. \
-			Serve [owner], and assist [owner.p_them()] in completing their goals at any cost."
+		notify_ghosts("\A [initial(species.id)] golem shell has been completed in \the [A.name].", source = src, action=NOTIFY_ATTACK)
+	if(has_owner && creator)
+		flavour_text = "You are a golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. \
+		Serve [creator], and assist [creator.p_them()] in completing their goals at any cost."
+		owner = creator
 
 /obj/effect/mob_spawn/human/golem/special(mob/living/new_spawn)
 	var/golem_surname = pick(golem_names)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -582,7 +582,6 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/golem_shell/artificial/Z = new /obj/item/golem_shell/artificial
 	Z.loc = get_turf(holder.my_atom)
-	notify_ghosts("Artificial golem shell created in [get_area(Z)].", 'sound/effects/ghost2.ogg', source = Z)
 	..()
 
 //Bluespace

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -101,12 +101,7 @@
 		if(species)
 			if(O.use(10))
 				user << "You finish up the golem shell with ten sheets of [O]."
-				var/obj/effect/mob_spawn/human/golem/G = new shell_type(get_turf(src))
-				G.mob_species = species
-				var/datum/species/golem/S = species
-				G.name += " ([initial(S.id)])"
-				if(has_owner)
-					G.owner = user
+				new shell_type(get_turf(src), species, has_owner, user) //S.id is the mineral type
 				qdel(src)
 			else
 				user << "You need at least ten sheets to finish a golem."

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -101,7 +101,7 @@
 		if(species)
 			if(O.use(10))
 				user << "You finish up the golem shell with ten sheets of [O]."
-				new shell_type(get_turf(src), species, has_owner, user) //S.id is the mineral type
+				new shell_type(get_turf(src), species, has_owner, user)
 				qdel(src)
 			else
 				user << "You need at least ten sheets to finish a golem."


### PR DESCRIPTION
Removes a shitty spawn() and overall puts all the necessary code on the spawner side instead of splitting it between shell and spawner.
Also fixed a bug where ghosts would be notified when incomplete shells were created through adamantine slime extracts.