### PR TITLE
Prevents tick_check'ed sleeps/spawns from shutting out the MC

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1287,14 +1287,13 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 /proc/stoplag()
 	. = round(1*DELTA_CALC)
 	sleep(world.tick_lag)
-	if (world.tick_usage > TICK_LIMIT_TO_RUN) //woke up, still not enough tick, sleep for more.
+	if (world.tick_usage > min(TICK_LIMIT_TO_RUN, CURRENT_TICKLIMIT)) //woke up, still not enough tick, sleep for more.
 		. += round(2*DELTA_CALC)
 		sleep(world.tick_lag*2*DELTA_CALC)
-		if (world.tick_usage > TICK_LIMIT_TO_RUN) //woke up, STILL not enough tick, sleep for more.
+		if (world.tick_usage > min(TICK_LIMIT_TO_RUN, CURRENT_TICKLIMIT)) //woke up, STILL not enough tick, sleep for more.
 			. += round(4*DELTA_CALC)
 			sleep(world.tick_lag*4*DELTA_CALC)
-			//you might be thinking of adding more steps to this, or making it use a loop and a counter var
-			//	not worth it.
+
 #undef DELTA_CALC
 
 /proc/flash_color(mob_or_client, flash_color="#960000", flash_time=20)

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -232,6 +232,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	while (1)
 		tickdrift = max(0, MC_AVERAGE_FAST(tickdrift, (((world.timeofday - init_timeofday) - (world.time - init_time)) / world.tick_lag)))
 		if (processing <= 0)
+			CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 			sleep(10)
 			continue
 
@@ -239,6 +240,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		//	because sleeps are processed in the order received, so longer sleeps are more likely to run first
 		if (world.tick_usage > TICK_LIMIT_MC)
 			sleep_delta += 2
+			CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING - (TICK_LIMIT_RUNNING * 0.5)
 			sleep(world.tick_lag * (processing + sleep_delta))
 			continue
 
@@ -267,6 +269,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 			if (!error_level)
 				iteration++
 			error_level++
+			CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 			sleep(10)
 			continue
 
@@ -278,6 +281,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 				if (!error_level)
 					iteration++
 				error_level++
+				CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 				sleep(10)
 				continue
 		error_level--
@@ -288,6 +292,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		iteration++
 		last_run = world.time
 		src.sleep_delta = MC_AVERAGE_FAST(src.sleep_delta, sleep_delta)
+		CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING - (TICK_LIMIT_RUNNING * 0.25) //reserve the tail 1/4 of the next tick for the mc.
 		sleep(world.tick_lag * (processing + sleep_delta))
 
 
@@ -445,7 +450,6 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 				return
 			queue_node = queue_node.queue_next
 
-	CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	. = 1
 
 //resets the queue, and all subsystems, while filtering out the subsystem lists


### PR DESCRIPTION
I don't know why I didn't do this before....

The biggest source of delays in shit that runs under the mc is shit that doesn't run under the mc using up all of the tick, causing the mc to not have much of a byond tick when it wakes up.

In the wild west of TICK_CHECK and stoplag(), it's first come first serve, so the first TICK_CHECK sleep to resume would eat up all of the tick.

By reserving the tail end of the next tick for the mc, we can ensure it gets a few fires in to things like throwing or lighting that tick, usually enough to clear out their list of things to do that tick anyways since they are generally very cheap.