### PR TITLE
Golems don't drop stuff when regenerating icons

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -135,9 +135,9 @@ There are several things that need to be remembered:
 
 		overlays_standing[UNIFORM_LAYER]	= standing
 
-	else
-		// Automatically drop anything in store / id / belt if you're not wearing a uniform.	//CHECK IF NECESARRY
-		for(var/obj/item/thing in list(r_store, l_store, wear_id, belt))						//
+	else if(!(dna && dna.species.nojumpsuit))
+		// Automatically drop anything in store / id / belt if you're not wearing a uniform.
+		for(var/obj/item/thing in list(r_store, l_store, wear_id, belt))
 			unEquip(thing)
 
 	apply_overlay(UNIFORM_LAYER)


### PR DESCRIPTION
:cl: XDTM
fix: Golems no longer drop belt, id, and pocket contents in a fit of extreme clumsiness when drawing a sword from a sheath.
/:cl:

Fixes #21842
