### PR TITLE
MMI'd clockcultists put in AI cores will properly lose clockcult status

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -26,3 +26,11 @@
 #define PRESSURE_ON 1
 #define PRESSURE_MAXED 2
 #define SCREWS_OUT -1
+
+//ai core defines
+#define EMPTY_CORE 0
+#define CIRCUIT_CORE 1
+#define SCREWED_CORE 2
+#define CABLED_CORE 3
+#define GLASS_CORE 4
+#define AI_READY_CORE 5

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -621,3 +621,5 @@ var/global/list/ghost_others_options = list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 // they are here to support hotkeys
 #define INTENT_HOTKEY_LEFT  "left"
 #define INTENT_HOTKEY_RIGHT "right"
+
+#define DEFAULT_AI_LAWID "default"

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -8,7 +8,7 @@
 	var/list/ion = list()
 	var/mob/living/silicon/owner
 	var/list/devillaws = null
-	var/id = "unknown"
+	var/id = DEFAULT_AI_LAWID
 
 /datum/ai_laws/proc/lawid_to_type(lawid)
 	var/all_ai_laws = subtypesof(/datum/ai_laws)

--- a/code/game/gamemodes/clock_cult/clock_items/soul_vessel.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/soul_vessel.dm
@@ -21,6 +21,7 @@
 	fluff_names = list("Judge", "Guard", "Servant", "Smith", "Auger")
 	autoping = FALSE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	force_replace_ai_name = TRUE
 
 /obj/item/device/mmi/posibrain/soul_vessel/New()
 	..()

--- a/code/game/gamemodes/clock_cult/clock_items/soul_vessel.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/soul_vessel.dm
@@ -19,12 +19,13 @@
 	new_mob_message = "<span class='brass'>The soul vessel emits a jet of steam before its cogwheel smooths out.</span>"
 	dead_message = "<span class='deadsay'>Its cogwheel, scratched and dented, lies motionless.</span>"
 	fluff_names = list("Judge", "Guard", "Servant", "Smith", "Auger")
-	clockwork = TRUE
 	autoping = FALSE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
 /obj/item/device/mmi/posibrain/soul_vessel/New()
 	..()
+	radio.on = 0
+	laws = new /datum/ai_laws/ratvar()
 	braintype = picked_fluff_name
 	all_clockwork_objects += src
 
@@ -37,6 +38,11 @@
 		desc = clockwork_desc
 	..()
 	desc = initial(desc)
+
+/obj/item/device/mmi/posibrain/soul_vessel/transfer_personality(mob/candidate)
+	. = ..()
+	if(.)
+		add_servant_of_ratvar(brainmob, TRUE)
 
 /obj/item/device/mmi/posibrain/soul_vessel/attack_self(mob/living/user)
 	if(!is_servant_of_ratvar(user))

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -24,22 +24,35 @@
 
 /obj/item/robot_suit/New()
 	..()
-	src.updateicon()
+	updateicon()
+
+/obj/item/robot_suit/prebuilt/New()
+	l_arm = new(src)
+	r_arm = new(src)
+	l_leg = new(src)
+	r_leg = new(src)
+	head = new(src)
+	head.flash1 = new(head)
+	head.flash2 = new(head)
+	chest = new(src)
+	chest.wired = TRUE
+	chest.cell = new /obj/item/weapon/stock_parts/cell/high/plus(chest)
+	..()
 
 /obj/item/robot_suit/proc/updateicon()
-	src.cut_overlays()
-	if(src.l_arm)
-		src.add_overlay("l_arm+o")
-	if(src.r_arm)
-		src.add_overlay("r_arm+o")
-	if(src.chest)
-		src.add_overlay("chest+o")
-	if(src.l_leg)
-		src.add_overlay("l_leg+o")
-	if(src.r_leg)
-		src.add_overlay("r_leg+o")
-	if(src.head)
-		src.add_overlay("head+o")
+	cut_overlays()
+	if(l_arm)
+		add_overlay("l_arm+o")
+	if(r_arm)
+		add_overlay("r_arm+o")
+	if(chest)
+		add_overlay("chest+o")
+	if(l_leg)
+		add_overlay("l_leg+o")
+	if(r_leg)
+		add_overlay("r_leg+o")
+	if(head)
+		add_overlay("head+o")
 
 /obj/item/robot_suit/proc/check_completion()
 	if(src.l_arm && src.r_arm)
@@ -155,10 +168,10 @@
 		var/obj/item/device/mmi/M = W
 		if(check_completion())
 			if(!isturf(loc))
-				user << "<span class='warning'>You can't put the MMI in, the frame has to be standing on the ground to be perfectly precise!</span>"
+				user << "<span class='warning'>You can't put [M] in, the frame has to be standing on the ground to be perfectly precise!</span>"
 				return
 			if(!M.brainmob)
-				user << "<span class='warning'>Sticking an empty MMI into the frame would sort of defeat the purpose!</span>"
+				user << "<span class='warning'>Sticking an empty [M.name] into the frame would sort of defeat the purpose!</span>"
 				return
 
 			var/mob/living/brain/BM = M.brainmob
@@ -175,7 +188,7 @@
 				return
 
 			if(jobban_isbanned(BM, "Cyborg"))
-				user << "<span class='warning'>This MMI does not seem to fit!</span>"
+				user << "<span class='warning'>This [M.name] does not seem to fit!</span>"
 				return
 
 			if(!user.unEquip(W))
@@ -185,16 +198,11 @@
 			if(!O)
 				return
 
-			if(M.hacked || M.clockwork)
+			if(M.laws && M.laws.id != DEFAULT_AI_LAWID)
 				aisync = 0
 				lawsync = 0
-				var/datum/ai_laws/L
-				if(M.clockwork)
-					L = new/datum/ai_laws/ratvar
-				else
-					L = new/datum/ai_laws/syndicate_override
-				O.laws = L
-				L.associate(O)
+				O.laws = M.laws
+				M.laws.associate(O)
 
 			O.invisibility = 0
 			//Transfer debug settings to new mob
@@ -209,12 +217,10 @@
 					O.connected_ai = forced_ai
 			if(!lawsync)
 				O.lawupdate = 0
-				if(!M.hacked && !M.clockwork)
+				if(M.laws.id == DEFAULT_AI_LAWID)
 					O.make_laws()
 
 			ticker.mode.remove_antag_for_borging(BM.mind)
-			if(!M.clockwork)
-				remove_servant_of_ratvar(BM, TRUE)
 			BM.mind.transfer_to(O)
 
 			if(O.mind && O.mind.special_role)

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -150,7 +150,7 @@
 					M.forceMove(src)
 					brain = M
 					user << "<span class='notice'>You add [M.name] to the frame.</span>"
-					update_icon()"
+					update_icon()
 					return
 
 				if(istype(P, /obj/item/weapon/crowbar) && brain)

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -179,7 +179,7 @@
 							remove_servant_of_ratvar(brain.brainmob, TRUE)
 						var/mob/living/silicon/ai/A = new /mob/living/silicon/ai(loc, laws, brain.brainmob)
 						if(brain.force_replace_ai_name)
-							fully_replace_character_name(A.name, brain.replacement_ai_name())
+							A.fully_replace_character_name(A.name, brain.replacement_ai_name())
 						feedback_inc("cyborg_ais_created",1)
 						qdel(src)
 					else

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -128,6 +128,9 @@
 					return
 
 				if(istype(P, /obj/item/weapon/aiModule))
+					if(brain && brain.laws.id != DEFAULT_AI_LAWID)
+						user << "<span class='warning'>The installed [brain.name] already has set laws!</span>"
+						return
 					var/obj/item/weapon/aiModule/module = P
 					module.install(laws, user)
 					return
@@ -135,22 +138,22 @@
 				if(istype(P, /obj/item/device/mmi) && !brain)
 					var/obj/item/device/mmi/M = P
 					if(!M.brainmob)
-						user << "<span class='warning'>Sticking an empty MMI into the frame would sort of defeat the purpose!</span>"
+						user << "<span class='warning'>Sticking an empty [M.name] into the frame would sort of defeat the purpose!</span>"
 						return
 					if(M.brainmob.stat == DEAD)
-						user << "<span class='warning'>Sticking a dead brain into the frame would sort of defeat the purpose!</span>"
+						user << "<span class='warning'>Sticking a dead [M.name] into the frame would sort of defeat the purpose!</span>"
 						return
 
 					if(!M.brainmob.client)
-						user << "<span class='warning'>Sticking an inactive brain into the frame would sort of defeat the purpose.</span>"
+						user << "<span class='warning'>Sticking an inactive [M.name] into the frame would sort of defeat the purpose.</span>"
 						return
 
-					if((config) && (!config.allow_ai) || jobban_isbanned(M.brainmob, "AI") || M.hacked || M.clockwork)
-						user << "<span class='warning'>This MMI does not seem to fit!</span>"
+					if((config) && (!config.allow_ai) || jobban_isbanned(M.brainmob, "AI"))
+						user << "<span class='warning'>This [M.name] does not seem to fit!</span>"
 						return
 
 					if(!M.brainmob.mind)
-						user << "<span class='warning'>This MMI is mindless!</span>"
+						user << "<span class='warning'>This [M.name] is mindless!</span>"
 						return
 
 					if(!user.drop_item())
@@ -158,7 +161,7 @@
 
 					M.forceMove(src)
 					brain = M
-					user << "<span class='notice'>Added a brain.</span>"
+					user << "<span class='notice'>You add [M.name] to the frame.</span>"
 					icon_state = "3b"
 					return
 
@@ -185,8 +188,10 @@
 				if(istype(P, /obj/item/weapon/screwdriver))
 					playsound(loc, P.usesound, 50, 1)
 					user << "<span class='notice'>You connect the monitor.</span>"
-					ticker.mode.remove_antag_for_borging(brain.brainmob.mind)
-					remove_servant_of_ratvar(brain.brainmob, TRUE)
+					if(brain)
+						ticker.mode.remove_antag_for_borging(brain.brainmob.mind)
+						if(!istype(brain.laws, /datum/ai_laws/ratvar))
+							remove_servant_of_ratvar(brain.brainmob, TRUE)
 					new /mob/living/silicon/ai(loc, laws, brain)
 					feedback_inc("cyborg_ais_created",1)
 					qdel(src)
@@ -211,6 +216,10 @@
 	icon_state = "ai-empty"
 	anchored = 1
 	state = GLASS_CORE
+
+/obj/structure/AIcore/deactivated/New()
+	..()
+	circuit = new(src)
 
 /obj/structure/AIcore/deactivated/attackby(obj/item/A, mob/user, params)
 	if(istype(A, /obj/item/device/aicard) && state == GLASS_CORE)

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -177,7 +177,9 @@
 						ticker.mode.remove_antag_for_borging(brain.brainmob.mind)
 						if(!istype(brain.laws, /datum/ai_laws/ratvar))
 							remove_servant_of_ratvar(brain.brainmob, TRUE)
-						new /mob/living/silicon/ai(loc, laws, brain)
+						var/mob/living/silicon/ai/A = new /mob/living/silicon/ai(loc, laws, brain.brainmob)
+						if(brain.force_replace_ai_name)
+							fully_replace_character_name(A.name, brain.replacement_ai_name())
 						feedback_inc("cyborg_ais_created",1)
 						qdel(src)
 					else

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -26,7 +26,7 @@
 		qdel(circuit)
 		circuit = null
 	if(brain)
-		brain.forceMove(loc)
+		qdel(brain)
 		brain = null
 	return ..()
 
@@ -156,8 +156,6 @@
 					if(!user.drop_item())
 						return
 
-					ticker.mode.remove_antag_for_borging(M.brainmob.mind)
-					remove_servant_of_ratvar(M, TRUE)
 					M.forceMove(src)
 					brain = M
 					user << "<span class='notice'>Added a brain.</span>"
@@ -187,7 +185,9 @@
 				if(istype(P, /obj/item/weapon/screwdriver))
 					playsound(loc, P.usesound, 50, 1)
 					user << "<span class='notice'>You connect the monitor.</span>"
-					new /mob/living/silicon/ai (loc, laws, brain)
+					ticker.mode.remove_antag_for_borging(brain.brainmob.mind)
+					remove_servant_of_ratvar(brain.brainmob, TRUE)
+					new /mob/living/silicon/ai(loc, laws, brain)
 					feedback_inc("cyborg_ais_created",1)
 					qdel(src)
 					return

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -255,7 +255,7 @@ That prevents a few funky behaviors.
 
 
 /obj/structure/AIcore/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/device/aicard/card)
-	if(!..())
+	if(state != AI_READY_CORE || !..())
 		return
  //Transferring a carded AI to a core.
 	if(interaction == AI_TRANS_FROM_CARD)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -211,9 +211,7 @@
 	var/A = locate(/mob/living/silicon/ai) in loc
 	if(A)
 		return
-	var/L = new /datum/ai_laws/default/asimov
-	var/B = new /obj/item/device/mmi
-	var/mob/living/silicon/ai/M = new(src.loc, L, B, 1) //spawn new AI at landmark as var M
+	var/mob/living/silicon/ai/spawned/M = new(loc) //spawn new AI at landmark as var M
 	M.name = src.name
 	M.real_name = src.name
 	M.aiPDA.toff = 1 //turns the AI's PDA messenger off, stopping it showing up on player PDAs

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -14,6 +14,7 @@
 	var/obj/mecha = null //This does not appear to be used outside of reference in mecha.dm.
 	var/obj/item/organ/brain/brain = null //The actual brain
 	var/datum/ai_laws/laws = new()
+	var/force_replace_ai_name = FALSE
 
 /obj/item/device/mmi/update_icon()
 	if(brain)
@@ -134,6 +135,8 @@
 	update_icon()
 	return
 
+/obj/item/device/mmi/proc/replacement_ai_name()
+	return brainmob.name
 
 /obj/item/device/mmi/verb/Toggle_Listening()
 	set name = "Toggle Listening"

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -9,12 +9,11 @@
 	origin_tech = "biotech=2;programming=3;engineering=2"
 	var/braintype = "Cyborg"
 	var/obj/item/device/radio/radio = null //Let's give it a radio.
-	var/hacked = 0 //Whether or not this is a Syndicate MMI
 	var/mob/living/brain/brainmob = null //The current occupant.
 	var/mob/living/silicon/robot = null //Appears unused.
 	var/obj/mecha = null //This does not appear to be used outside of reference in mecha.dm.
 	var/obj/item/organ/brain/brain = null //The actual brain
-	var/clockwork = FALSE //If this is a soul vessel
+	var/datum/ai_laws/laws = new()
 
 /obj/item/device/mmi/update_icon()
 	if(brain)
@@ -35,6 +34,7 @@
 
 /obj/item/device/mmi/New()
 	..()
+	laws.set_laws_config()
 	radio = new(src) //Spawns a radio inside the MMI.
 	radio.broadcasting = 0 //researching radio mmis turned the robofabs into radios because this didnt start as 0.
 
@@ -68,8 +68,6 @@
 			living_mob_list += brainmob
 
 		brainmob.reset_perspective()
-		if(clockwork)
-			add_servant_of_ratvar(brainmob, TRUE)
 		newbrain.loc = src //P-put your brain in it
 		brain = newbrain
 
@@ -205,10 +203,10 @@
 
 /obj/item/device/mmi/syndie
 	name = "Syndicate Man-Machine Interface"
-	desc = "Syndicate's own brand of MMI. It enforces laws designed to help Syndicate agents achieve their goals upon cyborgs created with it, but doesn't fit in Nanotrasen AI cores."
+	desc = "Syndicate's own brand of MMI. It enforces laws designed to help Syndicate agents achieve their goals upon cyborgs and AIs created with it."
 	origin_tech = "biotech=4;programming=4;syndicate=2"
-	hacked = 1
 
 /obj/item/device/mmi/syndie/New()
 	..()
+	laws = new /datum/ai_laws/syndicate_override()
 	radio.on = 0

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -99,7 +99,7 @@ var/global/posibrain_notif_cooldown = 0
 /obj/item/device/mmi/posibrain/proc/transfer_personality(mob/candidate)
 	if(used || (brainmob && brainmob.key)) //Prevents hostile takeover if two ghosts get the prompt or link for the same brain.
 		candidate << "This brain has already been taken! Please try your possesion again later!"
-		return
+		return FALSE
 	notified = 0
 	if(candidate.mind && !isobserver(candidate))
 		candidate.mind.transfer_to(brainmob)
@@ -111,12 +111,11 @@ var/global/posibrain_notif_cooldown = 0
 	brainmob.stat = CONSCIOUS
 	dead_mob_list -= brainmob
 	living_mob_list += brainmob
-	if(clockwork)
-		add_servant_of_ratvar(brainmob, TRUE)
 
 	visible_message(new_mob_message)
 	update_icon()
 	used = 1
+	return TRUE
 
 
 /obj/item/device/mmi/posibrain/examine()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -80,48 +80,47 @@ var/list/ai_list = list()
 
 	var/obj/machinery/camera/portable/builtInCamera
 
-/mob/living/silicon/ai/New(loc, datum/ai_laws/L, obj/item/device/mmi/B, safety = 0)
+/mob/living/silicon/ai/New(loc, datum/ai_laws/L, mob/target_ai)
 	..()
-	if(!safety) //Only used by AIize() to successfully spawn an AI.
-		if(!B) //If there is no player/brain inside.
-			new/obj/structure/AIcore/deactivated(loc) //New empty terminal.
-			qdel(src)//Delete AI.
-			return
-		else
-			if(B.brainmob.mind)
-				B.brainmob.mind.transfer_to(src)
-				rename_self("ai")
-				if(mind.special_role)
-					mind.store_memory("As an AI, you must obey your silicon laws above all else. Your objectives will consider you to be dead.")
-					src << "<span class='userdanger'>You have been installed as an AI! </span>"
-					src << "<span class='danger'>You must obey your silicon laws above all else. Your objectives will consider you to be dead.</span>"
+	if(!target_ai) //If there is no player/brain inside.
+		new/obj/structure/AIcore/deactivated(loc) //New empty terminal.
+		qdel(src)//Delete AI.
+		return
 
-			src << "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>"
-			src << "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>"
-			src << "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>"
-			src << "To use something, simply click on it."
-			src << "Use say :b to speak to your cyborgs through binary."
-			src << "For department channels, use the following say commands:"
-			src << ":o - AI Private, :c - Command, :s - Security, :e - Engineering, :u - Supply, :v - Service, :m - Medical, :n - Science."
-			show_laws()
-			src << "<b>These laws may be changed by other players, or by you being the traitor.</b>"
+	if(L && istype(L, /datum/ai_laws))
+		laws = L
+		laws.associate(src)
+	else
+		make_laws()
 
-			job = "AI"
+	if(target_ai.mind)
+		target_ai.mind.transfer_to(src)
+		if(mind.special_role)
+			mind.store_memory("As an AI, you must obey your silicon laws above all else. Your objectives will consider you to be dead.")
+			src << "<span class='userdanger'>You have been installed as an AI! </span>"
+			src << "<span class='danger'>You must obey your silicon laws above all else. Your objectives will consider you to be dead.</span>"
 
+	src << "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>"
+	src << "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>"
+	src << "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>"
+	src << "To use something, simply click on it."
+	src << "Use say :b to speak to your cyborgs through binary."
+	src << "For department channels, use the following say commands:"
+	src << ":o - AI Private, :c - Command, :s - Security, :e - Engineering, :u - Supply, :v - Service, :m - Medical, :n - Science."
+	show_laws()
+	src << "<b>These laws may be changed by other players, or by you being the traitor.</b>"
+
+	job = "AI"
+
+	eyeobj.ai = src
+	eyeobj.loc = src.loc
 	rename_self("ai")
-	name = real_name
 
 	holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holo1"))
 
 	spark_system = new /datum/effect_system/spark_spread()
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
-
-	if(L)
-		if (istype(L, /datum/ai_laws))
-			laws = L
-	else
-		make_laws()
 
 	verbs += /mob/living/silicon/ai/proc/show_laws_verb
 
@@ -142,10 +141,6 @@ var/list/ai_list = list()
 
 	ai_list += src
 	shuttle_caller_list += src
-
-	eyeobj.ai = src
-	eyeobj.name = "[src.name] (AI Eye)" // Give it a name
-	eyeobj.loc = src.loc
 
 	builtInCamera = new /obj/machinery/camera/portable(src)
 	builtInCamera.network = list("SS13")
@@ -866,5 +861,7 @@ var/list/ai_list = list()
 			exclusive control."
 		apc.update_icon()
 
-/mob/living/silicon/ai/spawned/New(loc, datum/ai_laws/L, obj/item/device/mmi/B, safety = 0)
-	..(loc,L,B,1)
+/mob/living/silicon/ai/spawned/New(loc, datum/ai_laws/L, mob/target_ai)
+	if(!target_ai)
+		target_ai = src //cheat! just give... ourselves as the spawned AI, because that's technically correct
+	..()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -317,53 +317,27 @@
 /mob/proc/AIize()
 	if(client)
 		stopLobbySound()
-	var/mob/living/silicon/ai/O = new (loc,,,1)//No MMI but safety is in effect.
 
-	if(mind)
-		mind.transfer_to(O)
-	else
-		O.key = key
-
-	var/obj/loc_landmark
+	var/turf/loc_landmark
 	for(var/obj/effect/landmark/start/sloc in landmarks_list)
-		if (sloc.name != "AI")
+		if(sloc.name != "AI")
 			continue
-		if (locate(/mob/living) in sloc.loc)
+		if(locate(/mob/living/silicon/ai) in sloc.loc)
 			continue
-		loc_landmark = sloc
-	if (!loc_landmark)
+		loc_landmark = sloc.loc
+	if(!loc_landmark)
 		for(var/obj/effect/landmark/tripai in landmarks_list)
-			if (tripai.name == "tripai")
-				if(locate(/mob/living) in tripai.loc)
+			if(tripai.name == "tripai")
+				if(locate(/mob/living/silicon/ai) in tripai.loc)
 					continue
-				loc_landmark = tripai
-	if (!loc_landmark)
-		O << "Oh god sorry we can't find an unoccupied AI spawn location, so we're spawning you on top of someone."
+				loc_landmark = tripai.loc
+	if(!loc_landmark)
+		src << "Oh god sorry we can't find an unoccupied AI spawn location, so we're spawning you on top of someone."
 		for(var/obj/effect/landmark/start/sloc in landmarks_list)
 			if (sloc.name == "AI")
-				loc_landmark = sloc
+				loc_landmark = sloc.loc
 
-	O.loc = loc_landmark.loc
-	for (var/obj/item/device/radio/intercom/comm in O.loc)
-		comm.ai += O
-
-	O << "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>"
-	O << "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>"
-	O << "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>"
-	O << "To use something, simply click on it."
-	O << {"Use say ":b to speak to your cyborgs through binary."} //"
-	O << "For department channels, use the following say commands:"
-	O << ":o - AI Private, :c - Command, :s - Security, :e - Engineering, :u - Supply, :v - Service, :m - Medical, :n - Science."
-	O.show_laws()
-	O << "<b>These laws may be changed by other players, or by you being the traitor.</b>"
-
-	O.verbs += /mob/living/silicon/ai/proc/show_laws_verb
-	O.verbs += /mob/living/silicon/ai/proc/ai_statuschange
-
-	O.job = "AI"
-
-	O.rename_self("ai")
-	. = O
+	. = new /mob/living/silicon/ai(loc_landmark, null, src)
 	qdel(src)
 	return
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -859,9 +859,9 @@
 		return
 	if(src.z != 1)
 		return
-	occupier = new /mob/living/silicon/ai(src,malf.laws,null,1) //DEAR GOD WHY?
+	occupier = new /mob/living/silicon/ai(src, malf.laws, malf) //DEAR GOD WHY?
 	occupier.adjustOxyLoss(malf.getOxyLoss())
-	if(!findtext(occupier.name,"APC Copy"))
+	if(!findtext(occupier.name, "APC Copy"))
 		occupier.name = "[malf.name] APC Copy"
 	if(malf.parent)
 		occupier.parent = malf.parent
@@ -879,13 +879,12 @@
 /obj/machinery/power/apc/proc/malfvacate(forced)
 	if(!occupier)
 		return
-	if(occupier.parent && occupier.parent.stat != 2)
+	if(occupier.parent && occupier.parent.stat != DEAD)
 		occupier.mind.transfer_to(occupier.parent)
 		occupier.parent.shunted = 0
-		occupier.parent.adjustOxyLoss(occupier.getOxyLoss())
+		occupier.parent.setOxyLoss(occupier.getOxyLoss())
 		occupier.parent.cancel_camera()
 		qdel(occupier)
-
 	else
 		occupier << "<span class='danger'>Primary core damaged, unable to return core processes.</span>"
 		if(forced)


### PR DESCRIPTION
:cl: Joan
rscadd: You can now put syndicate MMIs and soul vessels into AI cores.
/:cl:

But will only lose antag when actually made an AI, instead of when placed in the frame.
Also it'll delete the MMI when destroyed instead of ending up never deleting the MMI; you can't decon it with an MMI inside anyway.

i ended up refactoring huge chunks of ai code kill me please