### PR TITLE
Thermited walls now instead leaves behind a normal burned plating.

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -225,7 +225,6 @@
 		var/burning_time = max(100,300 - thermite)
 		var/turf/open/floor/F = ChangeTurf(/turf/open/floor/plating)
 		F.burn_tile()
-		F.icon_state = "wall_thermite"
 		F.add_hiddenprint(user)
 		spawn(burning_time)
 			if(O)


### PR DESCRIPTION
Instead of thermited walls leaving behind a floor tile which looks like a burned out normal wall, it will now instead merely leave behind a normal burnt plating. The only other alternative to fixing this bug was adding a bunch of sprites which would almost never be used, since thermiting normal walls already doesn't happen to frequently.

Fixes #11391