### PR TITLE
Fixes Pizza bomb not being correctly deleted.

### DIFF
--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -192,6 +192,7 @@
 		if(bomb in src)
 			bomb.detonate()
 			unprocess()
+			qdel(src)
 	if(!bomb_active || bomb_defused)
 		if(bomb_defused && bomb in src)
 			bomb.defuse()


### PR DESCRIPTION
Previously, when a Pizza bomb exploded while held by someone, it would not delete and would instead stick around(no pun intended). This fixes that.

Fixes #20248