### PR TITLE
Fixes wormholes not being usable by mechs

### DIFF
--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -63,6 +63,7 @@
 	P.icon = 'icons/obj/objects.dmi'
 	P.icon_state = "anom"
 	P.name = "wormhole"
+	P.mech_sized = TRUE
 	var/turf/T = get_turf(target)
 	message_admins("[ADMIN_LOOKUPFLW(chassis.occupant)] used a Wormhole Generator in [ADMIN_COORDJMP(T)]",0,1)
 	log_game("[key_name(chassis.occupant)] used a Wormhole Generator in [COORD(T)]")

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -9,6 +9,7 @@
 	var/creator = null
 	anchored = 1
 	var/precision = 1 // how close to the portal you will teleport. 0 = on the portal, 1 = adjacent
+	var/mech_sized = FALSE
 
 /obj/effect/portal/Bumped(mob/M as mob|obj)
 	teleport(M)
@@ -51,8 +52,9 @@
 /obj/effect/portal/proc/teleport(atom/movable/M as mob|obj)
 	if(istype(M, /obj/effect)) //sparks don't teleport
 		return
-	if(M.anchored&&istype(M, /obj/mecha))
-		return
+	if(M.anchored)
+		if(!(istype(M, /obj/mecha) && mech_sized))
+			return
 	if (!( target ))
 		qdel(src)
 		return

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -50,6 +50,7 @@
 	desc = "It looks highly unstable; It could close at any moment."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "anom"
+	mech_sized = TRUE
 
 /obj/effect/portal/wormhole/attack_hand(mob/user)
 	teleport(user)
@@ -60,8 +61,9 @@
 /obj/effect/portal/wormhole/teleport(atom/movable/M)
 	if(istype(M, /obj/effect))	//sparks don't teleport
 		return
-	if(M.anchored && !istype(M, /obj/mecha))
-		return
+	if(M.anchored)
+		if(!(istype(M, /obj/mecha) && mech_sized))
+			return
 
 	if(istype(M, /atom/movable))
 		var/turf/target

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -141,10 +141,15 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "bhole3"
 	desc = "A stable hole in the universe made by a wormhole jaunter. Turbulent doesn't even begin to describe how rough passage through one of these is, but at least it will always get you somewhere near a beacon."
+	mech_sized = TRUE //save your ripley
 
 /obj/effect/portal/wormhole/jaunt_tunnel/teleport(atom/movable/M)
-	if(M.anchored || istype(M, /obj/effect))
+	if(istype(M, /obj/effect))
 		return
+
+	if(M.anchored)
+		if(!(istype(M, /obj/mecha) && mech_sized))
+			return
 
 	if(istype(M, /atom/movable))
 		if(do_teleport(M, target, 6))


### PR DESCRIPTION
:cl: XDTM
fix: Mechs are now able to enter wormhole-sized portals.
/:cl:

Portals can now also be var-edited to be mech-sized, if necessary. Every portal that appears as a wormhole (mech wormhole gens, event wormholes, miner jaunters) can fit mechs. Normal portals such as the hand tele or the portal gun can't.

The reason for which i consider this a bug is that @KorPhaeron changed
`if(M.anchored && istype(M, /obj/mecha))`
into
`if(M.anchored && !istype(M, /obj/mecha))`
in #22587, which implies that mechas are supposed to cross wormholes.
Since mech wormhole generators actually create reskinned portals instead, it was not working properly.
