### PR TITLE
Refactor of outfits datums and corpse spawners

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -6,6 +6,8 @@ var/datum/subsystem/job/SSjob
 	flags = SS_NO_FIRE
 
 	var/list/occupations = list()		//List of all jobs
+	var/list/name_occupations = list()	//Dict of all jobs, keys are titles
+	var/list/type_occupations = list()	//Dict of all jobs, keys are types
 	var/list/unassigned = list()		//Players who need jobs
 	var/list/job_debug = list()			//Debug info
 	var/initial_players_to_assign = 0 	//used for checking against population caps
@@ -15,7 +17,8 @@ var/datum/subsystem/job/SSjob
 
 
 /datum/subsystem/job/Initialize(timeofday)
-	SetupOccupations()
+	if(!occupations.len)
+		SetupOccupations()
 	if(config.load_jobs_from_txt)
 		LoadJobs()
 	..()
@@ -37,6 +40,8 @@ var/datum/subsystem/job/SSjob
 		if(!job.config_check())
 			continue
 		occupations += job
+		name_occupations[job.title] = job
+		type_occupations[J] = job
 
 	return 1
 
@@ -49,14 +54,15 @@ var/datum/subsystem/job/SSjob
 
 
 /datum/subsystem/job/proc/GetJob(rank)
-	if(!rank)
-		return null
-	for(var/datum/job/J in occupations)
-		if(!J)
-			continue
-		if(J.title == rank)
-			return J
-	return null
+	if(!occupations.len)
+		SetupOccupations()
+	return name_occupations[rank]
+
+/datum/subsystem/job/proc/GetJobType(jobtype)
+	if(!occupations.len)
+		SetupOccupations()
+	return type_occupations[jobtype]
+
 
 /datum/subsystem/job/proc/AssignRole(mob/new_player/player, rank, latejoin=0)
 	Debug("Running AR, Player: [player], Rank: [rank], LJ: [latejoin]")
@@ -392,7 +398,6 @@ var/datum/subsystem/job/SSjob
 		var/new_mob = job.equip(H)
 		if(ismob(new_mob))
 			H = new_mob
-		job.apply_fingerprints(H)
 
 	H << "<b>You are the [rank].</b>"
 	H << "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>"
@@ -401,6 +406,10 @@ var/datum/subsystem/job/SSjob
 		H << "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>"
 	if(config.minimal_access_threshold)
 		H << "<FONT color='blue'><B>As this station was initially staffed with a [config.jobs_have_minimal_access ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></font>"
+
+	if(job && H)
+		job.after_spawn(H)
+
 	return H
 
 

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -18,6 +18,7 @@
 	var/suit_store = null
 	var/r_hand = null
 	var/l_hand = null
+	var/internals_slot = null //ID of slot containing a gas tank
 	var/list/backpack_contents = list() // In the list(path=count,otherpath=count) format
 
 /datum/outfit/proc/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -56,10 +57,6 @@
 		H.equip_to_slot_or_del(new glasses(H),slot_glasses)
 	if(id)
 		H.equip_to_slot_or_del(new id(H),slot_wear_id)
-	if(l_pocket)
-		H.equip_to_slot_or_del(new l_pocket(H),slot_l_store)
-	if(r_pocket)
-		H.equip_to_slot_or_del(new r_pocket(H),slot_r_store)
 	if(suit_store)
 		H.equip_to_slot_or_del(new suit_store(H),slot_s_store)
 
@@ -68,12 +65,67 @@
 	if(r_hand)
 		H.put_in_r_hand(new r_hand(H))
 
-	for(var/path in backpack_contents)
-		var/number = backpack_contents[path]
-		for(var/i=0,i<number,i++)
-			H.equip_to_slot_or_del(new path(H),slot_in_backpack)
+	if(!visualsOnly) // Items in pockets or backpack don't show up on mob's icon.
+		if(l_pocket)
+			H.equip_to_slot_or_del(new l_pocket(H),slot_l_store)
+		if(r_pocket)
+			H.equip_to_slot_or_del(new r_pocket(H),slot_r_store)
+
+		for(var/path in backpack_contents)
+			var/number = backpack_contents[path]
+			for(var/i=0,i<number,i++)
+				H.equip_to_slot_or_del(new path(H),slot_in_backpack)
+
+	if(!H.head && istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit))
+		var/obj/item/clothing/suit/space/hardsuit/HS = H.wear_suit
+		HS.ToggleHelmet()
 
 	post_equip(H, visualsOnly)
 
+	if(!visualsOnly)
+		apply_fingerprints(H)
+		if(internals_slot)
+			H.internal = H.get_item_by_slot(internals_slot)
+			H.update_action_buttons_icon()
+
 	H.update_body()
+	return 1
+
+/datum/outfit/proc/apply_fingerprints(mob/living/carbon/human/H)
+	if(!istype(H))
+		return
+	if(H.back)
+		H.back.add_fingerprint(H,1)	//The 1 sets a flag to ignore gloves
+		for(var/obj/item/I in H.back.contents)
+			I.add_fingerprint(H,1)
+	if(H.wear_id)
+		H.wear_id.add_fingerprint(H,1)
+	if(H.w_uniform)
+		H.w_uniform.add_fingerprint(H,1)
+	if(H.wear_suit)
+		H.wear_suit.add_fingerprint(H,1)
+	if(H.wear_mask)
+		H.wear_mask.add_fingerprint(H,1)
+	if(H.wear_neck)
+		H.wear_neck.add_fingerprint(H,1)
+	if(H.head)
+		H.head.add_fingerprint(H,1)
+	if(H.shoes)
+		H.shoes.add_fingerprint(H,1)
+	if(H.gloves)
+		H.gloves.add_fingerprint(H,1)
+	if(H.ears)
+		H.ears.add_fingerprint(H,1)
+	if(H.glasses)
+		H.glasses.add_fingerprint(H,1)
+	if(H.belt)
+		H.belt.add_fingerprint(H,1)
+		for(var/obj/item/I in H.belt.contents)
+			I.add_fingerprint(H,1)
+	if(H.s_store)
+		H.s_store.add_fingerprint(H,1)
+	if(H.l_store)
+		H.l_store.add_fingerprint(H,1)
+	if(H.r_store)
+		H.r_store.add_fingerprint(H,1)
 	return 1

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -357,17 +357,9 @@
 	mask = /obj/item/clothing/mask/gas/syndicate
 	suit = /obj/item/clothing/suit/space/hardsuit/syndi
 	r_pocket = /obj/item/weapon/tank/internals/emergency_oxygen/engi
+	internals_slot = slot_r_store
 	belt = /obj/item/weapon/storage/belt/military
 	r_hand = /obj/item/weapon/gun/ballistic/automatic/shotgun/bulldog
 	backpack_contents = list(/obj/item/weapon/storage/box/syndie=1,\
 		/obj/item/weapon/tank/jetpack/oxygen/harness=1,\
 		/obj/item/weapon/gun/ballistic/automatic/pistol=1)
-
-/datum/outfit/syndicate/full/post_equip(mob/living/carbon/human/H)
-	..()
-
-
-	var/obj/item/clothing/suit/space/hardsuit/syndi/suit = H.wear_suit
-	suit.ToggleHelmet()
-
-	H.internal = H.r_store

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -551,12 +551,20 @@ var/list/TYPES_SHORTCUTS = list(
 	if (isnull(dresscode))
 		return
 
-	var/datum/job/jobdatum
+	if (outfits[dresscode])
+		dresscode = outfits[dresscode]
+
 	if (dresscode == "As Job...")
-		var/jobname = input("Select job", "Robust quick dress shop") as null|anything in get_all_jobs()
-		if(isnull(jobname))
+		var/list/job_paths = subtypesof(/datum/outfit/job)
+		var/list/job_outfits = list()
+		for(var/path in job_paths)
+			var/datum/outfit/O = path
+			job_outfits[initial(O.name)] = path
+
+		dresscode = input("Select job equipment", "Robust quick dress shop") as null|anything in job_outfits
+		dresscode = job_outfits[dresscode]
+		if(isnull(dresscode))
 			return
-		jobdatum = SSjob.GetJob(jobname)
 
 
 	var/datum/outfit/custom = null
@@ -578,20 +586,14 @@ var/list/TYPES_SHORTCUTS = list(
 		if ("Custom")
 			//use custom one
 			M.equipOutfit(custom)
-		if ("As Job...")
-			if(jobdatum)
-				dresscode = jobdatum.title
-				M.job = jobdatum.title
-				jobdatum.equip(M)
-
 		else
-			M.equipOutfit(outfits[dresscode])
+			M.equipOutfit(dresscode)
 
 
 	M.regenerate_icons()
 
 	log_admin("[key_name(usr)] changed the equipment of [key_name(M)] to [dresscode].")
-	message_admins("<span class='adminnotice'>[key_name_admin(usr)] changed the equipment of [key_name_admin(M)] to [dresscode]..</span>")
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)] changed the equipment of [key_name_admin(M)] to [dresscode].</span>")
 
 /client/proc/startSinglo()
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -47,8 +47,12 @@
 /obj/effect/mob_spawn/New()
 	..()
 	if(roundstart)
-		//Add to the atom spawners register for roundstart atom spawning
-		SSobj.atom_spawners += src
+		if(ticker && ticker.current_state > GAME_STATE_SETTING_UP)
+			// The game has already initialised, just spawn it.
+			create()
+		else
+			//Add to the atom spawners register for roundstart atom spawning
+			SSobj.atom_spawners += src
 
 	if(instant)
 		create()
@@ -99,8 +103,9 @@
 /obj/effect/mob_spawn/human
 	mob_type = /mob/living/carbon/human
 	//Human specific stuff.
-	var/mob_species = null //Set to make them a mutant race such as lizard or skeleton. Uses the datum typepath instead of the ID.
-	var/uniform = null //Set this to an object path to have the slot filled with said object on the corpse.
+	var/mob_species = null		//Set to make them a mutant race such as lizard or skeleton. Uses the datum typepath instead of the ID.
+	var/outfit_type = null		//Will start with this if exists then apply specific slots. Job outfits are generated with IDs and disabled PDAs.
+	var/uniform = null			//Set this to an object path to have the slot filled with said object on the corpse.
 	var/r_hand = null
 	var/l_hand = null
 	var/suit = null
@@ -115,13 +120,12 @@
 	var/pocket1 = null
 	var/pocket2 = null
 	var/back = null
-	var/has_id = 0     //Just set to 1 if you want them to have an ID
-	var/id_job = null // Needs to be in quotes, such as "Clown" or "Chef." This just determines what the ID reads as, not their access
-	var/id_access = null //This is for access. See access.dm for which jobs give what access. Again, put in quotes. Use "Captain" if you want it to be all access.
-	var/id_access_list = null //Allows you to manually add access to an ID card.
-	var/id_icon = null //For setting it to be a gold, silver, centcom etc ID
+	var/has_id = FALSE			//Set to TRUE if you want them to have an ID
+	var/id_job = null			//Such as "Clown" or "Chef." This just determines what the ID reads as, not their access
+	var/id_access = null		//This is for access. See access.dm for which jobs give what access. Use "Captain" if you want it to be all access.
+	var/id_access_list = null	//Allows you to manually add access to an ID card.
+	var/id_icon = null			//For setting it to be a gold, silver, centcom etc ID
 	var/husk = null
-	var/outfit_type = null // Will start with this if exists then apply specific slots
 	var/list/implants = list()
 
 /obj/effect/mob_spawn/human/equip(mob/living/carbon/human/H)
@@ -129,8 +133,15 @@
 		H.set_species(mob_species)
 	if(husk)
 		H.Drain()
+
 	if(outfit_type)
 		H.equipOutfit(outfit_type)
+
+		// We don't want corpse PDAs to show up in the messenger list.
+		var/obj/item/device/pda/PDA = locate(/obj/item/device/pda) in H
+		if(PDA)
+			PDA.toff = TRUE
+
 	if(uniform)
 		H.equip_to_slot_or_del(new uniform(H), slot_w_uniform)
 	if(suit)
@@ -189,6 +200,10 @@
 	for(var/I in implants)
 		var/obj/item/weapon/implant/X = new I
 		X.implant(H)
+
+	if(!H.head && istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit))
+		var/obj/item/clothing/suit/space/hardsuit/HS = H.wear_suit
+		HS.ToggleHelmet()
 
 //Instant version - use when spawning corpses during runtime
 /obj/effect/mob_spawn/human/corpse
@@ -274,7 +289,6 @@
 	gloves = /obj/item/clothing/gloves/combat
 	radio = /obj/item/device/radio/headset
 	mask = /obj/item/clothing/mask/gas/syndicate
-	helmet = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 	back = /obj/item/weapon/tank/jetpack/oxygen
 	pocket1 = /obj/item/weapon/tank/internals/emergency_oxygen
 	has_id = 1
@@ -285,28 +299,13 @@
 
 /obj/effect/mob_spawn/human/cook
 	name = "Cook"
-	uniform = /obj/item/clothing/under/rank/chef
-	suit = /obj/item/clothing/suit/apron/chef
-	shoes = /obj/item/clothing/shoes/sneakers/black
-	helmet = /obj/item/clothing/head/chefhat
-	back = /obj/item/weapon/storage/backpack
-	radio = /obj/item/device/radio/headset
-	has_id = 1
-	id_job = "Cook"
-	id_access = "Cook"
+	outfit_type = /datum/outfit/job/cook
 
 
 /obj/effect/mob_spawn/human/doctor
 	name = "Doctor"
-	radio = /obj/item/device/radio/headset/headset_med
-	uniform = /obj/item/clothing/under/rank/medical
-	suit = /obj/item/clothing/suit/toggle/labcoat
-	back = /obj/item/weapon/storage/backpack/medic
-	pocket1 = /obj/item/device/flashlight/pen
-	shoes = /obj/item/clothing/shoes/sneakers/black
-	has_id = 1
-	id_job = "Medical Doctor"
-	id_access = "Medical Doctor"
+	outfit_type = /datum/outfit/job/doctor
+
 
 /obj/effect/mob_spawn/human/doctor/alive
 	death = FALSE
@@ -319,68 +318,40 @@
 	icon_state = "sleeper"
 	flavour_text = "You are a space doctor!"
 
+/obj/effect/mob_spawn/human/doctor/alive/equip(mob/living/carbon/human/H)
+	..()
+	// Remove radio and PDA so they wouldn't annoy station crew.
+	var/list/del_types = list(/obj/item/device/pda, /obj/item/device/radio/headset)
+	for(var/del_type in del_types)
+		var/obj/item/I = locate(del_type) in H
+		qdel(I)
 
 /obj/effect/mob_spawn/human/engineer
 	name = "Engineer"
-	radio = /obj/item/device/radio/headset/headset_eng
-	uniform = /obj/item/clothing/under/rank/engineer
-	back = /obj/item/weapon/storage/backpack/industrial
-	shoes = /obj/item/clothing/shoes/sneakers/orange
-	belt = /obj/item/weapon/storage/belt/utility/full
+	outfit_type = /datum/outfit/job/engineer
 	gloves = /obj/item/clothing/gloves/color/yellow
-	helmet = /obj/item/clothing/head/hardhat
-	has_id = 1
-	id_job = "Station Engineer"
-	id_access = "Station Engineer"
 
 /obj/effect/mob_spawn/human/engineer/rig
-	suit = /obj/item/clothing/suit/space/hardsuit/engine
-	mask = /obj/item/clothing/mask/breath
+	outfit_type = /datum/outfit/job/engineer/rig
 
 /obj/effect/mob_spawn/human/clown
 	name = "Clown"
-	uniform = /obj/item/clothing/under/rank/clown
-	shoes = /obj/item/clothing/shoes/clown_shoes
-	radio = /obj/item/device/radio/headset
-	mask = /obj/item/clothing/mask/gas/clown_hat
-	pocket1 = /obj/item/weapon/bikehorn
-	back = /obj/item/weapon/storage/backpack/clown
-	has_id = 1
-	id_job = "Clown"
-	id_access = "Clown"
+	outfit_type = /datum/outfit/job/clown
 
 /obj/effect/mob_spawn/human/scientist
 	name = "Scientist"
-	radio = /obj/item/device/radio/headset/headset_sci
-	uniform = /obj/item/clothing/under/rank/scientist
-	suit = /obj/item/clothing/suit/toggle/labcoat/science
-	back = /obj/item/weapon/storage/backpack
-	shoes = /obj/item/clothing/shoes/sneakers/white
-	has_id = 1
-	id_job = "Scientist"
-	id_access = "Scientist"
+	outfit_type = /datum/outfit/job/scientist
 
 /obj/effect/mob_spawn/human/miner
-	radio = /obj/item/device/radio/headset/headset_cargo/mining
-	uniform = /obj/item/clothing/under/rank/miner
-	gloves = /obj/item/clothing/gloves/color/black
-	back = /obj/item/weapon/storage/backpack/industrial
-	shoes = /obj/item/clothing/shoes/sneakers/black
-	has_id = 1
-	id_job = "Shaft Miner"
-	id_access = "Shaft Miner"
+	name = "Shaft Miner"
+	outfit_type = /datum/outfit/job/miner/asteroid
 
 /obj/effect/mob_spawn/human/miner/rig
-	suit = /obj/item/clothing/suit/space/hardsuit/mining
-	mask = /obj/item/clothing/mask/breath
+	outfit_type = /datum/outfit/job/miner/equipped/asteroid
 
 /obj/effect/mob_spawn/human/miner/explorer
-	uniform = /obj/item/clothing/under/rank/miner/lavaland
-	back = /obj/item/weapon/storage/backpack/explorer
-	shoes = /obj/item/clothing/shoes/workboots/mining
-	suit = /obj/item/clothing/suit/hooded/explorer
-	mask = /obj/item/clothing/mask/gas/explorer
-	belt = /obj/item/weapon/gun/energy/kinetic_accelerator
+	outfit_type = /datum/outfit/job/miner/equipped
+
 
 /obj/effect/mob_spawn/human/plasmaman
 	mob_species = /datum/species/plasmaman

--- a/code/modules/events/holiday/halloween.dm
+++ b/code/modules/events/holiday/halloween.dm
@@ -91,7 +91,7 @@
 			else if (prob(5))
 				var/turf/T = get_turf(H)
 				if(T)
-					spawn_atom_to_turf(/obj/effect/mob_spawn/human/corpse/clown, H, 1)
+					spawn_atom_to_turf(/obj/effect/mob_spawn/human/clown/corpse, H, 1)
 			else if (prob(1))
 				spawn_atom_to_turf(/mob/living/simple_animal/hostile/retaliate/clown, H, 1)
 

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -32,6 +32,7 @@ Assistant
 
 /datum/outfit/job/assistant
 	name = "Assistant"
+	jobtype = /datum/job/assistant
 
 /datum/outfit/job/assistant/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -22,9 +22,13 @@ Captain
 /datum/job/captain/get_access()
 	return get_all_accesses()
 
+/datum/job/captain/announce(mob/living/carbon/human/H)
+	..()
+	minor_announce("Captain [H.real_name] on deck!")
 
 /datum/outfit/job/captain
 	name = "Captain"
+	jobtype = /datum/job/captain
 
 	id = /obj/item/weapon/card/id/gold
 	belt = /obj/item/device/pda/captain
@@ -41,19 +45,8 @@ Captain
 	satchel = /obj/item/weapon/storage/backpack/satchel/cap
 	dufflebag = /obj/item/weapon/storage/backpack/dufflebag/captain
 
-/datum/outfit/job/captain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
+	implants = list(/obj/item/weapon/implant/mindshield)
 
-	var/obj/item/clothing/under/U = H.w_uniform
-	U.attachTie(new /obj/item/clothing/tie/medal/gold/captain())
-
-	if(visualsOnly)
-		return
-
-	var/obj/item/weapon/implant/mindshield/L = new/obj/item/weapon/implant/mindshield(H)
-	L.implant(H, null, 1)
-
-	minor_announce("Captain [H.real_name] on deck!")
 
 /*
 Head of Personnel
@@ -63,6 +56,7 @@ Head of Personnel
 	flag = HOP
 	department_head = list("Captain")
 	department_flag = CIVILIAN
+	head_announce = list("Supply", "Service")
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -89,6 +83,7 @@ Head of Personnel
 
 /datum/outfit/job/hop
 	name = "Head of Personnel"
+	jobtype = /datum/job/hop
 
 	id = /obj/item/weapon/card/id/silver
 	belt = /obj/item/device/pda/heads/hop
@@ -98,11 +93,3 @@ Head of Personnel
 	head = /obj/item/clothing/head/hopcap
 	backpack_contents = list(/obj/item/weapon/storage/box/ids=1,\
 		/obj/item/weapon/melee/classic_baton/telescopic=1, /obj/item/device/modular_computer/tablet/preset/advanced = 1)
-
-/datum/outfit/job/hop/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-
-	if(visualsOnly)
-		return
-
-	announce_head(H, list("Supply", "Service"))

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -19,6 +19,7 @@ Quartermaster
 
 /datum/outfit/job/quartermaster
 	name = "Quartermaster"
+	jobtype = /datum/job/qm
 
 	belt = /obj/item/device/pda/quartermaster
 	ears = /obj/item/device/radio/headset/headset_cargo
@@ -48,6 +49,7 @@ Cargo Technician
 
 /datum/outfit/job/cargo_tech
 	name = "Cargo Technician"
+	jobtype = /datum/job/cargo_tech
 
 	belt = /obj/item/device/pda/cargo
 	ears = /obj/item/device/radio/headset/headset_cargo
@@ -74,7 +76,8 @@ Shaft Miner
 	minimal_access = list(access_mining, access_mining_station, access_mailsorting, access_mineral_storeroom)
 
 /datum/outfit/job/miner
-	name = "Shaft Miner"
+	name = "Shaft Miner (Lavaland)"
+	jobtype = /datum/job/mining
 
 	belt = /obj/item/device/pda/shaftminer
 	ears = /obj/item/device/radio/headset/headset_cargo/mining
@@ -92,6 +95,42 @@ Shaft Miner
 	satchel = /obj/item/weapon/storage/backpack/satchel/explorer
 	dufflebag = /obj/item/weapon/storage/backpack/dufflebag
 	box = /obj/item/weapon/storage/box/survival_mining
+
+/datum/outfit/job/miner/asteroid
+	name = "Shaft Miner (Asteroid)"
+	uniform = /obj/item/clothing/under/rank/miner
+	shoes = /obj/item/clothing/shoes/workboots
+
+/datum/outfit/job/miner/equipped
+	name = "Shaft Miner (Lavaland + Equipment)"
+	suit = /obj/item/clothing/suit/hooded/explorer
+	mask = /obj/item/clothing/mask/gas/explorer
+	glasses = /obj/item/clothing/glasses/meson
+	suit_store = /obj/item/weapon/tank/internals/oxygen
+	internals_slot = slot_s_store
+	backpack_contents = list(
+		/obj/item/weapon/storage/bag/ore=1,
+		/obj/item/weapon/kitchen/knife/combat/survival=1,
+		/obj/item/weapon/mining_voucher=1,
+		/obj/item/device/t_scanner/adv_mining_scanner/lesser=1,
+		/obj/item/weapon/gun/energy/kinetic_accelerator=1)
+
+/datum/outfit/job/miner/equipped/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	if(istype(H.wear_suit, /obj/item/clothing/suit/hooded))
+		var/obj/item/clothing/suit/hooded/S = H.wear_suit
+		S.ToggleHood()
+
+/datum/outfit/job/miner/equipped/asteroid
+	name = "Shaft Miner (Asteroid + Equipment)"
+	uniform = /obj/item/clothing/under/rank/miner
+	shoes = /obj/item/clothing/shoes/workboots
+	suit = /obj/item/clothing/suit/space/hardsuit/mining
+	mask = /obj/item/clothing/mask/breath
+
+
 
 /*
 Bartender
@@ -115,6 +154,7 @@ Bartender
 
 /datum/outfit/job/bartender
 	name = "Bartender"
+	jobtype = /datum/job/bartender
 
 	glasses = /obj/item/clothing/glasses/sunglasses/reagent
 	belt = /obj/item/device/pda/bar
@@ -146,6 +186,7 @@ Cook
 
 /datum/outfit/job/cook
 	name = "Cook"
+	jobtype = /datum/job/cook
 
 	belt = /obj/item/device/pda/cook
 	ears = /obj/item/device/radio/headset/headset_srv
@@ -154,14 +195,15 @@ Cook
 	head = /obj/item/clothing/head/chefhat
 	backpack_contents = list(/obj/item/weapon/sharpener = 1)
 
-/datum/outfit/job/cook/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/cook/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
-	var/datum/job/cook/J = SSjob.GetJob(H.job)
+	var/datum/job/cook/J = SSjob.GetJobType(jobtype)
 	if(J) // Fix for runtime caused by invalid job being passed
-		J.cooks++
-		if(J.cooks>1)//Cooks
+		if(J.cooks>0)//Cooks
 			suit = /obj/item/clothing/suit/apron/chef
 			head = /obj/item/clothing/head/soft/mime
+		if(!visualsOnly)
+			J.cooks++
 
 /datum/outfit/job/cook/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
     ..()
@@ -186,11 +228,16 @@ Botanist
 
 	outfit = /datum/outfit/job/botanist
 
-	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
-	minimal_access = list(access_hydroponics, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
+	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue)
+	minimal_access = list(access_hydroponics, access_morgue)
+	// Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS
+	// Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT
+	// Given Morgue access because they have a viable means of cloning.
+
 
 /datum/outfit/job/botanist
 	name = "Botanist"
+	jobtype = /datum/job/hydro
 
 	belt = /obj/item/device/pda/botanist
 	ears = /obj/item/device/radio/headset/headset_srv
@@ -225,6 +272,7 @@ Janitor
 
 /datum/outfit/job/janitor
 	name = "Janitor"
+	jobtype = /datum/job/janitor
 
 	belt = /obj/item/device/pda/janitor
 	ears = /obj/item/device/radio/headset/headset_srv

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -19,6 +19,7 @@ Clown
 
 /datum/outfit/job/clown
 	name = "Clown"
+	jobtype = /datum/job/clown
 
 	belt = /obj/item/device/pda/clown
 	uniform = /obj/item/clothing/under/rank/clown
@@ -38,9 +39,10 @@ Clown
 	satchel = /obj/item/weapon/storage/backpack/clown
 	dufflebag = /obj/item/weapon/storage/backpack/dufflebag/clown //strangely has a duffle
 
+	implants = list(/obj/item/weapon/implant/sad_trombone)
+
 /datum/outfit/job/clown/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
-
 	if(visualsOnly)
 		return
 
@@ -48,12 +50,8 @@ Clown
 
 /datum/outfit/job/clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
-
 	if(visualsOnly)
 		return
-
-	var/obj/item/weapon/implant/sad_trombone/S = new/obj/item/weapon/implant/sad_trombone(H)
-	S.implant(H, null, 1)
 
 	H.dna.add_mutation(CLOWNMUT)
 	H.rename_self("clown")
@@ -79,6 +77,7 @@ Mime
 
 /datum/outfit/job/mime
 	name = "Mime"
+	jobtype = /datum/job/mime
 
 	belt = /obj/item/device/pda/mime
 	uniform = /obj/item/clothing/under/rank/mime
@@ -127,6 +126,7 @@ Librarian
 
 /datum/outfit/job/librarian
 	name = "Librarian"
+	jobtype = /datum/job/librarian
 
 	belt = /obj/item/device/pda/librarian
 	uniform = /obj/item/clothing/under/rank/librarian
@@ -156,6 +156,7 @@ Lawyer
 
 /datum/outfit/job/lawyer
 	name = "Lawyer"
+	jobtype = /datum/job/lawyer
 
 	belt = /obj/item/device/pda/lawyer
 	ears = /obj/item/device/radio/headset/headset_sec
@@ -169,11 +170,10 @@ Lawyer
 
 /datum/outfit/job/lawyer/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
-
 	if(visualsOnly)
 		return
 
-	var/datum/job/lawyer/J = SSjob.GetJob(H.job)
+	var/datum/job/lawyer/J = SSjob.GetJobType(jobtype)
 	J.lawyers++
 	if(J.lawyers>1)
 		uniform = /obj/item/clothing/under/lawyer/purpsuit

--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -20,6 +20,7 @@ Chaplain
 
 /datum/outfit/job/chaplain
 	name = "Chaplain"
+	jobtype = /datum/job/chaplain
 
 	belt = /obj/item/device/pda/chaplain
 	uniform = /obj/item/clothing/under/rank/chaplain
@@ -33,8 +34,9 @@ Chaplain
 
 	if(visualsOnly)
 		return
-	
-	H.mind.isholy = TRUE
+
+	if(H.mind)
+		H.mind.isholy = TRUE
 
 	var/obj/item/weapon/storage/book/bible/B = new /obj/item/weapon/storage/book/bible/booze(H)
 

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -6,6 +6,7 @@ Chief Engineer
 	flag = CHIEF
 	department_head = list("Captain")
 	department_flag = ENGSEC
+	head_announce = list("Engineering")
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -27,6 +28,7 @@ Chief Engineer
 
 /datum/outfit/job/ce
 	name = "Chief Engineer"
+	jobtype = /datum/job/chief_engineer
 
 	id = /obj/item/weapon/card/id/silver
 	belt = /obj/item/weapon/storage/belt/utility/chief/full
@@ -44,13 +46,17 @@ Chief Engineer
 	box = /obj/item/weapon/storage/box/engineer
 	pda_slot = slot_l_store
 
-/datum/outfit/job/ce/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
+/datum/outfit/job/ce/rig
+	name = "Chief Engineer (Hardsuit)"
 
-	if(visualsOnly)
-		return
+	mask = /obj/item/clothing/mask/breath
+	suit = /obj/item/clothing/suit/space/hardsuit/engine/elite
+	shoes = /obj/item/clothing/shoes/magboots/advance
+	suit_store = /obj/item/weapon/tank/internals/oxygen
+	gloves = /obj/item/clothing/gloves/color/yellow
+	head = null
+	internals_slot = slot_s_store
 
-	announce_head(H, list("Engineering"))
 
 /*
 Station Engineer
@@ -75,6 +81,7 @@ Station Engineer
 
 /datum/outfit/job/engineer
 	name = "Station Engineer"
+	jobtype = /datum/job/engineer
 
 	belt = /obj/item/weapon/storage/belt/utility/full
 	l_pocket = /obj/item/device/pda/engineering
@@ -90,6 +97,17 @@ Station Engineer
 	box = /obj/item/weapon/storage/box/engineer
 	pda_slot = slot_l_store
 	backpack_contents = list(/obj/item/device/modular_computer/tablet/preset/advanced=1)
+
+/datum/outfit/job/engineer/rig
+	name = "Station Engineer (Hardsuit)"
+
+	mask = /obj/item/clothing/mask/breath
+	suit = /obj/item/clothing/suit/space/hardsuit/engine
+	suit_store = /obj/item/weapon/tank/internals/oxygen
+	gloves = /obj/item/clothing/gloves/color/yellow
+	head = null
+	internals_slot = slot_s_store
+
 
 /*
 Atmospheric Technician
@@ -113,6 +131,7 @@ Atmospheric Technician
 
 /datum/outfit/job/atmos
 	name = "Atmospheric Technician"
+	jobtype = /datum/job/atmos
 
 	belt = /obj/item/weapon/storage/belt/utility/atmostech
 	l_pocket = /obj/item/device/pda/atmos
@@ -126,3 +145,11 @@ Atmospheric Technician
 	box = /obj/item/weapon/storage/box/engineer
 	pda_slot = slot_l_store
 	backpack_contents = list(/obj/item/device/modular_computer/tablet/preset/advanced=1)
+
+/datum/outfit/job/atmos/rig
+	name = "Atmospheric Technician (Hardsuit)"
+
+	mask = /obj/item/clothing/mask/gas
+	suit = /obj/item/clothing/suit/space/hardsuit/engine/atmos
+	suit_store = /obj/item/weapon/tank/internals/oxygen
+	internals_slot = slot_s_store

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -1,5 +1,4 @@
 /datum/job
-
 	//The name of the job
 	var/title = "NOPE"
 
@@ -9,6 +8,9 @@
 
 	//Determines who can demote this position
 	var/department_head = list()
+
+	//Tells the given channels that the given mob is the new department head. See communications.dm for valid channels.
+	var/list/head_announce = null
 
 	//Bitflags for the job
 	var/flag = 0
@@ -42,10 +44,16 @@
 	var/outfit = null
 
 //Only override this proc
-/datum/job/proc/equip_items(mob/living/carbon/human/H)
+/datum/job/proc/after_spawn(mob/living/carbon/human/H)
+
+
+/datum/job/proc/announce(mob/living/carbon/human/H)
+	if(head_announce)
+		announce_head(H, head_announce)
+
 
 //But don't override this
-/datum/job/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/job/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE, announce = TRUE)
 	if(!H)
 		return 0
 
@@ -57,44 +65,8 @@
 
 	H.dna.species.after_equip_job(src, H, visualsOnly)
 
-/datum/job/proc/apply_fingerprints(mob/living/carbon/human/H)
-	if(!istype(H))
-		return
-	if(H.back)
-		H.back.add_fingerprint(H,1)	//The 1 sets a flag to ignore gloves
-		for(var/obj/item/I in H.back.contents)
-			I.add_fingerprint(H,1)
-	if(H.wear_id)
-		H.wear_id.add_fingerprint(H,1)
-	if(H.w_uniform)
-		H.w_uniform.add_fingerprint(H,1)
-	if(H.wear_suit)
-		H.wear_suit.add_fingerprint(H,1)
-	if(H.wear_mask)
-		H.wear_mask.add_fingerprint(H,1)
-	if(H.wear_neck)
-		H.wear_neck.add_fingerprint(H,1)
-	if(H.head)
-		H.head.add_fingerprint(H,1)
-	if(H.shoes)
-		H.shoes.add_fingerprint(H,1)
-	if(H.gloves)
-		H.gloves.add_fingerprint(H,1)
-	if(H.ears)
-		H.ears.add_fingerprint(H,1)
-	if(H.glasses)
-		H.glasses.add_fingerprint(H,1)
-	if(H.belt)
-		H.belt.add_fingerprint(H,1)
-		for(var/obj/item/I in H.belt.contents)
-			I.add_fingerprint(H,1)
-	if(H.s_store)
-		H.s_store.add_fingerprint(H,1)
-	if(H.l_store)
-		H.l_store.add_fingerprint(H,1)
-	if(H.r_store)
-		H.r_store.add_fingerprint(H,1)
-	return 1
+	if(!visualsOnly && announce)
+		announce(H)
 
 /datum/job/proc/get_access()
 	if(!config)	//Needed for robots.
@@ -109,6 +81,12 @@
 
 	if(config.jobs_have_maint_access & EVERYONE_HAS_MAINT_ACCESS) //Config has global maint access set
 		. |= list(access_maint_tunnels)
+
+/datum/job/proc/announce_head(var/mob/living/carbon/human/H, var/channels) //tells the given channel that the given mob is the new department head. See communications.dm for valid channels.
+	spawn(4) //to allow some initialization
+		if(H && announcement_systems.len)
+			var/obj/machinery/announcement_system/announcer = pick(announcement_systems)
+			announcer.announce("NEWHEAD", H.real_name, H.job, channels)
 
 //If the configuration option is set to require players to be logged as old enough to play certain jobs, then this proc checks that they are, otherwise it just returns 1
 /datum/job/proc/player_old_enough(client/C)
@@ -132,8 +110,12 @@
 /datum/job/proc/config_check()
 	return 1
 
+
+
 /datum/outfit/job
 	name = "Standard Gear"
+
+	var/jobtype = null
 
 	uniform = /obj/item/clothing/under/color/grey
 	id = /obj/item/weapon/card/id
@@ -141,6 +123,8 @@
 	belt = /obj/item/device/pda
 	back = /obj/item/weapon/storage/backpack
 	shoes = /obj/item/clothing/shoes/sneakers/black
+
+	var/list/implants = null
 
 	var/backpack = /obj/item/weapon/storage/backpack
 	var/satchel  = /obj/item/weapon/storage/backpack/satchel
@@ -174,23 +158,25 @@
 	if(visualsOnly)
 		return
 
+	var/datum/job/J = SSjob.GetJobType(jobtype)
+	if(!J)
+		J = SSjob.GetJob(H.job)
+
 	var/obj/item/weapon/card/id/C = H.wear_id
 	if(istype(C))
-		var/datum/job/J = SSjob.GetJob(H.job) // Not sure the best idea
 		C.access = J.get_access()
 		C.registered_name = H.real_name
-		C.assignment = H.job
+		C.assignment = J.title
 		C.update_label()
 		H.sec_hud_set_ID()
 
 	var/obj/item/device/pda/PDA = H.get_item_by_slot(pda_slot)
 	if(istype(PDA))
 		PDA.owner = H.real_name
-		PDA.ownjob = H.job
+		PDA.ownjob = J.title
 		PDA.update_label()
 
-/datum/outfit/job/proc/announce_head(var/mob/living/carbon/human/H, var/channels) //tells the given channel that the given mob is the new department head. See communications.dm for valid channels.
-	spawn(4) //to allow some initialization
-		if(H && announcement_systems.len)
-			var/obj/machinery/announcement_system/announcer = pick(announcement_systems)
-			announcer.announce("NEWHEAD", H.real_name, H.job, channels)
+	if(implants)
+		for(var/implant_type in implants)
+			var/obj/item/weapon/implant/I = new implant_type(H)
+			I.implant(H, null, silent=TRUE)

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -6,6 +6,7 @@ Chief Medical Officer
 	flag = CMO
 	department_head = list("Captain")
 	department_flag = MEDSCI
+	head_announce = list("Medical")
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -25,6 +26,7 @@ Chief Medical Officer
 
 /datum/outfit/job/cmo
 	name = "Chief Medical Officer"
+	jobtype = /datum/job/cmo
 
 	id = /obj/item/weapon/card/id/silver
 	belt = /obj/item/device/pda/heads/cmo
@@ -39,14 +41,6 @@ Chief Medical Officer
 	backpack = /obj/item/weapon/storage/backpack/medic
 	satchel = /obj/item/weapon/storage/backpack/satchel/med
 	dufflebag = /obj/item/weapon/storage/backpack/dufflebag/med
-
-/datum/outfit/job/cmo/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-
-	if(visualsOnly)
-		return
-
-	announce_head(H, list("Medical")) //tell underlings (medical radio) they have a head
 
 /*
 Medical Doctor
@@ -69,6 +63,7 @@ Medical Doctor
 
 /datum/outfit/job/doctor
 	name = "Medical Doctor"
+	jobtype = /datum/job/doctor
 
 	belt = /obj/item/device/pda/medical
 	ears = /obj/item/device/radio/headset/headset_med
@@ -103,6 +98,7 @@ Chemist
 
 /datum/outfit/job/chemist
 	name = "Chemist"
+	jobtype = /datum/job/chemist
 
 	glasses = /obj/item/clothing/glasses/science
 	belt = /obj/item/device/pda/chemist
@@ -136,6 +132,7 @@ Geneticist
 
 /datum/outfit/job/geneticist
 	name = "Geneticist"
+	jobtype = /datum/job/geneticist
 
 	belt = /obj/item/device/pda/geneticist
 	ears = /obj/item/device/radio/headset/headset_medsci
@@ -169,6 +166,7 @@ Virologist
 
 /datum/outfit/job/virologist
 	name = "Virologist"
+	jobtype = /datum/job/virologist
 
 	belt = /obj/item/device/pda/viro
 	ears = /obj/item/device/radio/headset/headset_med

--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -6,6 +6,7 @@ Research Director
 	flag = RD
 	department_head = list("Captain")
 	department_flag = MEDSCI
+	head_announce = list("Science")
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -29,6 +30,7 @@ Research Director
 
 /datum/outfit/job/rd
 	name = "Research Director"
+	jobtype = /datum/job/rd
 
 	id = /obj/item/weapon/card/id/silver
 	belt = /obj/item/device/pda/heads/rd
@@ -43,13 +45,14 @@ Research Director
 	backpack = /obj/item/weapon/storage/backpack/science
 	satchel = /obj/item/weapon/storage/backpack/satchel/tox
 
-/datum/outfit/job/rd/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
+/datum/outfit/job/rd/rig
+	name = "Research Director (Hardsuit)"
 
-	if(visualsOnly)
-		return
-
-	announce_head(H, list("Science")) //tell underlings (science radio) they have a head
+	l_hand = null
+	mask = /obj/item/clothing/mask/breath
+	suit = /obj/item/clothing/suit/space/hardsuit/rd
+	suit_store = /obj/item/weapon/tank/internals/oxygen
+	internals_slot = slot_s_store
 
 /*
 Scientist
@@ -72,6 +75,7 @@ Scientist
 
 /datum/outfit/job/scientist
 	name = "Scientist"
+	jobtype = /datum/job/scientist
 
 	belt = /obj/item/device/pda/toxins
 	ears = /obj/item/device/radio/headset/headset_sci
@@ -103,6 +107,7 @@ Roboticist
 
 /datum/outfit/job/roboticist
 	name = "Roboticist"
+	jobtype = /datum/job/roboticist
 
 	belt = /obj/item/weapon/storage/belt/utility/full
 	l_pocket = /obj/item/device/pda/roboticist

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -12,6 +12,7 @@ Head of Security
 	flag = HOS
 	department_head = list("Captain")
 	department_flag = ENGSEC
+	head_announce = list("Security")
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
@@ -33,6 +34,7 @@ Head of Security
 
 /datum/outfit/job/hos
 	name = "Head of Security"
+	jobtype = /datum/job/hos
 
 	id = /obj/item/weapon/card/id/silver
 	belt = /obj/item/device/pda/heads/hos
@@ -53,16 +55,8 @@ Head of Security
 	dufflebag = /obj/item/weapon/storage/backpack/dufflebag/sec
 	box = /obj/item/weapon/storage/box/security
 
-/datum/outfit/job/hos/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
+	implants = list(/obj/item/weapon/implant/mindshield)
 
-	if(visualsOnly)
-		return
-
-	var/obj/item/weapon/implant/mindshield/L = new/obj/item/weapon/implant/mindshield(H)
-	L.implant(H, null, 1)
-
-	announce_head(H, list("Security")) //tell underlings (security radio) they have a head
 /*
 Warden
 */
@@ -90,6 +84,7 @@ Warden
 
 /datum/outfit/job/warden
 	name = "Warden"
+	jobtype = /datum/job/warden
 
 	belt = /obj/item/device/pda/warden
 	ears = /obj/item/device/radio/headset/headset_sec/alt
@@ -109,15 +104,8 @@ Warden
 	dufflebag = /obj/item/weapon/storage/backpack/dufflebag/sec
 	box = /obj/item/weapon/storage/box/security
 
+	implants = list(/obj/item/weapon/implant/mindshield)
 
-/datum/outfit/job/warden/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-
-	if(visualsOnly)
-		return
-
-	var/obj/item/weapon/implant/mindshield/L = new/obj/item/weapon/implant/mindshield(H)
-	L.implant(H, null, 1)
 
 /*
 Detective
@@ -141,6 +129,7 @@ Detective
 
 /datum/outfit/job/detective
 	name = "Detective"
+	jobtype = /datum/job/detective
 
 	belt = /obj/item/device/pda/detective
 	ears = /obj/item/device/radio/headset/headset_sec/alt
@@ -156,6 +145,8 @@ Detective
 		/obj/item/weapon/melee/classic_baton=1)
 	mask = /obj/item/clothing/mask/cigarette
 
+	implants = list(/obj/item/weapon/implant/mindshield)
+
 /datum/outfit/job/detective/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	var/obj/item/clothing/mask/cigarette/cig = H.wear_mask
@@ -163,9 +154,6 @@ Detective
 
 	if(visualsOnly)
 		return
-
-	var/obj/item/weapon/implant/mindshield/L = new/obj/item/weapon/implant/mindshield(H)
-	L.implant(H, null, 1)
 
 /*
 Security Officer
@@ -187,6 +175,7 @@ Security Officer
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue, access_weapons, access_forensics_lockers)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_court, access_weapons) //But see /datum/job/warden/get_access()
 
+
 /datum/job/officer/get_access()
 	var/list/L = list()
 	L |= ..() | check_config_for_sec_maint()
@@ -194,77 +183,51 @@ Security Officer
 
 var/list/sec_departments = list("engineering", "supply", "medical", "science")
 
-/datum/outfit/job/security
-	name = "Security Officer"
-
-	belt = /obj/item/device/pda/security
-	ears = /obj/item/device/radio/headset/headset_sec/alt
-	uniform = /obj/item/clothing/under/rank/security
-	gloves = /obj/item/clothing/gloves/color/black
-	head = /obj/item/clothing/head/helmet/sec
-	suit = /obj/item/clothing/suit/armor/vest/alt
-	shoes = /obj/item/clothing/shoes/jackboots
-	l_pocket = /obj/item/weapon/restraints/handcuffs
-	r_pocket = /obj/item/device/assembly/flash/handheld
-	suit_store = /obj/item/weapon/gun/energy/e_gun/advtaser
-	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1)
-
-	backpack = /obj/item/weapon/storage/backpack/security
-	satchel = /obj/item/weapon/storage/backpack/satchel/sec
-	dufflebag = /obj/item/weapon/storage/backpack/dufflebag/sec
-	box = /obj/item/weapon/storage/box/security
-
-	var/department = null
+/datum/job/officer/after_spawn(mob/living/carbon/human/H)
+	// Assign departament security
+	if(!sec_departments.len)
+		return
+	var/department = pick(sec_departments)
+	sec_departments -= department
+	var/ears = null
 	var/tie = null
 	var/list/dep_access = null
 	var/destination = null
 	var/spawn_point = null
 
-/datum/outfit/job/security/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
+	switch(department)
+		if("supply")
+			ears = /obj/item/device/radio/headset/headset_sec/alt/department/supply
+			dep_access = list(access_mailsorting, access_mining, access_mining_station)
+			destination = /area/security/checkpoint/supply
+			spawn_point = locate(/obj/effect/landmark/start/depsec/supply) in department_security_spawns
+			tie = /obj/item/clothing/tie/armband/cargo
+		if("engineering")
+			ears = /obj/item/device/radio/headset/headset_sec/alt/department/engi
+			dep_access = list(access_construction, access_engine)
+			destination = /area/security/checkpoint/engineering
+			spawn_point = locate(/obj/effect/landmark/start/depsec/engineering) in department_security_spawns
+			tie = /obj/item/clothing/tie/armband/engine
+		if("medical")
+			ears = /obj/item/device/radio/headset/headset_sec/alt/department/med
+			dep_access = list(access_medical)
+			destination = /area/security/checkpoint/medical
+			spawn_point = locate(/obj/effect/landmark/start/depsec/medical) in department_security_spawns
+			tie =  /obj/item/clothing/tie/armband/medblue
+		if("science")
+			ears = /obj/item/device/radio/headset/headset_sec/alt/department/sci
+			dep_access = list(access_research)
+			destination = /area/security/checkpoint/science
+			spawn_point = locate(/obj/effect/landmark/start/depsec/science) in department_security_spawns
+			tie = /obj/item/clothing/tie/armband/science
 
-	if(sec_departments.len)
-		department = pick(sec_departments)
-		if(!visualsOnly)
-			sec_departments -= department
-		switch(department)
-			if("supply")
-				ears = /obj/item/device/radio/headset/headset_sec/alt/department/supply
-				dep_access = list(access_mailsorting, access_mining, access_mining_station)
-				destination = /area/security/checkpoint/supply
-				spawn_point = locate(/obj/effect/landmark/start/depsec/supply) in department_security_spawns
-				tie = /obj/item/clothing/tie/armband/cargo
-			if("engineering")
-				ears = /obj/item/device/radio/headset/headset_sec/alt/department/engi
-				dep_access = list(access_construction, access_engine)
-				destination = /area/security/checkpoint/engineering
-				spawn_point = locate(/obj/effect/landmark/start/depsec/engineering) in department_security_spawns
-				tie = /obj/item/clothing/tie/armband/engine
-			if("medical")
-				ears = /obj/item/device/radio/headset/headset_sec/alt/department/med
-				dep_access = list(access_medical)
-				destination = /area/security/checkpoint/medical
-				spawn_point = locate(/obj/effect/landmark/start/depsec/medical) in department_security_spawns
-				tie =  /obj/item/clothing/tie/armband/medblue
-			if("science")
-				ears = /obj/item/device/radio/headset/headset_sec/alt/department/sci
-				dep_access = list(access_research)
-				destination = /area/security/checkpoint/science
-				spawn_point = locate(/obj/effect/landmark/start/depsec/science) in department_security_spawns
-				tie = /obj/item/clothing/tie/armband/science
-
-/datum/outfit/job/security/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-
-	var/obj/item/clothing/under/U = H.w_uniform
 	if(tie)
+		var/obj/item/clothing/under/U = H.w_uniform
 		U.attachTie(new tie)
-
-	if(visualsOnly)
-		return
-
-	var/obj/item/weapon/implant/mindshield/L = new/obj/item/weapon/implant/mindshield(H)
-	L.implant(H, null, 1)
+	if(ears)
+		if(H.ears)
+			qdel(H.ears)
+		H.equip_to_slot_or_del(new ears(H),slot_ears)
 
 	var/obj/item/weapon/card/id/W = H.wear_id
 	W.access |= dep_access
@@ -291,6 +254,32 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 		H << "<b>You have been assigned to [department]!</b>"
 	else
 		H << "<b>You have not been assigned to any department. Patrol the halls and help where needed.</b>"
+
+
+
+/datum/outfit/job/security
+	name = "Security Officer"
+	jobtype = /datum/job/officer
+
+	belt = /obj/item/device/pda/security
+	ears = /obj/item/device/radio/headset/headset_sec/alt
+	uniform = /obj/item/clothing/under/rank/security
+	gloves = /obj/item/clothing/gloves/color/black
+	head = /obj/item/clothing/head/helmet/sec
+	suit = /obj/item/clothing/suit/armor/vest/alt
+	shoes = /obj/item/clothing/shoes/jackboots
+	l_pocket = /obj/item/weapon/restraints/handcuffs
+	r_pocket = /obj/item/device/assembly/flash/handheld
+	suit_store = /obj/item/weapon/gun/energy/e_gun/advtaser
+	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1)
+
+	backpack = /obj/item/weapon/storage/backpack/security
+	satchel = /obj/item/weapon/storage/backpack/satchel/sec
+	dufflebag = /obj/item/weapon/storage/backpack/dufflebag/sec
+	box = /obj/item/weapon/storage/box/security
+
+	implants = list(/obj/item/weapon/implant/mindshield)
+
 
 /obj/item/device/radio/headset/headset_sec/department/New()
 	wires = new(src)

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -132,7 +132,6 @@
 	myjob = new/datum/job/assistant()
 	job = myjob.title
 	myjob.equip(src)
-	myjob.apply_fingerprints(src)
 
 /mob/living/carbon/human/interactive/attacked_by(obj/item/I, mob/living/user, def_zone)
 	. = ..()
@@ -206,7 +205,6 @@
 						for(var/obj/item/W in T)
 							qdel(W)
 						T.myjob.equip(T)
-						T.myjob.apply_fingerprints(T)
 						T.doSetup()
 						break
 			if(choice == "Random")
@@ -215,7 +213,6 @@
 				for(var/obj/item/W in T)
 					qdel(W)
 				T.myjob.equip(T)
-				T.myjob.apply_fingerprints(T)
 				T.doSetup()
 				if(prob(25))
 					var/list/validchoices = list()
@@ -239,7 +236,6 @@
 					for(var/obj/item/W in T)
 						qdel(W)
 					T.myjob.equip(T)
-					T.myjob.apply_fingerprints(T)
 					T.doSetup()
 				var/shouldDoppel = input("Do you want the SNPC to disguise themself as a crewmember?") as null|anything in list("Yes","No")
 				if(shouldDoppel)

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -30,7 +30,6 @@
 	gloves = /obj/item/clothing/gloves/combat
 	radio = /obj/item/device/radio/headset
 	mask = /obj/item/clothing/mask/gas/syndicate
-	helmet = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 	back = /obj/item/weapon/tank/jetpack/oxygen
 	pocket1 = /obj/item/weapon/tank/internals/emergency_oxygen
 	has_id = 1
@@ -45,7 +44,6 @@
 	gloves = /obj/item/clothing/gloves/combat
 	radio = /obj/item/device/radio/headset
 	mask = /obj/item/clothing/mask/gas/syndicate
-	helmet = /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite
 	back = /obj/item/weapon/tank/jetpack/oxygen/harness
 	has_id = 1
 	id_job = "Operative"
@@ -53,18 +51,9 @@
 
 
 
-/obj/effect/mob_spawn/human/corpse/clown
-	name = "Clown"
-	uniform = /obj/item/clothing/under/rank/clown
-	shoes = /obj/item/clothing/shoes/clown_shoes
-	radio = /obj/item/device/radio/headset
-	mask = /obj/item/clothing/mask/gas/clown_hat
-	pocket1 = /obj/item/weapon/bikehorn
-	back = /obj/item/weapon/storage/backpack/clown
-	has_id = 1
-	id_job = "Clown"
-	id_access = "Clown"
-
+/obj/effect/mob_spawn/human/clown/corpse
+	roundstart = FALSE
+	instant = TRUE
 
 
 /obj/effect/mob_spawn/human/corpse/pirate

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -24,7 +24,7 @@
 	obj_damage = 0
 	environment_smash = 0
 	del_on_death = 1
-	loot = list(/obj/effect/mob_spawn/human/corpse/clown)
+	loot = list(/obj/effect/mob_spawn/human/clown/corpse)
 
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 270


### PR DESCRIPTION
* **Job outfits (usually applied from "Select equipment") are now safe to use.** Outfitting a captain on Centcom wouldn't announce him to station, same for staff heads. Relevant code is moved to job datums.
* Some of the corpse spawners (clown, engineer, miner, etc) now use job outfits. Corpses spawn with proper job IDs and PDAs, but messengers are turned off by default. They wouldn't show up in PDA list unless re-enabled.
* If outfit has a hardsuit and lacks a helmet, hardsuit helmet will auto-engage.
* Outfits now support toggling internals on and spawning with implants (commonly used).
* All outfits now add owner's fingerprints to spawned gear. This functionality was limited to jobs code before.
* Some of the job outfits now have alt-versions (explorer suit miner, hardsuit engineer). They are used only by corpse spawners, but show up on "Select equipment" panel. Useful when you want to gear up real quick.

Fixes #21928. If there is an issue for adminspawned equips announcing to station, this fixes it too.