### PR TITLE
Wizards can now buy magic guardians for 2 points

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -389,6 +389,18 @@
 	log_name = "CT"
 	category = "Assistance"
 
+/datum/spellbook_entry/item/guardian
+	name = "Guardian Deck"
+	desc = "A deck of guardian tarot cards, capable of binding a personal guardian to you. There are multiple types of guardian available, but all of them will transfer some amount of damage to you."
+	item_path = /obj/item/weapon/guardiancreator/choose/dextrous/wizard
+	log_name = "GU"
+	category = "Assistance"
+
+/datum/spellbook_entry/item/guardian/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book)
+	. = ..()
+	if(.)
+		new /obj/item/weapon/paper/guardian/wizard(get_turf(user))
+
 /datum/spellbook_entry/item/bloodbottle
 	name = "Bottle of Blood"
 	desc = "A bottle of magically infused blood, the smell of which will attract extradimensional beings when broken. Be careful though, the kinds of creatures summoned by blood magic are indiscriminate in their killing, and you yourself may become a victim."

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -391,8 +391,9 @@
 
 /datum/spellbook_entry/item/guardian
 	name = "Guardian Deck"
-	desc = "A deck of guardian tarot cards, capable of binding a personal guardian to you. There are multiple types of guardian available, but all of them will transfer some amount of damage to you."
-	item_path = /obj/item/weapon/guardiancreator/choose/dextrous/wizard
+	desc = "A deck of guardian tarot cards, capable of binding a personal guardian to your body. There are multiple types of guardian available, but all of them will transfer some amount of damage to you. \
+	It would be wise to avoid buying these with anything capable of causing you to swap bodies with others."
+	item_path = /obj/item/weapon/guardiancreator/choose/wizard
 	log_name = "GU"
 	category = "Assistance"
 

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -577,7 +577,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
 /obj/item/weapon/guardiancreator/choose/dextrous
 	possible_guardians = list("Assassin", "Chaos", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
 
-/obj/item/weapon/guardiancreator/choose/dextrous/wizard
+/obj/item/weapon/guardiancreator/choose/wizard
 	possible_guardians = list("Assassin", "Chaos", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard")
 	allowmultiple = TRUE
 

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -571,6 +571,13 @@ var/global/list/parasites = list() //all currently existing/living guardians
 /obj/item/weapon/guardiancreator/choose
 	random = FALSE
 
+/obj/item/weapon/guardiancreator/choose/dextrous
+	possible_guardians = list("Assassin", "Chaos", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
+
+/obj/item/weapon/guardiancreator/choose/dextrous/wizard
+	possible_guardians = list("Assassin", "Chaos", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard")
+	allowmultiple = TRUE
+
 /obj/item/weapon/guardiancreator/tech
 	name = "holoparasite injector"
 	desc = "It contains an alien nanoswarm of unknown origin. Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, it requires an organic host as a home base and source of fuel."
@@ -614,12 +621,38 @@ var/global/list/parasites = list() //all currently existing/living guardians
  <br>
  <b>Standard</b>: Devastating close combat attacks and high damage resist. Can smash through weak walls.<br>
  <br>
- <b>Support</b>: Has two modes. Combat; Medium power attacks and damage resist. Healer; Heals instead of attack, but has low damage resist and slow movement. Can deploy a bluespace beacon and warp targets to it (including you) in either mode.<br>
- <br>
 "}
 
 /obj/item/weapon/paper/guardian/update_icon()
 	return
+
+/obj/item/weapon/paper/guardian/wizard
+	name = "Guardian Guide"
+	icon_state = "paper_words"
+	info = {"<b>A list of Guardian Types</b><br>
+
+ <br>
+ <b>Assassin</b>: Does medium damage and takes full damage, but can enter stealth, causing its next attack to do massive damage and ignore armor. However, it becomes briefly unable to recall after attacking from stealth.<br>
+ <br>
+ <b>Chaos</b>: Ignites enemies on touch and causes them to hallucinate all nearby people as the guardian. Automatically extinguishes the user if they catch on fire.<br>
+ <br>
+ <b>Charger</b>: Moves extremely fast, does medium damage on attack, and can charge at targets, damaging the first target hit and forcing them to drop any items they are holding.<br>
+ <br>
+ <b>Dexterous</b>: Does low damage on attack, but is capable of holding items and storing a single item within it. It will drop items held in its hands when it recalls, but it will retain the stored item.<br>
+ <br>
+ <b>Explosive</b>: High damage resist and medium power attack that may explosively teleport targets. Can turn any object, including objects too large to pick up, into a bomb, dealing explosive damage to the next person to touch it. The object will return to normal after the trap is triggered or after a delay.<br>
+ <br>
+ <b>Lightning</b>: Attacks apply lightning chains to targets. Has a lightning chain to the user. Lightning chains shock everything near them, doing constant damage.<br>
+ <br>
+ <b>Protector</b>: Causes you to teleport to it when out of range, unlike other parasites. Has two modes; Combat, where it does and takes medium damage, and Protection, where it does and takes almost no damage but moves slightly slower.<br>
+ <br>
+ <b>Ranged</b>: Has two modes. Ranged; which fires a constant stream of weak, armor-ignoring projectiles. Scout; Cannot attack, but can move through walls and is quite hard to see. Can lay surveillance snares, which alert it when crossed, in either mode.<br>
+ <br>
+ <b>Standard</b>: Devastating close combat attacks and high damage resist. Can smash through weak walls.<br>
+ <br>
+ <b>Support</b>: Has two modes. Combat; Medium power attacks and damage resist. Healer; Heals instead of attack, but has low damage resist and slow movement. Can deploy a bluespace beacon and warp targets to it (including you) in either mode.<br>
+ <br>
+"}
 
 
 /obj/item/weapon/storage/box/syndie_kit/guardian

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -631,7 +631,6 @@ var/global/list/parasites = list() //all currently existing/living guardians
 
 /obj/item/weapon/paper/guardian/wizard
 	name = "Guardian Guide"
-	icon_state = "paper_words"
 	info = {"<b>A list of Guardian Types</b><br>
 
  <br>
@@ -652,8 +651,6 @@ var/global/list/parasites = list() //all currently existing/living guardians
  <b>Ranged</b>: Has two modes. Ranged; which fires a constant stream of weak, armor-ignoring projectiles. Scout; Cannot attack, but can move through walls and is quite hard to see. Can lay surveillance snares, which alert it when crossed, in either mode.<br>
  <br>
  <b>Standard</b>: Devastating close combat attacks and high damage resist. Can smash through weak walls.<br>
- <br>
- <b>Support</b>: Has two modes. Combat; Medium power attacks and damage resist. Healer; Heals instead of attack, but has low damage resist and slow movement. Can deploy a bluespace beacon and warp targets to it (including you) in either mode.<br>
  <br>
 "}
 

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -172,7 +172,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
 		else
 			src << "<span class='holoparasite'>You moved out of range, and were pulled back! You can only move [range] meters from [summoner.real_name]!</span>"
 			visible_message("<span class='danger'>\The [src] jumps back to its user.</span>")
-			if(istype(summoner.loc, /obj/effect/dummy))
+			if(istype(summoner.loc, /obj/effect))
 				Recall(TRUE)
 			else
 				PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, loc)
@@ -316,7 +316,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
 //MANIFEST, RECALL, TOGGLE MODE/LIGHT, SHOW TYPE
 
 /mob/living/simple_animal/hostile/guardian/proc/Manifest(forced)
-	if(istype(summoner.loc, /obj/effect/dummy) || (cooldown > world.time && !forced))
+	if(istype(summoner.loc, /obj/effect) || (cooldown > world.time && !forced))
 		return FALSE
 	if(loc == summoner)
 		forceMove(summoner.loc)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -172,9 +172,12 @@ var/global/list/parasites = list() //all currently existing/living guardians
 		else
 			src << "<span class='holoparasite'>You moved out of range, and were pulled back! You can only move [range] meters from [summoner.real_name]!</span>"
 			visible_message("<span class='danger'>\The [src] jumps back to its user.</span>")
-			PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, get_turf(src))
-			forceMove(get_turf(summoner))
-			PoolOrNew(/obj/effect/overlay/temp/guardian/phase, get_turf(src))
+			if(istype(summoner.loc, /obj/effect/dummy))
+				Recall(TRUE)
+			else
+				PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, loc)
+				forceMove(summoner.loc)
+				PoolOrNew(/obj/effect/overlay/temp/guardian/phase, loc)
 
 /mob/living/simple_animal/hostile/guardian/canSuicide()
 	return 0
@@ -312,24 +315,24 @@ var/global/list/parasites = list() //all currently existing/living guardians
 
 //MANIFEST, RECALL, TOGGLE MODE/LIGHT, SHOW TYPE
 
-/mob/living/simple_animal/hostile/guardian/proc/Manifest()
-	if(cooldown > world.time)
-		return 0
+/mob/living/simple_animal/hostile/guardian/proc/Manifest(forced)
+	if(istype(summoner.loc, /obj/effect/dummy) || (cooldown > world.time && !forced))
+		return FALSE
 	if(loc == summoner)
-		forceMove(get_turf(summoner))
-		PoolOrNew(/obj/effect/overlay/temp/guardian/phase, get_turf(src))
+		forceMove(summoner.loc)
+		PoolOrNew(/obj/effect/overlay/temp/guardian/phase, loc)
 		cooldown = world.time + 10
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
-/mob/living/simple_animal/hostile/guardian/proc/Recall()
-	if(loc == summoner || cooldown > world.time)
-		return 0
-	PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, get_turf(src))
+/mob/living/simple_animal/hostile/guardian/proc/Recall(forced)
+	if(!summoner || loc == summoner || (cooldown > world.time && !forced))
+		return FALSE
+	PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, loc)
 
 	forceMove(summoner)
 	cooldown = world.time + 10
-	return 1
+	return TRUE
 
 /mob/living/simple_animal/hostile/guardian/proc/ToggleMode()
 	src << "<span class='danger'><B>You don't have another mode!</span></B>"

--- a/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
@@ -46,9 +46,9 @@
 	else
 		..()
 
-/mob/living/simple_animal/hostile/guardian/dextrous/Recall()
-	if(loc == summoner || cooldown > world.time)
-		return 0
+/mob/living/simple_animal/hostile/guardian/dextrous/Recall(forced)
+	if(!summoner || loc == summoner || (cooldown > world.time && !forced))
+		return FALSE
 	drop_all_held_items()
 	return ..() //lose items, then return
 

--- a/code/modules/mob/living/simple_animal/guardian/types/lightning.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/lightning.dm
@@ -37,7 +37,8 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/guardian/beam/Manifest()
-	if(..())
+	. = ..()
+	if(.)
 		if(summoner)
 			summonerchain = Beam(summoner, "lightning[rand(1,12)]", time=INFINITY, maxdistance=INFINITY, beam_type=/obj/effect/ebeam/chain)
 		while(loc != summoner)
@@ -48,7 +49,8 @@
 			sleep(3)
 
 /mob/living/simple_animal/hostile/guardian/beam/Recall()
-	if(..())
+	. = ..()
+	if(.)
 		removechains()
 
 /mob/living/simple_animal/hostile/guardian/beam/proc/shockallchains()

--- a/code/modules/mob/living/simple_animal/guardian/types/protector.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/protector.dm
@@ -60,7 +60,7 @@
 		if(get_dist(get_turf(summoner),get_turf(src)) <= range)
 			return
 		else
-			if(istype(summoner.loc, /obj/effect/dummy))
+			if(istype(summoner.loc, /obj/effect))
 				src << "<span class='holoparasite'>You moved out of range, and were pulled back! You can only move [range] meters from [summoner.real_name]!</span>"
 				visible_message("<span class='danger'>\The [src] jumps back to its user.</span>")
 				Recall(TRUE)

--- a/code/modules/mob/living/simple_animal/guardian/types/protector.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/protector.dm
@@ -60,8 +60,13 @@
 		if(get_dist(get_turf(summoner),get_turf(src)) <= range)
 			return
 		else
-			summoner << "<span class='holoparasite'>You moved out of range, and were pulled back! You can only move [range] meters from <font color=\"[namedatum.colour]\"><b>[real_name]</b></font>!</span>"
-			summoner.visible_message("<span class='danger'>\The [summoner] jumps back to [summoner.p_their()] protector.</span>")
-			PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, get_turf(summoner))
-			summoner.forceMove(get_turf(src))
-			PoolOrNew(/obj/effect/overlay/temp/guardian/phase, get_turf(summoner))
+			if(istype(summoner.loc, /obj/effect/dummy))
+				src << "<span class='holoparasite'>You moved out of range, and were pulled back! You can only move [range] meters from [summoner.real_name]!</span>"
+				visible_message("<span class='danger'>\The [src] jumps back to its user.</span>")
+				Recall(TRUE)
+			else
+				summoner << "<span class='holoparasite'>You moved out of range, and were pulled back! You can only move [range] meters from <font color=\"[namedatum.colour]\"><b>[real_name]</b></font>!</span>"
+				summoner.visible_message("<span class='danger'>\The [summoner] jumps back to [summoner.p_their()] protector.</span>")
+				PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, get_turf(summoner))
+				summoner.forceMove(get_turf(src))
+				PoolOrNew(/obj/effect/overlay/temp/guardian/phase, get_turf(summoner))


### PR DESCRIPTION
:cl: Joan
rscadd: Wizards can now buy magic guardians for 2 points. They are not limited to one guardian, meaning they can have up to 5. If that's wise is an entirely different question.
experiment: Wizards cannot buy support guardians, but can buy dexterous guardians, which can hold items.
/:cl:

This seems like a fun idea! Guardians are, in general, pretty bad for wizards because they give the wizard another point of attack, making them easier to kill. With no support guardian, by default wizards will also require a bit more creativity for self-healing.
