### PR TITLE
Forcing secret mode to be sandbox actually makes it sandbox.

### DIFF
--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -5,12 +5,11 @@ var/hsboxspawn = 1
 /mob
 	var/datum/hSB/sandbox = null
 /mob/proc/CanBuild()
-	if(master_mode == "sandbox")
-		sandbox = new/datum/hSB
-		sandbox.owner = src.ckey
-		if(src.client.holder)
-			sandbox.admin = 1
-		verbs += new/mob/proc/sandbox_panel
+	sandbox = new/datum/hSB
+	sandbox.owner = src.ckey
+	if(src.client.holder)
+		sandbox.admin = 1
+	verbs += new/mob/proc/sandbox_panel
 /mob/proc/sandbox_panel()
 	set name = "Sandbox Panel"
 	if(sandbox)


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/7737.

Fix done by removing a check for master_mode (which is why forcing secret doesn't work, the master mode is still secret). Nothing else in the codebase checks master_mode and the only thing that calls CanBuild() is sandbox initialization. But if this is an issue an alternative would be to do a snowflake check for secret+sandbox [wherever that would be stored].