### PR TITLE
Makes stoplag less forgiving on lag

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1259,14 +1259,13 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 #define DELTA_CALC max(((max(world.tick_usage, world.cpu) / 100) * max(Master.sleep_delta,1)), 1)
 
 /proc/stoplag()
-	. = round(1*DELTA_CALC)
-	sleep(world.tick_lag)
-	if (world.tick_usage > min(TICK_LIMIT_TO_RUN, CURRENT_TICKLIMIT)) //woke up, still not enough tick, sleep for more.
-		. += round(2*DELTA_CALC)
-		sleep(world.tick_lag*2*DELTA_CALC)
-		if (world.tick_usage > min(TICK_LIMIT_TO_RUN, CURRENT_TICKLIMIT)) //woke up, STILL not enough tick, sleep for more.
-			. += round(4*DELTA_CALC)
-			sleep(world.tick_lag*4*DELTA_CALC)
+	. = 0
+	var/i = 1
+	do
+		. += round(i*DELTA_CALC)
+		sleep(i*world.tick_lag*DELTA_CALC)
+		i *= 2
+	while (world.tick_usage > min(TICK_LIMIT_TO_RUN, CURRENT_TICKLIMIT))
 
 #undef DELTA_CALC
 


### PR DESCRIPTION
I once had a comment saying not to do this, because i had assumed not giving stoplag a bottom out would lead to cases where it slept for really long times.

But that was before I knew how much lag this getting overloaded with shit sleeping and waking up and sleeping and waking up can cause when a million things are doing it, and before i knew that because of how byond's Process scheduler works, the longer you sleep the sooner in a tick you run, so the edge case of this getting really long can only happen if the server is so super overloaded and fucked, that not doing it would lock everything up to the point that admins can't even restart the server.

:cl:
tweak: More performance tweaks with the modulated reactive ensured entropy frame governor system
/:cl:

