### PR TITLE
Gulag Mineral Ratio Change

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -207,8 +207,9 @@
 
 /turf/closed/mineral/random/labormineral
 	mineralSpawnChanceList = list(
-		/turf/closed/mineral/iron = 100, /turf/closed/mineral/uranium = 1, /turf/closed/mineral/diamond = 1,
-		/turf/closed/mineral/gold = 1, /turf/closed/mineral/silver = 1, /turf/closed/mineral/plasma = 1)
+		/turf/closed/mineral/uranium = 2, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 3, /turf/closed/mineral/titanium = 4,
+		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 80,
+		/turf/closed/mineral/gibtonite = 3)
 	icon_state = "rock_labor"
 
 
@@ -219,9 +220,9 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	defer_change = 1
 	mineralSpawnChanceList = list(
-		/turf/closed/mineral/iron/volcanic = 100, /turf/closed/mineral/uranium/volcanic = 1, /turf/closed/mineral/diamond/volcanic = 1,
-		/turf/closed/mineral/gold/volcanic = 1, /turf/closed/mineral/silver/volcanic = 1, /turf/closed/mineral/plasma/volcanic = 1)
-
+		/turf/closed/mineral/uranium/volcanic = 2, /turf/closed/mineral/diamond/volcanic = 1, /turf/closed/mineral/gold/volcanic = 3, /turf/closed/mineral/titanium/volcanic = 4,
+		/turf/closed/mineral/silver/volcanic = 6, /turf/closed/mineral/plasma/volcanic = 15, /turf/closed/mineral/iron/volcanic = 80,
+		/turf/closed/mineral/gibtonite/volcanic = 3)
 
 
 


### PR DESCRIPTION
Previously, obtaining points from the gulag would be very difficult since you would have to mine glass [which is only one point a pop] or test your luck at mining for minerals, the best you could get is iron [2 points a pop] and MAYBE another mineral which had a 1/>100 chance.

This hopes to alleviate the gulag sentences just a bit and make the 1:100 ratio more reasonable, while also providing useful materials for science [since they probably got enough metal from normal mining]. Iron is still the most prevalent mineral, have no fear security players.

Yes, I DID add gibtonite for them to blow themselves up with. No Scanners, No armor, fun times!

:cl: Cobby
:tweak: Ups Non-Iron mineral chance for the gulag portion of lavaland. Now the 1 minute : 100 Point ratio found in Space Law is more reasonable.
:tweak: Gibtonite can be found on the gulag side. Have no fear, prisoners will not get scanners unless they've somehow smuggled some over.
/:cl:
