### PR TITLE
Replaces autorifles on Delta and Meta with laser guns

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -51604,11 +51604,15 @@
 /area/ai_monitored/security/armory)
 "bOW" = (
 /obj/structure/rack,
-/obj/item/weapon/gun/ballistic/automatic/wt550{
+/obj/item/weapon/gun/energy/laser{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/weapon/gun/ballistic/automatic/wt550,
+/obj/item/weapon/gun/energy/laser,
+/obj/item/weapon/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/bot,
 /area/ai_monitored/security/armory)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8280,7 +8280,7 @@
 	pixel_x = 28
 	},
 /obj/structure/closet/secure_closet/warden,
-/obj/item/weapon/gun/ballistic/automatic/wt550,
+/obj/item/weapon/gun/energy/laser,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aoH" = (


### PR DESCRIPTION
This means that the warden on Meta has their own laser.(20 bullets ➡️ 12 lasers)
On Delta, this replaces 2 autorifles with the standard 3 laser guns.(40 bullets ➡️ 36 lasers)

The energy weapon thing is _really important_ because energy weapons are what most antags are built to fight against(emp grenades, dualsaber energy reflect, ling emp shriek, wizard disable tech, cult emp talisman/rune, clockcult energy weakness, probably more things I missed) and changing this really messes with those, because they're supposed to fuck over your weapons and give the traitor/whoever a more fair footing against sec, and making them ballistic weapons pretty much totally fucks that.

Shotguns/detective's revolver also fuck this up but I'm not dealing with those in this pr, or possibly ever~