### PR TITLE
Megafauna fixed.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -133,6 +133,18 @@
 				SetScore(BOSS_SCORE,C,1)
 				SetScore(score_type,C,1)
 
+//NO MORE MEGAFAUNA ON THE STATION YOU SHITTERS
+/mob/living/simple_animal/hostile/megafauna/process()
+	var/turf/mobturf = get_turf(src)
+	if(mobturf && (mobturf.z == ZLEVEL_LAVALAND))
+		return
+	else
+		if(!src.admin_spawned)
+			src.visible_message("<span class='danger'>[src] collapses in on itself as it is severed from the hell energy that protected it's abominable body from falling apart. Whew!</span>")
+			spawn_gibs()
+			qdel(src)
+
+
 /proc/UnlockMedal(medal,client/player)
 
 	if(!player || !medal)


### PR DESCRIPTION
:cl: Kilkun the Grinch
tweak: Megafauna now are affected by the laws of physics if they leave Lavaland.
/:cl:

"Oh Kilkun, why?" Well I'll tell you why.

The game is balanced around really high TTK and guerilla tactics. Everything works like that, barring things that exist in the void between worlds and forces of nature like giant wells of gravity. Except Lavaland. For some reason some CODER _COUGH_ Thought that making Monster Hunter: Byond edition was a good idea. And for the most part it was. Mining is actually fucking fun after the introduction and polishing period lavaland went through. HOWEVER: It's also balanced in a way to satiate coder paranoia that prevents miners from going ham with lasers. This has the side effect of making Kinetic accelerators the ONLY viable weapons to kill megafauna with in a reasonable amount of time (barring admin only shit like pulse rifles). Even Wizards lack any meaningful tools to kill megafauna (keeping in mind that they had multiple ways to kill Ascended Shadowlings.) Traitor gear, even the venerated revolver, is completely useless and requires more ammo than you can carry to kill Megafauna due to armor shenanigans. And if you are security or the captain? Forget about it. Short of shuffling a fireteam back and forth in a flashpoint engagement, megafauna are huge bullet sponges that you aren't going to kill with lasers unless you are super patient. To the point that its just easier and faster to call the shuttle.

Now I'm sure here's where you're saying: "But that's just a round ending device! Engineers and scientists have em too!" Well hold the phone right there. Who the fuck are shaft miners? They get a shitload of great gear from the start of the round and get tons of shit that outclasses even lategame RnD after killing a few tendrils. Sure whatever, that's fine and all... but why in the hell do they need a round ending tool then? Engineers and science have nothing else and on the social totem pole of the jobs on the station Shaft Miners sit pretty damn low. So why the hell do they get a singularity-tier tool? Why? I already tried making lasers relevant to Lavaland so that the station had a fighting chance if megafauna showed up, but that wasn't popular, so here's this instead.

No. Miners have more than enough crap to be griefy little shits, they don't need any more, especially not some special snowflake crap that isn't killed by grav sings or maxcap bombs for absolutely no reason.

This PR makes megafauna automatically delete themselves and spawn some giblets before they go. It only affects naturally spawned megafauna. Mobs memed into existence by admins are immune.

If you really want miners to have round destroying PvE grief shit, then I seriously suggest you think long and hard about the biases you might hold towards the job. If Miners really want to grief the round they can steal the QM's ID and make a singularity. But they won't because that takes effort, unlike jaunting an aggrod megafauna to the station.