### PR TITLE
Makes parcel descriptions less confusing

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1367,3 +1367,20 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 	animate(src, pixel_x = pixel_x + shiftx, pixel_y = pixel_y + shifty, time = 0.2, loop = duration)
 	pixel_x = initialpixelx
 	pixel_y = initialpixely
+
+/proc/weightclass2text(var/w_class)
+	switch(w_class)
+		if(WEIGHT_CLASS_TINY)
+			. = "tiny"
+		if(WEIGHT_CLASS_SMALL)
+			. = "small"
+		if(WEIGHT_CLASS_NORMAL)
+			. = "normal-sized"
+		if(WEIGHT_CLASS_BULKY)
+			. = "bulky"
+		if(WEIGHT_CLASS_HUGE)
+			. = "huge"
+		if(WEIGHT_CLASS_GIGANTIC)
+			. = "gigantic"
+		else
+			. = ""

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -155,29 +155,12 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 /obj/item/examine(mob/user) //This might be spammy. Remove?
 	..()
-	var/size
-	switch(src.w_class)
-		if(WEIGHT_CLASS_TINY)
-			size = "tiny"
-		if(WEIGHT_CLASS_SMALL)
-			size = "small"
-		if(WEIGHT_CLASS_NORMAL)
-			size = "normal-sized"
-		if(WEIGHT_CLASS_BULKY)
-			size = "bulky"
-		if(WEIGHT_CLASS_HUGE)
-			size = "huge"
-		if(WEIGHT_CLASS_GIGANTIC)
-			size = "gigantic"
-		else
-	//if ((CLUMSY in usr.mutations) && prob(50)) t = "funny-looking"
-
 	var/pronoun
 	if(src.gender == PLURAL)
 		pronoun = "They are"
 	else
 		pronoun = "It is"
-
+	var/size = weightclass2text(src.w_class)
 	user << "[pronoun] a [size] item." //e.g. They are a small item. or It is a bulky item.
 
 	if(user.research_scanner) //Mob has a research scanner active.

--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -71,6 +71,7 @@
 				user.put_in_hands(P)
 			I.forceMove(P)
 			var/size = round(I.w_class)
+			P.name = "[weightclass2text(size)] parcel"
 			P.w_class = size
 			size = min(size, 5)
 			P.icon_state = "deliverypackage[size]"

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -1,6 +1,6 @@
 /obj/structure/bigDelivery
 	name = "large parcel"
-	desc = "A big wrapped package."
+	desc = "A large delivery parcel."
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "deliverycloset"
 	density = 1
@@ -69,10 +69,9 @@
 			user << "<span class='warning'>You fail to remove [O]'s wrapping!</span>"
 
 
-
 /obj/item/smallDelivery
-	name = "small parcel"
-	desc = "A small wrapped package."
+	name = "parcel"
+	desc = "A brown paper delivery parcel."
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "deliverypackage3"
 	var/giftwrapped = 0


### PR DESCRIPTION
`"small parcel"` has been renamed to simply `"parcel"` and has been given a description that works better with the fact that the `w_class` of the parcel changes based on the item it has inside it

So now you'll have parcels that look like

```
That's a parcel.
A brown paper delivery parcel.
It is a tiny item.

That's a parcel.
A brown paper delivery parcel.
It is a small item.

That's a parcel.
A brown paper delivery parcel.
It is a normal-sized item.
```

Fixes #22663