### PR TITLE
Allows any sharp item for "incise" surgery step (30% success)

### DIFF
--- a/code/modules/surgery/generic_steps.dm
+++ b/code/modules/surgery/generic_steps.dm
@@ -2,13 +2,19 @@
 //make incision
 /datum/surgery_step/incise
 	name = "make incision"
-	implements = list(/obj/item/weapon/scalpel = 100, /obj/item/weapon/melee/energy/sword = 75, /obj/item/weapon/kitchen/knife = 65, /obj/item/weapon/shard = 45)
+	implements = list(/obj/item/weapon/scalpel = 100, /obj/item/weapon/melee/energy/sword = 75, /obj/item/weapon/kitchen/knife = 65,
+		/obj/item/weapon/shard = 45, /obj/item = 30) // 30% success with any sharp item.
 	time = 16
 
 /datum/surgery_step/incise/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to make an incision in [target]'s [parse_zone(target_zone)].", "<span class='notice'>You begin to make an incision in [target]'s [parse_zone(target_zone)]...</span>")
+	user.visible_message("[user] begins to make an incision in [target]'s [parse_zone(target_zone)].",
+		"<span class='notice'>You begin to make an incision in [target]'s [parse_zone(target_zone)]...</span>")
 
+/datum/surgery_step/incise/tool_check(mob/user, obj/item/tool)
+	if(implement_type == /obj/item && !tool.is_sharp())
+		return 0
 
+	return 1
 
 //clamp bleeders
 /datum/surgery_step/clamp_bleeders
@@ -17,7 +23,8 @@
 	time = 24
 
 /datum/surgery_step/clamp_bleeders/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to clamp bleeders in [target]'s [parse_zone(target_zone)].", "<span class='notice'>You begin to clamp bleeders in [target]'s [parse_zone(target_zone)]...</span>")
+	user.visible_message("[user] begins to clamp bleeders in [target]'s [parse_zone(target_zone)].",
+		"<span class='notice'>You begin to clamp bleeders in [target]'s [parse_zone(target_zone)]...</span>")
 
 /datum/surgery_step/clamp_bleeders/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
@@ -32,18 +39,21 @@
 	time = 24
 
 /datum/surgery_step/retract_skin/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to retract the skin in [target]'s [parse_zone(target_zone)].", "<span class='notice'>You begin to retract the skin in [target]'s [parse_zone(target_zone)]...</span>")
+	user.visible_message("[user] begins to retract the skin in [target]'s [parse_zone(target_zone)].",
+		"<span class='notice'>You begin to retract the skin in [target]'s [parse_zone(target_zone)]...</span>")
 
 
 
 //close incision
 /datum/surgery_step/close
 	name = "mend incision"
-	implements = list(/obj/item/weapon/cautery = 100, /obj/item/weapon/gun/energy/laser = 90, /obj/item/weapon/weldingtool = 70, /obj/item/weapon/lighter = 45, /obj/item/weapon/match = 20)
+	implements = list(/obj/item/weapon/cautery = 100, /obj/item/weapon/gun/energy/laser = 90, /obj/item/weapon/weldingtool = 70,
+		/obj/item/weapon/lighter = 45, /obj/item/weapon/match = 20)
 	time = 24
 
 /datum/surgery_step/close/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to mend the incision in [target]'s [parse_zone(target_zone)].", "<span class='notice'>You begin to mend the incision in [target]'s [parse_zone(target_zone)]...</span>")
+	user.visible_message("[user] begins to mend the incision in [target]'s [parse_zone(target_zone)].",
+		"<span class='notice'>You begin to mend the incision in [target]'s [parse_zone(target_zone)]...</span>")
 
 
 /datum/surgery_step/close/tool_check(mob/user, obj/item/tool)
@@ -77,11 +87,14 @@
 //saw bone
 /datum/surgery_step/saw
 	name = "saw bone"
-	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/energy/sword/cyborg/saw = 100, /obj/item/weapon/melee/arm_blade = 75, /obj/item/weapon/mounted_chainsaw = 65, /obj/item/weapon/twohanded/required/chainsaw = 50, /obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
+	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/energy/sword/cyborg/saw = 100,
+		/obj/item/weapon/melee/arm_blade = 75, /obj/item/weapon/mounted_chainsaw = 65, /obj/item/weapon/twohanded/required/chainsaw = 50,
+		/obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
 	time = 54
 
 /datum/surgery_step/saw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to saw through the bone in [target]'s [parse_zone(target_zone)].", "<span class='notice'>You begin to saw through the bone in [target]'s [parse_zone(target_zone)]...</span>")
+	user.visible_message("[user] begins to saw through the bone in [target]'s [parse_zone(target_zone)].",
+		"<span class='notice'>You begin to saw through the bone in [target]'s [parse_zone(target_zone)]...</span>")
 
 /datum/surgery_step/saw/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	target.apply_damage(50,"brute","[target_zone]")
@@ -96,8 +109,10 @@
 	time = 30
 
 /datum/surgery_step/drill/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to drill into the bone in [target]'s [parse_zone(target_zone)].", "<span class='notice'>You begin to drill into the bone in [target]'s [parse_zone(target_zone)]...</span>")
+	user.visible_message("[user] begins to drill into the bone in [target]'s [parse_zone(target_zone)].",
+		"<span class='notice'>You begin to drill into the bone in [target]'s [parse_zone(target_zone)]...</span>")
 
 /datum/surgery_step/drill/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] drills into [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You drill into [target]'s [parse_zone(target_zone)].</span>")
+	user.visible_message("[user] drills into [target]'s [parse_zone(target_zone)]!",
+		"<span class='notice'>You drill into [target]'s [parse_zone(target_zone)].</span>")
 	return 1

--- a/code/modules/surgery/generic_steps.dm
+++ b/code/modules/surgery/generic_steps.dm
@@ -12,9 +12,9 @@
 
 /datum/surgery_step/incise/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.is_sharp())
-		return 0
+		return FALSE
 
-	return 1
+	return TRUE
 
 //clamp bleeders
 /datum/surgery_step/clamp_bleeders


### PR DESCRIPTION
Also splits some of the lines to make `generic_steps.dm` readable on smaller screens.

:cl: CoreOverload
tweak: Any sharp item can now be used for "incise" surgery step, with 30% success probability.
/:cl:
