### PR TITLE
Revert "Removes animation on lighting changes, increases light max radii"

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -5,7 +5,8 @@
 #define LIGHTING_CAP_FRAC (255/LIGHTING_CAP)				//A precal'd variable we'll use in turf/redraw_lighting()
 #define LIGHTING_ICON 'icons/effects/alphacolors.dmi'
 #define LIGHTING_ICON_STATE ""
-#define LIGHTING_TIME 2									//Time to do any lighting change. Actual number pulled out of my ass
+#define LIGHTING_ANIMATE_TIME 2								//Time to animate() any lighting change. Actual number pulled out of my ass
+#define LIGHTING_MIN_ALPHA_DELTA_TO_ANIMATE 20				//How much does the alpha have to change to warrent an animation.
 #define LIGHTING_DARKEST_VISIBLE_ALPHA 250					//Anything darker than this is so dark, we'll just consider the whole tile unlit
 #define LIGHTING_LUM_FOR_FULL_BRIGHT 6						//Anything who's lum is lower then this starts off less bright.
 #define LIGHTING_MIN_RADIUS 4								//Lowest radius a light source can effect.

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -5,6 +5,7 @@
 #define LIGHTING_CAP_FRAC (255/LIGHTING_CAP)				//A precal'd variable we'll use in turf/redraw_lighting()
 #define LIGHTING_ICON 'icons/effects/alphacolors.dmi'
 #define LIGHTING_ICON_STATE ""
+#define LIGHTING_TIME 2									//Time to do any lighting change. Actual number pulled out of my ass
 #define LIGHTING_DARKEST_VISIBLE_ALPHA 250					//Anything darker than this is so dark, we'll just consider the whole tile unlit
 #define LIGHTING_LUM_FOR_FULL_BRIGHT 6						//Anything who's lum is lower then this starts off less bright.
 #define LIGHTING_MIN_RADIUS 4								//Lowest radius a light source can effect.

--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -338,10 +338,10 @@
 		if(newalpha >= LIGHTING_DARKEST_VISIBLE_ALPHA)
 			newalpha = 255
 		if(lighting_object.alpha != newalpha)
-			if(instantly)
+			if(instantly || abs(lighting_object.alpha - newalpha) < LIGHTING_MIN_ALPHA_DELTA_TO_ANIMATE)
 				lighting_object.alpha = newalpha
 			else
-				animate(lighting_object, alpha = newalpha, time = LIGHTING_TIME)
+				animate(lighting_object, alpha = newalpha, time = LIGHTING_ANIMATE_TIME)
 			if(newalpha >= LIGHTING_DARKEST_VISIBLE_ALPHA)
 				luminosity = 0
 				lighting_object.luminosity = 0

--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -313,7 +313,7 @@
 	else
 		if(!lighting_object)
 			lighting_object = new (src)
-		redraw_lighting()
+		redraw_lighting(1)
 		for(var/turf/open/space/T in RANGE_TURFS(1,src))
 			T.update_starlight()
 
@@ -324,7 +324,7 @@
 	if(lighting_object)
 		lighting_object.PutOut()
 
-/turf/proc/redraw_lighting()
+/turf/proc/redraw_lighting(instantly = 0)
 	if(lighting_object)
 		var/newalpha
 		if(lighting_lumcount <= 0)
@@ -338,7 +338,10 @@
 		if(newalpha >= LIGHTING_DARKEST_VISIBLE_ALPHA)
 			newalpha = 255
 		if(lighting_object.alpha != newalpha)
-			lighting_object.alpha = newalpha
+			if(instantly)
+				lighting_object.alpha = newalpha
+			else
+				animate(lighting_object, alpha = newalpha, time = LIGHTING_TIME)
 			if(newalpha >= LIGHTING_DARKEST_VISIBLE_ALPHA)
 				luminosity = 0
 				lighting_object.luminosity = 0
@@ -387,8 +390,8 @@
 
 
 #define LIGHTING_MAX_LUMINOSITY_STATIC	8	//Maximum luminosity to reduce lag.
-#define LIGHTING_MAX_LUMINOSITY_MOBILE	8	//Moving objects have a lower max luminosity since these update more often. (lag reduction)
-#define LIGHTING_MAX_LUMINOSITY_MOB     8
+#define LIGHTING_MAX_LUMINOSITY_MOBILE	7	//Moving objects have a lower max luminosity since these update more often. (lag reduction)
+#define LIGHTING_MAX_LUMINOSITY_MOB		6
 #define LIGHTING_MAX_LUMINOSITY_TURF	8	//turfs are static too, why was this 1?!
 
 //caps luminosity effects max-range based on what type the light's owner is.


### PR DESCRIPTION
Reverts tgstation/tgstation#22754

Tried it, the tile based snappiness to lights when moving down maint from removing the animate() is rather noticeable.

~~Might be a better idea to add a min change to the animate() so moving down lit hallways don't animate a bunch of 1-10 alpha changes.~~

~~I'd edit the pr to add that, but somebody moved the defines to a new file so i can't do that @MrPerson~~

Made it not animate unless the difference was 20 alpha or higher.