### PR TITLE
Portals can no longer be frozen.

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -21,7 +21,8 @@
 	if(user && Adjacent(user))
 		teleport(user)
 
-
+/obj/effect/portal/make_frozen_visual()
+	return
 
 /obj/effect/portal/New(loc, turf/target, creator=null, lifespan=300)
 	..()


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/21698.

Suggestions requested for

- Other stuff that shouldn't freeze
- Whether I should make FREEZEPROOF a define like lavaproof, and if so whether to do it under resistance flags or elsewhere, and if so how the fuck to do that
