### PR TITLE
Fixes plastitanium false wall icons updating to the wrong icon

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -81,7 +81,7 @@
 	if(density)
 		smooth = SMOOTH_TRUE
 		queue_smooth(src)
-		icon_state = "wall"
+		icon_state = initial(icon_state)
 	else
 		icon_state = "fwall_open"
 


### PR DESCRIPTION
False wall code is a little odd, and when closed, would always update to the icon named 'wall.'
Plastitanium walls were named 'wall3', instead. In it's dmi file, the icon state for 'wall' was that of titanium. When the icon would update, it would update to this incorrect icon state and it would appear to be titanium.
This should fix this.

This affects all false walls, but they function the same, anyways. I tested several others, and it appears to work fine.

Fixes #22264