### PR TITLE
Fixes not being able to drink/eat with a visor-up Riot Helmet.

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -52,6 +52,7 @@
 	visor_flags_inv = HIDEFACE
 	toggle_cooldown = 0
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	dog_fashion = null
 
 /obj/item/clothing/head/helmet/attack_self(mob/user)


### PR DESCRIPTION
This fixes the issue where you couldn't drink/eat stuff if the Riot Helmets visor was up.

Fixes #22100 