### PR TITLE
Controlling the station status displays no longer overrides the cargo supply timer

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -184,27 +184,20 @@
 
 
 /obj/machinery/status_display/receive_signal(datum/signal/signal)
-
+	if(supply_display)
+		mode = 4
+		return
 	switch(signal.data["command"])
 		if("blank")
 			mode = 0
-
 		if("shuttle")
 			mode = 1
-
 		if("message")
 			mode = 2
 			set_message(signal.data["msg1"], signal.data["msg2"])
-
 		if("alert")
 			mode = 3
 			set_picture(signal.data["picture_state"])
-
-		if("supply")
-			if(supply_display)
-				mode = 4
-
-
 
 /obj/machinery/ai_status_display
 	icon = 'icons/obj/status_display.dmi'


### PR DESCRIPTION
:cl: Mervill
fix: Controlling the station status displays no longer overrides the cargo supply timer
/:cl:

The cargo status displays now always show the cargo time, they aren't overwritten by setting the status displays in _any_ case. This means that it wont show the evac timer, either.

Fixes #7830