### PR TITLE
Fixes the charge spell being too miserly with charges

### DIFF
--- a/code/modules/spells/spell_types/charge.dm
+++ b/code/modules/spells/spell_types/charge.dm
@@ -58,7 +58,7 @@
 				if(istype(item,/obj/item/weapon/gun/magic/wand) && I.max_charges != 0)
 					var/obj/item/weapon/gun/magic/W = item
 					W.icon_state = initial(W.icon_state)
-				I.process_chamber()
+				I.recharge_newshot()
 				charged_item = I
 				break
 			else if(istype(item, /obj/item/weapon/stock_parts/cell/))


### PR DESCRIPTION
Process_chamber takes a charge to add a charge, so every time you charged a wand you'd end up with one fewer charge than you should have. It also incorrectly showed wands as charged thanks to giving wands -1 charges.

Fixes #22136

:cl:
bugfix: The charge spell will no longer bilk you on wand charges, and wands that are dead won't show up as charged.
/:cl: