### PR TITLE
Removes offending line from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,7 +292,6 @@ There is no strict process when it comes to merging pull requests, pull requests
 ## Banned content
 Do not add any of the following in a Pull Request or risk getting the PR closed:
 * National Socialist Party of Germany content, National Socialist Party of Germany related content, or National Socialist Party of Germany references
-* Code where one line of code is split across mutiple lines (except for strings and comments and in those cases existing longer lines must not be split up)
 
 ##A word on git
 Yes we know that the files have a tonne of mixed windows and linux line endings, attempts to fix this have been met with less than stellar success and as such we have decided to give up caring until such a time as it matters.


### PR DESCRIPTION
Apparently my multiline strings (and only MY strings, other people
have been splitting strings with just longer line lengths, and no one
complained then) are on the par with NAZI CONTENT, that is HARD BANNED
in the CONTRIBUTING.md file.

I mean this is just petty and vindictive. Apparently my multilines
ARE EQUIVALENT TO NAZIS.

It's dumb, you should remove it, and I can't believe this is an issue.