### PR TITLE
Fixes Kudzu

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -192,7 +192,7 @@
 
 /obj/item/seeds/proc/adjust_production(adjustamt)
 	if(yield != -1)
-		production = Clamp(production + adjustamt, 2, 10)
+		production = Clamp(production + adjustamt, 1, 10)
 		var/datum/plant_gene/core/C = get_gene(/datum/plant_gene/core/production)
 		if(C)
 			C.value = production
@@ -205,13 +205,13 @@
 			C.value = potency
 
 /obj/item/seeds/proc/adjust_weed_rate(adjustamt)
-	weed_rate = Clamp(weed_rate + adjustamt, 0, 100)
+	weed_rate = Clamp(weed_rate + adjustamt, 0, 10)
 	var/datum/plant_gene/core/C = get_gene(/datum/plant_gene/core/weed_rate)
 	if(C)
 		C.value = weed_rate
 
 /obj/item/seeds/proc/adjust_weed_chance(adjustamt)
-	weed_chance = Clamp(weed_chance + adjustamt, 0, 100)
+	weed_chance = Clamp(weed_chance + adjustamt, 0, 67)
 	var/datum/plant_gene/core/C = get_gene(/datum/plant_gene/core/weed_chance)
 	if(C)
 		C.value = weed_chance


### PR DESCRIPTION
> you can make 100 weeds spawn 100% every update

no wonder this was broken.

:cl: Cobby
:fix: Fixed Kudzu
:fix: Fixes an issue where you can never get below 2 production speed without using roundstart plants in disks.
/:cl:

This changes weedrate to cap at 10 [meaning at most 10 weeds can spawn at a SINGLE time]
changes weedchance to cap at 60% [meaning at most there's a 3/5 chance `weed_rate` weeds will spawn]

also changes production to 1, since the minimum has always been 1.

This can still create some pretty BS moments where if RNG favors kudzu, but that's RNG for you.