### PR TITLE
Fix Deltastation needing BYOND >= 511

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -50997,7 +50997,6 @@
 	req_access_txt = "56"
 	},
 /obj/machinery/light_switch{
-	pixel_w = 0;
 	pixel_x = 26;
 	pixel_y = 26
 	},


### PR DESCRIPTION
Let me test this then I'll call for fastmerge

🆑 Cyberboss
fix: Deltastation no longer requires BYOND 511
/🆑