### PR TITLE
Fixes missing materials upon deconstruction/retrieval

### DIFF
--- a/code/datums/material_container.dm
+++ b/code/datums/material_container.dm
@@ -143,13 +143,12 @@
 		if(M.amount < (sheet_amt * MINERAL_MATERIAL_AMOUNT))
 			sheet_amt = round(M.amount / MINERAL_MATERIAL_AMOUNT)
 		var/count = 0
-
 		while(sheet_amt > MAX_STACK_SIZE)
 			new M.sheet_type(get_turf(owner), MAX_STACK_SIZE)
 			count += MAX_STACK_SIZE
 			use_amount_type(sheet_amt * MINERAL_MATERIAL_AMOUNT, M.id)
 			sheet_amt -= MAX_STACK_SIZE
-
+			M.amount = (sheet_amt * MINERAL_MATERIAL_AMOUNT)
 		if(round(M.amount / MINERAL_MATERIAL_AMOUNT))
 			new M.sheet_type(get_turf(owner), sheet_amt)
 			count += sheet_amt

--- a/code/datums/material_container.dm
+++ b/code/datums/material_container.dm
@@ -148,8 +148,7 @@
 			count += MAX_STACK_SIZE
 			use_amount_type(sheet_amt * MINERAL_MATERIAL_AMOUNT, M.id)
 			sheet_amt -= MAX_STACK_SIZE
-			M.amount = (sheet_amt * MINERAL_MATERIAL_AMOUNT)
-		if(round(M.amount / MINERAL_MATERIAL_AMOUNT))
+		if(round((sheet_amt * MINERAL_MATERIAL_AMOUNT) / MINERAL_MATERIAL_AMOUNT))
 			new M.sheet_type(get_turf(owner), sheet_amt)
 			count += sheet_amt
 			use_amount_type(sheet_amt * MINERAL_MATERIAL_AMOUNT, M.id)


### PR DESCRIPTION
Fixes attempts to retrieve materials resulting in missing stacks if there is more than one full stack of a material in the machine.
This fix should affect anything that can contain more than one stack of materials (autolathe, exosuit fabricator, and so on).

Fixes  #22506.