### PR TITLE
Fixes #10161 in theory (bombcores not going off on microbomb)

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_explosive.dm
+++ b/code/game/objects/items/weapons/implants/implant_explosive.dm
@@ -38,6 +38,7 @@
 	message_admins("[key_name_admin(imp_in)]<A HREF='?_src_=holder;adminmoreinfo=\ref[imp_in]'>?</A> (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[imp_in]'>FLW</A>) has activated their [name] at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[imp_in.x];Y=[imp_in.y];Z=[imp_in.z]'>[A.name] (JMP)</a>.")
 //If the delay is short, just blow up already jeez
 	if(delay <= 7)
+		explosion(src,0,1,0,0,flame_range = 0)
 		explosion(src,heavy,medium,weak,weak, flame_range = weak)
 		if(imp_in)
 			imp_in.gib(1)
@@ -71,6 +72,7 @@
 	sleep(delay/4)
 	playsound(loc, 'sound/items/timer.ogg', 30, 0)
 	sleep(delay/4)
+	explosion(src,0,1,0,0,flame_range = 0)
 	explosion(src,heavy,medium,weak,weak, flame_range = weak)
 	if(imp_in)
 		imp_in.gib(1)


### PR DESCRIPTION
Fixes bombcores not going off on microbomb
That should be quick enough to force any bombcores to go off first, unless the server is lagging /really/ badly or explosions are subsystemized.
Fixes #10161