### PR TITLE
Fixes cards against space

### DIFF
--- a/code/modules/games/cas.dm
+++ b/code/modules/games/cas.dm
@@ -29,7 +29,6 @@ var/global/list/cards_against_space
 	card_text_file = "strings/cas_black.txt"
 
 /obj/item/toy/cards/deck/cas/New()
-	..()
 	if(!cards_against_space)  //saves loading from the files every single time a new deck is created, but still lets each deck have a random assortment, it's purely an optimisation
 		cards_against_space = list("cas_white" = file2list("strings/cas_white.txt"),"cas_black" = file2list("strings/cas_black.txt"))
 	allcards = cards_against_space[card_face]
@@ -55,6 +54,7 @@ var/global/list/cards_against_space
 		P.card_icon = "cas_white"
 		cards += P
 	shuffle(cards) // distribute blank cards throughout deck
+	..()
 
 /obj/item/toy/cards/deck/cas/attack_hand(mob/user)
 	if(user.lying)


### PR DESCRIPTION
:cl: Mervill
fix: Fixed cards against space
/:cl:

@MrStonedOne should look at this before it gets merged since the fix was to move `..()` from the top of the `New()` for CAS to the bottom, and I'm not quite sure what that might imply

fixes #22232 