### PR TITLE
Makes the cycler shotgun a bit more user firendly

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -207,12 +207,12 @@
 	..()
 	if (!alternate_magazine)
 		alternate_magazine = new mag_type(src)
+	pump()
 
 /obj/item/weapon/gun/ballistic/shotgun/automatic/dual_tube/attack_self(mob/living/user)
+	toggle_tube(user)
 	if(!chambered && magazine.contents.len)
 		pump()
-	else
-		toggle_tube(user)
 
 /obj/item/weapon/gun/ballistic/shotgun/automatic/dual_tube/proc/toggle_tube(mob/living/user)
 	var/current_mag = magazine


### PR DESCRIPTION
:cl: Mervill
fix: The Cycler Shotgun is now truly automatic
/:cl:

The Cycler Shotgun will now always `pump()` an available shell into the chamber when the tubes are switched. `pump()` is also called once during `New()` to eliminate having to pump the gun once when picked up.

Fixes #22638