### PR TITLE
Make voice analyzers in "inclusive" mode case insensitive

### DIFF
--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -51,7 +51,7 @@
 	. = 0
 	switch(mode)
 		if(1)
-			if(findtextEx(raw_message, recorded))
+			if(findtext(raw_message, recorded))
 				. = 1
 		if(2)
 			if(raw_message == recorded)


### PR DESCRIPTION
:cl: ChemicalRascal
tweak: Voice analyzers in "inclusive" mode (the default mode) are now case-insensitive.
/:cl:

[]: # When setting a voice analyser trigger string, it's not possible to speak in purely lower case, thus limiting the ways that voice analysers can be used in shenanigans.

For example: `say "beat"` will result in the player saying "Beat", and the voice analyzer thus won't trigger when someone calls out over the radio: "Security is beating me to death!", or similar, even though "beat" is a substring in that.

Changing the inclusive-mode test of the voice analyzer to be case insensitive is the easiest, touches-the-least-amount-of-other-stuff way to fix this issue.