### PR TITLE
Fix MALF overload alert to be working again

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -291,7 +291,7 @@
 		for(var/datum/AI_Module/small/overload_machine/overload in current_modules)
 			if(overload.uses > 0)
 				overload.uses --
-				audible_message("<span class='userdanger'>You hear a loud electrical buzzing sound coming from [M]!</span>")
+				M.audible_message("<span class='userdanger'>You hear a loud electrical buzzing sound coming from [M]! You suddenly don't want to be so closed to it...</span>")
 				src << "<span class='warning'>Overloading machine circuitry...</span>"
 				spawn(50)
 					if(M)
@@ -323,7 +323,7 @@
 		for(var/datum/AI_Module/small/override_machine/override in current_modules)
 			if(override.uses > 0)
 				override.uses --
-				audible_message("<span class='italics'>You hear a loud electrical buzzing sound!</span>")
+				M.audible_message("<span class='userdanger'>You hear a loud electrical buzzing sound!</span>")
 				src << "<span class='warning'>Reprogramming machine behaviour...</span>"
 				spawn(50)
 					if(M && !qdeleted(M))

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -291,7 +291,7 @@
 		for(var/datum/AI_Module/small/overload_machine/overload in current_modules)
 			if(overload.uses > 0)
 				overload.uses --
-				M.audible_message("<span class='userdanger'>You hear a loud electrical buzzing sound coming from [M]! You suddenly don't want to be so closed to it...</span>")
+				M.audible_message("<span class='userdanger'>You hear a loud electrical buzzing sound coming from [M]! You suddenly don't want to be so close to it...</span>")
 				src << "<span class='warning'>Overloading machine circuitry...</span>"
 				spawn(50)
 					if(M)

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -291,7 +291,7 @@
 		for(var/datum/AI_Module/small/overload_machine/overload in current_modules)
 			if(overload.uses > 0)
 				overload.uses --
-				M.audible_message("<span class='userdanger'>You hear a loud electrical buzzing sound coming from [M]! You suddenly don't want to be so close to it...</span>")
+				M.audible_message("<span class='userdanger'>You hear a loud electrical buzzing sound coming from [M]!</span>")
 				src << "<span class='warning'>Overloading machine circuitry...</span>"
 				spawn(50)
 					if(M)


### PR DESCRIPTION
MACHINE OVERLOAD/OVERRIDE ALERT ACTUALLY WORKS NOW
:cl:
bugfix: Machine overloads/overrides aren't as bullshit as you'll actually be able to dodge it now.
/:cl: