### PR TITLE
Fixes invisible basketballs on Metastation.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -609,7 +609,7 @@
 	pixel_y = 29
 	},
 /obj/item/toy/beach_ball{
-	icon = 'icons/obj/basketball.dmi';
+	icon = 'icons/obj/items.dmi';
 	icon_state = "basketball";
 	item_state = "basketball";
 	name = "basket ball"
@@ -5543,7 +5543,7 @@
 /area/maintenance/fore)
 "ajV" = (
 /obj/item/toy/beach_ball{
-	icon = 'icons/obj/basketball.dmi';
+	icon = 'icons/obj/items.dmi';
 	icon_state = "basketball";
 	item_state = "basketball";
 	name = "basket ball"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -608,12 +608,7 @@
 /obj/structure/holohoop{
 	pixel_y = 29
 	},
-/obj/item/toy/beach_ball{
-	icon = 'icons/obj/items.dmi';
-	icon_state = "basketball";
-	item_state = "basketball";
-	name = "basket ball"
-	},
+/obj/item/toy/beach_ball/holoball,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -5542,12 +5537,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ajV" = (
-/obj/item/toy/beach_ball{
-	icon = 'icons/obj/items.dmi';
-	icon_state = "basketball";
-	item_state = "basketball";
-	name = "basket ball"
-	},
+/obj/item/toy/beach_ball/holoball,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ajW" = (


### PR DESCRIPTION
As far as I could find, it was only on Metastation where the issue with invisible Basketballs occured. This was due to it referencing the while .dmi file for its icons. This thus fixes it.

Update: This now replaces the fake Basketball with the real basketball(teeechnically real), which is used on all other maps.

Fixes #22274 