### PR TITLE
Fixed offhands being dropable

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -119,7 +119,7 @@
 	name = "offhand"
 	icon_state = "offhand"
 	w_class = WEIGHT_CLASS_HUGE
-	flags = ABSTRACT
+	flags = ABSTRACT | NODROP
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/item/weapon/twohanded/offhand/unwield()


### PR DESCRIPTION
Possibly caused by https://github.com/tgstation/tgstation/pull/22457, you could lose the offhand of nodrop wielded items like defib paddles by resting or having someone strip it off of you.