### PR TITLE
Fixes some atmos runtimes

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -46,6 +46,7 @@ Pipelines + Other Objects -> Pipe network
 		nullifyNode(I)
 
 	SSair.atmos_machinery -= src
+	SSair.currentrun -= src
 
 	dropContents()
 	if(pipe_vision_img)


### PR DESCRIPTION
```
The following runtime has occurred 1 time(s).
runtime error: Cannot read null.airs
proc name: process atmos (/obj/machinery/portable_atmospherics/pump/process_atmos)
  source file: pump.dm,45
  usr: null
  src: the portable air pump (/obj/machinery/portable_atmospherics/pump)
  src.loc: null
```

From what I can understand, this occurs because the pump was qdeleted while SSair was taking a break processing atmos machinery. But, since it copied the list into `currentrun` it still tried to process it even though it was qdeleted