### PR TITLE
Prevents an exploit related to pulling a vehicle as its driver while in space

### DIFF
--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -137,7 +137,7 @@
 	if(has_gravity())
 		return 1
 
-	if(pulledby)
+	if(pulledby && (pulledby.loc != loc))
 		return 1
 
 	return 0


### PR DESCRIPTION
:cl: Mervill
fix: Patched an exploit related to pulling a vehicle as its driver while in space
/:cl:

Vehicles don't get spacemove if they are being pulled by a mob that shares it's loc.

fixes #20465