### PR TITLE
Bottles are Now Equal

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -5,7 +5,7 @@
 	desc = "A small bottle."
 	icon_state = "bottle"
 	item_state = "atoxinbottle"
-	possible_transfer_amounts = list(5,10,15,25,30)
+	possible_transfer_amounts = list(1,2,5,10,15,25,30)
 	volume = 30
 
 


### PR DESCRIPTION
No longer will Botany bottles be superior to you average working-class bottles.

:cl: Shadowdimentio
tweak: Bottles can now transfer reagents in measurements of one or two units.
/:cl:

Quality of life improvement for virologists and chemists, giving all bottles the 1 and 2 unit transfers that formerly only special ferilizer bottles from botany had. Get smashed, bottle hierarchy.