### PR TITLE
Autolathes can produce x5 and x10 items at a time

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -164,7 +164,7 @@
 			use_power(max(500,inserted/10))
 			qdel(O)
 	busy = 0
-	src.updateUsrDialog()
+	updateUsrDialog()
 	return 1
 
 /obj/machinery/autolathe/Topic(href, href_list)
@@ -173,9 +173,11 @@
 	if (!busy)
 		if(href_list["menu"])
 			screen = text2num(href_list["menu"])
+			updateUsrDialog()
 
 		if(href_list["category"])
 			selected_category = href_list["category"]
+			updateUsrDialog()
 
 		if(href_list["make"])
 
@@ -187,15 +189,9 @@
 			if(!being_built)
 				return
 
-			//multiplier checks : only stacks can have one and its value is 1, 10 ,25 or max_multiplier
 			var/multiplier = text2num(href_list["multiplier"])
-			var/max_multiplier = min(being_built.maxstack, being_built.materials[MAT_METAL] ?round(materials.amount(MAT_METAL)/being_built.materials[MAT_METAL]):INFINITY,being_built.materials[MAT_GLASS]?round(materials.amount(MAT_GLASS)/being_built.materials[MAT_GLASS]):INFINITY)
 			var/is_stack = ispath(being_built.build_path, /obj/item/stack)
 
-			if(!is_stack && (multiplier > 1))
-				return
-			if (!(multiplier in list(1,10,25,max_multiplier))) //"enough materials ?" is checked further down
-				return
 			/////////////////
 
 			var/coeff = (is_stack ? 1 : prod_coeff) //stacks are unaffected by production coefficient
@@ -209,9 +205,9 @@
 				use_power(power)
 				icon_state = "autolathe"
 				flick("autolathe_n",src)
-				spawn(32*coeff)
-					use_power(power)
-					if(is_stack)
+				if(is_stack)
+					spawn(32*coeff)
+						use_power(power)
 						var/list/materials_used = list(MAT_METAL=metal_cost*multiplier, MAT_GLASS=glass_cost*multiplier)
 						materials.use_amount(materials_used)
 
@@ -222,14 +218,20 @@
 						for(var/obj/item/stack/S in T.contents - N)
 							if(istype(S, N.merge_type))
 								N.merge(S)
-					else
-						var/list/materials_used = list(MAT_METAL=metal_cost*coeff, MAT_GLASS=glass_cost*coeff)
+						busy = 0
+						updateUsrDialog()
+
+				else
+					spawn(32*coeff*multiplier)
+						use_power(power)
+						var/list/materials_used = list(MAT_METAL=metal_cost*coeff*multiplier, MAT_GLASS=glass_cost*coeff*multiplier)
 						materials.use_amount(materials_used)
-						var/obj/item/new_item = new being_built.build_path(T)
-						new_item.materials = materials_used.Copy()
-						new_item.autolathe_crafted(src)
-					busy = 0
-					src.updateUsrDialog()
+						for(var/i=1, i<=multiplier, i++)
+							var/obj/item/new_item = new being_built.build_path(T)
+							new_item.materials = materials_used.Copy()
+							new_item.autolathe_crafted(src)
+						busy = 0
+						updateUsrDialog()
 
 		if(href_list["search"])
 			matching_designs.Cut()
@@ -238,10 +240,11 @@
 				var/datum/design/D = files.known_designs[v]
 				if(findtext(D.name,href_list["to_search"]))
 					matching_designs.Add(D)
+			updateUsrDialog()
 	else
 		usr << "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>"
 
-	src.updateUsrDialog()
+	updateUsrDialog()
 
 	return
 
@@ -304,6 +307,11 @@
 				dat += " <a href='?src=\ref[src];make=[D.id];multiplier=25'>x25</a>"
 			if(max_multiplier > 0 && !disabled)
 				dat += " <a href='?src=\ref[src];make=[D.id];multiplier=[max_multiplier]'>x[max_multiplier]</a>"
+		else
+			if(!disabled && can_build(D, 5))
+				dat += " <a href='?src=\ref[src];make=[D.id];multiplier=5'>x5</a>"
+			if(!disabled && can_build(D, 10))
+				dat += " <a href='?src=\ref[src];make=[D.id];multiplier=10'>x10</a>"
 
 		dat += "[get_design_cost(D)]<br>"
 
@@ -343,15 +351,15 @@
 		dat += "<b>[M.name] amount:</b> [M.amount] cm<sup>3</sup><br>"
 	return dat
 
-/obj/machinery/autolathe/proc/can_build(datum/design/D)
+/obj/machinery/autolathe/proc/can_build(datum/design/D, amount = 1)
 	if(D.make_reagents.len)
 		return 0
 
 	var/coeff = (ispath(D.build_path,/obj/item/stack) ? 1 : prod_coeff)
 
-	if(D.materials[MAT_METAL] && (materials.amount(MAT_METAL) < (D.materials[MAT_METAL] * coeff)))
+	if(D.materials[MAT_METAL] && (materials.amount(MAT_METAL) < (D.materials[MAT_METAL] * coeff * amount)))
 		return 0
-	if(D.materials[MAT_GLASS] && (materials.amount(MAT_GLASS) < (D.materials[MAT_GLASS] * coeff)))
+	if(D.materials[MAT_GLASS] && (materials.amount(MAT_GLASS) < (D.materials[MAT_GLASS] * coeff * amount)))
 		return 0
 	return 1
 


### PR DESCRIPTION
:cl: XDTM
add: Autolathes are now true to their name and can queue 5 or 10 copies of the same item.
/:cl:
Also fixed a small UI bug where it wouldn't update if you walked off but kept the window open. And removed some unnecessary src.
Reason for the PR: QoL change, very requested as far as i could see, since right now if you want to make several autolathe items all you can do is spam click on the item, which is not really fun for anyone involved.

A word of warning: each item in the autolathe takes 3.2 seconds to print, so printing 10 when unupgraded means 32 seconds of waiting
