### PR TITLE
The Meteor Shield station project now actually shields from meteors

### DIFF
--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -134,7 +134,8 @@
 	name = "Meteor Shield Satellite"
 	desc = "Meteor Point Defense Satellite"
 	mode = "M-SHIELD"
-	var/kill_range = 10
+	speed_process = TRUE
+	var/kill_range = 14
 
 /obj/machinery/satellite/meteor_shield/proc/space_los(meteor)
 	for(var/turf/T in getline(src,meteor))


### PR DESCRIPTION
:cl: Nanotrasen Station Project Advisory Board
wip: It is highly recommended that, when constructing the Meteor Shield project, you are able to see, at minimum, two meteor shields from a stationary location. The Nanotrasen Station Project Advisory Board is not liable for meteor damage taken under wider shield arrangements. 
/:cl:

Instead of, while standing next to a shield sat, letting you get hit by a meteor, it will remove meteors with greater speed and range! Like, you know, you'd expect it to do.