### PR TITLE
No more: "Law 2: Emag the holodeck"

### DIFF
--- a/code/modules/holodeck/computer_funcs.dm
+++ b/code/modules/holodeck/computer_funcs.dm
@@ -26,11 +26,11 @@
 	if(emag_programs.len)
 		dat += "<br>"
 		if(emagged)
-			dat += "Safety protocol: <span class='bad'>Offline</span> <a href='?\ref[src];safety=1'>Engage</a><br>"
+			dat += "<span class='bad'>HUMAN HARM PREVENTION PROTOCOL</span>: <span class='bad'>Offline</span>"
 			for(var/area/A in emag_programs)
 				dat += "<a href='?src=\ref[src];loadarea=[A.type]'>[A.name]</a><br>"
 		else
-			dat += "Safety protocol: <span class='good'>Online</span> <a href='?\ref[src];safety=0'>Disengage</a><br>"
+			dat += "<span class='bad'>HUMAN HARM PREVENTION PROTOCOL</span>: <span class='good'>Online</span> <a href='?\ref[src];safety=0'>Disengage</a><br>"
 
 	var/datum/browser/popup = new(user, "computer", name, 400, 500)
 	popup.set_content(dat)


### PR DESCRIPTION
Closes #22692 
It's not really an exploit, shit coming out of an emagged holodeck is real, unless we change that.

Mainly a wording change to law 1 prevent it from silicons
An Asimov silicons should not be able to toggle off the safeties at will

And they definitely should not be able to turn them back on, because you can't fix emagged shit

:cl: Cyberboss
tweak: The holodeck can no longer be un-emagged
tweak: Asimov AIs should not be emagging the holodeck
/:cl:

Leave this frozen if need be, but I think it needs to be addressed