### PR TITLE
fixes botcall's callbot not releasing control of ai's clicks.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -69,8 +69,8 @@
 		aicamera.captureimage(A, usr)
 		return
 	if(waypoint_mode)
-		set_waypoint(A)
 		waypoint_mode = 0
+		set_waypoint(A)
 		return
 
 	/*


### PR DESCRIPTION
Basically, while astar was trying to find the path, future clicks would still call set_waypoint, starting more astar operations.