### PR TITLE
Fixes some accidental deception with the panic bouncer

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -29,7 +29,6 @@ var/global/comms_allowed = 0 //By default, the server does not allow messages to
 //Cross server communications
 var/global/cross_address = "byond://" //This needs to be global as the message sent contains the comms key.
 var/global/cross_allowed = 0 //Don't bother attempting to send if the address wasn't set.
-var/global/panic_address = "byond://" //Reconnect a player this linked server if this server isn't accepting new players
 
 var/global/medal_hub = null
 var/global/medal_pass = " "

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -76,6 +76,7 @@
 
 	var/allow_panic_bunker_bounce = 0 //Send new players somewhere else
 	var/panic_server_name = "somewhere else"
+	var/panic_address = "byond://" //Reconnect a player this linked server if this server isn't accepting new players
 
 	//IP Intel vars
 	var/ipintel_email

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -400,7 +400,7 @@
 				if("panic_server_name")
 					panic_server_name = value
 				if("panic_server_address")
-					global.panic_address = value
+					panic_address = value
 					if(value != "byond:\\address:port")
 						allow_panic_bunker_bounce = 1
 				if("medal_hub_address")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -199,7 +199,7 @@ var/next_external_rsc = 0
 			if(config.allow_panic_bunker_bounce && tdata != "redirect")
 				src << "<span class='notice'>Sending you to [config.panic_server_name].</span>"
 				winset(src, null, "command=.options")
-				src << link("[global.panic_address]?redirect")
+				src << link("[config.panic_address]?redirect")
 			qdel(src)
 			return 0
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -246,7 +246,7 @@ NOTIFY_NEW_PLAYER_AGE 0
 
 ## If panic bunker is on and a player is rejected (see above), attempt to send them to this connected server (see below) instead.
 ##	You probably want this to be the same as CROSS_SERVER_ADDRESS
-PANIC_SERVER_ADDRESS byond:\\address:port
+PANIC_SERVER_ADDRESS byond://address:port
 
 ##Name of the place to send people rejected by the bunker
 PANIC_SERVER_NAME [Put the name here]


### PR DESCRIPTION
The config file accidentally stated that you'd want a url starting with 

> byond:\\\

 instead of 

> byond://

 (why? No idea.)

The panic server var has also been downgraded from a global var to a normal var upon request