### PR TITLE
Flan Refactor + spellaftereffects

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/dragoontomb.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dragoontomb.dmm
@@ -9,7 +9,7 @@
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/ruin/unpowered/no_grav)
 "d" = (
-/mob/living/simple_animal/hostile/flan,
+/mob/living/simple_animal/hostile/flan/water,
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered/no_grav)
 "e" = (

--- a/code/modules/mob/living/simple_animal/hostile/flan.dm
+++ b/code/modules/mob/living/simple_animal/hostile/flan.dm
@@ -20,6 +20,7 @@
 	attack_sound = 'sound/weapons/punch1.ogg'
 	a_intent = INTENT_HARM
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
+	unsuitable_atmos_damage = 0
 	ranged = 1
 	retreat_distance = 2
 	minimum_distance = 4

--- a/code/modules/mob/living/simple_animal/hostile/flan.dm
+++ b/code/modules/mob/living/simple_animal/hostile/flan.dm
@@ -26,13 +26,13 @@
 	minimum_distance = 4
 	AIStatus = AI_IDLE
 	ranged_message = "begins to cast something"
-	ranged_cooldown_time = 5
+	ranged_cooldown_time = 15
 	var/spellname = "a generic spell!"
 	var/spellsound = 'sound/effects/spray3.ogg'
 	var/spellanimation = ATTACK_EFFECT_SMASH		//More in defines/misc.dm
 	var/spelldamagetype = BRUTE
 	var/spelldamage = 15
-	var/spellcasttime = 15
+	var/spellcasttime = 15							//if you varedit this also varedit ranged_cooldown_time else the mob will attack again before the spell hits, looking weird but still working
 
 /mob/living/simple_animal/hostile/flan/New()		//Required for the inheritance of casting animations.
 	..()
@@ -75,7 +75,6 @@
 /mob/living/simple_animal/hostile/flan/fire/spellaftereffects(mob/living/A)
 	A.adjust_fire_stacks(2)
 	A.IgniteMob()
-	return
 
 /mob/living/simple_animal/hostile/flan/water
 	name = "Water Flan"
@@ -86,6 +85,5 @@
 	spellname = "a Water spell!"
 	spelldamage = 10			//Basic flan, learn the dance with em.
 
-/mob/living/simple_animal/hostile/flan/fire/spellaftereffects(mob/living/A)
+/mob/living/simple_animal/hostile/flan/water/spellaftereffects(mob/living/A)
 	A.ExtinguishMob()
-	return


### PR DESCRIPTION
If too feature-y just close it and say so.

Sets flans up better, splits the water one away from the base, adds the damage resistances.

Incorporates a spellcast timer. Meant to be changed on inheritance, but editable for badmins. Increased slightly, increased slightly again for fire flans.

Also adds the ability to have aftereffects on your spells, such as lighting shit on fire.

Changes the pathing in the dragoon tomb to get the right flans.