### PR TITLE
Dead things can't be used to open doors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -64,7 +64,7 @@
 		return
 	if(ismob(AM))
 		var/mob/B = AM
-		if(stat)
+		if(B.stat)
 			return
 		if(isliving(AM))
 			var/mob/living/M = AM

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -62,16 +62,19 @@
 /obj/machinery/door/Bumped(atom/AM)
 	if(operating || emagged)
 		return
-
-	if(isliving(AM))
-		var/mob/living/M = AM
-		if(world.time - M.last_bumped <= 10)
-			return	//Can bump-open one airlock per second. This is to prevent shock spam.
-		M.last_bumped = world.time
-		if(M.restrained() && !check_access(null))
+	if(ismob(AM))
+		var/mob/B = AM
+		if(stat)
 			return
-		bumpopen(M)
-		return
+		if(isliving(AM))
+			var/mob/living/M = AM
+			if(world.time - M.last_bumped <= 10)
+				return	//Can bump-open one airlock per second. This is to prevent shock spam.
+			M.last_bumped = world.time
+			if(M.restrained() && !check_access(null))
+				return
+			bumpopen(M)
+			return
 
 	if(istype(AM, /obj/mecha))
 		var/obj/mecha/mecha = AM

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -71,7 +71,7 @@
 	if (!( ticker ))
 		return
 	var/mob/M = AM
-	if(!M.restrained())
+	if(!M.stat && !M.restrained())
 		bumpopen(M)
 	return
 


### PR DESCRIPTION
Fixes #22334 

:cl: Cyberboss
fix: Dead things can no longer be used to open doors
/:cl: