### PR TITLE
Don't redestroy a tesla ball on stop orbit

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -145,7 +145,7 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 		orbitingball.orbiting_balls -= src
 		orbitingball.dissipate_strength = orbitingball.orbiting_balls.len
 	..()
-	if (!loc)
+	if (!loc && !qdeleted(src))
 		qdel(src)
 
 


### PR DESCRIPTION
Destroy can cause the parent ball you're orbiting to also be destroyed,
which calls stop orbit on your ball, which then caused you to get
destroyed again, this fixes that while still guarding against the case
the original !loc qdel code was added for - see pr #15486