### PR TITLE
[WIP]Reworks kudzu

### DIFF
--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -32,7 +32,7 @@
 	var/turf/T = get_turf(src)
 	message_admins("Kudzu planted by [key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) at ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>)",0,1)
 	investigate_log("was planted by [key_name(user)] at ([T.x],[T.y],[T.z])","kudzu")
-	new /obj/effect/spacevine_controller(user.loc, mutations, potency, production)
+	new /obj/effect/spacevine_controller(user.loc, mutations, potency, production, yield, endurance)
 	qdel(src)
 
 /obj/item/seeds/kudzu/attack_self(mob/user)


### PR DESCRIPTION
:cl: XDTM
fix: Kudzu will no longer be a weapon of mass destruction.
add: Kudzu now scales with yield and resistance: yield increases the maximum amount of vines per seed, while resistance increases/decreases the health of each vine. Potency and production speed still boost respectively mutation chance and spread chance.
del: Bluespace and Flowering kudzu mutations have been removed as they were pretty OP.
del: Nitrogen consuming and CO2 consuming kudzu mutations have been removed as they were pretty much pointless.
add: Added a new kudzu mutation: O2 production. This kudzu will fill the air with oxygen until it reaches one atmosphere of pressure; ideal for making new areas in space without dragging canisters!
tweak: Hardened kudzu now can drop wood.
tweak: Explosive kudzu now only has a 30% chance of exploding on death, from 100%
fix: Thorny kudzu now properly checks for protection before stinging.
tweak: Kudzu is no longer fully opaque to the mouse, so you can now click on things under it.
tweak: Kudzu will now block and thus be hit by projectiles. This means you can fire down a hallway with guns or emitters and have them hit kudzu instead of going through it.
/:cl:

First off, this definitely fixes the doom kudzu we have now. I tested and with some effort, time and a fireaxe a single man can clear a top-stats, fully grown kudzu seed if it's not specifically mutated beforehand.
The kudzu spawning process has been greatly simplified and many variable names now reflect what they do. Fun fact, the previous spread cap, which could get up to 150, was _the amount of kudzu that could grow per tick_, not the amount of maximum kudzu per controller.

Kudzu definitely needs more interesting mutations beyond spawning o2, and i could use some ideas.

<s>Fixes #20449 by removal.</s> Should not be an issue anymore already.
