### PR TITLE
Makes earmuffs and null rods protect from Voice of God, adds earmuffs to autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -171,6 +171,14 @@
 	build_path = /obj/item/weapon/electronics/firealarm
 	category = list("initial", "Electronics")
 
+/datum/design/earmuffs
+	name = "Earmuffs"
+	id = "earmuffs"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
+	build_path = /obj/item/clothing/ears/earmuffs
+	category = list("initial", "Misc")
+
 /datum/design/pipe_painter
 	name = "Pipe painter"
 	id = "pipe_painter"

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -120,7 +120,7 @@ var/static/regex/multispin_words = regex("like a record baby")
 
 	var/mob/living/list/listeners = list()
 	for(var/mob/living/L in get_hearers_in_view(8, owner))
-		if(!L.ear_deaf && L != owner && L.stat != DEAD)
+		if(!L.ear_deaf && !L.null_rod_check() && L != owner && L.stat != DEAD)
 			if(ishuman(L))
 				var/mob/living/carbon/human/H = L
 				if(istype(H.ears, /obj/item/clothing/ears/earmuffs))
@@ -185,39 +185,27 @@ var/static/regex/multispin_words = regex("like a record baby")
 	if(findtext(message, stun_words))
 		for(var/V in listeners)
 			var/mob/living/L = V
-			if(!L.isloyal()) //mindshield protects
-				L.Stun(3 * power_multiplier)
-			else
-				L << "<span class='notice'>Your mindshield implant shields your mind from the command!</span>"
+			L.Stun(3 * power_multiplier)
 		next_command = world.time + cooldown_stun
 
 	//WEAKEN
 	else if(findtext(message, weaken_words))
 		for(var/V in listeners)
 			var/mob/living/L = V
-			if(!L.isloyal()) //mindshield protects
-				L.Weaken(3 * power_multiplier)
-			else
-				L << "<span class='notice'>Your mindshield implant shields your mind from the command!</span>"
+			L.Weaken(3 * power_multiplier)
 		next_command = world.time + cooldown_stun
 
 	//SLEEP
 	else if((findtext(message, sleep_words)))
 		for(var/V in listeners)
 			var/mob/living/L = V
-			if(!L.isloyal()) //mindshield protects
-				L.Sleeping(2 * power_multiplier)
-			else
-				L << "<span class='notice'>Your mindshield implant shields your mind from the command!</span>"
+			L.Sleeping(2 * power_multiplier)
 		next_command = world.time + cooldown_stun
 
 	//VOMIT
 	else if((findtext(message, vomit_words)))
 		for(var/mob/living/carbon/C in listeners)
-			if(!C.isloyal()) //mindshield protects
-				C.vomit(10 * power_multiplier)
-			else
-				C << "<span class='notice'>Your mindshield implant shields your mind from the command!</span>"
+			C.vomit(10 * power_multiplier)
 		next_command = world.time + cooldown_stun
 
 	//SILENCE
@@ -225,8 +213,6 @@ var/static/regex/multispin_words = regex("like a record baby")
 		for(var/mob/living/carbon/C in listeners)
 			if(owner.mind && (owner.mind.assigned_role == "Librarian" || owner.mind.assigned_role == "Mime"))
 				power_multiplier *= 3
-			if(C.isloyal()) //mindshield protects
-				power_multiplier *= 0.5
 			C.silent += (10 * power_multiplier)
 		next_command = world.time + cooldown_stun
 
@@ -255,16 +241,12 @@ var/static/regex/multispin_words = regex("like a record baby")
 	else if((findtext(message, hurt_words)))
 		for(var/V in listeners)
 			var/mob/living/L = V
-			if(L.isloyal()) //mindshield protects
-				power_multiplier *= 0.5
 			L.apply_damage(15 * power_multiplier, def_zone = "chest")
 		next_command = world.time + cooldown_damage
 
 	//BLEED
 	else if((findtext(message, bleed_words)))
 		for(var/mob/living/carbon/human/H in listeners)
-			if(H.isloyal()) //mindshield protects
-				power_multiplier *= 0.5
 			H.bleed_rate += (5 * power_multiplier)
 		next_command = world.time + cooldown_damage
 
@@ -272,8 +254,6 @@ var/static/regex/multispin_words = regex("like a record baby")
 	else if((findtext(message, burn_words)))
 		for(var/V in listeners)
 			var/mob/living/L = V
-			if(L.isloyal()) //mindshield protects
-				power_multiplier *= 0.5
 			L.adjust_fire_stacks(1 * power_multiplier)
 			L.IgniteMob()
 		next_command = world.time + cooldown_damage
@@ -292,7 +272,7 @@ var/static/regex/multispin_words = regex("like a record baby")
 			var/mob/living/L = V
 			if(L.mind && L.mind.devilinfo)
 				L.say("[L.mind.devilinfo.truename]")
-			else if(!L.isloyal()) //mindshield protects
+			else
 				L.say("[L.real_name]")
 		next_command = world.time + cooldown_meme
 
@@ -454,8 +434,6 @@ var/static/regex/multispin_words = regex("like a record baby")
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, get_turf(owner), "sound/items/bikehorn.ogg", 300, 1), 25)
 		if(owner.mind && owner.mind.assigned_role == "Clown")
 			for(var/mob/living/carbon/C in listeners)
-				if(C.isloyal()) //mindshield protects
-					power_multiplier *= 0.25
 				C.slip(0,7 * power_multiplier)
 			next_command = world.time + cooldown_stun
 		else

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -112,6 +112,11 @@ var/static/regex/multispin_words = regex("like a record baby")
 	return TRUE
 
 /obj/item/organ/vocal_cords/colossus/handle_speech(message)
+	spans = list("colossus","yell") //reset spans, just in case someone gets deculted or the cords change owner
+	if(iscultist(owner))
+		spans = list("narsiesmall")
+	else if (is_servant_of_ratvar(owner))
+		spans = list("ratvar")
 	return uppertext(message)
 
 /obj/item/organ/vocal_cords/colossus/speak_with(message)
@@ -133,7 +138,6 @@ var/static/regex/multispin_words = regex("like a record baby")
 		return
 
 	var/power_multiplier = base_multiplier
-	spans = list("colossus","yell") //reset spans, just in case someone gets deculted or the cords change owner
 
 	if(owner.mind)
 		//Chaplains are very good at speaking with the voice of god
@@ -149,10 +153,8 @@ var/static/regex/multispin_words = regex("like a record baby")
 	//Cultists are closer to their gods and are more powerful, but they'll give themselves away
 	if(iscultist(owner))
 		power_multiplier *= 2
-		spans = list("narsiesmall")
 	else if (is_servant_of_ratvar(owner))
 		power_multiplier *= 2
-		spans = list("ratvar")
 
 	//Try to check if the speaker specified a name or a job to focus on
 	var/list/specific_listeners = list()

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -121,6 +121,10 @@ var/static/regex/multispin_words = regex("like a record baby")
 	var/mob/living/list/listeners = list()
 	for(var/mob/living/L in get_hearers_in_view(8, owner))
 		if(!L.ear_deaf && L != owner && L.stat != DEAD)
+			if(ishuman(L))
+				var/mob/living/carbon/human/H = L
+				if(istype(H.ears, /obj/item/clothing/ears/earmuffs))
+					continue
 			listeners += L
 
 	if(!listeners.len)

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -60,7 +60,7 @@ var/static/regex/multispin_words = regex("like a record baby")
 	slot = "vocal_cords"
 	actions_types = list(/datum/action/item_action/organ_action/colossus)
 	var/next_command = 0
-	var/cooldown_stun = 900
+	var/cooldown_stun = 1200
 	var/cooldown_damage = 600
 	var/cooldown_meme = 300
 	var/cooldown_none = 150
@@ -181,27 +181,39 @@ var/static/regex/multispin_words = regex("like a record baby")
 	if(findtext(message, stun_words))
 		for(var/V in listeners)
 			var/mob/living/L = V
-			L.Stun(3 * power_multiplier)
+			if(!L.isloyal()) //mindshield protects
+				L.Stun(3 * power_multiplier)
+			else
+				L << "<span class='notice'>Your mindshield implant shields your mind from the command!</span>"
 		next_command = world.time + cooldown_stun
 
 	//WEAKEN
 	else if(findtext(message, weaken_words))
 		for(var/V in listeners)
 			var/mob/living/L = V
-			L.Weaken(3 * power_multiplier)
+			if(!L.isloyal()) //mindshield protects
+				L.Weaken(3 * power_multiplier)
+			else
+				L << "<span class='notice'>Your mindshield implant shields your mind from the command!</span>"
 		next_command = world.time + cooldown_stun
 
 	//SLEEP
 	else if((findtext(message, sleep_words)))
 		for(var/V in listeners)
 			var/mob/living/L = V
-			L.Sleeping(2 * power_multiplier)
+			if(!L.isloyal()) //mindshield protects
+				L.Sleeping(2 * power_multiplier)
+			else
+				L << "<span class='notice'>Your mindshield implant shields your mind from the command!</span>"
 		next_command = world.time + cooldown_stun
 
 	//VOMIT
 	else if((findtext(message, vomit_words)))
 		for(var/mob/living/carbon/C in listeners)
-			C.vomit(10 * power_multiplier)
+			if(!C.isloyal()) //mindshield protects
+				C.vomit(10 * power_multiplier)
+			else
+				C << "<span class='notice'>Your mindshield implant shields your mind from the command!</span>"
 		next_command = world.time + cooldown_stun
 
 	//SILENCE
@@ -209,6 +221,8 @@ var/static/regex/multispin_words = regex("like a record baby")
 		for(var/mob/living/carbon/C in listeners)
 			if(owner.mind && (owner.mind.assigned_role == "Librarian" || owner.mind.assigned_role == "Mime"))
 				power_multiplier *= 3
+			if(C.isloyal()) //mindshield protects
+				power_multiplier *= 0.5
 			C.silent += (10 * power_multiplier)
 		next_command = world.time + cooldown_stun
 
@@ -237,12 +251,16 @@ var/static/regex/multispin_words = regex("like a record baby")
 	else if((findtext(message, hurt_words)))
 		for(var/V in listeners)
 			var/mob/living/L = V
+			if(L.isloyal()) //mindshield protects
+				power_multiplier *= 0.5
 			L.apply_damage(15 * power_multiplier, def_zone = "chest")
 		next_command = world.time + cooldown_damage
 
 	//BLEED
 	else if((findtext(message, bleed_words)))
 		for(var/mob/living/carbon/human/H in listeners)
+			if(H.isloyal()) //mindshield protects
+				power_multiplier *= 0.5
 			H.bleed_rate += (5 * power_multiplier)
 		next_command = world.time + cooldown_damage
 
@@ -250,6 +268,8 @@ var/static/regex/multispin_words = regex("like a record baby")
 	else if((findtext(message, burn_words)))
 		for(var/V in listeners)
 			var/mob/living/L = V
+			if(L.isloyal()) //mindshield protects
+				power_multiplier *= 0.5
 			L.adjust_fire_stacks(1 * power_multiplier)
 			L.IgniteMob()
 		next_command = world.time + cooldown_damage
@@ -268,7 +288,7 @@ var/static/regex/multispin_words = regex("like a record baby")
 			var/mob/living/L = V
 			if(L.mind && L.mind.devilinfo)
 				L.say("[L.mind.devilinfo.truename]")
-			else
+			else if(!L.isloyal()) //mindshield protects
 				L.say("[L.real_name]")
 		next_command = world.time + cooldown_meme
 
@@ -430,6 +450,8 @@ var/static/regex/multispin_words = regex("like a record baby")
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, get_turf(owner), "sound/items/bikehorn.ogg", 300, 1), 25)
 		if(owner.mind && owner.mind.assigned_role == "Clown")
 			for(var/mob/living/carbon/C in listeners)
+				if(C.isloyal()) //mindshield protects
+					power_multiplier *= 0.25
 				C.slip(0,7 * power_multiplier)
 			next_command = world.time + cooldown_stun
 		else

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -115,6 +115,7 @@ var/static/regex/multispin_words = regex("like a record baby")
 	return uppertext(message)
 
 /obj/item/organ/vocal_cords/colossus/speak_with(message)
+	var/log_message = uppertext(message)
 	message = lowertext(message)
 	playsound(get_turf(owner), 'sound/magic/clockwork/invoke_general.ogg', 300, 1, 5)
 
@@ -448,4 +449,7 @@ var/static/regex/multispin_words = regex("like a record baby")
 
 	else
 		next_command = world.time + cooldown_none
+
+	message_admins("[key_name_admin(owner)] has said '[log_message]' with a Voice of God, affecting [english_list(listeners)], with a power multiplier of [power_multiplier].")
+	log_game("[key_name(owner)] has said '[log_message]' with a Voice of God, affecting [english_list(listeners)], with a power multiplier of [power_multiplier].")
 


### PR DESCRIPTION
:cl: XDTM
add: Earmuffs and null rods protect against the Voice of God.
add: Earmuffs are now buildable in autolathes.
tweak: Voice of God stuns have a longer cooldown.
/:cl:

Also adds some logging to both admins and the log when VoG is used.

Fixes #22785.

Reason: I've been told that it makes murderboning really easy since it lets you deal the first stun in a fight against security, after which you can simply stun them with a taser or baton to win the fight. This adds a couple counters beyond deafening yourself.
