### PR TITLE
Fixes the issue where a newly cloned body could have their retardation removed via H2M2H

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -82,6 +82,7 @@
 		O.setOxyLoss(getOxyLoss(), 0)
 		O.setCloneLoss(getCloneLoss(), 0)
 		O.adjustFireLoss(getFireLoss(), 0)
+		O.setBrainLoss(getBrainLoss(), 0)
 		O.updatehealth()
 		O.radiation = radiation
 
@@ -236,6 +237,7 @@
 		O.setOxyLoss(getOxyLoss(), 0)
 		O.setCloneLoss(getCloneLoss(), 0)
 		O.adjustFireLoss(getFireLoss(), 0)
+		O.setBrainLoss(getBrainLoss(), 0)
 		O.updatehealth()
 		O.radiation = radiation
 


### PR DESCRIPTION
The title basically says it all. Previously you could do this to a newly cloned human to quickly remove their retardation. First, make them into a monkey. Then, into a human.

Fixes #19417  (Or atleast the remainder of it. Someone else somewhere down the line fixed the issue with the CloneLoss, so with this PR fixing the BrainLoss, said issue is now fully fixed.)