### PR TITLE
in which mso forgets static proc vars apply to types, and not instances

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -18,8 +18,8 @@
 		- If so, is there any protection against somebody spam-clicking a link?
 	If you have any  questions about this stuff feel free to ask. ~Carn
 	*/
+/client/var/inprefs = FALSE
 /client/Topic(href, href_list, hsrc)
-	var/static/inprefs = FALSE
 	if(!usr || usr != mob)	//stops us calling Topic for somebody else's client. Also helps prevent usr=null
 		return
 	// asset_cache


### PR DESCRIPTION
also, this stupid splitting of define and procs is stupid, so i put the var there so i can use the web editor. deal with it.