### PR TITLE
Makes "Oh, Hi Daniel" shuttle unbuyable

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -155,7 +155,6 @@
 	name = "Oh, Hi Daniel"
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
-	credit_cost = -5000
 
 /datum/map_template/shuttle/emergency/goon
 	suffix = "goon"


### PR DESCRIPTION
This was a sad excuse of a shuttle: meme name, meme desc and meme map. It's not a shuttle, it's a fucking wooden box! Absolutely pointless.

Separate PR from #22756 because I want this merged even if the rest of PR is not going to make it.