### PR TITLE
Readds opening doors with corpses (but not with drones/borgs)

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -64,7 +64,7 @@
 		return
 	if(ismob(AM))
 		var/mob/B = AM
-		if(B.stat && istype(B, /mob/living/simple_animal/drone))
+		if((isdrone(B) || iscyborg(B)) && B.stat)
 			return
 		if(isliving(AM))
 			var/mob/living/M = AM

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -64,7 +64,7 @@
 		return
 	if(ismob(AM))
 		var/mob/B = AM
-		if(B.stat)
+		if(B.stat && istype(B, /mob/living/simple_animal/drone))
 			return
 		if(isliving(AM))
 			var/mob/living/M = AM

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -71,7 +71,7 @@
 	if (!( ticker ))
 		return
 	var/mob/M = AM
-	if(M.restrained() || ((isdrone(M) || iscyborg(M)) && B.stat))
+	if(M.restrained() || ((isdrone(M) || iscyborg(M)) && M.stat))
 		return
 	bumpopen(M)
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -71,9 +71,9 @@
 	if (!( ticker ))
 		return
 	var/mob/M = AM
-	if(!M.stat && !M.restrained())
-		bumpopen(M)
-	return
+	if(M.restrained() || ((isdrone(M) || iscyborg(M)) && B.stat))
+		return
+	bumpopen(M)
 
 /obj/machinery/door/window/bumpopen(mob/user)
 	if( operating || !src.density )


### PR DESCRIPTION
Small tweak to make https://github.com/tgstation/tgstation/pull/22355 more proper.

Doors can still be opened by slamming corpses into them, just not drone corpses.

Reasoning: This literally wasn't a bug and was in no way overpowered or detrimental to the game. Interactions like this that allow you to open a door with the corpse of your foe is the kind of emergent gameplay that makes SS13 stand out above other games. Removing it is just shooting ourselves in the foot.