### PR TITLE
[s] Fixed invisible synths

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -51,7 +51,7 @@
 		default_features = S.default_features.Copy()
 		nojumpsuit = S.nojumpsuit
 		no_equip = S.no_equip.Copy()
-		limbs_id = S.id
+		limbs_id = S.limbs_id
 		use_skintones = S.use_skintones
 		fixed_mut_color = S.fixed_mut_color
 		hair_color = S.hair_color


### PR DESCRIPTION
They were invisible if they assumed the disguise of a species with a limbs_id
Closes #22645
Fixes #21751