### PR TITLE
Emitters no longer message admins when powered on/off

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -167,7 +167,6 @@
 				update_icon()
 				investigate_log("lost power and turned <font color='red'>off</font>","singulo")
 				log_game("Emitter lost power in ([x],[y],[z])")
-				message_admins("Emitter lost power in ([x],[y],[z] - <a href='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 			return
 
 		src.last_shot = world.time


### PR DESCRIPTION
Fixes #4777

As requested by Kor in #22932 
"Just remove the emitter power loss notice, it's all logged in the singulo investigate tab if it actually results in a singularity getting loose"

Ignore the extra commits, can't fix them till I get home later.