### PR TITLE
Makes spiders incapable of wraping anchored atoms

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -86,7 +86,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 10
 	poison_per_bite = 3
-	var/atom/cocoon_target
+	var/atom/movable/cocoon_target
 	var/fed = 0
 
 //hunters have the most poison and move the fastest, so they can find prey
@@ -129,7 +129,7 @@
 		if(!busy && prob(30))	//30% chance to stop wandering and do something
 			//first, check for potential food nearby to cocoon
 			for(var/mob/living/C in can_see)
-				if(C.stat && !istype(C,/mob/living/simple_animal/hostile/poison/giant_spider))
+				if(C.stat && !istype(C,/mob/living/simple_animal/hostile/poison/giant_spider) && !C.anchored)
 					cocoon_target = C
 					busy = MOVING_TO_TARGET
 					Goto(C, move_to_delay)
@@ -198,16 +198,21 @@
 	if(!cocoon_target)
 		var/list/choices = list()
 		for(var/mob/living/L in view(1,src))
-			if(L == src)
+			if(L == src | L.anchored)
 				continue
 			if(Adjacent(L))
 				choices += L
 		for(var/obj/O in src.loc)
+			if(O.anchored)
+				continue
 			if(Adjacent(O))
 				choices += O
 		cocoon_target = input(src,"What do you wish to cocoon?") in null|choices
 
 	if(stat != DEAD && cocoon_target && busy != SPINNING_COCOON)
+		if(cocoon_target.anchored)
+			cocoon_target = null
+			return
 		busy = SPINNING_COCOON
 		src.visible_message("<span class='notice'>\the [src] begins to secrete a sticky substance around \the [cocoon_target].</span>")
 		stop_automated_movement = 1


### PR DESCRIPTION
:cl: A whole bunch of spiders in a SWAT suit
bugfix: spiders can't wrap anchored things
/:cl:

Previously player-spiders could do silly things like wrap ghosts/air pipes/objects anchored to the wall(why, intercom, why).

Both player-spiders and AI-spiders could wrap anchored mobs.

All this is now (hopefully) impossible . Tested locally, however as I was unable to replicate wrapping ghosts under any circumstances (the only one I can think of is VVing the ghost into the target of a spider, which this now blocks 👌).

Fixes: #22513