### PR TITLE
clickcode + silicons = paper plane folding ???

### DIFF
--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -104,9 +104,12 @@
 		H.emote("scream")
 
 /obj/item/weapon/paper/AltClick(mob/living/carbon/user, obj/item/I)
-	if((!in_range(src, user)) || user.stat || user.restrained() || (issilicon(user)) )
-		return
-	user << "<span class='notice'>You fold [src] into the shape of a plane!</span>"
-	user.unEquip(src)
-	I = new /obj/item/weapon/paperplane(loc, src)
-	user.put_in_hands(I)
+	if ( iscarbon(user) )
+		if( (!in_range(src, user)) || user.stat || user.restrained() )
+			return
+		user << "<span class='notice'>You fold [src] into the shape of a plane!</span>"
+		user.unEquip(src)
+		I = new /obj/item/weapon/paperplane(loc, src)
+		user.put_in_hands(I)
+	else
+		user << "<span class='notice'> You lack the dexterity to fold \the [src]. </span>"

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -104,7 +104,7 @@
 		H.emote("scream")
 
 /obj/item/weapon/paper/AltClick(mob/living/carbon/user, obj/item/I)
-	if ( iscarbon(user) )
+	if ( is_type(user) )
 		if( (!in_range(src, user)) || user.stat || user.restrained() )
 			return
 		user << "<span class='notice'>You fold [src] into the shape of a plane!</span>"

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -104,7 +104,7 @@
 		H.emote("scream")
 
 /obj/item/weapon/paper/AltClick(mob/living/carbon/user, obj/item/I)
-	if ( is_type(user) )
+	if ( istype(user) )
 		if( (!in_range(src, user)) || user.stat || user.restrained() )
 			return
 		user << "<span class='notice'>You fold [src] into the shape of a plane!</span>"

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -104,7 +104,7 @@
 		H.emote("scream")
 
 /obj/item/weapon/paper/AltClick(mob/living/carbon/user, obj/item/I)
-	if((!in_range(src, user)) || usr.stat || usr.restrained())
+	if((!in_range(src, user)) || usr.stat || usr.restrained() || (issilicon(user)) )
 		return
 	user << "<span class='notice'>You fold [src] into the shape of a plane!</span>"
 	user.unEquip(src)

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -104,7 +104,7 @@
 		H.emote("scream")
 
 /obj/item/weapon/paper/AltClick(mob/living/carbon/user, obj/item/I)
-	if((!in_range(src, user)) || usr.stat || usr.restrained() || (issilicon(user)) )
+	if((!in_range(src, user)) || user.stat || user.restrained() || (issilicon(user)) )
 		return
 	user << "<span class='notice'>You fold [src] into the shape of a plane!</span>"
 	user.unEquip(src)


### PR DESCRIPTION
Fixes a bug where silicons could fold paper.

"but cobby, silicons aren't even in mob/living/carbon" - Yes, you are correct. Clickcode does not discriminate, however.