### PR TITLE
Removes instances of '/area/space/nearstation' from tgstation

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /turf/open/space,
 /area/space)
@@ -221,7 +221,7 @@
 /area/security/prison)
 "aaH" = (
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "aaI" = (
 /obj/structure/bookcase,
 /turf/open/floor/plasteel/floorgrime,
@@ -8601,7 +8601,7 @@
 /area/maintenance/electrical)
 "asC" = (
 /turf/open/floor/plasteel/airless,
-/area/space/nearstation)
+/area/space)
 "asD" = (
 /turf/open/floor/plating/warnplate{
 	dir = 4
@@ -9080,10 +9080,10 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "atS" = (
 /turf/closed/wall,
-/area/space/nearstation)
+/area/space)
 "atT" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -9589,7 +9589,7 @@
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged3"
 	},
-/area/space/nearstation)
+/area/space)
 "avc" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -9982,7 +9982,7 @@
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged2"
 	},
-/area/space/nearstation)
+/area/space)
 "avV" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -24196,7 +24196,7 @@
 "bcU" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bcV" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -24646,7 +24646,7 @@
 "bdV" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "bdW" = (
 /obj/item/clothing/gloves/color/rainbow,
 /obj/item/clothing/head/soft/rainbow,
@@ -41521,7 +41521,7 @@
 /obj/structure/lattice,
 /obj/structure/closet,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bNc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -42016,7 +42016,7 @@
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged5"
 	},
-/area/space/nearstation)
+/area/space)
 "bOj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -43840,7 +43840,7 @@
 	amount = 5
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "bSv" = (
 /obj/machinery/camera{
 	c_tag = "Construction Area";
@@ -44794,7 +44794,7 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bUs" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -45316,7 +45316,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bVw" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -45343,7 +45343,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "bVA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46997,7 +46997,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "bZn" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -51516,7 +51516,7 @@
 	dir = 6
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ciD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	name = "output gas connector port"
@@ -51848,7 +51848,7 @@
 "cjn" = (
 /obj/item/weapon/weldingtool,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cjo" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plasteel,
@@ -54586,7 +54586,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cpi" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -54913,7 +54913,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cpQ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -55981,7 +55981,7 @@
 "csk" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "csl" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -56116,17 +56116,17 @@
 	state = 2
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "csB" = (
 /obj/item/weapon/wirecutters,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csC" = (
 /turf/open/floor/plating/airless/warnplate{
 	dir = 1
 	},
-/area/space/nearstation)
+/area/space)
 "csD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -56166,16 +56166,16 @@
 /turf/open/floor/plating/airless/warnplate{
 	dir = 9
 	},
-/area/space/nearstation)
+/area/space)
 "csI" = (
 /turf/open/floor/plating/airless/warnplate{
 	dir = 5
 	},
-/area/space/nearstation)
+/area/space)
 "csJ" = (
 /obj/item/weapon/crowbar,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csK" = (
 /obj/machinery/light{
 	dir = 4;
@@ -56213,21 +56213,21 @@
 "csP" = (
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "csQ" = (
 /obj/item/weapon/wrench,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "csR" = (
 /obj/machinery/the_singularitygen,
 /turf/open/floor/plating/airless/warnplate{
 	dir = 8
 	},
-/area/space/nearstation)
+/area/space)
 "csS" = (
 /obj/item/weapon/weldingtool,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/xmastree,
@@ -56317,7 +56317,7 @@
 /turf/open/floor/plating/airless/warnplate{
 	dir = 2
 	},
-/area/space/nearstation)
+/area/space)
 "ctg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -56374,7 +56374,7 @@
 /turf/open/floor/plating/airless/warnplate{
 	dir = 10
 	},
-/area/space/nearstation)
+/area/space)
 "ctn" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -59404,7 +59404,7 @@
 /turf/open/floor/plating/airless/warnplate{
 	dir = 6
 	},
-/area/space/nearstation)
+/area/space)
 "czE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -59450,7 +59450,7 @@
 /obj/item/weapon/wrench,
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "czJ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -59715,7 +59715,7 @@
 	tag = ""
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAl" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -59724,7 +59724,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAm" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59739,7 +59739,7 @@
 	tag = "90Curve"
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAn" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -59748,7 +59748,7 @@
 	tag = ""
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAo" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59756,7 +59756,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAp" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59769,7 +59769,7 @@
 	d2 = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAq" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -59777,7 +59777,7 @@
 	},
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAr" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59791,7 +59791,7 @@
 	tag = ""
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAs" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4";
@@ -59799,13 +59799,13 @@
 	},
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAt" = (
 /obj/machinery/the_singularitygen/tesla,
 /turf/open/floor/plating/airless/warnplate{
 	dir = 4
 	},
-/area/space/nearstation)
+/area/space)
 "cAu" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2";
@@ -59813,7 +59813,7 @@
 	},
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAv" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59822,7 +59822,7 @@
 	tag = "90Curve"
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAw" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -59837,7 +59837,7 @@
 	tag = ""
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAx" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59846,7 +59846,7 @@
 	tag = ""
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cAy" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plating,
@@ -60486,7 +60486,7 @@
 "cBR" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cBS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60578,7 +60578,7 @@
 "cCa" = (
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cCb" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -76736,7 +76736,7 @@ arH
 alU
 aaH
 bNb
-apQ
+aaf
 atO
 asK
 azF
@@ -78080,11 +78080,11 @@ aaa
 aaa
 aag
 aaa
-aoV
+aaa
 bZm
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 aaa
 aaS
 aaa
@@ -78271,7 +78271,7 @@ alU
 ank
 alU
 alU
-aoV
+aaa
 alU
 amC
 amC
@@ -78337,11 +78337,11 @@ aaa
 aaa
 aag
 aaa
-aoV
+aaa
 bVz
-apQ
-apQ
-aoV
+aaf
+aaf
+aaa
 aaa
 aaS
 aaf
@@ -78528,7 +78528,7 @@ amD
 anm
 amC
 ali
-aoV
+aaa
 ali
 amC
 alU
@@ -78594,11 +78594,11 @@ aaa
 aaa
 aag
 aaa
-bVw
+aag
 bVz
-bVw
-bVw
-aoV
+aag
+aag
+aaa
 aaa
 aaS
 aaa
@@ -78785,7 +78785,7 @@ amC
 amC
 amC
 ali
-apQ
+aaf
 ali
 amC
 alU
@@ -78851,11 +78851,11 @@ aaa
 aaa
 aag
 aaa
-apQ
+aaf
 bVz
-aoV
-bVw
-aoV
+aaa
+aag
+aaa
 aaa
 aaS
 aaS
@@ -79042,7 +79042,7 @@ amE
 ann
 amC
 alU
-aoV
+aaa
 ali
 amC
 alU
@@ -79108,11 +79108,11 @@ aaa
 aaa
 aag
 aaa
-apQ
+aaf
 bVz
-apQ
-bVw
-aoV
+aaf
+aag
+aaa
 aaa
 aaa
 aaf
@@ -79299,7 +79299,7 @@ alU
 alU
 ank
 alU
-aoV
+aaa
 alU
 amC
 amC
@@ -79367,9 +79367,9 @@ aag
 aaa
 bVx
 caf
-aoV
-bVw
-apQ
+aaa
+aag
+aaf
 aaa
 aaa
 aaf
@@ -79556,7 +79556,7 @@ amF
 alU
 amC
 alU
-apQ
+aaf
 alU
 alU
 alU
@@ -79622,11 +79622,11 @@ bCq
 bCq
 bLv
 bCq
-aoV
+aaa
 cbj
-aoV
-bVw
-apQ
+aaa
+aag
+aaf
 aaf
 bCq
 bCq
@@ -79813,7 +79813,7 @@ alU
 alU
 amC
 alU
-apQ
+aaf
 aaH
 alU
 arO
@@ -80328,8 +80328,8 @@ alU
 amC
 alU
 aaH
-apQ
-apQ
+aaf
+aaf
 aaH
 alU
 ali
@@ -80585,12 +80585,12 @@ ali
 aKY
 ali
 asC
-apQ
+aaf
 aaH
-apQ
-aoV
-aoV
-apQ
+aaf
+aaa
+aaa
+aaf
 avY
 axo
 ayB
@@ -80843,11 +80843,11 @@ amC
 ali
 asC
 aaH
-apQ
-aoV
-aoV
-aoV
-aoV
+aaf
+aaa
+aaa
+aaa
+aaa
 avY
 axo
 ayA
@@ -81101,10 +81101,10 @@ alU
 alU
 alU
 aaH
-apQ
-aoV
-apQ
-apQ
+aaf
+aaa
+aaf
+aaf
 avY
 axo
 ayA
@@ -81414,8 +81414,8 @@ bGi
 bJb
 bGi
 bGi
-aoV
-aoV
+aaa
+aaa
 bCq
 bPU
 bHE
@@ -81671,8 +81671,8 @@ bHz
 byE
 bKk
 bGi
-aoV
-aoV
+aaa
+aaa
 bCq
 bPW
 bCq
@@ -81928,8 +81928,8 @@ bHy
 byE
 bKj
 bGi
-aoV
-aoV
+aaa
+aaa
 bCq
 bHE
 bHE
@@ -82185,8 +82185,8 @@ bxy
 bJd
 bKm
 bxy
-apQ
-apQ
+aaf
+aaf
 bCq
 bPY
 apE
@@ -82455,12 +82455,12 @@ bHE
 bHE
 bHE
 bLv
-apQ
-aoV
-aoV
-aoV
-aoV
-aoV
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
 bLv
 cgH
 bLv
@@ -82699,8 +82699,8 @@ byE
 byE
 byE
 bGi
-apQ
-apQ
+aaf
+aaf
 bLv
 bQa
 bHE
@@ -82712,12 +82712,12 @@ bLv
 bLv
 bLv
 bLv
-aoV
-aoV
-aoV
-aoV
-aoV
-apQ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
 bLv
 cgH
 bLv
@@ -82956,8 +82956,8 @@ bEQ
 bGM
 bKn
 bGi
-aoV
-aoV
+aaa
+aaa
 bLv
 bPZ
 bHE
@@ -82965,16 +82965,16 @@ bHE
 bTz
 bHE
 bLv
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bLv
 cgH
 bLv
@@ -83213,8 +83213,8 @@ byE
 byE
 bKp
 bGi
-apQ
-apQ
+aaf
+aaf
 bLv
 bHE
 bHE
@@ -83222,16 +83222,16 @@ bSs
 bCq
 bHE
 bLv
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 bcU
-apQ
+aaf
 aaH
 cCa
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 bLv
 cgH
 bLv
@@ -83479,16 +83479,16 @@ bSr
 bCq
 bHE
 bLv
-apQ
-apQ
-aoV
-aoV
+aaf
+aaf
+aaa
+aaa
 aaH
 bdV
 aaH
-apQ
-apQ
-apQ
+aaf
+aaf
+aaf
 bLv
 cgH
 bLv
@@ -83727,8 +83727,8 @@ bGn
 bGn
 bKq
 bxy
-apQ
-apQ
+aaf
+aaf
 bCq
 bOK
 bCq
@@ -83736,16 +83736,16 @@ bCq
 bCq
 bHE
 bLv
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
 cjn
 bSu
 aaH
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 bLv
 cgH
 bLv
@@ -83993,16 +83993,16 @@ aaa
 bLv
 bHE
 bLv
-aoV
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
+aaa
 aaH
-apQ
-aoV
-aoV
-aoV
+aaf
+aaa
+aaa
+aaa
 bLv
 cgH
 bLv
@@ -84250,16 +84250,16 @@ aaf
 bLv
 bUt
 bLv
-apQ
-apQ
-aoV
-aoV
-aoV
+aaf
+aaf
+aaa
+aaa
+aaa
 aaH
-aoV
-aoV
-apQ
-apQ
+aaa
+aaa
+aaf
+aaf
 bLv
 cgH
 bLv
@@ -84507,16 +84507,16 @@ aaa
 bLv
 bUs
 bLv
-aoV
-aoV
-aoV
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
 bCq
 cgH
 bCq
@@ -87874,19 +87874,19 @@ cqc
 cqC
 cqV
 ccw
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-apQ
-aoV
-aoV
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
 crU
 ccw
 ctv
@@ -88144,7 +88144,7 @@ cAp
 cAo
 cAo
 cAv
-apQ
+aaf
 cig
 ctv
 aaa
@@ -88401,7 +88401,7 @@ cAq
 aaH
 aaH
 cAl
-apQ
+aaf
 cig
 ctv
 aaf
@@ -88648,17 +88648,17 @@ cqY
 cqY
 cAl
 csA
-aoV
-aoV
+aaa
+aaa
 csA
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
 csA
 aaH
 cAl
-apQ
+aaf
 cig
 ctR
 aaf
@@ -88904,18 +88904,18 @@ cqY
 cqY
 cqY
 cAl
-aoV
-aoV
-aoV
-apQ
-aoV
+aaa
+aaa
+aaa
+aaf
+aaa
 csS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 cAu
 cAw
-apQ
+aaf
 cig
 ctv
 aaf
@@ -89161,18 +89161,18 @@ cqX
 crs
 cqY
 cAl
-aoV
-aoV
-apQ
-apQ
-apQ
-apQ
-apQ
-aoV
-aoV
+aaa
+aaa
+aaf
+aaf
+aaf
+aaf
+aaf
+aaa
+aaa
 aaH
 cAl
-aoV
+aaa
 cig
 ctv
 aaa
@@ -89418,18 +89418,18 @@ cra
 crI
 cqY
 cAl
-aoV
-aoV
-apQ
+aaa
+aaa
+aaf
 csH
 csR
 ctm
-apQ
-apQ
+aaf
+aaf
 csA
 aaH
 cAl
-aoV
+aaa
 cig
 ctv
 aaa
@@ -89675,18 +89675,18 @@ cqZ
 crt
 czE
 cAm
-aoV
-aoV
-apQ
+aaa
+aaa
+aaf
 csC
 csQ
 ctf
-apQ
-aoV
-aoV
+aaf
+aaa
+aaa
 cAu
 cAw
-aoV
+aaa
 cig
 ctv
 aaa
@@ -89934,16 +89934,16 @@ cqY
 cAl
 csA
 csB
-apQ
+aaf
 csI
 cAt
 czD
-apQ
-aoV
-aoV
+aaf
+aaa
+aaa
 aaH
 cAl
-aoV
+aaa
 cig
 ctv
 aaa
@@ -90189,18 +90189,18 @@ cAP
 crv
 cqY
 cAl
-aoV
-aoV
-apQ
-apQ
-apQ
-apQ
-apQ
-aoV
-aoV
+aaa
+aaa
+aaf
+aaf
+aaf
+aaf
+aaf
+aaa
+aaa
 aaH
 cAl
-aoV
+aaa
 cig
 ctv
 aaf
@@ -90446,18 +90446,18 @@ cqY
 cqY
 cqY
 cAl
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 csJ
-aoV
-apQ
-aoV
-aoV
-aoV
+aaa
+aaf
+aaa
+aaa
+aaa
 cAu
 cAw
-apQ
+aaf
 cig
 ctv
 aaf
@@ -90704,17 +90704,17 @@ cqY
 cqY
 cAl
 csA
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
 csA
-aoV
-aoV
+aaa
+aaa
 csA
 aaH
 cAl
-apQ
+aaf
 cig
 ctR
 aaf
@@ -90971,7 +90971,7 @@ cAs
 aaH
 aaH
 cAl
-apQ
+aaf
 cig
 ctv
 aaf
@@ -91228,7 +91228,7 @@ cAr
 cAo
 cAo
 cAx
-apQ
+aaf
 cig
 ctv
 aaa
@@ -91472,19 +91472,19 @@ cqc
 cqC
 crc
 ccw
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
 cBR
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 crU
 ccw
 ctv
@@ -92744,7 +92744,7 @@ bOd
 cfN
 cfN
 bLK
-apQ
+aaf
 bOh
 bOh
 bOh
@@ -93258,7 +93258,7 @@ cfi
 bRH
 cgV
 bMQ
-apQ
+aaf
 bQA
 ckU
 clT
@@ -93515,7 +93515,7 @@ cez
 cfQ
 cgY
 ciu
-bVu
+csw
 ckb
 ckW
 clU
@@ -94286,7 +94286,7 @@ bOd
 cfP
 cgZ
 bMQ
-apQ
+aaf
 bQA
 ckX
 clV
@@ -94543,7 +94543,7 @@ bOe
 cfQ
 chb
 ciu
-bVu
+csw
 ckb
 ckZ
 clW
@@ -94800,7 +94800,7 @@ bUL
 cfS
 bOd
 bMQ
-apQ
+aaf
 bOh
 bOh
 bOh
@@ -95314,7 +95314,7 @@ bUR
 cfT
 chc
 bMQ
-apQ
+aaf
 bQA
 cla
 cBP
@@ -95828,7 +95828,7 @@ bLK
 bLK
 che
 bLK
-apQ
+aaf
 bOh
 bOh
 bOh
@@ -96063,40 +96063,40 @@ bFJ
 bvd
 bKH
 bzs
-bRK
-apQ
-bRK
-apQ
+bNa
+aaf
+bNa
+aaf
 bVv
-apQ
-bRK
-apQ
+aaf
+bNa
+aaf
 bVv
-apQ
-bRK
-apQ
+aaf
+bNa
+aaf
 bVv
-apQ
-bRK
-apQ
+aaf
+bNa
+aaf
 bVv
-apQ
-apQ
+aaf
+aaf
 bLK
 chg
 bLK
-apQ
-aoV
-aoV
-apQ
-apQ
-apQ
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
+aaf
+aaa
+aaa
+aaf
+aaf
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaf
@@ -96338,22 +96338,22 @@ bPj
 bQA
 bPj
 bOh
-apQ
+aaf
 bLK
 cyG
 bLK
-aoV
-aoV
-aoV
-apQ
-apQ
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaf
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaf
@@ -96595,22 +96595,22 @@ cbI
 ccC
 cdD
 bOh
-apQ
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
+aaf
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaf
@@ -96852,22 +96852,22 @@ cbH
 ccB
 cbH
 bOh
-apQ
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
+aaf
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaf
@@ -97109,22 +97109,22 @@ cbH
 ccD
 cbH
 bOh
-apQ
-apQ
-apQ
-apQ
-apQ
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-aoV
-aoV
-csz
-aoV
-aoV
+aaf
+aaf
+aaf
+aaf
+aaf
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aae
+aaa
+aaa
 aaa
 aaa
 aaf
@@ -97366,22 +97366,22 @@ bOh
 bOh
 bOh
 bOh
-apQ
-apQ
+aaf
+aaf
 ciC
-bVu
-bVu
-bVu
-bVu
-bVu
-caJ
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
+csw
+csw
+csw
+csw
+csw
+ctO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaf
@@ -97606,24 +97606,24 @@ bJC
 bKH
 bzs
 bUr
-bVu
-bVu
-bVu
-bVu
-bVu
-bVu
-bVu
-bVu
-bVu
-bVu
-bVu
-bVu
-caJ
-apQ
-apQ
-apQ
-apQ
-apQ
+csw
+csw
+csw
+csw
+csw
+csw
+csw
+csw
+csw
+csw
+csw
+csw
+ctO
+aaf
+aaf
+aaf
+aaf
+aaf
 cfj
 cfU
 cfj
@@ -97632,13 +97632,13 @@ ckf
 cfj
 cfj
 bUr
-bVu
-bVu
-bVu
-bVu
-bVu
-bVu
-bVu
+csw
+csw
+csw
+csw
+csw
+csw
+csw
 csw
 csw
 csw
@@ -97888,14 +97888,14 @@ ciy
 cke
 clg
 cfj
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaf
@@ -98145,14 +98145,14 @@ ciA
 cjr
 clh
 cfj
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaf
@@ -98408,8 +98408,8 @@ cpQ
 cpQ
 cpQ
 czJ
-apQ
-aoV
+aaf
+aaa
 aaa
 aaa
 aaf
@@ -98663,10 +98663,10 @@ cmd
 cmd
 cmd
 cmd
-bVw
-bVw
-bVw
-bVw
+aag
+aag
+aag
+aag
 aaa
 aaa
 aaf
@@ -98923,7 +98923,7 @@ cmd
 cmd
 cqs
 aaa
-bVw
+aag
 aaa
 aaa
 aaf
@@ -99180,7 +99180,7 @@ ciM
 cpN
 cqt
 aaa
-bVw
+aag
 aaa
 aaa
 aaf
@@ -99437,7 +99437,7 @@ cmd
 cmd
 cqs
 aaa
-bVw
+aag
 aaa
 aaa
 aaf
@@ -99692,9 +99692,9 @@ cmd
 cos
 cmd
 czI
-bVw
-bVw
-bVw
+aag
+aag
+aag
 aaa
 aaa
 aaf
@@ -99946,11 +99946,11 @@ clk
 clk
 bAw
 bzs
-apQ
+aaf
 aaa
-apQ
-apQ
-apQ
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -100204,8 +100204,8 @@ cmg
 cnc
 cnD
 bzs
-apQ
-apQ
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -100975,8 +100975,8 @@ cmh
 cnd
 cnE
 bPn
-aoV
-aoV
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -108858,13 +108858,13 @@ aaf
 aaa
 aaa
 atS
-apQ
-aoV
-aoV
+aaf
+aaa
+aaa
 atS
-apQ
-apQ
-apQ
+aaf
+aaf
+aaf
 atS
 aCR
 aEn
@@ -109115,13 +109115,13 @@ aaa
 aaa
 aaa
 atS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 atS
-aoV
-aoV
-apQ
+aaa
+aaa
+aaf
 atS
 aaf
 aaa
@@ -109372,13 +109372,13 @@ aaa
 aaa
 aaa
 atS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 aaH
-aoV
-aoV
-apQ
+aaa
+aaa
+aaf
 atS
 aaf
 aaa
@@ -109629,13 +109629,13 @@ aaa
 aaa
 aaa
 atS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 aaH
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 atS
 aaf
 aaa
@@ -109886,13 +109886,13 @@ aaa
 aaa
 aaa
 aaH
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 atS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 atS
 aaf
 aaa
@@ -110143,14 +110143,14 @@ aaa
 aaa
 aaa
 atS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 atS
-aoV
-aoV
-aoV
-apQ
+aaa
+aaa
+aaa
+aaf
 aaf
 aaa
 aaf
@@ -110400,14 +110400,14 @@ aaa
 aae
 aaa
 atS
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
 atS
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
 aaf
 aaa
 aaf
@@ -110656,15 +110656,15 @@ aaa
 aaa
 aaa
 aaa
-apQ
-aoV
-aoV
-aoV
+aaf
+aaa
+aaa
+aaa
 atS
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
 aaf
 aaa
 aaf
@@ -110913,15 +110913,15 @@ aaa
 aaa
 aaa
 aaa
-apQ
-aoV
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-aoV
+aaf
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
 aaf
 aaa
 aaf
@@ -111170,15 +111170,15 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aoV
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-aoV
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaf


### PR DESCRIPTION
This is the master PR for a series about removing `/area/space/nearstation` from the maps.

Why
- I was going to post a side-by-side of what various areas look like with and without `/area/space/nearstation`, but it's essentially nil in all cases.
- Birdstation only uses it three times, in what looks like a copy-paste section from tgstation
- Pubby uses it a tiny bit, but again it looks like it was because of copy-paste, not actual intent
- Okand didn't use the tile in either of their maps, which don't seem to have complains about light
- tgstation is the only map that uses the tile extensively, and I bet if you testmerge this literally nobody will notice

Unless someone can show me a screenshot of this tile actually being useful, I'm dragging it out behind the chemical shed 

**Why separate commits?**
It's aattoommiicc