### PR TITLE
Reduces lag caused by bags

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -325,7 +325,9 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 								continue
 							if(I.type in rejections) // To limit bag spamming: any given type only complains once
 								continue
-							if(!S.can_be_inserted(I))	// Note can_be_inserted still makes noise when the answer is no
+							if(!S.can_be_inserted(I, stop_messages = 1))	// Note can_be_inserted still makes noise when the answer is no
+								if(S.contents.len >= S.storage_slots)
+									break
 								rejections += I.type	// therefore full bags are still a little spammy
 								failure = 1
 								continue

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -11,7 +11,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	var/silent = 0 // No message on putting items in
 	var/list/can_hold = new/list() //Typecache of objects which this item can store (if set, it can't store anything else)
-	var/list/cant_hold = new/list() //Typecache of objects which this item can't store (in effect only if can_hold isn't set)
+	var/list/cant_hold = new/list() //Typecache of objects which this item can't store
 	var/list/is_seeing = new/list() //List of mobs which are currently seeing the contents of this item's storage
 	var/max_w_class = WEIGHT_CLASS_SMALL //Max size of objects that this object can store (in effect only if can_hold isn't set)
 	var/max_combined_w_class = 14 //The sum of the w_classes of all the items in this storage item.
@@ -263,11 +263,11 @@
 			if(!stop_messages)
 				usr << "<span class='warning'>[src] cannot hold [W]!</span>"
 			return 0
-	else
-		if(is_type_in_typecache(W, cant_hold)) //Check for specific items which this container can't hold.
-			if(!stop_messages)
-				usr << "<span class='warning'>[src] cannot hold [W]!</span>"
-			return 0
+
+	if(is_type_in_typecache(W, cant_hold)) //Check for specific items which this container can't hold.
+		if(!stop_messages)
+			usr << "<span class='warning'>[src] cannot hold [W]!</span>"
+		return 0
 
 	if(W.w_class > max_w_class)
 		if(!stop_messages)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -10,8 +10,8 @@
 	icon = 'icons/obj/storage.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
 	var/silent = 0 // No message on putting items in
-	var/list/can_hold = new/list() //List of objects which this item can store (if set, it can't store anything else)
-	var/list/cant_hold = new/list() //List of objects which this item can't store (in effect only if can_hold isn't set)
+	var/list/can_hold = new/list() //Typecache of objects which this item can store (if set, it can't store anything else)
+	var/list/cant_hold = new/list() //Typecache of objects which this item can't store (in effect only if can_hold isn't set)
 	var/list/is_seeing = new/list() //List of mobs which are currently seeing the contents of this item's storage
 	var/max_w_class = WEIGHT_CLASS_SMALL //Max size of objects that this object can store (in effect only if can_hold isn't set)
 	var/max_combined_w_class = 14 //The sum of the w_classes of all the items in this storage item.
@@ -259,18 +259,12 @@
 		return 0 //Storage item is full
 
 	if(can_hold.len)
-		var/ok = 0
-		for(var/A in can_hold)
-			if(istype(W, A))
-				ok = 1
-				break
-		if(!ok)
+		if(!is_type_in_typecache(W, can_hold))
 			if(!stop_messages)
 				usr << "<span class='warning'>[src] cannot hold [W]!</span>"
 			return 0
-
-	for(var/A in cant_hold) //Check for specific items which this container can't hold.
-		if(istype(W, A))
+	else
+		if(is_type_in_typecache(W, cant_hold)) //Check for specific items which this container can't hold.
 			if(!stop_messages)
 				usr << "<span class='warning'>[src] cannot hold [W]!</span>"
 			return 0
@@ -327,7 +321,7 @@
 					observe.client.screen -= W
 
 		add_fingerprint(usr)
-		if(rustle_jimmies)
+		if(rustle_jimmies && !prevent_warning)
 			playsound(src.loc, "rustle", 50, 1, -5)
 
 		if(!prevent_warning)
@@ -409,7 +403,8 @@
 		close(user)
 		return
 
-	playsound(loc, "rustle", 50, 1, -5)
+	if(rustle_jimmies)
+		playsound(loc, "rustle", 50, 1, -5)
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -474,6 +469,10 @@
 
 /obj/item/weapon/storage/New()
 	..()
+
+	can_hold = typecacheof(can_hold)
+	cant_hold = typecacheof(cant_hold)
+
 	if(allow_quick_empty)
 		verbs += /obj/item/weapon/storage/verb/quick_empty
 	else


### PR DESCRIPTION
:cl: XDTM
fix: Storage bags should now cause less lag when picking up large amounts of items.
fix: Storage bags now don't send an error message for every single item they fail to pick up.
/:cl:

Storage bags now stop looping if they're full, which is especially useful if a miner walks on a tile containing hundereds of stacked ores repeatedly. Also it won't spam error messages anymore, there's no need to say "This item cannot be put in this kind of bag" a dozen times.
Lag will still happen if someone tries to use a bag on a large amount of non-bag items.
