### PR TITLE
[s]Fixes autolathe multiplying materials

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -228,8 +228,8 @@
 						materials.use_amount(materials_used)
 						for(var/i=1, i<=multiplier, i++)
 							var/obj/item/new_item = new being_built.build_path(T)
-							new_item.materials[MAT_METAL] = materials_used[MAT_METAL] / multiplier
-							new_item.materials[MAT_GLASS] = materials_used[MAT_GLASS] / multiplier
+							for(var/mat in materials_used)
+								new_item.materials[mat] = materials_used[mat] / multiplier
 							new_item.autolathe_crafted(src)
 						busy = 0
 						updateUsrDialog()

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -228,7 +228,8 @@
 						materials.use_amount(materials_used)
 						for(var/i=1, i<=multiplier, i++)
 							var/obj/item/new_item = new being_built.build_path(T)
-							new_item.materials = materials_used.Copy()
+							new_item.materials[MAT_METAL] = materials_used[MAT_METAL] / multiplier
+							new_item.materials[MAT_GLASS] = materials_used[MAT_GLASS] / multiplier
 							new_item.autolathe_crafted(src)
 						busy = 0
 						updateUsrDialog()


### PR DESCRIPTION
When using the x5 or x10 option the autolathe would use the total cost instead of the cost per item when calculating how many materials to put in each item, resulting in each item having enough materials to produce all of them.

Fixes #22543