### PR TITLE
Fixes smoothing when repairing reinforced walls

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -120,6 +120,14 @@
 
 #define isorgan(A) (istype(A, /obj/item/organ))
 
+var/list/static/global/pointed_types = typecacheof(list(
+	/obj/item/weapon/pen,
+	/obj/item/weapon/screwdriver,
+	/obj/item/weapon/reagent_containers/syringe,
+	/obj/item/weapon/kitchen/fork))
+
+#define is_pointed(W) (is_type_in_typecache(W, pointed_types))
+
 //Assemblies
 #define isassembly(O) (istype(O, /obj/item/device/assembly))
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -755,32 +755,13 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		loc = loc.loc
 	return null
 
-//Quick type checks for some tools
-var/global/list/common_tools = list(
-/obj/item/stack/cable_coil,
-/obj/item/weapon/wrench,
-/obj/item/weapon/weldingtool,
-/obj/item/weapon/screwdriver,
-/obj/item/weapon/wirecutters,
-/obj/item/device/multitool,
-/obj/item/weapon/crowbar)
+var/list/static/global/pointed_types = typecacheof(list(
+	/obj/item/weapon/pen,
+	/obj/item/weapon/screwdriver,
+	/obj/item/weapon/reagent_containers/syringe,
+	/obj/item/weapon/kitchen/fork))
 
-/proc/istool(O)
-	if(O && is_type_in_list(O, common_tools))
-		return 1
-	return 0
-
-/proc/is_pointed(obj/item/W)
-	if(istype(W, /obj/item/weapon/pen))
-		return 1
-	if(istype(W, /obj/item/weapon/screwdriver))
-		return 1
-	if(istype(W, /obj/item/weapon/reagent_containers/syringe))
-		return 1
-	if(istype(W, /obj/item/weapon/kitchen/fork))
-		return 1
-	else
-		return 0
+#define is_pointed(W) (is_type_in_typecache(W, pointed_types))
 
 //For objects that should embed, but make no sense being is_sharp or is_pointed()
 //e.g: rods

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -755,13 +755,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		loc = loc.loc
 	return null
 
-var/list/static/global/pointed_types = typecacheof(list(
-	/obj/item/weapon/pen,
-	/obj/item/weapon/screwdriver,
-	/obj/item/weapon/reagent_containers/syringe,
-	/obj/item/weapon/kitchen/fork))
-
-#define is_pointed(W) (is_type_in_typecache(W, pointed_types))
 
 //For objects that should embed, but make no sense being is_sharp or is_pointed()
 //e.g: rods

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -10,6 +10,21 @@
 	obj_integrity = 200
 	max_integrity = 200
 
+/obj/structure/girder/examine(mob/user)
+	. = ..()
+	switch(state)
+		if(GIRDER_REINF)
+			user << "<span class='notice'>The support struts are <b>screwed</b> in place.</span>"
+		if(GIRDER_REINF_STRUTS)
+			user << "<span class='notice'>The support struts are <i>unscrewed</i> and the inner <b>grille</b> is intact.</span>"
+		if(GIRDER_NORMAL)
+			if(can_displace)
+				user << "<span class='notice'>The bolts are <b>wrenched</b> in place.</span>"
+		if(GIRDER_DISPLACED)
+			user << "<span class='notice'>The bolts are <i>loosened</i>, but the <b>screws</b> are holding [src] together.</span>"
+		if(GIRDER_DISASSEMBLED)
+			user << "<span class='notice'>[src] is disassembled! You probably shouldn't be able to see this examine message.</span>"
+
 /obj/structure/girder/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
 	if(istype(W, /obj/item/weapon/screwdriver))
@@ -33,6 +48,14 @@
 					return
 				user << "<span class='notice'>You unsecure the support struts.</span>"
 				state = GIRDER_REINF_STRUTS
+		else if(state == GIRDER_REINF_STRUTS)
+			playsound(src.loc, W.usesound, 100, 1)
+			user << "<span class='notice'>You start securing support struts...</span>"
+			if(do_after(user, 40*W.toolspeed, target = src))
+				if(state != GIRDER_REINF_STRUTS)
+					return
+				user << "<span class='notice'>You secure the support struts.</span>"
+				state = GIRDER_REINF
 
 	else if(istype(W, /obj/item/weapon/wrench))
 		if(state == GIRDER_DISPLACED)
@@ -73,9 +96,9 @@
 
 	else if(istype(W, /obj/item/weapon/wirecutters) && state == GIRDER_REINF_STRUTS)
 		playsound(src.loc, W.usesound, 100, 1)
-		user << "<span class='notice'>You start removing support struts...</span>"
+		user << "<span class='notice'>You start removing the inner grille...</span>"
 		if(do_after(user, 40*W.toolspeed, target = src))
-			user << "<span class='notice'>You remove the support struts.</span>"
+			user << "<span class='notice'>You remove the inner grille.</span>"
 			new /obj/item/stack/sheet/plasteel(get_turf(src))
 			var/obj/structure/girder/G = new (loc)
 			transfer_fingerprints_to(G)

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -234,13 +234,14 @@
 	return 0
 
 /turf/closed/wall/r_wall/proc/update_icon()
-	if(d_state)
+	if(d_state != INTACT)
 		smooth = SMOOTH_FALSE
 		clear_smooth_overlays()
 		icon_state = "r_wall-[d_state]"
 	else
 		smooth = SMOOTH_TRUE
 		queue_smooth_neighbors(src)
+		queue_smooth(src)
 		icon_state = "r_wall"
 
 /turf/closed/wall/r_wall/singularity_pull(S, current_size)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -122,7 +122,6 @@
 	playsound(src, 'sound/weapons/Genhit.ogg', 25, 1)
 	src.add_fingerprint(user)
 	..()
-	return
 
 
 /turf/closed/wall/attackby(obj/item/weapon/W, mob/user, params)
@@ -148,8 +147,6 @@
 	//the istype cascade has been spread among various procs for easy overriding
 	if(try_wallmount(W,user,T) || try_decon(W,user,T) || try_destroy(W,user,T))
 		return
-
-	return
 
 
 /turf/closed/wall/proc/try_wallmount(obj/item/weapon/W, mob/user, turf/T)
@@ -227,15 +224,10 @@
 		F.burn_tile()
 		F.icon_state = "wall_thermite"
 		F.add_hiddenprint(user)
-		spawn(burning_time)
-			if(O)
-				qdel(O)
+		QDEL_IN(O, burning_time)
 	else
 		thermite = 0
-		spawn(50)
-			if(O)
-				qdel(O)
-	return
+		QDEL_IN(O, 50)
 
 /turf/closed/wall/singularity_pull(S, current_size)
 	if(current_size >= STAGE_FIVE)


### PR DESCRIPTION
:cl:
add: Girders now offer hints to their deconstruction when examined.
/:cl:

Fixes #22805.

- Removes some unused code in unsorted.dm
- Replaces is_pointed with a global list and a #define
- Removes some trailing returns
- Makes thermite use QDEL_IN rather than spawn()
- Girders (especially reinforced girders) now offer hints to how to
destruct them.