### PR TITLE
Unfucks SMES construction/deconstruction

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -43,7 +43,8 @@
 
 /obj/machinery/power/smes/examine(user)
 	..()
-	user << "<span class='warning'>This SMES has no power terminal!</span>"
+	if(!terminal)
+		user << "<span class='warning'>This SMES has no power terminal!</span>"
 
 /obj/machinery/power/smes/New()
 	..()
@@ -178,7 +179,7 @@
 		log_game("[src] has been deconstructed by [key_name(user)]")
 		investigate_log("SMES deconstructed by [key_name(user)]","singulo")
 		return
-	else if(istype(I, /obj/item/weapon/crowbar))
+	else if(panel_open && istype(I, /obj/item/weapon/crowbar))
 		return
 
 	return ..()
@@ -186,7 +187,7 @@
 /obj/machinery/power/smes/default_deconstruction_crowbar(obj/item/weapon/crowbar/C)
 	if(istype(C) && terminal)
 		usr << "<span class='warning'>You must first remove the power terminal!</span>"
-		return 0
+		return FALSE
 
 	return ..()
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -41,6 +41,10 @@
 	var/static/list/smesImageCache
 
 
+/obj/machinery/power/smes/examine(user)
+	..()
+	user << "<span class='warning'>This SMES has no power terminal!</span>"
+
 /obj/machinery/power/smes/New()
 	..()
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/smes(null)
@@ -104,7 +108,7 @@
 				user << "<span class='notice'>Terminal found.</span>"
 				break
 		if(!terminal)
-			user << "<span class='alert'>No power source found.</span>"
+			user << "<span class='alert'>No power terminal found.</span>"
 			return
 		stat &= ~BROKEN
 		update_icon()
@@ -174,6 +178,15 @@
 		log_game("[src] has been deconstructed by [key_name(user)]")
 		investigate_log("SMES deconstructed by [key_name(user)]","singulo")
 		return
+	else if(istype(I, /obj/item/weapon/crowbar))
+		return
+
+	return ..()
+
+/obj/machinery/power/smes/default_deconstruction_crowbar(obj/item/weapon/crowbar/C)
+	if(istype(C) && terminal)
+		usr << "<span class='warning'>You must first remove the power terminal!</span>"
+		return 0
 
 	return ..()
 
@@ -197,11 +210,13 @@
 	terminal = new/obj/machinery/power/terminal(T)
 	terminal.setDir(get_dir(T,src))
 	terminal.master = src
+	stat &= ~BROKEN
 
 /obj/machinery/power/smes/disconnect_terminal()
 	if(terminal)
 		terminal.master = null
 		terminal = null
+		stat |= BROKEN
 
 
 /obj/machinery/power/smes/update_icon()
@@ -248,7 +263,6 @@
 	return round(5.5*charge/capacity)
 
 /obj/machinery/power/smes/process()
-
 	if(stat & BROKEN)
 		return
 

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -54,13 +54,13 @@
 			user << "<span class='warning'>You must first expose the power terminal!</span>"
 			return
 
-		if(master && master.can_terminal_dismantle())
+		if(!master || master.can_terminal_dismantle())
 			user.visible_message("[user.name] dismantles the power terminal from [master].", \
 								"<span class='notice'>You begin to cut the cables...</span>")
 
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			if(do_after(user, 50*W.toolspeed, target = src))
-				if(master && master.can_terminal_dismantle())
+				if(!master || master.can_terminal_dismantle())
 					if(prob(50) && electrocute_mob(user, powernet, src, 1, TRUE))
 						var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 						s.set_up(5, 1, master)


### PR DESCRIPTION
This PR changes SMES construction/deconstruction to be more intuitive.

* Adding a power terminal to SMES updates its status, forcing it to start working. You no longer need to wrench the SMES to activate it.
* Removing SMES terminal is now a required step in SMES deconstruction. No more orphaned terminals left behind.
* SMES that don't work because they lack a terminal now have an examine line.
* Orphaned terminals can now be deconstructed.