### PR TITLE
Makes it so the default thermomachine board no longer builds nothing.

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -33,6 +33,14 @@
 							/obj/item/stack/cable_coil = 1,
 							/obj/item/weapon/stock_parts/console_screen = 1)
 
+/obj/item/weapon/circuitboard/machine/thermomachine/New()
+	if(prob(50))
+		name = "circuit board (Freezer)"
+		build_path = /obj/machinery/atmospherics/components/unary/thermomachine/freezer
+	else
+		name = "circuit board (Heater)"
+		build_path = /obj/machinery/atmospherics/components/unary/thermomachine/heater
+
 /obj/item/weapon/circuitboard/machine/thermomachine/attackby(obj/item/I, mob/user, params)
 	var/obj/item/weapon/circuitboard/machine/freezer = /obj/item/weapon/circuitboard/machine/thermomachine/freezer
 	var/obj/item/weapon/circuitboard/machine/heater = /obj/item/weapon/circuitboard/machine/thermomachine/heater

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -34,6 +34,7 @@
 							/obj/item/weapon/stock_parts/console_screen = 1)
 
 /obj/item/weapon/circuitboard/machine/thermomachine/New()
+	..()
 	if(prob(50))
 		name = "circuit board (Freezer)"
 		build_path = /obj/machinery/atmospherics/components/unary/thermomachine/freezer


### PR DESCRIPTION
The default Thermomachine circuit board, when build, will have the build_path to create either the freezer or the heater, and thus won't end up causing a machine construction which can never be finished due to lacking a build path.

Fixes #22254 