### PR TITLE
Fixes rad immune species accumulating infinite radiation

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -851,6 +851,7 @@
 						H.emote("gasp")
 						H.domutcheck()
 		return 0
+	H.radiation = 0
 	return 1
 
 /datum/species/proc/go_bald(mob/living/carbon/human/H)


### PR DESCRIPTION
Rad immune species will remove all radiation when handle_mutations_and_radiation() is called like in non-carbons.

Fixes https://github.com/tgstation/tgstation/issues/13450