### PR TITLE
Fixes hydro's winter coat hood bad icon

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -493,7 +493,7 @@
 	hoodtype = /obj/item/clothing/head/winterhood/hydro
 
 /obj/item/clothing/head/winterhood/hydro
-	item_state = "winterhood_hydro"
+	icon_state = "winterhood_hydro"
 
 /obj/item/clothing/suit/hooded/wintercoat/cargo
 	name = "cargo winter coat"


### PR DESCRIPTION
Fixes #22367

The back sprite is an overlay so it generates from icon_state instead of using the item_state.
