### PR TITLE
Fixes storage pockets preventing the use of items on the clothing item

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -392,7 +392,7 @@
 		return	//Robots can't interact with storage items.
 
 	if(!can_be_inserted(W, 0 , user))
-		return
+		return 0
 
 	handle_item_insertion(W, 0 , user)
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -79,9 +79,10 @@
 		user << "<span class='notice'>You fix the damages on [src] with [C].</span>"
 		return 1
 	if(pockets)
-		return pockets.attackby(W, user, params)
-	else
-		return ..()
+		var/i = pockets.attackby(W, user, params)
+		if(i)
+			return i
+	return ..()
 
 /obj/item/clothing/AltClick(mob/user)
 	if(pockets && pockets.quickdraw && pockets.contents.len && !user.incapacitated())


### PR DESCRIPTION
:cl: XDTM
fix: You can now properly apply items to clothing with pockets, such as slime speed potions on clown shoes.
/:cl:

You'll still insert it in the pocket if the pocket allows that item.

Fixes #19980.
