### PR TITLE
Fixes carbons not taking damage from having more than 100 radiation

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -258,7 +258,7 @@
 				dna.temporary_mutations.Remove(mut)
 
 	if(radiation)
-
+		radiation = Clamp(radiation, 0, 100)
 		switch(radiation)
 			if(0 to 50)
 				radiation = max(radiation-1,0)
@@ -274,8 +274,6 @@
 			if(75 to 100)
 				radiation = max(radiation-3,0)
 				adjustToxLoss(3)
-			else
-				radiation = Clamp(radiation, 0, 100)
 
 /mob/living/carbon/handle_chemicals_in_body()
 	if(reagents)


### PR DESCRIPTION
The problem was that damage from radiation was dealt before the radiation was lowered to 100, making bringing radiation higher than 100 between handle_mutations_and_radiation() calls (which radioactive reagents do) result in no damage.