### PR TITLE
Replaces the remaining(or most) of the right click verbs on machines with Altclick/Ctrlclick.

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -122,18 +122,15 @@
 				return
 			storedpda.icon_state = P.icon_state
 			storedpda.desc = P.desc
-			ejectpda()
+			AltClick(user)
 
 		else
 			user << "<span class='notice'>\The [src] is empty.</span>"
 
 
-/obj/machinery/pdapainter/verb/ejectpda()
-	set name = "Eject PDA"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.stat || usr.restrained() || !usr.canmove)
+/obj/machinery/pdapainter/AltClick(mob/user)
+	..()
+	if(user.stat || user.restrained() || !user.canmove)
 		return
 
 	if(storedpda)
@@ -141,7 +138,7 @@
 		storedpda = null
 		update_icon()
 	else
-		usr << "<span class='notice'>The [src] is empty.</span>"
+		user << "<span class='notice'>The [src] is empty.</span>"
 
 
 /obj/machinery/pdapainter/power_change()

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -292,17 +292,14 @@
 	connected.updateUsrDialog()
 	return TRUE
 
-/obj/machinery/clonepod/verb/eject()
-	set name = "Eject Cloner"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!usr)
+/obj/machinery/clonepod/AltClick(mob/user)
+	..()
+	if(!user)
 		return
-	if(usr.stat || !usr.canmove || usr.restrained())
+	if(user.stat || !user.canmove || user.restrained())
 		return
 	go_out()
-	add_fingerprint(usr)
+	add_fingerprint(user)
 
 /obj/machinery/clonepod/proc/go_out()
 	if (locked)

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -36,26 +36,16 @@ var/list/doppler_arrays = list()
 	else
 		return ..()
 
-/obj/machinery/doppler_array/verb/rotate()
-	set name = "Rotate Tachyon-doppler Dish"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!usr || !isturf(usr.loc))
-		return
-	if(usr.stat || usr.restrained() || !usr.canmove)
-		return
-	src.setDir(turn(src.dir, 90))
-	return
 
 /obj/machinery/doppler_array/AltClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
+	..()
+	if(!istype(user) || user.incapacitated() || user.stat || !user.canmove || user.restrained())
 		user << "<span class='warning'>You can't do that right now!</span>"
 		return
 	if(!in_range(src, user))
 		return
-	else
-		rotate()
+	src.setDir(turn(src.dir, 90))
+	return 1
 
 /obj/machinery/doppler_array/proc/sense_explosion(turf/epicenter,devastation_range,heavy_impact_range,light_impact_range,
 												  took,orig_dev_range,orig_heavy_range,orig_light_range)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -148,20 +148,17 @@
 		update_icon()
 		return
 	else if(beaker)
-		eject_beaker(user)
+		AltClick(user)
 	else
-		toggle_mode()
+		CtrlClick(user)
 
-/obj/machinery/iv_drip/verb/eject_beaker(mob/user)
-	set category = "Object"
-	set name = "Remove IV Container"
-	set src in view(1)
-
-	if(!isliving(usr))
-		usr << "<span class='warning'>You can't do that!</span>"
+/obj/machinery/iv_drip/AltClick(mob/user)
+	..()
+	if(!isliving(user))
+		user << "<span class='warning'>You can't do that!</span>"
 		return
 
-	if(usr.stat)
+	if(user.stat)
 		return
 
 	if(beaker)
@@ -169,20 +166,17 @@
 		beaker = null
 		update_icon()
 
-/obj/machinery/iv_drip/verb/toggle_mode()
-	set category = "Object"
-	set name = "Toggle Mode"
-	set src in view(1)
-
-	if(!isliving(usr))
-		usr << "<span class='warning'>You can't do that!</span>"
+/obj/machinery/iv_drip/CtrlClick(mob/user)
+	..()
+	if(!isliving(user))
+		user << "<span class='warning'>You can't do that!</span>"
 		return
 
-	if(usr.stat)
+	if(user.stat)
 		return
 
 	mode = !mode
-	usr << "The IV drip is now [mode ? "injecting" : "taking blood"]."
+	user << "The IV drip is now [mode ? "injecting" : "taking blood"]."
 	update_icon()
 
 /obj/machinery/iv_drip/examine()

--- a/code/game/machinery/overview.dm
+++ b/code/game/machinery/overview.dm
@@ -1,16 +1,14 @@
 //#define AMAP
 
-/obj/machinery/computer/security/verb/station_map()
-	set name = ".map"
-	set category = "Object"
-	set src in view(1)
-	usr.set_machine(src)
+/obj/machinery/computer/security/AltClick(mob/user)
+	..()
+	user.set_machine(src)
 	if(!mapping)
 		return
 
-	log_game("[usr]([usr.key]) used station map L[z] in [src.loc.loc]")
+	log_game("[user]([user.key]) used station map L[z] in [src.loc.loc]")
 
-	src.drawmap(usr)
+	src.drawmap(user)
 
 /obj/machinery/computer/security/proc/drawmap(mob/user)
 

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -139,15 +139,12 @@
 
 
 
-/obj/machinery/gibber/verb/eject()
-	set category = "Object"
-	set name = "empty gibber"
-	set src in oview(1)
-
-	if(usr.incapacitated())
+/obj/machinery/gibber/AltClick(mob/user)
+	..()
+	if(user.incapacitated())
 		return
 	src.go_out()
-	add_fingerprint(usr)
+	add_fingerprint(user)
 	return
 
 /obj/machinery/gibber/proc/go_out()

--- a/code/modules/food_and_drinks/kitchen_machinery/juicer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/juicer.dm
@@ -51,7 +51,6 @@
 				return 0
 			O.loc = src
 			beaker = O
-			src.verbs += /obj/machinery/juicer/verb/detach
 			update_icon()
 			src.updateUsrDialog()
 			return 0
@@ -128,18 +127,19 @@
 	src.updateUsrDialog()
 	return
 
-/obj/machinery/juicer/verb/detach()
-	set category = "Object"
-	set name = "Detach container from the juicer"
-	set src in oview(1)
+/obj/machinery/juicer/proc/detach()
 	if(usr.stat || !usr.canmove || usr.restrained())
 		return
 	if (!beaker)
 		return
-	src.verbs -= /obj/machinery/juicer/verb/detach
 	beaker.loc = src.loc
 	beaker = null
 	update_icon()
+
+/obj/machinery/juicer/AltClick(mob/user)
+	..()
+	detach()
+
 
 /obj/machinery/juicer/proc/get_juice_id(obj/item/weapon/reagent_containers/food/snacks/grown/O)
 	for (var/i in allowed_items)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -266,15 +266,12 @@
 	src.processing = 0
 	src.visible_message("\the [src] finishes processing.")
 
-/obj/machinery/processor/verb/eject()
-	set category = "Object"
-	set name = "Eject Contents"
-	set src in oview(1)
-
-	if(usr.stat || !usr.canmove || usr.restrained())
+/obj/machinery/processor/AltClick(mob/user)
+	..()
+	if(user.stat || !user.canmove || user.restrained())
 		return
 	src.empty()
-	add_fingerprint(usr)
+	add_fingerprint(user)
 	return
 
 /obj/machinery/processor/proc/empty()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -58,28 +58,18 @@
 		power_usage -= 50 * M.rating
 	active_power_usage = power_usage
 
-/obj/machinery/power/emitter/verb/rotate()
-	set name = "Rotate"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.stat || !usr.canmove || usr.restrained())
-		return
-	if (src.anchored)
-		usr << "<span class='warning'>It is fastened to the floor!</span>"
-		return 0
-	src.setDir(turn(src.dir, 270))
-	return 1
-
 /obj/machinery/power/emitter/AltClick(mob/user)
 	..()
-	if(user.incapacitated())
+	if(user.incapacitated() || user.stat || !user.canmove || user.restrained())
 		user << "<span class='warning'>You can't do that right now!</span>"
 		return
 	if(!in_range(src, user))
 		return
-	else
-		rotate()
+	if (src.anchored)
+		user << "<span class='warning'>It is fastened to the floor!</span>"
+		return 0
+	src.setDir(turn(src.dir, 270))
+	return 1
 
 /obj/machinery/power/emitter/initialize()
 	..()

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -57,38 +57,27 @@
 		master = null
 	return ..()
 
-/obj/structure/particle_accelerator/verb/rotate()
-	set name = "Rotate Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.stat || !usr.canmove || usr.restrained())
-		return
-	if (anchored)
-		usr << "It is fastened to the floor!"
-		return 0
-	setDir(turn(dir, -90))
-	return 1
-
 /obj/structure/particle_accelerator/AltClick(mob/user)
 	..()
-	if(user.incapacitated())
+	if(user.incapacitated() || usr.stat || !usr.canmove || usr.restrained())
 		user << "<span class='warning'>You can't do that right now!</span>"
 		return
 	if(!in_range(src, user))
 		return
-	else
-		rotate()
+	if(anchored)
+		user << "It is fastened to the floor!"
+		return 0
+	setDir(turn(dir, -90))
+	return 1
 
-/obj/structure/particle_accelerator/verb/rotateccw()
-	set name = "Rotate Counter Clockwise"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.stat || !usr.canmove || usr.restrained())
+/obj/structure/particle_accelerator/CtrlClick(mob/user)
+	..()
+	if(user.incapacitated() || user.stat || !user.canmove || user.restrained())
+		return
+	if(!in_range(src, user))
 		return
 	if (anchored)
-		usr << "It is fastened to the floor!"
+		user << "It is fastened to the floor!"
 		return 0
 	setDir(turn(dir, 90))
 	return 1


### PR DESCRIPTION
This PR does as it says in the title. I am pretty sure I got all machines, but if I missed one or two, please tell me.

PDA Painter: Altclick to eject PDA
Clone Pod: Altclick to Eject.
Doppler Array: Altclick to rotate
IV Drip: Altclick to eject bloodpack. Ctrlclick to toggle mode.
That map thingy. Ctrlclick to use it.
Gibber: Altclick to eject.
Juicer: Altclick to eject beaker. (yes, I had to do usr instead of user to get this shit to work without runtiming)
Processor: Altclick to eject.
PA: Altclick to rotate clockwise. Ctrlclick for counter clockwise.

Fixes #17409
