### PR TITLE
Fixes hit text for holodeck monkeys

### DIFF
--- a/code/modules/holodeck/mobs.dm
+++ b/code/modules/holodeck/mobs.dm
@@ -17,4 +17,3 @@
 	butcher_results = list()
 	response_help = "pets"
 	response_disarm = "pushes aside"
-	response_harm = "bites"


### PR DESCRIPTION
Removes the bites line, causing it to inherit the hits from simple_animal.

Reason: Fixes #22356.