### PR TITLE
Changes the names of Circuit Boards so they are easier on players.

### DIFF
--- a/_maps/map_files/PubbyStation/monastery_shuttle.dm
+++ b/_maps/map_files/PubbyStation/monastery_shuttle.dm
@@ -7,5 +7,5 @@
 	no_destination_swap = TRUE
 
 /obj/item/weapon/circuitboard/computer/shuttle/monastery_shuttle
-	name = "circuit board (Monastery Shuttle)"
+	name = "Monastery Shuttle (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/monastery_shuttle

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -31,7 +31,7 @@
 	update_icon()
 
 /obj/item/weapon/circuitboard/machine/sleeper
-	name = "circuit board (Sleeper)"
+	name = "Sleeper (Machine Board)"
 	build_path = /obj/machinery/sleeper
 	origin_tech = "programming=3;biotech=2;engineering=3"
 	req_components = list(

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -36,7 +36,7 @@ var/list/announcement_systems = list()
 	update_icon()
 
 /obj/item/weapon/circuitboard/machine/announcement_system
-	name = "circuit board (Announcement System)"
+	name = "Announcement System (Machine Board)"
 	build_path = /obj/machinery/announcement_system
 	origin_tech = "programming=3;bluespace=3;magnets=2"
 	req_components = list(

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -56,7 +56,7 @@
 	matching_designs = list()
 
 /obj/item/weapon/circuitboard/machine/autolathe
-	name = "circuit board (Autolathe)"
+	name = "Autolathe (Machine Board)"
 	build_path = /obj/machinery/autolathe
 	origin_tech = "engineering=2;programming=2"
 	req_components = list(

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -67,7 +67,7 @@
 		heal_level = 100
 
 /obj/item/weapon/circuitboard/machine/clonepod
-	name = "circuit board (Clone Pod)"
+	name = "Clone Pod (Machine Board)"
 	build_path = /obj/machinery/clonepod
 	origin_tech = "programming=2;biotech=2"
 	req_components = list(

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -157,58 +157,58 @@
 	var/build_path = null
 
 /obj/item/weapon/circuitboard/computer/turbine_computer
-	name = "circuit board (Turbine Computer)"
+	name = "Turbine Computer (Computer Board)"
 	build_path = /obj/machinery/computer/turbine_computer
 	origin_tech = "programming=4;engineering=4;powerstorage=4"
 /obj/item/weapon/circuitboard/computer/telesci_console
-	name = "circuit board (Telescience Console)"
+	name = "Telescience Console (Computer Board)"
 	build_path = /obj/machinery/computer/telescience
 	origin_tech = "programming=3;bluespace=3;plasmatech=4"
 /obj/item/weapon/circuitboard/computer/message_monitor
-	name = "circuit board (Message Monitor)"
+	name = "Message Monitor (Computer Board)"
 	build_path = /obj/machinery/computer/message_monitor
 	origin_tech = "programming=2"
 /obj/item/weapon/circuitboard/computer/security
-	name = "circuit board (Security Cameras)"
+	name = "Security Cameras (Computer Board)"
 	build_path = /obj/machinery/computer/security
 	origin_tech = "programming=2;combat=2"
 
 /obj/item/weapon/circuitboard/computer/aiupload
-	name = "circuit board (AI Upload)"
+	name = "AI Upload (Computer Board)"
 	build_path = /obj/machinery/computer/upload/ai
 	origin_tech = "programming=4;engineering=4"
 /obj/item/weapon/circuitboard/computer/borgupload
-	name = "circuit board (Cyborg Upload)"
+	name = "Cyborg Upload (Computer Board)"
 	build_path = /obj/machinery/computer/upload/borg
 	origin_tech = "programming=4;engineering=4"
 /obj/item/weapon/circuitboard/computer/med_data
-	name = "circuit board (Medical Records Console)"
+	name = "Medical Records Console (Computer Board)"
 	build_path = /obj/machinery/computer/med_data
 	origin_tech = "programming=2;biotech=2"
 /obj/item/weapon/circuitboard/computer/pandemic
-	name = "circuit board (PanD.E.M.I.C. 2200)"
+	name = "PanD.E.M.I.C. 2200 (Computer Board)"
 	build_path = /obj/machinery/computer/pandemic
 	origin_tech = "programming=2;biotech=2"
 /obj/item/weapon/circuitboard/computer/scan_consolenew
-	name = "circuit board (DNA Machine)"
+	name = "DNA Machine (Computer Board)"
 	build_path = /obj/machinery/computer/scan_consolenew
 	origin_tech = "programming=2;biotech=2"
 /obj/item/weapon/circuitboard/computer/communications
-	name = "circuit board (Communications)"
+	name = "Communications (Computer Board)"
 	build_path = /obj/machinery/computer/communications
 	origin_tech = "programming=3;magnets=3"
 	var/lastTimeUsed = 0
 
 /obj/item/weapon/circuitboard/computer/card
-	name = "circuit board (ID Console)"
+	name = "ID Console (Computer Board)"
 	build_path = /obj/machinery/computer/card
 	origin_tech = "programming=3"
 /obj/item/weapon/circuitboard/computer/card/centcom
-	name = "circuit board (Centcom ID Console)"
+	name = "Centcom ID Console (Computer Board)"
 	build_path = /obj/machinery/computer/card/centcom
 
 /obj/item/weapon/circuitboard/computer/card/minor
-	name = "circuit board (Department Management Console)"
+	name = "Department Management Console (Computer Board)"
 	build_path = /obj/machinery/computer/card/minor
 	var/target_dept = 1
 	var/list/dept_list = list("General","Security","Medical","Science","Engineering")
@@ -225,112 +225,112 @@
 	user << "Currently set to \"[dept_list[target_dept]]\"."
 
 //obj/item/weapon/circuitboard/computer/shield
-//	name = "Circuit board (Shield Control)"
+//	name = "Shield Control (Computer Board)"
 //	build_path = /obj/machinery/computer/stationshield
 /obj/item/weapon/circuitboard/computer/teleporter
-	name = "circuit board (Teleporter)"
+	name = "Teleporter (Computer Board)"
 	build_path = /obj/machinery/computer/teleporter
 	origin_tech = "programming=3;bluespace=3;plasmatech=3"
 /obj/item/weapon/circuitboard/computer/secure_data
-	name = "circuit board (Security Records Console)"
+	name = "Security Records Console (Computer Board)"
 	build_path = /obj/machinery/computer/secure_data
 	origin_tech = "programming=2;combat=2"
 /obj/item/weapon/circuitboard/computer/stationalert
-	name = "circuit board (Station Alerts)"
+	name = "Station Alerts (Computer Board)"
 	build_path = /obj/machinery/computer/station_alert
 /*/obj/item/weapon/circuitboard/computer/atmospheresiphonswitch
-	name = "circuit board (Atmosphere siphon control)"
+	name = "Atmosphere siphon control (Computer Board)"
 	build_path = /obj/machinery/computer/atmosphere/siphonswitch*/
 /obj/item/weapon/circuitboard/computer/atmos_control
-	name = "circuit board (Atmospheric Monitor)"
+	name = "Atmospheric Monitor (Computer Board)"
 	build_path = /obj/machinery/computer/atmos_control
 /obj/item/weapon/circuitboard/computer/atmos_control/tank
-	name = "circuit board (Tank Control)"
+	name = "Tank Control (Computer Board)"
 	build_path = /obj/machinery/computer/atmos_control/tank
 	origin_tech = "programming=2;engineering=3;materials=2"
 /obj/item/weapon/circuitboard/computer/atmos_alert
-	name = "circuit board (Atmospheric Alert)"
+	name = "Atmospheric Alert (Computer Board)"
 	build_path = /obj/machinery/computer/atmos_alert
 /obj/item/weapon/circuitboard/computer/pod
-	name = "circuit board (Massdriver control)"
+	name = "Massdriver control (Computer Board)"
 	build_path = /obj/machinery/computer/pod
 /obj/item/weapon/circuitboard/computer/robotics
-	name = "circuit board (Robotics Control)"
+	name = "Robotics Control (Computer Board)"
 	build_path = /obj/machinery/computer/robotics
 	origin_tech = "programming=3"
 /obj/item/weapon/circuitboard/computer/cloning
-	name = "circuit board (Cloning)"
+	name = "Cloning (Computer Board)"
 	build_path = /obj/machinery/computer/cloning
 	origin_tech = "programming=2;biotech=2"
 /obj/item/weapon/circuitboard/computer/arcade/battle
-	name = "circuit board (Arcade Battle)"
+	name = "Arcade Battle (Computer Board)"
 	build_path = /obj/machinery/computer/arcade/battle
 	origin_tech = "programming=1"
 /obj/item/weapon/circuitboard/computer/arcade/orion_trail
-	name = "circuit board (Orion Trail)"
+	name = "Orion Trail (Computer Board)"
 	build_path = /obj/machinery/computer/arcade/orion_trail
 	origin_tech = "programming=1"
 /obj/item/weapon/circuitboard/computer/turbine_control
-	name = "circuit board (Turbine control)"
+	name = "Turbine control (Computer Board)"
 	build_path = /obj/machinery/computer/turbine_computer
 /obj/item/weapon/circuitboard/computer/solar_control
-	name = "circuit board (Solar Control)"  //name fixed 250810
+	name = "Solar Control (Computer Board)"  //name fixed 250810
 	build_path = /obj/machinery/power/solar_control
 	origin_tech = "programming=2;powerstorage=2"
 /obj/item/weapon/circuitboard/computer/powermonitor
-	name = "circuit board (Power Monitor)"  //name fixed 250810
+	name = "Power Monitor (Computer Board)"  //name fixed 250810
 	build_path = /obj/machinery/computer/monitor
 	origin_tech = "programming=2;powerstorage=2"
 /obj/item/weapon/circuitboard/computer/olddoor
-	name = "circuit board (DoorMex)"
+	name = "DoorMex (Computer Board)"
 	build_path = /obj/machinery/computer/pod/old
 /obj/item/weapon/circuitboard/computer/syndicatedoor
-	name = "circuit board (ProComp Executive)"
+	name = "ProComp Executive (Computer Board)"
 	build_path = /obj/machinery/computer/pod/old/syndicate
 /obj/item/weapon/circuitboard/computer/swfdoor
-	name = "circuit board (Magix)"
+	name = "Magix (Computer Board)"
 	build_path = /obj/machinery/computer/pod/old/swf
 /obj/item/weapon/circuitboard/computer/prisoner
-	name = "circuit board (Prisoner Management Console)"
+	name = "Prisoner Management Console (Computer Board)"
 	build_path = /obj/machinery/computer/prisoner
 /obj/item/weapon/circuitboard/computer/gulag_teleporter_console
-	name = "circuit board (Labor Camp teleporter console)"
+	name = "Labor Camp teleporter console (Computer Board)"
 	build_path = /obj/machinery/computer/gulag_teleporter_computer
 
 /obj/item/weapon/circuitboard/computer/rdconsole
-	name = "circuit board (RD Console)"
+	name = "RD Console (Computer Board)"
 	build_path = /obj/machinery/computer/rdconsole/core
 
 /obj/item/weapon/circuitboard/computer/rdconsole/attackby(obj/item/I, mob/user, params)
 	if(istype(I,/obj/item/weapon/screwdriver))
 		if(build_path == /obj/machinery/computer/rdconsole/core)
-			name = "circuit board (RD Console - Robotics)"
+			name = "RD Console - Robotics (Computer Board)"
 			build_path = /obj/machinery/computer/rdconsole/robotics
 			user << "<span class='notice'>Access protocols successfully updated.</span>"
 		else
-			name = "circuit board (RD Console)"
+			name = "RD Console (Computer Board)"
 			build_path = /obj/machinery/computer/rdconsole/core
 			user << "<span class='notice'>Defaulting access protocols.</span>"
 	else
 		return ..()
 
 /obj/item/weapon/circuitboard/computer/mecha_control
-	name = "circuit board (Exosuit Control Console)"
+	name = "Exosuit Control Console (Computer Board)"
 	build_path = /obj/machinery/computer/mecha
 /obj/item/weapon/circuitboard/computer/rdservercontrol
-	name = "circuit board (R&D Server Control)"
+	name = "R&D Server Control (Computer Board)"
 	build_path = /obj/machinery/computer/rdservercontrol
 /obj/item/weapon/circuitboard/computer/crew
-	name = "circuit board (Crew Monitoring Console)"
+	name = "Crew Monitoring Console (Computer Board)"
 	build_path = /obj/machinery/computer/crew
 	origin_tech = "programming=2;biotech=2"
 /obj/item/weapon/circuitboard/computer/mech_bay_power_console
-	name = "circuit board (Mech Bay Power Control Console)"
+	name = "Mech Bay Power Control Console (Computer Board)"
 	build_path = /obj/machinery/computer/mech_bay_power_console
 	origin_tech = "programming=3;powerstorage=3"
 
 /obj/item/weapon/circuitboard/computer/cargo
-	name = "circuit board (Supply Console)"
+	name = "Supply Console (Computer Board)"
 	build_path = /obj/machinery/computer/cargo
 	origin_tech = "programming=3"
 	var/contraband = 0
@@ -353,27 +353,27 @@
 
 
 /obj/item/weapon/circuitboard/computer/cargo/request
-	name = "circuit board (Supply Request Console)"
+	name = "Supply Request Console (Computer Board)"
 	build_path = /obj/machinery/computer/cargo/request
 
 /obj/item/weapon/circuitboard/computer/operating
-	name = "circuit board (Operating Computer)"
+	name = "Operating Computer (Computer Board)"
 	build_path = /obj/machinery/computer/operating
 	origin_tech = "programming=2;biotech=3"
 /obj/item/weapon/circuitboard/computer/mining
-	name = "circuit board (Outpost Status Display)"
+	name = "Outpost Status Display (Computer Board)"
 	build_path = /obj/machinery/computer/security/mining
 /obj/item/weapon/circuitboard/computer/comm_monitor
-	name = "circuit board (Telecommunications Monitor)"
+	name = "Telecommunications Monitor (Computer Board)"
 	build_path = /obj/machinery/computer/telecomms/monitor
 	origin_tech = "programming=3;magnets=3;bluespace=2"
 /obj/item/weapon/circuitboard/computer/comm_server
-	name = "circuit board (Telecommunications Server Monitor)"
+	name = "Telecommunications Server Monitor (Computer Board)"
 	build_path = /obj/machinery/computer/telecomms/server
 	origin_tech = "programming=3;magnets=3;bluespace=2"
 
 /obj/item/weapon/circuitboard/computer/shuttle
-	name = "circuit board (Shuttle)"
+	name = "Shuttle (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle
 	var/shuttleId
 	var/possible_destinations = ""
@@ -389,52 +389,52 @@
 		return ..()
 
 /obj/item/weapon/circuitboard/computer/labor_shuttle
-	name = "circuit board (Labor Shuttle)"
+	name = "Labor Shuttle (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/labor
 /obj/item/weapon/circuitboard/computer/labor_shuttle/one_way
-	name = "circuit board (Prisoner Shuttle Console)"
+	name = "Prisoner Shuttle Console (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/labor/one_way
 /obj/item/weapon/circuitboard/computer/ferry
-	name = "circuit board (Transport Ferry)"
+	name = "Transport Ferry (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/ferry
 /obj/item/weapon/circuitboard/computer/ferry/request
-	name = "circuit board (Transport Ferry Console)"
+	name = "Transport Ferry Console (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/ferry/request
 /obj/item/weapon/circuitboard/computer/mining_shuttle
-	name = "circuit board (Mining Shuttle)"
+	name = "Mining Shuttle (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/mining
 /obj/item/weapon/circuitboard/computer/white_ship
-	name = "circuit board (White Ship)"
+	name = "White Ship (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/white_ship
 /obj/item/weapon/circuitboard/computer/holodeck// Not going to let people get this, but it's just here for future
-	name = "circuit board (Holodeck Control)"
+	name = "Holodeck Control (Computer Board)"
 	build_path = /obj/machinery/computer/holodeck
 	origin_tech = "programming=4"
 /obj/item/weapon/circuitboard/computer/aifixer
-	name = "circuit board (AI Integrity Restorer)"
+	name = "AI Integrity Restorer (Computer Board)"
 	build_path = /obj/machinery/computer/aifixer
 	origin_tech = "programming=2;biotech=2"
 /*/obj/item/weapon/circuitboard/computer/prison_shuttle
-	name = "circuit board (Prison Shuttle)"
+	name = "Prison Shuttle (Computer Board)"
 	build_path = /obj/machinery/computer/prison_shuttle*/
 /obj/item/weapon/circuitboard/computer/slot_machine
-	name = "circuit board (Slot Machine)"
+	name = "Slot Machine (Computer Board)"
 	build_path = /obj/machinery/computer/slot_machine
 	origin_tech = "programming=1"
 
 /obj/item/weapon/circuitboard/computer/libraryconsole
-	name = "circuit board (Library Visitor Console)"
+	name = "Library Visitor Console (Computer Board)"
 	build_path = /obj/machinery/computer/libraryconsole
 	origin_tech = "programming=1"
 
 /obj/item/weapon/circuitboard/computer/libraryconsole/attackby(obj/item/I, mob/user, params)
 	if(istype(I,/obj/item/weapon/screwdriver))
 		if(build_path == /obj/machinery/computer/libraryconsole/bookmanagement)
-			name = "circuit board (Library Visitor Console)"
+			name = "Library Visitor Console (Computer Board)"
 			build_path = /obj/machinery/computer/libraryconsole
 			user << "<span class='notice'>Defaulting access protocols.</span>"
 		else
-			name = "circuit board (Book Inventory Management Console)"
+			name = "Book Inventory Management Console (Computer Board)"
 			build_path = /obj/machinery/computer/libraryconsole/bookmanagement
 			user << "<span class='notice'>Access protocols successfully updated.</span>"
 	else

--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -19,7 +19,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/clonescanner
-	name = "circuit board (Cloning Scanner)"
+	name = "Cloning Scanner (Machine Board)"
 	build_path = /obj/machinery/dna_scannernew
 	origin_tech = "programming=2;biotech=2"
 	req_components = list(

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -163,7 +163,7 @@ The console is located at computer/gulag_teleporter.dm
 		R.fields["criminal"] = "Incarcerated"
 
 /obj/item/weapon/circuitboard/machine/gulag_teleporter
-	name = "circuit board (labor camp teleporter)"
+	name = "labor camp teleporter (Machine Board)"
 	build_path = /obj/machinery/gulag_teleporter
 	origin_tech = "programming=3;engineering=4;bluespace=4;materials=4"
 	req_components = list(

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -241,7 +241,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	return 1
 
 /obj/item/weapon/circuitboard/machine/holopad
-	name = "circuit board (AI Holopad)"
+	name = "AI Holopad (Machine Board)"
 	build_path = /obj/machinery/holopad
 	origin_tech = "programming=1"
 	req_components = list(/obj/item/weapon/stock_parts/capacitor = 1)

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -42,7 +42,7 @@
 	files = new /datum/research/limbgrower(src)
 
 /obj/item/weapon/circuitboard/machine/limbgrower
-	name = "circuit board (Limb Grower)"
+	name = "Limb Grower (Machine Board)"
 	build_path = /obj/machinery/limbgrower
 	origin_tech = "programming=2;biotech=2"
 	req_components = list(

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -21,7 +21,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/quantumpad
-	name = "circuit board (Quantum Pad)"
+	name = "Quantum Pad (Machine Board)"
 	build_path = /obj/machinery/quantumpad
 	origin_tech = "programming=3;engineering=3;plasmatech=3;bluespace=4"
 	req_components = list(

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -17,7 +17,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/recharger
-	name = "circuit board (Weapon Recharger)"
+	name = "Weapon Recharger (Machine Board)"
 	build_path = /obj/machinery/recharger
 	origin_tech = "powerstorage=4;engineering=3;materials=4"
 	req_components = list(/obj/item/weapon/stock_parts/capacitor = 1)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -19,7 +19,7 @@
 	update_icon()
 
 /obj/item/weapon/circuitboard/machine/cyborgrecharger
-	name = "circuit board (Cyborg Recharger)"
+	name = "Cyborg Recharger (Machine Board)"
 	build_path = /obj/machinery/recharge_station
 	origin_tech = "powerstorage=3;engineering=3"
 	req_components = list(

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -26,7 +26,7 @@ var/const/SAFETY_COOLDOWN = 100
 	update_icon()
 
 /obj/item/weapon/circuitboard/machine/recycler
-	name = "circuit board (Recycler)"
+	name = "Recycler (Machine Board)"
 	build_path = /obj/machinery/recycler
 	origin_tech = "programming=2;engineering=2"
 	req_components = list(

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -32,7 +32,7 @@
 	update_icon()
 
 /obj/item/weapon/circuitboard/machine/space_heater
-	name = "circuit board (Space Heater)"
+	name = "Space Heater (Machine Board)"
 	build_path = /obj/machinery/space_heater
 	origin_tech = "programming=2;engineering=2;plasmatech=2"
 	req_components = list(

--- a/code/game/machinery/telecomms/machines/broadcaster.dm
+++ b/code/game/machinery/telecomms/machines/broadcaster.dm
@@ -98,7 +98,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/telecomms/broadcaster
-	name = "circuit board (Subspace Broadcaster)"
+	name = "Subspace Broadcaster (Machine Board)"
 	build_path = /obj/machinery/telecomms/broadcaster
 	origin_tech = "programming=2;engineering=2;bluespace=1"
 	req_components = list(

--- a/code/game/machinery/telecomms/machines/bus.dm
+++ b/code/game/machinery/telecomms/machines/bus.dm
@@ -55,7 +55,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/telecomms/bus
-	name = "circuit board (Bus Mainframe)"
+	name = "Bus Mainframe (Machine Board)"
 	build_path = /obj/machinery/telecomms/bus
 	origin_tech = "programming=2;engineering=2"
 	req_components = list(

--- a/code/game/machinery/telecomms/machines/hub.dm
+++ b/code/game/machinery/telecomms/machines/hub.dm
@@ -39,7 +39,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/telecomms/hub
-	name = "circuit board (Hub Mainframe)"
+	name = "Hub Mainframe (Machine Board)"
 	build_path = /obj/machinery/telecomms/hub
 	origin_tech = "programming=2;engineering=2"
 	req_components = list(

--- a/code/game/machinery/telecomms/machines/processor.dm
+++ b/code/game/machinery/telecomms/machines/processor.dm
@@ -41,7 +41,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/telecomms/processor
-	name = "circuit board (Processor Unit)"
+	name = "Processor Unit (Machine Board)"
 	build_path = /obj/machinery/telecomms/processor
 	origin_tech = "programming=2;engineering=2"
 	req_components = list(

--- a/code/game/machinery/telecomms/machines/receiver.dm
+++ b/code/game/machinery/telecomms/machines/receiver.dm
@@ -57,7 +57,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/telecomms/receiver
-	name = "circuit board (Subspace Receiver)"
+	name = "Subspace Receiver (Machine Board)"
 	build_path = /obj/machinery/telecomms/receiver
 	origin_tech = "programming=2;engineering=2;bluespace=1"
 	req_components = list(

--- a/code/game/machinery/telecomms/machines/relay.dm
+++ b/code/game/machinery/telecomms/machines/relay.dm
@@ -51,7 +51,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/telecomms/relay
-	name = "circuit board (Relay Mainframe)"
+	name = "Relay Mainframe (Machine Board)"
 	build_path = /obj/machinery/telecomms/relay
 	origin_tech = "programming=2;engineering=2;bluespace=2"
 	req_components = list(

--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -39,7 +39,7 @@
 	server_radio = new()
 
 /obj/item/weapon/circuitboard/machine/telecomms/server
-	name = "circuit board (Telecommunication Server)"
+	name = "Telecommunication Server (Machine Board)"
 	build_path = /obj/machinery/telecomms/server
 	origin_tech = "programming=2;engineering=2"
 	req_components = list(

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -259,7 +259,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/teleporter_hub
-	name = "circuit board (Teleporter Hub)"
+	name = "Teleporter Hub (Machine Board)"
 	build_path = /obj/machinery/teleport/hub
 	origin_tech = "programming=3;engineering=4;bluespace=4;materials=4"
 	req_components = list(
@@ -372,7 +372,7 @@
 	link_console_and_hub()
 
 /obj/item/weapon/circuitboard/machine/teleporter_station
-	name = "circuit board (Teleporter Station)"
+	name = "Teleporter Station (Machine Board)"
 	build_path = /obj/machinery/teleport/station
 	origin_tech = "programming=4;engineering=4;bluespace=4;plasmatech=3"
 	req_components = list(

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -76,7 +76,7 @@
 	power_change()
 
 /obj/item/weapon/circuitboard/machine/vendor
-	name = "circuit board (Booze-O-Mat Vendor)"
+	name = "Booze-O-Mat Vendor (Machine Board)"
 	build_path = /obj/machinery/vending/boozeomat
 	origin_tech = "programming=1"
 	req_components = list(
@@ -103,7 +103,7 @@
 
 /obj/item/weapon/circuitboard/machine/vendor/proc/set_type(var/obj/machinery/vending/typepath)
 	build_path = typepath
-	name = "circuit board ([names_paths[build_path]] Vendor)"
+	name = "[names_paths[build_path]] Vendor (Machine Board)"
 	req_components = list(initial(typepath.refill_canister) = 3)
 
 /obj/item/weapon/circuitboard/machine/vendor/apply_default_parts(obj/machinery/M)

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -31,7 +31,7 @@
 	recharging_turf = get_step(loc, dir)
 
 /obj/item/weapon/circuitboard/machine/mech_recharger
-	name = "circuit board (Mechbay Recharger)"
+	name = "Mechbay Recharger (Machine Board)"
 	build_path = /obj/machinery/mech_bay_recharge_port
 	origin_tech = "programming=3;powerstorage=3;engineering=3"
 	req_components = list(

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -42,7 +42,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/mechfab
-	name = "circuit board (Exosuit Fabricator)"
+	name = "Exosuit Fabricator (Machine Board)"
 	build_path = /obj/machinery/mecha_part_fabricator
 	origin_tech = "programming=2;engineering=2"
 	req_components = list(

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -322,81 +322,81 @@
 	origin_tech = "programming=2"
 
 /obj/item/weapon/circuitboard/mecha/ripley/peripherals
-	name = "circuit board (Ripley Peripherals Control module)"
+	name = "Ripley Peripherals Control module (Exosuit Board)"
 	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/ripley/main
-	name = "circuit board (Ripley Central Control module)"
+	name = "Ripley Central Control module (Exosuit Board)"
 	icon_state = "mainboard"
 
 /obj/item/weapon/circuitboard/mecha/gygax
 	origin_tech = "programming=4;combat=3;engineering=3"
 
 /obj/item/weapon/circuitboard/mecha/gygax/peripherals
-	name = "circuit board (Gygax Peripherals Control module)"
+	name = "Gygax Peripherals Control module (Exosuit Board)"
 	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/gygax/targeting
-	name = "circuit board (Gygax Weapon Control and Targeting module)"
+	name = "Gygax Weapon Control and Targeting module (Exosuit Board)"
 	icon_state = "mcontroller"
 	origin_tech = "programming=4;combat=4"
 
 /obj/item/weapon/circuitboard/mecha/gygax/main
-	name = "circuit board (Gygax Central Control module)"
+	name = "Gygax Central Control module (Exosuit Board)"
 	icon_state = "mainboard"
 
 /obj/item/weapon/circuitboard/mecha/durand
 	origin_tech = "programming=4;combat=3;engineering=3"
 
 /obj/item/weapon/circuitboard/mecha/durand/peripherals
-	name = "circuit board (Durand Peripherals Control module)"
+	name = "Durand Peripherals Control module (Exosuit Board)"
 	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/durand/targeting
-	name = "circuit board (Durand Weapon Control and Targeting module)"
+	name = "Durand Weapon Control and Targeting module (Exosuit Board)"
 	icon_state = "mcontroller"
 	origin_tech = "programming=4;combat=4;engineering=3"
 
 /obj/item/weapon/circuitboard/mecha/durand/main
-	name = "circuit board (Durand Central Control module)"
+	name = "Durand Central Control module (Exosuit Board)"
 	icon_state = "mainboard"
 
 /obj/item/weapon/circuitboard/mecha/honker
 	origin_tech = "programming=3;engineering=3"
 
 /obj/item/weapon/circuitboard/mecha/honker/peripherals
-	name = "circuit board (H.O.N.K Peripherals Control module)"
+	name = "H.O.N.K Peripherals Control module (Exosuit Board)"
 	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/honker/targeting
-	name = "circuit board (H.O.N.K Weapon Control and Targeting module)"
+	name = "H.O.N.K Weapon Control and Targeting module (Exosuit Board)"
 	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/honker/main
-	name = "circuit board (H.O.N.K Central Control module)"
+	name = "H.O.N.K Central Control module (Exosuit Board)"
 	icon_state = "mainboard"
 
 /obj/item/weapon/circuitboard/mecha/odysseus
 	origin_tech = "programming=3;biotech=3"
 
 /obj/item/weapon/circuitboard/mecha/odysseus/peripherals
-	name = "circuit board (Odysseus Peripherals Control module)"
+	name = "Odysseus Peripherals Control module (Exosuit Board)"
 	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/odysseus/main
-	name = "circuit board (Odysseus Central Control module)"
+	name = "Odysseus Central Control module (Exosuit Board)"
 	icon_state = "mainboard"
 
 /obj/item/weapon/circuitboard/mecha/phazon
 	origin_tech = "programming=5;plasmatech=4"
 
 /obj/item/weapon/circuitboard/mecha/phazon/peripherals
-	name = "circuit board (Phazon Peripherals Control module)"
+	name = "Phazon Peripherals Control module (Exosuit Board)"
 	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/phazon/targeting
-	name = "circuit board (Phazon Weapon Control and Targeting module)"
+	name = "Phazon Weapon Control and Targeting module (Exosuit Board)"
 	icon_state = "mcontroller"
 
 /obj/item/weapon/circuitboard/mecha/phazon/main
-	name = "circuit board (Phazon Central Control module)"
+	name = "Phazon Central Control module (Exosuit Board)"

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -273,5 +273,5 @@ That prevents a few funky behaviors.
 
 
 /obj/item/weapon/circuitboard/aicore
-	name = "circuit board (AI core)"
+	name = "AI core (AI Core Board)" //Well, duh, but best to be consistent
 	origin_tech = "programming=3"

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -29,7 +29,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/cryo_tube
-	name = "circuit board (Cryotube)"
+	name = "Cryotube (Machine Board)"
 	build_path = /obj/machinery/atmospherics/components/unary/cryo_cell
 	origin_tech = "programming=4;biotech=3;engineering=4;plasmatech=3"
 	req_components = list(

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -24,7 +24,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/thermomachine
-	name = "circuit board (Thermomachine)"
+	name = "Thermomachine (Machine Board)"
 	desc = "You can use a screwdriver to switch between heater and freezer."
 	origin_tech = "programming=3;plasmatech=3"
 	req_components = list(
@@ -36,10 +36,10 @@
 /obj/item/weapon/circuitboard/machine/thermomachine/New()
 	..()
 	if(prob(50))
-		name = "circuit board (Freezer)"
+		name = "Freezer (Machine Board)"
 		build_path = /obj/machinery/atmospherics/components/unary/thermomachine/freezer
 	else
-		name = "circuit board (Heater)"
+		name = "Heater (Machine Board)"
 		build_path = /obj/machinery/atmospherics/components/unary/thermomachine/heater
 
 /obj/item/weapon/circuitboard/machine/thermomachine/attackby(obj/item/I, mob/user, params)
@@ -208,7 +208,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/thermomachine/freezer
-	name = "circuit board (Freezer)"
+	name = "Freezer (Machine Board)"
 	build_path = /obj/machinery/atmospherics/components/unary/thermomachine/freezer
 
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/RefreshParts()
@@ -233,7 +233,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/thermomachine/heater
-	name = "circuit board (Heater)"
+	name = "Heater (Machine Board)"
 	build_path = /obj/machinery/atmospherics/components/unary/thermomachine/heater
 
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/RefreshParts()

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -52,7 +52,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/gibber
-	name = "circuit board (Gibber)"
+	name = "Gibber (Machine Board)"
 	build_path = /obj/machinery/gibber
 	origin_tech = "programming=2;engineering=2"
 	req_components = list(

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -29,7 +29,7 @@
 	..()
 
 /obj/item/weapon/circuitboard/machine/microwave
-	name = "circuit board (Microwave)"
+	name = "Microwave (Machine Board)"
 	build_path = /obj/machinery/microwave
 	origin_tech = "programming=2;magnets=2"
 	req_components = list(

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -20,7 +20,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/monkey_recycler
-	name = "circuit board (Monkey Recycler)"
+	name = "Monkey Recycler (Machine Board)"
 	build_path = /obj/machinery/monkey_recycler
 	origin_tech = "programming=1;biotech=2"
 	req_components = list(

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -21,7 +21,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/processor
-	name = "circuit board (Food Processor)"
+	name = "Food Processor (Machine Board)"
 	build_path = /obj/machinery/processor
 	origin_tech = "programming=1"
 	req_components = list(
@@ -29,17 +29,17 @@
 							/obj/item/weapon/stock_parts/manipulator = 1)
 
 /obj/item/weapon/circuitboard/machine/processor
-	name = "circuit board (Food Processor)"
+	name = "Food Processor (Machine Board)"
 	build_path = /obj/machinery/processor
 
 /obj/item/weapon/circuitboard/machine/processor/attackby(obj/item/I, mob/user, params)
 	if(istype(I,/obj/item/weapon/screwdriver))
 		if(build_path == /obj/machinery/processor)
-			name = "circuit board (slime Processor)"
+			name = "Slime Processor (Machine Board)"
 			build_path = /obj/machinery/processor/slime
 			user << "<span class='notice'>Name protocols successfully updated.</span>"
 		else
-			name = "circuit board (Food Processor)"
+			name = "Food Processor (Machine Board)"
 			build_path = /obj/machinery/processor
 			user << "<span class='notice'>Defaulting name protocols.</span>"
 	else
@@ -294,5 +294,5 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/processor/slime
-	name = "circuit board (Slime Processor)"
+	name = "Slime Processor (Machine Board)"
 	build_path = /obj/machinery/processor/slime

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -25,7 +25,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/smartfridge
-	name = "circuit board (Smartfridge)"
+	name = "Smartfridge (Machine Board)"
 	build_path = /obj/machinery/smartfridge
 	origin_tech = "programming=1"
 	req_components = list(/obj/item/weapon/stock_parts/matter_bin = 1)

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -44,7 +44,7 @@
 		updateUsrDialog()
 
 /obj/item/weapon/circuitboard/machine/biogenerator
-	name = "circuit board (Biogenerator)"
+	name = "Biogenerator (Machine Board)"
 	build_path = /obj/machinery/biogenerator
 	origin_tech = "programming=2;biotech=3;materials=3"
 	req_components = list(

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -27,7 +27,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/plantgenes
-	name = "circuit board (Plant DNA Manipulator)"
+	name = "Plant DNA Manipulator (Machine Board)"
 	build_path = /obj/machinery/plantgenes
 	origin_tech = "programming=3;biotech=3"
 	req_components = list(

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -41,7 +41,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/hydroponics
-	name = "circuit board (Hydroponics Tray)"
+	name = "Hydroponics Tray (Machine Board)"
 	build_path = /obj/machinery/hydroponics/constructable
 	origin_tech = "programming=1;biotech=2"
 	req_components = list(

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -54,7 +54,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/seed_extractor
-	name = "circuit board (Seed Extractor)"
+	name = "Seed Extractor (Machine Board)"
 	build_path = /obj/machinery/seed_extractor
 	origin_tech = "programming=1"
 	req_components = list(

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -197,7 +197,7 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 /obj/machinery/computer/libraryconsole/bookmanagement/New()
 	..()
 	if(circuit)
-		circuit.name = "circuit board (Book Inventory Management Console)"
+		circuit.name = "Book Inventory Management Console (Machine Board)"
 		circuit.build_path = /obj/machinery/computer/libraryconsole/bookmanagement
 
 /obj/machinery/computer/libraryconsole/bookmanagement/interact(mob/user)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -28,7 +28,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/ore_redemption
-	name = "circuit board (Ore Redemption)"
+	name = "Ore Redemption (Machine Board)"
 	build_path = /obj/machinery/mineral/ore_redemption
 	origin_tech = "programming=1;engineering=2"
 	req_components = list(

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -71,7 +71,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/mining_equipment_vendor
-	name = "circuit board (Mining Equipment Vendor)"
+	name = "Mining Equipment Vendor (Machine Board)"
 	build_path = /obj/machinery/mineral/equipment_vendor
 	origin_tech = "programming=1;engineering=3"
 	req_components = list(
@@ -225,7 +225,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/mining_equipment_vendor/golem
-	name = "circuit board (Golem Ship Equipment Vendor)"
+	name = "Golem Ship Equipment Vendor (Machine Board)"
 	build_path = /obj/machinery/mineral/equipment_vendor/golem
 
 

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -121,7 +121,7 @@
 	..()
 
 /obj/item/weapon/circuitboard/machine/ntnet_relay
-	name = "circuit board (NTNet Relay)"
+	name = "NTNet Relay (Machine Board)"
 	build_path = /obj/machinery/ntnet_relay
 	origin_tech = "programming=3;bluespace=3;magnets=2"
 	req_components = list(

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -113,7 +113,7 @@ display round(lastgen) and plasmatank amount
 	sheet_name = sheet.name
 
 /obj/item/weapon/circuitboard/machine/pacman
-	name = "circuit board (PACMAN-type Generator)"
+	name = "PACMAN-type Generator (Machine Board)"
 	build_path = /obj/machinery/power/port_gen/pacman
 	origin_tech = "programming=2;powerstorage=3;plasmatech=3;engineering=3"
 	req_components = list(
@@ -123,12 +123,12 @@ display round(lastgen) and plasmatank amount
 							/obj/item/weapon/stock_parts/capacitor = 1)
 
 /obj/item/weapon/circuitboard/machine/pacman/super
-	name = "circuit board (SUPERPACMAN-type Generator)"
+	name = "SUPERPACMAN-type Generator (Machine Board)"
 	build_path = /obj/machinery/power/port_gen/pacman/super
 	origin_tech = "programming=3;powerstorage=4;engineering=4"
 
 /obj/item/weapon/circuitboard/machine/pacman/mrs
-	name = "circuit board (MRSPACMAN-type Generator)"
+	name = "MRSPACMAN-type Generator (Machine Board)"
 	build_path = "/obj/machinery/power/port_gen/pacman/mrs"
 	origin_tech = "programming=3;powerstorage=4;engineering=4;plasmatech=4"
 

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -26,7 +26,7 @@
 	connect_to_network()
 
 /obj/item/weapon/circuitboard/machine/rtg
-	name = "circuit board (RTG)"
+	name = "RTG (Machine Board)"
 	build_path = /obj/machinery/power/rtg
 	origin_tech = "programming=2;materials=4;powerstorage=3;engineering=2"
 	req_components = list(
@@ -77,7 +77,7 @@
 	board_path = /obj/item/weapon/circuitboard/machine/rtg/advanced
 
 /obj/item/weapon/circuitboard/machine/rtg/advanced
-	name = "circuit board (Advanced RTG)"
+	name = "Advanced RTG (Machine Board)"
 	build_path = /obj/machinery/power/rtg/advanced
 	origin_tech = "programming=3;materials=5;powerstorage=4;engineering=3;plasmatech=3"
 	req_components = list(

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -35,7 +35,7 @@
 	RefreshParts()
 
 /obj/item/weapon/circuitboard/machine/emitter
-	name = "circuit board (Emitter)"
+	name = "Emitter (Machine Board)"
 	build_path = /obj/machinery/power/emitter
 	origin_tech = "programming=3;powerstorage=4;engineering=4"
 	req_components = list(

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -63,7 +63,7 @@
 	return
 
 /obj/item/weapon/circuitboard/machine/smes
-	name = "circuit board (SMES)"
+	name = "SMES (Machine Board)"
 	build_path = /obj/machinery/power/smes
 	origin_tech = "programming=3;powerstorage=3;engineering=3"
 	req_components = list(

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -14,7 +14,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/tesla_coil
-	name = "circuit board (Tesla Coil)"
+	name = "Tesla Coil (Machine Board)"
 	build_path = /obj/machinery/power/tesla_coil
 	origin_tech = "programming=3;magnets=3;powerstorage=3"
 	req_components = list(/obj/item/weapon/stock_parts/capacitor = 1)
@@ -72,7 +72,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/grounding_rod
-	name = "circuit board (Grounding Rod)"
+	name = "Grounding Rod (Machine Board)"
 	build_path = /obj/machinery/power/grounding_rod
 	origin_tech = "programming=3;powerstorage=3;magnets=3;plasmatech=2"
 	req_components = list(/obj/item/weapon/stock_parts/capacitor = 1)

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -78,7 +78,7 @@
 	inturf = get_step(src, dir)
 
 /obj/item/weapon/circuitboard/machine/power_compressor
-	name = "circuit board (Power Compressor)"
+	name = "Power Compressor (Machine Board)"
 	build_path = /obj/machinery/power/compressor
 	origin_tech = "programming=4;powerstorage=4;engineering=4"
 	req_components = list(
@@ -194,7 +194,7 @@
 	outturf = get_step(src, dir)
 
 /obj/item/weapon/circuitboard/machine/power_turbine
-	name = "circuit board (Power Turbine)"
+	name = "Power Turbine (Machine Board)"
 	build_path = /obj/machinery/power/turbine
 	origin_tech = "programming=4;powerstorage=4;engineering=4"
 	req_components = list(

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -251,7 +251,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/chem_dispenser
-	name = "circuit board (Portable Chem Dispenser)"
+	name = "Portable Chem Dispenser (Machine Board)"
 	build_path = /obj/machinery/chem_dispenser/constructable
 	origin_tech = "materials=4;programming=4;plasmatech=4;biotech=3"
 	req_components = list(

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -18,7 +18,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/chem_heater
-	name = "circuit board (Chemical Heater)"
+	name = "Chemical Heater (Machine Board)"
 	build_path = /obj/machinery/chem_heater
 	origin_tech = "programming=2;engineering=2;biotech=2"
 	req_components = list(

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -24,7 +24,7 @@
 	..()
 
 /obj/item/weapon/circuitboard/machine/chem_master
-	name = "circuit board (ChemMaster 3000)"
+	name = "ChemMaster 3000 (Machine Board)"
 	build_path = /obj/machinery/chem_master
 	origin_tech = "materials=3;programming=2;biotech=3"
 	req_components = list(
@@ -42,7 +42,7 @@
 			new_path = /obj/machinery/chem_master/condimaster
 
 		build_path = new_path
-		name = "circuit board ([new_name] 3000)"
+		name = "[new_name] 3000 (Machine Board)"
 		user << "<span class='notice'>You change the circuit board setting to \"[new_name]\".</span>"
 	else
 		return ..()
@@ -361,5 +361,5 @@
 	condi = 1
 
 /obj/item/weapon/circuitboard/machine/chem_master/condi
-	name = "circuit board (CondiMaster 3000)"
+	name = "CondiMaster 3000 (Machine Board)"
 	build_path = /obj/machinery/chem_master/condimaster

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -39,7 +39,7 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 	return ..()
 
 /obj/item/weapon/circuitboard/machine/circuit_imprinter
-	name = "circuit board (Circuit Imprinter)"
+	name = "Circuit Imprinter (Machine Board)"
 	build_path = /obj/machinery/r_n_d/circuit_imprinter
 	origin_tech = "engineering=2;programming=2"
 	req_components = list(

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -19,7 +19,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/destructive_analyzer
-	name = "circuit board (Destructive Analyzer)"
+	name = "Destructive Analyzer (Machine Board)"
 	build_path = /obj/machinery/r_n_d/destructive_analyzer
 	origin_tech = "magnets=2;engineering=2;programming=2"
 	req_components = list(

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -89,7 +89,7 @@
 	SetTypeReactions()
 
 /obj/item/weapon/circuitboard/machine/experimentor
-	name = "circuit board (E.X.P.E.R.I-MENTOR)"
+	name = "E.X.P.E.R.I-MENTOR (Machine Board)"
 	build_path = /obj/machinery/r_n_d/experimentor
 	origin_tech = "magnets=1;engineering=1;programming=1;biotech=1;bluespace=2"
 	req_components = list(

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -39,7 +39,7 @@ Note: Must be placed west/left of and R&D console to function.
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/protolathe
-	name = "circuit board (Protolathe)"
+	name = "Protolathe (Machine Board)"
 	build_path = /obj/machinery/r_n_d/protolathe
 	origin_tech = "engineering=2;programming=2"
 	req_components = list(

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -1069,7 +1069,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole/robotics/New()
 	..()
 	if(circuit)
-		circuit.name = "circuit board (RD Console - Robotics)"
+		circuit.name = "RD Console - Robotics (Computer Board)"
 		circuit.build_path = /obj/machinery/computer/rdconsole/robotics
 
 /obj/machinery/computer/rdconsole/core

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -21,7 +21,7 @@
 	initialize() //Agouri
 
 /obj/item/weapon/circuitboard/machine/rdserver
-	name = "circuit board (R&D Server)"
+	name = "R&D Server (Machine Board)"
 	build_path = /obj/machinery/r_n_d/server
 	origin_tech = "programming=3"
 	req_components = list(

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -25,7 +25,7 @@
 	..()
 
 /obj/item/weapon/circuitboard/computer/syndicate_shuttle
-	name = "circuit board (Syndicate Shuttle)"
+	name = "Syndicate Shuttle (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/syndicate
 	var/challenge = FALSE
 	var/moved = FALSE

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -197,7 +197,7 @@
 	return
 
 /obj/item/weapon/circuitboard/machine/bsa/back
-	name = "circuit board (Bluespace Artillery Generator)"
+	name = "Bluespace Artillery Generator (Machine Board)"
 	build_path = /obj/machinery/bsa/back
 	origin_tech = "engineering=2;combat=2;bluespace=2" //No freebies!
 	req_components = list(
@@ -205,7 +205,7 @@
 							/obj/item/stack/cable_coil = 2)
 
 /obj/item/weapon/circuitboard/machine/bsa/middle
-	name = "circuit board (Bluespace Artillery Fusor)"
+	name = "Bluespace Artillery Fusor (Machine Board)"
 	build_path = /obj/machinery/bsa/middle
 	origin_tech = "engineering=2;combat=2;bluespace=2"
 	req_components = list(
@@ -213,7 +213,7 @@
 							/obj/item/stack/cable_coil = 2)
 
 /obj/item/weapon/circuitboard/machine/bsa/front
-	name = "circuit board (Bluespace Artillery Bore)"
+	name = "Bluespace Artillery Bore (Machine Board)"
 	build_path = /obj/machinery/bsa/front
 	origin_tech = "engineering=2;combat=2;bluespace=2"
 	req_components = list(
@@ -221,7 +221,7 @@
 							/obj/item/stack/cable_coil = 2)
 
 /obj/item/weapon/circuitboard/machine/computer/bsa_control
-	name = "circuit board (Bluespace Artillery Controls)"
+	name = "Bluespace Artillery Controls (Computer Board)"
 	build_path = /obj/machinery/computer/bsa_control
 	origin_tech = "engineering=2;combat=2;bluespace=2"
 

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -117,7 +117,7 @@ var/list/non_simple_animals = typecacheof(list(/mob/living/carbon/monkey,/mob/li
 
 
 /obj/item/weapon/circuitboard/machine/dna_vault
-	name = "circuit board (DNA Vault)"
+	name = "DNA Vault (Machine Board)"
 	build_path = /obj/machinery/dna_vault
 	origin_tech = "engineering=2;combat=2;bluespace=2" //No freebies!
 	req_components = list(

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -37,7 +37,7 @@
 	return coverage.len
 
 /obj/item/weapon/circuitboard/machine/computer/sat_control
-	name = "circuit board (Satellite Network Control)"
+	name = "Satellite Network Control (Computer Board)"
 	build_path = /obj/machinery/computer/sat_control
 	origin_tech = "engineering=3"
 

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -16,7 +16,7 @@
 	B.apply_default_parts(src)
 
 /obj/item/weapon/circuitboard/machine/telesci_pad
-	name = "circuit board (Telepad)"
+	name = "Telepad (Machine Board)"
 	build_path = /obj/machinery/telepad
 	origin_tech = "programming=4;engineering=3;plasmatech=4;bluespace=4"
 	req_components = list(


### PR DESCRIPTION
This changes Circuit Board names to:

X (Machine Board)
Y (Computer Board)
Z (Exosuit Board)

This firstly makes it quicker to see what the board will be used for. Especially useful for machines which requires multiple frames, interlinked machines(like teleporter, cloning), and helpful for new players.

It also makes finding the board you want easier in the stacks of circuit boards known as Tech Storage.