### PR TITLE
[s]Throttles preferences hrefs

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -19,6 +19,7 @@
 	If you have any  questions about this stuff feel free to ask. ~Carn
 	*/
 /client/Topic(href, href_list, hsrc)
+	var/static/inprefs = FALSE
 	if(!usr || usr != mob)	//stops us calling Topic for somebody else's client. Also helps prevent usr=null
 		return
 	// asset_cache
@@ -45,7 +46,12 @@
 		if("usr")
 			hsrc = mob
 		if("prefs")
-			return prefs.process_link(usr,href_list)
+			if (inprefs)
+				return
+			inprefs = TRUE
+			. = prefs.process_link(usr,href_list)
+			inprefs = FALSE
+			return
 		if("vars")
 			return view_var_Topic(href,href_list,hsrc)
 


### PR DESCRIPTION
The user will not be allowed to trigger a click on a preferences href until their previous one has finished.

rshoe is using it spam us.

I know somebody was talking about trying to do a more proper fix, such as by making it not re-generate these when it's the same, so i'll test merge this until 24 hours or they make such a pr.
