### PR TITLE
Adds key logging to abandoned crate explosions

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -35,7 +35,7 @@
 		var/message = "[ADMIN_LOOKUPFLW(user)] has detonated [src.name]."
 		bombers += message
 		message_admins(message)
-		log_game("[key_name(user)] has detonated a [src.name].")
+		log_game("[key_name(user)] has detonated [src.name].")
 	for(var/atom/movable/AM in src)
 		qdel(AM)
 	explosion(get_turf(src), 0, 1, 5, 5)

--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -32,13 +32,13 @@
 /obj/structure/closet/crate/secure/proc/boom(mob/user)
 	if(user)
 		user << "<span class='danger'>The crate's anti-tamper system activates!</span>"
+		var/message = "[ADMIN_LOOKUPFLW(user)] has detonated [src.name]."
+		bombers += message
+		message_admins(message)
+		log_game("[key_name(user)] has detonated a [src.name].")
 	for(var/atom/movable/AM in src)
 		qdel(AM)
 	explosion(get_turf(src), 0, 1, 5, 5)
-	var/message = "[ADMIN_LOOKUPFLW(user)] has detonated [src.name]."
-	bombers += message
-	message_admins(message)
-	log_game("[key_name(user)] has detonated a [src.name].")
 	qdel(src)
 
 /obj/structure/closet/crate/secure/weapon

--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -35,6 +35,10 @@
 	for(var/atom/movable/AM in src)
 		qdel(AM)
 	explosion(get_turf(src), 0, 1, 5, 5)
+	var/message = "[ADMIN_LOOKUPFLW(user)] has detonated [src.name]."
+	bombers += message
+	message_admins(message)
+	log_game("[key_name(user)] has detonated a [src.name].")
 	qdel(src)
 
 /obj/structure/closet/crate/secure/weapon


### PR DESCRIPTION
Adds key logging to abandoned crate explosions in order to determine who
detonated an abandoned crate.

This is my first time messing with the logging and I'm not entirely aware of the logging structure, so tell me if I've flubbed.

Effectively fixes #22568