### PR TITLE
Fixes issue with attorney badges speech bubble

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -526,7 +526,7 @@ BLIND     // can't see anything
 			adjusted = DIGITIGRADE_STYLE
 		H.update_inv_w_uniform()
 
-	if(hastie)
+	if(hastie && slot != slot_hands)
 		hastie.on_uniform_equip(src, user)
 
 /obj/item/clothing/under/dropped(mob/user)

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -50,10 +50,10 @@
 	U.cut_overlays()
 	U.hastie = null
 
-/obj/item/clothing/tie/proc/on_uniform_equip(obj/item/clothing/under/U)
+/obj/item/clothing/tie/proc/on_uniform_equip(obj/item/clothing/under/U, user)
 	return
 
-/obj/item/clothing/tie/proc/on_uniform_dropped(obj/item/clothing/under/U)
+/obj/item/clothing/tie/proc/on_uniform_dropped(obj/item/clothing/under/U, user)
 	return
 /*
 /obj/item/clothing/tie/blue
@@ -389,21 +389,19 @@
 	if(!..())
 		return 0
 	if(isliving(U.loc))
-		on_uniform_equip(U)
+		on_uniform_equip(U, user)
 
 /obj/item/clothing/tie/lawyers_badge/detach(obj/item/clothing/under/U, user)
 	..()
 	if(isliving(U.loc))
-		on_uniform_dropped(U)
+		on_uniform_dropped(U, user)
 
-/obj/item/clothing/tie/lawyers_badge/on_uniform_equip(obj/item/clothing/under/U)
-	if(!isliving(U.loc))
-		return
-	var/mob/living/L = U.loc
-	L.bubble_icon = "lawyer"
+/obj/item/clothing/tie/lawyers_badge/on_uniform_equip(obj/item/clothing/under/U, user)
+	var/mob/living/L = user
+	if(L)
+		L.bubble_icon = "lawyer"
 
-/obj/item/clothing/tie/lawyers_badge/on_uniform_dropped(obj/item/clothing/under/U)
-	if(!isliving(U.loc))
-		return
-	var/mob/living/L = U.loc
-	L.bubble_icon = initial(L.bubble_icon)
+/obj/item/clothing/tie/lawyers_badge/on_uniform_dropped(obj/item/clothing/under/U, user)
+	var/mob/living/L = user
+	if(L)
+		L.bubble_icon = initial(L.bubble_icon)


### PR DESCRIPTION
:cl: Mervill
fix: You will now lose the lawyer's speech bubble effect if you unequip the layer's badge
/:cl:

This solves the issue by preventing `/obj/item/clothing/tie/proc/on_uniform_equip()` from being run if the target equip slot is the hands. At the moment the lawyers badge is the only item that uses this proc.

`on_uniform_equip()` / `on_uniform_dropped()` were both given `user` as an argument, since this is how it's used in `/obj/item/clothing/under/equipped()` and `/obj/item/clothing/under/dropped()`. This is my first time using the `user` magisteria, so I probably did something wrong.

fixes #20857