### PR TITLE
Fixes delivery chutes not being deconstructable

### DIFF
--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -46,7 +46,8 @@
 		mode = PRESSURE_OFF
 		flush = 0
 	else
-		mode = PRESSURE_ON
+		if(initial(mode))
+			mode = PRESSURE_ON
 		flush = initial(flush)
 		trunk.linked = src // link the pipe trunk to self
 


### PR DESCRIPTION
Fixes being unable to use a screwdriver or subsequent tools on delivery chutes in order to deconstruct them.

Fixes #22091