### PR TITLE
Fixes Syndicate Scientist Lavaland Role

### DIFF
--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -125,14 +125,14 @@
 	radio = /obj/item/device/radio/headset/syndicate/alt
 	back = /obj/item/weapon/storage/backpack
 	pocket1 = /obj/item/weapon/gun/ballistic/automatic/pistol
-	pocket2 = /obj/item/weapon/card/id/syndicate/anyone
 	roundstart = FALSE
 	death = FALSE
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "sleeper"
 	has_id = 1
 	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. Unfortunatley, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Continue your research as best you can, and try to keep a low profile. Do not abandon the base without good cause.</b> The base is rigged with explosives should the worst happen, do not let the base fall into enemy hands!</b>"
-
+	id_access_list = list(access_syndicate)
+	
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms
 	name = "Syndicate Comms Agent"
 	r_hand = /obj/item/weapon/melee/energy/sword/saber


### PR DESCRIPTION
Removes Agent ID card [We can take the bandaid off now!] and replaces with syndicate access on their actual id.
