### PR TITLE
Only standard handcuffs can be used to make chained shoes

### DIFF
--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -97,9 +97,7 @@
 /obj/item/clothing/shoes/sneakers/orange/attackby(obj/H, loc, params)
 	..()
 	// Note: not using istype here because we want to ignore all subtypes
-	if (H.type == /obj/item/weapon/restraints/handcuffs && !chained)
-		if (src.icon_state != "orange")
-			return
+	if (H.type == /obj/item/weapon/restraints/handcuffs && !chained && icon_state == "orange")
 		qdel(H)
 		src.chained = 1
 		src.slowdown = 15

--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -96,11 +96,10 @@
 
 /obj/item/clothing/shoes/sneakers/orange/attackby(obj/H, loc, params)
 	..()
-	if ((istype(H, /obj/item/weapon/restraints/handcuffs) && !( src.chained )))
-		//H = null
-		if (src.icon_state != "orange") return
-		if(istype(H, /obj/item/weapon/restraints/handcuffs/cable))
-			return 0
+	// Note: not using istype here because we want to ignore all subtypes
+	if (H.type == /obj/item/weapon/restraints/handcuffs && !src.chained)
+		if (src.icon_state != "orange")
+			return
 		qdel(H)
 		src.chained = 1
 		src.slowdown = 15

--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -97,9 +97,7 @@
 /obj/item/clothing/shoes/sneakers/orange/attackby(obj/H, loc, params)
 	..()
 	// Note: not using istype here because we want to ignore all subtypes
-	if (H.type == /obj/item/weapon/restraints/handcuffs && !src.chained)
-		if (src.icon_state != "orange")
-			return
+	if (H.type == /obj/item/weapon/restraints/handcuffs && !chained)
 		qdel(H)
 		src.chained = 1
 		src.slowdown = 15

--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -98,6 +98,8 @@
 	..()
 	// Note: not using istype here because we want to ignore all subtypes
 	if (H.type == /obj/item/weapon/restraints/handcuffs && !chained)
+		if (src.icon_state != "orange")
+			return
 		qdel(H)
 		src.chained = 1
 		src.slowdown = 15

--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -97,7 +97,7 @@
 /obj/item/clothing/shoes/sneakers/orange/attackby(obj/H, loc, params)
 	..()
 	// Note: not using istype here because we want to ignore all subtypes
-	if (H.type == /obj/item/weapon/restraints/handcuffs && !chained && icon_state == "orange")
+	if (H.type == /obj/item/weapon/restraints/handcuffs && !chained)
 		qdel(H)
 		src.chained = 1
 		src.slowdown = 15


### PR DESCRIPTION
:cl: Mervill
fix: Only standard handcuffs can be used to make chained shoes
/:cl:

fixes #18500
