### PR TITLE
Fix bundle

### DIFF
--- a/code/datums/weather/weather_types.dm
+++ b/code/datums/weather/weather_types.dm
@@ -133,7 +133,7 @@
 
 	area_type = /area
 	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer,
-	/area/ai_monitored/turret_protected/ai, /area/storage/emergency, /area/storage/emergency2, /area/shuttle/labor, /area/shuttle/arrival)
+	/area/ai_monitored/turret_protected/ai, /area/storage/emergency, /area/storage/emergency2, /area/shuttle)
 	target_z = ZLEVEL_STATION
 
 	immunity_type = "rad"

--- a/code/datums/weather/weather_types.dm
+++ b/code/datums/weather/weather_types.dm
@@ -132,7 +132,8 @@
 	end_message = "<span class='notice'>The air seems to be cooling off again.</span>"
 
 	area_type = /area
-	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer, /area/ai_monitored/turret_protected/ai, /area/storage/emergency, /area/storage/emergency2, /area/shuttle/labor)
+	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer,
+	/area/ai_monitored/turret_protected/ai, /area/storage/emergency, /area/storage/emergency2, /area/shuttle/labor, /area/shuttle/arrival)
 	target_z = ZLEVEL_STATION
 
 	immunity_type = "rad"

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -33,6 +33,7 @@
 /obj/structure/spider/stickyweb/New()
 	if(prob(50))
 		icon_state = "stickyweb2"
+	. = ..()
 
 /obj/structure/spider/stickyweb/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height==0) return 1
@@ -60,6 +61,7 @@
 	pixel_x = rand(3,-3)
 	pixel_y = rand(3,-3)
 	START_PROCESSING(SSobj, src)
+	. = ..()
 
 /obj/structure/spider/eggcluster/process()
 	amount_grown += rand(0,2)
@@ -94,6 +96,7 @@
 	pixel_x = rand(6,-6)
 	pixel_y = rand(6,-6)
 	START_PROCESSING(SSobj, src)
+	. = ..()
 
 /obj/structure/spider/spiderling/hunter
 	grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/hunter
@@ -189,6 +192,7 @@
 
 /obj/structure/spider/cocoon/New()
 	icon_state = pick("cocoon1","cocoon2","cocoon3")
+	. = ..()
 
 /obj/structure/spider/cocoon/container_resist(mob/living/user)
 	var/breakout_time = 1

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -370,7 +370,8 @@
 		cost = 5
 	. = use_charges(cost)
 	var/fraction = min(1, . / reagents.maximum_volume)
-	fraction /= affected_turfs.len
+	if(affected_turfs.len)
+		fraction /= affected_turfs.len
 	for(var/t in affected_turfs)
 		reagents.reaction(t, TOUCH, fraction * volume_multiplier)
 		reagents.trans_to(t, ., volume_multiplier)

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -1476,10 +1476,10 @@
 				TARGET = retal_target
 			else
 				var/mob/living/M = locate(/mob/living) in oview(7,src)
-				if(M != src && !compareFaction(M.faction))
-					TARGET = M
 				if(!M)
 					doing = doing & ~FIGHTING
+				else if(M != src && !compareFaction(M.faction))
+					TARGET = M
 
 	//no infighting
 	if(retal)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -64,6 +64,7 @@
 		if(CH.holder == src)
 			CH.on_remove(src)
 			CH.holder = null
+			all_components.Remove(CH.device_type)
 			qdel(CH)
 	physical = null
 	return ..()

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -38,12 +38,14 @@
 		next_record = world.time + record_interval
 
 		var/list/supply = history["supply"]
-		supply += attached.powernet.viewavail
+		if(attached.powernet)
+			supply += attached.powernet.viewavail
 		if(supply.len > record_size)
 			supply.Cut(1, 2)
 
 		var/list/demand = history["demand"]
-		demand += attached.powernet.viewload
+		if(attached.powernet)
+			demand += attached.powernet.viewload
 		if(demand.len > record_size)
 			demand.Cut(1, 2)
 
@@ -59,28 +61,28 @@
 	data["stored"] = record_size
 	data["interval"] = record_interval / 10
 	data["attached"] = attached ? TRUE : FALSE
+	data["history"] = history
+	data["areas"] = list()
+
 	if(attached)
 		data["supply"] = attached.powernet.viewavail
 		data["demand"] = attached.powernet.viewload
-	data["history"] = history
-
-	data["areas"] = list()
-	for(var/obj/machinery/power/terminal/term in attached.powernet.nodes)
-		var/obj/machinery/power/apc/A = term.master
-		if(istype(A))
-			var/cell_charge
-			if(!A.cell)
-				cell_charge = 0
-			else
-				cell_charge = A.cell.percent()
-			data["areas"] += list(list(
-				"name" = A.area.name,
-				"charge" = cell_charge,
-				"load" = A.lastused_total,
-				"charging" = A.charging,
-				"eqp" = A.equipment,
-				"lgt" = A.lighting,
-				"env" = A.environ
-			))
+		for(var/obj/machinery/power/terminal/term in attached.powernet.nodes)
+			var/obj/machinery/power/apc/A = term.master
+			if(istype(A))
+				var/cell_charge
+				if(!A.cell)
+					cell_charge = 0
+				else
+					cell_charge = A.cell.percent()
+				data["areas"] += list(list(
+					"name" = A.area.name,
+					"charge" = cell_charge,
+					"load" = A.lastused_total,
+					"charging" = A.charging,
+					"eqp" = A.equipment,
+					"lgt" = A.lighting,
+					"env" = A.environ
+				))
 
 	return data


### PR DESCRIPTION

Adds shuttles to radstorm protected areas. Fixes #20432
Fixes spider structures having null armor
Fixes division by 0 with hellcan
Fixes runtime in automatons
Fixes runtime with recharger in modular computer destroy
Fixes runtime in power monitor

:cl:
tweak: Shuttle are now safe from radstorms
/:cl: