### PR TITLE
Fixes deathgasp not working

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -83,7 +83,7 @@
 	message_alien = "lets out a waning guttural screech, green blood bubbling from its maw..."
 	message_larva = "lets out a sickly hiss of air and falls limply to the floor..."
 	message_monkey = "lets out a faint chimper as it collapses and stops moving..."
-	stat_allowed = UNCONSCIOUS
+	stat_allowed = DEAD
 
 /datum/emote/living/deathgasp/run_emote(mob/user, params)
 	. = ..()


### PR DESCRIPTION
Deathgasp is a special snowflake that is only called after the mob is already dead... so gotta allow that.