### PR TITLE
[READY]Makes addtimer use callbacks

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1317,7 +1317,7 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))
 
-#define QDEL_IN(item, time) addtimer(GLOBAL_PROC, "qdel", time, TIMER_NORMAL, item)
+#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC,  /proc/qdel, item), time)
 
 /proc/check_for_cleanbot_bug()
 	var/static/admins_warned //bet you didn't know you could do this!

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1317,7 +1317,7 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))
 
-#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC,  /proc/qdel, item), time)
+#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, item), time)
 
 /proc/check_for_cleanbot_bug()
 	var/static/admins_warned //bet you didn't know you could do this!

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -56,7 +56,7 @@
 	animate(alert, transform = matrix(), time = 2.5, easing = CUBIC_EASING)
 
 	if(alert.timeout)
-		addtimer(src, "alert_timeout", alert.timeout, TIMER_NORMAL, alert, category)
+		addtimer(CALLBACK(src,  .proc/alert_timeout, alert, category), alert.timeout)
 		alert.timeout = world.time + alert.timeout - world.tick_lag
 	return alert
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -56,7 +56,7 @@
 	animate(alert, transform = matrix(), time = 2.5, easing = CUBIC_EASING)
 
 	if(alert.timeout)
-		addtimer(CALLBACK(src,  .proc/alert_timeout, alert, category), alert.timeout)
+		addtimer(CALLBACK(src, .proc/alert_timeout, alert, category), alert.timeout)
 		alert.timeout = world.time + alert.timeout - world.tick_lag
 	return alert
 

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -112,7 +112,7 @@
 	C.parallax_movedir = new_parallax_movedir
 	if (C.parallax_animate_timer)
 		deltimer(C.parallax_animate_timer)
-	C.parallax_animate_timer = addtimer(src, .update_parallax_motionblur, min(shortesttimer, PARALLAX_LOOP_TIME), TIMER_NORMAL, C, animatedir, new_parallax_movedir, newtransform)
+	C.parallax_animate_timer = addtimer(CALLBACK(src, .proc/update_parallax_motionblur, C, animatedir, new_parallax_movedir, newtransform), min(shortesttimer, PARALLAX_LOOP_TIME))
 
 /datum/hud/proc/update_parallax_motionblur(client/C, animatedir, new_parallax_movedir, matrix/newtransform)
 	C.parallax_animate_timer = FALSE

--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -146,7 +146,7 @@ var/list/obj/item/device/paicard/pai_card_list = list()
 				continue
 			//G << 'sound/misc/server-ready.ogg' //Alerting them to their consideration
 			G << "<span class='ghostalert'>Someone is requesting a pAI personality! Use the pAI button to submit yourself as one.</span>"
-		addtimer(src, "spam_again", spam_delay)
+		addtimer(CALLBACK(src,  .proc/spam_again), spam_delay)
 	var/list/available = list()
 	for(var/datum/paiCandidate/c in SSpai.candidates)
 		if(c.ready)

--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -146,7 +146,7 @@ var/list/obj/item/device/paicard/pai_card_list = list()
 				continue
 			//G << 'sound/misc/server-ready.ogg' //Alerting them to their consideration
 			G << "<span class='ghostalert'>Someone is requesting a pAI personality! Use the pAI button to submit yourself as one.</span>"
-		addtimer(CALLBACK(src,  .proc/spam_again), spam_delay)
+		addtimer(CALLBACK(src, .proc/spam_again), spam_delay)
 	var/list/available = list()
 	for(var/datum/paiCandidate/c in SSpai.candidates)
 		if(c.ready)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -26,30 +26,19 @@ var/datum/subsystem/timer/SStimer
 		can_fire = 0 //nothing to do, lets stop firing.
 		return
 	for(var/datum/timedevent/event in processing)
-		if(!event.thingToCall || qdeleted(event.thingToCall))
-			qdel(event)
 		if(event.timeToRun <= world.time)
-			runevent(event)
+			event.callback.InvokeAsync()
 			qdel(event)
 		if (MC_TICK_CHECK)
 			return
-
-/datum/subsystem/timer/proc/runevent(datum/timedevent/event)
-	set waitfor = 0
-	if(event.thingToCall == GLOBAL_PROC && istext(event.procToCall))
-		call("/proc/[event.procToCall]")(arglist(event.argList))
-	else
-		call(event.thingToCall, event.procToCall)(arglist(event.argList))
 
 /datum/subsystem/timer/Recover()
 	processing |= SStimer.processing
 	hashes |= SStimer.hashes
 
 /datum/timedevent
-	var/thingToCall
-	var/procToCall
+	var/datum/callback/callback
 	var/timeToRun
-	var/argList
 	var/id
 	var/hash
 	var/static/nextid = 1
@@ -62,39 +51,32 @@ var/datum/subsystem/timer/SStimer
 	SStimer.hashes -= hash
 	return QDEL_HINT_IWILLGC
 
-/proc/addtimer(thingToCall, procToCall, wait, unique = TIMER_NORMAL, ...)
-	if (!thingToCall || !procToCall)
+/proc/addtimer(datum/callback/callback, wait, unique = TIMER_NORMAL)
+	if (!callback)
 		return
 	if (!SStimer.can_fire)
 		SStimer.can_fire = 1
 
 	var/datum/timedevent/event = new()
-	event.thingToCall = thingToCall
-	event.procToCall = procToCall
+	event.callback = callback
 	event.timeToRun = world.time + wait
-	var/hashlist = args.Copy()
+	var/list/hashlist = args.Copy()
 
-	hashlist[1] = "[thingToCall](\ref[thingToCall])"
+	hashlist[1] = "[callback.object](\ref[callback.object])"
+	hashlist.Insert(2, callback.delegate, callback.arguments)
 	event.hash = jointext(hashlist, null)
 
-	var/bad_args = unique != TIMER_NORMAL && unique != TIMER_UNIQUE
-	if(args.len > 4 || bad_args)
-		if(bad_args)
-			stack_trace("Invalid arguments in call to addtimer! Attempt to call [thingToCall] proc [procToCall]")
-			event.argList = args.Copy(4)
-		else
-			event.argList = args.Copy(5)
-
-	// Check for dupes if unique = 1.
-	if(!bad_args && unique != TIMER_NORMAL)	//faster than checking if(unique == TIMER_UNIQUE)
+	if(unique == TIMER_UNIQUE)
 		var/datum/timedevent/hash_event = SStimer.hashes[event.hash]
 		if(hash_event)
 			return hash_event.id
+
 	SStimer.hashes[event.hash] = event
 	if (wait <= 0)
-		SStimer.runevent(event)
+		callback.InvokeAsync()
 		SStimer.hashes -= event.hash
 		return
+
 	// If we are unique (or we're not checking that), add the timer and return the id.
 	SStimer.processing += event
 

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -29,7 +29,7 @@ var/datum/subsystem/weather/SSweather
 		var/datum/weather/W = pickweight(possible_weather_for_this_z)
 		run_weather(W.name, Z)
 		eligible_zlevels -= Z
-		addtimer(src, "make_z_eligible", rand(3000, 6000) + W.weather_duration_upper, TIMER_UNIQUE, Z) //Around 5-10 minutes between weathers
+		addtimer(CALLBACK(src,  .proc/make_z_eligible, Z), rand(3000, 6000) + W.weather_duration_upper, TIMER_UNIQUE) //Around 5-10 minutes between weathers
 
 /datum/subsystem/weather/Initialize(start_timeofday)
 	..()

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -29,7 +29,7 @@ var/datum/subsystem/weather/SSweather
 		var/datum/weather/W = pickweight(possible_weather_for_this_z)
 		run_weather(W.name, Z)
 		eligible_zlevels -= Z
-		addtimer(CALLBACK(src,  .proc/make_z_eligible, Z), rand(3000, 6000) + W.weather_duration_upper, TIMER_UNIQUE) //Around 5-10 minutes between weathers
+		addtimer(CALLBACK(src, .proc/make_z_eligible, Z), rand(3000, 6000) + W.weather_duration_upper, TIMER_UNIQUE) //Around 5-10 minutes between weathers
 
 /datum/subsystem/weather/Initialize(start_timeofday)
 	..()

--- a/code/datums/antagonists/datum_clockcult.dm
+++ b/code/datums/antagonists/datum_clockcult.dm
@@ -40,7 +40,7 @@
 		ticker.mode.servants_of_ratvar += owner.mind
 		ticker.mode.update_servant_icons_added(owner.mind)
 		if(jobban_isbanned(owner, ROLE_SERVANT_OF_RATVAR))
-			addtimer(CALLBACK(ticker.mode,  /datum/game_mode.proc/replace_jobbaned_player, owner, ROLE_SERVANT_OF_RATVAR, ROLE_SERVANT_OF_RATVAR), 0)
+			addtimer(CALLBACK(ticker.mode, /datum/game_mode.proc/replace_jobbaned_player, owner, ROLE_SERVANT_OF_RATVAR, ROLE_SERVANT_OF_RATVAR), 0)
 	if(owner.mind)
 		owner.mind.special_role = "Servant of Ratvar"
 	owner.attack_log += "\[[time_stamp()]\] <font color=#BE8700>Has been converted to the cult of Ratvar!</font>"

--- a/code/datums/antagonists/datum_clockcult.dm
+++ b/code/datums/antagonists/datum_clockcult.dm
@@ -40,7 +40,7 @@
 		ticker.mode.servants_of_ratvar += owner.mind
 		ticker.mode.update_servant_icons_added(owner.mind)
 		if(jobban_isbanned(owner, ROLE_SERVANT_OF_RATVAR))
-			addtimer(ticker.mode, "replace_jobbaned_player", 0, TIMER_NORMAL, owner, ROLE_SERVANT_OF_RATVAR, ROLE_SERVANT_OF_RATVAR)
+			addtimer(CALLBACK(ticker.mode,  /datum/game_mode.proc/replace_jobbaned_player, owner, ROLE_SERVANT_OF_RATVAR, ROLE_SERVANT_OF_RATVAR), 0)
 	if(owner.mind)
 		owner.mind.special_role = "Servant of Ratvar"
 	owner.attack_log += "\[[time_stamp()]\] <font color=#BE8700>Has been converted to the cult of Ratvar!</font>"

--- a/code/datums/antagonists/datum_cult.dm
+++ b/code/datums/antagonists/datum_cult.dm
@@ -20,7 +20,7 @@
 			var/datum/game_mode/cult/C = ticker.mode
 			C.memorize_cult_objectives(owner.mind)
 		if(jobban_isbanned(owner, ROLE_CULTIST))
-			addtimer(ticker.mode, "replace_jobbaned_player", 0, TIMER_NORMAL, owner, ROLE_CULTIST, ROLE_CULTIST)
+			addtimer(CALLBACK(ticker.mode,  /datum/game_mode.proc/replace_jobbaned_player, owner, ROLE_CULTIST, ROLE_CULTIST), 0)
 	if(owner.mind)
 		owner.mind.special_role = "Cultist"
 	owner.attack_log += "\[[time_stamp()]\] <font color=#960000>Has been converted to the cult of Nar'Sie!</font>"

--- a/code/datums/antagonists/datum_cult.dm
+++ b/code/datums/antagonists/datum_cult.dm
@@ -20,7 +20,7 @@
 			var/datum/game_mode/cult/C = ticker.mode
 			C.memorize_cult_objectives(owner.mind)
 		if(jobban_isbanned(owner, ROLE_CULTIST))
-			addtimer(CALLBACK(ticker.mode,  /datum/game_mode.proc/replace_jobbaned_player, owner, ROLE_CULTIST, ROLE_CULTIST), 0)
+			addtimer(CALLBACK(ticker.mode, /datum/game_mode.proc/replace_jobbaned_player, owner, ROLE_CULTIST, ROLE_CULTIST), 0)
 	if(owner.mind)
 		owner.mind.special_role = "Cultist"
 	owner.attack_log += "\[[time_stamp()]\] <font color=#960000>Has been converted to the cult of Nar'Sie!</font>"

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -57,7 +57,7 @@
 
 /datum/callback/proc/Invoke(...)
 	if (!object)
-		CRASH("Cannot call null.[delegate]")
+		return
 
 	var/list/calling_arguments = arguments
 
@@ -75,7 +75,7 @@
 /datum/callback/proc/InvokeAsync(...)
 	set waitfor = 0
 	if (!object)
-		CRASH("Cannot call null.[delegate]")
+		return
 
 	var/list/calling_arguments = arguments
 

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -2,9 +2,9 @@
 	USAGE:
 
 		var/datum/callback/C = new(object|null, /proc/type/path|"procstring", arg1, arg2, ... argn)
-		var/timerid = addtimer(CALLBACK(C, time, timertype)
+		var/timerid = addtimer(C, time, timertype)
 		OR
-		var/timerid = addtimer(CALLBACK(CALLBACK(object|null, /proc/type/path|procstring, arg1, arg2, ... argn), time, timertype)
+		var/timerid = addtimer(CALLBACK(object|null, /proc/type/path|procstring, arg1, arg2, ... argn), time, timertype)
 
 		Note: proc strings can only be given for datum proc calls, global procs must be proc paths
 		Also proc strings are strongly advised against because they don't compile error if the proc stops existing

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -2,9 +2,9 @@
 	USAGE:
 
 		var/datum/callback/C = new(object|null, /proc/type/path|"procstring", arg1, arg2, ... argn)
-		var/timerid = addtimer(C, time, timertype)
+		var/timerid = addtimer(CALLBACK(C, time, timertype)
 		OR
-		var/timerid = addtimer(CALLBACK(object|null, /proc/type/path|procstring, arg1, arg2, ... argn), time, timertype)
+		var/timerid = addtimer(CALLBACK(CALLBACK(object|null, /proc/type/path|procstring, arg1, arg2, ... argn), time, timertype)
 
 		Note: proc strings can only be given for datum proc calls, global procs must be proc paths
 		Also proc strings are strongly advised against because they don't compile error if the proc stops existing

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -82,9 +82,9 @@
 /datum/teleport/proc/playSpecials(atom/location,datum/effect_system/effect,sound)
 	if(location)
 		if(effect)
-			addtimer(src, "do_effect", 0, TIMER_NORMAL, location, effect)
+			addtimer(CALLBACK(src,  .proc/do_effect, location, effect), 0)
 		if(sound)
-			addtimer(src, "do_sound", 0, TIMER_NORMAL, location, sound)
+			addtimer(CALLBACK(src,  .proc/do_sound, location, sound), 0)
 
 /datum/teleport/proc/do_effect(atom/location, datum/effect_system/effect)
 	src = null

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -82,9 +82,9 @@
 /datum/teleport/proc/playSpecials(atom/location,datum/effect_system/effect,sound)
 	if(location)
 		if(effect)
-			addtimer(CALLBACK(src,  .proc/do_effect, location, effect), 0)
+			addtimer(CALLBACK(src, .proc/do_effect, location, effect), 0)
 		if(sound)
-			addtimer(CALLBACK(src,  .proc/do_sound, location, sound), 0)
+			addtimer(CALLBACK(src, .proc/do_sound, location, sound), 0)
 
 /datum/teleport/proc/do_effect(atom/location, datum/effect_system/effect)
 	src = null

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -471,7 +471,7 @@
 		D.adjustStaminaLoss(20)
 		D.Stun(5)
 		restraining = 1
-		addtimer(src, "drop_restraining", 50, TIMER_UNIQUE)
+		addtimer(CALLBACK(src,  .proc/drop_restraining), 50, TIMER_UNIQUE)
 	return 1
 
 /datum/martial_art/cqc/proc/Consecutive(mob/living/carbon/human/A, mob/living/carbon/human/D)

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -471,7 +471,7 @@
 		D.adjustStaminaLoss(20)
 		D.Stun(5)
 		restraining = 1
-		addtimer(CALLBACK(src,  .proc/drop_restraining), 50, TIMER_UNIQUE)
+		addtimer(CALLBACK(src, .proc/drop_restraining), 50, TIMER_UNIQUE)
 	return 1
 
 /datum/martial_art/cqc/proc/Consecutive(mob/living/carbon/human/A, mob/living/carbon/human/D)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -62,7 +62,7 @@
 	var/damnation_type = 0
 	var/datum/mind/soulOwner //who owns the soul.  Under normal circumstances, this will point to src
 	var/isholy = FALSE //is this person a chaplain or admin role allowed to use bibles
-	
+
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
 
 /datum/mind/New(var/key)
@@ -1496,7 +1496,7 @@
 			if(istype(S, type))
 				continue
 		S.charge_counter = delay
-		addtimer(S, "start_recharge", 0)
+		addtimer(CALLBACK(S,  /obj/effect/proc_holder/spell.proc/start_recharge), 0)
 
 /datum/mind/proc/get_ghost(even_if_they_cant_reenter)
 	for(var/mob/dead/observer/G in dead_mob_list)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1496,7 +1496,7 @@
 			if(istype(S, type))
 				continue
 		S.charge_counter = delay
-		addtimer(CALLBACK(S,  /obj/effect/proc_holder/spell.proc/start_recharge), 0)
+		addtimer(CALLBACK(S, /obj/effect/proc_holder/spell.proc/start_recharge), 0)
 
 /datum/mind/proc/get_ghost(even_if_they_cant_reenter)
 	for(var/mob/dead/observer/G in dead_mob_list)

--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -237,7 +237,7 @@
 		owner.visible_message("<span class='danger'>[owner] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
 		owner.Paralyse(10)
 		owner.Jitter(1000)
-		addtimer(src, "jitter_less", 90, TIMER_NORMAL, owner)
+		addtimer(CALLBACK(src,  .proc/jitter_less, owner), 90)
 
 /datum/mutation/human/epilepsy/proc/jitter_less(mob/living/carbon/human/owner)
 	if(owner)

--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -237,7 +237,7 @@
 		owner.visible_message("<span class='danger'>[owner] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
 		owner.Paralyse(10)
 		owner.Jitter(1000)
-		addtimer(CALLBACK(src,  .proc/jitter_less, owner), 90)
+		addtimer(CALLBACK(src, .proc/jitter_less, owner), 90)
 
 /datum/mutation/human/epilepsy/proc/jitter_less(mob/living/carbon/human/owner)
 	if(owner)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -110,7 +110,7 @@
 	owner.add_stun_absorption("inathneq", 150, 2, "'s flickering blue aura momentarily intensifies!", "Inath-neq's power absorbs the stun!", " glowing with a flickering blue light!")
 	owner.status_flags |= GODMODE
 	animate(owner, color = oldcolor, time = 150, easing = EASE_IN)
-	addtimer(owner, "update_atom_colour", 150)
+	addtimer(CALLBACK(owner,  /atom/proc/update_atom_colour), 150)
 	playsound(owner, 'sound/magic/Ethereal_Enter.ogg', 50, 1)
 
 /datum/status_effect/inathneqs_endowment/on_remove()

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -110,7 +110,7 @@
 	owner.add_stun_absorption("inathneq", 150, 2, "'s flickering blue aura momentarily intensifies!", "Inath-neq's power absorbs the stun!", " glowing with a flickering blue light!")
 	owner.status_flags |= GODMODE
 	animate(owner, color = oldcolor, time = 150, easing = EASE_IN)
-	addtimer(CALLBACK(owner,  /atom/proc/update_atom_colour), 150)
+	addtimer(CALLBACK(owner, /atom/proc/update_atom_colour), 150)
 	playsound(owner, 'sound/magic/Ethereal_Enter.ogg', 50, 1)
 
 /datum/status_effect/inathneqs_endowment/on_remove()

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -19,7 +19,7 @@ var/global/list/all_status_effects = list() //a list of all status effects, if f
 	if(owner)
 		LAZYADD(owner.status_effects, src)
 	all_status_effects += src
-	addtimer(CALLBACK(src,  .proc/start_ticking), 1) //Give us time to set any variables
+	addtimer(CALLBACK(src, .proc/start_ticking), 1) //Give us time to set any variables
 
 /datum/status_effect/Destroy()
 	STOP_PROCESSING(SSprocessing, src)

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -19,7 +19,7 @@ var/global/list/all_status_effects = list() //a list of all status effects, if f
 	if(owner)
 		LAZYADD(owner.status_effects, src)
 	all_status_effects += src
-	addtimer(src, "start_ticking", 1) //Give us time to set any variables
+	addtimer(CALLBACK(src,  .proc/start_ticking), 1) //Give us time to set any variables
 
 /datum/status_effect/Destroy()
 	STOP_PROCESSING(SSprocessing, src)

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -70,7 +70,7 @@
 				M << telegraph_message
 			if(telegraph_sound)
 				M << sound(telegraph_sound)
-	addtimer(src, "start", telegraph_duration)
+	addtimer(CALLBACK(src,  .proc/start), telegraph_duration)
 
 /datum/weather/proc/start()
 	if(stage >= MAIN_STAGE)
@@ -85,7 +85,7 @@
 			if(weather_sound)
 				M << sound(weather_sound)
 	START_PROCESSING(SSweather, src)
-	addtimer(src, "wind_down", weather_duration)
+	addtimer(CALLBACK(src,  .proc/wind_down), weather_duration)
 
 /datum/weather/proc/wind_down()
 	if(stage >= WIND_DOWN_STAGE)
@@ -100,7 +100,7 @@
 			if(end_sound)
 				M << sound(end_sound)
 	STOP_PROCESSING(SSweather, src)
-	addtimer(src, "end", end_duration)
+	addtimer(CALLBACK(src,  .proc/end), end_duration)
 
 /datum/weather/proc/end()
 	if(stage == END_STAGE)

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -70,7 +70,7 @@
 				M << telegraph_message
 			if(telegraph_sound)
 				M << sound(telegraph_sound)
-	addtimer(CALLBACK(src,  .proc/start), telegraph_duration)
+	addtimer(CALLBACK(src, .proc/start), telegraph_duration)
 
 /datum/weather/proc/start()
 	if(stage >= MAIN_STAGE)
@@ -85,7 +85,7 @@
 			if(weather_sound)
 				M << sound(weather_sound)
 	START_PROCESSING(SSweather, src)
-	addtimer(CALLBACK(src,  .proc/wind_down), weather_duration)
+	addtimer(CALLBACK(src, .proc/wind_down), weather_duration)
 
 /datum/weather/proc/wind_down()
 	if(stage >= WIND_DOWN_STAGE)
@@ -100,7 +100,7 @@
 			if(end_sound)
 				M << sound(end_sound)
 	STOP_PROCESSING(SSweather, src)
-	addtimer(CALLBACK(src,  .proc/end), end_duration)
+	addtimer(CALLBACK(src, .proc/end), end_duration)
 
 /datum/weather/proc/end()
 	if(stage == END_STAGE)

--- a/code/datums/wires/airalarm.dm
+++ b/code/datums/wires/airalarm.dm
@@ -31,13 +31,13 @@
 			if(!A.shorted)
 				A.shorted = TRUE
 				A.update_icon()
-			addtimer(A, "reset", 1200, TIMER_NORMAL, wire)
+			addtimer(CALLBACK(A,  /obj/machinery/airalarm.proc/reset, wire), 1200)
 		if(WIRE_IDSCAN) // Toggle lock.
 			A.locked = !A.locked
 		if(WIRE_AI) // Disable AI control for a while.
 			if(!A.aidisabled)
 				A.aidisabled = TRUE
-			addtimer(A, "reset", 100, TIMER_NORMAL, wire)
+			addtimer(CALLBACK(A,  /obj/machinery/airalarm.proc/reset, wire), 100)
 		if(WIRE_PANIC) // Toggle panic siphon.
 			if(!A.shorted)
 				if(A.mode == 1) // AALARM_MODE_SCRUB

--- a/code/datums/wires/airalarm.dm
+++ b/code/datums/wires/airalarm.dm
@@ -31,13 +31,13 @@
 			if(!A.shorted)
 				A.shorted = TRUE
 				A.update_icon()
-			addtimer(CALLBACK(A,  /obj/machinery/airalarm.proc/reset, wire), 1200)
+			addtimer(CALLBACK(A, /obj/machinery/airalarm.proc/reset, wire), 1200)
 		if(WIRE_IDSCAN) // Toggle lock.
 			A.locked = !A.locked
 		if(WIRE_AI) // Disable AI control for a while.
 			if(!A.aidisabled)
 				A.aidisabled = TRUE
-			addtimer(CALLBACK(A,  /obj/machinery/airalarm.proc/reset, wire), 100)
+			addtimer(CALLBACK(A, /obj/machinery/airalarm.proc/reset, wire), 100)
 		if(WIRE_PANIC) // Toggle panic siphon.
 			if(!A.shorted)
 				if(A.mode == 1) // AALARM_MODE_SCRUB

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -29,14 +29,14 @@
 		if(WIRE_POWER1, WIRE_POWER2) // Short for a long while.
 			if(!A.shorted)
 				A.shorted = TRUE
-				addtimer(CALLBACK(A,  /obj/machinery/power/apc.proc/reset, wire), 1200)
+				addtimer(CALLBACK(A, /obj/machinery/power/apc.proc/reset, wire), 1200)
 		if(WIRE_IDSCAN) // Unlock for a little while.
 			A.locked = FALSE
-			addtimer(CALLBACK(A,  /obj/machinery/power/apc.proc/reset, wire), 300)
+			addtimer(CALLBACK(A, /obj/machinery/power/apc.proc/reset, wire), 300)
 		if(WIRE_AI) // Disable AI control for a very short time.
 			if(!A.aidisabled)
 				A.aidisabled = TRUE
-				addtimer(CALLBACK(A,  /obj/machinery/power/apc.proc/reset, wire), 10)
+				addtimer(CALLBACK(A, /obj/machinery/power/apc.proc/reset, wire), 10)
 
 /datum/wires/apc/on_cut(index, mend)
 	var/obj/machinery/power/apc/A = holder

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -29,14 +29,14 @@
 		if(WIRE_POWER1, WIRE_POWER2) // Short for a long while.
 			if(!A.shorted)
 				A.shorted = TRUE
-				addtimer(A, "reset", 1200, TIMER_NORMAL, wire)
+				addtimer(CALLBACK(A,  /obj/machinery/power/apc.proc/reset, wire), 1200)
 		if(WIRE_IDSCAN) // Unlock for a little while.
 			A.locked = FALSE
-			addtimer(A, "reset", 300, TIMER_NORMAL, wire)
+			addtimer(CALLBACK(A,  /obj/machinery/power/apc.proc/reset, wire), 300)
 		if(WIRE_AI) // Disable AI control for a very short time.
 			if(!A.aidisabled)
 				A.aidisabled = TRUE
-				addtimer(A, "reset", 10, TIMER_NORMAL, wire)
+				addtimer(CALLBACK(A,  /obj/machinery/power/apc.proc/reset, wire), 10)
 
 /datum/wires/apc/on_cut(index, mend)
 	var/obj/machinery/power/apc/A = holder

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -27,13 +27,13 @@
 	switch(wire)
 		if(WIRE_HACK)
 			A.adjust_hacked(!A.hacked)
-			addtimer(A, "reset", 60, TIMER_NORMAL, wire)
+			addtimer(CALLBACK(A,  /obj/machinery/autolathe.proc/reset, wire), 60)
 		if(WIRE_SHOCK)
 			A.shocked = !A.shocked
-			addtimer(A, "reset", 60, TIMER_NORMAL, wire)
+			addtimer(CALLBACK(A,  /obj/machinery/autolathe.proc/reset, wire), 60)
 		if(WIRE_DISABLE)
 			A.disabled = !A.disabled
-			addtimer(A, "reset", 60, TIMER_NORMAL, wire)
+			addtimer(CALLBACK(A,  /obj/machinery/autolathe.proc/reset, wire), 60)
 
 /datum/wires/autolathe/on_cut(wire, mend)
 	var/obj/machinery/autolathe/A = holder

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -27,13 +27,13 @@
 	switch(wire)
 		if(WIRE_HACK)
 			A.adjust_hacked(!A.hacked)
-			addtimer(CALLBACK(A,  /obj/machinery/autolathe.proc/reset, wire), 60)
+			addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)
 		if(WIRE_SHOCK)
 			A.shocked = !A.shocked
-			addtimer(CALLBACK(A,  /obj/machinery/autolathe.proc/reset, wire), 60)
+			addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)
 		if(WIRE_DISABLE)
 			A.disabled = !A.disabled
-			addtimer(CALLBACK(A,  /obj/machinery/autolathe.proc/reset, wire), 60)
+			addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)
 
 /datum/wires/autolathe/on_cut(wire, mend)
 	var/obj/machinery/autolathe/A = holder

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -197,7 +197,7 @@ var/list/teleportlocs = list()
 					if(D.operating)
 						D.nextstate = CLOSED
 					else if(!D.density)
-						addtimer(CALLBACK(D,  /obj/machinery/door/firedoor.proc/close), 0)
+						addtimer(CALLBACK(D, /obj/machinery/door/firedoor.proc/close), 0)
 			for(var/obj/machinery/firealarm/F in RA)
 				F.update_icon()
 		for (var/obj/machinery/camera/C in RA)
@@ -223,7 +223,7 @@ var/list/teleportlocs = list()
 					if(D.operating)
 						D.nextstate = OPEN
 					else if(D.density)
-						addtimer(CALLBACK(D,  /obj/machinery/door/firedoor.proc/open), 0)
+						addtimer(CALLBACK(D, /obj/machinery/door/firedoor.proc/open), 0)
 			for(var/obj/machinery/firealarm/F in RA)
 				F.update_icon()
 
@@ -257,7 +257,7 @@ var/list/teleportlocs = list()
 	for (var/mob/living/silicon/SILICON in player_list)
 		if(SILICON.triggerAlarm("Burglar", src, cameras, trigger))
 			//Cancel silicon alert after 1 minute
-			addtimer(CALLBACK(SILICON,  /mob/living/silicon.proc/cancelAlarm,"Burglar",src,trigger), 600)
+			addtimer(CALLBACK(SILICON, /mob/living/silicon.proc/cancelAlarm,"Burglar",src,trigger), 600)
 
 /area/proc/set_fire_alarm_effect()
 	fire = 1
@@ -294,7 +294,7 @@ var/list/teleportlocs = list()
 				if(D.operating)
 					D.nextstate = OPEN
 				else if(D.density)
-					addtimer(CALLBACK(D,  /obj/machinery/door/firedoor.proc/open), 0)
+					addtimer(CALLBACK(D, /obj/machinery/door/firedoor.proc/open), 0)
 
 /area/proc/updateicon()
 	if ((fire || eject || party) && (!requires_power||power_environ))//If it doesn't require power, can still activate this proc.

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -197,7 +197,7 @@ var/list/teleportlocs = list()
 					if(D.operating)
 						D.nextstate = CLOSED
 					else if(!D.density)
-						addtimer(D, "close", 0)
+						addtimer(CALLBACK(D,  /obj/machinery/door/firedoor.proc/close), 0)
 			for(var/obj/machinery/firealarm/F in RA)
 				F.update_icon()
 		for (var/obj/machinery/camera/C in RA)
@@ -223,7 +223,7 @@ var/list/teleportlocs = list()
 					if(D.operating)
 						D.nextstate = OPEN
 					else if(D.density)
-						addtimer(D, "open", 0)
+						addtimer(CALLBACK(D,  /obj/machinery/door/firedoor.proc/open), 0)
 			for(var/obj/machinery/firealarm/F in RA)
 				F.update_icon()
 
@@ -257,7 +257,7 @@ var/list/teleportlocs = list()
 	for (var/mob/living/silicon/SILICON in player_list)
 		if(SILICON.triggerAlarm("Burglar", src, cameras, trigger))
 			//Cancel silicon alert after 1 minute
-			addtimer(SILICON, "cancelAlarm", 600, TIMER_NORMAL,"Burglar",src,trigger)
+			addtimer(CALLBACK(SILICON,  /mob/living/silicon.proc/cancelAlarm,"Burglar",src,trigger), 600)
 
 /area/proc/set_fire_alarm_effect()
 	fire = 1
@@ -294,7 +294,7 @@ var/list/teleportlocs = list()
 				if(D.operating)
 					D.nextstate = OPEN
 				else if(D.density)
-					addtimer(D, "open", 0)
+					addtimer(CALLBACK(D,  /obj/machinery/door/firedoor.proc/open), 0)
 
 /area/proc/updateicon()
 	if ((fire || eject || party) && (!requires_power||power_environ))//If it doesn't require power, can still activate this proc.

--- a/code/game/gamemodes/changeling/powers/biodegrade.dm
+++ b/code/game/gamemodes/changeling/powers/biodegrade.dm
@@ -22,7 +22,7 @@
 		user.visible_message("<span class='warning'>[user] vomits a glob of acid on [user.p_their()] [O]!</span>", \
 			"<span class='warning'>We vomit acidic ooze onto our restraints!</span>")
 
-		addtimer(src, "dissolve_handcuffs", 30, TIMER_NORMAL, user, O)
+		addtimer(CALLBACK(src,  .proc/dissolve_handcuffs, user, O), 30)
 		used = TRUE
 
 	if(user.wear_suit && user.wear_suit.breakouttime && !used)
@@ -31,7 +31,7 @@
 			return 0
 		user.visible_message("<span class='warning'>[user] vomits a glob of acid across the front of [user.p_their()] [S]!</span>", \
 			"<span class='warning'>We vomit acidic ooze onto our straight jacket!</span>")
-		addtimer(src, "dissolve_straightjacket", 30, TIMER_NORMAL, user, S)
+		addtimer(CALLBACK(src,  .proc/dissolve_straightjacket, user, S), 30)
 		used = TRUE
 
 
@@ -41,7 +41,7 @@
 			return 0
 		C.visible_message("<span class='warning'>[C]'s hinges suddenly begin to melt and run!</span>")
 		user << "<span class='warning'>We vomit acidic goop onto the interior of [C]!</span>"
-		addtimer(src, "open_closet", 70, TIMER_NORMAL, user, C)
+		addtimer(CALLBACK(src,  .proc/open_closet, user, C), 70)
 		used = TRUE
 
 	if(istype(user.loc, /obj/structure/spider/cocoon) && !used)
@@ -50,7 +50,7 @@
 			return 0
 		C.visible_message("<span class='warning'>[src] shifts and starts to fall apart!</span>")
 		user << "<span class='warning'>We secrete acidic enzymes from our skin and begin melting our cocoon...</span>"
-		addtimer(src, "dissolve_cocoon", 25, TIMER_NORMAL, user, C) //Very short because it's just webs
+		addtimer(CALLBACK(src,  .proc/dissolve_cocoon, user, C), 25) //Very short because it's just webs
 		used = TRUE
 
 	if(used)

--- a/code/game/gamemodes/changeling/powers/biodegrade.dm
+++ b/code/game/gamemodes/changeling/powers/biodegrade.dm
@@ -22,7 +22,7 @@
 		user.visible_message("<span class='warning'>[user] vomits a glob of acid on [user.p_their()] [O]!</span>", \
 			"<span class='warning'>We vomit acidic ooze onto our restraints!</span>")
 
-		addtimer(CALLBACK(src,  .proc/dissolve_handcuffs, user, O), 30)
+		addtimer(CALLBACK(src, .proc/dissolve_handcuffs, user, O), 30)
 		used = TRUE
 
 	if(user.wear_suit && user.wear_suit.breakouttime && !used)
@@ -31,7 +31,7 @@
 			return 0
 		user.visible_message("<span class='warning'>[user] vomits a glob of acid across the front of [user.p_their()] [S]!</span>", \
 			"<span class='warning'>We vomit acidic ooze onto our straight jacket!</span>")
-		addtimer(CALLBACK(src,  .proc/dissolve_straightjacket, user, S), 30)
+		addtimer(CALLBACK(src, .proc/dissolve_straightjacket, user, S), 30)
 		used = TRUE
 
 
@@ -41,7 +41,7 @@
 			return 0
 		C.visible_message("<span class='warning'>[C]'s hinges suddenly begin to melt and run!</span>")
 		user << "<span class='warning'>We vomit acidic goop onto the interior of [C]!</span>"
-		addtimer(CALLBACK(src,  .proc/open_closet, user, C), 70)
+		addtimer(CALLBACK(src, .proc/open_closet, user, C), 70)
 		used = TRUE
 
 	if(istype(user.loc, /obj/structure/spider/cocoon) && !used)
@@ -50,7 +50,7 @@
 			return 0
 		C.visible_message("<span class='warning'>[src] shifts and starts to fall apart!</span>")
 		user << "<span class='warning'>We secrete acidic enzymes from our skin and begin melting our cocoon...</span>"
-		addtimer(CALLBACK(src,  .proc/dissolve_cocoon, user, C), 25) //Very short because it's just webs
+		addtimer(CALLBACK(src, .proc/dissolve_cocoon, user, C), 25) //Very short because it's just webs
 		used = TRUE
 
 	if(used)

--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -18,7 +18,7 @@
 	user.update_stat()
 	user.update_canmove()
 
-	addtimer(src, "ready_to_regenerate", LING_FAKEDEATH_TIME, TIMER_UNIQUE, user)
+	addtimer(CALLBACK(src,  .proc/ready_to_regenerate, user), LING_FAKEDEATH_TIME, TIMER_UNIQUE)
 
 	feedback_add_details("changeling_powers","FD")
 	return 1

--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -18,7 +18,7 @@
 	user.update_stat()
 	user.update_canmove()
 
-	addtimer(CALLBACK(src,  .proc/ready_to_regenerate, user), LING_FAKEDEATH_TIME, TIMER_UNIQUE)
+	addtimer(CALLBACK(src, .proc/ready_to_regenerate, user), LING_FAKEDEATH_TIME, TIMER_UNIQUE)
 
 	feedback_add_details("changeling_powers","FD")
 	return 1

--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -36,7 +36,7 @@
 			by quick repeated use!</span>"
 
 	recent_uses++
-	addtimer(CALLBACK(src,  .proc/fleshmend, user), 0)
+	addtimer(CALLBACK(src, .proc/fleshmend, user), 0)
 
 	feedback_add_details("changeling_powers","RR")
 	return 1

--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -36,7 +36,7 @@
 			by quick repeated use!</span>"
 
 	recent_uses++
-	addtimer(src, "fleshmend", 0, TIMER_NORMAL, user)
+	addtimer(CALLBACK(src,  .proc/fleshmend, user), 0)
 
 	feedback_add_details("changeling_powers","RR")
 	return 1

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -149,7 +149,7 @@
 	target.visible_message("<span class='warning'>A grotesque blade forms around [target.name]\'s arm!</span>", "<span class='userdanger'>Your arm twists and mutates, transforming into a horrific monstrosity!</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
 	playsound(target, 'sound/effects/blobattack.ogg', 30, 1)
 
-	addtimer(src, "remove_fake", 600, TIMER_NORMAL, target, blade)
+	addtimer(CALLBACK(src,  .proc/remove_fake, target, blade), 600)
 
 	feedback_add_details("changeling_powers","AS")
 	return 1
@@ -224,7 +224,7 @@
 
 /obj/effect/proc_holder/changeling/sting/LSD/sting_action(mob/user, mob/living/carbon/target)
 	add_logs(user, target, "stung", "LSD sting")
-	addtimer(src, "hallucination_time", rand(300,600), TIMER_NORMAL, target)
+	addtimer(CALLBACK(src,  .proc/hallucination_time, target), rand(300,600))
 	feedback_add_details("changeling_powers","HS")
 	return 1
 

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -149,7 +149,7 @@
 	target.visible_message("<span class='warning'>A grotesque blade forms around [target.name]\'s arm!</span>", "<span class='userdanger'>Your arm twists and mutates, transforming into a horrific monstrosity!</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
 	playsound(target, 'sound/effects/blobattack.ogg', 30, 1)
 
-	addtimer(CALLBACK(src,  .proc/remove_fake, target, blade), 600)
+	addtimer(CALLBACK(src, .proc/remove_fake, target, blade), 600)
 
 	feedback_add_details("changeling_powers","AS")
 	return 1
@@ -224,7 +224,7 @@
 
 /obj/effect/proc_holder/changeling/sting/LSD/sting_action(mob/user, mob/living/carbon/target)
 	add_logs(user, target, "stung", "LSD sting")
-	addtimer(CALLBACK(src,  .proc/hallucination_time, target), rand(300,600))
+	addtimer(CALLBACK(src, .proc/hallucination_time, target), rand(300,600))
 	feedback_add_details("changeling_powers","HS")
 	return 1
 

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_overlay.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_overlay.dm
@@ -30,7 +30,7 @@
 /obj/effect/clockwork/overlay/wall/New()
 	..()
 	queue_smooth_neighbors(src)
-	addtimer(GLOBAL_PROC, "queue_smooth", 1, TIMER_NORMAL, src)
+	addtimer(CALLBACK(GLOBAL_PROC,  .proc/queue_smooth, src), 1)
 
 /obj/effect/clockwork/overlay/wall/Destroy()
 	queue_smooth_neighbors(src)

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_overlay.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_overlay.dm
@@ -30,7 +30,7 @@
 /obj/effect/clockwork/overlay/wall/New()
 	..()
 	queue_smooth_neighbors(src)
-	addtimer(CALLBACK(GLOBAL_PROC,  .proc/queue_smooth, src), 1)
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/queue_smooth, src), 1)
 
 /obj/effect/clockwork/overlay/wall/Destroy()
 	queue_smooth_neighbors(src)

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -111,7 +111,7 @@
 		if(glow)
 			qdel(glow)
 		animate(src, color = oldcolor, time = 20)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 20)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 20)
 		visible_message("<span class='warning'>[src] slowly stops glowing!</span>")
 		return
 	post_channel(L)
@@ -137,7 +137,7 @@
 		qdel(src)
 	else
 		animate(src, color = oldcolor, time = 20)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 20)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 20)
 		visible_message("<span class='warning'>[src] slowly stops glowing!</span>")
 
 
@@ -217,7 +217,7 @@
 		var/datum/status_effect/cyborg_power_regen/CPR = cyborg.apply_status_effect(STATUS_EFFECT_POWERREGEN)
 		CPR.power_to_give = giving_power * 0.1 //ten ticks, restoring 10% each
 		animate(cyborg, color = previous_color, time = 100)
-		addtimer(CALLBACK(cyborg,  /atom/proc/update_atom_colour), 100)
+		addtimer(CALLBACK(cyborg, /atom/proc/update_atom_colour), 100)
 
 /obj/effect/clockwork/sigil/transmission/proc/cyborg_checks(mob/living/silicon/robot/cyborg)
 	if(!cyborg.cell)
@@ -287,7 +287,7 @@
 		return
 	visible_message("<span class='warning'>[src] begins to glow bright blue!</span>")
 	animate(src, alpha = 255, time = 10)
-	addtimer(CALLBACK(src,  .proc/update_alpha), 10)
+	addtimer(CALLBACK(src, .proc/update_alpha), 10)
 	sleep(10)
 //as long as they're still on the sigil and are either not a servant or they're a servant AND it has remaining vitality
 	while(L && (!is_servant_of_ratvar(L) || (is_servant_of_ratvar(L) && vitality)) && get_turf(L) == get_turf(src))
@@ -383,7 +383,7 @@
 		visible_message("<span class='warning'>[src] slowly stops glowing!</span>")
 	if(sigil_active || alpha == 255)
 		animate(src, alpha = initial(alpha), time = 10)
-		addtimer(CALLBACK(src,  .proc/update_alpha), 10)
+		addtimer(CALLBACK(src, .proc/update_alpha), 10)
 
 /obj/effect/clockwork/sigil/vitality/proc/update_alpha()
 	if(sigil_active)

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -111,7 +111,7 @@
 		if(glow)
 			qdel(glow)
 		animate(src, color = oldcolor, time = 20)
-		addtimer(src, "update_atom_colour", 20)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 20)
 		visible_message("<span class='warning'>[src] slowly stops glowing!</span>")
 		return
 	post_channel(L)
@@ -137,7 +137,7 @@
 		qdel(src)
 	else
 		animate(src, color = oldcolor, time = 20)
-		addtimer(src, "update_atom_colour", 20)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 20)
 		visible_message("<span class='warning'>[src] slowly stops glowing!</span>")
 
 
@@ -217,7 +217,7 @@
 		var/datum/status_effect/cyborg_power_regen/CPR = cyborg.apply_status_effect(STATUS_EFFECT_POWERREGEN)
 		CPR.power_to_give = giving_power * 0.1 //ten ticks, restoring 10% each
 		animate(cyborg, color = previous_color, time = 100)
-		addtimer(cyborg, "update_atom_colour", 100)
+		addtimer(CALLBACK(cyborg,  /atom/proc/update_atom_colour), 100)
 
 /obj/effect/clockwork/sigil/transmission/proc/cyborg_checks(mob/living/silicon/robot/cyborg)
 	if(!cyborg.cell)
@@ -287,7 +287,7 @@
 		return
 	visible_message("<span class='warning'>[src] begins to glow bright blue!</span>")
 	animate(src, alpha = 255, time = 10)
-	addtimer(src, "update_alpha", 10)
+	addtimer(CALLBACK(src,  .proc/update_alpha), 10)
 	sleep(10)
 //as long as they're still on the sigil and are either not a servant or they're a servant AND it has remaining vitality
 	while(L && (!is_servant_of_ratvar(L) || (is_servant_of_ratvar(L) && vitality)) && get_turf(L) == get_turf(src))
@@ -383,7 +383,7 @@
 		visible_message("<span class='warning'>[src] slowly stops glowing!</span>")
 	if(sigil_active || alpha == 255)
 		animate(src, alpha = initial(alpha), time = 10)
-		addtimer(src, "update_alpha", 10)
+		addtimer(CALLBACK(src,  .proc/update_alpha), 10)
 
 /obj/effect/clockwork/sigil/vitality/proc/update_alpha()
 	if(sigil_active)

--- a/code/game/gamemodes/clock_cult/clock_effects/spatial_gateway.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/spatial_gateway.dm
@@ -15,7 +15,7 @@
 
 /obj/effect/clockwork/spatial_gateway/New()
 	..()
-	addtimer(CALLBACK(src,  .proc/check_setup), 1)
+	addtimer(CALLBACK(src, .proc/check_setup), 1)
 
 /obj/effect/clockwork/spatial_gateway/Destroy()
 	deltimer(timerid)
@@ -135,7 +135,7 @@
 	if(!no_cost)
 		uses = max(0, uses - 1)
 		linked_gateway.uses = max(0, linked_gateway.uses - 1)
-	addtimer(CALLBACK(src,  .proc/check_uses), 10)
+	addtimer(CALLBACK(src, .proc/check_uses), 10)
 	return TRUE
 
 /obj/effect/clockwork/spatial_gateway/proc/check_uses()

--- a/code/game/gamemodes/clock_cult/clock_effects/spatial_gateway.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/spatial_gateway.dm
@@ -15,7 +15,7 @@
 
 /obj/effect/clockwork/spatial_gateway/New()
 	..()
-	addtimer(src, "check_setup", 1)
+	addtimer(CALLBACK(src,  .proc/check_setup), 1)
 
 /obj/effect/clockwork/spatial_gateway/Destroy()
 	deltimer(timerid)
@@ -135,7 +135,7 @@
 	if(!no_cost)
 		uses = max(0, uses - 1)
 		linked_gateway.uses = max(0, linked_gateway.uses - 1)
-	addtimer(src, "check_uses", 10)
+	addtimer(CALLBACK(src,  .proc/check_uses), 10)
 	return TRUE
 
 /obj/effect/clockwork/spatial_gateway/proc/check_uses()

--- a/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
@@ -188,7 +188,7 @@
 	if(reinf)
 		prosel_cost -= REPLICANT_ROD
 	for(var/obj/structure/grille/G in get_turf(src))
-		addtimer(proselytizer, "proselytize", 0, TIMER_NORMAL, G, user)
+		addtimer(CALLBACK(proselytizer,  /obj/item/clockwork/clockwork_proselytizer.proc/proselytize, G, user), 0)
 	return list("operation_time" = prosel_time, "new_obj_type" = windowtype, "alloy_cost" = prosel_cost, "spawn_dir" = dir, "dir_in_new" = new_dir)
 
 /obj/structure/window/reinforced/clockwork/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)

--- a/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
@@ -188,7 +188,7 @@
 	if(reinf)
 		prosel_cost -= REPLICANT_ROD
 	for(var/obj/structure/grille/G in get_turf(src))
-		addtimer(CALLBACK(proselytizer,  /obj/item/clockwork/clockwork_proselytizer.proc/proselytize, G, user), 0)
+		addtimer(CALLBACK(proselytizer, /obj/item/clockwork/clockwork_proselytizer.proc/proselytize, G, user), 0)
 	return list("operation_time" = prosel_time, "new_obj_type" = windowtype, "alloy_cost" = prosel_cost, "spawn_dir" = dir, "dir_in_new" = new_dir)
 
 /obj/structure/window/reinforced/clockwork/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)

--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -64,7 +64,7 @@
 				add_logs(ranged_ability_user, L, "bound with Geis")
 				if(slab.speed_multiplier >= 0.5) //excuse my debug...
 					ranged_ability_user.notransform = TRUE
-					addtimer(CALLBACK(src,  .proc/reset_user_notransform, ranged_ability_user), 5) //stop us moving for a little bit so we don't break the scripture following this
+					addtimer(CALLBACK(src, .proc/reset_user_notransform, ranged_ability_user), 5) //stop us moving for a little bit so we don't break the scripture following this
 				slab.busy = null
 				var/datum/clockwork_scripture/geis/conversion = new
 				conversion.slab = slab

--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -64,7 +64,7 @@
 				add_logs(ranged_ability_user, L, "bound with Geis")
 				if(slab.speed_multiplier >= 0.5) //excuse my debug...
 					ranged_ability_user.notransform = TRUE
-					addtimer(src, "reset_user_notransform", 5, TIMER_NORMAL, ranged_ability_user) //stop us moving for a little bit so we don't break the scripture following this
+					addtimer(CALLBACK(src,  .proc/reset_user_notransform, ranged_ability_user), 5) //stop us moving for a little bit so we don't break the scripture following this
 				slab.busy = null
 				var/datum/clockwork_scripture/geis/conversion = new
 				conversion.slab = slab

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_armor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_armor.dm
@@ -44,7 +44,7 @@
 			user.emote("scream")
 			user.apply_damage(30, BRUTE, "head")
 			user.adjustBrainLoss(30)
-		addtimer(CALLBACK(user,  /mob/living.proc/unEquip), src, 1) //equipped happens before putting stuff on(but not before picking items up), 1). thus, we need to wait for it to be on before forcing it off.
+		addtimer(CALLBACK(user, /mob/living.proc/unEquip), src, 1) //equipped happens before putting stuff on(but not before picking items up), 1). thus, we need to wait for it to be on before forcing it off.
 
 /obj/item/clothing/head/helmet/clockwork/mob_can_equip(mob/M, mob/equipper, slot, disable_warning = 0)
 	if(equipper && !is_servant_of_ratvar(equipper))
@@ -106,7 +106,7 @@
 			user.apply_damage(15, BURN, "chest")
 			user.adjust_fire_stacks(2)
 			user.IgniteMob()
-		addtimer(CALLBACK(user,  /mob/living.proc/unEquip, src, 1), 1)
+		addtimer(CALLBACK(user, /mob/living.proc/unEquip, src, 1), 1)
 
 /obj/item/clothing/gloves/clockwork
 	name = "clockwork gauntlets"
@@ -166,7 +166,7 @@
 			user.emote("scream")
 			user.apply_damage(7, BRUTE, "l_arm")
 			user.apply_damage(7, BRUTE, "r_arm")
-		addtimer(CALLBACK(user,  /mob/living.proc/unEquip, src, 1), 1)
+		addtimer(CALLBACK(user, /mob/living.proc/unEquip, src, 1), 1)
 
 /obj/item/clothing/shoes/clockwork
 	name = "clockwork treads"
@@ -213,4 +213,4 @@
 			user.emote("scream")
 			user.apply_damage(7, BURN, "l_leg")
 			user.apply_damage(7, BURN, "r_leg")
-		addtimer(CALLBACK(user,  /mob/living.proc/unEquip, src, 1), 1)
+		addtimer(CALLBACK(user, /mob/living.proc/unEquip, src, 1), 1)

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_armor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_armor.dm
@@ -44,7 +44,7 @@
 			user.emote("scream")
 			user.apply_damage(30, BRUTE, "head")
 			user.adjustBrainLoss(30)
-		addtimer(user, "unEquip", 1, TIMER_NORMAL, src, 1) //equipped happens before putting stuff on(but not before picking items up). thus, we need to wait for it to be on before forcing it off.
+		addtimer(CALLBACK(user,  /mob/living.proc/unEquip), src, 1) //equipped happens before putting stuff on(but not before picking items up), 1). thus, we need to wait for it to be on before forcing it off.
 
 /obj/item/clothing/head/helmet/clockwork/mob_can_equip(mob/M, mob/equipper, slot, disable_warning = 0)
 	if(equipper && !is_servant_of_ratvar(equipper))
@@ -106,7 +106,7 @@
 			user.apply_damage(15, BURN, "chest")
 			user.adjust_fire_stacks(2)
 			user.IgniteMob()
-		addtimer(user, "unEquip", 1, TIMER_NORMAL, src, 1)
+		addtimer(CALLBACK(user,  /mob/living.proc/unEquip, src, 1), 1)
 
 /obj/item/clothing/gloves/clockwork
 	name = "clockwork gauntlets"
@@ -166,7 +166,7 @@
 			user.emote("scream")
 			user.apply_damage(7, BRUTE, "l_arm")
 			user.apply_damage(7, BRUTE, "r_arm")
-		addtimer(user, "unEquip", 1, TIMER_NORMAL, src, 1)
+		addtimer(CALLBACK(user,  /mob/living.proc/unEquip, src, 1), 1)
 
 /obj/item/clothing/shoes/clockwork
 	name = "clockwork treads"
@@ -213,4 +213,4 @@
 			user.emote("scream")
 			user.apply_damage(7, BURN, "l_leg")
 			user.apply_damage(7, BURN, "r_leg")
-		addtimer(user, "unEquip", 1, TIMER_NORMAL, src, 1)
+		addtimer(CALLBACK(user,  /mob/living.proc/unEquip, src, 1), 1)

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
@@ -102,7 +102,7 @@
 
 /obj/item/clockwork/slab/dropped(mob/user)
 	. = ..()
-	addtimer(src, "check_on_mob", 1, TIMER_NORMAL, user) //dropped is called before the item is out of the slot, so we need to check slightly later
+	addtimer(CALLBACK(src,  .proc/check_on_mob, user), 1) //dropped is called before the item is out of the slot, so we need to check slightly later
 
 /obj/item/clockwork/slab/proc/check_on_mob(mob/user)
 	if(user && !(src in user.held_items) && slab_ability && slab_ability.ranged_ability_user) //if we happen to check and we AREN'T in user's hands, remove whatever ability we have
@@ -436,7 +436,7 @@
 		if("toggle")
 			recollecting = !recollecting
 		if("recite")
-			addtimer(src, "recite_scripture", 0, TIMER_NORMAL, text2path(params["category"]), usr, FALSE)
+			addtimer(CALLBACK(src,  .proc/recite_scripture, text2path(params["category"]), usr, FALSE), 0)
 		if("select")
 			selected_scripture = params["category"]
 		if("bind")

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
@@ -102,7 +102,7 @@
 
 /obj/item/clockwork/slab/dropped(mob/user)
 	. = ..()
-	addtimer(CALLBACK(src,  .proc/check_on_mob, user), 1) //dropped is called before the item is out of the slot, so we need to check slightly later
+	addtimer(CALLBACK(src, .proc/check_on_mob, user), 1) //dropped is called before the item is out of the slot, so we need to check slightly later
 
 /obj/item/clockwork/slab/proc/check_on_mob(mob/user)
 	if(user && !(src in user.held_items) && slab_ability && slab_ability.ranged_ability_user) //if we happen to check and we AREN'T in user's hands, remove whatever ability we have
@@ -436,7 +436,7 @@
 		if("toggle")
 			recollecting = !recollecting
 		if("recite")
-			addtimer(CALLBACK(src,  .proc/recite_scripture, text2path(params["category"]), usr, FALSE), 0)
+			addtimer(CALLBACK(src, .proc/recite_scripture, text2path(params["category"]), usr, FALSE), 0)
 		if("select")
 			selected_scripture = params["category"]
 		if("bind")

--- a/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
@@ -52,7 +52,7 @@
 
 /obj/item/clothing/glasses/judicial_visor/dropped(mob/user)
 	. = ..()
-	addtimer(src, "check_on_mob", 1, TIMER_NORMAL, user) //dropped is called before the item is out of the slot, so we need to check slightly later
+	addtimer(CALLBACK(src,  .proc/check_on_mob, user), 1) //dropped is called before the item is out of the slot, so we need to check slightly later
 
 /obj/item/clothing/glasses/judicial_visor/proc/check_on_mob(mob/user)
 	if(user && src != user.get_item_by_slot(slot_glasses)) //if we happen to check and we AREN'T in the slot, we need to remove our shit from whoever we got dropped from
@@ -131,7 +131,7 @@
 				continue
 			V.recharging = TRUE //To prevent exploiting multiple visors to bypass the cooldown
 			V.update_status()
-			addtimer(V, "recharge_visor", (ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown) * 2, TIMER_NORMAL, ranged_ability_user)
+			addtimer(CALLBACK(V,  /obj/item/clothing/glasses/judicial_visor.proc/recharge_visor), (ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown) * 2, ranged_ability_user)
 		clockwork_say(ranged_ability_user, text2ratvar("Kneel, heathens!"))
 		ranged_ability_user.visible_message("<span class='warning'>[ranged_ability_user]'s judicial visor fires a stream of energy at [target], creating a strange mark!</span>", "<span class='heavy_brass'>You direct [visor]'s power to [target]. You must wait for some time before doing this again.</span>")
 		var/turf/targetturf = get_turf(target)
@@ -139,7 +139,7 @@
 		add_logs(ranged_ability_user, targetturf, "created a judicial marker")
 		ranged_ability_user.update_action_buttons_icon()
 		ranged_ability_user.update_inv_glasses()
-		addtimer(visor, "recharge_visor", ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown, TIMER_NORMAL, ranged_ability_user)//Cooldown is reduced by 10x if Ratvar is up
+		addtimer(CALLBACK(visor,  /obj/item/clothing/glasses/judicial_visor.proc/recharge_visor), ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown, ranged_ability_user)//Cooldown is reduced by 10x if Ratvar is up
 		remove_ranged_ability()
 
 		return TRUE
@@ -160,7 +160,7 @@
 	..()
 	SetLuminosity(4, 3)
 	user = caster
-	addtimer(src, "judicialblast", 0, TIMER_NORMAL)
+	addtimer(CALLBACK(src,  .proc/judicialblast), 0)
 
 /obj/effect/clockwork/judicial_marker/proc/judicialblast()
 	playsound(src, 'sound/magic/MAGIC_MISSILE.ogg', 50, 1, 1, 1)

--- a/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
@@ -52,7 +52,7 @@
 
 /obj/item/clothing/glasses/judicial_visor/dropped(mob/user)
 	. = ..()
-	addtimer(CALLBACK(src,  .proc/check_on_mob, user), 1) //dropped is called before the item is out of the slot, so we need to check slightly later
+	addtimer(CALLBACK(src, .proc/check_on_mob, user), 1) //dropped is called before the item is out of the slot, so we need to check slightly later
 
 /obj/item/clothing/glasses/judicial_visor/proc/check_on_mob(mob/user)
 	if(user && src != user.get_item_by_slot(slot_glasses)) //if we happen to check and we AREN'T in the slot, we need to remove our shit from whoever we got dropped from
@@ -131,7 +131,7 @@
 				continue
 			V.recharging = TRUE //To prevent exploiting multiple visors to bypass the cooldown
 			V.update_status()
-			addtimer(CALLBACK(V,  /obj/item/clothing/glasses/judicial_visor.proc/recharge_visor), (ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown) * 2, ranged_ability_user)
+			addtimer(CALLBACK(V, /obj/item/clothing/glasses/judicial_visor.proc/recharge_visor), (ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown) * 2, ranged_ability_user)
 		clockwork_say(ranged_ability_user, text2ratvar("Kneel, heathens!"))
 		ranged_ability_user.visible_message("<span class='warning'>[ranged_ability_user]'s judicial visor fires a stream of energy at [target], creating a strange mark!</span>", "<span class='heavy_brass'>You direct [visor]'s power to [target]. You must wait for some time before doing this again.</span>")
 		var/turf/targetturf = get_turf(target)
@@ -139,7 +139,7 @@
 		add_logs(ranged_ability_user, targetturf, "created a judicial marker")
 		ranged_ability_user.update_action_buttons_icon()
 		ranged_ability_user.update_inv_glasses()
-		addtimer(CALLBACK(visor,  /obj/item/clothing/glasses/judicial_visor.proc/recharge_visor), ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown, ranged_ability_user)//Cooldown is reduced by 10x if Ratvar is up
+		addtimer(CALLBACK(visor, /obj/item/clothing/glasses/judicial_visor.proc/recharge_visor), ratvar_awakens ? visor.recharge_cooldown*0.1 : visor.recharge_cooldown, ranged_ability_user)//Cooldown is reduced by 10x if Ratvar is up
 		remove_ranged_ability()
 
 		return TRUE
@@ -160,7 +160,7 @@
 	..()
 	SetLuminosity(4, 3)
 	user = caster
-	addtimer(CALLBACK(src,  .proc/judicialblast), 0)
+	addtimer(CALLBACK(src, .proc/judicialblast), 0)
 
 /obj/effect/clockwork/judicial_marker/proc/judicialblast()
 	playsound(src, 'sound/magic/MAGIC_MISSILE.ogg', 50, 1, 1, 1)

--- a/code/game/gamemodes/clock_cult/clock_items/ratvarian_spear.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/ratvarian_spear.dm
@@ -36,7 +36,7 @@
 		throwforce = initial(throwforce)
 		armour_penetration = 0
 		clockwork_desc = "A powerful spear of Ratvarian making. It's more effective against enemy cultists and silicons, though it won't last for long."
-		timerid = addtimer(CALLBACK(src,  .proc/break_spear), 600)
+		timerid = addtimer(CALLBACK(src, .proc/break_spear), 600)
 
 /obj/item/clockwork/ratvarian_spear/cyborg/ratvar_act() //doesn't break!
 	if(ratvar_awakens)

--- a/code/game/gamemodes/clock_cult/clock_items/ratvarian_spear.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/ratvarian_spear.dm
@@ -36,7 +36,7 @@
 		throwforce = initial(throwforce)
 		armour_penetration = 0
 		clockwork_desc = "A powerful spear of Ratvarian making. It's more effective against enemy cultists and silicons, though it won't last for long."
-		timerid = addtimer(src, "break_spear", 600, TIMER_NORMAL)
+		timerid = addtimer(CALLBACK(src,  .proc/break_spear), 600)
 
 /obj/item/clockwork/ratvarian_spear/cyborg/ratvar_act() //doesn't break!
 	if(ratvar_awakens)

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
@@ -210,7 +210,7 @@
 	var/invoker_old_color = invoker.color
 	invoker.color = "#AF0AAF"
 	animate(invoker, color = invoker_old_color, time = flee_time+grace_period)
-	addtimer(invoker, "update_atom_colour", flee_time+grace_period)
+	addtimer(CALLBACK(invoker,  /atom/proc/update_atom_colour), flee_time+grace_period)
 	if(chant_number != chant_amount) //if this is the last chant, we don't have a movement period because the chant is over
 		var/endtime = world.time + flee_time
 		var/starttime = world.time

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_drivers.dm
@@ -210,7 +210,7 @@
 	var/invoker_old_color = invoker.color
 	invoker.color = "#AF0AAF"
 	animate(invoker, color = invoker_old_color, time = flee_time+grace_period)
-	addtimer(CALLBACK(invoker,  /atom/proc/update_atom_colour), flee_time+grace_period)
+	addtimer(CALLBACK(invoker, /atom/proc/update_atom_colour), flee_time+grace_period)
 	if(chant_number != chant_amount) //if this is the last chant, we don't have a movement period because the chant is over
 		var/endtime = world.time + flee_time
 		var/starttime = world.time

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_revenant.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_revenant.dm
@@ -204,7 +204,7 @@
 		playsound(invoker, 'sound/magic/lightningbolt.ogg', 100, 0)
 		if(invoker.stat == CONSCIOUS)
 			animate(invoker, color = oldcolor, time = 10)
-			addtimer(invoker, "update_atom_colour", 10)
+			addtimer(CALLBACK(invoker, /atom/proc/update_atom_colour), 10)
 			for(var/mob/living/L in view(7, invoker))
 				if(is_servant_of_ratvar(L) || L.null_rod_check())
 					continue

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
@@ -210,10 +210,10 @@
 	if(!ratvar_awakens)
 		R.clockwork_desc = "A powerful spear of Ratvarian making. It's more effective against enemy cultists and silicons, though it won't last for long."
 		owner << "<span class='warning'>Your spear begins to break down in this plane of existence. You can't use it for long!</span>"
-		R.timerid = addtimer(R, "break_spear", base_cooldown, TIMER_NORMAL)
+		R.timerid = addtimer(CALLBACK(R,  /obj/item/clockwork/ratvarian_spear.proc/break_spear), base_cooldown)
 	cooldown = base_cooldown + world.time
 	owner.update_action_buttons_icon()
-	addtimer(src, "update_actions", base_cooldown, TIMER_NORMAL)
+	addtimer(CALLBACK(src,  .proc/update_actions), base_cooldown)
 	return TRUE
 
 /datum/action/innate/function_call/proc/update_actions()

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
@@ -210,10 +210,10 @@
 	if(!ratvar_awakens)
 		R.clockwork_desc = "A powerful spear of Ratvarian making. It's more effective against enemy cultists and silicons, though it won't last for long."
 		owner << "<span class='warning'>Your spear begins to break down in this plane of existence. You can't use it for long!</span>"
-		R.timerid = addtimer(CALLBACK(R,  /obj/item/clockwork/ratvarian_spear.proc/break_spear), base_cooldown)
+		R.timerid = addtimer(CALLBACK(R, /obj/item/clockwork/ratvarian_spear.proc/break_spear), base_cooldown)
 	cooldown = base_cooldown + world.time
 	owner.update_action_buttons_icon()
-	addtimer(CALLBACK(src,  .proc/update_actions), base_cooldown)
+	addtimer(CALLBACK(src, .proc/update_actions), base_cooldown)
 	return TRUE
 
 /datum/action/innate/function_call/proc/update_actions()

--- a/code/game/gamemodes/clock_cult/clock_structure.dm
+++ b/code/game/gamemodes/clock_cult/clock_structure.dm
@@ -36,7 +36,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 
 /obj/structure/destructible/clockwork/examine(mob/user)
 	var/can_see_clockwork = is_servant_of_ratvar(user) || isobserver(user)

--- a/code/game/gamemodes/clock_cult/clock_structure.dm
+++ b/code/game/gamemodes/clock_cult/clock_structure.dm
@@ -36,7 +36,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
 /obj/structure/destructible/clockwork/examine(mob/user)
 	var/can_see_clockwork = is_servant_of_ratvar(user) || isobserver(user)

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -23,7 +23,7 @@
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/New()
 	..()
-	addtimer(CALLBACK(src,  .proc/spawn_animation), 0)
+	addtimer(CALLBACK(src, .proc/spawn_animation), 0)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/spawn_animation()
 	var/turf/T = get_turf(src)
@@ -208,7 +208,7 @@
 					sleep(3)
 					new/obj/structure/destructible/clockwork/massive/ratvar(startpoint)
 				else
-					addtimer(CALLBACK(SSshuttle.emergency,  /obj/docking_port/mobile/emergency.proc/request, null, 0), 0) //call the shuttle immediately
+					addtimer(CALLBACK(SSshuttle.emergency, /obj/docking_port/mobile/emergency.proc/request, null, 0), 0) //call the shuttle immediately
 					sleep(3)
 					send_to_playing_players("<span class='ratvar'>\"[text2ratvar("Behold")]!\"</span>\n<span class='inathneq_large'>\"[text2ratvar("See Engine's mercy")]!\"</span>\n\
 					<span class='sevtug_large'>\"[text2ratvar("Observe Engine's design skills")]!\"</span>\n<span class='nezbere_large'>\"[text2ratvar("Behold Engine's light")]!!\"</span>\n\

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -23,7 +23,7 @@
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/New()
 	..()
-	addtimer(src, "spawn_animation", 0)
+	addtimer(CALLBACK(src,  .proc/spawn_animation), 0)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/spawn_animation()
 	var/turf/T = get_turf(src)
@@ -208,7 +208,7 @@
 					sleep(3)
 					new/obj/structure/destructible/clockwork/massive/ratvar(startpoint)
 				else
-					addtimer(SSshuttle.emergency, "request", 0, TIMER_NORMAL, null, 0) //call the shuttle immediately
+					addtimer(CALLBACK(SSshuttle.emergency,  /obj/docking_port/mobile/emergency.proc/request, null, 0), 0) //call the shuttle immediately
 					sleep(3)
 					send_to_playing_players("<span class='ratvar'>\"[text2ratvar("Behold")]!\"</span>\n<span class='inathneq_large'>\"[text2ratvar("See Engine's mercy")]!\"</span>\n\
 					<span class='sevtug_large'>\"[text2ratvar("Observe Engine's design skills")]!\"</span>\n<span class='nezbere_large'>\"[text2ratvar("Behold Engine's light")]!!\"</span>\n\

--- a/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
@@ -24,7 +24,7 @@
 	var/image/alert_overlay = image('icons/effects/clockwork_effects.dmi', "ratvar_alert")
 	var/area/A = get_area(src)
 	notify_ghosts("The Justiciar's light calls to you! Reach out to Ratvar in [A.name] to be granted a shell to spread his glory!", null, source = src, alert_overlay = alert_overlay)
-	addtimer(CALLBACK(SSshuttle.emergency,  /obj/docking_port/mobile/emergency..proc/request, null, 0.1), 50)
+	addtimer(CALLBACK(SSshuttle.emergency, /obj/docking_port/mobile/emergency..proc/request, null, 0.1), 50)
 
 /obj/structure/destructible/clockwork/massive/ratvar/Destroy()
 	ratvar_awakens--

--- a/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
@@ -24,7 +24,7 @@
 	var/image/alert_overlay = image('icons/effects/clockwork_effects.dmi', "ratvar_alert")
 	var/area/A = get_area(src)
 	notify_ghosts("The Justiciar's light calls to you! Reach out to Ratvar in [A.name] to be granted a shell to spread his glory!", null, source = src, alert_overlay = alert_overlay)
-	addtimer(SSshuttle.emergency, "request", 50, TIMER_NORMAL, null, 0.1)
+	addtimer(CALLBACK(SSshuttle.emergency,  /obj/docking_port/mobile/emergency..proc/request, null, 0.1), 50)
 
 /obj/structure/destructible/clockwork/massive/ratvar/Destroy()
 	ratvar_awakens--

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -46,7 +46,7 @@
 		var/previouscolor = color
 		color = "#FAE48C"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
 /obj/structure/destructible/cult/proc/getETA()
 	var/time = (cooldowntime - world.time)/600

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -46,7 +46,7 @@
 		var/previouscolor = color
 		color = "#FAE48C"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 
 /obj/structure/destructible/cult/proc/getETA()
 	var/time = (cooldowntime - world.time)/600

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -188,7 +188,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		var/oldcolor = color
 		color = rgb(255, 0, 0)
 		animate(src, color = oldcolor, time = 5)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 5)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 5)
 
 //Malformed Rune: This forms if a rune is not drawn correctly. Invoking it does nothing but hurt the user.
 /obj/effect/rune/malformed
@@ -402,7 +402,7 @@ var/list/teleport_runes = list()
 		..()
 		do_sacrifice(L, invokers)
 	animate(src, color = oldcolor, time = 5)
-	addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 5)
+	addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 5)
 	rune_in_use = FALSE
 
 /obj/effect/rune/convert/proc/do_convert(mob/living/convertee, list/invokers)
@@ -795,7 +795,7 @@ var/list/wall_runes = list()
 			W.density = TRUE
 			W.update_state()
 			W.spread_density()
-	density_timer = addtimer(CALLBACK(src,  .proc/lose_density), 900)
+	density_timer = addtimer(CALLBACK(src, .proc/lose_density), 900)
 
 /obj/effect/rune/wall/proc/lose_density()
 	if(density)
@@ -805,7 +805,7 @@ var/list/wall_runes = list()
 		var/oldcolor = color
 		add_atom_colour("#696969", FIXED_COLOUR_PRIORITY)
 		animate(src, color = oldcolor, time = 50, easing = EASE_IN)
-		addtimer(CALLBACK(src,  .proc/recharge), 50)
+		addtimer(CALLBACK(src, .proc/recharge), 50)
 
 /obj/effect/rune/wall/proc/recharge()
 	recharging = FALSE

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -188,7 +188,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		var/oldcolor = color
 		color = rgb(255, 0, 0)
 		animate(src, color = oldcolor, time = 5)
-		addtimer(src, "update_atom_colour", 5)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 5)
 
 //Malformed Rune: This forms if a rune is not drawn correctly. Invoking it does nothing but hurt the user.
 /obj/effect/rune/malformed
@@ -402,7 +402,7 @@ var/list/teleport_runes = list()
 		..()
 		do_sacrifice(L, invokers)
 	animate(src, color = oldcolor, time = 5)
-	addtimer(src, "update_atom_colour", 5)
+	addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 5)
 	rune_in_use = FALSE
 
 /obj/effect/rune/convert/proc/do_convert(mob/living/convertee, list/invokers)
@@ -795,7 +795,7 @@ var/list/wall_runes = list()
 			W.density = TRUE
 			W.update_state()
 			W.spread_density()
-	density_timer = addtimer(src, "lose_density", 900)
+	density_timer = addtimer(CALLBACK(src,  .proc/lose_density), 900)
 
 /obj/effect/rune/wall/proc/lose_density()
 	if(density)
@@ -805,7 +805,7 @@ var/list/wall_runes = list()
 		var/oldcolor = color
 		add_atom_colour("#696969", FIXED_COLOUR_PRIORITY)
 		animate(src, color = oldcolor, time = 50, easing = EASE_IN)
-		addtimer(src, "recharge", 50)
+		addtimer(CALLBACK(src,  .proc/recharge), 50)
 
 /obj/effect/rune/wall/proc/recharge()
 	recharging = FALSE

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -179,7 +179,7 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 
 	G.add_gang_hud(gangster_mind)
 	if(jobban_isbanned(gangster_mind.current, ROLE_GANG))
-		addtimer(CALLBACK(src,  /datum/game_mode.proc/replace_jobbaned_player, gangster_mind.current, ROLE_GANG, ROLE_GANG), 0)
+		addtimer(CALLBACK(src, /datum/game_mode.proc/replace_jobbaned_player, gangster_mind.current, ROLE_GANG, ROLE_GANG), 0)
 	return 2
 ////////////////////////////////////////////////////////////////////
 //Deals with players reverting to neutral (Not a gangster anymore)//

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -179,7 +179,7 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 
 	G.add_gang_hud(gangster_mind)
 	if(jobban_isbanned(gangster_mind.current, ROLE_GANG))
-		addtimer(src, "replace_jobbaned_player", 0, TIMER_NORMAL, gangster_mind.current, ROLE_GANG, ROLE_GANG)
+		addtimer(CALLBACK(src,  /datum/game_mode.proc/replace_jobbaned_player, gangster_mind.current, ROLE_GANG, ROLE_GANG), 0)
 	return 2
 ////////////////////////////////////////////////////////////////////
 //Deals with players reverting to neutral (Not a gangster anymore)//

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -162,8 +162,8 @@
 	for(var/obj/machinery/door/D in airlocks)
 		if(D.z != ZLEVEL_STATION)
 			continue
-		addtimer(CALLBACK(D,  /obj/machinery/door.proc/hostile_lockdown, src), 0)
-		addtimer(CALLBACK(D,  /obj/machinery/door.proc/disable_lockdown), 900)
+		addtimer(CALLBACK(D, /obj/machinery/door.proc/hostile_lockdown, src), 0)
+		addtimer(CALLBACK(D, /obj/machinery/door.proc/disable_lockdown), 900)
 
 	var/obj/machinery/computer/communications/C = locate() in machines
 	if(C)
@@ -172,7 +172,7 @@
 	verbs -= /mob/living/silicon/ai/proc/lockdown
 	minor_announce("Hostile runtime detected in door controllers. Isolation Lockdown protocols are now in effect. Please remain calm.","Network Alert:", 1)
 	src << "<span class = 'warning'>Lockdown Initiated. Network reset in 90 seconds.</span>"
-	addtimer(CALLBACK(GLOBAL_PROC,  .proc/minor_announce,
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/minor_announce,
 		"Automatic system reboot complete. Have a secure day.",
 		"Network reset:"), 900)
 

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -162,8 +162,8 @@
 	for(var/obj/machinery/door/D in airlocks)
 		if(D.z != ZLEVEL_STATION)
 			continue
-		addtimer(D, "hostile_lockdown", 0, TIMER_NORMAL, src)
-		addtimer(D, "disable_lockdown", 900)
+		addtimer(CALLBACK(D,  /obj/machinery/door.proc/hostile_lockdown, src), 0)
+		addtimer(CALLBACK(D,  /obj/machinery/door.proc/disable_lockdown), 900)
 
 	var/obj/machinery/computer/communications/C = locate() in machines
 	if(C)
@@ -172,9 +172,9 @@
 	verbs -= /mob/living/silicon/ai/proc/lockdown
 	minor_announce("Hostile runtime detected in door controllers. Isolation Lockdown protocols are now in effect. Please remain calm.","Network Alert:", 1)
 	src << "<span class = 'warning'>Lockdown Initiated. Network reset in 90 seconds.</span>"
-	addtimer(GLOBAL_PROC, "minor_announce", 900, TIMER_NORMAL,
+	addtimer(CALLBACK(GLOBAL_PROC,  .proc/minor_announce,
 		"Automatic system reboot complete. Have a secure day.",
-		"Network reset:")
+		"Network reset:"), 900)
 
 /datum/AI_Module/large/destroy_rcd
 	module_name = "Destroy RCDs"

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -41,7 +41,7 @@
 	B.victim << "<span class='danger'>You feel the captive mind of [src] begin to resist your control.</span>"
 
 	var/delay = rand(150,250) + B.victim.brainloss
-	addtimer(src, "return_control", delay, TIMER_NORMAL, src.loc)
+	addtimer(CALLBACK(src,  .proc/return_control, src.loc), delay)
 
 /mob/living/captive_brain/proc/return_control(mob/living/simple_animal/borer/B)
     if(!B || !B.controlling)
@@ -272,7 +272,7 @@ var/total_borer_hosts_needed = 10
 					else
 						src << "<span class='warning'>You start shaking off your lethargy as the sugar leaves your host's blood. This will take about 10 seconds...</span>"
 
-					waketimerid = addtimer(src,"wakeup",10,TIMER_NORMAL)
+					waketimerid = addtimer(CALLBACK(src, "wakeup"), 10)
 			if(controlling)
 
 				if(docile)
@@ -509,7 +509,7 @@ var/total_borer_hosts_needed = 10
 
 	leaving = TRUE
 
-	addtimer(src, "release_host", 100, TIMER_NORMAL)
+	addtimer(CALLBACK(src, .proc/release_host), 100)
 
 /mob/living/simple_animal/borer/proc/release_host()
 	if(!victim || !src || qdeleted(victim) || qdeleted(src))
@@ -633,7 +633,7 @@ var/total_borer_hosts_needed = 10
 	bonding = TRUE
 
 	var/delay = 200+(victim.brainloss*5)
-	addtimer(src, "assume_control", delay, TIMER_NORMAL)
+	addtimer(CALLBACK(src, .proc/assume_control), delay)
 
 /mob/living/simple_animal/borer/proc/assume_control()
 	if(!victim || !src || controlling || victim.stat == DEAD)

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -41,7 +41,7 @@
 	B.victim << "<span class='danger'>You feel the captive mind of [src] begin to resist your control.</span>"
 
 	var/delay = rand(150,250) + B.victim.brainloss
-	addtimer(CALLBACK(src,  .proc/return_control, src.loc), delay)
+	addtimer(CALLBACK(src, .proc/return_control, src.loc), delay)
 
 /mob/living/captive_brain/proc/return_control(mob/living/simple_animal/borer/B)
     if(!B || !B.controlling)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -186,7 +186,7 @@
 		adjustBruteLoss(25) //hella effective
 		inhibited = 1
 		update_action_buttons_icon()
-		addtimer(src, "reset_inhibit", 30, TIMER_NORMAL)
+		addtimer(CALLBACK(src,  .proc/reset_inhibit), 30)
 
 /mob/living/simple_animal/revenant/proc/reset_inhibit()
 	if(src)
@@ -332,7 +332,7 @@
 
 /obj/item/weapon/ectoplasm/revenant/New()
 	..()
-	addtimer(src, "try_reform", 600, TIMER_NORMAL)
+	addtimer(CALLBACK(src,  .proc/try_reform), 600)
 
 /obj/item/weapon/ectoplasm/revenant/proc/try_reform()
 	if(src)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -186,7 +186,7 @@
 		adjustBruteLoss(25) //hella effective
 		inhibited = 1
 		update_action_buttons_icon()
-		addtimer(CALLBACK(src,  .proc/reset_inhibit), 30)
+		addtimer(CALLBACK(src, .proc/reset_inhibit), 30)
 
 /mob/living/simple_animal/revenant/proc/reset_inhibit()
 	if(src)
@@ -332,7 +332,7 @@
 
 /obj/item/weapon/ectoplasm/revenant/New()
 	..()
-	addtimer(CALLBACK(src,  .proc/try_reform), 600)
+	addtimer(CALLBACK(src, .proc/try_reform), 600)
 
 /obj/item/weapon/ectoplasm/revenant/proc/try_reform()
 	if(src)

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -195,7 +195,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/overload/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(CALLBACK(src,  .proc/overload, T, user), 0)
+			addtimer(CALLBACK(src, .proc/overload, T, user), 0)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/overload/proc/overload(turf/T, mob/user)
 	for(var/obj/machinery/light/L in T)
@@ -235,7 +235,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(CALLBACK(src,  .proc/defile, T), 0)
+			addtimer(CALLBACK(src, .proc/defile, T), 0)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile/proc/defile(turf/T)
 	if(T.flags & NOJAUNT)
@@ -282,7 +282,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(CALLBACK(src,  .proc/malfunction, T, user), 0)
+			addtimer(CALLBACK(src, .proc/malfunction, T, user), 0)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction/proc/malfunction(turf/T, mob/user)
 	for(var/mob/living/simple_animal/bot/bot in T)
@@ -326,7 +326,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/blight/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(CALLBACK(src,  .proc/blight, T, user), 0)
+			addtimer(CALLBACK(src, .proc/blight, T, user), 0)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/blight/proc/blight(turf/T, mob/user)
 	for(var/mob/living/mob in T)

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -195,7 +195,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/overload/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(src, "overload", 0, TIMER_NORMAL, T, user)
+			addtimer(CALLBACK(src,  .proc/overload, T, user), 0)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/overload/proc/overload(turf/T, mob/user)
 	for(var/obj/machinery/light/L in T)
@@ -235,7 +235,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(src, "defile", 0, TIMER_NORMAL, T)
+			addtimer(CALLBACK(src,  .proc/defile, T), 0)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile/proc/defile(turf/T)
 	if(T.flags & NOJAUNT)
@@ -282,7 +282,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(src, "malfunction", 0, TIMER_NORMAL, T, user)
+			addtimer(CALLBACK(src,  .proc/malfunction, T, user), 0)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction/proc/malfunction(turf/T, mob/user)
 	for(var/mob/living/simple_animal/bot/bot in T)
@@ -326,7 +326,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/blight/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
 		for(var/turf/T in targets)
-			addtimer(src, "blight", 0, TIMER_NORMAL, T, user)
+			addtimer(CALLBACK(src,  .proc/blight, T, user), 0)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/blight/proc/blight(turf/T, mob/user)
 	for(var/mob/living/mob in T)

--- a/code/game/gamemodes/miniantags/revenant/revenant_blight.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_blight.dm
@@ -62,6 +62,6 @@
 					affected_mob.dna.species.handle_hair(affected_mob,"#1d2953")
 				affected_mob.visible_message("<span class='warning'>[affected_mob] looks terrifyingly gaunt...</span>", "<span class='revennotice'>You suddenly feel like your skin is <i>wrong</i>...</span>")
 				affected_mob.add_atom_colour("#1d2953", TEMPORARY_COLOUR_PRIORITY)
-				addtimer(CALLBACK(src,  .proc/cure), 100)
+				addtimer(CALLBACK(src, .proc/cure), 100)
 		else
 			return

--- a/code/game/gamemodes/miniantags/revenant/revenant_blight.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_blight.dm
@@ -62,6 +62,6 @@
 					affected_mob.dna.species.handle_hair(affected_mob,"#1d2953")
 				affected_mob.visible_message("<span class='warning'>[affected_mob] looks terrifyingly gaunt...</span>", "<span class='revennotice'>You suddenly feel like your skin is <i>wrong</i>...</span>")
 				affected_mob.add_atom_colour("#1d2953", TEMPORARY_COLOUR_PRIORITY)
-				addtimer(src, "cure", 100, TIMER_NORMAL)
+				addtimer(CALLBACK(src,  .proc/cure), 100)
 		else
 			return

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -76,7 +76,7 @@
 	scan_for_target()
 	point_to_target()
 	my_god_jc_a_bomb()
-	addtimer(CALLBACK(src,  .proc/refresh_target), 50, TIMER_UNIQUE)
+	addtimer(CALLBACK(src, .proc/refresh_target), 50, TIMER_UNIQUE)
 
 /obj/item/weapon/pinpointer/proc/scan_for_target() //Looks for whatever it's tracking
 	if(target)

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -76,7 +76,7 @@
 	scan_for_target()
 	point_to_target()
 	my_god_jc_a_bomb()
-	addtimer(src, "refresh_target", 50, TIMER_UNIQUE)
+	addtimer(CALLBACK(src,  .proc/refresh_target), 50, TIMER_UNIQUE)
 
 /obj/item/weapon/pinpointer/proc/scan_for_target() //Looks for whatever it's tracking
 	if(target)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -275,7 +275,7 @@
 	rev_mind.special_role = "Revolutionary"
 	update_rev_icons_added(rev_mind)
 	if(jobban_isbanned(rev_mind.current, ROLE_REV))
-		addtimer(CALLBACK(src,  .proc/replace_jobbaned_player), 0, rev_mind.current, ROLE_REV, ROLE_REV)
+		addtimer(CALLBACK(src, .proc/replace_jobbaned_player), 0, rev_mind.current, ROLE_REV, ROLE_REV)
 	return 1
 //////////////////////////////////////////////////////////////////////////////
 //Deals with players being converted from the revolution (Not a rev anymore)//  // Modified to handle borged MMIs.  Accepts another var if the target is being borged at the time  -- Polymorph.

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -275,7 +275,7 @@
 	rev_mind.special_role = "Revolutionary"
 	update_rev_icons_added(rev_mind)
 	if(jobban_isbanned(rev_mind.current, ROLE_REV))
-		addtimer(src, "replace_jobbaned_player", 0, TIMER_NORMAL, rev_mind.current, ROLE_REV, ROLE_REV)
+		addtimer(CALLBACK(src,  .proc/replace_jobbaned_player), 0, rev_mind.current, ROLE_REV, ROLE_REV)
 	return 1
 //////////////////////////////////////////////////////////////////////////////
 //Deals with players being converted from the revolution (Not a rev anymore)//  // Modified to handle borged MMIs.  Accepts another var if the target is being borged at the time  -- Polymorph.

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -161,7 +161,7 @@
 	if(device)
 		device.pulsed()
 
-	addtimer(CALLBACK(src,  .proc/update_icon), 15)
+	addtimer(CALLBACK(src, .proc/update_icon), 15)
 
 /obj/machinery/button/power_change()
 	..()

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -161,7 +161,7 @@
 	if(device)
 		device.pulsed()
 
-	addtimer(src, "update_icon", 15)
+	addtimer(CALLBACK(src,  .proc/update_icon), 15)
 
 /obj/machinery/button/power_change()
 	..()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -102,7 +102,7 @@
 						if(can_use())
 							cameranet.addCamera(src)
 						emped = 0 //Resets the consecutive EMP count
-						addtimer(CALLBACK(src,  .proc/cancelCameraAlarm), 100)
+						addtimer(CALLBACK(src, .proc/cancelCameraAlarm), 100)
 			for(var/mob/O in mob_list)
 				if (O.client && O.client.eye == src)
 					O.unset_machine()
@@ -286,7 +286,7 @@
 	if(status)
 		change_msg = "reactivates"
 		triggerCameraAlarm()
-		addtimer(CALLBACK(src,  .proc/cancelCameraAlarm), 100)
+		addtimer(CALLBACK(src, .proc/cancelCameraAlarm), 100)
 	if(displaymessage)
 		if(user)
 			visible_message("<span class='danger'>[user] [change_msg] [src]!</span>")

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -102,7 +102,7 @@
 						if(can_use())
 							cameranet.addCamera(src)
 						emped = 0 //Resets the consecutive EMP count
-						addtimer(src, "cancelCameraAlarm", 100)
+						addtimer(CALLBACK(src,  .proc/cancelCameraAlarm), 100)
 			for(var/mob/O in mob_list)
 				if (O.client && O.client.eye == src)
 					O.unset_machine()
@@ -286,7 +286,7 @@
 	if(status)
 		change_msg = "reactivates"
 		triggerCameraAlarm()
-		addtimer(src, "cancelCameraAlarm", 100)
+		addtimer(CALLBACK(src,  .proc/cancelCameraAlarm), 100)
 	if(displaymessage)
 		if(user)
 			visible_message("<span class='danger'>[user] [change_msg] [src]!</span>")

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -134,7 +134,7 @@
 		if(!G)
 			return FALSE
 	if(clonemind.damnation_type) //Can't clone the damned.
-		addtimer(CALLBACK(src,  .proc/horrifyingsound), 0)
+		addtimer(CALLBACK(src, .proc/horrifyingsound), 0)
 		mess = 1
 		icon_state = "pod_g"
 		update_icon()
@@ -145,7 +145,7 @@
 	countdown.start()
 
 	eject_wait = TRUE
-	addtimer(CALLBACK(src,  .proc/wait_complete), 30)
+	addtimer(CALLBACK(src, .proc/wait_complete), 30)
 
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src)
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -134,7 +134,7 @@
 		if(!G)
 			return FALSE
 	if(clonemind.damnation_type) //Can't clone the damned.
-		addtimer(src, "horrifyingsound", 0)
+		addtimer(CALLBACK(src,  .proc/horrifyingsound), 0)
 		mess = 1
 		icon_state = "pod_g"
 		update_icon()
@@ -145,7 +145,7 @@
 	countdown.start()
 
 	eject_wait = TRUE
-	addtimer(src, "wait_complete", 30)
+	addtimer(CALLBACK(src,  .proc/wait_complete), 30)
 
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src)
 

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -114,7 +114,7 @@
 			user.clear_fullscreen("flash", 5)
 		watchers[user] = C
 		use_power(50)
-		addtimer(src, "use_camera_console", 5, TIMER_NORMAL, user)
+		addtimer(CALLBACK(src,  .proc/use_camera_console, user), 5)
 	else
 		user.unset_machine()
 

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -114,7 +114,7 @@
 			user.clear_fullscreen("flash", 5)
 		watchers[user] = C
 		use_power(50)
-		addtimer(CALLBACK(src,  .proc/use_camera_console, user), 5)
+		addtimer(CALLBACK(src, .proc/use_camera_console, user), 5)
 	else
 		user.unset_machine()
 

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -260,7 +260,7 @@ var/global/datum/crewmonitor/crewmonitor = new
 		return ..()
 
 /datum/crewmonitor/proc/queueUpdate(z)
-	addtimer(CALLBACK(crewmonitor,  .proc/update, z), 5, TIMER_UNIQUE)
+	addtimer(CALLBACK(crewmonitor, .proc/update, z), 5, TIMER_UNIQUE)
 
 /datum/crewmonitor/proc/sendResources(var/client/client)
 	send_asset(client, "crewmonitor.js")

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -260,7 +260,7 @@ var/global/datum/crewmonitor/crewmonitor = new
 		return ..()
 
 /datum/crewmonitor/proc/queueUpdate(z)
-	addtimer(crewmonitor, "update", 5, TIMER_UNIQUE, z)
+	addtimer(CALLBACK(crewmonitor,  .proc/update, z), 5, TIMER_UNIQUE)
 
 /datum/crewmonitor/proc/sendResources(var/client/client)
 	send_asset(client, "crewmonitor.js")

--- a/code/game/machinery/computer/gulag_teleporter.dm
+++ b/code/game/machinery/computer/gulag_teleporter.dm
@@ -15,7 +15,7 @@
 
 /obj/machinery/computer/gulag_teleporter_computer/New()
 	..()
-	addtimer(src, "scan_machinery", 5)
+	addtimer(CALLBACK(src,  .proc/scan_machinery), 5)
 
 /obj/machinery/computer/gulag_teleporter_computer/Destroy()
 	if(id)
@@ -124,7 +124,7 @@
 		if("teleport")
 			if(!teleporter || !beacon)
 				return
-			addtimer(src, "teleport", 5, TIMER_NORMAL, usr)
+			addtimer(CALLBACK(src,  .proc/teleport, usr), 5)
 
 /obj/machinery/computer/gulag_teleporter_computer/proc/scan_machinery()
 	teleporter = findteleporter()

--- a/code/game/machinery/computer/gulag_teleporter.dm
+++ b/code/game/machinery/computer/gulag_teleporter.dm
@@ -15,7 +15,7 @@
 
 /obj/machinery/computer/gulag_teleporter_computer/New()
 	..()
-	addtimer(CALLBACK(src,  .proc/scan_machinery), 5)
+	addtimer(CALLBACK(src, .proc/scan_machinery), 5)
 
 /obj/machinery/computer/gulag_teleporter_computer/Destroy()
 	if(id)
@@ -124,7 +124,7 @@
 		if("teleport")
 			if(!teleporter || !beacon)
 				return
-			addtimer(CALLBACK(src,  .proc/teleport, usr), 5)
+			addtimer(CALLBACK(src, .proc/teleport, usr), 5)
 
 /obj/machinery/computer/gulag_teleporter_computer/proc/scan_machinery()
 	teleporter = findteleporter()

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -49,7 +49,7 @@
 			// Will help make emagging the console not so easy to get away with.
 			MK.info += "<br><br><font color='red'>£%@%(*$%&(£&?*(%&£/{}</font>"
 			var/time = 100 * length(src.linkedServer.decryptkey)
-			addtimer(CALLBACK(src,  .proc/UnmagConsole), time)
+			addtimer(CALLBACK(src, .proc/UnmagConsole), time)
 			message = rebootmsg
 		else
 			user << "<span class='notice'>A no server error appears on the screen.</span>"

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -49,7 +49,7 @@
 			// Will help make emagging the console not so easy to get away with.
 			MK.info += "<br><br><font color='red'>£%@%(*$%&(£&?*(%&£/{}</font>"
 			var/time = 100 * length(src.linkedServer.decryptkey)
-			addtimer(src, "UnmagConsole", time)
+			addtimer(CALLBACK(src,  .proc/UnmagConsole), time)
 			message = rebootmsg
 		else
 			user << "<span class='notice'>A no server error appears on the screen.</span>"

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -100,7 +100,7 @@
 
 /obj/structure/barricade/security/New()
 	..()
-	addtimer(CALLBACK(src,  .proc/deploy), 40)
+	addtimer(CALLBACK(src, .proc/deploy), 40)
 
 /obj/structure/barricade/security/proc/deploy()
 	icon_state = "barrier1"

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -100,7 +100,7 @@
 
 /obj/structure/barricade/security/New()
 	..()
-	addtimer(src, "deploy", 40)
+	addtimer(CALLBACK(src,  .proc/deploy), 40)
 
 /obj/structure/barricade/security/proc/deploy()
 	icon_state = "barrier1"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -232,7 +232,7 @@ var/list/airlock_overlays = list()
 			if(cyclelinkedairlock.operating)
 				cyclelinkedairlock.delayed_close_requested = TRUE
 			else
-				addtimer(CALLBACK(cyclelinkedairlock,  .proc/close), 2)
+				addtimer(CALLBACK(cyclelinkedairlock, .proc/close), 2)
 	..()
 
 
@@ -1244,9 +1244,9 @@ var/list/airlock_overlays = list()
 		playsound(src.loc, 'sound/machines/airlockforced.ogg', 30, 1)
 
 	if(autoclose && normalspeed)
-		addtimer(CALLBACK(src,  .proc/autoclose), 150)
+		addtimer(CALLBACK(src, .proc/autoclose), 150)
 	else if(autoclose && !normalspeed)
-		addtimer(CALLBACK(src,  .proc/autoclose), 15)
+		addtimer(CALLBACK(src, .proc/autoclose), 15)
 
 	if(!density)
 		return 1
@@ -1266,7 +1266,7 @@ var/list/airlock_overlays = list()
 	update_freelook_sight()
 	if(delayed_close_requested)
 		delayed_close_requested = FALSE
-		addtimer(CALLBACK(src,  .proc/close), 2)
+		addtimer(CALLBACK(src, .proc/close), 2)
 	return 1
 
 
@@ -1279,7 +1279,7 @@ var/list/airlock_overlays = list()
 	if(safe)
 		for(var/atom/movable/M in get_turf(src))
 			if(M.density && M != src) //something is blocking the door
-				addtimer(CALLBACK(src,  .proc/autoclose), 60)
+				addtimer(CALLBACK(src, .proc/autoclose), 60)
 				return
 
 	if(forced < 2)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -232,7 +232,7 @@ var/list/airlock_overlays = list()
 			if(cyclelinkedairlock.operating)
 				cyclelinkedairlock.delayed_close_requested = TRUE
 			else
-				addtimer(cyclelinkedairlock, "close", 2)
+				addtimer(CALLBACK(cyclelinkedairlock,  .proc/close), 2)
 	..()
 
 
@@ -1244,9 +1244,9 @@ var/list/airlock_overlays = list()
 		playsound(src.loc, 'sound/machines/airlockforced.ogg', 30, 1)
 
 	if(autoclose && normalspeed)
-		addtimer(src, "autoclose", 150)
+		addtimer(CALLBACK(src,  .proc/autoclose), 150)
 	else if(autoclose && !normalspeed)
-		addtimer(src, "autoclose", 15)
+		addtimer(CALLBACK(src,  .proc/autoclose), 15)
 
 	if(!density)
 		return 1
@@ -1266,7 +1266,7 @@ var/list/airlock_overlays = list()
 	update_freelook_sight()
 	if(delayed_close_requested)
 		delayed_close_requested = FALSE
-		addtimer(src, "close", 2)
+		addtimer(CALLBACK(src,  .proc/close), 2)
 	return 1
 
 
@@ -1279,7 +1279,7 @@ var/list/airlock_overlays = list()
 	if(safe)
 		for(var/atom/movable/M in get_turf(src))
 			if(M.density && M != src) //something is blocking the door
-				addtimer(src, "autoclose", 60)
+				addtimer(CALLBACK(src,  .proc/autoclose), 60)
 				return
 
 	if(forced < 2)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -465,7 +465,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 
 /obj/machinery/door/airlock/clockwork/attackby(obj/item/I, mob/living/user, params)
 	if(!attempt_construction(I, user))

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -465,7 +465,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
 /obj/machinery/door/airlock/clockwork/attackby(obj/item/I, mob/living/user, params)
 	if(!attempt_construction(I, user))

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -92,7 +92,7 @@
 	for(var/obj/machinery/door/window/brigdoor/door in targets)
 		if(door.density)
 			continue
-		addtimer(CALLBACK(door,  /obj/machinery/door/window/brigdoor.proc/close), 0)
+		addtimer(CALLBACK(door, /obj/machinery/door/window/brigdoor.proc/close), 0)
 
 	for(var/obj/structure/closet/secure_closet/brig/C in targets)
 		if(C.broken)
@@ -121,7 +121,7 @@
 	for(var/obj/machinery/door/window/brigdoor/door in targets)
 		if(!door.density)
 			continue
-		addtimer(CALLBACK(door,  /obj/machinery/door/window/brigdoor.proc/open), 0)
+		addtimer(CALLBACK(door, /obj/machinery/door/window/brigdoor.proc/open), 0)
 
 	for(var/obj/structure/closet/secure_closet/brig/C in targets)
 		if(C.broken)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -92,7 +92,7 @@
 	for(var/obj/machinery/door/window/brigdoor/door in targets)
 		if(door.density)
 			continue
-		addtimer(door, "close", 0)
+		addtimer(CALLBACK(door,  /obj/machinery/door/window/brigdoor.proc/close), 0)
 
 	for(var/obj/structure/closet/secure_closet/brig/C in targets)
 		if(C.broken)
@@ -121,7 +121,7 @@
 	for(var/obj/machinery/door/window/brigdoor/door in targets)
 		if(!door.density)
 			continue
-		addtimer(door, "open", 0)
+		addtimer(CALLBACK(door,  /obj/machinery/door/window/brigdoor.proc/open), 0)
 
 	for(var/obj/structure/closet/secure_closet/brig/C in targets)
 		if(C.broken)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -191,7 +191,7 @@
 		if(secondsElectrified == 0)
 			secondsElectrified = -1
 			shockedby += "\[[time_stamp()]\]EM Pulse"
-			addtimer(CALLBACK(src,  .proc/unelectrify), 300)
+			addtimer(CALLBACK(src, .proc/unelectrify), 300)
 	..()
 
 /obj/machinery/door/proc/unelectrify()
@@ -253,7 +253,7 @@
 		for(var/atom/movable/M in get_turf(src))
 			if(M.density && M != src) //something is blocking the door
 				if(autoclose)
-					addtimer(CALLBACK(src,  .proc/autoclose), 60)
+					addtimer(CALLBACK(src, .proc/autoclose), 60)
 				return
 	operating = 1
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -191,7 +191,7 @@
 		if(secondsElectrified == 0)
 			secondsElectrified = -1
 			shockedby += "\[[time_stamp()]\]EM Pulse"
-			addtimer(src, "unelectrify", 300)
+			addtimer(CALLBACK(src,  .proc/unelectrify), 300)
 	..()
 
 /obj/machinery/door/proc/unelectrify()
@@ -253,7 +253,7 @@
 		for(var/atom/movable/M in get_turf(src))
 			if(M.density && M != src) //something is blocking the door
 				if(autoclose)
-					addtimer(src, "autoclose", 60)
+					addtimer(CALLBACK(src,  .proc/autoclose), 60)
 				return
 	operating = 1
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -30,9 +30,9 @@
 /obj/machinery/door/poddoor/shuttledock/proc/check()
 	var/turf/T = get_step(src, checkdir)
 	if(!istype(T, turftype))
-		addtimer(src, "open", 0, TIMER_UNIQUE)
+		addtimer(CALLBACK(src,  .proc/open), 0, TIMER_UNIQUE)
 	else
-		addtimer(src, "close", 0, TIMER_UNIQUE)
+		addtimer(CALLBACK(src,  .proc/close), 0, TIMER_UNIQUE)
 
 /obj/machinery/door/poddoor/Bumped(atom/AM)
 	if(density)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -30,9 +30,9 @@
 /obj/machinery/door/poddoor/shuttledock/proc/check()
 	var/turf/T = get_step(src, checkdir)
 	if(!istype(T, turftype))
-		addtimer(CALLBACK(src,  .proc/open), 0, TIMER_UNIQUE)
+		addtimer(CALLBACK(src, .proc/open), 0, TIMER_UNIQUE)
 	else
-		addtimer(CALLBACK(src,  .proc/close), 0, TIMER_UNIQUE)
+		addtimer(CALLBACK(src, .proc/close), 0, TIMER_UNIQUE)
 
 /obj/machinery/door/poddoor/Bumped(atom/AM)
 	if(density)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -339,7 +339,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 
 /obj/machinery/door/window/clockwork/allowed(mob/M)
 	if(is_servant_of_ratvar(M))

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -339,7 +339,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
 /obj/machinery/door/window/clockwork/allowed(mob/M)
 	if(is_servant_of_ratvar(M))

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -56,10 +56,10 @@
 
 	if(program)
 		program.receive_user_command(href_list["command"])
-		addtimer(CALLBACK(program,  /datum/computer/file/embedded_program.proc/process), 5)
+		addtimer(CALLBACK(program, /datum/computer/file/embedded_program.proc/process), 5)
 
 	usr.set_machine(src)
-	addtimer(CALLBACK(src,  .proc/updateDialog), 5)
+	addtimer(CALLBACK(src, .proc/updateDialog), 5)
 
 /obj/machinery/embedded_controller/process()
 	if(program)

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -56,10 +56,10 @@
 
 	if(program)
 		program.receive_user_command(href_list["command"])
-		addtimer(program, "process", 5)
+		addtimer(CALLBACK(program,  /datum/computer/file/embedded_program.proc/process), 5)
 
 	usr.set_machine(src)
-	addtimer(src, "updateDialog", 5)
+	addtimer(CALLBACK(src,  .proc/updateDialog), 5)
 
 /obj/machinery/embedded_controller/process()
 	if(program)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -94,7 +94,7 @@
 	playsound(src.loc, 'sound/ambience/signal.ogg', 75, 0)
 
 /obj/machinery/firealarm/proc/alarm_in(time)
-	addtimer(CALLBACK(src,  .proc/alarm), time)
+	addtimer(CALLBACK(src, .proc/alarm), time)
 
 /obj/machinery/firealarm/proc/reset()
 	if(!is_operational())
@@ -103,7 +103,7 @@
 	A.firereset(src)
 
 /obj/machinery/firealarm/proc/reset_in(time)
-	addtimer(CALLBACK(src,  .proc/reset), time)
+	addtimer(CALLBACK(src, .proc/reset), time)
 
 /obj/machinery/firealarm/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, \
 									datum/tgui/master_ui = null, datum/ui_state/state = default_state)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -94,7 +94,7 @@
 	playsound(src.loc, 'sound/ambience/signal.ogg', 75, 0)
 
 /obj/machinery/firealarm/proc/alarm_in(time)
-	addtimer(src, "alarm", time, TIMER_NORMAL)
+	addtimer(CALLBACK(src,  .proc/alarm), time)
 
 /obj/machinery/firealarm/proc/reset()
 	if(!is_operational())
@@ -103,7 +103,7 @@
 	A.firereset(src)
 
 /obj/machinery/firealarm/proc/reset_in(time)
-	addtimer(src, "reset", time, TIMER_NORMAL)
+	addtimer(CALLBACK(src,  .proc/reset), time)
 
 /obj/machinery/firealarm/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, \
 									datum/tgui/master_ui = null, datum/ui_state/state = default_state)

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -35,7 +35,7 @@ The console is located at computer/gulag_teleporter.dm
 				/obj/item/clothing/mask/gas))
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/gulag_teleporter(null)
 	B.apply_default_parts(src)
-	addtimer(CALLBACK(src,  .proc/locate_reclaimer), 5)
+	addtimer(CALLBACK(src, .proc/locate_reclaimer), 5)
 
 /obj/machinery/gulag_teleporter/Destroy()
 	if(linked_reclaimer)

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -35,7 +35,7 @@ The console is located at computer/gulag_teleporter.dm
 				/obj/item/clothing/mask/gas))
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/gulag_teleporter(null)
 	B.apply_default_parts(src)
-	addtimer(src, "locate_reclaimer", 5)
+	addtimer(CALLBACK(src,  .proc/locate_reclaimer), 5)
 
 /obj/machinery/gulag_teleporter/Destroy()
 	if(linked_reclaimer)

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -121,7 +121,7 @@
 				use_power(power)
 				flick("limbgrower_fill",src)
 				icon_state = "limbgrower_idleon"
-				addtimer(src, "build_item",32*prod_coeff)
+				addtimer(CALLBACK(src,  .proc/build_item),32*prod_coeff)
 
 	else
 		usr << "<span class=\"alert\">The limb grower is busy. Please wait for completion of previous operation.</span>"

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -121,7 +121,7 @@
 				use_power(power)
 				flick("limbgrower_fill",src)
 				icon_state = "limbgrower_idleon"
-				addtimer(CALLBACK(src,  .proc/build_item),32*prod_coeff)
+				addtimer(CALLBACK(src, .proc/build_item),32*prod_coeff)
 
 	else
 		usr << "<span class=\"alert\">The limb grower is busy. Please wait for completion of previous operation.</span>"

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -134,7 +134,7 @@
 				on = !on
 
 				if(on)
-					addtimer(src, "magnetic_process", 0)
+					addtimer(CALLBACK(src,  .proc/magnetic_process), 0)
 
 
 

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -134,7 +134,7 @@
 				on = !on
 
 				if(on)
-					addtimer(CALLBACK(src,  .proc/magnetic_process), 0)
+					addtimer(CALLBACK(src, .proc/magnetic_process), 0)
 
 
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -152,7 +152,7 @@ var/const/SAFETY_COOLDOWN = 100
 	safety_mode = TRUE
 	update_icon()
 	L.loc = src.loc
-	addtimer(CALLBACK(src,  .proc/reboot), SAFETY_COOLDOWN)
+	addtimer(CALLBACK(src, .proc/reboot), SAFETY_COOLDOWN)
 
 /obj/machinery/recycler/proc/reboot()
 	playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -152,7 +152,7 @@ var/const/SAFETY_COOLDOWN = 100
 	safety_mode = TRUE
 	update_icon()
 	L.loc = src.loc
-	addtimer(src, "reboot", SAFETY_COOLDOWN)
+	addtimer(CALLBACK(src,  .proc/reboot), SAFETY_COOLDOWN)
 
 /obj/machinery/recycler/proc/reboot()
 	playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -217,7 +217,7 @@
 				occupant.adjustFireLoss(rand(10, 16))
 			if(iscarbon(occupant))
 				occupant.emote("scream")
-		addtimer(CALLBACK(src,  .proc/cook), 50)
+		addtimer(CALLBACK(src, .proc/cook), 50)
 	else
 		uv_cycles = initial(uv_cycles)
 		uv = FALSE
@@ -263,7 +263,7 @@
 	add_fingerprint(user)
 	if(locked)
 		visible_message("<span class='notice'>You see [user] kicking against the doors of [src]!</span>", "<span class='notice'>You start kicking against the doors...</span>")
-		addtimer(CALLBACK(src,  .proc/resist_open, user), 300)
+		addtimer(CALLBACK(src, .proc/resist_open, user), 300)
 	else
 		open_machine()
 		dump_contents()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -217,7 +217,7 @@
 				occupant.adjustFireLoss(rand(10, 16))
 			if(iscarbon(occupant))
 				occupant.emote("scream")
-		addtimer(src, "cook", 50, TIMER_NORMAL)
+		addtimer(CALLBACK(src,  .proc/cook), 50)
 	else
 		uv_cycles = initial(uv_cycles)
 		uv = FALSE
@@ -263,7 +263,7 @@
 	add_fingerprint(user)
 	if(locked)
 		visible_message("<span class='notice'>You see [user] kicking against the doors of [src]!</span>", "<span class='notice'>You start kicking against the doors...</span>")
-		addtimer(src, "resist_open", 300, TIMER_NORMAL, user)
+		addtimer(CALLBACK(src,  .proc/resist_open, user), 300)
 	else
 		open_machine()
 		dump_contents()

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -34,7 +34,7 @@
 	. = (payload in src) && (active || ignore_active) && !defused
 	if(.)
 		payload.detonate()
-		
+
 /obj/machinery/syndicatebomb/obj_break()
 	if(!try_detonate())
 		..()
@@ -419,7 +419,7 @@
 		chem_splash(get_turf(src), spread_range, list(reactants), temp_boost)
 
 		// Detonate it again in one second, until it's out of juice.
-		addtimer(src, "detonate", 10)
+		addtimer(CALLBACK(src,  .proc/detonate), 10)
 
 	// If it's not a time release bomb, do normal explosion
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -419,7 +419,7 @@
 		chem_splash(get_turf(src), spread_range, list(reactants), temp_boost)
 
 		// Detonate it again in one second, until it's out of juice.
-		addtimer(CALLBACK(src,  .proc/detonate), 10)
+		addtimer(CALLBACK(src, .proc/detonate), 10)
 
 	// If it's not a time release bomb, do normal explosion
 

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -103,7 +103,7 @@
 
  	// So he can't jump out the gate right away.
 	R.SetLockdown()
-	addtimer(CALLBACK(src,  .proc/unlock_new_robot, R), 50)
+	addtimer(CALLBACK(src, .proc/unlock_new_robot, R), 50)
 
 /obj/machinery/transformer/proc/unlock_new_robot(mob/living/silicon/robot/R)
 	playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -103,7 +103,7 @@
 
  	// So he can't jump out the gate right away.
 	R.SetLockdown()
-	addtimer(src, "unlock_new_robot", 50, TIMER_NORMAL, R)
+	addtimer(CALLBACK(src,  .proc/unlock_new_robot, R), 50)
 
 /obj/machinery/transformer/proc/unlock_new_robot(mob/living/silicon/robot/R)
 	playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -87,7 +87,7 @@
 /obj/item/mecha_parts/mecha_equipment/proc/start_cooldown()
 	set_ready_state(0)
 	chassis.use_power(energy_drain)
-	addtimer(src, "set_ready_state", equip_cooldown, TIMER_NORMAL, 1)
+	addtimer(CALLBACK(src,  .proc/set_ready_state, 1), equip_cooldown)
 
 /obj/item/mecha_parts/mecha_equipment/proc/do_after_cooldown(atom/target)
 	if(!chassis)

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -87,7 +87,7 @@
 /obj/item/mecha_parts/mecha_equipment/proc/start_cooldown()
 	set_ready_state(0)
 	chassis.use_power(energy_drain)
-	addtimer(CALLBACK(src,  .proc/set_ready_state, 1), equip_cooldown)
+	addtimer(CALLBACK(src, .proc/set_ready_state, 1), equip_cooldown)
 
 /obj/item/mecha_parts/mecha_equipment/proc/do_after_cooldown(atom/target)
 	if(!chassis)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -68,7 +68,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/start_cooldown()
 	set_ready_state(0)
 	chassis.use_power(energy_drain*get_shot_amount())
-	addtimer(src, "set_ready_state", equip_cooldown, TIMER_NORMAL, 1)
+	addtimer(CALLBACK(src,  .proc/set_ready_state, 1), equip_cooldown)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	equip_cooldown = 8
@@ -344,7 +344,7 @@
 	var/turf/T = get_turf(src)
 	message_admins("[key_name(chassis.occupant, chassis.occupant.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[chassis.occupant]'>?</A>) fired a [src] in ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)",0,1)
 	log_game("[key_name(chassis.occupant)] fired a [src] ([T.x],[T.y],[T.z])")
-	addtimer(F, "prime", det_time)
+	addtimer(CALLBACK(F, /obj/item/weapon/grenade/flashbang.proc/prime), det_time)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/clusterbang //Because I am a heartless bastard -Sieve //Heartless? for making the poor man's honkblast? - Kaze
 	name = "\improper SOB-3 grenade launcher"

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -68,7 +68,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/start_cooldown()
 	set_ready_state(0)
 	chassis.use_power(energy_drain*get_shot_amount())
-	addtimer(CALLBACK(src,  .proc/set_ready_state, 1), equip_cooldown)
+	addtimer(CALLBACK(src, .proc/set_ready_state, 1), equip_cooldown)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	equip_cooldown = 8

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -52,7 +52,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	for(var/i in 1 to number)
 		if(total_effects > 20)
 			return
-		addtimer(CALLBACK(src,  .proc/generate_effect), 0)
+		addtimer(CALLBACK(src, .proc/generate_effect), 0)
 
 /datum/effect_system/proc/generate_effect()
 	if(holder)
@@ -68,7 +68,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	for(var/j in 1 to steps_amt)
 		sleep(5)
 		step(E,direction)
-	addtimer(CALLBACK(src,  .proc/decrement_total_effect), 20)
+	addtimer(CALLBACK(src, .proc/decrement_total_effect), 20)
 
 /datum/effect_system/proc/decrement_total_effect()
 	total_effects--

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -52,7 +52,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	for(var/i in 1 to number)
 		if(total_effects > 20)
 			return
-		addtimer(src, "generate_effect", 0)
+		addtimer(CALLBACK(src,  .proc/generate_effect), 0)
 
 /datum/effect_system/proc/generate_effect()
 	if(holder)
@@ -68,7 +68,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	for(var/j in 1 to steps_amt)
 		sleep(5)
 		step(E,direction)
-	addtimer(src, "decrement_total_effect", 20)
+	addtimer(CALLBACK(src,  .proc/decrement_total_effect), 20)
 
 /datum/effect_system/proc/decrement_total_effect()
 	total_effects--

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -42,7 +42,7 @@
 
 /obj/effect/particle_effect/smoke/proc/kill_smoke()
 	STOP_PROCESSING(SSobj, src)
-	addtimer(src, "fade_out", 0)
+	addtimer(CALLBACK(src,  .proc/fade_out), 0)
 	QDEL_IN(src, 10)
 
 /obj/effect/particle_effect/smoke/process()
@@ -64,7 +64,7 @@
 	if(C.smoke_delay)
 		return 0
 	C.smoke_delay++
-	addtimer(src, "remove_smoke_delay", 10, TIMER_NORMAL, C)
+	addtimer(CALLBACK(src,  .proc/remove_smoke_delay, C), 10)
 	return 1
 
 /obj/effect/particle_effect/smoke/proc/remove_smoke_delay(mob/living/carbon/C)

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -42,7 +42,7 @@
 
 /obj/effect/particle_effect/smoke/proc/kill_smoke()
 	STOP_PROCESSING(SSobj, src)
-	addtimer(CALLBACK(src,  .proc/fade_out), 0)
+	addtimer(CALLBACK(src, .proc/fade_out), 0)
 	QDEL_IN(src, 10)
 
 /obj/effect/particle_effect/smoke/process()
@@ -64,7 +64,7 @@
 	if(C.smoke_delay)
 		return 0
 	C.smoke_delay++
-	addtimer(CALLBACK(src,  .proc/remove_smoke_delay, C), 10)
+	addtimer(CALLBACK(src, .proc/remove_smoke_delay, C), 10)
 	return 1
 
 /obj/effect/particle_effect/smoke/proc/remove_smoke_delay(mob/living/carbon/C)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -52,7 +52,7 @@ var/list/blacklisted_glowshroom_turfs = typecacheof(list(
 	else //if on the floor, glowshroom on-floor sprite
 		icon_state = "[base_icon_state]f"
 
-	addtimer(src, "Spread", delay)
+	addtimer(CALLBACK(src,  .proc/Spread), delay)
 
 /obj/structure/glowshroom/proc/Spread()
 	for(var/i = 1 to yield)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -52,7 +52,7 @@ var/list/blacklisted_glowshroom_turfs = typecacheof(list(
 	else //if on the floor, glowshroom on-floor sprite
 		icon_state = "[base_icon_state]f"
 
-	addtimer(CALLBACK(src,  .proc/Spread), delay)
+	addtimer(CALLBACK(src, .proc/Spread), delay)
 
 /obj/structure/glowshroom/proc/Spread()
 	for(var/i = 1 to yield)

--- a/code/game/objects/items/body_egg.dm
+++ b/code/game/objects/items/body_egg.dm
@@ -20,14 +20,14 @@
 	owner.status_flags |= XENO_HOST
 	START_PROCESSING(SSobj, src)
 	owner.med_hud_set_status()
-	addtimer(src, "AddInfectionImages", 0, TIMER_NORMAL, owner)
+	addtimer(CALLBACK(src,  .proc/AddInfectionImages, owner), 0)
 
 /obj/item/organ/body_egg/Remove(var/mob/living/carbon/M, special = 0)
 	STOP_PROCESSING(SSobj, src)
 	if(owner)
 		owner.status_flags &= ~(XENO_HOST)
 		owner.med_hud_set_status()
-		addtimer(src, "RemoveInfectionImages", 0, TIMER_NORMAL, owner)
+		addtimer(CALLBACK(src,  .proc/RemoveInfectionImages, owner), 0)
 	..()
 
 /obj/item/organ/body_egg/process()

--- a/code/game/objects/items/body_egg.dm
+++ b/code/game/objects/items/body_egg.dm
@@ -20,14 +20,14 @@
 	owner.status_flags |= XENO_HOST
 	START_PROCESSING(SSobj, src)
 	owner.med_hud_set_status()
-	addtimer(CALLBACK(src,  .proc/AddInfectionImages, owner), 0)
+	addtimer(CALLBACK(src, .proc/AddInfectionImages, owner), 0)
 
 /obj/item/organ/body_egg/Remove(var/mob/living/carbon/M, special = 0)
 	STOP_PROCESSING(SSobj, src)
 	if(owner)
 		owner.status_flags &= ~(XENO_HOST)
 		owner.med_hud_set_status()
-		addtimer(CALLBACK(src,  .proc/RemoveInfectionImages, owner), 0)
+		addtimer(CALLBACK(src, .proc/RemoveInfectionImages, owner), 0)
 	..()
 
 /obj/item/organ/body_egg/process()

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -59,7 +59,7 @@
 
 	user << "Your name has been sent to your employers for approval."
 	// Autoapproves after a certain time
-	response_timer_id = addtimer(CALLBACK(src,  .proc/rename_station, new_name, user), approval_time)
+	response_timer_id = addtimer(CALLBACK(src, .proc/rename_station, new_name, user), approval_time)
 	admins << "<span class='adminnotice'><b><font color=orange>CUSTOM STATION RENAME:</font></b>[key_name_admin(user)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) proposes to rename the station to [new_name] (will autoapprove in [approval_time / 10] seconds). (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[user]'>BSA</A>) (<A HREF='?_src_=holder;reject_custom_name=\ref[src]'>REJECT</A>) (<a href='?_src_=holder;CentcommReply=\ref[user]'>RPLY</a>)</span>"
 
 /obj/item/station_charter/proc/reject_proposed(user)

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -59,7 +59,7 @@
 
 	user << "Your name has been sent to your employers for approval."
 	// Autoapproves after a certain time
-	response_timer_id = addtimer(src, "rename_station", approval_time, TIMER_NORMAL, new_name, user)
+	response_timer_id = addtimer(CALLBACK(src,  .proc/rename_station, new_name, user), approval_time)
 	admins << "<span class='adminnotice'><b><font color=orange>CUSTOM STATION RENAME:</font></b>[key_name_admin(user)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) proposes to rename the station to [new_name] (will autoapprove in [approval_time / 10] seconds). (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[user]'>BSA</A>) (<A HREF='?_src_=holder;reject_custom_name=\ref[src]'>REJECT</A>) (<a href='?_src_=holder;CentcommReply=\ref[user]'>RPLY</a>)</span>"
 
 /obj/item/station_charter/proc/reject_proposed(user)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -197,7 +197,7 @@
 				. = TRUE
 
 /obj/item/device/radio/talk_into(atom/movable/M, message, channel, list/spans)
-	addtimer(src,"talk_into_impl",0, TIMER_NORMAL,M,message,channel,spans)
+	addtimer(CALLBACK(src, .proc/talk_into_impl, M, message, channel, spans), 0)
 	return ITALICS | REDUCE_RANGE
 
 /obj/item/device/radio/proc/talk_into_impl(atom/movable/M, message, channel, list/spans)

--- a/code/game/objects/items/nuke_tools.dm
+++ b/code/game/objects/items/nuke_tools.dm
@@ -43,7 +43,7 @@
 	core = ncore
 	icon_state = "core_container_loaded"
 	user << "<span class='warning'>Container is sealing...</span>"
-	addtimer(src, "seal", 50)
+	addtimer(CALLBACK(src,  .proc/seal), 50)
 	return 1
 
 /obj/item/nuke_core_container/proc/seal()

--- a/code/game/objects/items/nuke_tools.dm
+++ b/code/game/objects/items/nuke_tools.dm
@@ -43,7 +43,7 @@
 	core = ncore
 	icon_state = "core_container_loaded"
 	user << "<span class='warning'>Container is sealing...</span>"
-	addtimer(CALLBACK(src,  .proc/seal), 50)
+	addtimer(CALLBACK(src, .proc/seal), 50)
 	return 1
 
 /obj/item/nuke_core_container/proc/seal()

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -363,7 +363,7 @@
 	if(charging)
 		return
 	if(candy < candymax)
-		addtimer(CALLBACK(src,  .proc/charge_lollipops), charge_delay)
+		addtimer(CALLBACK(src, .proc/charge_lollipops), charge_delay)
 		charging = TRUE
 
 /obj/item/borg/lollipop/proc/charge_lollipops()

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -363,7 +363,7 @@
 	if(charging)
 		return
 	if(candy < candymax)
-		addtimer(src, "charge_lollipops", charge_delay, TIMER_NORMAL)
+		addtimer(CALLBACK(src,  .proc/charge_lollipops), charge_delay)
 		charging = TRUE
 
 /obj/item/borg/lollipop/proc/charge_lollipops()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -231,8 +231,8 @@
 	toggle_action.Grant(R)
 	return 1
 
-/obj/item/borg/uprgade/selfrepair/dropped()
-	addtimer(src, "check_dropped", 1)
+/obj/item/borg/upgrade/selfrepair/dropped()
+	addtimer(CALLBACK(src,  .proc/check_dropped), 1)
 
 /obj/item/borg/upgrade/selfrepair/proc/check_dropped()
 	if(loc != cyborg)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -232,7 +232,7 @@
 	return 1
 
 /obj/item/borg/upgrade/selfrepair/dropped()
-	addtimer(CALLBACK(src,  .proc/check_dropped), 1)
+	addtimer(CALLBACK(src, .proc/check_dropped), 1)
 
 /obj/item/borg/upgrade/selfrepair/proc/check_dropped()
 	if(loc != cyborg)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -362,7 +362,7 @@
 
 /obj/effect/decal/cleanable/ash/snappop_phoenix/New()
 	. = ..()
-	addtimer(CALLBACK(src,  .proc/respawn), respawn_time)
+	addtimer(CALLBACK(src, .proc/respawn), respawn_time)
 
 /obj/effect/decal/cleanable/ash/snappop_phoenix/proc/respawn()
 	new /obj/item/toy/snappop/phoenix(get_turf(src))

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -362,7 +362,7 @@
 
 /obj/effect/decal/cleanable/ash/snappop_phoenix/New()
 	. = ..()
-	addtimer(src, "respawn", respawn_time)
+	addtimer(CALLBACK(src,  .proc/respawn), respawn_time)
 
 /obj/effect/decal/cleanable/ash/snappop_phoenix/proc/respawn()
 	new /obj/item/toy/snappop/phoenix(get_turf(src))

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -551,7 +551,7 @@ RCD
 		buzz loudly!</b></span>","<span class='danger'><b>[src] begins \
 		vibrating violently!</b></span>")
 	// 5 seconds to get rid of it
-	addtimer(CALLBACK(src,  .proc/detonate_pulse_explode), 50)
+	addtimer(CALLBACK(src, .proc/detonate_pulse_explode), 50)
 
 /obj/item/weapon/rcd/proc/detonate_pulse_explode()
 	explosion(src, 0, 0, 3, 1, flame_range = 1)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -551,7 +551,7 @@ RCD
 		buzz loudly!</b></span>","<span class='danger'><b>[src] begins \
 		vibrating violently!</b></span>")
 	// 5 seconds to get rid of it
-	addtimer(src, "detonate_pulse_explode", 50)
+	addtimer(CALLBACK(src,  .proc/detonate_pulse_explode), 50)
 
 /obj/item/weapon/rcd/proc/detonate_pulse_explode()
 	explosion(src, 0, 0, 3, 1, flame_range = 1)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -94,7 +94,7 @@
 
 		target.add_overlay(image_overlay, 1)
 		user << "<span class='notice'>You plant the bomb. Timer counting down from [timer].</span>"
-		addtimer(src, "explode", timer * 10)
+		addtimer(CALLBACK(src,  .proc/explode), timer * 10)
 
 /obj/item/weapon/c4/proc/explode()
 	if(qdeleted(src))

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -94,7 +94,7 @@
 
 		target.add_overlay(image_overlay, 1)
 		user << "<span class='notice'>You plant the bomb. Timer counting down from [timer].</span>"
-		addtimer(CALLBACK(src,  .proc/explode), timer * 10)
+		addtimer(CALLBACK(src, .proc/explode), timer * 10)
 
 /obj/item/weapon/c4/proc/explode()
 	if(qdeleted(src))

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -45,7 +45,7 @@
 				var/mob/living/carbon/C = user
 				C.throw_mode_on()
 
-			addtimer(src, "prime", det_time)
+			addtimer(CALLBACK(src,  .proc/prime), det_time)
 
 
 /obj/item/weapon/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
@@ -287,7 +287,7 @@
 		message_admins("grenade primed by an assembly, attached by [key_name_admin(M)]<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>(?)</A> (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[M]'>FLW</A>) and last touched by [key_name_admin(last)]<A HREF='?_src_=holder;adminmoreinfo=\ref[last]'>(?)</A> (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[last]'>FLW</A>) ([nadeassembly.a_left.name] and [nadeassembly.a_right.name]) at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>[A.name] (JMP)</a>.")
 		log_game("grenade primed by an assembly, attached by [key_name(M)] and last touched by [key_name(last)] ([nadeassembly.a_left.name] and [nadeassembly.a_right.name]) at [A.name] ([T.x], [T.y], [T.z])")
 	else
-		addtimer(src, "prime", det_time)
+		addtimer(CALLBACK(src,  .proc/prime), det_time)
 	var/turf/DT = get_turf(src)
 	var/area/DA = get_area(DT)
 	log_game("A grenade detonated at [DA.name] ([DT.x], [DT.y], [DT.z])")

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -45,7 +45,7 @@
 				var/mob/living/carbon/C = user
 				C.throw_mode_on()
 
-			addtimer(CALLBACK(src,  .proc/prime), det_time)
+			addtimer(CALLBACK(src, .proc/prime), det_time)
 
 
 /obj/item/weapon/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
@@ -287,7 +287,7 @@
 		message_admins("grenade primed by an assembly, attached by [key_name_admin(M)]<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>(?)</A> (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[M]'>FLW</A>) and last touched by [key_name_admin(last)]<A HREF='?_src_=holder;adminmoreinfo=\ref[last]'>(?)</A> (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[last]'>FLW</A>) ([nadeassembly.a_left.name] and [nadeassembly.a_right.name]) at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>[A.name] (JMP)</a>.")
 		log_game("grenade primed by an assembly, attached by [key_name(M)] and last touched by [key_name(last)] ([nadeassembly.a_left.name] and [nadeassembly.a_right.name]) at [A.name] ([T.x], [T.y], [T.z])")
 	else
-		addtimer(CALLBACK(src,  .proc/prime), det_time)
+		addtimer(CALLBACK(src, .proc/prime), det_time)
 	var/turf/DT = get_turf(src)
 	var/area/DA = get_area(DT)
 	log_game("A grenade detonated at [DA.name] ([DT.x], [DT.y], [DT.z])")

--- a/code/game/objects/items/weapons/grenades/clusterbuster.dm
+++ b/code/game/objects/items/weapons/grenades/clusterbuster.dm
@@ -43,7 +43,7 @@
 	payload = payload_type
 	active = 1
 	walk_away(src,loc,rand(1,4))
-	addtimer(CALLBACK(src,  .proc/prime), rand(15,60))
+	addtimer(CALLBACK(src, .proc/prime), rand(15,60))
 
 /obj/item/weapon/grenade/clusterbuster/segment/prime()
 

--- a/code/game/objects/items/weapons/grenades/clusterbuster.dm
+++ b/code/game/objects/items/weapons/grenades/clusterbuster.dm
@@ -43,7 +43,7 @@
 	payload = payload_type
 	active = 1
 	walk_away(src,loc,rand(1,4))
-	addtimer(src, "prime", rand(15,60))
+	addtimer(CALLBACK(src,  .proc/prime), rand(15,60))
 
 /obj/item/weapon/grenade/clusterbuster/segment/prime()
 

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -58,7 +58,7 @@
 			if(iscarbon(user))
 				var/mob/living/carbon/C = user
 				C.throw_mode_on()
-			addtimer(src, "prime", det_time)
+			addtimer(CALLBACK(src,  .proc/prime), det_time)
 
 /obj/item/weapon/grenade/iedcasing/prime() //Blowing that can up
 	update_mob()

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -58,7 +58,7 @@
 			if(iscarbon(user))
 				var/mob/living/carbon/C = user
 				C.throw_mode_on()
-			addtimer(CALLBACK(src,  .proc/prime), det_time)
+			addtimer(CALLBACK(src, .proc/prime), det_time)
 
 /obj/item/weapon/grenade/iedcasing/prime() //Blowing that can up
 	update_mob()

--- a/code/game/objects/items/weapons/grenades/plastic.dm
+++ b/code/game/objects/items/weapons/grenades/plastic.dm
@@ -84,7 +84,7 @@
 		target.add_overlay(image_overlay, 1)
 		if(!nadeassembly)
 			user << "<span class='notice'>You plant the bomb. Timer counting down from [det_time].</span>"
-			addtimer(src, "prime", det_time*10)
+			addtimer(CALLBACK(src,  .proc/prime), det_time*10)
 
 /obj/item/weapon/grenade/plastic/suicide_act(mob/user)
 	message_admins("[key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) suicided with [src] at ([user.x],[user.y],[user.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)",0,1)

--- a/code/game/objects/items/weapons/grenades/plastic.dm
+++ b/code/game/objects/items/weapons/grenades/plastic.dm
@@ -84,7 +84,7 @@
 		target.add_overlay(image_overlay, 1)
 		if(!nadeassembly)
 			user << "<span class='notice'>You plant the bomb. Timer counting down from [det_time].</span>"
-			addtimer(CALLBACK(src,  .proc/prime), det_time*10)
+			addtimer(CALLBACK(src, .proc/prime), det_time*10)
 
 /obj/item/weapon/grenade/plastic/suicide_act(mob/user)
 	message_admins("[key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) suicided with [src] at ([user.x],[user.y],[user.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)",0,1)

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -46,7 +46,7 @@
 		if(isfloorturf(T))
 			var/turf/open/floor/F = T
 			F.wet = TURF_WET_PERMAFROST
-			addtimer(F, "MakeDry", rand(3000, 3100), TIMER_NORMAL, TURF_WET_PERMAFROST)
+			addtimer(CALLBACK(F,  /turf/open/floor.proc/MakeDry), rand(3000, 3100), TURF_WET_PERMAFROST)
 			for(var/mob/living/carbon/L in T)
 				L.adjustStaminaLoss(stamina_damage)
 				L.bodytemperature -= 230

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -46,7 +46,7 @@
 		if(isfloorturf(T))
 			var/turf/open/floor/F = T
 			F.wet = TURF_WET_PERMAFROST
-			addtimer(CALLBACK(F,  /turf/open/floor.proc/MakeDry), rand(3000, 3100), TURF_WET_PERMAFROST)
+			addtimer(CALLBACK(F, /turf/open/floor.proc/MakeDry), rand(3000, 3100), TURF_WET_PERMAFROST)
 			for(var/mob/living/carbon/L in T)
 				L.adjustStaminaLoss(stamina_damage)
 				L.bodytemperature -= 230

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -299,7 +299,7 @@
 
 /obj/item/weapon/restraints/legcuffs/beartrap/energy/New()
 	..()
-	addtimer(CALLBACK(src,  .proc/dissipate), 100)
+	addtimer(CALLBACK(src, .proc/dissipate), 100)
 
 /obj/item/weapon/restraints/legcuffs/beartrap/energy/proc/dissipate()
 	if(!istype(loc, /mob))

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -299,7 +299,7 @@
 
 /obj/item/weapon/restraints/legcuffs/beartrap/energy/New()
 	..()
-	addtimer(src, "dissipate", 100)
+	addtimer(CALLBACK(src,  .proc/dissipate), 100)
 
 /obj/item/weapon/restraints/legcuffs/beartrap/energy/proc/dissipate()
 	if(!istype(loc, /mob))

--- a/code/game/objects/items/weapons/implants/implantchair.dm
+++ b/code/game/objects/items/weapons/implants/implantchair.dm
@@ -77,10 +77,10 @@
 		ready_implants--
 		if(!replenishing && auto_replenish)
 			replenishing = TRUE
-			addtimer(src,"replenish",replenish_cooldown)
+			addtimer(CALLBACK(src,"replenish"),replenish_cooldown)
 		if(injection_cooldown > 0)
 			ready = FALSE
-			addtimer(src,"set_ready",injection_cooldown)
+			addtimer(CALLBACK(src,"set_ready"),injection_cooldown)
 	else
 		playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 25, 1)
 	update_icon()
@@ -106,7 +106,7 @@
 	if(ready_implants < max_implants)
 		ready_implants++
 	if(ready_implants < max_implants)
-		addtimer(src,"replenish",replenish_cooldown)
+		addtimer(CALLBACK(src,"replenish"),replenish_cooldown)
 	else
 		replenishing = FALSE
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -271,7 +271,7 @@
 		impale(user)
 		return
 	if((wielded) && prob(50))
-		addtimer(src, "jedi_spin", 0, TIMER_UNIQUE, user)
+		addtimer(CALLBACK(src,  .proc/jedi_spin, user), 0, TIMER_UNIQUE)
 
 /obj/item/weapon/twohanded/dualsaber/proc/jedi_spin(mob/living/user)
 	for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2))
@@ -339,7 +339,7 @@
 	playsound(loc, hitsound, get_clamped_volume(), 1, -1)
 	add_fingerprint(user)
 	// Light your candles while spinning around the room
-	addtimer(src, "jedi_spin", 0, TIMER_UNIQUE, user)
+	addtimer(CALLBACK(src,  .proc/jedi_spin, user), 0, TIMER_UNIQUE)
 
 /obj/item/weapon/twohanded/dualsaber/green/New()
 	item_color = "green"

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -271,7 +271,7 @@
 		impale(user)
 		return
 	if((wielded) && prob(50))
-		addtimer(CALLBACK(src,  .proc/jedi_spin, user), 0, TIMER_UNIQUE)
+		addtimer(CALLBACK(src, .proc/jedi_spin, user), 0, TIMER_UNIQUE)
 
 /obj/item/weapon/twohanded/dualsaber/proc/jedi_spin(mob/living/user)
 	for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2))
@@ -339,7 +339,7 @@
 	playsound(loc, hitsound, get_clamped_volume(), 1, -1)
 	add_fingerprint(user)
 	// Light your candles while spinning around the room
-	addtimer(CALLBACK(src,  .proc/jedi_spin, user), 0, TIMER_UNIQUE)
+	addtimer(CALLBACK(src, .proc/jedi_spin, user), 0, TIMER_UNIQUE)
 
 /obj/item/weapon/twohanded/dualsaber/green/New()
 	item_color = "green"

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -215,7 +215,7 @@ var/global/image/acid_overlay = image("icon" = 'icons/effects/effects.dmi', "ico
 	being_shocked = 1
 	var/power_bounced = power / 2
 	tesla_zap(src, 3, power_bounced)
-	addtimer(src, "reset_shocked", 10)
+	addtimer(CALLBACK(src,  .proc/reset_shocked), 10)
 
 /obj/proc/reset_shocked()
 	being_shocked = 0

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -215,7 +215,7 @@ var/global/image/acid_overlay = image("icon" = 'icons/effects/effects.dmi', "ico
 	being_shocked = 1
 	var/power_bounced = power / 2
 	tesla_zap(src, 3, power_bounced)
-	addtimer(CALLBACK(src,  .proc/reset_shocked), 10)
+	addtimer(CALLBACK(src, .proc/reset_shocked), 10)
 
 /obj/proc/reset_shocked()
 	being_shocked = 0

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -222,7 +222,7 @@
 /obj/structure/alien/egg/New()
 	new /obj/item/clothing/mask/facehugger(src)
 	..()
-	addtimer(CALLBACK(src,  .proc/Grow), rand(MIN_GROWTH_TIME, MAX_GROWTH_TIME))
+	addtimer(CALLBACK(src, .proc/Grow), rand(MIN_GROWTH_TIME, MAX_GROWTH_TIME))
 
 /obj/structure/alien/egg/Destroy()
 	remove_from_proximity_list(src, 1)

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -222,7 +222,7 @@
 /obj/structure/alien/egg/New()
 	new /obj/item/clothing/mask/facehugger(src)
 	..()
-	addtimer(src, "Grow", rand(MIN_GROWTH_TIME, MAX_GROWTH_TIME))
+	addtimer(CALLBACK(src,  .proc/Grow), rand(MIN_GROWTH_TIME, MAX_GROWTH_TIME))
 
 /obj/structure/alien/egg/Destroy()
 	remove_from_proximity_list(src, 1)

--- a/code/game/objects/structures/divine.dm
+++ b/code/game/objects/structures/divine.dm
@@ -36,7 +36,7 @@
 	user << "<span class='notice'>The water feels warm and soothing as you touch it. The fountain immediately dries up shortly afterwards.</span>"
 	user.reagents.add_reagent("godblood",20)
 	update_icons()
-	addtimer(CALLBACK(src,  .proc/update_icons), time_between_uses)
+	addtimer(CALLBACK(src, .proc/update_icons), time_between_uses)
 
 
 /obj/structure/healingfountain/proc/update_icons()

--- a/code/game/objects/structures/divine.dm
+++ b/code/game/objects/structures/divine.dm
@@ -36,7 +36,7 @@
 	user << "<span class='notice'>The water feels warm and soothing as you touch it. The fountain immediately dries up shortly afterwards.</span>"
 	user.reagents.add_reagent("godblood",20)
 	update_icons()
-	addtimer(src, "update_icons", time_between_uses)
+	addtimer(CALLBACK(src,  .proc/update_icons), time_between_uses)
 
 
 /obj/structure/healingfountain/proc/update_icons()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -239,7 +239,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 
 /obj/structure/grille/ratvar/ratvar_act()
 	return

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -239,7 +239,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
 /obj/structure/grille/ratvar/ratvar_act()
 	return

--- a/code/game/objects/structures/hivebot.dm
+++ b/code/game/objects/structures/hivebot.dm
@@ -15,7 +15,7 @@
 	smoke.start()
 	visible_message("<span class='boldannounce'>The [src] warps in!</span>")
 	playsound(src.loc, 'sound/effects/EMPulse.ogg', 25, 1)
-	addtimer(src, "warpbots", rand(10, 600))
+	addtimer(CALLBACK(src,  .proc/warpbots), rand(10, 600))
 
 /obj/structure/hivebot_beacon/proc/warpbots()
 	icon_state = "def_radar"

--- a/code/game/objects/structures/hivebot.dm
+++ b/code/game/objects/structures/hivebot.dm
@@ -15,7 +15,7 @@
 	smoke.start()
 	visible_message("<span class='boldannounce'>The [src] warps in!</span>")
 	playsound(src.loc, 'sound/effects/EMPulse.ogg', 25, 1)
-	addtimer(CALLBACK(src,  .proc/warpbots), rand(10, 600))
+	addtimer(CALLBACK(src, .proc/warpbots), rand(10, 600))
 
 /obj/structure/hivebot_beacon/proc/warpbots()
 	icon_state = "def_radar"

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -99,7 +99,7 @@
 			var/mob/living/M = user
 			M.electrocute_act(15,"Energy Barrier", safety=1)
 			shockcd = TRUE
-			addtimer(src, "cooldown", 5)
+			addtimer(CALLBACK(src,  .proc/cooldown), 5)
 
 /obj/structure/holosign/barrier/cyborg/hacked/Bumped(atom/user)
 	if(!shockcd)
@@ -107,4 +107,4 @@
 			var/mob/living/M = user
 			M.electrocute_act(15,"Energy Barrier", safety=1)
 			shockcd = TRUE
-			addtimer(src, "cooldown", 5)
+			addtimer(CALLBACK(src,  .proc/cooldown), 5)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -99,7 +99,7 @@
 			var/mob/living/M = user
 			M.electrocute_act(15,"Energy Barrier", safety=1)
 			shockcd = TRUE
-			addtimer(CALLBACK(src,  .proc/cooldown), 5)
+			addtimer(CALLBACK(src, .proc/cooldown), 5)
 
 /obj/structure/holosign/barrier/cyborg/hacked/Bumped(atom/user)
 	if(!shockcd)
@@ -107,4 +107,4 @@
 			var/mob/living/M = user
 			M.electrocute_act(15,"Energy Barrier", safety=1)
 			shockcd = TRUE
-			addtimer(CALLBACK(src,  .proc/cooldown), 5)
+			addtimer(CALLBACK(src, .proc/cooldown), 5)

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -97,7 +97,7 @@
 	isSwitchingStates = 0
 
 	if(close_delay != -1)
-		addtimer(src, "Close", close_delay)
+		addtimer(CALLBACK(src,  .proc/Close), close_delay)
 
 /obj/structure/mineral_door/proc/Close()
 	if(isSwitchingStates || state != 1)

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -97,7 +97,7 @@
 	isSwitchingStates = 0
 
 	if(close_delay != -1)
-		addtimer(CALLBACK(src,  .proc/Close), close_delay)
+		addtimer(CALLBACK(src, .proc/Close), close_delay)
 
 /obj/structure/mineral_door/proc/Close()
 	if(isSwitchingStates || state != 1)

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -160,4 +160,4 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -160,4 +160,4 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -187,7 +187,7 @@
 		return
 	// Don't break if they're just flying past
 	if(AM.throwing)
-		addtimer(src, "throw_check", 5, TIMER_NORMAL, AM)
+		addtimer(CALLBACK(src,  .proc/throw_check, AM), 5)
 	else
 		check_break(AM)
 
@@ -342,7 +342,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 
 /obj/structure/table/reinforced/brass/ratvar_act()
 	obj_integrity = max_integrity

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -187,7 +187,7 @@
 		return
 	// Don't break if they're just flying past
 	if(AM.throwing)
-		addtimer(CALLBACK(src,  .proc/throw_check, AM), 5)
+		addtimer(CALLBACK(src, .proc/throw_check, AM), 5)
 	else
 		check_break(AM)
 
@@ -342,7 +342,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
 /obj/structure/table/reinforced/brass/ratvar_act()
 	obj_integrity = max_integrity

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -486,7 +486,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 
 /obj/structure/window/reinforced/clockwork/fulltile
 	icon_state = "clockwork_window"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -486,7 +486,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
 /obj/structure/window/reinforced/clockwork/fulltile
 	icon_state = "clockwork_window"

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -266,4 +266,4 @@
 	if(!wet && wet_time)
 		wet_time = 0
 	if(wet)
-		addtimer(src, "HandleWet", 15)
+		addtimer(CALLBACK(src,  .proc/HandleWet), 15)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -266,4 +266,4 @@
 	if(!wet && wet_time)
 		wet_time = 0
 	if(wet)
-		addtimer(CALLBACK(src,  .proc/HandleWet), 15)
+		addtimer(CALLBACK(src, .proc/HandleWet), 15)

--- a/code/game/turfs/simulated/chasm.dm
+++ b/code/game/turfs/simulated/chasm.dm
@@ -28,7 +28,7 @@
 	for(var/thing in thing_to_check)
 		if(droppable(thing))
 			. = 1
-			addtimer(src, "drop", 0, TIMER_NORMAL, thing)
+			addtimer(CALLBACK(src,  .proc/drop, thing), 0)
 
 /turf/open/chasm/proc/droppable(atom/movable/AM)
 	if(!isliving(AM) && !isobj(AM))

--- a/code/game/turfs/simulated/chasm.dm
+++ b/code/game/turfs/simulated/chasm.dm
@@ -28,7 +28,7 @@
 	for(var/thing in thing_to_check)
 		if(droppable(thing))
 			. = 1
-			addtimer(CALLBACK(src,  .proc/drop, thing), 0)
+			addtimer(CALLBACK(src, .proc/drop, thing), 0)
 
 /turf/open/chasm/proc/droppable(atom/movable/AM)
 	if(!isliving(AM) && !isobj(AM))

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -133,7 +133,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 
 
 /turf/open/floor/bluespace

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -133,7 +133,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
 
 /turf/open/floor/bluespace

--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -134,7 +134,7 @@
 		var/previouscolor = color
 		color = "#FAE48C"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 
 /turf/open/floor/engine/cult/airless
 	initial_gas_mix = "TEMP=2.7"

--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -134,7 +134,7 @@
 		var/previouscolor = color
 		color = "#FAE48C"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
 /turf/open/floor/engine/cult/airless
 	initial_gas_mix = "TEMP=2.7"

--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -24,7 +24,7 @@
 		var/previouscolor = color
 		color = "#FAE48C"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
 /turf/closed/wall/mineral/cult/artificer
 	name = "runed stone wall"
@@ -79,7 +79,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
 /turf/closed/wall/clockwork/dismantle_wall(devastated=0, explode=0)
 	if(devastated)

--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -24,7 +24,7 @@
 		var/previouscolor = color
 		color = "#FAE48C"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 
 /turf/closed/wall/mineral/cult/artificer
 	name = "runed stone wall"
@@ -79,7 +79,7 @@
 		var/previouscolor = color
 		color = "#960000"
 		animate(src, color = previouscolor, time = 8)
-		addtimer(src, "update_atom_colour", 8)
+		addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 
 /turf/closed/wall/clockwork/dismantle_wall(devastated=0, explode=0)
 	if(devastated)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -100,7 +100,7 @@
 
 	//remove our adminhelp verb temporarily to prevent spamming of admins.
 	src.verbs -= /client/verb/adminhelp
-	adminhelptimerid = addtimer(src, "giveadminhelpverb", 1200, TIMER_NORMAL) //2 minute cooldown of admin helps
+	adminhelptimerid = addtimer(CALLBACK(src,  .proc/giveadminhelpverb), 1200) //2 minute cooldown of admin helps
 
 	msg = keywords_lookup(msg)
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -100,7 +100,7 @@
 
 	//remove our adminhelp verb temporarily to prevent spamming of admins.
 	src.verbs -= /client/verb/adminhelp
-	adminhelptimerid = addtimer(CALLBACK(src,  .proc/giveadminhelpverb), 1200) //2 minute cooldown of admin helps
+	adminhelptimerid = addtimer(CALLBACK(src, .proc/giveadminhelpverb), 1200) //2 minute cooldown of admin helps
 
 	msg = keywords_lookup(msg)
 

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -18,7 +18,7 @@ var/highlander = FALSE
 
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] used THERE CAN BE ONLY ONE!</span>")
 	log_admin("[key_name(usr)] used THERE CAN BE ONLY ONE.")
-	addtimer(CALLBACK(SSshuttle.emergency,  /obj/docking_port/mobile/emergency.proc/request, null, 1), 50)
+	addtimer(CALLBACK(SSshuttle.emergency, /obj/docking_port/mobile/emergency.proc/request, null, 1), 50)
 
 /mob/living/carbon/human/proc/make_scottish()
 	ticker.mode.traitors += mind

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -18,7 +18,7 @@ var/highlander = FALSE
 
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] used THERE CAN BE ONLY ONE!</span>")
 	log_admin("[key_name(usr)] used THERE CAN BE ONLY ONE.")
-	addtimer(SSshuttle.emergency, "request", 50, TIMER_NORMAL, null, 1)
+	addtimer(CALLBACK(SSshuttle.emergency,  /obj/docking_port/mobile/emergency.proc/request, null, 1), 50)
 
 /mob/living/carbon/human/proc/make_scottish()
 	ticker.mode.traitors += mind

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -72,7 +72,7 @@
 				D.safe = !D.safe
 
 	for(var/D in open_or_close)
-		addtimer(D, doors_need_closing ? "close" : "open",0, TIMER_NORMAL)
+		addtimer(CALLBACK(D, doors_need_closing ? /obj/machinery/door/airlock.proc/close : /obj/machinery/door/airlock.proc/open), 0)
 
 	sleep(10)
 	cooldown = 0

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -204,7 +204,7 @@
 		I.owner << "<span class='warning'>Your photon projector implant overheats and deactivates!</span>"
 		I.Retract()
 	overheat = FALSE
-	addtimer(CALLBACK(src,  .proc/cooldown), flashcd * 2)
+	addtimer(CALLBACK(src, .proc/cooldown), flashcd * 2)
 
 /obj/item/device/assembly/flash/armimplant/try_use_flash(mob/user = null)
 	if(overheat)
@@ -212,7 +212,7 @@
 			I.owner << "<span class='warning'>Your photon projector is running too hot to be used again so quickly!</span>"
 		return FALSE
 	overheat = TRUE
-	addtimer(CALLBACK(src,  .proc/cooldown), flashcd)
+	addtimer(CALLBACK(src, .proc/cooldown), flashcd)
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	update_icon(1)
 	return TRUE
@@ -275,7 +275,7 @@
 	else if(flash)
 		item_state = "flashshield_flash"
 		item_state = "flashshield_flash"
-		addtimer(CALLBACK(src,  .proc/update_icon), 5)
+		addtimer(CALLBACK(src, .proc/update_icon), 5)
 
 	if(holder)
 		holder.update_icon()

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -204,7 +204,7 @@
 		I.owner << "<span class='warning'>Your photon projector implant overheats and deactivates!</span>"
 		I.Retract()
 	overheat = FALSE
-	addtimer(src, "cooldown", flashcd * 2)
+	addtimer(CALLBACK(src,  .proc/cooldown), flashcd * 2)
 
 /obj/item/device/assembly/flash/armimplant/try_use_flash(mob/user = null)
 	if(overheat)
@@ -212,7 +212,7 @@
 			I.owner << "<span class='warning'>Your photon projector is running too hot to be used again so quickly!</span>"
 		return FALSE
 	overheat = TRUE
-	addtimer(src, "cooldown", flashcd)
+	addtimer(CALLBACK(src,  .proc/cooldown), flashcd)
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	update_icon(1)
 	return TRUE
@@ -275,7 +275,7 @@
 	else if(flash)
 		item_state = "flashshield_flash"
 		item_state = "flashshield_flash"
-		addtimer(src, "update_icon", 5)
+		addtimer(CALLBACK(src,  .proc/update_icon), 5)
 
 	if(holder)
 		holder.update_icon()

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -78,7 +78,7 @@
 /obj/item/device/assembly/prox_sensor/dropped()
 	..()
 	if(scanning)
-		addtimer(src, "sense", 0)
+		addtimer(CALLBACK(src,  .proc/sense), 0)
 
 /obj/item/device/assembly/prox_sensor/Destroy()
 	remove_from_proximity_list(src, sensitivity)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -78,7 +78,7 @@
 /obj/item/device/assembly/prox_sensor/dropped()
 	..()
 	if(scanning)
-		addtimer(CALLBACK(src,  .proc/sense), 0)
+		addtimer(CALLBACK(src, .proc/sense), 0)
 
 /obj/item/device/assembly/prox_sensor/Destroy()
 	remove_from_proximity_list(src, sensitivity)

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -227,7 +227,7 @@
 		var/turf/T = get_turf(body)
 		new /obj/effect/ctf/ammo(T)
 		recently_dead_ckeys += body.ckey
-		addtimer(src, "clear_cooldown", respawn_cooldown, TIMER_UNIQUE, body.ckey)
+		addtimer(CALLBACK(src,  .proc/clear_cooldown, body.ckey), respawn_cooldown, TIMER_UNIQUE)
 		body.dust()
 
 /obj/machinery/capture_the_flag/proc/clear_cooldown(var/ckey)
@@ -280,7 +280,7 @@
 			CTF.ctf_enabled = FALSE
 			CTF.team_members = list()
 			CTF.arena_cleared = FALSE
-			addtimer(CTF, "start_ctf", 300)
+			addtimer(CALLBACK(CTF,  .proc/start_ctf), 300)
 
 /obj/machinery/capture_the_flag/proc/toggle_ctf()
 	if(!ctf_enabled)
@@ -338,7 +338,7 @@
 
 /obj/item/weapon/gun/ballistic/automatic/pistol/deagle/ctf/dropped()
 	. = ..()
-	addtimer(src, "floor_vanish", 1)
+	addtimer(CALLBACK(src,  .proc/floor_vanish), 1)
 
 /obj/item/weapon/gun/ballistic/automatic/pistol/deagle/ctf/proc/floor_vanish()
 	if(isturf(loc))
@@ -369,7 +369,7 @@
 
 /obj/item/ammo_box/magazine/recharge/ctf/dropped()
 	. = ..()
-	addtimer(src, "floor_vanish", 1)
+	addtimer(CALLBACK(src,  .proc/floor_vanish), 1)
 
 /obj/item/ammo_box/magazine/recharge/ctf/proc/floor_vanish()
 	if(isturf(loc))

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -227,7 +227,7 @@
 		var/turf/T = get_turf(body)
 		new /obj/effect/ctf/ammo(T)
 		recently_dead_ckeys += body.ckey
-		addtimer(CALLBACK(src,  .proc/clear_cooldown, body.ckey), respawn_cooldown, TIMER_UNIQUE)
+		addtimer(CALLBACK(src, .proc/clear_cooldown, body.ckey), respawn_cooldown, TIMER_UNIQUE)
 		body.dust()
 
 /obj/machinery/capture_the_flag/proc/clear_cooldown(var/ckey)
@@ -280,7 +280,7 @@
 			CTF.ctf_enabled = FALSE
 			CTF.team_members = list()
 			CTF.arena_cleared = FALSE
-			addtimer(CALLBACK(CTF,  .proc/start_ctf), 300)
+			addtimer(CALLBACK(CTF, .proc/start_ctf), 300)
 
 /obj/machinery/capture_the_flag/proc/toggle_ctf()
 	if(!ctf_enabled)
@@ -338,7 +338,7 @@
 
 /obj/item/weapon/gun/ballistic/automatic/pistol/deagle/ctf/dropped()
 	. = ..()
-	addtimer(CALLBACK(src,  .proc/floor_vanish), 1)
+	addtimer(CALLBACK(src, .proc/floor_vanish), 1)
 
 /obj/item/weapon/gun/ballistic/automatic/pistol/deagle/ctf/proc/floor_vanish()
 	if(isturf(loc))
@@ -369,7 +369,7 @@
 
 /obj/item/ammo_box/magazine/recharge/ctf/dropped()
 	. = ..()
-	addtimer(CALLBACK(src,  .proc/floor_vanish), 1)
+	addtimer(CALLBACK(src, .proc/floor_vanish), 1)
 
 /obj/item/ammo_box/magazine/recharge/ctf/proc/floor_vanish()
 	if(isturf(loc))

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -67,7 +67,7 @@
 				O.invisibility = 0
 				invis_objects += O
 
-	addtimer(CALLBACK(src,  .proc/invis_update), 5)
+	addtimer(CALLBACK(src, .proc/invis_update), 5)
 
 /obj/item/clothing/glasses/meson/engine/proc/invis_update()
 	for(var/obj/O in invis_objects)

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -67,7 +67,7 @@
 				O.invisibility = 0
 				invis_objects += O
 
-	addtimer(src, "invis_update", 5)
+	addtimer(CALLBACK(src,  .proc/invis_update), 5)
 
 /obj/item/clothing/glasses/meson/engine/proc/invis_update()
 	for(var/obj/O in invis_objects)

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -147,12 +147,12 @@
 		user.Stun(INFINITY)
 
 		animate(user, color = "#00ccee", time = 3)
-		phase_timer_id = addtimer(CALLBACK(src,  .proc/phase_2, user, to_turf, phase_in_ds), 3)
+		phase_timer_id = addtimer(CALLBACK(src, .proc/phase_2, user, to_turf, phase_in_ds), 3)
 
 /obj/item/clothing/suit/space/chronos/proc/phase_2(mob/living/carbon/human/user, turf/to_turf, phase_in_ds)
 	if(teleporting && activated && user)
 		animate(user, alpha = 0, time = 2)
-		phase_timer_id = addtimer(CALLBACK(src,  .proc/phase_3, user, to_turf, phase_in_ds), 2)
+		phase_timer_id = addtimer(CALLBACK(src, .proc/phase_3, user, to_turf, phase_in_ds), 2)
 	else
 		finish_chronowalk(user, to_turf)
 
@@ -160,14 +160,14 @@
 	if(teleporting && activated && user)
 		user.forceMove(to_turf)
 		animate(user, alpha = 255, time = phase_in_ds)
-		phase_timer_id = addtimer(CALLBACK(src,  .proc/phase_4, user, to_turf), phase_in_ds)
+		phase_timer_id = addtimer(CALLBACK(src, .proc/phase_4, user, to_turf), phase_in_ds)
 	else
 		finish_chronowalk(user, to_turf)
 
 /obj/item/clothing/suit/space/chronos/proc/phase_4(mob/living/carbon/human/user, turf/to_turf)
 	if(teleporting && activated && user)
 		animate(user, color = "#ffffff", time = 3)
-		phase_timer_id = addtimer(CALLBACK(src,  .proc/finish_chronowalk, user, to_turf), 3)
+		phase_timer_id = addtimer(CALLBACK(src, .proc/finish_chronowalk, user, to_turf), 3)
 	else
 		finish_chronowalk(user, to_turf)
 

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -147,12 +147,12 @@
 		user.Stun(INFINITY)
 
 		animate(user, color = "#00ccee", time = 3)
-		phase_timer_id = addtimer(src, "phase_2", 3, TIMER_NORMAL, user, to_turf, phase_in_ds)
+		phase_timer_id = addtimer(CALLBACK(src,  .proc/phase_2, user, to_turf, phase_in_ds), 3)
 
 /obj/item/clothing/suit/space/chronos/proc/phase_2(mob/living/carbon/human/user, turf/to_turf, phase_in_ds)
 	if(teleporting && activated && user)
 		animate(user, alpha = 0, time = 2)
-		phase_timer_id = addtimer(src, "phase_3", 2, TIMER_NORMAL, user, to_turf, phase_in_ds)
+		phase_timer_id = addtimer(CALLBACK(src,  .proc/phase_3, user, to_turf, phase_in_ds), 2)
 	else
 		finish_chronowalk(user, to_turf)
 
@@ -160,14 +160,14 @@
 	if(teleporting && activated && user)
 		user.forceMove(to_turf)
 		animate(user, alpha = 255, time = phase_in_ds)
-		phase_timer_id = addtimer(src, "phase_4", phase_in_ds, TIMER_NORMAL, user, to_turf)
+		phase_timer_id = addtimer(CALLBACK(src,  .proc/phase_4, user, to_turf), phase_in_ds)
 	else
 		finish_chronowalk(user, to_turf)
 
 /obj/item/clothing/suit/space/chronos/proc/phase_4(mob/living/carbon/human/user, turf/to_turf)
 	if(teleporting && activated && user)
 		animate(user, color = "#ffffff", time = 3)
-		phase_timer_id = addtimer(src, "finish_chronowalk", 3, TIMER_NORMAL, user, to_turf)
+		phase_timer_id = addtimer(CALLBACK(src,  .proc/finish_chronowalk, user, to_turf), 3)
 	else
 		finish_chronowalk(user, to_turf)
 

--- a/code/modules/clothing/spacesuits/flightsuit.dm
+++ b/code/modules/clothing/spacesuits/flightsuit.dm
@@ -303,7 +303,7 @@
 		if(!suit)
 			disable_flight(1)
 		if(!resync)
-			addtimer(CALLBACK(src,  .proc/resync), 600)
+			addtimer(CALLBACK(src, .proc/resync), 600)
 			resync = 1
 		if(!wearer)	//Oh god our user fell off!
 			disable_flight(1)
@@ -672,7 +672,7 @@
 			return TRUE
 		usermessage("Warning: Velocity too high to safely disengage. Retry to confirm emergency shutoff.", 2)
 		override_safe = TRUE
-		addtimer(CALLBACK(src,  .proc/enable_safe), 50)
+		addtimer(CALLBACK(src, .proc/enable_safe), 50)
 		return FALSE
 	update_icon()
 

--- a/code/modules/clothing/spacesuits/flightsuit.dm
+++ b/code/modules/clothing/spacesuits/flightsuit.dm
@@ -303,7 +303,7 @@
 		if(!suit)
 			disable_flight(1)
 		if(!resync)
-			addtimer(src, "resync", 600, TIMER_NORMAL)
+			addtimer(CALLBACK(src,  .proc/resync), 600)
 			resync = 1
 		if(!wearer)	//Oh god our user fell off!
 			disable_flight(1)
@@ -672,7 +672,7 @@
 			return TRUE
 		usermessage("Warning: Velocity too high to safely disengage. Retry to confirm emergency shutoff.", 2)
 		override_safe = TRUE
-		addtimer(src, "enable_safe", 50, TIMER_NORMAL)
+		addtimer(CALLBACK(src,  .proc/enable_safe), 50)
 		return FALSE
 	update_icon()
 

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -249,7 +249,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	if(target_dist<=3) //"Eaten"
 		target.hal_screwyhud = 1
 		target.SetSleeping(20)
-		addtimer(src, "wake_and_restore", rand(50, 100))
+		addtimer(CALLBACK(src,  .proc/wake_and_restore), rand(50, 100))
 
 /obj/effect/hallucination/battle
 
@@ -400,7 +400,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	my_target = T
 	QDEL_IN(src, 300)
 	step_away(src,my_target,2)
-	addtimer(src, "attack_loop", 0)
+	addtimer(CALLBACK(src,  .proc/attack_loop), 0)
 
 
 /obj/effect/fake_attacker/proc/updateimage()

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -249,7 +249,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	if(target_dist<=3) //"Eaten"
 		target.hal_screwyhud = 1
 		target.SetSleeping(20)
-		addtimer(CALLBACK(src,  .proc/wake_and_restore), rand(50, 100))
+		addtimer(CALLBACK(src, .proc/wake_and_restore), rand(50, 100))
 
 /obj/effect/hallucination/battle
 
@@ -400,7 +400,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	my_target = T
 	QDEL_IN(src, 300)
 	step_away(src,my_target,2)
-	addtimer(CALLBACK(src,  .proc/attack_loop), 0)
+	addtimer(CALLBACK(src, .proc/attack_loop), 0)
 
 
 /obj/effect/fake_attacker/proc/updateimage()

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -77,7 +77,7 @@
 		if(iscyborg(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
 			var/mob/living/silicon/robot/bro = user
 			bro.cell.use(30)
-			addtimer(reagents, "add_reagent", 600, TIMER_NORMAL, refill, trans)
+			addtimer(CALLBACK(reagents,  /datum/reagents.proc/add_reagent, refill, trans), 600)
 
 /obj/item/weapon/reagent_containers/food/drinks/attackby(obj/item/I, mob/user, params)
 	if(I.is_hot())

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -77,7 +77,7 @@
 		if(iscyborg(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
 			var/mob/living/silicon/robot/bro = user
 			bro.cell.use(30)
-			addtimer(CALLBACK(reagents,  /datum/reagents.proc/add_reagent, refill, trans), 600)
+			addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent, refill, trans), 600)
 
 /obj/item/weapon/reagent_containers/food/drinks/attackby(obj/item/I, mob/user, params)
 	if(I.is_hot())

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -369,7 +369,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/lollipop/cyborg/New()
 	..()
-	addtimer(src, "spamcheck", 1200)
+	addtimer(CALLBACK(src,  .proc/spamcheck), 1200)
 
 /obj/item/weapon/reagent_containers/food/snacks/lollipop/cyborg/equipped(mob/living/user, slot)
 	. = ..(user, slot)
@@ -395,7 +395,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/gumball/cyborg/New()
 	..()
-	addtimer(src, "spamcheck", 1200)
+	addtimer(CALLBACK(src,  .proc/spamcheck), 1200)
 
 /obj/item/weapon/reagent_containers/food/snacks/gumball/cyborg/equipped(mob/living/user, slot)
 	. = ..(user, slot)

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -369,7 +369,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/lollipop/cyborg/New()
 	..()
-	addtimer(CALLBACK(src,  .proc/spamcheck), 1200)
+	addtimer(CALLBACK(src, .proc/spamcheck), 1200)
 
 /obj/item/weapon/reagent_containers/food/snacks/lollipop/cyborg/equipped(mob/living/user, slot)
 	. = ..(user, slot)
@@ -395,7 +395,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/gumball/cyborg/New()
 	..()
-	addtimer(CALLBACK(src,  .proc/spamcheck), 1200)
+	addtimer(CALLBACK(src, .proc/spamcheck), 1200)
 
 /obj/item/weapon/reagent_containers/food/snacks/gumball/cyborg/equipped(mob/living/user, slot)
 	. = ..(user, slot)

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -88,7 +88,7 @@
 
 /turf/open/floor/holofloor/carpet/New()
 	..()
-	addtimer(CALLBACK(src,  .proc/update_icon), 1)
+	addtimer(CALLBACK(src, .proc/update_icon), 1)
 
 /turf/open/floor/holofloor/carpet/update_icon()
 	if(!..())

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -88,7 +88,7 @@
 
 /turf/open/floor/holofloor/carpet/New()
 	..()
-	addtimer(src, "update_icon", 1)
+	addtimer(CALLBACK(src,  .proc/update_icon), 1)
 
 /turf/open/floor/holofloor/carpet/update_icon()
 	if(!..())

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -117,7 +117,7 @@
 		C.throw_mode_on()
 	icon_state = "firelemon_active"
 	playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
-	addtimer(src, "prime", rand(10, 60))
+	addtimer(CALLBACK(src,  .proc/prime), rand(10, 60))
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/firelemon/burn()
 	prime()

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -117,7 +117,7 @@
 		C.throw_mode_on()
 	icon_state = "firelemon_active"
 	playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
-	addtimer(CALLBACK(src,  .proc/prime), rand(10, 60))
+	addtimer(CALLBACK(src, .proc/prime), rand(10, 60))
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/firelemon/burn()
 	prime()

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -155,7 +155,7 @@
 				L.Weaken(3)
 				if(ishuman(L))
 					shake_camera(L, 20, 1)
-					addtimer(L, "vomit", 20)
+					addtimer(CALLBACK(L,  /mob/living/carbon.proc/vomit), 20)
 
 /**********************Resonator**********************/
 
@@ -234,7 +234,7 @@
 	if(pressure < 50)
 		name = "strong resonance field"
 		resonance_damage = 60
-	addtimer(src, "burst", timetoburst, TIMER_NORMAL, proj_turf)
+	addtimer(CALLBACK(src,  .proc/burst, proj_turf), timetoburst)
 
 /obj/effect/resonance/Destroy()
 	if(res)
@@ -548,7 +548,7 @@
 		D.fire()
 		charged = 0
 		icon_state = "mining_hammer1_uncharged"
-		addtimer(src, "Recharge", charge_time)
+		addtimer(CALLBACK(src,  .proc/Recharge), charge_time)
 		return
 	if(proximity_flag && target == mark && isliving(target))
 		var/mob/living/L = target

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -155,7 +155,7 @@
 				L.Weaken(3)
 				if(ishuman(L))
 					shake_camera(L, 20, 1)
-					addtimer(CALLBACK(L,  /mob/living/carbon.proc/vomit), 20)
+					addtimer(CALLBACK(L, /mob/living/carbon.proc/vomit), 20)
 
 /**********************Resonator**********************/
 
@@ -234,7 +234,7 @@
 	if(pressure < 50)
 		name = "strong resonance field"
 		resonance_damage = 60
-	addtimer(CALLBACK(src,  .proc/burst, proj_turf), timetoburst)
+	addtimer(CALLBACK(src, .proc/burst, proj_turf), timetoburst)
 
 /obj/effect/resonance/Destroy()
 	if(res)
@@ -548,7 +548,7 @@
 		D.fire()
 		charged = 0
 		icon_state = "mining_hammer1_uncharged"
-		addtimer(CALLBACK(src,  .proc/Recharge), charge_time)
+		addtimer(CALLBACK(src, .proc/Recharge), charge_time)
 		return
 	if(proximity_flag && target == mark && isliving(target))
 		var/mob/living/L = target

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -19,7 +19,7 @@
 	..()
 	Radio = new/obj/item/device/radio(src)
 	Radio.listening = 0
-	addtimer(CALLBACK(src,  .proc/locate_stacking_machine), 7)
+	addtimer(CALLBACK(src, .proc/locate_stacking_machine), 7)
 
 /obj/machinery/mineral/labor_claim_console/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/card/id/prisoner))

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -19,7 +19,7 @@
 	..()
 	Radio = new/obj/item/device/radio(src)
 	Radio.listening = 0
-	addtimer(src, "locate_stacking_machine", 7)
+	addtimer(CALLBACK(src,  .proc/locate_stacking_machine), 7)
 
 /obj/machinery/mineral/labor_claim_console/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/card/id/prisoner))

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -46,7 +46,7 @@
 	name = harvested_name
 	desc = harvested_desc
 	harvested = TRUE
-	addtimer(src, "regrow", rand(regrowth_time_low, regrowth_time_high))
+	addtimer(CALLBACK(src,  .proc/regrow), rand(regrowth_time_low, regrowth_time_high))
 	return 1
 
 /obj/structure/flora/ash/proc/regrow()

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -46,7 +46,7 @@
 	name = harvested_name
 	desc = harvested_desc
 	harvested = TRUE
-	addtimer(CALLBACK(src,  .proc/regrow), rand(regrowth_time_low, regrowth_time_high))
+	addtimer(CALLBACK(src, .proc/regrow), rand(regrowth_time_low, regrowth_time_high))
 	return 1
 
 /obj/structure/flora/ash/proc/regrow()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -796,11 +796,11 @@
 	calculate_anger_mod(user)
 	timer = world.time + CLICK_CD_MELEE //by default, melee attacks only cause melee blasts, and have an accordingly short cooldown
 	if(proximity_flag)
-		addtimer(CALLBACK(src,  .proc/aoe_burst, T, user), 0)
+		addtimer(CALLBACK(src, .proc/aoe_burst, T, user), 0)
 		add_logs(user, target, "fired 3x3 blast at", src)
 	else
 		if(ismineralturf(target) && get_dist(user, target) < 6) //target is minerals, we can hit it(even if we can't see it)
-			addtimer(CALLBACK(src,  .proc/cardinal_blasts, T, user), 0)
+			addtimer(CALLBACK(src, .proc/cardinal_blasts, T, user), 0)
 			timer = world.time + cooldown_time
 		else if(target in view(5, get_turf(user))) //if the target is in view, hit it
 			timer = world.time + cooldown_time
@@ -809,12 +809,12 @@
 				PoolOrNew(/obj/effect/overlay/temp/hierophant/chaser, list(get_turf(user), user, target, chaser_speed, friendly_fire_check))
 				add_logs(user, target, "fired a chaser at", src)
 			else
-				addtimer(CALLBACK(src,  .proc/cardinal_blasts, T, user), 0) //otherwise, just do cardinal blast
+				addtimer(CALLBACK(src, .proc/cardinal_blasts, T, user), 0) //otherwise, just do cardinal blast
 				add_logs(user, target, "fired cardinal blast at", src)
 		else
 			user << "<span class='warning'>That target is out of range!</span>" //too far away
 			timer = world.time
-	addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
+	addtimer(CALLBACK(src, .proc/prepare_icon_update), 0)
 
 /obj/item/weapon/hierophant_club/proc/calculate_anger_mod(mob/user) //we get stronger as the user loses health
 	chaser_cooldown = initial(chaser_cooldown)
@@ -857,7 +857,7 @@
 			user.visible_message("<span class='hierophant_warning'>[user] starts fiddling with [src]'s pommel...</span>", \
 			"<span class='notice'>You start detaching the hierophant beacon...</span>")
 			timer = world.time + 51
-			addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
+			addtimer(CALLBACK(src, .proc/prepare_icon_update), 0)
 			if(do_after(user, 50, target = user) && !beacon)
 				var/turf/T = get_turf(user)
 				playsound(T,'sound/magic/Blind.ogg', 200, 1, -4)
@@ -869,7 +869,7 @@
 				<span class='notice'>You can remove the beacon to place it again by striking it with the club.</span>")
 			else
 				timer = world.time
-				addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
+				addtimer(CALLBACK(src, .proc/prepare_icon_update), 0)
 		else
 			user << "<span class='warning'>You need to be on solid ground to detach the beacon!</span>"
 		return
@@ -886,7 +886,7 @@
 	user.update_action_buttons_icon()
 	user.visible_message("<span class='hierophant_warning'>[user] starts to glow faintly...</span>")
 	timer = world.time + 50
-	addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
+	addtimer(CALLBACK(src, .proc/prepare_icon_update), 0)
 	beacon.icon_state = "hierophant_tele_on"
 	var/obj/effect/overlay/temp/hierophant/telegraph/edge/TE1 = PoolOrNew(/obj/effect/overlay/temp/hierophant/telegraph/edge, user.loc)
 	var/obj/effect/overlay/temp/hierophant/telegraph/edge/TE2 = PoolOrNew(/obj/effect/overlay/temp/hierophant/telegraph/edge, beacon.loc)
@@ -898,7 +898,7 @@
 			user << "<span class='warning'>The beacon is blocked by something, preventing teleportation!</span>"
 			user.update_action_buttons_icon()
 			timer = world.time
-			addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
+			addtimer(CALLBACK(src, .proc/prepare_icon_update), 0)
 			beacon.icon_state = "hierophant_tele_off"
 			return
 		PoolOrNew(/obj/effect/overlay/temp/hierophant/telegraph, list(T, user))
@@ -910,7 +910,7 @@
 			if(user)
 				user.update_action_buttons_icon()
 			timer = world.time
-			addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
+			addtimer(CALLBACK(src, .proc/prepare_icon_update), 0)
 			if(beacon)
 				beacon.icon_state = "hierophant_tele_off"
 			return
@@ -919,7 +919,7 @@
 			user << "<span class='warning'>The beacon is blocked by something, preventing teleportation!</span>"
 			user.update_action_buttons_icon()
 			timer = world.time
-			addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
+			addtimer(CALLBACK(src, .proc/prepare_icon_update), 0)
 			beacon.icon_state = "hierophant_tele_off"
 			return
 		add_logs(user, beacon, "teleported self from ([source.x],[source.y],[source.z]) to")
@@ -932,7 +932,7 @@
 			var/obj/effect/overlay/temp/hierophant/blast/B = PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(t, user, TRUE)) //but absolutely will hurt enemies
 			B.damage = 30
 		for(var/mob/living/L in range(1, source))
-			addtimer(CALLBACK(src,  .proc/teleport_mob, source, L, T, user), 0) //regardless, take all mobs near us along
+			addtimer(CALLBACK(src, .proc/teleport_mob, source, L, T, user), 0) //regardless, take all mobs near us along
 		sleep(6) //at this point the blasts detonate
 		if(beacon)
 			beacon.icon_state = "hierophant_tele_off"
@@ -940,7 +940,7 @@
 		qdel(TE1)
 		qdel(TE2)
 		timer = world.time
-		addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
+		addtimer(CALLBACK(src, .proc/prepare_icon_update), 0)
 	if(beacon)
 		beacon.icon_state = "hierophant_tele_off"
 	teleporting = FALSE
@@ -979,7 +979,7 @@
 	sleep(2)
 	PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(T, user, friendly_fire_check))
 	for(var/d in cardinal)
-		addtimer(CALLBACK(src,  .proc/blast_wall, T, d, user), 0)
+		addtimer(CALLBACK(src, .proc/blast_wall, T, d, user), 0)
 
 /obj/item/weapon/hierophant_club/proc/blast_wall(turf/T, dir, mob/living/user) //make a wall of blasts blast_range tiles long
 	if(!T)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -796,11 +796,11 @@
 	calculate_anger_mod(user)
 	timer = world.time + CLICK_CD_MELEE //by default, melee attacks only cause melee blasts, and have an accordingly short cooldown
 	if(proximity_flag)
-		addtimer(src, "aoe_burst", 0, TIMER_NORMAL, T, user)
+		addtimer(CALLBACK(src,  .proc/aoe_burst, T, user), 0)
 		add_logs(user, target, "fired 3x3 blast at", src)
 	else
 		if(ismineralturf(target) && get_dist(user, target) < 6) //target is minerals, we can hit it(even if we can't see it)
-			addtimer(src, "cardinal_blasts", 0, TIMER_NORMAL, T, user)
+			addtimer(CALLBACK(src,  .proc/cardinal_blasts, T, user), 0)
 			timer = world.time + cooldown_time
 		else if(target in view(5, get_turf(user))) //if the target is in view, hit it
 			timer = world.time + cooldown_time
@@ -809,12 +809,12 @@
 				PoolOrNew(/obj/effect/overlay/temp/hierophant/chaser, list(get_turf(user), user, target, chaser_speed, friendly_fire_check))
 				add_logs(user, target, "fired a chaser at", src)
 			else
-				addtimer(src, "cardinal_blasts", 0, TIMER_NORMAL, T, user) //otherwise, just do cardinal blast
+				addtimer(CALLBACK(src,  .proc/cardinal_blasts, T, user), 0) //otherwise, just do cardinal blast
 				add_logs(user, target, "fired cardinal blast at", src)
 		else
 			user << "<span class='warning'>That target is out of range!</span>" //too far away
 			timer = world.time
-	addtimer(src, "prepare_icon_update", 0)
+	addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
 
 /obj/item/weapon/hierophant_club/proc/calculate_anger_mod(mob/user) //we get stronger as the user loses health
 	chaser_cooldown = initial(chaser_cooldown)
@@ -857,7 +857,7 @@
 			user.visible_message("<span class='hierophant_warning'>[user] starts fiddling with [src]'s pommel...</span>", \
 			"<span class='notice'>You start detaching the hierophant beacon...</span>")
 			timer = world.time + 51
-			addtimer(src, "prepare_icon_update", 0)
+			addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
 			if(do_after(user, 50, target = user) && !beacon)
 				var/turf/T = get_turf(user)
 				playsound(T,'sound/magic/Blind.ogg', 200, 1, -4)
@@ -869,7 +869,7 @@
 				<span class='notice'>You can remove the beacon to place it again by striking it with the club.</span>")
 			else
 				timer = world.time
-				addtimer(src, "prepare_icon_update", 0)
+				addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
 		else
 			user << "<span class='warning'>You need to be on solid ground to detach the beacon!</span>"
 		return
@@ -886,7 +886,7 @@
 	user.update_action_buttons_icon()
 	user.visible_message("<span class='hierophant_warning'>[user] starts to glow faintly...</span>")
 	timer = world.time + 50
-	addtimer(src, "prepare_icon_update", 0)
+	addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
 	beacon.icon_state = "hierophant_tele_on"
 	var/obj/effect/overlay/temp/hierophant/telegraph/edge/TE1 = PoolOrNew(/obj/effect/overlay/temp/hierophant/telegraph/edge, user.loc)
 	var/obj/effect/overlay/temp/hierophant/telegraph/edge/TE2 = PoolOrNew(/obj/effect/overlay/temp/hierophant/telegraph/edge, beacon.loc)
@@ -898,7 +898,7 @@
 			user << "<span class='warning'>The beacon is blocked by something, preventing teleportation!</span>"
 			user.update_action_buttons_icon()
 			timer = world.time
-			addtimer(src, "prepare_icon_update", 0)
+			addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
 			beacon.icon_state = "hierophant_tele_off"
 			return
 		PoolOrNew(/obj/effect/overlay/temp/hierophant/telegraph, list(T, user))
@@ -910,7 +910,7 @@
 			if(user)
 				user.update_action_buttons_icon()
 			timer = world.time
-			addtimer(src, "prepare_icon_update", 0)
+			addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
 			if(beacon)
 				beacon.icon_state = "hierophant_tele_off"
 			return
@@ -919,7 +919,7 @@
 			user << "<span class='warning'>The beacon is blocked by something, preventing teleportation!</span>"
 			user.update_action_buttons_icon()
 			timer = world.time
-			addtimer(src, "prepare_icon_update", 0)
+			addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
 			beacon.icon_state = "hierophant_tele_off"
 			return
 		add_logs(user, beacon, "teleported self from ([source.x],[source.y],[source.z]) to")
@@ -932,7 +932,7 @@
 			var/obj/effect/overlay/temp/hierophant/blast/B = PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(t, user, TRUE)) //but absolutely will hurt enemies
 			B.damage = 30
 		for(var/mob/living/L in range(1, source))
-			addtimer(src, "teleport_mob", 0, TIMER_NORMAL, source, L, T, user) //regardless, take all mobs near us along
+			addtimer(CALLBACK(src,  .proc/teleport_mob, source, L, T, user), 0) //regardless, take all mobs near us along
 		sleep(6) //at this point the blasts detonate
 		if(beacon)
 			beacon.icon_state = "hierophant_tele_off"
@@ -940,7 +940,7 @@
 		qdel(TE1)
 		qdel(TE2)
 		timer = world.time
-		addtimer(src, "prepare_icon_update", 0)
+		addtimer(CALLBACK(src,  .proc/prepare_icon_update), 0)
 	if(beacon)
 		beacon.icon_state = "hierophant_tele_off"
 	teleporting = FALSE
@@ -979,7 +979,7 @@
 	sleep(2)
 	PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(T, user, friendly_fire_check))
 	for(var/d in cardinal)
-		addtimer(src, "blast_wall", 0, TIMER_NORMAL, T, d, user)
+		addtimer(CALLBACK(src,  .proc/blast_wall, T, d, user), 0)
 
 /obj/item/weapon/hierophant_club/proc/blast_wall(turf/T, dir, mob/living/user) //make a wall of blasts blast_range tiles long
 	if(!T)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -625,7 +625,7 @@ interface with the mining shuttle at the landing site if a mobile beacon is also
 		return
 
 	anti_spam_cd = 1
-	addtimer(src, "clear_cooldown", 100)
+	addtimer(CALLBACK(src,  .proc/clear_cooldown), 100)
 
 	var/turf/landing_spot = get_turf(src)
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -625,7 +625,7 @@ interface with the mining shuttle at the landing site if a mobile beacon is also
 		return
 
 	anti_spam_cd = 1
-	addtimer(CALLBACK(src,  .proc/clear_cooldown), 100)
+	addtimer(CALLBACK(src, .proc/clear_cooldown), 100)
 
 	var/turf/landing_spot = get_turf(src)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -118,13 +118,13 @@ var/list/image/ghost_images_simple = list() //this is a list of all ghost images
 	var/old_color = color
 	color = "#960000"
 	animate(src, color = old_color, time = 10)
-	addtimer(src, "update_atom_colour", 10)
+	addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 10)
 
 /mob/dead/observer/ratvar_act()
 	var/old_color = color
 	color = "#FAE48C"
 	animate(src, color = old_color, time = 10)
-	addtimer(src, "update_atom_colour", 10)
+	addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 10)
 
 /mob/dead/observer/Destroy()
 	ghost_images_full -= ghostimage
@@ -501,14 +501,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	listclearnulls(ghost_images_default)
 	listclearnulls(ghost_images_simple)
 	listclearnulls(ghost_darkness_images)
-	
+
 	for (var/mob/dead/observer/O in player_list)
 		O.updateghostimages()
 
 /mob/dead/observer/proc/updateghostimages()
 	if (!client)
 		return
-	
+
 	if(lastsetting)
 		switch(lastsetting) //checks the setting we last came from, for a little efficiency so we don't try to delete images from the client that it doesn't have anyway
 			if(GHOST_OTHERS_THEIR_SETTING)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -118,13 +118,13 @@ var/list/image/ghost_images_simple = list() //this is a list of all ghost images
 	var/old_color = color
 	color = "#960000"
 	animate(src, color = old_color, time = 10)
-	addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 10)
+	addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 10)
 
 /mob/dead/observer/ratvar_act()
 	var/old_color = color
 	color = "#FAE48C"
 	animate(src, color = old_color, time = 10)
-	addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 10)
+	addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 10)
 
 /mob/dead/observer/Destroy()
 	ghost_images_full -= ghostimage

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -743,7 +743,7 @@
 		tryWalk(TARGET)
 	LAST_TARGET = TARGET
 	if(alternateProcessing)
-		addtimer(src, "doProcess", processTime)
+		addtimer(CALLBACK(src,  .proc/doProcess), processTime)
 
 /mob/living/carbon/human/interactive/proc/favouredObjIn(var/list/inList)
 	var/list/outList = list()

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -743,7 +743,7 @@
 		tryWalk(TARGET)
 	LAST_TARGET = TARGET
 	if(alternateProcessing)
-		addtimer(CALLBACK(src,  .proc/doProcess), processTime)
+		addtimer(CALLBACK(src, .proc/doProcess), processTime)
 
 /mob/living/carbon/human/interactive/proc/favouredObjIn(var/list/inList)
 	var/list/outList = list()

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -40,7 +40,7 @@ var/global/posibrain_notif_cooldown = 0
 		notify_ghosts("[name] [msg] in [get_area(src)]!", ghost_sound = !newlymade ? 'sound/effects/ghost2.ogg':null, enter_link = "<a href=?src=\ref[src];activate=1>(Click to enter)</a>", source = src, action = NOTIFY_ATTACK)
 		if(!newlymade)
 			posibrain_notif_cooldown = 1
-			addtimer(src, "reset_posibrain_cooldown", askDelay, TIMER_NORMAL)
+			addtimer(CALLBACK(src,  .proc/reset_posibrain_cooldown), askDelay)
 
 /obj/item/device/mmi/posibrain/proc/reset_posibrain_cooldown()
 	posibrain_notif_cooldown = 0

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -40,7 +40,7 @@ var/global/posibrain_notif_cooldown = 0
 		notify_ghosts("[name] [msg] in [get_area(src)]!", ghost_sound = !newlymade ? 'sound/effects/ghost2.ogg':null, enter_link = "<a href=?src=\ref[src];activate=1>(Click to enter)</a>", source = src, action = NOTIFY_ATTACK)
 		if(!newlymade)
 			posibrain_notif_cooldown = 1
-			addtimer(CALLBACK(src,  .proc/reset_posibrain_cooldown), askDelay)
+			addtimer(CALLBACK(src, .proc/reset_posibrain_cooldown), askDelay)
 
 /obj/item/device/mmi/posibrain/proc/reset_posibrain_cooldown()
 	posibrain_notif_cooldown = 0

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -33,7 +33,7 @@
 	if(ticker && ticker.mode)
 		sql_report_death(src)
 	if(mind && mind.devilinfo)
-		addtimer(CALLBACK(mind.devilinfo,  /datum/devilinfo.proc/beginResurrectionCheck, src), 0)
+		addtimer(CALLBACK(mind.devilinfo, /datum/devilinfo.proc/beginResurrectionCheck, src), 0)
 
 /mob/living/carbon/human/proc/makeSkeleton()
 	status_flags |= DISFIGURED

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -33,7 +33,7 @@
 	if(ticker && ticker.mode)
 		sql_report_death(src)
 	if(mind && mind.devilinfo)
-		addtimer(mind.devilinfo, "beginResurrectionCheck", 0, TIMER_NORMAL, src)
+		addtimer(CALLBACK(mind.devilinfo,  /datum/devilinfo.proc/beginResurrectionCheck, src), 0)
 
 /mob/living/carbon/human/proc/makeSkeleton()
 	status_flags |= DISFIGURED

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -729,7 +729,7 @@
 		var/static/image/electrocution_skeleton_anim = image(icon = icon, icon_state = "electrocuted_base")
 		electrocution_skeleton_anim.appearance_flags = RESET_COLOR
 		add_overlay(electrocution_skeleton_anim)
-		addtimer(CALLBACK(src,  .proc/end_electrocution_animation, electrocution_skeleton_anim), anim_duration)
+		addtimer(CALLBACK(src, .proc/end_electrocution_animation, electrocution_skeleton_anim), anim_duration)
 
 	else //or just do a generic animation
 		flick_overlay_view(image(icon,src,"electrocuted_generic",ABOVE_MOB_LAYER), src, anim_duration)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -729,7 +729,7 @@
 		var/static/image/electrocution_skeleton_anim = image(icon = icon, icon_state = "electrocuted_base")
 		electrocution_skeleton_anim.appearance_flags = RESET_COLOR
 		add_overlay(electrocution_skeleton_anim)
-		addtimer(src, "end_electrocution_animation", anim_duration, TIMER_NORMAL, electrocution_skeleton_anim)
+		addtimer(CALLBACK(src,  .proc/end_electrocution_animation, electrocution_skeleton_anim), anim_duration)
 
 	else //or just do a generic animation
 		flick_overlay_view(image(icon,src,"electrocuted_generic",ABOVE_MOB_LAYER), src, anim_duration)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -842,7 +842,7 @@
 						if(!( H.hair_style == "Shaved") || !(H.hair_style == "Bald") || (HAIR in species_traits))
 							H << "<span class='danger'>Your hair starts to \
 								fall out in clumps...<span>"
-							addtimer(src, "go_bald", 50, TIMER_UNIQUE, H)
+							addtimer(CALLBACK(src,  .proc/go_bald, H), 50)
 
 				if(75 to 100)
 					if(prob(1))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -842,7 +842,7 @@
 						if(!( H.hair_style == "Shaved") || !(H.hair_style == "Bald") || (HAIR in species_traits))
 							H << "<span class='danger'>Your hair starts to \
 								fall out in clumps...<span>"
-							addtimer(CALLBACK(src,  .proc/go_bald, H), 50)
+							addtimer(CALLBACK(src, .proc/go_bald, H), 50)
 
 				if(75 to 100)
 					if(prob(1))

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -366,7 +366,7 @@
 	var/mob/living/carbon/human/H = owner
 	H.visible_message("<span class='warning'>[H] starts vibrating!</span>", "<span class='danger'>You start charging your bluespace core...</span>")
 	playsound(get_turf(H), 'sound/weapons/flash.ogg', 25, 1)
-	addtimer(src, "teleport", 15, TIMER_NORMAL, H)
+	addtimer(CALLBACK(src,  .proc/teleport, H), 15)
 
 /datum/action/innate/unstable_teleport/proc/teleport(mob/living/carbon/human/H)
 	H.visible_message("<span class='warning'>[H] disappears in a shower of sparks!</span>", "<span class='danger'>You teleport!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -366,7 +366,7 @@
 	var/mob/living/carbon/human/H = owner
 	H.visible_message("<span class='warning'>[H] starts vibrating!</span>", "<span class='danger'>You start charging your bluespace core...</span>")
 	playsound(get_turf(H), 'sound/weapons/flash.ogg', 25, 1)
-	addtimer(CALLBACK(src,  .proc/teleport, H), 15)
+	addtimer(CALLBACK(src, .proc/teleport, H), 15)
 
 /datum/action/innate/unstable_teleport/proc/teleport(mob/living/carbon/human/H)
 	H.visible_message("<span class='warning'>[H] disappears in a shower of sparks!</span>", "<span class='danger'>You teleport!</span>")

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -124,7 +124,7 @@
 				H.CloseWings()
 			else
 				H.OpenWings()
-			addtimer(H, "[open ? "Open" : "Close"]Wings", wing_time)
+			addtimer(CALLBACK(H, open ? /mob/living/carbon/human.proc/OpenWings : /mob/living/carbon/human.proc/CloseWings), wing_time)
 
 /datum/emote/living/flap/aflap
 	key = "aflap"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -338,7 +338,7 @@
 /mob/living/proc/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash)
 	if(get_eye_protection() < intensity && (override_blindness_check || !(disabilities & BLIND)))
 		overlay_fullscreen("flash", type)
-		addtimer(src, "clear_fullscreen", 25, TIMER_NORMAL, "flash", 25)
+		addtimer(CALLBACK(src, .proc/clear_fullscreen, "flash", 25), 25)
 		return 1
 
 //called when the mob receives a loud bang

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -167,7 +167,7 @@
 	blind_eyes(1)
 	update_sight()
 	src << "You've lost power!"
-	addtimer(CALLBACK(src,  .proc/start_RestorePowerRoutine), 20)
+	addtimer(CALLBACK(src, .proc/start_RestorePowerRoutine), 20)
 
 #undef POWER_RESTORATION_OFF
 #undef POWER_RESTORATION_START

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -167,7 +167,7 @@
 	blind_eyes(1)
 	update_sight()
 	src << "You've lost power!"
-	addtimer(src, "start_RestorePowerRoutine", 20)
+	addtimer(CALLBACK(src,  .proc/start_RestorePowerRoutine), 20)
 
 #undef POWER_RESTORATION_OFF
 #undef POWER_RESTORATION_START

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -119,7 +119,7 @@
 	AR.Grant(src)
 	AL.Grant(src)
 	emittersemicd = TRUE
-	addtimer(src, "emittercool", 600)
+	addtimer(CALLBACK(src,  .proc/emittercool), 600)
 
 /mob/living/silicon/pai/make_laws()
 	laws = new /datum/ai_laws/pai()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -119,7 +119,7 @@
 	AR.Grant(src)
 	AL.Grant(src)
 	emittersemicd = TRUE
-	addtimer(CALLBACK(src,  .proc/emittercool), 600)
+	addtimer(CALLBACK(src, .proc/emittercool), 600)
 
 /mob/living/silicon/pai/make_laws()
 	laws = new /datum/ai_laws/pai()

--- a/code/modules/mob/living/silicon/pai/pai_shell.dm
+++ b/code/modules/mob/living/silicon/pai/pai_shell.dm
@@ -17,7 +17,7 @@
 		return FALSE
 
 	emittersemicd = TRUE
-	addtimer(src, "emittercool", emittercd)
+	addtimer(CALLBACK(src,  .proc/emittercool), emittercd)
 	canmove = TRUE
 	density = TRUE
 	if(istype(card.loc, /obj/item/device/pda))
@@ -46,9 +46,9 @@
 /mob/living/silicon/pai/proc/fold_in(force = FALSE)
 	emittersemicd = TRUE
 	if(!force)
-		addtimer(src, "emittercool", emittercd)
+		addtimer(CALLBACK(src,  .proc/emittercool), emittercd)
 	else
-		addtimer(src, "emittercool", emitteroverloadcd)
+		addtimer(CALLBACK(src,  .proc/emittercool), emitteroverloadcd)
 	icon_state = "[chassis]"
 	if(!holoform)
 		. = fold_out(force)

--- a/code/modules/mob/living/silicon/pai/pai_shell.dm
+++ b/code/modules/mob/living/silicon/pai/pai_shell.dm
@@ -17,7 +17,7 @@
 		return FALSE
 
 	emittersemicd = TRUE
-	addtimer(CALLBACK(src,  .proc/emittercool), emittercd)
+	addtimer(CALLBACK(src, .proc/emittercool), emittercd)
 	canmove = TRUE
 	density = TRUE
 	if(istype(card.loc, /obj/item/device/pda))
@@ -46,9 +46,9 @@
 /mob/living/silicon/pai/proc/fold_in(force = FALSE)
 	emittersemicd = TRUE
 	if(!force)
-		addtimer(CALLBACK(src,  .proc/emittercool), emittercd)
+		addtimer(CALLBACK(src, .proc/emittercool), emittercd)
 	else
-		addtimer(CALLBACK(src,  .proc/emittercool), emitteroverloadcd)
+		addtimer(CALLBACK(src, .proc/emittercool), emitteroverloadcd)
 	icon_state = "[chassis]"
 	if(!holoform)
 		. = fold_out(force)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -178,7 +178,7 @@
 	R.module = RM
 	R.update_module_innate()
 	RM.rebuild_modules()
-	addtimer(CALLBACK(RM,  .proc/do_transform_animation), 0)
+	addtimer(CALLBACK(RM, .proc/do_transform_animation), 0)
 	qdel(src)
 	return RM
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -178,7 +178,7 @@
 	R.module = RM
 	R.update_module_innate()
 	RM.rebuild_modules()
-	addtimer(RM, "do_transform_animation", 0)
+	addtimer(CALLBACK(RM,  .proc/do_transform_animation), 0)
 	qdel(src)
 	return RM
 

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -306,13 +306,13 @@ Auto Patrol[]"},
 	target = null
 	last_found = world.time
 	frustration = 0
-	addtimer(src, "handle_automated_action", 0) //ensure bot quickly responds
+	addtimer(CALLBACK(src,  .proc/handle_automated_action), 0) //ensure bot quickly responds
 
 /mob/living/simple_animal/bot/ed209/proc/back_to_hunt()
 	anchored = 0
 	frustration = 0
 	mode = BOT_HUNT
-	addtimer(src, "handle_automated_action", 0) //ensure bot quickly responds
+	addtimer(CALLBACK(src,  .proc/handle_automated_action), 0) //ensure bot quickly responds
 
 // look for a criminal in view of the bot
 

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -306,13 +306,13 @@ Auto Patrol[]"},
 	target = null
 	last_found = world.time
 	frustration = 0
-	addtimer(CALLBACK(src,  .proc/handle_automated_action), 0) //ensure bot quickly responds
+	addtimer(CALLBACK(src, .proc/handle_automated_action), 0) //ensure bot quickly responds
 
 /mob/living/simple_animal/bot/ed209/proc/back_to_hunt()
 	anchored = 0
 	frustration = 0
 	mode = BOT_HUNT
-	addtimer(CALLBACK(src,  .proc/handle_automated_action), 0) //ensure bot quickly responds
+	addtimer(CALLBACK(src, .proc/handle_automated_action), 0) //ensure bot quickly responds
 
 // look for a criminal in view of the bot
 

--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -61,7 +61,7 @@
 	anchored = A.anchored
 	density = A.density
 	appearance = A.appearance
-	addtimer(CALLBACK(src,  .proc/disable), 600)
+	addtimer(CALLBACK(src, .proc/disable), 600)
 
 /obj/guardian_bomb/proc/disable()
 	stored_obj.forceMove(get_turf(src))

--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -61,7 +61,7 @@
 	anchored = A.anchored
 	density = A.density
 	appearance = A.appearance
-	addtimer(src, "disable", 600, TIMER_NORMAL)
+	addtimer(CALLBACK(src,  .proc/disable), 600)
 
 /obj/guardian_bomb/proc/disable()
 	stored_obj.forceMove(get_turf(src))

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -421,7 +421,7 @@
 /mob/living/simple_animal/hostile/proc/GainPatience()
 	if(lose_patience_timeout)
 		LosePatience()
-		lose_patience_timer_id = addtimer(CALLBACK(src,  .proc/LoseTarget), lose_patience_timeout)
+		lose_patience_timer_id = addtimer(CALLBACK(src, .proc/LoseTarget), lose_patience_timeout)
 
 
 /mob/living/simple_animal/hostile/proc/LosePatience()
@@ -432,7 +432,7 @@
 /mob/living/simple_animal/hostile/proc/LoseSearchObjects()
 	search_objects = 0
 	deltimer(search_objects_timer_id)
-	search_objects_timer_id = addtimer(CALLBACK(src,  .proc/RegainSearchObjects), search_objects_regain_time)
+	search_objects_timer_id = addtimer(CALLBACK(src, .proc/RegainSearchObjects), search_objects_regain_time)
 
 
 /mob/living/simple_animal/hostile/proc/RegainSearchObjects(value)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -421,7 +421,7 @@
 /mob/living/simple_animal/hostile/proc/GainPatience()
 	if(lose_patience_timeout)
 		LosePatience()
-		lose_patience_timer_id = addtimer(src, "LoseTarget", lose_patience_timeout)
+		lose_patience_timer_id = addtimer(CALLBACK(src,  .proc/LoseTarget), lose_patience_timeout)
 
 
 /mob/living/simple_animal/hostile/proc/LosePatience()
@@ -432,7 +432,7 @@
 /mob/living/simple_animal/hostile/proc/LoseSearchObjects()
 	search_objects = 0
 	deltimer(search_objects_timer_id)
-	search_objects_timer_id = addtimer(src, "RegainSearchObjects", search_objects_regain_time)
+	search_objects_timer_id = addtimer(CALLBACK(src,  .proc/RegainSearchObjects), search_objects_regain_time)
 
 
 /mob/living/simple_animal/hostile/proc/RegainSearchObjects(value)

--- a/code/modules/mob/living/simple_animal/hostile/mecha_pilot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mecha_pilot.dm
@@ -231,13 +231,13 @@
 					if(mecha.defense_action && mecha.defense_action.owner && !mecha.defence_mode)
 						mecha.leg_overload_mode = 0
 						mecha.defense_action.Activate(TRUE)
-						addtimer(mecha.defense_action, "Activate", 100, TIMER_NORMAL, FALSE) //10 seconds of defence, then toggle off
+						addtimer(CALLBACK(mecha.defense_action,  /datum/action/innate/mecha/mech_defence_mode.proc/Activate, FALSE), 100) //10 seconds of defence, then toggle off
 
 				else if(prob(retreat_chance))
 					//Speed boost if possible
 					if(mecha.overload_action && mecha.overload_action.owner && !mecha.leg_overload_mode)
 						mecha.overload_action.Activate(TRUE)
-						addtimer(mecha.overload_action, "Activate", 100, TIMER_NORMAL, FALSE) //10 seconds of speeeeed, then toggle off
+						addtimer(CALLBACK(mecha.overload_action,  /datum/action/innate/mecha/mech_defence_mode.proc/Activate, FALSE), 100) //10 seconds of speeeeed, then toggle off
 
 					retreat_distance = 50
 					spawn(100)

--- a/code/modules/mob/living/simple_animal/hostile/mecha_pilot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mecha_pilot.dm
@@ -231,13 +231,13 @@
 					if(mecha.defense_action && mecha.defense_action.owner && !mecha.defence_mode)
 						mecha.leg_overload_mode = 0
 						mecha.defense_action.Activate(TRUE)
-						addtimer(CALLBACK(mecha.defense_action,  /datum/action/innate/mecha/mech_defence_mode.proc/Activate, FALSE), 100) //10 seconds of defence, then toggle off
+						addtimer(CALLBACK(mecha.defense_action, /datum/action/innate/mecha/mech_defence_mode.proc/Activate, FALSE), 100) //10 seconds of defence, then toggle off
 
 				else if(prob(retreat_chance))
 					//Speed boost if possible
 					if(mecha.overload_action && mecha.overload_action.owner && !mecha.leg_overload_mode)
 						mecha.overload_action.Activate(TRUE)
-						addtimer(CALLBACK(mecha.overload_action,  /datum/action/innate/mecha/mech_defence_mode.proc/Activate, FALSE), 100) //10 seconds of speeeeed, then toggle off
+						addtimer(CALLBACK(mecha.overload_action, /datum/action/innate/mecha/mech_defence_mode.proc/Activate, FALSE), 100) //10 seconds of speeeeed, then toggle off
 
 					retreat_distance = 50
 					spawn(100)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -88,19 +88,19 @@ Difficulty: Hard
 
 	var/warped = FALSE
 	if(!try_bloodattack())
-		addtimer(CALLBACK(src,  .proc/blood_spray), 0)
+		addtimer(CALLBACK(src, .proc/blood_spray), 0)
 		warped = blood_warp()
 		if(warped && prob(100 - anger_modifier))
 			return
 
 	if(prob(90 - anger_modifier) || slaughterlings())
 		if(health > maxHealth * 0.5)
-			addtimer(CALLBACK(src,  .proc/charge), 0)
+			addtimer(CALLBACK(src, .proc/charge), 0)
 		else
 			if(prob(70) || warped)
-				addtimer(CALLBACK(src,  .proc/triple_charge), 0)
+				addtimer(CALLBACK(src, .proc/triple_charge), 0)
 			else
-				addtimer(CALLBACK(src,  .proc/warp_charge), 0)
+				addtimer(CALLBACK(src, .proc/warp_charge), 0)
 
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/New()
@@ -201,7 +201,7 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/try_bloodattack()
 	var/list/targets = get_mobs_on_blood()
 	if(targets.len)
-		addtimer(CALLBACK(src,  .proc/bloodattack, targets, prob(50)), 0)
+		addtimer(CALLBACK(src, .proc/bloodattack, targets, prob(50)), 0)
 
 		return TRUE
 	return FALSE
@@ -268,7 +268,7 @@ Difficulty: Hard
 			L.forceMove(targetturf)
 			playsound(targetturf, 'sound/magic/exit_blood.ogg', 100, 1, -1)
 			if(L.stat != CONSCIOUS)
-				addtimer(CALLBACK(src,  .proc/devour, L), 2)
+				addtimer(CALLBACK(src, .proc/devour, L), 2)
 	sleep(1)
 
 /obj/effect/overlay/temp/bubblegum_hands

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -88,19 +88,19 @@ Difficulty: Hard
 
 	var/warped = FALSE
 	if(!try_bloodattack())
-		addtimer(src, "blood_spray", 0)
+		addtimer(CALLBACK(src,  .proc/blood_spray), 0)
 		warped = blood_warp()
 		if(warped && prob(100 - anger_modifier))
 			return
 
 	if(prob(90 - anger_modifier) || slaughterlings())
 		if(health > maxHealth * 0.5)
-			addtimer(src, "charge", 0)
+			addtimer(CALLBACK(src,  .proc/charge), 0)
 		else
 			if(prob(70) || warped)
-				addtimer(src, "triple_charge", 0)
+				addtimer(CALLBACK(src,  .proc/triple_charge), 0)
 			else
-				addtimer(src, "warp_charge", 0)
+				addtimer(CALLBACK(src,  .proc/warp_charge), 0)
 
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/New()
@@ -201,7 +201,7 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/try_bloodattack()
 	var/list/targets = get_mobs_on_blood()
 	if(targets.len)
-		addtimer(src, "bloodattack", 0, TIMER_NORMAL, targets, prob(50))
+		addtimer(CALLBACK(src,  .proc/bloodattack, targets, prob(50)), 0)
 
 		return TRUE
 	return FALSE
@@ -268,7 +268,7 @@ Difficulty: Hard
 			L.forceMove(targetturf)
 			playsound(targetturf, 'sound/magic/exit_blood.ogg', 100, 1, -1)
 			if(L.stat != CONSCIOUS)
-				addtimer(src, "devour", 2, TIMER_NORMAL, L)
+				addtimer(CALLBACK(src,  .proc/devour, L), 2)
 	sleep(1)
 
 /obj/effect/overlay/temp/bubblegum_hands

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -77,7 +77,7 @@ Difficulty: Very Hard
 			double_spiral()
 		else
 			visible_message("<span class='colossus'>\"<b>Judgement.</b>\"</span>")
-			addtimer(src, "spiral_shoot", 0, TIMER_NORMAL, rand(0, 1))
+			addtimer(CALLBACK(src,  .proc/spiral_shoot, rand(0, 1)), 0)
 
 	else if(prob(20))
 		ranged_cooldown = world.time + 30
@@ -88,7 +88,7 @@ Difficulty: Very Hard
 			blast()
 		else
 			ranged_cooldown = world.time + 40
-			addtimer(src, "alternating_dir_shots", 0)
+			addtimer(CALLBACK(src,  .proc/alternating_dir_shots), 0)
 
 
 /mob/living/simple_animal/hostile/megafauna/colossus/New()
@@ -108,7 +108,7 @@ Difficulty: Very Hard
 /obj/effect/overlay/temp/at_shield/New(new_loc, new_target)
 	..()
 	target = new_target
-	addtimer(src, "orbit", 0, TIMER_NORMAL, target, 0, FALSE, 0, 0, FALSE, TRUE)
+	addtimer(CALLBACK(src,  /atom/movable/proc/orbit, target, 0, FALSE, 0, 0, FALSE, TRUE), 0)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/bullet_act(obj/item/projectile/P)
 	if(!stat)
@@ -139,8 +139,8 @@ Difficulty: Very Hard
 	visible_message("<span class='colossus'>\"<b>Die.</b>\"</span>")
 
 	sleep(10)
-	addtimer(src, "spiral_shoot", 0)
-	addtimer(src, "spiral_shoot", 0, TIMER_NORMAL, 1)
+	addtimer(CALLBACK(src,  .proc/spiral_shoot), 0)
+	addtimer(CALLBACK(src,  .proc/spiral_shoot, 1), 0)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/spiral_shoot(negative = 0, counter_start = 1)
 	var/counter = counter_start

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -77,7 +77,7 @@ Difficulty: Very Hard
 			double_spiral()
 		else
 			visible_message("<span class='colossus'>\"<b>Judgement.</b>\"</span>")
-			addtimer(CALLBACK(src,  .proc/spiral_shoot, rand(0, 1)), 0)
+			addtimer(CALLBACK(src, .proc/spiral_shoot, rand(0, 1)), 0)
 
 	else if(prob(20))
 		ranged_cooldown = world.time + 30
@@ -88,7 +88,7 @@ Difficulty: Very Hard
 			blast()
 		else
 			ranged_cooldown = world.time + 40
-			addtimer(CALLBACK(src,  .proc/alternating_dir_shots), 0)
+			addtimer(CALLBACK(src, .proc/alternating_dir_shots), 0)
 
 
 /mob/living/simple_animal/hostile/megafauna/colossus/New()
@@ -108,7 +108,7 @@ Difficulty: Very Hard
 /obj/effect/overlay/temp/at_shield/New(new_loc, new_target)
 	..()
 	target = new_target
-	addtimer(CALLBACK(src,  /atom/movable/proc/orbit, target, 0, FALSE, 0, 0, FALSE, TRUE), 0)
+	addtimer(CALLBACK(src, /atom/movable/proc/orbit, target, 0, FALSE, 0, 0, FALSE, TRUE), 0)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/bullet_act(obj/item/projectile/P)
 	if(!stat)
@@ -139,8 +139,8 @@ Difficulty: Very Hard
 	visible_message("<span class='colossus'>\"<b>Die.</b>\"</span>")
 
 	sleep(10)
-	addtimer(CALLBACK(src,  .proc/spiral_shoot), 0)
-	addtimer(CALLBACK(src,  .proc/spiral_shoot, 1), 0)
+	addtimer(CALLBACK(src, .proc/spiral_shoot), 0)
+	addtimer(CALLBACK(src, .proc/spiral_shoot, 1), 0)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/spiral_shoot(negative = 0, counter_start = 1)
 	var/counter = counter_start

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -123,7 +123,7 @@ Difficulty: Medium
 
 /obj/effect/overlay/temp/target/New(loc)
 	..()
-	addtimer(src, "fall", 0)
+	addtimer(CALLBACK(src,  .proc/fall), 0)
 
 /obj/effect/overlay/temp/target/proc/fall()
 	var/turf/T = get_turf(src)
@@ -141,15 +141,15 @@ Difficulty: Medium
 
 	if(prob(15 + anger_modifier) && !client)
 		if(health < maxHealth/2)
-			addtimer(src, "swoop_attack", 0, TIMER_NORMAL, 1)
+			addtimer(CALLBACK(src,  .proc/swoop_attack, 1), 0)
 		else
 			fire_rain()
 
 	else if(prob(10+anger_modifier) && !client)
 		if(health > maxHealth/2)
-			addtimer(src, "swoop_attack", 0)
+			addtimer(CALLBACK(src,  .proc/swoop_attack), 0)
 		else
-			addtimer(src, "triple_swoop", 0)
+			addtimer(CALLBACK(src,  .proc/triple_swoop), 0)
 	else
 		fire_walls()
 
@@ -163,7 +163,7 @@ Difficulty: Medium
 	playsound(get_turf(src),'sound/magic/Fireball.ogg', 200, 1)
 
 	for(var/d in cardinal)
-		addtimer(src, "fire_wall", 0, TIMER_NORMAL, d)
+		addtimer(CALLBACK(src,  .proc/fire_wall, d), 0)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/fire_wall(dir)
 	var/list/hit_things = list(src)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -123,7 +123,7 @@ Difficulty: Medium
 
 /obj/effect/overlay/temp/target/New(loc)
 	..()
-	addtimer(CALLBACK(src,  .proc/fall), 0)
+	addtimer(CALLBACK(src, .proc/fall), 0)
 
 /obj/effect/overlay/temp/target/proc/fall()
 	var/turf/T = get_turf(src)
@@ -141,15 +141,15 @@ Difficulty: Medium
 
 	if(prob(15 + anger_modifier) && !client)
 		if(health < maxHealth/2)
-			addtimer(CALLBACK(src,  .proc/swoop_attack, 1), 0)
+			addtimer(CALLBACK(src, .proc/swoop_attack, 1), 0)
 		else
 			fire_rain()
 
 	else if(prob(10+anger_modifier) && !client)
 		if(health > maxHealth/2)
-			addtimer(CALLBACK(src,  .proc/swoop_attack), 0)
+			addtimer(CALLBACK(src, .proc/swoop_attack), 0)
 		else
-			addtimer(CALLBACK(src,  .proc/triple_swoop), 0)
+			addtimer(CALLBACK(src, .proc/triple_swoop), 0)
 	else
 		fire_walls()
 
@@ -163,7 +163,7 @@ Difficulty: Medium
 	playsound(get_turf(src),'sound/magic/Fireball.ogg', 200, 1)
 
 	for(var/d in cardinal)
-		addtimer(CALLBACK(src,  .proc/fire_wall, d), 0)
+		addtimer(CALLBACK(src, .proc/fire_wall, d), 0)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/fire_wall(dir)
 	var/list/hit_things = list(src)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -139,7 +139,7 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/hierophant/AttackingTarget()
 	if(!blinking)
 		if(target && isliving(target))
-			addtimer(src, "melee_blast", 0, TIMER_NORMAL, get_turf(target)) //melee attacks on living mobs produce a 3x3 blast
+			addtimer(CALLBACK(src,  .proc/melee_blast, get_turf(target)), 0) //melee attacks on living mobs produce a 3x3 blast
 		..()
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/DestroySurroundings()
@@ -215,7 +215,7 @@ Difficulty: Hard
 							blinking = TRUE
 							sleep(5)
 						animate(src, color = oldcolor, time = 8)
-						addtimer(src, "update_atom_colour", 8)
+						addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 						sleep(8)
 						blinking = FALSE
 					else
@@ -229,13 +229,13 @@ Difficulty: Hard
 						cross_counter--
 						var/delay = 7
 						if(prob(60))
-							addtimer(src, "cardinal_blasts", 0, TIMER_NORMAL, target)
+							addtimer(CALLBACK(src,  .proc/cardinal_blasts, target), 0)
 						else
-							addtimer(src, "diagonal_blasts", 0, TIMER_NORMAL, target)
+							addtimer(CALLBACK(src,  .proc/diagonal_blasts, target), 0)
 							delay = 5 //this one isn't so mean, so do the next one faster(if there is one)
 						sleep(delay)
 					animate(src, color = oldcolor, time = 8)
-					addtimer(src, "update_atom_colour", 8)
+					addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 					sleep(8)
 					blinking = FALSE
 				if("chaser_swarm") //fire four fucking chasers at a target and their friends.
@@ -257,7 +257,7 @@ Difficulty: Hard
 						sleep(10)
 					chaser_cooldown = world.time + initial(chaser_cooldown)
 					animate(src, color = oldcolor, time = 8)
-					addtimer(src, "update_atom_colour", 8)
+					addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
 					sleep(8)
 					blinking = FALSE
 			return
@@ -268,18 +268,18 @@ Difficulty: Hard
 	else if(prob(70 - anger_modifier)) //a cross blast of some type
 		if(prob(anger_modifier)) //at us?
 			if(prob(anger_modifier * 2) && health < maxHealth * 0.5) //we're super angry do it at all dirs
-				addtimer(src, "alldir_blasts", 0, TIMER_NORMAL, src)
+				addtimer(CALLBACK(src,  .proc/alldir_blasts, src), 0)
 			else if(prob(60))
-				addtimer(src, "cardinal_blasts", 0, TIMER_NORMAL, src)
+				addtimer(CALLBACK(src,  .proc/cardinal_blasts, src), 0)
 			else
-				addtimer(src, "diagonal_blasts", 0, TIMER_NORMAL, src)
+				addtimer(CALLBACK(src,  .proc/diagonal_blasts, src), 0)
 		else //at them?
 			if(prob(anger_modifier * 2) && health < maxHealth * 0.5 && !target_is_slow) //we're super angry do it at all dirs
-				addtimer(src, "alldir_blasts", 0, TIMER_NORMAL, target)
+				addtimer(CALLBACK(src,  .proc/alldir_blasts, target), 0)
 			else if(prob(60))
-				addtimer(src, "cardinal_blasts", 0, TIMER_NORMAL, target)
+				addtimer(CALLBACK(src,  .proc/cardinal_blasts, target), 0)
 			else
-				addtimer(src, "diagonal_blasts", 0, TIMER_NORMAL, target)
+				addtimer(CALLBACK(src,  .proc/diagonal_blasts, target), 0)
 	else if(chaser_cooldown < world.time) //if chasers are off cooldown, fire some!
 		var/obj/effect/overlay/temp/hierophant/chaser/C = PoolOrNew(/obj/effect/overlay/temp/hierophant/chaser, list(loc, src, target, chaser_speed, FALSE))
 		chaser_cooldown = world.time + initial(chaser_cooldown)
@@ -288,7 +288,7 @@ Difficulty: Hard
 			OC.moving = 4
 			OC.moving_dir = pick(cardinal - C.moving_dir)
 	else //just release a burst of power
-		addtimer(src, "burst", 0, TIMER_NORMAL, get_turf(src))
+		addtimer(CALLBACK(src,  .proc/burst, get_turf(src)), 0)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/diagonal_blasts(mob/victim) //fire diagonal cross blasts with a delay
 	var/turf/T = get_turf(victim)
@@ -299,7 +299,7 @@ Difficulty: Hard
 	sleep(2)
 	PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(T, src, FALSE))
 	for(var/d in diagonals)
-		addtimer(src, "blast_wall", 0, TIMER_NORMAL, T, d)
+		addtimer(CALLBACK(src,  .proc/blast_wall, T, d), 0)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/cardinal_blasts(mob/victim) //fire cardinal cross blasts with a delay
 	var/turf/T = get_turf(victim)
@@ -310,7 +310,7 @@ Difficulty: Hard
 	sleep(2)
 	PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(T, src, FALSE))
 	for(var/d in cardinal)
-		addtimer(src, "blast_wall", 0, TIMER_NORMAL, T, d)
+		addtimer(CALLBACK(src,  .proc/blast_wall, T, d), 0)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/alldir_blasts(mob/victim) //fire alldir cross blasts with a delay
 	var/turf/T = get_turf(victim)
@@ -321,7 +321,7 @@ Difficulty: Hard
 	sleep(2)
 	PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(T, src, FALSE))
 	for(var/d in alldirs)
-		addtimer(src, "blast_wall", 0, TIMER_NORMAL, T, d)
+		addtimer(CALLBACK(src,  .proc/blast_wall, T, d), 0)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/blast_wall(turf/T, set_dir) //make a wall of blasts beam_range tiles long
 	var/range = beam_range
@@ -340,13 +340,13 @@ Difficulty: Hard
 		return
 	arena_cooldown = world.time + initial(arena_cooldown)
 	for(var/d in cardinal)
-		addtimer(src, "arena_squares", 0, TIMER_NORMAL, T, d)
+		addtimer(CALLBACK(src,  .proc/arena_squares, T, d), 0)
 	for(var/t in RANGE_TURFS(11, T))
 		if(t && get_dist(t, T) == 11)
 			new /obj/effect/overlay/temp/hierophant/wall(t)
 			PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(t, src, FALSE))
 	if(get_dist(src, T) >= 11) //hey you're out of range I need to get closer to you!
-		addtimer(src, "blink", 0, TIMER_NORMAL, T)
+		addtimer(CALLBACK(src,  .proc/blink, T), 0)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/arena_squares(turf/T, set_dir) //make a fancy effect extending from the arena target
 	var/turf/previousturf = T
@@ -487,7 +487,7 @@ Difficulty: Hard
 	friendly_fire_check = is_friendly_fire
 	if(new_speed)
 		speed = new_speed
-	addtimer(src, "seek_target", 1)
+	addtimer(CALLBACK(src,  .proc/seek_target), 1)
 
 /obj/effect/overlay/temp/hierophant/chaser/proc/get_target_dir()
 	. = get_cardinal_dir(src, targetturf)
@@ -567,7 +567,7 @@ Difficulty: Hard
 	if(ismineralturf(loc)) //drill mineral turfs
 		var/turf/closed/mineral/M = loc
 		M.gets_drilled(caster)
-	addtimer(src, "blast", 0)
+	addtimer(CALLBACK(src,  .proc/blast), 0)
 
 /obj/effect/overlay/temp/hierophant/blast/proc/blast()
 	var/turf/T = get_turf(src)
@@ -629,7 +629,7 @@ Difficulty: Hard
 		if(H.beacon == src)
 			user << "<span class='notice'>You start removing your hierophant beacon...</span>"
 			H.timer = world.time + 51
-			addtimer(H, "prepare_icon_update", 0)
+			addtimer(CALLBACK(H,  /obj/item/weapon/hierophant_club.proc/prepare_icon_update), 0)
 			if(do_after(user, 50, target = src))
 				playsound(src,'sound/magic/Blind.ogg', 200, 1, -4)
 				PoolOrNew(/obj/effect/overlay/temp/hierophant/telegraph/teleport, list(get_turf(src), user))
@@ -639,7 +639,7 @@ Difficulty: Hard
 				qdel(src)
 			else
 				H.timer = world.time
-				addtimer(H, "prepare_icon_update", 0)
+				addtimer(CALLBACK(H,  /obj/item/weapon/hierophant_club.proc/prepare_icon_update), 0)
 		else
 			user << "<span class='hierophant_warning'>You touch the beacon with the club, but nothing happens.</span>"
 	else

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -139,7 +139,7 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/hierophant/AttackingTarget()
 	if(!blinking)
 		if(target && isliving(target))
-			addtimer(CALLBACK(src,  .proc/melee_blast, get_turf(target)), 0) //melee attacks on living mobs produce a 3x3 blast
+			addtimer(CALLBACK(src, .proc/melee_blast, get_turf(target)), 0) //melee attacks on living mobs produce a 3x3 blast
 		..()
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/DestroySurroundings()
@@ -215,7 +215,7 @@ Difficulty: Hard
 							blinking = TRUE
 							sleep(5)
 						animate(src, color = oldcolor, time = 8)
-						addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+						addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 						sleep(8)
 						blinking = FALSE
 					else
@@ -229,13 +229,13 @@ Difficulty: Hard
 						cross_counter--
 						var/delay = 7
 						if(prob(60))
-							addtimer(CALLBACK(src,  .proc/cardinal_blasts, target), 0)
+							addtimer(CALLBACK(src, .proc/cardinal_blasts, target), 0)
 						else
-							addtimer(CALLBACK(src,  .proc/diagonal_blasts, target), 0)
+							addtimer(CALLBACK(src, .proc/diagonal_blasts, target), 0)
 							delay = 5 //this one isn't so mean, so do the next one faster(if there is one)
 						sleep(delay)
 					animate(src, color = oldcolor, time = 8)
-					addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+					addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 					sleep(8)
 					blinking = FALSE
 				if("chaser_swarm") //fire four fucking chasers at a target and their friends.
@@ -257,7 +257,7 @@ Difficulty: Hard
 						sleep(10)
 					chaser_cooldown = world.time + initial(chaser_cooldown)
 					animate(src, color = oldcolor, time = 8)
-					addtimer(CALLBACK(src,  /atom/proc/update_atom_colour), 8)
+					addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 					sleep(8)
 					blinking = FALSE
 			return
@@ -268,18 +268,18 @@ Difficulty: Hard
 	else if(prob(70 - anger_modifier)) //a cross blast of some type
 		if(prob(anger_modifier)) //at us?
 			if(prob(anger_modifier * 2) && health < maxHealth * 0.5) //we're super angry do it at all dirs
-				addtimer(CALLBACK(src,  .proc/alldir_blasts, src), 0)
+				addtimer(CALLBACK(src, .proc/alldir_blasts, src), 0)
 			else if(prob(60))
-				addtimer(CALLBACK(src,  .proc/cardinal_blasts, src), 0)
+				addtimer(CALLBACK(src, .proc/cardinal_blasts, src), 0)
 			else
-				addtimer(CALLBACK(src,  .proc/diagonal_blasts, src), 0)
+				addtimer(CALLBACK(src, .proc/diagonal_blasts, src), 0)
 		else //at them?
 			if(prob(anger_modifier * 2) && health < maxHealth * 0.5 && !target_is_slow) //we're super angry do it at all dirs
-				addtimer(CALLBACK(src,  .proc/alldir_blasts, target), 0)
+				addtimer(CALLBACK(src, .proc/alldir_blasts, target), 0)
 			else if(prob(60))
-				addtimer(CALLBACK(src,  .proc/cardinal_blasts, target), 0)
+				addtimer(CALLBACK(src, .proc/cardinal_blasts, target), 0)
 			else
-				addtimer(CALLBACK(src,  .proc/diagonal_blasts, target), 0)
+				addtimer(CALLBACK(src, .proc/diagonal_blasts, target), 0)
 	else if(chaser_cooldown < world.time) //if chasers are off cooldown, fire some!
 		var/obj/effect/overlay/temp/hierophant/chaser/C = PoolOrNew(/obj/effect/overlay/temp/hierophant/chaser, list(loc, src, target, chaser_speed, FALSE))
 		chaser_cooldown = world.time + initial(chaser_cooldown)
@@ -288,7 +288,7 @@ Difficulty: Hard
 			OC.moving = 4
 			OC.moving_dir = pick(cardinal - C.moving_dir)
 	else //just release a burst of power
-		addtimer(CALLBACK(src,  .proc/burst, get_turf(src)), 0)
+		addtimer(CALLBACK(src, .proc/burst, get_turf(src)), 0)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/diagonal_blasts(mob/victim) //fire diagonal cross blasts with a delay
 	var/turf/T = get_turf(victim)
@@ -299,7 +299,7 @@ Difficulty: Hard
 	sleep(2)
 	PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(T, src, FALSE))
 	for(var/d in diagonals)
-		addtimer(CALLBACK(src,  .proc/blast_wall, T, d), 0)
+		addtimer(CALLBACK(src, .proc/blast_wall, T, d), 0)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/cardinal_blasts(mob/victim) //fire cardinal cross blasts with a delay
 	var/turf/T = get_turf(victim)
@@ -310,7 +310,7 @@ Difficulty: Hard
 	sleep(2)
 	PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(T, src, FALSE))
 	for(var/d in cardinal)
-		addtimer(CALLBACK(src,  .proc/blast_wall, T, d), 0)
+		addtimer(CALLBACK(src, .proc/blast_wall, T, d), 0)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/alldir_blasts(mob/victim) //fire alldir cross blasts with a delay
 	var/turf/T = get_turf(victim)
@@ -321,7 +321,7 @@ Difficulty: Hard
 	sleep(2)
 	PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(T, src, FALSE))
 	for(var/d in alldirs)
-		addtimer(CALLBACK(src,  .proc/blast_wall, T, d), 0)
+		addtimer(CALLBACK(src, .proc/blast_wall, T, d), 0)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/blast_wall(turf/T, set_dir) //make a wall of blasts beam_range tiles long
 	var/range = beam_range
@@ -340,13 +340,13 @@ Difficulty: Hard
 		return
 	arena_cooldown = world.time + initial(arena_cooldown)
 	for(var/d in cardinal)
-		addtimer(CALLBACK(src,  .proc/arena_squares, T, d), 0)
+		addtimer(CALLBACK(src, .proc/arena_squares, T, d), 0)
 	for(var/t in RANGE_TURFS(11, T))
 		if(t && get_dist(t, T) == 11)
 			new /obj/effect/overlay/temp/hierophant/wall(t)
 			PoolOrNew(/obj/effect/overlay/temp/hierophant/blast, list(t, src, FALSE))
 	if(get_dist(src, T) >= 11) //hey you're out of range I need to get closer to you!
-		addtimer(CALLBACK(src,  .proc/blink, T), 0)
+		addtimer(CALLBACK(src, .proc/blink, T), 0)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/arena_squares(turf/T, set_dir) //make a fancy effect extending from the arena target
 	var/turf/previousturf = T
@@ -487,7 +487,7 @@ Difficulty: Hard
 	friendly_fire_check = is_friendly_fire
 	if(new_speed)
 		speed = new_speed
-	addtimer(CALLBACK(src,  .proc/seek_target), 1)
+	addtimer(CALLBACK(src, .proc/seek_target), 1)
 
 /obj/effect/overlay/temp/hierophant/chaser/proc/get_target_dir()
 	. = get_cardinal_dir(src, targetturf)
@@ -567,7 +567,7 @@ Difficulty: Hard
 	if(ismineralturf(loc)) //drill mineral turfs
 		var/turf/closed/mineral/M = loc
 		M.gets_drilled(caster)
-	addtimer(CALLBACK(src,  .proc/blast), 0)
+	addtimer(CALLBACK(src, .proc/blast), 0)
 
 /obj/effect/overlay/temp/hierophant/blast/proc/blast()
 	var/turf/T = get_turf(src)
@@ -629,7 +629,7 @@ Difficulty: Hard
 		if(H.beacon == src)
 			user << "<span class='notice'>You start removing your hierophant beacon...</span>"
 			H.timer = world.time + 51
-			addtimer(CALLBACK(H,  /obj/item/weapon/hierophant_club.proc/prepare_icon_update), 0)
+			addtimer(CALLBACK(H, /obj/item/weapon/hierophant_club.proc/prepare_icon_update), 0)
 			if(do_after(user, 50, target = src))
 				playsound(src,'sound/magic/Blind.ogg', 200, 1, -4)
 				PoolOrNew(/obj/effect/overlay/temp/hierophant/telegraph/teleport, list(get_turf(src), user))
@@ -639,7 +639,7 @@ Difficulty: Hard
 				qdel(src)
 			else
 				H.timer = world.time
-				addtimer(CALLBACK(H,  /obj/item/weapon/hierophant_club.proc/prepare_icon_update), 0)
+				addtimer(CALLBACK(H, /obj/item/weapon/hierophant_club.proc/prepare_icon_update), 0)
 		else
 			user << "<span class='hierophant_warning'>You touch the beacon with the club, but nothing happens.</span>"
 	else

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -78,7 +78,7 @@ Difficulty: Medium
 			minimum_distance = 0
 			speed = 0
 			charging = 1
-			addtimer(CALLBACK(src,  .proc/reset_charge), 50)
+			addtimer(CALLBACK(src, .proc/reset_charge), 50)
 
 /mob/living/simple_animal/hostile/megafauna/legion/proc/reset_charge()
 	ranged = 1

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -78,7 +78,7 @@ Difficulty: Medium
 			minimum_distance = 0
 			speed = 0
 			charging = 1
-			addtimer(src, "reset_charge", 50)
+			addtimer(CALLBACK(src,  .proc/reset_charge), 50)
 
 /mob/living/simple_animal/hostile/megafauna/legion/proc/reset_charge()
 	ranged = 1

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -156,7 +156,7 @@ var/global/list/AISwarmerCapsByType = list(/mob/living/simple_animal/hostile/swa
 /mob/living/simple_animal/hostile/swarmer/ai/proc/StartAction(deci = 0)
 	stop_automated_movement = TRUE
 	AIStatus = AI_OFF
-	addtimer(CALLBACK(src,  .proc/EndAction), deci)
+	addtimer(CALLBACK(src, .proc/EndAction), deci)
 
 
 /mob/living/simple_animal/hostile/swarmer/ai/proc/EndAction()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -156,7 +156,7 @@ var/global/list/AISwarmerCapsByType = list(/mob/living/simple_animal/hostile/swa
 /mob/living/simple_animal/hostile/swarmer/ai/proc/StartAction(deci = 0)
 	stop_automated_movement = TRUE
 	AIStatus = AI_OFF
-	addtimer(src, "EndAction", deci, TIMER_NORMAL)
+	addtimer(CALLBACK(src,  .proc/EndAction), deci)
 
 
 /mob/living/simple_animal/hostile/swarmer/ai/proc/EndAction()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -159,7 +159,7 @@
 			retreat_distance = 10
 			minimum_distance = 10
 			if(will_burrow)
-				addtimer(src, "Burrow", chase_time)
+				addtimer(CALLBACK(src,  .proc/Burrow), chase_time)
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/AttackingTarget()
 	if(istype(target, /obj/item/weapon/ore))
@@ -251,7 +251,7 @@
 
 /obj/item/organ/hivelord_core/New()
 	..()
-	addtimer(src, "inert_check", 2400)
+	addtimer(CALLBACK(src,  .proc/inert_check), 2400)
 
 /obj/item/organ/hivelord_core/proc/inert_check()
 	if(!owner && !preserved)
@@ -339,7 +339,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/New()
 	..()
-	addtimer(src, "death", 100)
+	addtimer(CALLBACK(src,  .proc/death), 100)
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/blood
 	name = "blood brood"
@@ -493,7 +493,7 @@
 	if(ismineralturf(turftype))
 		var/turf/closed/mineral/M = turftype
 		M.gets_drilled()
-	addtimer(src, "Trip", 10)
+	addtimer(CALLBACK(src,  .proc/Trip), 10)
 
 /obj/effect/goliath_tentacle/original
 
@@ -642,7 +642,7 @@
 	environment_smash = 2
 	mob_size = MOB_SIZE_LARGE
 	speed = 1
-	addtimer(src, "Deflate", 100)
+	addtimer(CALLBACK(src,  .proc/Deflate), 100)
 
 /mob/living/simple_animal/hostile/asteroid/fugu/proc/Deflate()
 	if(wumbo)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -159,7 +159,7 @@
 			retreat_distance = 10
 			minimum_distance = 10
 			if(will_burrow)
-				addtimer(CALLBACK(src,  .proc/Burrow), chase_time)
+				addtimer(CALLBACK(src, .proc/Burrow), chase_time)
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/AttackingTarget()
 	if(istype(target, /obj/item/weapon/ore))
@@ -251,7 +251,7 @@
 
 /obj/item/organ/hivelord_core/New()
 	..()
-	addtimer(CALLBACK(src,  .proc/inert_check), 2400)
+	addtimer(CALLBACK(src, .proc/inert_check), 2400)
 
 /obj/item/organ/hivelord_core/proc/inert_check()
 	if(!owner && !preserved)
@@ -339,7 +339,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/New()
 	..()
-	addtimer(CALLBACK(src,  .proc/death), 100)
+	addtimer(CALLBACK(src, .proc/death), 100)
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/blood
 	name = "blood brood"
@@ -493,7 +493,7 @@
 	if(ismineralturf(turftype))
 		var/turf/closed/mineral/M = turftype
 		M.gets_drilled()
-	addtimer(CALLBACK(src,  .proc/Trip), 10)
+	addtimer(CALLBACK(src, .proc/Trip), 10)
 
 /obj/effect/goliath_tentacle/original
 
@@ -642,7 +642,7 @@
 	environment_smash = 2
 	mob_size = MOB_SIZE_LARGE
 	speed = 1
-	addtimer(CALLBACK(src,  .proc/Deflate), 100)
+	addtimer(CALLBACK(src, .proc/Deflate), 100)
 
 /mob/living/simple_animal/hostile/asteroid/fugu/proc/Deflate()
 	if(wumbo)

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -65,7 +65,7 @@
 /mob/living/simple_animal/hostile/mushroom/adjustHealth(amount, updating_health = TRUE, forced = FALSE) //Possibility to flee from a fight just to make it more visually interesting
 	if(!retreat_distance && prob(33))
 		retreat_distance = 5
-		addtimer(src, "stop_retreat", 30)
+		addtimer(CALLBACK(src,  .proc/stop_retreat), 30)
 	. = ..()
 
 /mob/living/simple_animal/hostile/mushroom/proc/stop_retreat()
@@ -111,7 +111,7 @@
 	revive(full_heal = 1)
 	UpdateMushroomCap()
 	recovery_cooldown = 1
-	addtimer(src, "recovery_recharge", 300)
+	addtimer(CALLBACK(src,  .proc/recovery_recharge), 300)
 
 /mob/living/simple_animal/hostile/mushroom/proc/recovery_recharge()
 	recovery_cooldown = 0

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -65,7 +65,7 @@
 /mob/living/simple_animal/hostile/mushroom/adjustHealth(amount, updating_health = TRUE, forced = FALSE) //Possibility to flee from a fight just to make it more visually interesting
 	if(!retreat_distance && prob(33))
 		retreat_distance = 5
-		addtimer(CALLBACK(src,  .proc/stop_retreat), 30)
+		addtimer(CALLBACK(src, .proc/stop_retreat), 30)
 	. = ..()
 
 /mob/living/simple_animal/hostile/mushroom/proc/stop_retreat()
@@ -111,7 +111,7 @@
 	revive(full_heal = 1)
 	UpdateMushroomCap()
 	recovery_cooldown = 1
-	addtimer(CALLBACK(src,  .proc/recovery_recharge), 300)
+	addtimer(CALLBACK(src, .proc/recovery_recharge), 300)
 
 /mob/living/simple_animal/hostile/mushroom/proc/recovery_recharge()
 	recovery_cooldown = 0

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -23,7 +23,7 @@
 	for(var/turf/T in anchors)
 		var/datum/beam/B = Beam(T, "vine", time=INFINITY, maxdistance=5, beam_type=/obj/effect/ebeam/vine)
 		B.sleep_time = 10 //these shouldn't move, so let's slow down updates to 1 second (any slower and the deletion of the vines would be too slow)
-	addtimer(src, "bear_fruit", growth_time)
+	addtimer(CALLBACK(src,  .proc/bear_fruit), growth_time)
 
 /obj/structure/alien/resin/flower_bud_enemy/proc/bear_fruit()
 	visible_message("<span class='danger'>the plant has borne fruit!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -23,7 +23,7 @@
 	for(var/turf/T in anchors)
 		var/datum/beam/B = Beam(T, "vine", time=INFINITY, maxdistance=5, beam_type=/obj/effect/ebeam/vine)
 		B.sleep_time = 10 //these shouldn't move, so let's slow down updates to 1 second (any slower and the deletion of the vines would be too slow)
-	addtimer(CALLBACK(src,  .proc/bear_fruit), growth_time)
+	addtimer(CALLBACK(src, .proc/bear_fruit), growth_time)
 
 /obj/structure/alien/resin/flower_bud_enemy/proc/bear_fruit()
 	visible_message("<span class='danger'>the plant has borne fruit!</span>")

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -393,7 +393,7 @@
 				else if(canmove && isturf(loc) && prob(33))
 					step(src, pick(cardinal))
 		else if(!AIproc)
-			addtimer(src, "AIprocess", 0)
+			addtimer(CALLBACK(src,  .proc/AIprocess), 0)
 
 /mob/living/simple_animal/slime/handle_automated_movement()
 	return //slime random movement is currently handled in handle_targets()

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -393,7 +393,7 @@
 				else if(canmove && isturf(loc) && prob(33))
 					step(src, pick(cardinal))
 		else if(!AIproc)
-			addtimer(CALLBACK(src,  .proc/AIprocess), 0)
+			addtimer(CALLBACK(src, .proc/AIprocess), 0)
 
 /mob/living/simple_animal/slime/handle_automated_movement()
 	return //slime random movement is currently handled in handle_targets()

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -224,8 +224,8 @@
 			user.visible_message("<span class='notice'>With a sudden blaze, [H] stands back up.</span>")
 			H.fakefire()
 			FulfillContract(H, 1)//Revival contracts are always signed in blood
-			addtimer(H, "fakefireextinguish",5, TIMER_UNIQUE)
-		addtimer(src,"resetcooldown",300, TIMER_UNIQUE)
+			addtimer(CALLBACK(H,  /mob/living/carbon/human.proc/fakefireextinguish), 5, TIMER_UNIQUE)
+		addtimer(CALLBACK(src, "resetcooldown"), 300, TIMER_UNIQUE)
 	else
 		..()
 

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -224,7 +224,7 @@
 			user.visible_message("<span class='notice'>With a sudden blaze, [H] stands back up.</span>")
 			H.fakefire()
 			FulfillContract(H, 1)//Revival contracts are always signed in blood
-			addtimer(CALLBACK(H,  /mob/living/carbon/human.proc/fakefireextinguish), 5, TIMER_UNIQUE)
+			addtimer(CALLBACK(H, /mob/living/carbon/human.proc/fakefireextinguish), 5, TIMER_UNIQUE)
 		addtimer(CALLBACK(src, "resetcooldown"), 300, TIMER_UNIQUE)
 	else
 		..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -134,7 +134,7 @@
 		name = "[area.name] APC"
 		stat |= MAINT
 		src.update_icon()
-		addtimer(src, "update", 5)
+		addtimer(CALLBACK(src,  .proc/update), 5)
 
 /obj/machinery/power/apc/Destroy()
 	apcs_list -= src
@@ -188,7 +188,7 @@
 
 	make_terminal()
 
-	addtimer(src, "update", 5)
+	addtimer(CALLBACK(src,  .proc/update), 5)
 
 /obj/machinery/power/apc/examine(mob/user)
 	..()
@@ -361,7 +361,7 @@
 
 // Used in process so it doesn't update the icon too much
 /obj/machinery/power/apc/proc/queue_icon_update()
-	addtimer(src, "update_icon", APC_UPDATE_ICON_COOLDOWN, TIMER_UNIQUE)
+	addtimer(CALLBACK(src,  .proc/update_icon), APC_UPDATE_ICON_COOLDOWN, TIMER_UNIQUE)
 
 //attack with an item - open/close cover, insert cell, or (un)lock interface
 
@@ -842,7 +842,7 @@
 		return
 	malf << "Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process."
 	malf.malfhack = src
-	malf.malfhacking = addtimer(malf, "malfhacked", 600, TIMER_NORMAL, src)
+	malf.malfhacking = addtimer(CALLBACK(malf,  /mob/living/silicon/ai/.proc/malfhacked, src), 600)
 
 	var/obj/screen/alert/hackingapc/A
 	A = malf.throw_alert("hackingapc", /obj/screen/alert/hackingapc)
@@ -1167,7 +1167,7 @@
 	environ = 0
 	update_icon()
 	update()
-	addtimer(src, "reset", 600, TIMER_NORMAL, APC_RESET_EMP)
+	addtimer(CALLBACK(src,  .proc/reset, APC_RESET_EMP), 600)
 	..()
 
 /obj/machinery/power/apc/blob_act(obj/structure/blob/B)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -134,7 +134,7 @@
 		name = "[area.name] APC"
 		stat |= MAINT
 		src.update_icon()
-		addtimer(CALLBACK(src,  .proc/update), 5)
+		addtimer(CALLBACK(src, .proc/update), 5)
 
 /obj/machinery/power/apc/Destroy()
 	apcs_list -= src
@@ -188,7 +188,7 @@
 
 	make_terminal()
 
-	addtimer(CALLBACK(src,  .proc/update), 5)
+	addtimer(CALLBACK(src, .proc/update), 5)
 
 /obj/machinery/power/apc/examine(mob/user)
 	..()
@@ -361,7 +361,7 @@
 
 // Used in process so it doesn't update the icon too much
 /obj/machinery/power/apc/proc/queue_icon_update()
-	addtimer(CALLBACK(src,  .proc/update_icon), APC_UPDATE_ICON_COOLDOWN, TIMER_UNIQUE)
+	addtimer(CALLBACK(src, .proc/update_icon), APC_UPDATE_ICON_COOLDOWN, TIMER_UNIQUE)
 
 //attack with an item - open/close cover, insert cell, or (un)lock interface
 
@@ -842,7 +842,7 @@
 		return
 	malf << "Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process."
 	malf.malfhack = src
-	malf.malfhacking = addtimer(CALLBACK(malf,  /mob/living/silicon/ai/.proc/malfhacked, src), 600)
+	malf.malfhacking = addtimer(CALLBACK(malf, /mob/living/silicon/ai/.proc/malfhacked, src), 600)
 
 	var/obj/screen/alert/hackingapc/A
 	A = malf.throw_alert("hackingapc", /obj/screen/alert/hackingapc)
@@ -1167,7 +1167,7 @@
 	environ = 0
 	update_icon()
 	update()
-	addtimer(CALLBACK(src,  .proc/reset, APC_RESET_EMP), 600)
+	addtimer(CALLBACK(src, .proc/reset, APC_RESET_EMP), 600)
 	..()
 
 /obj/machinery/power/apc/blob_act(obj/structure/blob/B)

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -124,7 +124,7 @@
 		"<span class='italics'>You hear a loud electrical crack!</span>")
 	playsound(src.loc, 'sound/magic/LightningShock.ogg', 100, 1, extrarange = 5)
 	tesla_zap(src, 5, power_gen * 0.05)
-	addtimer(GLOBAL_PROC, "explosion", 100, TIMER_NORMAL, get_turf(src), 2, 3, 4, 8) // Not a normal explosion.
+	addtimer(CALLBACK(GLOBAL_PROC,  .proc/explosion, get_turf(src), 2, 3, 4, 8), 100) // Not a normal explosion.
 
 /obj/machinery/power/rtg/abductor/bullet_act(obj/item/projectile/Proj)
 	..()

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -124,7 +124,7 @@
 		"<span class='italics'>You hear a loud electrical crack!</span>")
 	playsound(src.loc, 'sound/magic/LightningShock.ogg', 100, 1, extrarange = 5)
 	tesla_zap(src, 5, power_gen * 0.05)
-	addtimer(CALLBACK(GLOBAL_PROC,  .proc/explosion, get_turf(src), 2, 3, 4, 8), 100) // Not a normal explosion.
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/explosion, get_turf(src), 2, 3, 4, 8), 100) // Not a normal explosion.
 
 /obj/machinery/power/rtg/abductor/bullet_act(obj/item/projectile/Proj)
 	..()

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -128,4 +128,4 @@
 	s.start()
 	var/atom/target = get_edge_target_turf(AM, get_dir(src, get_step_away(AM, src)))
 	AM.throw_at(target, 200, 4)
-	addtimer(src, "clear_shock", 5)
+	addtimer(CALLBACK(src,  .proc/clear_shock), 5)

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -128,4 +128,4 @@
 	s.start()
 	var/atom/target = get_edge_target_turf(AM, get_dir(src, get_step_away(AM, src)))
 	AM.throw_at(target, 200, 4)
-	addtimer(CALLBACK(src,  .proc/clear_shock), 5)
+	addtimer(CALLBACK(src, .proc/clear_shock), 5)

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -25,7 +25,7 @@
 /obj/effect/accelerated_particle/New(loc)
 	..()
 
-	addtimer(src, "move", 1)
+	addtimer(CALLBACK(src,  .proc/move), 1)
 
 
 /obj/effect/accelerated_particle/Bump(atom/A)

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -25,7 +25,7 @@
 /obj/effect/accelerated_particle/New(loc)
 	..()
 
-	addtimer(CALLBACK(src,  .proc/move), 1)
+	addtimer(CALLBACK(src, .proc/move), 1)
 
 
 /obj/effect/accelerated_particle/Bump(atom/A)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -56,7 +56,7 @@
 	flick("coilhit", src)
 	playsound(src.loc, 'sound/magic/LightningShock.ogg', 100, 1, extrarange = 5)
 	tesla_zap(src, 5, power_produced)
-	addtimer(CALLBACK(src,  .proc/reset_shocked), 10)
+	addtimer(CALLBACK(src, .proc/reset_shocked), 10)
 
 /obj/machinery/power/grounding_rod
 	name = "Grounding Rod"

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -56,7 +56,7 @@
 	flick("coilhit", src)
 	playsound(src.loc, 'sound/magic/LightningShock.ogg', 100, 1, extrarange = 5)
 	tesla_zap(src, 5, power_produced)
-	addtimer(src, "reset_shocked", 10)
+	addtimer(CALLBACK(src,  .proc/reset_shocked), 10)
 
 /obj/machinery/power/grounding_rod
 	name = "Grounding Rod"

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -100,7 +100,7 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 		energy_to_raise = energy_to_raise * 1.25
 
 		playsound(src.loc, 'sound/magic/lightning_chargeup.ogg', 100, 1, extrarange = 30)
-		addtimer(src, "new_mini_ball", 100)
+		addtimer(CALLBACK(src,  .proc/new_mini_ball), 100)
 
 	else if(energy < energy_to_lower && orbiting_balls.len)
 		energy_to_raise = energy_to_raise / 1.25

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -100,7 +100,7 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 		energy_to_raise = energy_to_raise * 1.25
 
 		playsound(src.loc, 'sound/magic/lightning_chargeup.ogg', 100, 1, extrarange = 30)
-		addtimer(CALLBACK(src,  .proc/new_mini_ball), 100)
+		addtimer(CALLBACK(src, .proc/new_mini_ball), 100)
 
 	else if(energy < energy_to_lower && orbiting_balls.len)
 		energy_to_raise = energy_to_raise / 1.25

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -86,7 +86,7 @@
 	if(!holds_charge)
 		// Put it on a delay because moving item from slot to hand
 		// calls dropped().
-		addtimer(CALLBACK(src,  .proc/empty_if_not_held), 2)
+		addtimer(CALLBACK(src, .proc/empty_if_not_held), 2)
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/proc/empty_if_not_held()
 	if(!ismob(loc))
@@ -112,7 +112,7 @@
 	else
 		carried = 1
 
-	addtimer(CALLBACK(src,  .proc/reload), overheat_time * carried)
+	addtimer(CALLBACK(src, .proc/reload), overheat_time * carried)
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/emp_act(severity)
 	return

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -86,7 +86,7 @@
 	if(!holds_charge)
 		// Put it on a delay because moving item from slot to hand
 		// calls dropped().
-		addtimer(src, "empty_if_not_held", 2)
+		addtimer(CALLBACK(src,  .proc/empty_if_not_held), 2)
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/proc/empty_if_not_held()
 	if(!ismob(loc))
@@ -112,7 +112,7 @@
 	else
 		carried = 1
 
-	addtimer(src, "reload", overheat_time * carried)
+	addtimer(CALLBACK(src,  .proc/reload), overheat_time * carried)
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/emp_act(severity)
 	return

--- a/code/modules/projectiles/guns/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/grenade_launcher.dm
@@ -50,4 +50,4 @@
 	F.active = 1
 	F.icon_state = initial(F.icon_state) + "_active"
 	playsound(user.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
-	addtimer(CALLBACK(F,  /obj/item/weapon/grenade.proc/prime), 15)
+	addtimer(CALLBACK(F, /obj/item/weapon/grenade.proc/prime), 15)

--- a/code/modules/projectiles/guns/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/grenade_launcher.dm
@@ -50,4 +50,4 @@
 	F.active = 1
 	F.icon_state = initial(F.icon_state) + "_active"
 	playsound(user.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
-	addtimer(F, "prime", 15)
+	addtimer(CALLBACK(F,  /obj/item/weapon/grenade.proc/prime), 15)

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -47,7 +47,7 @@
 	current_target = target
 	active = 1
 	current_beam = new(user,current_target,time=6000,beam_icon_state="medbeam",btype=/obj/effect/ebeam/medical)
-	addtimer(CALLBACK(current_beam,  /datum/beam.proc/Start), 0)
+	addtimer(CALLBACK(current_beam, /datum/beam.proc/Start), 0)
 
 	feedback_add_details("gun_fired","[src.type]")
 

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -47,7 +47,7 @@
 	current_target = target
 	active = 1
 	current_beam = new(user,current_target,time=6000,beam_icon_state="medbeam",btype=/obj/effect/ebeam/medical)
-	addtimer(current_beam, "Start", 0)
+	addtimer(CALLBACK(current_beam,  /datum/beam.proc/Start), 0)
 
 	feedback_add_details("gun_fired","[src.type]")
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -29,7 +29,7 @@
 		if(C.dna && C.dna.check_mutation(HULK))
 			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 		else if(C.status_flags & CANWEAKEN)
-			addtimer(CALLBACK(C,  /mob/living/carbon.proc/do_jitter_animation, jitter), 5)
+			addtimer(CALLBACK(C, /mob/living/carbon.proc/do_jitter_animation, jitter), 5)
 
 /obj/item/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -29,7 +29,7 @@
 		if(C.dna && C.dna.check_mutation(HULK))
 			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 		else if(C.status_flags & CANWEAKEN)
-			addtimer(C, "do_jitter_animation", 5, TIMER_NORMAL, jitter)
+			addtimer(CALLBACK(C,  /mob/living/carbon.proc/do_jitter_animation, jitter), 5)
 
 /obj/item/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -121,10 +121,10 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
-	addtimer(CALLBACK(src,  .proc/chemical_mob_spawn, holder, 5, "Gold Slime"), 50)
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime"), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
 
 /datum/chemical_reaction/slime/slimecritlesser
 	name = "Slime Crit Lesser"
@@ -137,10 +137,10 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
-	addtimer(CALLBACK(src,  .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", "neutral"), 50)
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", "neutral"), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
 
 /datum/chemical_reaction/slime/slimecritfriendly
 	name = "Slime Crit Friendly"
@@ -153,10 +153,10 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
-	addtimer(CALLBACK(src,  .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", "neutral"), 50)
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", "neutral"), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
 
 //Silver
 /datum/chemical_reaction/slime/slimebork
@@ -289,10 +289,10 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
-	addtimer(CALLBACK(src,  .proc/freeze, holder), 50)
+	addtimer(CALLBACK(src, .proc/freeze, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
 
 /datum/chemical_reaction/slime/slimefreeze/proc/freeze(datum/reagents/holder)
 	if(holder && holder.my_atom)
@@ -339,10 +339,10 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/turf/TU = get_turf(holder.my_atom)
 	TU.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
-	addtimer(CALLBACK(src,  .proc/slime_burn, holder), 50)
+	addtimer(CALLBACK(src, .proc/slime_burn, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
 
 /datum/chemical_reaction/slime/slimefire/proc/slime_burn(datum/reagents/holder)
 	if(holder && holder.my_atom)
@@ -551,10 +551,10 @@
 	message_admins("Slime Explosion reaction started at <a href='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>[T.loc.name] (JMP)</a>. Last Fingerprint: [touch_msg]")
 	log_game("Slime Explosion reaction started at [T.loc.name] ([T.x],[T.y],[T.z]). Last Fingerprint: [lastkey ? lastkey : "N/A"].")
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
-	addtimer(CALLBACK(src,  .proc/boom, holder), 50)
+	addtimer(CALLBACK(src, .proc/boom, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
 
 /datum/chemical_reaction/slime/slimeexplosion/proc/boom(datum/reagents/holder)
 	if(holder && holder.my_atom)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -121,10 +121,10 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
-	addtimer(src, "chemical_mob_spawn", 50, TIMER_NORMAL, holder, 5, "Gold Slime")
+	addtimer(CALLBACK(src,  .proc/chemical_mob_spawn, holder, 5, "Gold Slime"), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(src, "delete_extract", 55, TIMER_NORMAL, holder)
+	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
 
 /datum/chemical_reaction/slime/slimecritlesser
 	name = "Slime Crit Lesser"
@@ -137,10 +137,10 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
-	addtimer(src, "chemical_mob_spawn", 50, TIMER_NORMAL, holder, 3, "Lesser Gold Slime", "neutral")
+	addtimer(CALLBACK(src,  .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", "neutral"), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(src, "delete_extract", 55, TIMER_NORMAL, holder)
+	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
 
 /datum/chemical_reaction/slime/slimecritfriendly
 	name = "Slime Crit Friendly"
@@ -153,10 +153,10 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
-	addtimer(src, "chemical_mob_spawn", 50, TIMER_NORMAL, holder, 1, "Friendly Gold Slime", "neutral")
+	addtimer(CALLBACK(src,  .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", "neutral"), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(src, "delete_extract", 55, TIMER_NORMAL, holder)
+	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
 
 //Silver
 /datum/chemical_reaction/slime/slimebork
@@ -289,10 +289,10 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
-	addtimer(src, "freeze", 50, TIMER_NORMAL, holder)
+	addtimer(CALLBACK(src,  .proc/freeze, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(src, "delete_extract", 55, TIMER_NORMAL, holder)
+	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
 
 /datum/chemical_reaction/slime/slimefreeze/proc/freeze(datum/reagents/holder)
 	if(holder && holder.my_atom)
@@ -339,10 +339,10 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/turf/TU = get_turf(holder.my_atom)
 	TU.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
-	addtimer(src, "slime_burn", 50, TIMER_NORMAL, holder)
+	addtimer(CALLBACK(src,  .proc/slime_burn, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(src, "delete_extract", 55, TIMER_NORMAL, holder)
+	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
 
 /datum/chemical_reaction/slime/slimefire/proc/slime_burn(datum/reagents/holder)
 	if(holder && holder.my_atom)
@@ -551,10 +551,10 @@
 	message_admins("Slime Explosion reaction started at <a href='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>[T.loc.name] (JMP)</a>. Last Fingerprint: [touch_msg]")
 	log_game("Slime Explosion reaction started at [T.loc.name] ([T.x],[T.y],[T.z]). Last Fingerprint: [lastkey ? lastkey : "N/A"].")
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
-	addtimer(src, "boom", 50, TIMER_NORMAL, holder)
+	addtimer(CALLBACK(src,  .proc/boom, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(src, "delete_extract", 55, TIMER_NORMAL, holder)
+	M.qdel_timer = addtimer(CALLBACK(src,  .proc/delete_extract, holder), 55)
 
 /datum/chemical_reaction/slime/slimeexplosion/proc/boom(datum/reagents/holder)
 	if(holder && holder.my_atom)

--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -392,7 +392,7 @@
 	updateDialog()
 
 	if(flush && air_contents.return_pressure() >= SEND_PRESSURE) // flush can happen even without power
-		addtimer(CALLBACK(src,  .proc/flush), 0)
+		addtimer(CALLBACK(src, .proc/flush), 0)
 
 	if(stat & NOPOWER) // won't charge if no power
 		return

--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -392,7 +392,7 @@
 	updateDialog()
 
 	if(flush && air_contents.return_pressure() >= SEND_PRESSURE) // flush can happen even without power
-		addtimer(src, "flush", 0)
+		addtimer(CALLBACK(src,  .proc/flush), 0)
 
 	if(stat & NOPOWER) // won't charge if no power
 		return

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -47,7 +47,7 @@
 
 /obj/structure/cursed_money/New()
 	. = ..()
-	addtimer(src, "collapse", 600)
+	addtimer(CALLBACK(src,  .proc/collapse), 600)
 
 /obj/structure/cursed_money/proc/collapse()
 	visible_message("<span class='warning'>[src] falls in on itself, \

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -47,7 +47,7 @@
 
 /obj/structure/cursed_money/New()
 	. = ..()
-	addtimer(CALLBACK(src,  .proc/collapse), 600)
+	addtimer(CALLBACK(src, .proc/collapse), 600)
 
 /obj/structure/cursed_money/proc/collapse()
 	visible_message("<span class='warning'>[src] falls in on itself, \

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -73,7 +73,7 @@ var/datum/events/keycard_events = new()
 	event = event_type
 	waiting = 1
 	keycard_events.fireEvent("triggerEvent", src)
-	addtimer(src, "eventSent", 20)
+	addtimer(CALLBACK(src,  .proc/eventSent), 20)
 
 /obj/machinery/keycard_auth/proc/eventSent()
 	triggerer = null
@@ -83,7 +83,7 @@ var/datum/events/keycard_events = new()
 /obj/machinery/keycard_auth/proc/triggerEvent(source)
 	icon_state = "auth_on"
 	event_source = source
-	addtimer(src, "eventTriggered", 20)
+	addtimer(CALLBACK(src,  .proc/eventTriggered), 20)
 
 /obj/machinery/keycard_auth/proc/eventTriggered()
 	icon_state = "auth_off"

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -73,7 +73,7 @@ var/datum/events/keycard_events = new()
 	event = event_type
 	waiting = 1
 	keycard_events.fireEvent("triggerEvent", src)
-	addtimer(CALLBACK(src,  .proc/eventSent), 20)
+	addtimer(CALLBACK(src, .proc/eventSent), 20)
 
 /obj/machinery/keycard_auth/proc/eventSent()
 	triggerer = null
@@ -83,7 +83,7 @@ var/datum/events/keycard_events = new()
 /obj/machinery/keycard_auth/proc/triggerEvent(source)
 	icon_state = "auth_on"
 	event_source = source
-	addtimer(CALLBACK(src,  .proc/eventTriggered), 20)
+	addtimer(CALLBACK(src, .proc/eventTriggered), 20)
 
 /obj/machinery/keycard_auth/proc/eventTriggered()
 	icon_state = "auth_off"

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -18,10 +18,10 @@
 	. = ..()
 	if(!.)
 		return
-	addtimer(CALLBACK(src,  .proc/close), 0, TIMER_UNIQUE)
+	addtimer(CALLBACK(src, .proc/close), 0, TIMER_UNIQUE)
 	// Close any attached airlocks as well
 	for(var/obj/machinery/door/D in orange(1, src))
-		addtimer(CALLBACK(src,  .proc/close), 0, TIMER_UNIQUE)
+		addtimer(CALLBACK(src, .proc/close), 0, TIMER_UNIQUE)
 
 /obj/machinery/door/airlock/onShuttleMove()
 	shuttledocked = 0

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -18,10 +18,10 @@
 	. = ..()
 	if(!.)
 		return
-	addtimer(src, "close", 0, TIMER_UNIQUE)
+	addtimer(CALLBACK(src,  .proc/close), 0, TIMER_UNIQUE)
 	// Close any attached airlocks as well
 	for(var/obj/machinery/door/D in orange(1, src))
-		addtimer(src, "close", 0, TIMER_UNIQUE)
+		addtimer(CALLBACK(src,  .proc/close), 0, TIMER_UNIQUE)
 
 /obj/machinery/door/airlock/onShuttleMove()
 	shuttledocked = 0

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -99,7 +99,7 @@
 		L.visible_message("<span class='revennotice'>A strange purple glow wraps itself around [L] as [L.p_they()] suddenly fall[L.p_s()] unconscious.</span>",
 			"<span class='revendanger'>[desc]</span>")
 		// Don't let them sit suround unconscious forever
-		addtimer(CALLBACK(src,  .proc/sleeper_dreams, L), 100)
+		addtimer(CALLBACK(src, .proc/sleeper_dreams, L), 100)
 
 	// Existing sleepers
 	for(var/i in found)

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -99,7 +99,7 @@
 		L.visible_message("<span class='revennotice'>A strange purple glow wraps itself around [L] as [L.p_they()] suddenly fall[L.p_s()] unconscious.</span>",
 			"<span class='revendanger'>[desc]</span>")
 		// Don't let them sit suround unconscious forever
-		addtimer(src, "sleeper_dreams", 100, TIMER_NORMAL, L)
+		addtimer(CALLBACK(src,  .proc/sleeper_dreams, L), 100)
 
 	// Existing sleepers
 	for(var/i in found)

--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -160,7 +160,7 @@
 	src.client.eye = src
 	src.visible_message("<span class='warning'><B>[src] appears in a firey blaze!</B>")
 	playsound(get_turf(src), 'sound/magic/exit_blood.ogg', 100, 1, -1)
-	addtimer(src, "fakefireextinguish", 15, TIMER_UNIQUE)
+	addtimer(CALLBACK(src,  .proc/fakefireextinguish), 15, TIMER_UNIQUE)
 
 /obj/effect/proc_holder/spell/targeted/sintouch
 	name = "Sin Touch"

--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -160,7 +160,7 @@
 	src.client.eye = src
 	src.visible_message("<span class='warning'><B>[src] appears in a firey blaze!</B>")
 	playsound(get_turf(src), 'sound/magic/exit_blood.ogg', 100, 1, -1)
-	addtimer(CALLBACK(src,  .proc/fakefireextinguish), 15, TIMER_UNIQUE)
+	addtimer(CALLBACK(src, .proc/fakefireextinguish), 15, TIMER_UNIQUE)
 
 /obj/effect/proc_holder/spell/targeted/sintouch
 	name = "Sin Touch"

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -20,7 +20,7 @@
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/cast(list/targets,mob/user = usr) //magnets, so mostly hardcoded
 	playsound(get_turf(user), 'sound/magic/Ethereal_Enter.ogg', 50, 1, -1)
 	for(var/mob/living/target in targets)
-		addtimer(CALLBACK(src,  .proc/do_jaunt, target), 0)
+		addtimer(CALLBACK(src, .proc/do_jaunt, target), 0)
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/do_jaunt(mob/living/target)
 	target.notransform = 1

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -20,7 +20,7 @@
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/cast(list/targets,mob/user = usr) //magnets, so mostly hardcoded
 	playsound(get_turf(user), 'sound/magic/Ethereal_Enter.ogg', 50, 1, -1)
 	for(var/mob/living/target in targets)
-		addtimer(src, "do_jaunt", 0, TIMER_NORMAL, target)
+		addtimer(CALLBACK(src,  .proc/do_jaunt, target), 0)
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/do_jaunt(mob/living/target)
 	target.notransform = 1

--- a/code/modules/spells/spell_types/knock.dm
+++ b/code/modules/spells/spell_types/knock.dm
@@ -16,9 +16,9 @@
 	user << sound("sound/magic/Knock.ogg")
 	for(var/turf/T in targets)
 		for(var/obj/machinery/door/door in T.contents)
-			addtimer(src, "open_door", 0, TIMER_NORMAL, door)
+			addtimer(CALLBACK(src,  .proc/open_door, door), 0)
 		for(var/obj/structure/closet/C in T.contents)
-			addtimer(src, "open_closet", 0, TIMER_NORMAL, C)
+			addtimer(CALLBACK(src,  .proc/open_closet, C), 0)
 
 /obj/effect/proc_holder/spell/aoe_turf/knock/proc/open_door(var/obj/machinery/door/door)
 	if(istype(door, /obj/machinery/door/airlock))

--- a/code/modules/spells/spell_types/knock.dm
+++ b/code/modules/spells/spell_types/knock.dm
@@ -16,9 +16,9 @@
 	user << sound("sound/magic/Knock.ogg")
 	for(var/turf/T in targets)
 		for(var/obj/machinery/door/door in T.contents)
-			addtimer(CALLBACK(src,  .proc/open_door, door), 0)
+			addtimer(CALLBACK(src, .proc/open_door, door), 0)
 		for(var/obj/structure/closet/C in T.contents)
-			addtimer(CALLBACK(src,  .proc/open_closet, C), 0)
+			addtimer(CALLBACK(src, .proc/open_closet, C), 0)
 
 /obj/effect/proc_holder/spell/aoe_turf/knock/proc/open_door(var/obj/machinery/door/door)
 	if(istype(door, /obj/machinery/door/airlock))

--- a/code/modules/spells/spell_types/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/spacetime_distortion.dm
@@ -34,7 +34,7 @@
 	perform(turf_steps,user=user)
 
 /obj/effect/proc_holder/spell/spacetime_dist/after_cast(list/targets)
-	addtimer(CALLBACK(src,  .proc/clean_turfs), duration)
+	addtimer(CALLBACK(src, .proc/clean_turfs), duration)
 
 /obj/effect/proc_holder/spell/spacetime_dist/cast(list/targets, mob/user = usr)
 	effects = list()

--- a/code/modules/spells/spell_types/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/spacetime_distortion.dm
@@ -34,7 +34,7 @@
 	perform(turf_steps,user=user)
 
 /obj/effect/proc_holder/spell/spacetime_dist/after_cast(list/targets)
-	addtimer(src, "clean_turfs", duration)
+	addtimer(CALLBACK(src,  .proc/clean_turfs), duration)
 
 /obj/effect/proc_holder/spell/spacetime_dist/cast(list/targets, mob/user = usr)
 	effects = list()

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -181,7 +181,7 @@
 /obj/machinery/bsa/full/proc/reload()
 	ready = FALSE
 	use_power(power_used_per_shot)
-	addtimer(src,"ready_cannon",600)
+	addtimer(CALLBACK(src,"ready_cannon"),600)
 
 /obj/machinery/bsa/full/proc/ready_cannon()
 	ready = TRUE

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -57,7 +57,7 @@
 /obj/item/organ/cyberimp/chest/reviver/on_life()
 	if(reviving)
 		if(owner.stat == UNCONSCIOUS)
-			addtimer(src, "heal", 30)
+			addtimer(CALLBACK(src,  .proc/heal), 30)
 		else
 			cooldown = revive_cost + world.time
 			reviving = FALSE
@@ -100,7 +100,7 @@
 		var/mob/living/carbon/human/H = owner
 		if(H.stat != DEAD && prob(50 / severity))
 			H.heart_attack = TRUE
-			addtimer(src, "undo_heart_attack", 600 / severity)
+			addtimer(CALLBACK(src,  .proc/undo_heart_attack), 600 / severity)
 
 /obj/item/organ/cyberimp/chest/reviver/proc/undo_heart_attack()
 	var/mob/living/carbon/human/H = owner

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -57,7 +57,7 @@
 /obj/item/organ/cyberimp/chest/reviver/on_life()
 	if(reviving)
 		if(owner.stat == UNCONSCIOUS)
-			addtimer(CALLBACK(src,  .proc/heal), 30)
+			addtimer(CALLBACK(src, .proc/heal), 30)
 		else
 			cooldown = revive_cost + world.time
 			reviving = FALSE
@@ -100,7 +100,7 @@
 		var/mob/living/carbon/human/H = owner
 		if(H.stat != DEAD && prob(50 / severity))
 			H.heart_attack = TRUE
-			addtimer(CALLBACK(src,  .proc/undo_heart_attack), 600 / severity)
+			addtimer(CALLBACK(src, .proc/undo_heart_attack), 600 / severity)
 
 /obj/item/organ/cyberimp/chest/reviver/proc/undo_heart_attack()
 	var/mob/living/carbon/human/H = owner

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -113,7 +113,7 @@
 	if(crit_fail)
 		return
 	crit_fail = TRUE
-	addtimer(CALLBACK(src,  .proc/reboot), 90 / severity)
+	addtimer(CALLBACK(src, .proc/reboot), 90 / severity)
 
 /obj/item/organ/cyberimp/brain/anti_stun/proc/reboot()
 	crit_fail = FALSE

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -113,7 +113,7 @@
 	if(crit_fail)
 		return
 	crit_fail = TRUE
-	addtimer(src, "reboot", 90 / severity)
+	addtimer(CALLBACK(src,  .proc/reboot), 90 / severity)
 
 /obj/item/organ/cyberimp/brain/anti_stun/proc/reboot()
 	crit_fail = FALSE

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -124,7 +124,7 @@
 		if(!special)
 			H.heart_attack = 1
 
-	addtimer(CALLBACK(src,  .proc/stop_if_unowned), 120)
+	addtimer(CALLBACK(src, .proc/stop_if_unowned), 120)
 
 /obj/item/organ/heart/proc/stop_if_unowned()
 	if(!owner)
@@ -136,7 +136,7 @@
 		visible_message("<span class='notice'>[user] squeezes [src] to \
 			make it beat again!</span>")
 		Restart()
-		addtimer(CALLBACK(src,  .proc/stop_if_unowned), 80)
+		addtimer(CALLBACK(src, .proc/stop_if_unowned), 80)
 
 /obj/item/organ/heart/Insert(mob/living/carbon/M, special = 0)
 	..()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -124,7 +124,7 @@
 		if(!special)
 			H.heart_attack = 1
 
-	addtimer(src, "stop_if_unowned", 120)
+	addtimer(CALLBACK(src,  .proc/stop_if_unowned), 120)
 
 /obj/item/organ/heart/proc/stop_if_unowned()
 	if(!owner)
@@ -136,7 +136,7 @@
 		visible_message("<span class='notice'>[user] squeezes [src] to \
 			make it beat again!</span>")
 		Restart()
-		addtimer(src, "stop_if_unowned", 80)
+		addtimer(CALLBACK(src,  .proc/stop_if_unowned), 80)
 
 /obj/item/organ/heart/Insert(mob/living/carbon/M, special = 0)
 	..()

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -412,7 +412,7 @@ var/static/regex/multispin_words = regex("like a record baby")
 
 	//HONK
 	else if((findtext(message, honk_words)))
-		addtimer(GLOBAL_PROC, "playsound", 25, TIMER_NORMAL, get_turf(owner), "sound/items/bikehorn.ogg", 300, 1)
+		addtimer(CALLBACK(GLOBAL_PROC,  .proc/playsound, get_turf(owner), "sound/items/bikehorn.ogg", 300, 1), 25)
 		if(owner.mind && owner.mind.assigned_role == "Clown")
 			for(var/mob/living/carbon/C in listeners)
 				C.slip(0,7 * power_multiplier)

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -412,7 +412,7 @@ var/static/regex/multispin_words = regex("like a record baby")
 
 	//HONK
 	else if((findtext(message, honk_words)))
-		addtimer(CALLBACK(GLOBAL_PROC,  .proc/playsound, get_turf(owner), "sound/items/bikehorn.ogg", 300, 1), 25)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, get_turf(owner), "sound/items/bikehorn.ogg", 300, 1), 25)
 		if(owner.mind && owner.mind.assigned_role == "Clown")
 			for(var/mob/living/carbon/C in listeners)
 				C.slip(0,7 * power_multiplier)

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -26,7 +26,7 @@ var/list/GPS_list = list()
 	emped = TRUE
 	overlays -= "working"
 	add_overlay("emp")
-	addtimer(CALLBACK(src,  .proc/reboot), 300)
+	addtimer(CALLBACK(src, .proc/reboot), 300)
 
 /obj/item/device/gps/proc/reboot()
 	emped = FALSE

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -26,7 +26,7 @@ var/list/GPS_list = list()
 	emped = TRUE
 	overlays -= "working"
 	add_overlay("emp")
-	addtimer(src, "reboot", 300)
+	addtimer(CALLBACK(src,  .proc/reboot), 300)
 
 /obj/item/device/gps/proc/reboot()
 	emped = FALSE

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -67,7 +67,7 @@
 	playsound(src.loc, 'sound/machines/airlock_alien_prying.ogg', 100, 1)
 	A.audible_message("<span class='italics'>You hear a loud metallic grinding sound.</span>")
 
-	addtimer(src, "growl", 20, TIMER_NORMAL, user)
+	addtimer(CALLBACK(src,  .proc/growl, user), 20)
 
 	if(do_after(user, delay=160, needhand=FALSE, target=A, progress=TRUE))
 		playsound(src.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -67,7 +67,7 @@
 	playsound(src.loc, 'sound/machines/airlock_alien_prying.ogg', 100, 1)
 	A.audible_message("<span class='italics'>You hear a loud metallic grinding sound.</span>")
 
-	addtimer(CALLBACK(src,  .proc/growl, user), 20)
+	addtimer(CALLBACK(src, .proc/growl, user), 20)
 
 	if(do_after(user, delay=160, needhand=FALSE, target=A, progress=TRUE))
 		playsound(src.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)


### PR DESCRIPTION
Needs review and then quick merge to avoid conflict hell.

Also, keep an eye out for any pr active now or merged recently that uses addtimer, as i'll have to rebase and fix them too, and ones existing after this is merged will need to be updated.

The new addtimer syntax is addtimer(CALLBACK(thing, .proc/proctocall, args), time, TIMER_TYPE) with timertype being optional and defaulting to TIMER_NORMAL.

@Fox-McCloud this will interest you since it removed string proc references.