### PR TITLE
Fixes destructive analyzer not being able to scan chem containers

### DIFF
--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -59,7 +59,7 @@
 		return
 	if(default_deconstruction_crowbar(O))
 		return
-	if((O.container_type & OPENCONTAINER) && O.is_open_container())
+	if(is_open_container() && O.is_open_container())
 		return 0 //inserting reagents into the machine
 	if(Insert_Item(O, user))
 		return 1


### PR DESCRIPTION
That check was for the machine, not the item, @Firecage :^)

Fixes #22738