### PR TITLE
Revert "Fixes AIs being able to see cult runes"

### DIFF
--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -5,10 +5,7 @@
 
 #define INVISIBILITY_LIGHTING 20
 
-#define SEE_INVISIBLE_AI 24
-
 #define SEE_INVISIBLE_LIVING 25
-#define INVISIBILITY_AI 25
 
 #define SEE_INVISIBLE_LEVEL_ONE 35 //currently unused
 #define INVISIBILITY_LEVEL_ONE 35 //currently unused

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1,6 +1,5 @@
-var/list/sacrificed = list() //a mixed list of minds and mobs
+/var/list/sacrificed = list() //a mixed list of minds and mobs
 var/list/non_revealed_runes = (subtypesof(/obj/effect/rune) - /obj/effect/rune/malformed)
-var/list/ai_hidden_runes = list()
 
 /*
 
@@ -14,30 +13,6 @@ To draw a rune, use an arcane tome.
 
 */
 
-//for hiding from the ai
-/datum/ai_fake_rune
-	var/image/ai_image
-
-/datum/ai_fake_rune/New(_loc)
-	. = ..()
-	ai_hidden_runes += src
-
-	var/obj/effect/decal/cleanable/blood/splatter/s = new(_loc)
-	ai_image = image(s.icon, icon_state = s.icon_state, loc = _loc, layer = TURF_LAYER)
-	qdel(s)
-
-	for(var/a in ai_list)
-		var/mob/living/silicon/ai/AI = a
-		AI.invisify_rune(src)
-
-/datum/ai_fake_rune/Destroy()
-	ai_hidden_runes -= src
-	for(var/a in ai_list)
-		var/mob/living/silicon/ai/AI = a
-		AI.uninvisify_rune(src)
-	qdel(ai_image)
-	return ..()
-
 /obj/effect/rune
 	name = "rune"
 	var/cultist_name = "basic rune"
@@ -49,8 +24,6 @@ To draw a rune, use an arcane tome.
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = ABOVE_NORMAL_TURF_LAYER
 	color = "#FF0000"
-
-	invisibility = INVISIBILITY_AI
 
 	var/invocation = "Aiy ele-mayo!" //This is said by cultists when the rune is invoked.
 	var/req_cultists = 1 //The amount of cultists required around the rune to invoke it. If only 1, any cultist can invoke it.
@@ -65,17 +38,11 @@ To draw a rune, use an arcane tome.
 
 	var/req_keyword = 0 //If the rune requires a keyword - go figure amirite
 	var/keyword //The actual keyword for the rune
-	var/datum/ai_fake_rune/ai_hidden
 
 /obj/effect/rune/New(loc, set_keyword)
-	. = ..()
-	ai_hidden = new(loc)
+	..()
 	if(set_keyword)
 		keyword = set_keyword
-
-/obj/effect/rune/Destroy()
-	qdel(ai_hidden)
-	return ..()
 
 /obj/effect/rune/examine(mob/user)
 	..()

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -5,13 +5,8 @@
 	icon_state = "rune1"
 	gender = NEUTER
 	var/do_icon_rotate = TRUE
-	var/datum/ai_fake_rune/ai_hidden = null
 
 /obj/effect/decal/cleanable/crayon/New(location, main = "#FFFFFF", var/type = "rune1", var/e_name = "rune", var/rotation = 0, var/alt_icon = null)
-	if(name == "rune")
-		ai_hidden = new(location)
-		invisibility = INVISIBILITY_AI
-
 	..()
 	loc = location
 
@@ -31,9 +26,6 @@
 
 	add_atom_colour(main, FIXED_COLOUR_PRIORITY)
 
-/obj/effect/decal/cleanable/crayon/Destroy()
-	qdel(ai_hidden)
-	return ..()
 
 /obj/effect/decal/cleanable/crayon/gang
 	layer = HIGH_OBJ_LAYER //Harder to hide

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -28,9 +28,6 @@ var/list/ai_list = list()
 	med_hud = DATA_HUD_MEDICAL_BASIC
 	sec_hud = DATA_HUD_SECURITY_BASIC
 	mob_size = MOB_SIZE_LARGE
-
-	see_invisible = SEE_INVISIBLE_AI
-
 	var/list/network = list("SS13")
 	var/obj/machinery/camera/current = null
 	var/list/connected_robots = list()
@@ -501,7 +498,7 @@ var/list/ai_list = list()
 	call_bot_cooldown = world.time + CALL_BOT_COOLDOWN
 	Bot.call_bot(src, waypoint)
 	call_bot_cooldown = 0
-
+	
 
 /mob/living/silicon/ai/triggerAlarm(class, area/A, O, obj/alarmsource)
 	if(alarmsource.z != z)
@@ -871,14 +868,6 @@ var/list/ai_list = list()
 		src << "Hack complete. \The [apc] is now under your \
 			exclusive control."
 		apc.update_icon()
-
-/mob/living/silicon/ai/proc/invisify_rune(datum/ai_fake_rune/rune)
-	if(client)
-		client.images += rune.ai_image
-
-/mob/living/silicon/ai/proc/uninvisify_rune(datum/ai_fake_rune/rune)
-	if(client)
-		client.images -= rune.ai_image
 
 /mob/living/silicon/ai/spawned/New(loc, datum/ai_laws/L, mob/target_ai)
 	if(!target_ai)

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -1,7 +1,9 @@
 /mob/living/silicon/ai/Login()
 	..()
-	for(var/r in ai_hidden_runes)
-		invisify_rune(r)
+	for(var/obj/effect/rune/rune in world)
+		var/image/blood = image(loc = rune)
+		blood.override = 1
+		client.images += blood
 
 	if(stat != DEAD)
 		for(var/obj/machinery/ai_status_display/O in machines) //change status


### PR DESCRIPTION
Reverts tgstation/tgstation#22577

@Cyberboss 

\>Making runes invisible to ghosts with see_darkness disables

\>adding invisibility memes to ais when image.override is a thing.

\>not even fixing that the fake blood would still say rune on mouse over in the meantime.

