### PR TITLE
Fixes the descriptions on the Syndi Spacesuit and Helmet.

### DIFF
--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -3,14 +3,14 @@
 	name = "red space helmet"
 	icon_state = "syndicate"
 	item_state = "syndicate"
-	desc = "Has a tag: Totally not property of an enemy corporation, honest."
+	desc = "Has a tag on it: Totally not property of an enemy corporation, honest!"
 	armor = list(melee = 40, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30, fire = 80, acid = 85)
 
 /obj/item/clothing/suit/space/syndicate
 	name = "red space suit"
 	icon_state = "syndicate"
 	item_state = "space_suit_syndicate"
-	desc = "Has a tag on it: Totally not property of of a hostile corporation, honest!"
+	desc = "Has a tag on it: Totally not property of an enemy corporation, honest!"
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
 	armor = list(melee = 40, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30, fire = 80, acid = 85)


### PR DESCRIPTION
This fixes the descriptions on the Syndicate Spacesuit and Helmet, and also makes their descriptions match better.

Fixes #22419 