### PR TITLE
Moves reagents back into atoms. Fixes confusion between reagents/reagents_list

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1,6 +1,5 @@
 /datum
 	var/var_edited = FALSE //Warrenty void if seal is broken
-	var/datum/reagents/reagents = null
 	var/fingerprintslast = null
 
 /datum/proc/vv_edit_var(var_name, var_value) //called whenever a var is edited
@@ -52,13 +51,13 @@
 	var/refid = "\ref[D]"
 	var/icon/sprite
 	var/hash
-	
+
 	var/type = /list
 	if (!islist)
 		type = D.type
 
 
-	
+
 	if(istype(D,/atom))
 		var/atom/AT = D
 		if(AT.icon && AT.icon_state)

--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -42,10 +42,10 @@
 
 /datum/recipe/proc/check_reagents(datum/reagents/avail_reagents) //1=precisely, 0=insufficiently, -1=superfluous
 	. = 1
-	for (var/r_r in reagents)
+	for (var/r_r in reagents_list)
 		var/aval_r_amnt = avail_reagents.get_reagent_amount(r_r)
-		if (!(abs(aval_r_amnt - reagents[r_r])<0.5)) //if NOT equals
-			if (aval_r_amnt>reagents[r_r])
+		if (!(abs(aval_r_amnt - reagents_list[r_r])<0.5)) //if NOT equals
+			if (aval_r_amnt>reagents_list[r_r])
 				. = -1
 			else
 				return 0

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -8,6 +8,7 @@
 	var/list/blood_DNA
 	var/container_type = 0
 	var/admin_spawned = 0	//was this spawned by an admin? used for stat tracking stuff.
+	var/datum/reagents/reagents = null
 
 	//This atom's HUD (med/sec, etc) images. Associative list.
 	var/list/image/hud_list = null
@@ -52,6 +53,8 @@
 			for(var/aa in viewing_alternate_appearances[aakey])
 				var/datum/alternate_appearance/AA = aa
 				AA.hide(list(src))
+	if(reagents)
+		qdel(reagents)
 	return ..()
 
 /atom/proc/CanPass(atom/movable/mover, turf/target, height=1.5)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -109,8 +109,6 @@
 	. = ..()
 	if(loc)
 		loc.handle_atom_del(src)
-	if(reagents)
-		qdel(reagents)
 	for(var/atom/movable/AM in contents)
 		qdel(AM)
 	loc = null

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -113,10 +113,10 @@
 				return
 
 
-			var/synth_cost = being_built.reagents["synthflesh"]*prod_coeff
+			var/synth_cost = being_built.reagents_list["synthflesh"]*prod_coeff
 			var/power = max(2000, synth_cost/5)
 
-			if(reagents.has_reagent("synthflesh", being_built.reagents["synthflesh"]*prod_coeff))
+			if(reagents.has_reagent("synthflesh", being_built.reagents_list["synthflesh"]*prod_coeff))
 				busy = 1
 				use_power(power)
 				flick("limbgrower_fill",src)
@@ -130,8 +130,8 @@
 	return
 
 /obj/machinery/limbgrower/proc/build_item()
-	if(reagents.has_reagent("synthflesh", being_built.reagents["synthflesh"]*prod_coeff))	//sanity check, if this happens we are in big trouble
-		reagents.remove_reagent("synthflesh",being_built.reagents["synthflesh"]*prod_coeff)
+	if(reagents.has_reagent("synthflesh", being_built.reagents_list["synthflesh"]*prod_coeff))	//sanity check, if this happens we are in big trouble
+		reagents.remove_reagent("synthflesh",being_built.reagents_list["synthflesh"]*prod_coeff)
 		var/buildpath = being_built.build_path
 		if(ispath(buildpath, /obj/item/bodypart))	//This feels like spatgheti code, but i need to initilise a limb somehow
 			build_limb(buildpath)
@@ -221,12 +221,12 @@
 	return dat
 
 /obj/machinery/limbgrower/proc/can_build(datum/design/D)
-	return (reagents.has_reagent("synthflesh", D.reagents["synthflesh"]*prod_coeff)) //Return whether the machine has enough synthflesh to produce the design
+	return (reagents.has_reagent("synthflesh", D.reagents_list["synthflesh"]*prod_coeff)) //Return whether the machine has enough synthflesh to produce the design
 
 /obj/machinery/limbgrower/proc/get_design_cost(datum/design/D)
 	var/dat
-	if(D.reagents["synthflesh"])
-		dat += "[D.reagents["synthflesh"] * prod_coeff] Synthetic flesh "
+	if(D.reagents_list["synthflesh"])
+		dat += "[D.reagents_list["synthflesh"] * prod_coeff] Synthetic flesh "
 	return dat
 
 /obj/machinery/limbgrower/emag_act(mob/user)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -88,11 +88,6 @@
 
 	refill()
 
-/obj/item/toy/crayon/Destroy()
-	if(reagents)
-		qdel(reagents)
-	. = ..()
-
 /obj/item/toy/crayon/proc/refill()
 	if(charges == -1)
 		charges_left = 100

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -124,8 +124,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	reagents.add_reagent("nicotine", 15)
 
 /obj/item/clothing/mask/cigarette/Destroy()
-	if(reagents)
-		qdel(reagents)
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 
@@ -354,8 +352,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	name = "empty [initial(name)]"
 
 /obj/item/clothing/mask/cigarette/pipe/Destroy()
-	if(reagents)
-		qdel(reagents)
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -317,7 +317,3 @@ var/global/chicken_count = 0
 		user.visible_message("[user] milks [src] using \the [O].", "<span class='notice'>You milk [src] using \the [O].</span>")
 	else
 		user << "<span class='danger'>The udder is dry. Wait a bit longer...</span>"
-
-/obj/item/udder/Destroy()
-	qdel(reagents)
-	return ..()

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -12,7 +12,7 @@ var/const/INJECT = 5 //injection
 	var/list/datum/reagent/reagent_list = new/list()
 	var/total_volume = 0
 	var/maximum_volume = 100
-	var/datum/my_atom = null
+	var/atom/my_atom = null
 	var/chem_temp = 150
 	var/last_tick = 1
 	var/addiction_tick = 1
@@ -691,7 +691,7 @@ var/const/INJECT = 5 //injection
 
 // Convenience proc to create a reagents holder for an atom
 // Max vol is maximum volume of holder
-/datum/proc/create_reagents(max_vol)
+/atom/proc/create_reagents(max_vol)
 	if(reagents)
 		qdel(reagents)
 	reagents = new/datum/reagents(max_vol)

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -67,7 +67,7 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 		qdel(src)
 
 /obj/machinery/r_n_d/circuit_imprinter/proc/check_mat(datum/design/being_built, M)	// now returns how many times the item can be built with the material
-	var/list/all_materials = being_built.reagents + being_built.materials
+	var/list/all_materials = being_built.reagents_list + being_built.materials
 
 	var/A = materials.amount(M)
 	if(!A)

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -6,7 +6,7 @@
 	name = "Left Arm"
 	id = "leftarm"
 	build_type = LIMBGROWER
-	reagents = list("synthflesh" = 25)
+	reagents_list = list("synthflesh" = 25)
 	build_path = /obj/item/bodypart/l_arm
 	category = list("initial","human","lizard","plasmaman")
 
@@ -14,7 +14,7 @@
 	name = "Right Arm"
 	id = "rightarm"
 	build_type = LIMBGROWER
-	reagents = list("synthflesh" = 25)
+	reagents_list = list("synthflesh" = 25)
 	build_path = /obj/item/bodypart/r_arm
 	category = list("initial","human","lizard","plasmaman")
 
@@ -22,7 +22,7 @@
 	name = "Left Leg"
 	id = "leftleg"
 	build_type = LIMBGROWER
-	reagents = list("synthflesh" = 25)
+	reagents_list = list("synthflesh" = 25)
 	build_path = /obj/item/bodypart/l_leg
 	category = list("initial","human","lizard","plasmaman")
 
@@ -30,7 +30,7 @@
 	name = "Right Leg"
 	id = "rightleg"
 	build_type = LIMBGROWER
-	reagents = list("synthflesh" = 25)
+	reagents_list = list("synthflesh" = 25)
 	build_path = /obj/item/bodypart/r_leg
 	category = list("initial","human","lizard","plasmaman")
 
@@ -38,6 +38,6 @@
 	name = "Arm Blade"
 	id = "armblade"
 	build_type = LIMBGROWER
-	reagents = list("synthflesh" = 75)
+	reagents_list = list("synthflesh" = 75)
 	build_path = /obj/item/weapon/melee/synthetic_arm_blade
 	category = list("special")

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -67,7 +67,7 @@ Note: Must be placed west/left of and R&D console to function.
 	efficiency_coeff = min(max(0, T), 1)
 
 /obj/machinery/r_n_d/protolathe/proc/check_mat(datum/design/being_built, M)	// now returns how many times the item can be built with the material
-	var/list/all_materials = being_built.reagents + being_built.materials
+	var/list/all_materials = being_built.reagents_list + being_built.materials
 
 	var/A = materials.amount(M)
 	if(!A)


### PR DESCRIPTION
#20236 moved it to datums, but that was partially reverted somewhere

If chem gas was a thing this would make sense, but seeing as how it isn't let's put it back for now as not a single datum actually uses reagents

Fixes a bunch of shit qdeling their reagents when it was handled at the atom level

Fixes some things referencing reagents when they should be referencing reagents_list

As always, fix your shit @Iamgoofball 

Inb4 branchname, I was looking for reagent null bugs and found this instead