### PR TITLE
Fixes the crusher, and future twohands required items, equipping to slots

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -111,7 +111,7 @@
 
 /obj/item/weapon/twohanded/equipped(mob/user, slot)
 	..()
-	if(!user.is_holding(src) && wielded)
+	if(!user.is_holding(src) && wielded && !istype(src, /obj/item/weapon/twohanded/required))
 		unwield(user)
 
 ///////////OFFHAND///////////////
@@ -159,6 +159,9 @@
 
 /obj/item/weapon/twohanded/required/equipped(mob/user, slot)
 	..()
+	var/slotbit = slotdefine2slotbit(slot)
+	if(slotbit == slot_flags)
+		return
 	if(slot == slot_hands)
 		wield(user)
 	else

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -160,7 +160,7 @@
 /obj/item/weapon/twohanded/required/equipped(mob/user, slot)
 	..()
 	var/slotbit = slotdefine2slotbit(slot)
-	if(slotbit == slot_flags)
+	if(slot_flags & slotbit)
 		return
 	if(slot == slot_hands)
 		wield(user)


### PR DESCRIPTION
If it has slot_flags is can now actually go there, instead of being unwielded in two seperate procs, which drops it.

Fixes #22536.