### PR TITLE
Fixes cyborgs making strange sounds when empd

### DIFF
--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -154,7 +154,7 @@
 	brainmob << "<span class='notice'>Radio is [radio.listening==1 ? "now" : "no longer"] receiving broadcast.</span>"
 
 /obj/item/device/mmi/emp_act(severity)
-	if(!brainmob)
+	if(!brainmob || iscyborg(loc))
 		return
 	else
 		switch(severity)


### PR DESCRIPTION
Fixes #9716

I could move this check down to the emote as well and still let the MMI get hurt but the MMI taking invisible unrepairable damage separate from the cyborg while part of it seems counter intuitive