### PR TITLE
Swipe to speed clone, emag to murder horribly

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -133,7 +133,7 @@
 			return FALSE
 	if(clonemind.damnation_type) //Can't clone the damned.
 		addtimer(src, "horrifyingsound", 0)
-		mess = 1
+		mess = TRUE
 		icon_state = "pod_g"
 		update_icon()
 		return FALSE
@@ -250,7 +250,8 @@
 		if(!check_access(W))
 			user << "<span class='danger'>Access Denied.</span>"
 			return
-		if(!occupant || !mess)
+		if(!(occupant || mess))
+			user << "<span class='danger'>Error: Pod has no occupant.</span>"
 			return
 		else
 			connected_message("Authorized Ejection")
@@ -282,14 +283,14 @@
 /obj/machinery/clonepod/proc/go_out()
 	countdown.stop()
 
-	if (mess) //Clean that mess and dump those gibs!
+	if(mess) //Clean that mess and dump those gibs!
 		mess = FALSE
 		new /obj/effect/gibspawner/generic(loc)
 		audible_message("<span class='italics'>You hear a splat.</span>")
 		icon_state = "pod_0"
 		return
 
-	if (!occupant)
+	if(!occupant)
 		return
 
 	if(grab_ghost_when == CLONER_MATURE_CLONE)
@@ -340,7 +341,7 @@
 /obj/machinery/clonepod/handle_atom_del(atom/A)
 	if(A == occupant)
 		occupant = null
-		go_out()
+		countdown.stop()
 
 /obj/machinery/clonepod/proc/horrifyingsound()
 	for(var/i in 1 to 5)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -222,7 +222,7 @@
 
 			use_power(7500) //This might need tweaking.
 
-		else if((occupant.cloneloss <= (100 - heal_level)) && (!eject_wait))
+		else if((occupant.cloneloss <= (100 - heal_level)))
 			connected_message("Cloning Process Complete.")
 			SPEAK("The cloning cycle of [occupant.real_name] is \
 				complete.")
@@ -280,8 +280,6 @@
 	return TRUE
 
 /obj/machinery/clonepod/proc/go_out()
-	if (locked)
-		return
 	countdown.stop()
 
 	if (mess) //Clean that mess and dump those gibs!


### PR DESCRIPTION
:cl: coiax
add: Swiping an authorised ID card will eject the occupant of a cloning
pod early. Previously, it just "unlocked" the pod if the occupant's
health was high enough.
del: There is no minimum health requirement to eject a pod's occupant
anymore.
add: Pods now announce on the radio when someone is ejected, and will
always know a person's real name, regardless of how disfigured they are.
add: Emagging a clone pod now horribly kills the occupant and prevents
subsequent cloning. Previously, it just ejected the pod's occupant.
/:cl:

In addition, removed some `<b>` tags from the radio messages, because
formatting in speech is something I disapprove of.

Reasoning
=========

Any speed cloning involves toggling the equipment power of the APC as a
routine procedure, so much so that on certain maps, the Genetics APC is
pre-unlocked. This simplifies things and decreases needless clicking.
Toggling the power remains the option in the absence of an ID or for
silicons.

Emagging the cloning pod is hilarious, and we don't get to see the EMP
malfunction enough. It also allows you to perma kill people, but it does
produce a number of alarms, both in game and on the medical radio.