### PR TITLE
The Start Now verb sets the round to start immediately

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -11,6 +11,8 @@ var/datum/subsystem/ticker/ticker
 
 	var/current_state = GAME_STATE_STARTUP	//state of current round (used by process()) Use the defines GAME_STATE_* !
 	var/force_ending = 0					//Round was ended by admin intervention
+	// If true, there is no lobby phase, the game starts immediately.
+	var/start_immediately = FALSE
 
 	var/hide_mode = 0
 	var/datum/game_mode/mode = null
@@ -81,6 +83,9 @@ var/datum/subsystem/ticker/ticker
 				++totalPlayers
 				if(player.ready)
 					++totalPlayersReady
+
+			if(start_immediately)
+				timeLeft = 0
 
 			//countdown
 			if(timeLeft < 0)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -513,15 +513,17 @@ var/global/BSACooldown = 0
 	set category = "Server"
 	set desc="Start the round RIGHT NOW"
 	set name="Start Now"
-	if(ticker.current_state == GAME_STATE_PREGAME)
-		ticker.can_fire = 1
-		ticker.timeLeft = 0
+	if(ticker.current_state == GAME_STATE_PREGAME || ticker.current_state == GAME_STATE_STARTUP)
+		ticker.start_immediately = TRUE
 		log_admin("[usr.key] has started the game.")
-		message_admins("<font color='blue'>[usr.key] has started the game.</font>")
+		var/msg = ""
+		if(ticker.current_state == GAME_STATE_STARTUP)
+			msg = " (The server is still setting up, but the round will be \
+				started as soon as possible.)"
+		message_admins("<font color='blue'>\
+			[usr.key] has started the game.[msg]</font>")
 		feedback_add_details("admin_verb","SN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 		return 1
-	else if (ticker.current_state == GAME_STATE_STARTUP)
-		usr << "<font color='red'>Error: Start Now: Game is in startup, please wait until it has finished.</font>"
 	else
 		usr << "<font color='red'>Error: Start Now: Game has already started.</font>"
 


### PR DESCRIPTION
Previously, if you pressed Start Now while the server was still
initialising, it would complain, and you'd have to wait until the lobby
was ready.

Now pressing it will have the server start as soon as able.

Uses: debugging qol.