### PR TITLE
The chameleon stamp should properly deny cargo manifests now.

### DIFF
--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -19,7 +19,7 @@
 	return stamped && stamped.len && !is_denied()
 
 /obj/item/weapon/paper/manifest/proc/is_denied()
-	return stamped && (/obj/item/weapon/stamp/denied in stamped)
+	return stamped && ("stamp-deny" in stamped)
 
 /datum/supply_order
 	var/id

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -73,7 +73,7 @@
 	glass_colour_type = /datum/client_colour/glass_colour/red
 
 /obj/item/clothing/glasses/hud/security/chameleon
-	name = "Chamleon Security HUD"
+	name = "Chameleon Security HUD"
 	desc = "A stolen security HUD integrated with Syndicate chameleon technology. Toggle to disguise the HUD. Provides flash protection."
 	flash_protect = 1
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -316,7 +316,7 @@
 
 		if(!stamped)
 			stamped = new
-		stamped += P.type
+		stamped += P.icon_state
 		add_overlay(stampoverlay)
 
 		user << "<span class='notice'>You stamp the paper with your rubber stamp.</span>"


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/12052.

Note that the stamped list now runs off icon_state, rather than base type; to my knowledge this is the only thing that currently uses it.

Also fixes a spelling error that bugged the fuck out of me while searching around