### PR TITLE
Adds emergency shuttle escapees count to end stats

### DIFF
--- a/code/__DEFINES/math.dm
+++ b/code/__DEFINES/math.dm
@@ -15,3 +15,5 @@
 //collapsed to percent_of_tick_used * tick_lag
 #define TICK_DELTA_TO_MS(percent_of_tick_used) ((percent_of_tick_used) * world.tick_lag)
 #define TICK_USAGE_TO_MS(starting_tickusage) (TICK_DELTA_TO_MS(world.tick_usage-starting_tickusage))
+
+#define PERCENT(val) (round(val*100, 0.1))


### PR DESCRIPTION
:cl: coiax
add: The end of round stats include the number of people who escaped on
the main emergency shuttle.
/:cl:

![image](https://cloud.githubusercontent.com/assets/609465/21788799/96baf6bc-d6c8-11e6-8464-1289978fa541.png)
