### PR TITLE
Fixes latejoin panel and world topic showing incorrect round duration

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -374,7 +374,7 @@
 
 
 /mob/new_player/proc/LateChoices()
-	var/mills = world.time // 1/10 of a second, not real milliseconds but whatever
+	var/mills = world.time - round_start_time // 1/10 of a second, not real milliseconds but whatever
 	//var/secs = ((mills % 36000) % 600) / 10 //Not really needed, but I'll leave it here for refrence.. or something
 	var/mins = (mills % 36000) / 600
 	var/hours = mills / 36000

--- a/code/world.dm
+++ b/code/world.dm
@@ -133,7 +133,7 @@ var/last_irc_status = 0
 			// Key-authed callers may know the truth behind the "secret"
 
 		s["security_level"] = get_security_level()
-		s["round_duration"] = round(world.time/10)
+		s["round_duration"] = round((world.time-round_start_time)/10)
 		// Amount of world's ticks in seconds, useful for calculating round duration
 
 		if(SSshuttle && SSshuttle.emergency)


### PR DESCRIPTION
It's adjusted for `round_start_time` now.