### PR TITLE
[s]Throttles botcall's call bot command

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1,3 +1,4 @@
+#define CALL_BOT_COOLDOWN 900
 var/list/ai_list = list()
 
 //Not sure why this is necessary...
@@ -69,6 +70,7 @@ var/list/ai_list = list()
 	var/last_announcement = "" // For AI VOX, if enabled
 	var/turf/waypoint //Holds the turf of the currently selected waypoint.
 	var/waypoint_mode = 0 //Waypoint mode is for selecting a turf via clicking.
+	var/call_bot_cooldown = 0 //time of next call bot command
 	var/apc_override = 0 //hack for letting the AI use its APC even when visionless
 	var/nuking = FALSE
 	var/obj/machinery/doomsday_device/doomsday_device
@@ -401,6 +403,9 @@ var/list/ai_list = list()
 			src << "Target is not on or near any active cameras on the station."
 		return
 	if(href_list["callbot"]) //Command a bot to move to a selected location.
+		if(call_bot_cooldown > world.time)
+			src << "<span class='danger'>Error: Your last call bot command is still processing, please wait for the bot to finish calculating a route.</span>"
+			return
 		Bot = locate(href_list["callbot"]) in living_mob_list
 		if(!Bot || Bot.remote_disabled || src.control_disabled)
 			return //True if there is no bot found, the bot is manually emagged, or the AI is carded with wireless off.
@@ -494,8 +499,11 @@ var/list/ai_list = list()
 	if(Bot.calling_ai && Bot.calling_ai != src) //Prevents an override if another AI is controlling this bot.
 		src << "<span class='danger'>Interface error. Unit is already in use.</span>"
 		return
-
+	src << "<span class='notice'>Sending command to bot...</span>"
+	call_bot_cooldown = world.time + CALL_BOT_COOLDOWN
 	Bot.call_bot(src, waypoint)
+	call_bot_cooldown = FALSE
+	
 
 /mob/living/silicon/ai/triggerAlarm(class, area/A, O, obj/alarmsource)
 	if(alarmsource.z != z)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -502,7 +502,7 @@ var/list/ai_list = list()
 	src << "<span class='notice'>Sending command to bot...</span>"
 	call_bot_cooldown = world.time + CALL_BOT_COOLDOWN
 	Bot.call_bot(src, waypoint)
-	call_bot_cooldown = FALSE
+	call_bot_cooldown = 0
 	
 
 /mob/living/silicon/ai/triggerAlarm(class, area/A, O, obj/alarmsource)


### PR DESCRIPTION
It will now make the ai wait until the bot's astar operation has finished before it can send another call bot command (to any bot).

There is a secondary time out of 90 seconds in case the astar operation just never returns, this is mainly a failsafe.

Had the mc and sleep queue grind to a halt because an AI sent a call command to a bot that was tough on astar, had it not respond immediately (and there is no message until after astar runs so the ai didn't know the command even worked), then do it again. In total there were **_19_** simultaneous astar operations running, so by the time the mc would wake up, world.tick_usage was well over 100% and it would go back to sleep waiting some more.

This also adds a message to the ai saying it's sending the command to the bot, so they at least don't try sending the same command to the bot thinking something didn't work.

Secret/Security tag is because I don't really see a benefit in advertising that botcall lags.
:cl:
tweak: AI's call bot command has been throttled to prevent edge cases causing lag. You will not be able to call another bot until the first bot has finished mapping out it's route.
/:cl:

Requesting quick merge because right now this is just asking for somebody to cripple a server with autohotkey