### PR TITLE
seedRuins exits with a warning if provided a z level that does not exist

### DIFF
--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -62,6 +62,13 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 /proc/seedRuins(list/z_levels = null, budget = 0, whitelist = /area/space, list/potentialRuins = space_ruins_templates)
 	if(!z_levels || !z_levels.len)
 		z_levels = list(1)
+
+	for(var/zl in z_levels)
+		var/turf/T = locate(1, 1, zl)
+		if(!T)
+			WARNING("Z level [zl] does not exist - Not generating ruins")
+			return
+
 	var/overall_sanity = 100
 	var/list/ruins = potentialRuins.Copy()
 

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -61,7 +61,8 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 
 /proc/seedRuins(list/z_levels = null, budget = 0, whitelist = /area/space, list/potentialRuins = space_ruins_templates)
 	if(!z_levels || !z_levels.len)
-		z_levels = list(1)
+		WARNING("No Z levels provided - Not generating ruins")
+		return
 
 	for(var/zl in z_levels)
 		var/turf/T = locate(1, 1, zl)


### PR DESCRIPTION
This mostly stops runtimes from occurring when starting runtimestation. It's good practice, too