### PR TITLE
Makes exporting items not worth anything. 

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -135,7 +135,4 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 var/list/exports_list = list()
 
 /proc/setupExports()
-	for(var/subtype in subtypesof(/datum/export))
-		var/datum/export/E = new subtype
-		if(E.export_types && E.export_types.len) // Exports without a type are invalid/base types
-			exports_list += E
+	return


### PR DESCRIPTION
:cl: ma44
del: Exporting items will no longer give points.
/:cl:


I believe this is a good change because exports are overpowered and KorPhaeron and Oranges believe its a issue so I'm here to remove it. 