### PR TITLE
Next time on WILL THIS WORK: Implant Explosives!

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_explosive.dm
+++ b/code/game/objects/items/weapons/implants/implant_explosive.dm
@@ -20,7 +20,7 @@
 				"}
 	return dat
 
-/obj/item/weapon/implant/explosive/trigger(emote, mob/source)
+/obj/item/weapon/implant/explosive/trigger(emote, mob/living/source)
 	if(emote == "deathgasp")
 		activate("death")
 


### PR DESCRIPTION
It's either because *deathgasp is only on /mob/living OR it's because only /mob/living can accept explosives. I'm not sure and it's almost 3am.

Not tested for reasons above. Sorry.

fixes #22546 i think