### PR TITLE
Catwalks now drop two rods when deconstructed. Also fixes metal duplication exploit.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -31,7 +31,7 @@
 	var/close_sound = 'sound/machines/click.ogg'
 	var/cutting_sound = 'sound/items/Welder.ogg'
 	var/material_drop = /obj/item/stack/sheet/metal
-	var/material_drop_amount = 3
+	var/material_drop_amount = 2
 	var/delivery_icon = "deliverycloset" //which icon to use when packagewrapped. null to be unwrappable.
 
 /obj/structure/closet/New()

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -60,6 +60,11 @@
 	smooth = SMOOTH_TRUE
 	canSmoothWith = null
 
+/obj/structure/lattice/catwalk/New()
+	..()
+	stored.amount++
+	stored.update_icon()
+
 /obj/structure/lattice/catwalk/Move()
 	var/turf/T = loc
 	for(var/obj/structure/cable/C in T)


### PR DESCRIPTION
Because they take two rods to build, duh.
Not a reported issue but it's a fix anyway!

BONUS: Turns out closets dropped 3 sheets of metal when deconstructed. They take 2 to build. This fixes that too. How long did THAT go unreported?