### PR TITLE
Changes to Metastation Xenobiology

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /turf/open/space,
 /area/space)
@@ -46691,10 +46691,7 @@
 /area/crew_quarters/bar)
 "bCu" = (
 /obj/structure/table/wood/poker,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/item/weapon/gun/ballistic/revolver/russian = 5, /obj/item/weapon/storage/box/syndie_kit/throwing_weapons, /obj/item/toy/cards/deck/syndicate = 2);
-	name = "gambling valuables spawner"
-	},
+/obj/effect/spawner/lootdrop/gambling,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bCv" = (
@@ -89461,11 +89458,17 @@
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/toxins/xenobiology)
@@ -93887,6 +93890,521 @@
 /area/medical/research{
 	name = "Research Division"
 	})
+"dfN" = (
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/open/space,
+/area/space)
+"dfO" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 1
+	},
+/area/toxins/xenobiology)
+"dfP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 1
+	},
+/area/toxins/xenobiology)
+"dfQ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
+/area/toxins/xenobiology)
+"dfR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dfS" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 2
+	},
+/area/toxins/xenobiology)
+"dfT" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dfU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dfV" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dfW" = (
+/obj/machinery/button/door{
+	id = "xenobio1";
+	name = "Containment Blast Doors";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plasteel/warnwhite{
+	dir = 1
+	},
+/area/toxins/xenobiology)
+"dfX" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warnwhite/corner{
+	dir = 4
+	},
+/area/toxins/xenobiology)
+"dfY" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dfZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warnwhite/corner{
+	dir = 8
+	},
+/area/toxins/xenobiology)
+"dga" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/warnwhite{
+	dir = 1
+	},
+/area/toxins/xenobiology)
+"dgb" = (
+/obj/machinery/computer/camera_advanced/xenobio,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dgc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dgd" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dge" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dgf" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dgg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	req_access_txt = 1
+	},
+/turf/open/floor/plasteel/warnwhite{
+	dir = 2
+	},
+/area/toxins/xenobiology)
+"dgh" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/warnwhite{
+	dir = 2
+	},
+/area/toxins/xenobiology)
+"dgi" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Aft-Starboard";
+	dir = 8;
+	network = list("SS13","RD")
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/toxins/xenobiology)
+"dgj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/toxins/xenobiology)
+"dgk" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/toxins/xenobiology)
+"dgl" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 10
+	},
+/area/toxins/xenobiology)
+"dgm" = (
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 2
+	},
+/area/toxins/xenobiology)
+"dgn" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 2
+	},
+/area/toxins/xenobiology)
+"dgo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Break Room";
+	req_access_txt = ""
+	},
+/turf/open/floor/plasteel/whitepurple{
+	dir = 4
+	},
+/area/toxins/xenobiology)
+"dgp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 9
+	},
+/area/toxins/xenobiology)
+"dgq" = (
+/obj/machinery/camera{
+	c_tag = "Bar - Backroom";
+	dir = 2;
+	network = list("SS13")
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 1
+	},
+/area/toxins/xenobiology)
+"dgr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/airalarm{
+	frequency = 1439;
+	pixel_y = 23
+	},
+/obj/structure/closet/wardrobe/science_white,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 5
+	},
+/area/toxins/xenobiology)
+"dgs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	req_access_txt = 1
+	},
+/obj/item/weapon/twohanded/required/kirbyplants{
+	icon_state = "plant-10";
+	layer = 4.1
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
+/area/toxins/xenobiology)
+"dgt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1;
+	scrub_Toxins = 0
+	},
+/obj/structure/closet/wardrobe/science_white,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/toxins/xenobiology)
+"dgu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	req_access_txt = 1
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
+/area/toxins/xenobiology)
+"dgv" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/wardrobe/science_white,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/toxins/xenobiology)
+"dgw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	req_access_txt = 1
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
+/area/toxins/xenobiology)
+"dgx" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dgy" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/crayons,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/toxins/xenobiology)
+"dgz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
+/area/toxins/xenobiology)
+"dgA" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dgB" = (
+/obj/structure/table/glass,
+/obj/item/weapon/wrench/brass,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/toxins/xenobiology)
+"dgC" = (
+/obj/effect/spawner/lootdrop/two_percent_egg,
+/turf/open/floor/engine,
+/area/toxins/xenobiology)
+"dgD" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
+/area/toxins/xenobiology)
+"dgE" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/white,
+/area/toxins/xenobiology)
+"dgF" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/toxins/xenobiology)
+"dgG" = (
+/obj/structure/table/glass,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
+/area/toxins/xenobiology)
+"dgH" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/purple,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/toxins/xenobiology)
+"dgI" = (
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 10
+	},
+/area/toxins/xenobiology)
+"dgJ" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Foyer";
+	dir = 1;
+	network = list("SS13","Medbay")
+	},
+/turf/open/floor/plasteel/whitepurple/side,
+/area/toxins/xenobiology)
+"dgK" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/purple,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 6
+	},
+/area/toxins/xenobiology)
 
 (1,1,1) = {"
 aaa
@@ -112318,7 +112836,7 @@ cNj
 cOc
 cOL
 cEd
-aaa
+dfN
 aaa
 aaf
 aaa
@@ -123379,18 +123897,6 @@ aaa
 aaf
 aaa
 aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaf
 aaa
 aaa
 aaa
@@ -123398,16 +123904,28 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
 aaa
-aaf
-aaf
 aaa
-aaf
-aaf
-aai
-aag
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123635,37 +124153,37 @@ aaa
 aaa
 aaf
 aaa
-cTC
-cTC
-cTy
-cTy
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-aaf
-aaa
-aaa
-aaf
 aaa
 aaa
 aaa
-aaf
 aaa
-aag
-aag
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123891,38 +124409,38 @@ aaf
 aaf
 aaf
 aaf
-aaf
-cTC
-cUl
-cUz
-cUS
-cVc
-cVo
-cVt
-cVD
-cVN
-cVo
-cVt
-dfs
-cVN
-cVo
-cVt
-dfw
-cVB
-cTC
-cXd
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-aaf
 aaa
-aai
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124149,37 +124667,37 @@ aaa
 aaa
 aaf
 aaa
-cTC
-cUk
-cUy
-cUR
-cVb
-cVo
-cVs
-cVC
-cVB
-cVo
-cVs
-cVC
-cVB
-cVo
-cVs
-cVC
-cVB
-cTC
-cXb
-cXv
-cXv
-cXv
-cXv
-cXv
-cXv
-deO
-bKF
-cTC
+aaa
+aaf
 aaa
 aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
+aaa
+aaf
+aaf
+aaa
+aaf
+aaf
+aai
 aag
+aaa
 aaa
 aaa
 aaa
@@ -124402,42 +124920,42 @@ cTy
 cTy
 cTy
 cTy
+cTy
+cTy
+aaf
+aaa
+cTC
+cTC
+cTy
+cTy
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+brr
+aaa
 aaa
 aaf
+aaa
+aaa
+aaa
 aaf
-aaa
-cTC
-cUn
-cUC
-cUV
-cVe
-cVo
-cVs
-cVB
-cVB
-cVo
-cVs
-cVB
-cVB
-cVo
-cWw
-cWE
-cWL
-cTC
-cXf
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-deP
-cNQ
-cTC
-aaa
 aaa
 aag
 aag
+aaa
 aaa
 aaa
 aaa
@@ -124654,47 +125172,47 @@ cSJ
 cTt
 cTw
 cTz
+dcN
+dcN
 cTA
 dcN
 dcN
 dcQ
 cTy
-aaa
-aaa
+aaf
+aaf
+cTC
+cUl
+cUz
+dfQ
+cVc
+cVo
+cVt
+cVD
+cVN
+cVo
+cVt
+dfs
+cVN
+cVo
+cVt
+dfw
+cVB
+cTC
+dgk
+cXu
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
 aaf
 aaa
-cTC
-cUm
-cUA
-cUU
-cVd
-cVo
-cVu
-cVE
-cVO
-cVo
-cWe
-cWj
-cWo
-cVo
-cVw
-cWD
-cWK
-cWV
-cXe
-cXw
-cTC
-cVB
-deF
-deJ
-cTC
-bxW
-cTC
-cTC
-cTC
-cTC
-aaa
 aai
+aaa
 aaa
 aaa
 aaa
@@ -124914,44 +125432,44 @@ cTy
 cTy
 cTy
 cTy
+cTy
+cTy
 dcW
 cTy
-aaa
-cTO
-cTC
-cTC
-cTC
-cTC
-cUA
-cUU
-cVg
-cTu
-cVw
-cVG
-cVS
-cWb
-cVw
-cWk
-cWp
-cWb
-cWy
-cVH
-cWN
-cWX
-cXh
-dex
-deC
-cVB
-cVB
-cVB
-cTC
-bxW
-cTC
-dds
-dfA
-cTC
 aaf
+aaa
+cTC
+cUk
+cUy
+dfR
+dfS
+cVo
+cVs
+cVC
+cVB
+cVo
+cVs
+cVC
+cVB
+cVo
+cVs
+cVC
+cVB
+cTC
+cXb
+cXv
+cXv
+cXv
+cXv
+cXv
+cXv
+deO
+bKF
+cTC
+aaa
+aaa
 aag
+aaa
 aaa
 aaa
 aaa
@@ -125170,45 +125688,45 @@ bVE
 aaa
 aaf
 aaa
+aaa
+aaa
 cTy
 dcW
 cTy
-cTy
+aaf
+aaa
 cTC
-cTR
-cTU
-cTY
-cUo
-cUD
-cUW
-cVf
-cVp
-cVv
-cVF
-cVR
-cVZ
-cWf
-cVF
-cVR
-cWu
-cWx
-cYU
-deT
-cWW
-cXg
-cXx
-deB
-deB
-deG
+cUn
+dfO
+cUR
+cVb
+cVo
+cVs
 cVB
+cVB
+cVo
+cVs
+cVB
+cVB
+cVo
+cWw
+cWE
+cWL
 cTC
-deQ
-cTo
-deV
-dds
-cTy
+cXf
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+deP
+cNQ
+cTC
 aaa
 aaa
+aag
+aag
 aaa
 aaa
 aaa
@@ -125427,45 +125945,45 @@ bVE
 aaa
 aaf
 aaa
-cTy
-dcY
-dcN
-cTB
-cTP
-cTT
-cTW
-cUj
-cUp
-cUF
-cUY
-cVi
-cVr
-cVy
-cVI
-cVV
-cWd
-cWd
-cYG
-cYH
-cWd
-cWd
-cWd
-cWP
-cWY
-cXj
-dez
-cVB
-cVB
-cVC
-deL
-cTC
-deR
-deS
-deW
-dfz
-cXN
-cXl
 aaa
+aaa
+cTy
+dcW
+cTy
+aaf
+aaa
+cTC
+cUm
+dfP
+cUV
+cVe
+cVo
+cVu
+cVE
+cVO
+cVo
+cWe
+cWj
+cWo
+cVo
+cVw
+cWD
+cWK
+cWV
+cXe
+cXw
+cTC
+cVB
+deF
+dgC
+cTC
+bxW
+cTC
+cTC
+cTC
+cTC
+aaa
+aai
 aaa
 aaa
 aaa
@@ -125684,45 +126202,45 @@ bVE
 aaf
 aaf
 aaf
-cTy
-cTy
-cTy
-cTy
-cTC
-cTS
-cTV
-cUi
-cTC
-cUE
-cUX
-cVh
-cVq
-cVx
-cVH
-cVU
-cWc
-cWg
-cVH
-cWq
-cWv
-cWg
-cYU
-deU
-cVh
-cXi
-dey
-deD
-cVB
-deH
-deK
-cTC
-bKD
-cTo
-deV
-dds
-cTy
 aaa
+aaa
+cTy
+dcW
+cTO
+cTC
+cTC
+cTC
+cTC
+cUA
+cUU
+cVg
+cTu
+cVw
+cVG
+cVS
+cWb
+cVw
+cWk
+cWp
+cWb
+dfW
+cVH
+cWN
+cWX
+cXh
+dex
+deC
+cVB
+cVB
+cVB
+cTC
+bxW
+cTC
+dds
+dfA
+cTC
 aaf
+aag
 aaa
 aaa
 aaa
@@ -125943,43 +126461,43 @@ aaa
 aaf
 aaa
 aaa
-aaa
-aaa
-cTQ
+cTy
+dcW
 cTC
-cTX
-cTC
-cTC
-cUG
-cUX
-cVk
-cTu
-cVA
-cVL
-cVX
-cWb
-cWi
-cWn
-cVX
-cWb
-cVx
-cVH
+cTR
+cTU
+cTY
+cUo
+cUD
+cUW
+cVf
+cVp
+cVv
+cVF
+cVR
+cVZ
+cWf
+cVF
+cVR
+cWu
+dfX
+dgb
 cWR
-cXa
-cXr
-deA
-deC
+cWW
+cXg
+cXx
+deB
+deB
+deG
 cVB
-cVB
-deN
 cTC
-cXs
-cTC
+deQ
+cTo
+deV
 dds
-dds
-cTC
+cTy
 aaa
-aag
+aaa
 aaa
 aaa
 aaa
@@ -126200,43 +126718,43 @@ bVE
 bVE
 bVE
 aaa
+cTy
+dcY
+cTP
+cTT
+cTW
+cUj
+cUp
+cUF
+cUY
+cVi
+cVr
+cVy
+cVI
+dfT
+cVI
+cVI
+dfU
+dfV
+cVI
+dfY
+cWd
+dgd
+cWY
+cXj
+dez
+cVB
+cVB
+cVC
+deL
+cTC
+deR
+deS
+deW
+dfz
+cXN
+cXl
 aaa
-aaa
-aaa
-aaf
-cTE
-cTC
-cUq
-cUG
-cUX
-cVj
-cVo
-cVz
-cVK
-cVW
-cVo
-cWh
-cWm
-cWt
-cVo
-cWz
-cWG
-cWQ
-cWZ
-cXq
-cXw
-cTC
-deE
-deI
-deM
-cTC
-cXs
-cTC
-cTC
-cTC
-cTC
-aaf
-aag
 aaa
 aaa
 aaa
@@ -126457,43 +126975,43 @@ cQP
 cRu
 bVE
 aaa
-aaa
-aaa
-aaf
-aaf
-aaf
+cTy
+cTy
 cTC
-cUw
-cUP
+cTS
+cTV
+cUi
+cTC
+cUE
 cUX
-cVm
-cVo
+cVh
+cVq
+cVx
+cVH
+cVU
+cWc
+cWg
+cVH
+cWq
+cWv
+dfZ
+cYU
+dge
+dgg
+dgl
+dey
+deD
 cVB
-cVB
-cVs
-cVo
-cVB
-cVB
-cVs
-cVo
-cWC
-cWJ
-cWU
+deH
+deK
 cTC
-cXt
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cXs
-cTC
+bKD
+cTo
+deV
+dds
+cTy
+aaa
 aaf
-aaa
-aaa
-aag
-aag
 aaa
 aaa
 aaa
@@ -126716,41 +127234,41 @@ bVE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaf
+cTQ
 cTC
-cUv
-cUH
-cUZ
-cVl
-cVo
+cTX
+cTC
+cTC
+cUG
+cUX
+cVk
+cTu
+cVA
+cVL
+cVX
+cWb
+cWi
+cWn
+cVX
+cWb
+dga
+dgc
+dgf
+dgh
+dgm
+deA
+deC
 cVB
-cVC
-cVs
-cVo
 cVB
-cVC
-cVs
-cVo
-cWB
-cWH
-cWT
+deN
 cTC
 cXs
-cXs
-cXs
-cXs
-cXs
-cXs
-cXs
-cXs
 cTC
-aaf
-aaf
+dds
+dds
+cTC
 aaa
-aai
-aaa
+aag
 aaa
 aaa
 aaa
@@ -126974,40 +127492,40 @@ aaa
 aaf
 aaf
 aaa
-aaa
 aaf
+cTE
 cTC
-cUx
-cUQ
-cVa
-cVn
+cUq
+cUG
+cUX
+cVj
 cVo
-cVB
-cVM
-cVY
+cVz
+cVK
+cVW
 cVo
-cVN
-dft
-cVY
+cWh
+cWm
+cWt
 cVo
-cVB
-cVC
-cVs
+cWz
+cWG
+cWQ
+dgi
+dgn
+cXw
 cTC
-cXu
+deE
+deI
+deM
 cTC
-cTC
-cTC
-cTC
+cXs
 cTC
 cTC
 cTC
 cTC
 aaf
-aaa
-aaa
 aag
-aaa
 aaa
 aaa
 aaa
@@ -127230,41 +127748,41 @@ bVE
 aaa
 aaf
 aaa
-aaa
 aaf
 aaf
+aaf
 cTC
-cTC
-cTy
-cTy
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
+cUw
+cUP
+cUX
+cVm
+cVo
 cVB
-dfx
-cVY
+cVB
+cVs
+cVo
+cVB
+cVB
+cVs
+cVo
+cWC
+cWJ
+cWU
+cTX
+dgo
 cTC
 cTC
 cTC
+cTC
+cTC
+cTC
+cXt
+cTC
+aaf
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
 aaa
-aaf
-aaf
 aag
 aag
-aaf
 aaa
 aaa
 aaa
@@ -127490,37 +128008,37 @@ aaa
 aaa
 aaa
 aaf
-aaa
-aaf
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
 cTC
+cUv
+cUH
+cUZ
+cVl
+cVo
+cVB
+cVC
+cVs
+cVo
+cVB
+cVC
+cVs
+cVo
+cWB
+cWH
+cWT
+cTX
+dgp
+dgs
+dgu
+dgw
+dgz
+dgD
+dgG
+dgI
 cTC
-cTC
-cTC
-cTC
-aaa
 aaf
-aaa
-aaa
-aaa
 aaf
-aaa
-aaa
-aaa
-aaa
 aaa
 aai
-aaa
 aaa
 aaa
 aaa
@@ -127745,39 +128263,39 @@ aaa
 aaf
 aaa
 aaa
+aaa
+aaf
+cTC
+cUx
+cUQ
+cVa
+cVn
+cVo
+cVB
+cVM
+cVY
+cVo
+cVN
+dft
+cVY
+cVo
+cVB
+cVC
+cVs
+cTX
+dgq
+cVH
+cVH
+dgx
+dgA
+dgE
+cVH
+dgJ
+cTC
 aaf
 aaa
 aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aag
 aaa
 aaa
 aaa
@@ -128001,41 +128519,41 @@ bVE
 aaf
 aaf
 aaf
-aaf
-aaf
-aaa
-aaa
-aaf
-aaa
 aaa
 aaf
 aaf
+cTC
+cTC
+cTy
+cTy
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cVB
+dfx
+cVY
+dgj
+dgr
+dgt
+dgv
+dgy
+dgB
+dgF
+dgH
+dgK
+cTC
 aaf
-aaa
 aaf
+aag
+aag
 aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -128258,39 +128776,39 @@ bVE
 aaa
 aaf
 aaa
+aaa
+aaa
 aaf
+aaa
 aaf
-aai
-aob
-aob
-aai
-aob
-aob
-aob
-aqJ
-aob
-aob
+aaa
+aaa
+aaa
 aaf
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+cTy
+cTy
+cTy
+cTC
+cTC
+cTC
+aaf
+aaa
 aai
-aob
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -128532,22 +129050,22 @@ aaa
 aai
 aaa
 aaa
+aaf
+aaa
+aaf
+aaa
+aaa
+aaf
 aaa
 aaa
 aaa
 aaa
 aaa
+aaf
 aaa
+aaf
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -128800,11 +129318,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+aaj
+aaj
+aaj
+aaf
 aaa
 aaa
 aaa
@@ -129060,7 +129578,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaf
 aaa
 aaa
 aaa

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -168,3 +168,8 @@
 				/obj/structure/closet/crate/secure/loot = 20,
 				"" = 80
 				)
+
+/obj/effect/spawner/lootdrop/two_percent_egg
+	name = "2% chance xeno egg spawner"
+	loot = list(/obj/effect/decal/remains/xeno = 49,
+				/obj/structure/alien/egg = 1)


### PR DESCRIPTION
:cl: coiax
add: Metastation Xenobiology Lab has been moved slightly (again) and a new breakroom has been added.
/:cl:

![image](https://cloud.githubusercontent.com/assets/609465/21596892/2e0dc346-d142-11e6-93fc-b3e19ce8b2f5.png)

Changes:
- Xenobiology lab now has its own air supply tank, the existing air tank
is not nearly enough.
- Xenobiology now has a breakroom, features include a large number of wardrobes (for clothing all of the new life that is created), a brass wrench and a set of crayons (in homage to the sheer amount of cultery that takes place in xeno), as well as a microwave and donk pockets
- Xenobiology has been moved a little more down and to the right, which means there should be an air gap with all current shuttles (not including the fucking asteroid meme)