### PR TITLE
Energy weapons are less affected by EMPs

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -4,6 +4,7 @@
 	caliber = "energy"
 	projectile_type = /obj/item/projectile/energy
 	var/e_cost = 100 //The amount of energy a cell needs to expend to create this shot.
+	var/emp_retained_shots = 2
 	var/select_name = "energy"
 	fire_sound = 'sound/weapons/Laser.ogg'
 	firing_effect_type = /obj/effect/overlay/temp/dir_setting/firing_effect/energy

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -20,7 +20,7 @@
 
 /obj/item/weapon/gun/energy/emp_act(severity)
 	var/obj/item/ammo_casing/energy/EC = ammo_type[select]
-	if(EC.e_cost < 0) //just... don't bother if it's at or below 0
+	if(!EC || EC.e_cost < 0) //just... don't bother if it's at or below 0
 		return
 	var/shots_left = 0
 	var/temp_power = power_supply.charge

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -28,7 +28,7 @@
 		shots_left++
 		temp_power -= EC.e_cost
 	temp_power = round(EC.e_cost / severity)
-	while(shots_left > 3)
+	while(shots_left > 2)
 		power_supply.use(temp_power)
 		shots_left--
 	chambered = null //we empty the chamber

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -28,7 +28,7 @@
 		shots_left++
 		temp_power -= EC.e_cost
 	temp_power = round(EC.e_cost / severity)
-	while(shots_left > 2)
+	while(shots_left > EC.emp_retained_shots)
 		power_supply.use(temp_power)
 		shots_left--
 	chambered = null //we empty the chamber

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -19,7 +19,18 @@
 	var/use_cyborg_cell = 0 //whether the gun's cell drains the cyborg user's cell to recharge
 
 /obj/item/weapon/gun/energy/emp_act(severity)
-	power_supply.use(round(power_supply.charge / severity))
+	var/obj/item/ammo_casing/energy/EC = ammo_type[select]
+	if(EC.e_cost < 0) //just... don't bother if it's at or below 0
+		return
+	var/shots_left = 0
+	var/temp_power = power_supply.charge
+	while(temp_power - EC.e_cost > 0)
+		shots_left++
+		temp_power -= EC.e_cost
+	temp_power = round(EC.e_cost / severity)
+	while(shots_left > 3)
+		power_supply.use(temp_power)
+		shots_left--
 	chambered = null //we empty the chamber
 	recharge_newshot() //and try to charge a new shot
 	update_icon()


### PR DESCRIPTION
:cl: Joan
tweak: Energy weapons affected by EMPs will retain 2 shots. Weaker EMPs will leave more shots available.
/:cl:

Soften the counter. Make the counter less hard.
This is a var, so you can, at your discretion, make some weapons less or more affected by EMPs.