### PR TITLE
Fixes the issue where people with GODMODE could be dismembered.

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -10,6 +10,8 @@
 	var/mob/living/carbon/C = owner
 	if(!dismemberable)
 		return 0
+	if(C.status_flags & GODMODE)
+		return 0
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		if(NODISMEMBER in H.dna.species.species_traits) // species don't allow dismemberment


### PR DESCRIPTION
The dismember() proc didn't check for the GODMODE status_flag, and thus people with GODMODE enabled could still be dismembered. This resolves that issue. Tested, and couldn't dismember someone with GODMODE with melee, projectiles, and with explosions, though someone without GODMODE could still be dismembered.

Fixes #19419