### PR TITLE
Fixes sdql2 applying comparison operators to lists incorrectly

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -304,19 +304,19 @@
 		if(op != "")
 			switch(op)
 				if("+")
-					result += val
+					result = (result + val)
 				if("-")
-					result -= val
+					result = (result - val)
 				if("*")
-					result *= val
+					result = (result * val)
 				if("/")
-					result /= val
+					result = (result / val)
 				if("&")
-					result &= val
+					result = (result & val)
 				if("|")
-					result |= val
+					result = (result | val)
 				if("^")
-					result ^= val
+					result = (result ^ val)
 				if("=", "==")
 					result = (result == val)
 				if("!=", "<>")

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -304,7 +304,6 @@
 		if(op != "")
 			switch(op)
 				if("+")
-					//Before you consider doing += here, see pr #22627
 					result = (result + val)
 				if("-")
 					result = (result - val)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -304,6 +304,7 @@
 		if(op != "")
 			switch(op)
 				if("+")
+					//Before you consider doing += here, see pr #22627
 					result = (result + val)
 				if("-")
 					result = (result - val)


### PR DESCRIPTION
if result is already assigned a list, doing things like `+=` or `&=` would change the list by reference. this would cause things like WHERE var & `something` to behave incorrectly if var was a list, actually changing the list by removing every thing that wasn't `something` rather than creating a new list with everything that matches

@kevinz000 