### PR TITLE
Window flash all tabbed out clients once the server is ready

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -72,6 +72,8 @@ var/datum/subsystem/ticker/ticker
 			world << "<span class='boldnotice'>Welcome to [station_name()]!</span>"
 			world << "Please set up your character and select \"Ready\". The game will start in [config.lobby_countdown] seconds."
 			current_state = GAME_STATE_PREGAME
+			for(var/client/C in clients)
+				window_flash(C) //let them know lobby has opened up.
 
 		if(GAME_STATE_PREGAME)
 				//lobby stats for statpanels


### PR DESCRIPTION
:cl:
add: The window will flash in the taskbar when a new round is ready and about to start.
/:cl:
So that people tabbed out from last round know a new round is starting soon, and so that coders know when their test server is ready.

I refuse to respect the freeze until a hardline date has been set.
