### PR TITLE
Fixes runtimes related to blowing up 25 vending machines at once

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -506,7 +506,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	else ..()
 
 /obj/item/throw_impact(atom/A)
-	if(A)
+	if(A && !qdeleted(A))
 		var/itempush = 1
 		if(w_class < 4)
 			itempush = 0 //too light to push anything

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -506,10 +506,11 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	else ..()
 
 /obj/item/throw_impact(atom/A)
-	var/itempush = 1
-	if(w_class < 4)
-		itempush = 0 //too light to push anything
-	return A.hitby(src, 0, itempush)
+	if(A)
+		var/itempush = 1
+		if(w_class < 4)
+			itempush = 0 //too light to push anything
+		return A.hitby(src, 0, itempush)
 
 /obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
 	thrownby = thrower


### PR DESCRIPTION
![](http://i.imgur.com/L4Y5h2C.png)

[log before this pr](http://pastebin.com/vD8NhMT4)

[log after this pr](http://pastebin.com/ehTUJBuM)

More correctly, this is an issue where `/obj/item/throw_impact(atom/A)` can receive a null atom in some instances, for example during a catastrophic vending-machine based explosion 