### PR TITLE
[s] Added a salute() verb

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -922,3 +922,11 @@ var/next_mob_id = 0
 		if ("attack_log")
 			return debug_variable(var_name, attack_log, 0, src, FALSE)
 	. = ..()
+	
+
+/mob/verb/saluted(mob/living/carbon/human/M as mob in oview(6))
+	set name = "Salute"
+	set category = "IC"
+
+	if(ishuman(M))
+		usr.visible_message("[usr] salutes [M]")


### PR DESCRIPTION
Adds a new verb to mobs. You right click someone and chose "Salute" and you will produce the visible message "(User) salutes (target)".

This helps prevent lack of roleplay from saluting your superiors.

Requested by @optimumtact
