### PR TITLE
Fixes some emote bugs and grammar

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -11,6 +11,7 @@ var/global/list/emote_list = list()
 	var/message_alien = "" //Message displayed if the user is a grown alien
 	var/message_larva = "" //Message displayed if the user is an alien larva
 	var/message_robot = "" //Message displayed if the user is a robot
+	var/message_AI = "" //Message displayed if the user is an AI
 	var/message_monkey = "" //Message displayed if the user is a monkey
 	var/message_param = "" //Message to display if a param was given
 	var/emote_type = EMOTE_VISIBLE //Whether the emote is visible or audible
@@ -38,6 +39,8 @@ var/global/list/emote_list = list()
 		msg = replacetext(msg, "their", user.p_their())
 	if(findtext(msg, "them"))
 		msg = replacetext(msg, "them", user.p_them())
+	if(findtext(msg, "%s"))
+		msg = replacetext(msg, "%s", user.p_s())
 
 	var/mob/living/L = user
 	for(var/obj/item/weapon/implant/I in L.implants)
@@ -71,24 +74,27 @@ var/global/list/emote_list = list()
 		. = message_alien
 	else if(islarva(user) && message_larva)
 		. = message_larva
-	else if(issilicon(user) && message_robot)
+	else if(iscyborg(user) && message_robot)
 		. = message_robot
+	else if(isAI(user) && message_AI)
+		. = message_AI
 	else if(ismonkey(user) && message_monkey)
 		. = message_monkey
 
 /datum/emote/proc/select_param(mob/user, params)
 	return replacetext(message_param, "%t", params)
 
-/datum/emote/proc/can_run_emote(mob/user)
+/datum/emote/proc/can_run_emote(mob/user, help_check)
 	. = TRUE
-	if(user.stat > stat_allowed  || (user.status_flags & FAKEDEATH))
-		return FALSE
 	if(!is_type_in_typecache(user, mob_type_allowed_typecache))
-		return FALSE
-	if(restraint_check && user.restrained())
 		return FALSE
 	if(is_type_in_typecache(user, mob_type_blacklist_typecache))
 		return FALSE
+	if(!help_check)
+		if(user.stat > stat_allowed  || (user.status_flags & FAKEDEATH))
+			return FALSE
+		if(restraint_check && user.restrained())
+			return FALSE
 
 
 /datum/emote/sound

--- a/code/modules/mob/living/brain/emote.dm
+++ b/code/modules/mob/living/brain/emote.dm
@@ -5,7 +5,7 @@
 /datum/emote/brain/can_run_emote(mob/user)
 	. = ..()
 	var/mob/living/brain/B = user
-	if(!(B.container && istype(B.container, /obj/item/device/mmi)))
+	if(!istype(user) || (!(B.container && istype(B.container, /obj/item/device/mmi))))
 		return FALSE
 
 /datum/emote/brain/alarm

--- a/code/modules/mob/living/brain/emote.dm
+++ b/code/modules/mob/living/brain/emote.dm
@@ -5,7 +5,7 @@
 /datum/emote/brain/can_run_emote(mob/user)
 	. = ..()
 	var/mob/living/brain/B = user
-	if(!istype(user) || (!(B.container && istype(B.container, /obj/item/device/mmi))))
+	if(!istype(B) || (!(B.container && istype(B.container, /obj/item/device/mmi))))
 		return FALSE
 
 /datum/emote/brain/alarm

--- a/code/modules/mob/living/carbon/alien/humanoid/death.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/death.dm
@@ -2,16 +2,11 @@
 	if(stat == DEAD)
 		return
 
-	stat = DEAD
+	. = ..()
 
-	if(!gibbed)
-		playsound(loc, 'sound/voice/hiss6.ogg', 80, 1, 1)
-		visible_message("<span class='name'>[src]</span> lets out a waning guttural screech, green blood bubbling from its maw...")
-		update_canmove()
-		update_icons()
-		status_flags |= CANPUSH
-
-	return ..()
+	update_canmove()
+	update_icons()
+	status_flags |= CANPUSH
 
 //When the alien queen dies, all others must pay the price for letting her die.
 /mob/living/carbon/alien/humanoid/royal/queen/death(gibbed)
@@ -25,4 +20,4 @@
 		if(istype(node)) // just in case someone would ever add a diffirent node to hivenode slot
 			node.queen_death()
 
-	return ..(gibbed)
+	return ..()

--- a/code/modules/mob/living/carbon/alien/larva/death.dm
+++ b/code/modules/mob/living/carbon/alien/larva/death.dm
@@ -1,13 +1,10 @@
 /mob/living/carbon/alien/larva/death(gibbed)
 	if(stat == DEAD)
 		return
-	stat = DEAD
-	icon_state = "larva_dead"
 
-	if(!gibbed)
-		visible_message("<span class='name'>[src]</span> lets out a waning high-pitched cry.")
+	. = ..()
 
-	return ..(gibbed)
+	update_icons()
 
 /mob/living/carbon/alien/larva/spawn_gibs(with_bodyparts)
 	if(with_bodyparts)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -1,7 +1,16 @@
 /mob/living/carbon/death(gibbed)
+	if(stat == DEAD)
+		return
+
 	silent = 0
 	losebreath = 0
-	..()
+
+	if(!gibbed)
+		emote("deathgasp")
+
+	. = ..()
+	if(ticker && ticker.mode)
+		ticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 
 /mob/living/carbon/gib(no_brain, no_organs, no_bodyparts)
 	for(var/mob/M in src)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -20,6 +20,7 @@
 	key_third_person = "claps"
 	message = "claps."
 	muzzle_ignore = TRUE
+	restraint_check = TRUE
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/gnarl
@@ -40,12 +41,14 @@
 	key_third_person = "rolls"
 	message = "rolls."
 	mob_type_allowed_typecache = list(/mob/living/carbon/monkey, /mob/living/carbon/alien)
+	restraint_check = TRUE
 
 /datum/emote/living/carbon/scratch
 	key = "scratch"
 	key_third_person = "scratches"
 	message = "scratches."
 	mob_type_allowed_typecache = list(/mob/living/carbon/monkey, /mob/living/carbon/alien)
+	restraint_check = TRUE
 
 /datum/emote/living/carbon/screech
 	key = "screech"
@@ -58,6 +61,7 @@
 	key_third_person = "signs"
 	message_param = "signs the number %t."
 	mob_type_allowed_typecache = list(/mob/living/carbon/monkey, /mob/living/carbon/alien)
+	restraint_check = TRUE
 
 /datum/emote/living/carbon/sign/select_param(mob/user, params)
 	. = ..()
@@ -69,6 +73,7 @@
 	key_third_person = "signals"
 	message_param = "raises %t fingers."
 	mob_type_allowed_typecache = list(/mob/living/carbon/human)
+	restraint_check = TRUE
 
 /datum/emote/living/carbon/tail
 	key = "tail"

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -16,7 +16,9 @@
 /mob/living/carbon/human/death(gibbed)
 	if(stat == DEAD)
 		return
-	stat = DEAD
+
+	. = ..()
+
 	dizziness = 0
 	jitteriness = 0
 	heart_attack = 0
@@ -26,15 +28,10 @@
 		if(M.occupant == src)
 			M.go_out()
 
-	if(!gibbed)
-		emote("deathgasp") //let the world KNOW WE ARE DEAD
-
 	dna.species.spec_death(gibbed, src)
 
 	if(ticker && ticker.mode)
 		sql_report_death(src)
-		ticker.mode.check_win()		//Calls the rounds wincheck, mainly for wizard, malf, and changeling now
-	. = ..(gibbed)
 	if(mind && mind.devilinfo)
 		addtimer(mind.devilinfo, "beginResurrectionCheck", 0, TIMER_NORMAL, src)
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -28,6 +28,7 @@
 	key = "handshake"
 	message = "shakes their own hands."
 	message_param = "shakes hands with %t."
+	restraint_check = TRUE
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/human/hug
@@ -35,6 +36,7 @@
 	key_third_person = "hugs"
 	message = "hugs themself."
 	message_param = "hugs %t."
+	restraint_check = TRUE
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/human/mumble
@@ -58,6 +60,7 @@
 	key_third_person = "salutes"
 	message = "salutes."
 	message_param = "salutes to %t."
+	restraint_check = TRUE
 
 /datum/emote/living/carbon/human/shrug
 	key = "shrug"
@@ -94,7 +97,6 @@
 	key = "wing"
 	key_third_person = "wings"
 	message = "their wings."
-	restraint_check = TRUE
 
 /datum/emote/living/carbon/human/wing/run_emote(mob/user, params)
 	. = ..()

--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -3,17 +3,3 @@
 
 /mob/living/carbon/monkey/dust_animation()
 	PoolOrNew(/obj/effect/overlay/temp/dust_animation, list(loc, "dust-m"))
-
-/mob/living/carbon/monkey/death(gibbed)
-	if(stat == DEAD)
-		return
-
-	stat = DEAD
-
-	if(!gibbed)
-		emote("deathgasp")
-
-	if(ticker && ticker.mode)
-		ticker.mode.check_win()
-
-	return ..(gibbed)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -44,17 +44,15 @@
 
 
 /mob/living/death(gibbed)
+	stat = DEAD
 	unset_machine()
 	timeofdeath = world.time
 	tod = worldtime2text()
 	var/turf/T = get_turf(src)
 	if(mind && mind.name && mind.active && (T.z != ZLEVEL_CENTCOM))
 		var/area/A = get_area(T)
-		var/rendered = "<span class='game deadsay'><span class='name'>\
-			[mind.name]</span> has died at <span class='name'>[A.name]\
-			</span>.</span>"
-		deadchat_broadcast(rendered, follow_target = src,
-			message_type=DEADCHAT_DEATHRATTLE)
+		var/rendered = "<span class='deadsay'><b>[mind.name]</b> has died at <b>[A.name]</b>.</span>"
+		deadchat_broadcast(rendered, follow_target = src, message_type=DEADCHAT_DEATHRATTLE)
 	if(mind)
 		mind.store_memory("Time of death: [tod]", 0)
 	living_mob_list -= src
@@ -74,3 +72,4 @@
 	update_canmove()
 	med_hud_set_health()
 	med_hud_set_status()
+	return TRUE

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -75,7 +75,6 @@
 	key_third_person = "dances"
 	message = "dances around happily."
 	restraint_check = TRUE
-	restraint_check = TRUE
 
 /datum/emote/living/deathgasp
 	key = "deathgasp"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -45,6 +45,7 @@
 	key = "cross"
 	key_third_person = "crosses"
 	message = "crosses their arms."
+	restraint_check = TRUE
 
 /datum/emote/living/chuckle
 	key = "chuckle"
@@ -74,12 +75,14 @@
 	key_third_person = "dances"
 	message = "dances around happily."
 	restraint_check = TRUE
+	restraint_check = TRUE
 
 /datum/emote/living/deathgasp
 	key = "deathgasp"
 	key_third_person = "deathgasps"
 	message = "seizes up and falls limp, their eyes dead and lifeless..."
-	message_robot = "memes up and die."
+	message_robot = "shudders violently for a moment before falling still, its eyes slowly darkening."
+	message_AI = "lets out a flurry of sparks, its screen flickering as its systems slowly halt."
 	message_alien = "lets out a waning guttural screech, green blood bubbling from its maw..."
 	message_larva = "lets out a sickly hiss of air and falls limply to the floor..."
 	message_monkey = "lets out a faint chimper as it collapses and stops moving..."
@@ -102,14 +105,13 @@
 
 /datum/emote/living/faint/run_emote(mob/user, params)
 	. = ..()
-	if(!user.sleeping)
+	if(.)
 		user.SetSleeping(10)
 
 /datum/emote/living/flap
 	key = "flap"
 	key_third_person = "flaps"
 	message = "flaps their wings."
-	restraint_check = TRUE
 	var/wing_time = 20
 
 /datum/emote/living/flap/run_emote(mob/user, params)
@@ -134,10 +136,11 @@
 /datum/emote/living/flip
 	key = "flip"
 	key_third_person = "flips"
+	restraint_check = TRUE
 
 /datum/emote/living/flip/run_emote(mob/user, params)
 	. = ..()
-	if(!user.sleeping)
+	if(!.)
 		user.SpinAnimation(7,1)
 
 /datum/emote/living/frown
@@ -192,6 +195,7 @@
 	key = "jump"
 	key_third_person = "jumps"
 	message = "jumps!"
+	restraint_check = TRUE
 
 /datum/emote/living/kiss
 	key = "kiss"
@@ -222,6 +226,7 @@
 	key = "point"
 	key_third_person = "points"
 	message = "points."
+	message_param = "points at %t."
 	restraint_check = TRUE
 
 /datum/emote/living/pout
@@ -263,7 +268,7 @@
 /datum/emote/living/smile
 	key = "smile"
 	key_third_person = "smiles"
-	message = "smiles;"
+	message = "smiles."
 
 /datum/emote/living/sneeze
 	key = "sneeze"
@@ -274,7 +279,7 @@
 /datum/emote/living/smug
 	key = "smug"
 	key_third_person = "smugs"
-	message = "grims smugly."
+	message = "grins smugly."
 
 /datum/emote/living/sniff
 	key = "sniff"
@@ -308,7 +313,7 @@
 /datum/emote/living/surrender
 	key = "surrender"
 	key_third_person = "surrenders"
-	message = "puts their hands o their head and falls to the ground, they surrender%s!"
+	message = "puts their hands on their head and falls to the ground, they surrender%s!"
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/surrender/run_emote(mob/user, params)
@@ -362,16 +367,16 @@
 	key_third_person = "custom"
 	message = null
 
-/datum/emote/living/custom/proc/check_invalid(input)
+/datum/emote/living/custom/proc/check_invalid(mob/user, input)
 	. = TRUE
 	if(copytext(input,1,5) == "says")
-		src << "<span class='danger'>Invalid emote.</span>"
+		user << "<span class='danger'>Invalid emote.</span>"
 	else if(copytext(input,1,9) == "exclaims")
-		src << "<span class='danger'>Invalid emote.</span>"
+		user << "<span class='danger'>Invalid emote.</span>"
 	else if(copytext(input,1,6) == "yells")
-		src << "<span class='danger'>Invalid emote.</span>"
+		user << "<span class='danger'>Invalid emote.</span>"
 	else if(copytext(input,1,5) == "asks")
-		src << "<span class='danger'>Invalid emote.</span>"
+		user << "<span class='danger'>Invalid emote.</span>"
 	else
 		. = FALSE
 
@@ -384,7 +389,7 @@
 		return FALSE
 	else if(!params)
 		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
-		if(custom_emote && !check_invalid(custom_emote))
+		if(custom_emote && !check_invalid(user, custom_emote))
 			var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
 			switch(type)
 				if("Visible")
@@ -414,7 +419,7 @@
 		if(e in keys)
 			continue
 		var/datum/emote/E = emote_list[e]
-		if(E.can_run_emote(user))
+		if(E.can_run_emote(user, TRUE))
 			keys += E.key
 
 	keys = sortList(keys)

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -1,10 +1,8 @@
 /mob/living/silicon/ai/death(gibbed)
 	if(stat == DEAD)
 		return
-	if(!gibbed)
-		visible_message("<b>[src]</b> lets out a flurry of sparks, its screen flickering as its systems slowly halt.")
-	stat = DEAD
 
+	. = ..()
 
 	if("[icon_state]_dead" in icon_states(src.icon,1))
 		icon_state = "[icon_state]_dead"
@@ -42,4 +40,3 @@
 			if(istype(loc, /obj/item/device/aicard))
 				loc.icon_state = "aicard-404"
 
-	return ..()

--- a/code/modules/mob/living/silicon/death.dm
+++ b/code/modules/mob/living/silicon/death.dm
@@ -5,7 +5,9 @@
 	new /obj/effect/decal/remains/robot(loc)
 
 /mob/living/silicon/death(gibbed)
+	if(!gibbed)
+		emote("deathgasp")
 	diag_hud_set_status()
 	diag_hud_set_health()
 	update_health_hud()
-	..()
+	. = ..()

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -2,7 +2,6 @@
 /mob/living/silicon/robot/gib_animation()
 	PoolOrNew(/obj/effect/overlay/temp/gib_animation, list(loc, "gibbed-r"))
 
-
 /mob/living/silicon/robot/dust()
 	if(mmi)
 		qdel(mmi)
@@ -17,10 +16,11 @@
 /mob/living/silicon/robot/death(gibbed)
 	if(stat == DEAD)
 		return
-	if(!gibbed)
-		visible_message("<b>[src]</b> shudders violently for a moment before falling still, its eyes slowly darkening.")
+
+	. = ..()
+
 	locked = 0 //unlock cover
-	stat = DEAD
+
 	update_canmove()
 	if(camera && camera.status)
 		camera.toggle_cam(src,0)
@@ -31,5 +31,3 @@
 	update_icons()
 
 	sql_report_cyborg_death(src)
-
-	return ..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -302,7 +302,6 @@
 			visible_message("<span class='danger'>\The [src] stops moving...</span>")
 	if(del_on_death)
 		ghostize()
-		stat = DEAD
 		//Prevent infinite loops if the mob Destroy() is overriden in such
 		//a manner as to cause a call to death() again
 		del_on_death = FALSE
@@ -311,7 +310,6 @@
 	else
 		health = 0
 		icon_state = icon_dead
-		stat = DEAD
 		density = 0
 		lying = 1
 	..()


### PR DESCRIPTION
Also fixes deathgasp except, you know, the probably proper way.
Closes #22535
Help will display all the motes you could POSSIBLY do, even if you happen to be restrained at the time.