### PR TITLE
EMPing will sometimes randomly pulse wires

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -79,7 +79,8 @@
 		if(WIRE_SHOCK) // Pulse to shock the door for 10 ticks.
 			if(!A.secondsElectrified)
 				A.secondsElectrified = 30
-				A.shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
+				if(usr)
+					A.shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
 				add_logs(usr, A, "electrified")
 				spawn(10)
 					if(A)

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -1,3 +1,5 @@
+#define MAXIMUM_EMP_WIRES 3
+
 var/list/wire_colors = list(
 	"blue",
 	"brown",
@@ -156,6 +158,17 @@ var/list/wire_name_directory = list()
 		S.loc = holder.loc
 		return S
 
+/datum/wires/proc/emp_pulse()
+	var/list/possible_wires = shuffle(wires)
+	var/remaining_pulses = MAXIMUM_EMP_WIRES
+
+	for(var/wire in possible_wires)
+		if(prob(10))
+			pulse(wire)
+		remaining_pulses--
+		if(remaining_pulses >= 0)
+			break
+
 // Overridable Procs
 /datum/wires/proc/interactable(mob/user)
 	return TRUE
@@ -245,3 +258,5 @@ var/list/wire_name_directory = list()
 						. = TRUE
 					else
 						L << "<span class='warning'>You need an attachable assembly!</span>"
+
+#undef MAXIMUM_EMP_WIRES

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -163,7 +163,7 @@ var/list/wire_name_directory = list()
 	var/remaining_pulses = MAXIMUM_EMP_WIRES
 
 	for(var/wire in possible_wires)
-		if(prob(10))
+		if(prob(33))
 			pulse(wire)
 		remaining_pulses--
 		if(remaining_pulses >= 0)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -152,7 +152,8 @@
 	return
 
 /atom/proc/emp_act(severity)
-	return
+	if(istype(wires))
+		wires.emp_pulse()
 
 /atom/proc/bullet_act(obj/item/projectile/P, def_zone)
 	. = P.on_hit(src, 0, def_zone)


### PR DESCRIPTION
:cl: coiax
add: EMPs may cause random wires to be pulsed. Please ensure that
sensitive equipment avoids exposure to heavy electromagnetic pulses.
/:cl:

~~10%~~ 33% wire pulse chance, maximum of 3 pulses per atom per EMP.

- [x] ~~Currently not setting off syndicate bombs, need to work out why~~ I had to set off like 50 EMPs near the bomb for it to go off.