### PR TITLE
Fixes kudzu (i hope)

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -353,7 +353,7 @@
 			var/obj/item/seeds/kudzu/KZ = new(loc)
 			KZ.mutations |= mutations
 			KZ.potency = min(100, master.mutativeness * 10)
-			KZ.production = (master.spread_cap / initial(master.spread_cap)) * 50
+			KZ.production = (master.spread_cap / initial(master.spread_cap)) * 5
 	mutations = list()
 	SetOpacity(0)
 	if(has_buckled_mobs())


### PR DESCRIPTION
Kudzu was spawning seeds with ten times the potency they were spawned with, causing a chain reaction of infinite amounts of kudzu. This will fix the kudzu spreading over the cap but probably won't slow down its growth speed, which is a more complicated issue.