### PR TITLE
Makes lighting more responsive.

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -7,8 +7,8 @@ var/datum/subsystem/lighting/SSlighting
 	name = "Lighting"
 	init_order = 1
 	wait = 1
-	flags = SS_POST_FIRE_TIMING
-	priority = 40
+	flags = SS_TICKER
+	priority = 25
 	display_order = 5
 
 	var/list/changed_lights = list()		//list of all datum/light_source that need updating


### PR DESCRIPTION
Lowers priority, doubles tick rate, makes it run sooner in the tick. (bonus points, if it gets paused by MC_TICK_CHECK before it finishes, and there ends up being spare time in the byond tick left over, it will get some more runtime at the tail end of the tick, meaning it runs twice a tick during low lag times.)

I was avoiding doing this when i first made stoned mc because i wasn't sure if we'd hit some point where these get ticker subsystems get contentious, but that hasn't happened and now it seems like making this a ticker subsystem is sane way of doing this.

:cl:
experiment: Lighting was made more responsive.
/:cl:
