### PR TITLE
Current shuttle is no longer stated on the "Status" panel

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -525,7 +525,7 @@ var/next_mob_id = 0
 			stat(null, "Next Map: [nextmap.friendlyname]")
 		stat(null, "Server Time: [time2text(world.realtime, "YYYY-MM-DD hh:mm")]")
 		if(SSshuttle.emergency)
-			stat(null, "Current Shuttle: [SSshuttle.emergency.name]")
+			//stat(null, "Current Shuttle: [SSshuttle.emergency.name]")
 			var/ETA = SSshuttle.emergency.getModeStr()
 			if(ETA)
 				stat(null, "[ETA] [SSshuttle.emergency.getTimerStr()]")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -525,7 +525,6 @@ var/next_mob_id = 0
 			stat(null, "Next Map: [nextmap.friendlyname]")
 		stat(null, "Server Time: [time2text(world.realtime, "YYYY-MM-DD hh:mm")]")
 		if(SSshuttle.emergency)
-			//stat(null, "Current Shuttle: [SSshuttle.emergency.name]")
 			var/ETA = SSshuttle.emergency.getModeStr()
 			if(ETA)
 				stat(null, "[ETA] [SSshuttle.emergency.getTimerStr()]")


### PR DESCRIPTION
Why? Because **SURPRISE MOTHERFUCKERS!**

If meme shuttles are buyable, this is an issue, and making "Status" panel show current shuttle name is **not a fix for it**. If meme shuttles are not buyable and appear only when badmins want to have fun, it's not an issue at all. 

If you want something that can't be changed by players, use pods.