### PR TITLE
Clothing without a casual variant will no longer say it can be worn differently when examined

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -580,10 +580,11 @@ BLIND     // can't see anything
 
 /obj/item/clothing/under/examine(mob/user)
 	..()
-	if(adjusted == ALT_STYLE)
-		user << "Alt-click on [src] to wear it normally."
-	else
-		user << "Alt-click on [src] to wear it casually."
+	if(can_adjust)
+		if(adjusted == ALT_STYLE)
+			user << "Alt-click on [src] to wear it normally."
+		else
+			user << "Alt-click on [src] to wear it casually."
 	switch(sensor_mode)
 		if(0)
 			user << "Its sensors appear to be disabled."

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -122,3 +122,4 @@
 	icon_state = "blueshift"
 	item_state = "blueshift"
 	item_color = "blueshift"
+	can_adjust = 0


### PR DESCRIPTION
:cl: Mervill
fix: Clothing without a casual variant will no longer say it can be worn differently when examined
/:cl:

The issue referenced below was actually already fixed by setting `can_adjust` on the rainbow jumpsuit to 0, however in testing I noticed that even if `can_adjust = 0`, the examine text would still say that you could alt-click the clothing to wear it casually.

Also fixes one instance of a shirt that can't be worn casually

fixes #19404
fixes #19733