### PR TITLE
Fixes issue where X4 and the different C4 could be placed on non-carbon mobs.

### DIFF
--- a/code/game/objects/items/weapons/grenades/plastic.dm
+++ b/code/game/objects/items/weapons/grenades/plastic.dm
@@ -68,7 +68,7 @@
 /obj/item/weapon/grenade/plastic/afterattack(atom/movable/AM, mob/user, flag)
 	if (!flag)
 		return
-	if (istype(AM, /mob/living/carbon))
+	if (ismob(AM))
 		return
 	user << "<span class='notice'>You start planting the [src]. The timer is set to [det_time]...</span>"
 


### PR DESCRIPTION
You can no longer place X4 and the alternative C4 on non-carbon mobs, since this was seen as a bug, and it is thus also consistent with the original C4 where we removed being able to place it on mobs.

Fixes #21113