### PR TITLE
Allows syringes and droppers to show their reagents when examined while wearing things such as Science Goggles.

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -23,8 +23,6 @@
 
 #define NOSLIP		1024 		//prevents from slipping on wet floors, in space etc (NOTE: flag shared with THICKMATERIAL for external suits and helmet)
 
-#define OPENCONTAINER	4096	// is an open container for chemistry purposes
-#define TRANSPARENT	8192
 #define HEADBANGPROTECT		4096
 
 // BLOCK_GAS_SMOKE_EFFECT only used in masks at the moment.

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -24,7 +24,7 @@
 #define NOSLIP		1024 		//prevents from slipping on wet floors, in space etc (NOTE: flag shared with THICKMATERIAL for external suits and helmet)
 
 #define OPENCONTAINER	4096	// is an open container for chemistry purposes
-#define SEMIOPENCONTAINER	8192
+#define TRANSPARENT	8192
 #define HEADBANGPROTECT		4096
 
 // BLOCK_GAS_SMOKE_EFFECT only used in masks at the moment.

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -24,6 +24,7 @@
 #define NOSLIP		1024 		//prevents from slipping on wet floors, in space etc (NOTE: flag shared with THICKMATERIAL for external suits and helmet)
 
 #define OPENCONTAINER	4096	// is an open container for chemistry purposes
+#define SEMIOPENCONTAINER	8192
 #define HEADBANGPROTECT		4096
 
 // BLOCK_GAS_SMOKE_EFFECT only used in masks at the moment.

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -1,3 +1,6 @@
 #define SOLID 1
 #define LIQUID 2
 #define GAS 3
+
+#define OPENCONTAINER	4096	// is an open container for chemistry purposes
+#define TRANSPARENT		8192	//Used for non-open containers which you still want to be able to see the reagents off.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -210,7 +210,7 @@ atom/proc/is_semi_open_container()
 	// *****RM
 	//user << "[name]: Dn:[density] dir:[dir] cont:[contents] icon:[icon] is:[icon_state] loc:[loc]"
 
-	if(reagents && is_open_container() || reagents && is_semi_open_container()) //is_open_container() isn't really the right proc for this, but w/e
+	if(reagents && (is_open_container() || is_semi_open_container())) //is_open_container() isn't really the right proc for this, but w/e
 		user << "It contains:"
 		if(reagents.reagent_list.len)
 			if(user.can_see_reagents()) //Show each individual reagent

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -6,6 +6,7 @@
 	var/list/fingerprints
 	var/list/fingerprintshidden
 	var/list/blood_DNA
+	var/container_type = 0
 	var/admin_spawned = 0	//was this spawned by an admin? used for stat tracking stuff.
 
 	//This atom's HUD (med/sec, etc) images. Associative list.
@@ -130,10 +131,10 @@
 // returns true if open
 // false if closed
 /atom/proc/is_open_container()
-	return flags & OPENCONTAINER
+	return container_type & OPENCONTAINER
 
-atom/proc/is_transparent()
-	return flags & TRANSPARENT
+/atom/proc/is_transparent()
+	return container_type & TRANSPARENT
 
 /*//Convenience proc to see whether a container can be accessed in a certain way.
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -132,8 +132,8 @@
 /atom/proc/is_open_container()
 	return flags & OPENCONTAINER
 
-atom/proc/is_semi_open_container()
-	return flags & SEMIOPENCONTAINER
+atom/proc/is_transparet()
+	return flags & TRANSPARENT
 
 /*//Convenience proc to see whether a container can be accessed in a certain way.
 
@@ -210,7 +210,7 @@ atom/proc/is_semi_open_container()
 	// *****RM
 	//user << "[name]: Dn:[density] dir:[dir] cont:[contents] icon:[icon] is:[icon_state] loc:[loc]"
 
-	if(reagents && (is_open_container() || is_semi_open_container())) //is_open_container() isn't really the right proc for this, but w/e
+	if(reagents && (is_open_container() || is_transparent())) //is_open_container() isn't really the right proc for this, but w/e
 		user << "It contains:"
 		if(reagents.reagent_list.len)
 			if(user.can_see_reagents()) //Show each individual reagent

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -132,6 +132,9 @@
 /atom/proc/is_open_container()
 	return flags & OPENCONTAINER
 
+atom/proc/is_semi_open_container()
+	return flags & SEMIOPENCONTAINER
+
 /*//Convenience proc to see whether a container can be accessed in a certain way.
 
 /atom/proc/can_subract_container()
@@ -207,7 +210,7 @@
 	// *****RM
 	//user << "[name]: Dn:[density] dir:[dir] cont:[contents] icon:[icon] is:[icon_state] loc:[loc]"
 
-	if(reagents && is_open_container()) //is_open_container() isn't really the right proc for this, but w/e
+	if(reagents && is_open_container() || reagents && is_semi_open_container()) //is_open_container() isn't really the right proc for this, but w/e
 		user << "It contains:"
 		if(reagents.reagent_list.len)
 			if(user.can_see_reagents()) //Show each individual reagent

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -132,7 +132,7 @@
 /atom/proc/is_open_container()
 	return flags & OPENCONTAINER
 
-atom/proc/is_transparet()
+atom/proc/is_transparent()
 	return flags & TRANSPARENT
 
 /*//Convenience proc to see whether a container can be accessed in a certain way.

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -10,7 +10,7 @@
 	icon = 'icons/obj/machines/limbgrower.dmi'
 	icon_state = "limbgrower_idleoff"
 	density = 1
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 
 	var/operating = 0
 	anchored = 1

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -328,8 +328,9 @@ MASS SPECTROMETER
 	icon_state = "spectrometer"
 	item_state = "analyzer"
 	w_class = WEIGHT_CLASS_SMALL
-	flags = CONDUCT | OPENCONTAINER
+	flags = CONDUCT
 	slot_flags = SLOT_BELT
+	container_type = OPENCONTAINER
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 7

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -617,7 +617,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		item_state = "[param_color]_vape"
 
 /obj/item/clothing/mask/vape/attackby(obj/item/O, mob/user, params)
-	if(istype(O, /obj/item/weapon/reagent_containers) && (O.flags & OPENCONTAINER))
+	if(istype(O, /obj/item/weapon/reagent_containers) && (O.container_type & OPENCONTAINER))
 		if(reagents.total_volume < chem_volume)
 			if(O.reagents.total_volume > 0)
 				O.reagents.trans_to(src,25)

--- a/code/game/objects/items/weapons/implants/implant_chem.dm
+++ b/code/game/objects/items/weapons/implants/implant_chem.dm
@@ -3,7 +3,7 @@
 	desc = "Injects things."
 	icon_state = "reagents"
 	origin_tech = "materials=3;biotech=4"
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 
 /obj/item/weapon/implant/chem/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
@@ -60,7 +60,7 @@
 /obj/item/weapon/implantcase/chem/New()
 	imp = new /obj/item/weapon/implant/chem(src)
 	..()
-	
+
 /obj/item/weapon/implantcase/chem/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W,/obj/item/weapon/reagent_containers/syringe) && imp)
 		W.afterattack(imp, user, params)

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -113,7 +113,8 @@
 	amount_per_transfer_from_this = 50
 	possible_transfer_amounts = list(25,50,100)
 	volume = 500
-	flags = NODROP | OPENCONTAINER | NOBLUDGEON
+	flags = NODROP | NOBLUDGEON
+	container_type = OPENCONTAINER
 	slot_flags = 0
 
 	var/obj/item/weapon/watertank/tank
@@ -347,7 +348,7 @@
 	var/usage_ratio = 5 //5 unit added per 1 removed
 	var/injection_amount = 1
 	amount_per_transfer_from_this = 5
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	spillable = 0
 	possible_transfer_amounts = list(5,10,15)
 

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -5,7 +5,7 @@
 	icon_state = "cart"
 	anchored = 0
 	density = 1
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	//copypaste sorry
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 	var/obj/item/weapon/storage/bag/trash/mybag	= null

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "mopbucket"
 	density = 1
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	var/amount_per_transfer_from_this = 5	//shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -454,7 +454,7 @@
 
 	if(istype(O, /obj/item/weapon/reagent_containers))
 		var/obj/item/weapon/reagent_containers/RG = O
-		if(RG.flags & OPENCONTAINER)
+		if(RG.container_type & OPENCONTAINER)
 			RG.reagents.add_reagent("water", min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
 			user << "<span class='notice'>You fill [RG] from [src].</span>"
 			return 1

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -85,7 +85,7 @@
 		else
 			if(istype(I, /obj/item/weapon/reagent_containers))
 				var/obj/item/weapon/reagent_containers/RC = I
-				if(RC.flags & OPENCONTAINER)
+				if(RC.container_type & OPENCONTAINER)
 					for(var/datum/reagent/A in RC.reagents.reagent_list)
 						.[A.type] += A.volume
 			.[I.type] += 1

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -12,7 +12,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "rag"
-	flags = OPENCONTAINER | NOBLUDGEON
+	flags = NOBLUDGEON
+	container_type = OPENCONTAINER
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list()
 	volume = 5

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -6,7 +6,7 @@
 	desc = "yummy"
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = null
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	var/gulp_size = 5 //This is now officially broken ... need to think of a nice way to fix it.
 	possible_transfer_amounts = list(5,10,15,20,25,30,50)
 	volume = 50
@@ -103,7 +103,8 @@
 	materials = list(MAT_METAL=100)
 	possible_transfer_amounts = list()
 	volume = 5
-	flags = CONDUCT | OPENCONTAINER
+	flags = CONDUCT
+	container_type = OPENCONTAINER
 	spillable = 1
 	resistance_flags = FIRE_PROOF
 

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -10,7 +10,7 @@
 	desc = "Just your average condiment container."
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "emptycondiment"
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	possible_transfer_amounts = list(1, 5, 10, 15, 20, 25, 30, 50)
 	volume = 50
 	//Possible_states has the reagent id as key and a list of, in order, the icon_state, the name and the desc as values. Used in the on_reagent_change() to change names, descs and sprites.

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -286,7 +286,7 @@
 	desc = "A simple bowl, used for soups and salads."
 	icon = 'icons/obj/food/soupsalad.dmi'
 	icon_state = "bowl"
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	materials = list(MAT_GLASS = 500)
 	w_class = WEIGHT_CLASS_NORMAL
 

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -15,7 +15,7 @@
 	var/portion = 10
 	var/selected_drink
 	var/list/stored_food = list()
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	var/obj/item/weapon/reagent_containers/mixer
 
 /obj/machinery/food_cart/New()

--- a/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
@@ -17,7 +17,7 @@
 	var/list/product_types = list()
 	var/dispense_flavour = ICECREAM_VANILLA
 	var/flavour_name = "vanilla"
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	obj_integrity = 300
 	max_integrity = 300
 

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -92,7 +92,7 @@
 				src.icon_state = "mw"
 				src.broken = 0 // Fix it!
 				src.dirty = 0 // just to be sure
-				src.flags = OPENCONTAINER
+				src.container_type = OPENCONTAINER
 				return 0 //to use some fuel
 		else
 			user << "<span class='warning'>It's broken!</span>"
@@ -109,7 +109,7 @@
 			src.dirty = 0 // It's clean!
 			src.broken = 0 // just to be sure
 			src.icon_state = "mw"
-			src.flags = OPENCONTAINER
+			src.container_type = OPENCONTAINER
 			src.updateUsrDialog()
 			return 1 // Disables the after-attack so we don't spray the floor/user.
 		else
@@ -130,7 +130,7 @@
 			src.dirty = 0 // It's clean!
 			src.broken = 0 // just to be sure
 			src.icon_state = "mw"
-			src.flags = OPENCONTAINER
+			src.container_type = OPENCONTAINER
 
 	else if(src.dirty==100) // The microwave is all dirty so can't be used!
 		user << "<span class='warning'>It's dirty!</span>"

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -21,7 +21,7 @@
 	icon_state = "weedspray"
 	item_state = "spray"
 	volume = 100
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	slot_flags = SLOT_BELT
 	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
@@ -43,7 +43,7 @@
 	icon_state = "pestspray"
 	item_state = "plantbgone"
 	volume = 100
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	slot_flags = SLOT_BELT
 	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -83,7 +83,7 @@
  */
 /obj/item/weapon/pen/sleepy
 	origin_tech = "engineering=4;syndicate=2"
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 
 
 /obj/item/weapon/pen/sleepy/attack(mob/living/M, mob/user)

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -296,7 +296,7 @@
 
 /obj/item/ammo_casing/shotgun/dart/New()
 	..()
-	flags |= OPENCONTAINER
+	container_type |= OPENCONTAINER
 	create_reagents(30)
 	reagents.set_reacting(FALSE)
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -126,7 +126,8 @@
 	item_state = "plasmacutter"
 	origin_tech = "combat=1;materials=3;magnets=2;plasmatech=3;engineering=1"
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma)
-	flags = CONDUCT | OPENCONTAINER
+	flags = CONDUCT
+	container_type = OPENCONTAINER
 	attack_verb = list("attacked", "slashed", "cut", "sliced")
 	force = 12
 	sharpness = IS_SHARP

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -170,7 +170,7 @@
 	if(default_unfasten_wrench(user, I))
 		return
 
-	if(istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER))
+	if(istype(I, /obj/item/weapon/reagent_containers) && (I.container_type & OPENCONTAINER))
 		var/obj/item/weapon/reagent_containers/B = I
 		. = 1 //no afterattack
 		if(beaker)

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -54,7 +54,7 @@
 	if(default_deconstruction_crowbar(I))
 		return
 
-	if(istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER))
+	if(istype(I, /obj/item/weapon/reagent_containers) && (I.container_type & OPENCONTAINER))
 		. = 1 //no afterattack
 		if(beaker)
 			user << "<span class='warning'>A beaker is already loaded into the machine!</span>"

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -103,7 +103,7 @@
 	if(default_unfasten_wrench(user, I))
 		return
 
-	if(istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER))
+	if(istype(I, /obj/item/weapon/reagent_containers) && (I.container_type & OPENCONTAINER))
 		. = 1 // no afterattack
 		if(panel_open)
 			user << "<span class='warning'>You can't use the [src.name] while its panel is opened!</span>"

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -278,7 +278,7 @@
 
 
 /obj/machinery/computer/pandemic/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER))
+	if(istype(I, /obj/item/weapon/reagent_containers) && (I.container_type & OPENCONTAINER))
 		. = 1 //no afterattack
 		if(stat & (NOPOWER|BROKEN))
 			return

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -121,7 +121,7 @@
 		if(default_unfasten_wrench(user, I))
 				return
 
-		if (istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER) )
+		if (istype(I, /obj/item/weapon/reagent_containers) && (I.container_type & OPENCONTAINER) )
 				if (!beaker)
 						if(!user.drop_item())
 								return 1

--- a/code/modules/reagents/chemistry/readme.dm
+++ b/code/modules/reagents/chemistry/readme.dm
@@ -241,7 +241,7 @@ About the Tools:
 			'pouring' our reagents into something else.
 
 		atom/proc/is_open_container()
-			Checks atom/var/flags & OPENCONTAINER.
+			Checks obj/var/container_type & OPENCONTAINER.
 			If this returns 1 , you can use syringes, beakers etc
 			to manipulate the contents of this object.
 			If it's 0, you'll need to write your own custom reagent

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -6,7 +6,7 @@
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list(1, 2, 3, 4, 5)
 	volume = 5
-	flags = TRANSPARENT
+	container_type = TRANSPARENT
 
 /obj/item/weapon/reagent_containers/dropper/afterattack(obj/target, mob/user , proximity)
 	if(!proximity) return

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -6,7 +6,7 @@
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list(1, 2, 3, 4, 5)
 	volume = 5
-	flags = SEMIOPENCONTAINER
+	flags = TRANSPARENT
 
 /obj/item/weapon/reagent_containers/dropper/afterattack(obj/target, mob/user , proximity)
 	if(!proximity) return

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -6,6 +6,7 @@
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list(1, 2, 3, 4, 5)
 	volume = 5
+	flags = SEMIOPENCONTAINER
 
 /obj/item/weapon/reagent_containers/dropper/afterattack(obj/target, mob/user , proximity)
 	if(!proximity) return

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -3,7 +3,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50)
 	volume = 50
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	spillable = 1
 	resistance_flags = ACID_PROOF
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -8,7 +8,7 @@
 	volume = 30
 	possible_transfer_amounts = list()
 	resistance_flags = ACID_PROOF
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 	slot_flags = SLOT_BELT
 	var/ignore_flags = 0
 	var/infinite = FALSE

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -4,7 +4,8 @@
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "cleaner"
 	item_state = "cleaner"
-	flags = OPENCONTAINER | NOBLUDGEON
+	flags = NOBLUDGEON
+	container_type = OPENCONTAINER
 	slot_flags = SLOT_BELT
 	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -14,7 +14,7 @@
 	var/busy = 0		// needed for delayed drawing of blood
 	var/proj_piercing = 0 //does it pierce through thick clothes when shot with syringe gun
 	materials = list(MAT_METAL=10, MAT_GLASS=20)
-	flags = TRANSPARENT
+	container_type = TRANSPARENT
 
 /obj/item/weapon/reagent_containers/syringe/New()
 	..()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -14,7 +14,7 @@
 	var/busy = 0		// needed for delayed drawing of blood
 	var/proj_piercing = 0 //does it pierce through thick clothes when shot with syringe gun
 	materials = list(MAT_METAL=10, MAT_GLASS=20)
-	flags = SEMIOPENCONTAINER
+	flags = TRANSPARENT
 
 /obj/item/weapon/reagent_containers/syringe/New()
 	..()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -14,6 +14,7 @@
 	var/busy = 0		// needed for delayed drawing of blood
 	var/proj_piercing = 0 //does it pierce through thick clothes when shot with syringe gun
 	materials = list(MAT_METAL=10, MAT_GLASS=20)
+	flags = SEMIOPENCONTAINER
 
 /obj/item/weapon/reagent_containers/syringe/New()
 	..()

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -8,7 +8,7 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 	name = "Circuit Imprinter"
 	desc = "Manufactures circuit boards for the construction of machines."
 	icon_state = "circuit_imprinter"
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 
 	var/datum/material_container/materials
 	var/efficiency_coeff

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -11,7 +11,7 @@ Note: Must be placed west/left of and R&D console to function.
 	name = "Protolathe"
 	desc = "Converts raw materials into useful objects."
 	icon_state = "protolathe"
-	flags = OPENCONTAINER
+	container_type = OPENCONTAINER
 
 	var/datum/material_container/materials
 	var/efficiency_coeff

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -47,7 +47,7 @@
 
 
 
-/obj/machinery/r_n_d/attackby(obj/item/O, mob/user, params)
+/obj/machinery/r_n_d/attackby(obj/O, mob/user, params)
 	if (shocked)
 		if(shock(user,50))
 			return 1
@@ -59,7 +59,7 @@
 		return
 	if(default_deconstruction_crowbar(O))
 		return
-	if((flags & OPENCONTAINER) && O.is_open_container())
+	if((O.container_type & OPENCONTAINER) && O.is_open_container())
 		return 0 //inserting reagents into the machine
 	if(Insert_Item(O, user))
 		return 1

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -47,7 +47,7 @@
 
 
 
-/obj/machinery/r_n_d/attackby(obj/O, mob/user, params)
+/obj/machinery/r_n_d/attackby(obj/item/O, mob/user, params)
 	if (shocked)
 		if(shock(user,50))
 			return 1


### PR DESCRIPTION
This allows people to now see what reagents droppers and syringes contains when they are examined while wearing items with the reagent scanner functionality(such as Science Goggles). This is to fix a consistency issue(and it also didn't make any sense why you couldn't see what reagents they contained).

Fixes #19476

Edit: Once more tested now that I moved the defines from flags to container_type. Everything still appears to work as intended, and no runtimes either.
