### PR TITLE
Vitiligo Level Bugfix

### DIFF
--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -21,7 +21,7 @@ BONUS
 	resistance = -1
 	stage_speed = -1
 	transmittable = -2
-	level = 4
+	level = 5
 	severity = 1
 
 /datum/symptom/vitiligo/Activate(datum/disease/advance/A)
@@ -65,7 +65,7 @@ BONUS
 	resistance = -1
 	stage_speed = -1
 	transmittable = -2
-	level = 4
+	level = 5
 	severity = 1
 
 /datum/symptom/revitiligo/Activate(datum/disease/advance/A)


### PR DESCRIPTION
:cl: 
fix:  	Re-Vitiligo Levels to match wiki.
/:cl:

Matches the wiki now. Lvl 4 goes back to having 10 items, lvl 5 to 7.
