### PR TITLE
Removes laser tag firing pins crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1345,7 +1345,7 @@
 
 /datum/supply_pack/misc/lasertag/pins
 	name = "Laser Tag Firing Pins Crate"
-	cost = 3000
+	cost = 10000
 	contraband = TRUE
 	contains = list(/obj/item/weapon/storage/box/lasertagpins)
 	crate_name = "laser tag crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1343,13 +1343,6 @@
 					/obj/item/clothing/head/helmet/bluetaghelm)
 	crate_name = "laser tag crate"
 
-/datum/supply_pack/misc/lasertag/pins
-	name = "Laser Tag Firing Pins Crate"
-	cost = 10000
-	contraband = TRUE
-	contains = list(/obj/item/weapon/storage/box/lasertagpins)
-	crate_name = "laser tag crate"
-
 /datum/supply_pack/misc/clownpin
 	name = "Hilarious Firing Pin Crate"
 	cost = 5000


### PR DESCRIPTION
:cl: Hyena
tweak: removes laser tag firing pins crate
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:it kills the whole reason of having secure firing pins crate and these are unsecured so basically free guns and sec cant catch you redhanded
