### PR TITLE
Firealarms now go off if it's too cold

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -82,7 +82,7 @@
 		playsound(src.loc, 'sound/effects/sparks4.ogg', 50, 1)
 
 /obj/machinery/firealarm/temperature_expose(datum/gas_mixture/air, temperature, volume)
-	if(!emagged && detecting && !stat && temperature > T0C + 200)
+	if(!emagged && detecting && !stat && (temperature > T0C + 200 || temperature < BODYTEMP_COLD_DAMAGE_LIMIT))
 		alarm()
 	..()
 


### PR DESCRIPTION
:cl: Cyberboss
tweak: Firealarms now go off if it's too cold
/:cl:

Reasoning: The general use case is a breach to space, which doesn't trigger firedoors by default. Hopefully this causes it to kick in after some time