### PR TITLE
Revenge of Uplink Discount System

### DIFF
--- a/code/modules/uplink/uplink.dm
+++ b/code/modules/uplink/uplink.dm
@@ -18,7 +18,7 @@ var/global/list/uplinks = list()
 	var/datum/game_mode/gamemode = null
 	var/spent_telecrystals = 0
 	var/purchase_log = ""
-	var/list/uplink_items = list()
+	var/list/uplink_items
 
 /obj/item/device/uplink/New()
 	..()

--- a/code/modules/uplink/uplink.dm
+++ b/code/modules/uplink/uplink.dm
@@ -18,10 +18,12 @@ var/global/list/uplinks = list()
 	var/datum/game_mode/gamemode = null
 	var/spent_telecrystals = 0
 	var/purchase_log = ""
+	var/list/uplink_items = list()
 
 /obj/item/device/uplink/New()
 	..()
 	uplinks += src
+	uplink_items = get_uplink_items(gamemode)
 
 /obj/item/device/uplink/Destroy()
 	uplinks -= src
@@ -67,8 +69,6 @@ var/global/list/uplinks = list()
 	data["telecrystals"] = telecrystals
 	data["lockable"] = lockable
 
-	var/list/uplink_items = get_uplink_items(gamemode)
-
 	data["categories"] = list()
 	for(var/category in uplink_items)
 		var/list/cat = list(
@@ -77,6 +77,8 @@ var/global/list/uplinks = list()
 		if(category == selected_cat)
 			for(var/item in uplink_items[category])
 				var/datum/uplink_item/I = uplink_items[category][item]
+				if(I.limited_stock == 0)
+					continue
 				cat["items"] += list(list(
 					"name" = I.name,
 					"cost" = I.cost,
@@ -94,7 +96,6 @@ var/global/list/uplinks = list()
 		if("buy")
 			var/item = params["item"]
 
-			var/list/uplink_items = get_uplink_items(gamemode)
 			var/list/buyable_items = list()
 			for(var/category in uplink_items)
 				buyable_items += uplink_items[category]

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -11,6 +11,8 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			uplink_items[I.category][I.name] = I
 
 	var/list/filtered_uplink_items = list()
+	var/list/sale_items = list()
+
 	for(var/category in uplink_items)
 		for(var/item in uplink_items[category])
 			var/datum/uplink_item/I = uplink_items[category][item]
@@ -30,7 +32,28 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			if(!filtered_uplink_items[category])
 				filtered_uplink_items[category] = list()
 			filtered_uplink_items[category][item] = I
+			if(I.limited_stock < 0 && !I.cant_discount && I.item && I.cost > 1)
+				sale_items += I
 
+	for(var/i = 0, i < 3, i++)
+		var/datum/uplink_item/I = pick_n_take(sale_items)
+		var/datum/uplink_item/A = new I.type
+		var/discount = pick(4;0.75,2;0.5,1;0.25)
+		var/list/disclaimer = list("Void where prohibited.", "Not recommended for children.", "Contains small parts.", "Check local laws for legality in region.", "Do not taunt.", "Not responsible for direct, indirect, incidental or consequential damages resulting from any defect, error or failure to perform.", "Keep away from fire or flames.", "Product is provided \"as is\" without any implied or expressed warranties.", "As seen on TV.", "For recreational use only.", "Use only as directed.", "16% sales tax will be charged for orders originating within Space Nebraska.")
+		A.limited_stock = 1
+		I.refundable = FALSE //THIS MAN USES ONE WEIRD TRICK GAIN FREE TC, CODERS HATES HIM!
+		A.refundable = FALSE
+		if(A.cost >= 20) //Tough love for nuke ops
+			discount *= 0.5
+		A.cost = max(round(A.cost * discount),1)
+		A.category = "Discounted Gear"
+		A.name += " ([round(((initial(A.cost)-A.cost)/initial(A.cost))*100)]% off!)"
+		A.desc += " Normally costs [initial(A.cost)] TC. All sales final. [pick(disclaimer)]"
+		A.item == I.item
+
+		if(!filtered_uplink_items[A.category])
+			filtered_uplink_items[A.category] = list()
+		filtered_uplink_items[A.category][A.name] = A
 	return filtered_uplink_items
 
 
@@ -49,6 +72,8 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	var/refund_amount = 0 // specified refund amount in case there needs to be a TC penalty for refunds.
 	var/refundable = FALSE
 	var/surplus = 100 // Chance of being included in the surplus crate.
+	var/cant_discount = FALSE
+	var/limited_stock = -1 //Setting this above zero limits how many times this item can be bought by the same traitor in a round, -1 is unlimited
 	var/list/include_modes = list() // Game modes to allow this item in.
 	var/list/exclude_modes = list() // Game modes to disallow this item from.
 	var/player_minimum //The minimum crew size needed for this item to be added to uplinks.
@@ -64,7 +89,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	if (!user || user.incapacitated())
 		return
 
-	if(U.telecrystals < cost)
+	if(U.telecrystals < cost || limited_stock == 0)
 		return
 	else
 		U.telecrystals -= cost
@@ -78,6 +103,9 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	else
 		U.purchase_log += "<big>\icon[A]</big>"
 
+	if(limited_stock > 0)
+		limited_stock -= 1
+
 	if(ishuman(user) && istype(A, /obj/item))
 		var/mob/living/carbon/human/H = user
 		if(H.put_in_hands(A))
@@ -86,11 +114,16 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			H << "\The [A] materializes onto the floor."
 	return 1
 
+//Discounts (dynamically filled above)
+/datum/uplink_item/discounts
+	category = "Discounted Gear"
+
 // Nuclear Operative (Special Offers)
 /datum/uplink_item/nukeoffer
 	category = "Special Offers"
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
+	cant_discount = TRUE
 
 /datum/uplink_item/nukeoffer/c20r
 	name = "C-20r bundle"
@@ -754,14 +787,14 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/storage/box/syndie_kit/cutouts
 	cost = 1
 	surplus = 20
-	
+
 /datum/uplink_item/stealthy_tools/fakenucleardisk
 	name = "Decoy Nuclear Authentication Disk"
 	desc = "It's just a normal disk. Visually it's identical to the real deal, but it won't hold up under closer scrutiny. Don't try to give this to us to complete your objective, we know better!"
 	item = /obj/item/weapon/disk/fakenucleardisk
 	cost = 1
 	surplus = 1
-	
+
 //Space Suits and Hardsuits
 /datum/uplink_item/suits
 	category = "Space Suits and Hardsuits"
@@ -908,6 +941,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "Because sometimes quantity is quality. Contains 10 C-4 plastic explosives."
 	item = /obj/item/weapon/storage/backpack/dufflebag/syndie/c4
 	cost = 9 //10% discount!
+	cant_discount = TRUE
 
 /datum/uplink_item/device_tools/x4bag
 	name = "Bag of X-4 explosives"
@@ -915,6 +949,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			blast through the wall, injuring anything on the opposite side, while being safer to the user. For when you want a wider, deeper, hole."
 	item = /obj/item/weapon/storage/backpack/dufflebag/syndie/x4
 	cost = 4 //
+	cant_discount = TRUE
 
 /datum/uplink_item/device_tools/powersink
 	name = "Power Sink"
@@ -1133,6 +1168,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			Can blow the deepest of covers."
 	item = /obj/item/toy/syndicateballoon
 	cost = 20
+	cant_discount = TRUE
 
 /datum/uplink_item/badass/bundle
 	name = "Syndicate Bundle"
@@ -1142,6 +1178,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/storage/box/syndicate
 	cost = 20
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
+	cant_discount = TRUE
 
 /datum/uplink_item/badass/surplus
 	name = "Syndicate Surplus Crate"
@@ -1151,6 +1188,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 20
 	player_minimum = 25
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
+	cant_discount = TRUE
 
 /datum/uplink_item/badass/surplus/spawn_item(turf/loc, obj/item/device/uplink/U)
 	var/list/uplink_items = get_uplink_items(ticker.mode)
@@ -1178,6 +1216,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			decided on a strategy yet."
 	item = /obj/item/weapon/paper
 	cost = 0
+	cant_discount = TRUE
 
 /datum/uplink_item/badass/random/spawn_item(turf/loc, obj/item/device/uplink/U)
 	var/list/uplink_items = get_uplink_items(ticker.mode)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -35,13 +35,13 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			if(I.limited_stock < 0 && !I.cant_discount && I.item && I.cost > 1)
 				sale_items += I
 
-	for(var/i = 0, i < 3, i++)
+	for(var/i in 1 to 3)
 		var/datum/uplink_item/I = pick_n_take(sale_items)
 		var/datum/uplink_item/A = new I.type
 		var/discount = pick(4;0.75,2;0.5,1;0.25)
 		var/list/disclaimer = list("Void where prohibited.", "Not recommended for children.", "Contains small parts.", "Check local laws for legality in region.", "Do not taunt.", "Not responsible for direct, indirect, incidental or consequential damages resulting from any defect, error or failure to perform.", "Keep away from fire or flames.", "Product is provided \"as is\" without any implied or expressed warranties.", "As seen on TV.", "For recreational use only.", "Use only as directed.", "16% sales tax will be charged for orders originating within Space Nebraska.")
 		A.limited_stock = 1
-		I.refundable = FALSE //THIS MAN USES ONE WEIRD TRICK GAIN FREE TC, CODERS HATES HIM!
+		I.refundable = FALSE //THIS MAN USES ONE WEIRD TRICK TO GAIN FREE TC, CODERS HATES HIM!
 		A.refundable = FALSE
 		if(A.cost >= 20) //Tough love for nuke ops
 			discount *= 0.5

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -49,7 +49,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 		A.category = "Discounted Gear"
 		A.name += " ([round(((initial(A.cost)-A.cost)/initial(A.cost))*100)]% off!)"
 		A.desc += " Normally costs [initial(A.cost)] TC. All sales final. [pick(disclaimer)]"
-		A.item == I.item
+		A.item = I.item
 
 		if(!filtered_uplink_items[A.category])
 			filtered_uplink_items[A.category] = list()


### PR DESCRIPTION
Every uplink will have three random items on sale for between 25% and 75% off (strongly weighted towards the smaller deals). 

<b>All these items are single purchase only.</b> 

Which items are on sale are unique per uplink, so don't worry too much about the world exploding to death through cheap syndibombs. 

Any item that already implies a discount is barred from being put on sale. Nuke ops get this system too, but discounts are lessened if they hit high cost items like a mech.

Son of #14160

Lowering the cost of items can help tempt antags into trying new and novel approaches to antagery. It also adds a special temptation to stealing other antags uplinks, as which items they have a discount for will be different from their own.

_Part of the unfinished business 2016 series_

:cl:
add: There's a new category in uplinks for discounted gear. These special discounts however can only be taken once, so even if you are lucky enough to see syndibombs for 75% off you won't be able to nuke the entire station with them.
/:cl: