### PR TITLE
New access level for cloning rooms and cloning pods

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -75982,7 +75982,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_research{
 	name = "Genetics Lab";
-	req_access_txt = "5;9"
+	req_access_txt = "5; 9; 68"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -75934,8 +75934,7 @@
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "CloningDoor";
 	name = "Cloning Lab";
-	req_access_txt = "0";
-	req_one_access_txt = "5"
+	req_access_txt = "5; 68"
 	},
 /turf/open/floor/plasteel/whiteblue,
 /area/medical/genetics_cloning)

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -32995,7 +32995,7 @@
 "bvt" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Genetics Research";
-	req_access_txt = "5; 9"
+	req_access_txt = "5; 9; 68"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -31507,7 +31507,7 @@
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "GeneticsDoor";
 	name = "Genetics";
-	req_access_txt = "5; 9"
+	req_access_txt = "5; 68"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -14,7 +14,7 @@
 	density = 1
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "pod_0"
-	req_access = list(access_genetics) //For premature unlocking.
+	req_access = list(access_cloning) //For premature unlocking.
 	verb_say = "states"
 	var/heal_level = 90 //The clone is released once its health reaches this level.
 	var/locked = FALSE

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -274,7 +274,7 @@
 		if(3) //medbay
 			return list(access_medical, access_genetics, access_cloning, access_morgue, access_chemistry, access_virology, access_surgery, access_cmo)
 		if(4) //research
-			return list(access_research, access_tox, access_tox_storage, access_genetics, access_robotics, access_cloning, access_xenobiology, access_minisat, access_rd, access_network)
+			return list(access_research, access_tox, access_tox_storage, access_genetics, access_robotics, access_xenobiology, access_minisat, access_rd, access_network)
 		if(5) //engineering and maintenance
 			return list(access_construction, access_maint_tunnels, access_engine, access_engine_equip, access_external_airlocks, access_tech_storage, access_atmospherics, access_tcomsat, access_minisat, access_ce)
 		if(6) //supply

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -65,6 +65,7 @@
 /var/const/access_minisat = 65
 /var/const/access_weapons = 66 //Weapon authorization for secbots
 /var/const/access_network = 67
+/var/const/access_cloning = 68 //Cloning room
 
 	//BEGIN CENTCOM ACCESS
 	/*Should leave plenty of room if we need to add more access levels.
@@ -243,7 +244,7 @@
 	            access_hydroponics, access_library, access_lawyer, access_virology, access_cmo, access_qm, access_surgery,
 	            access_theatre, access_research, access_mining, access_mailsorting, access_weapons,
 	            access_heads_vault, access_mining_station, access_xenobiology, access_ce, access_hop, access_hos, access_RC_announce,
-	            access_keycard_auth, access_tcomsat, access_gateway, access_mineral_storeroom, access_minisat, access_network)
+	            access_keycard_auth, access_tcomsat, access_gateway, access_mineral_storeroom, access_minisat, access_network, access_cloning)
 
 /proc/get_all_centcom_access()
 	return list(access_cent_general, access_cent_thunder, access_cent_specops, access_cent_medical, access_cent_living, access_cent_storage, access_cent_teleporter, access_cent_captain)
@@ -271,9 +272,9 @@
 		if(2) //security
 			return list(access_sec_doors, access_weapons, access_security, access_brig, access_armory, access_forensics_lockers, access_court, access_hos)
 		if(3) //medbay
-			return list(access_medical, access_genetics, access_morgue, access_chemistry, access_virology, access_surgery, access_cmo)
+			return list(access_medical, access_genetics, access_cloning, access_morgue, access_chemistry, access_virology, access_surgery, access_cmo)
 		if(4) //research
-			return list(access_research, access_tox, access_tox_storage, access_genetics, access_robotics, access_xenobiology, access_minisat, access_rd, access_network)
+			return list(access_research, access_tox, access_tox_storage, access_genetics, access_robotics, access_cloning, access_xenobiology, access_minisat, access_rd, access_network)
 		if(5) //engineering and maintenance
 			return list(access_construction, access_maint_tunnels, access_engine, access_engine_equip, access_external_airlocks, access_tech_storage, access_atmospherics, access_tcomsat, access_minisat, access_ce)
 		if(6) //supply
@@ -432,6 +433,8 @@
 			return "Weapon Permit"
 		if(access_network)
 			return "Network Access"
+		if(access_cloning)
+			return "Cloning Room"
 
 /proc/get_centcom_access_desc(A)
 	switch(A)

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -98,7 +98,7 @@ Chemist
 
 	outfit = /datum/outfit/job/chemist
 
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_mineral_storeroom)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_cloning, access_mineral_storeroom)
 	minimal_access = list(access_medical, access_chemistry, access_mineral_storeroom)
 
 /datum/outfit/job/chemist
@@ -164,7 +164,7 @@ Virologist
 
 	outfit = /datum/outfit/job/virologist
 
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_mineral_storeroom)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_cloning, access_mineral_storeroom)
 	minimal_access = list(access_medical, access_virology, access_mineral_storeroom)
 
 /datum/outfit/job/virologist

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -16,10 +16,10 @@ Chief Medical Officer
 
 	outfit = /datum/outfit/job/cmo
 
-	access = list(access_medical, access_morgue, access_genetics, access_heads, access_mineral_storeroom,
+	access = list(access_medical, access_morgue, access_genetics, access_cloning, access_heads, access_mineral_storeroom,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_maint_tunnels)
-	minimal_access = list(access_medical, access_morgue, access_genetics, access_heads, access_mineral_storeroom,
+	minimal_access = list(access_medical, access_morgue, access_genetics, access_cloning, access_heads, access_mineral_storeroom,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_maint_tunnels)
 
@@ -64,8 +64,8 @@ Medical Doctor
 
 	outfit = /datum/outfit/job/doctor
 
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_mineral_storeroom)
-	minimal_access = list(access_medical, access_morgue, access_surgery)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_cloning, access_mineral_storeroom)
+	minimal_access = list(access_medical, access_morgue, access_surgery, access_cloning)
 
 /datum/outfit/job/doctor
 	name = "Medical Doctor"
@@ -131,8 +131,8 @@ Geneticist
 
 	outfit = /datum/outfit/job/geneticist
 
-	access = list(access_medical, access_morgue, access_chemistry, access_virology, access_genetics, access_research, access_xenobiology, access_robotics, access_mineral_storeroom, access_tech_storage)
-	minimal_access = list(access_medical, access_morgue, access_genetics, access_research)
+	access = list(access_medical, access_morgue, access_chemistry, access_virology, access_genetics, access_cloning, access_research, access_xenobiology, access_robotics, access_mineral_storeroom, access_tech_storage)
+	minimal_access = list(access_medical, access_morgue, access_genetics, access_cloning, access_research)
 
 /datum/outfit/job/geneticist
 	name = "Geneticist"

--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -16,12 +16,12 @@ Research Director
 
 	outfit = /datum/outfit/job/rd
 
-	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
+	access = list(access_rd, access_heads, access_tox, access_genetics, access_cloning, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload,
 			            access_RC_announce, access_keycard_auth, access_gateway, access_mineral_storeroom,
 			            access_tech_storage, access_minisat, access_maint_tunnels, access_network)
-	minimal_access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
+	minimal_access = list(access_rd, access_heads, access_tox, access_genetics, access_cloning, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload,
 			            access_RC_announce, access_keycard_auth, access_gateway, access_mineral_storeroom,

--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -16,12 +16,12 @@ Research Director
 
 	outfit = /datum/outfit/job/rd
 
-	access = list(access_rd, access_heads, access_tox, access_genetics, access_cloning, access_morgue,
+	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload,
 			            access_RC_announce, access_keycard_auth, access_gateway, access_mineral_storeroom,
 			            access_tech_storage, access_minisat, access_maint_tunnels, access_network)
-	minimal_access = list(access_rd, access_heads, access_tox, access_genetics, access_cloning, access_morgue,
+	minimal_access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload,
 			            access_RC_announce, access_keycard_auth, access_gateway, access_mineral_storeroom,


### PR DESCRIPTION
### Summary:
1. New access level, _Cloning Room_, provided to Medical Doctor, Geneticist and CMO on minimal access. Chemist and Virologist gain this on extended access.
2. On BoxStation and MetaStation, the cloning room door facing the medbay requires both Medical and Cloning Room access.
3. On BoxStation and MetaStation, the cloning room door facing Genetics Research requires Medical, Cloning Room and Genetics Lab access.
4. Cloning pods require Cloning Room access to unlock, instead of Genetics access.

![Image of airlock electronics settings for cloning lab doors](https://my.mixtape.moe/yvfyuu.png)
MetaStation's cloning room doors also have these sets of requirements.

### Rationale:

This PR was made to make the cloning room on BoxStation accessible to medical doctors, even with minimal access. For this a new access level has been created, named _Cloning Room_, which allows a doctor to access the Genetics cloning room without being able to enter the research portion of Genetics. 
The Cloning Room access level is provided to all medical doctors, geneticists and Chief Medical Officers. In a skeleton crew it is also provided to chemists and virologists.

Geneticists may still find work to do with clones; even if doctors are cloning people with a good cryo mix that fixes genes and brains, geneticists are still needed to give UI+UE treatment to clones who've lost their previous identity after having to undergo a brain transplant.

I also want to make cloning lab access consistent across the current maps, so that Cloning Room and medical access is needed to enter the cloning room on each map.

This PR also makes cloning pods require Cloning Room access to be unlocked, so doctors can unlock it to eject the pod in emergencies (I'm aware of the APC trick). Genetics access will no longer be accepted, but anybody with Genetics access (geneticists, CMOs and RDs) can still unlock the pod as they have Cloning Room access.

I'm using "Cloning Room" instead of "Cloning Lab" because I believe Nanotrasen views cloning on its own as an established procedure, rather than an experiment. There isn't much research that can be done using the cloning machines.

### Changelog:
:cl: Erwgd
add: A new access level is available, named "Cloning Room". Medical Doctors, Geneticists and CMOs start with it.
tweak: On Box Station and on Meta Station, the cloning lab doors require Cloning Room access in addition to each door's previous requirements.
tweak: Cloning pods are now unlocked with Cloning Room access only.
/:cl: