### PR TITLE
Fixes borg emote sounds using pitch vary

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -99,9 +99,10 @@ var/global/list/emote_list = list()
 
 /datum/emote/sound
 	var/sound //Sound to play when emote is called
+	var/vary = FALSE	//used for the honk borg emote
 	mob_type_allowed_typecache = list(/mob/living/brain, /mob/living/silicon)
 
 /datum/emote/sound/run_emote(mob/user, params)
 	. = ..()
 	if(.)
-		playsound(user.loc, sound, 50, 10)
+		playsound(user.loc, sound, 50, vary)

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -33,6 +33,7 @@
 	key = "honk"
 	key_third_person = "honks"
 	message = "honks."
+	vary = TRUE
 	sound = 'sound/items/bikehorn.ogg'
 
 /datum/emote/sound/silicon/ping


### PR DESCRIPTION
This was resulting in *beep sounding like the PDA message sound.
The only one that used it before the refactor was the honk emote.

:cl:
fix: Borg emotes should now play at the correct pitch
/:cl: