### PR TITLE
Scripture and logging fixes

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -8,7 +8,7 @@
 /obj/effect/proc_holder/slab/remove_ranged_ability(msg)
 	..()
 	finished = TRUE
-	QDEL_IN(src, 2)
+	QDEL_IN(src, 6)
 
 /obj/effect/proc_holder/slab/InterceptClickOn(mob/living/caller, params, atom/target)
 	if(..() || in_progress)
@@ -70,7 +70,8 @@
 				conversion.slab = slab
 				conversion.invoker = ranged_ability_user
 				conversion.target = target
-				successful = conversion.run_scripture()
+				conversion.run_scripture()
+				successful = TRUE
 
 		remove_ranged_ability()
 
@@ -230,6 +231,9 @@
 		if(!totaldamage && (!L.reagents || !L.reagents.has_reagent("holywater")))
 			ranged_ability_user << "<span class='inathneq'>\"[L] is unhurt and untainted.\"</span>"
 			return TRUE
+
+		successful = TRUE
+
 		var/targetturf = get_turf(L)
 		if(totaldamage)
 			L.adjustBruteLoss(-brutedamage)
@@ -280,6 +284,8 @@
 			ranged_ability_user << "<span class='inathneq'>\"[L.p_they(TRUE)] [L.p_are()] already shielded by a Vanguard.\"</span>"
 			return TRUE
 
+		successful = TRUE
+
 		if(L == ranged_ability_user)
 			for(var/mob/living/LT in spiral_range(7, T))
 				if(LT.stat == DEAD || !is_servant_of_ratvar(LT) || LT == ranged_ability_user || !(LT in view(7, get_turf(ranged_ability_user))) || \
@@ -310,6 +316,8 @@
 		return TRUE
 
 	if(target in view(7, get_turf(ranged_ability_user)))
+		successful = TRUE
+
 		clockwork_say(ranged_ability_user, text2ratvar("Kneel, heathens!"))
 		ranged_ability_user.visible_message("<span class='warning'>[ranged_ability_user]'s eyes fire a stream of energy at [target], creating a strange mark!</span>", \
 		"<span class='heavy_brass'>You direct the judicial force to [target].</span>")

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -52,6 +52,7 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 /datum/clockwork_scripture/proc/creation_update() //updates any on-creation effects
 
 /datum/clockwork_scripture/proc/run_scripture()
+	var/successful = FALSE
 	if(can_recite() && has_requirements())
 		if(slab.busy)
 			invoker << "<span class='warning'>[slab] refuses to work, displaying the message: \"[slab.busy]!\"</span>"
@@ -82,12 +83,14 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 				if(used_cache_components[i])
 					clockwork_component_cache[i] += consumed_components[i]
 			update_slab_info()
-		else if(slab && !slab.no_cost && !ratvar_awakens) //if the slab exists and isn't debug and ratvar isn't up, log the scripture as being used
-			feedback_add_details("clockcult_scripture_recited", name)
+		else
+			successful = TRUE
+			if(slab && !slab.no_cost && !ratvar_awakens) //if the slab exists and isn't debug and ratvar isn't up, log the scripture as being used
+				feedback_add_details("clockcult_scripture_recited", name)
 	if(slab)
 		slab.busy = null
 	qdel(src)
-	return TRUE
+	return successful
 
 /datum/clockwork_scripture/proc/can_recite() //If the words can be spoken
 	if(!invoker || !slab || invoker.get_active_held_item() != slab)
@@ -263,6 +266,7 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 	var/ranged_type = /obj/effect/proc_holder/slab
 	var/ranged_message = "This is a huge goddamn bug, how'd you cast this?"
 	var/timeout_time = 0
+	var/allow_mobility = TRUE //if moving and swapping hands is allowed during the while
 	var/datum/progressbar/progbar
 
 /datum/clockwork_scripture/ranged_ability/Destroy()
@@ -279,17 +283,21 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 	var/successful = FALSE
 	if(timeout_time)
 		progbar = new(invoker, timeout_time, slab)
-	while(slab && slab.slab_ability && !slab.slab_ability.finished && (slab.slab_ability.in_progress || !timeout_time || world.time <= end_time))
-		successful = slab.slab_ability.successful
+	var/turf/T = get_turf(invoker)
+	while(slab && slab.slab_ability && !slab.slab_ability.finished && (slab.slab_ability.in_progress || !timeout_time || world.time <= end_time) && \
+		(allow_mobility || (can_recite() && T == get_turf(invoker))))
 		if(progbar)
 			if(slab.slab_ability.in_progress)
 				qdel(progbar)
 			else
 				progbar.update(end_time - world.time)
 		sleep(1)
+	successful = slab.slab_ability.successful
 	if(slab)
-		if(slab.slab_ability && !slab.slab_ability.finished)
-			slab.slab_ability.remove_ranged_ability()
+		if(slab.slab_ability)
+			successful = slab.slab_ability.successful
+			if(!slab.slab_ability.finished)
+				slab.slab_ability.remove_ranged_ability()
 		slab.icon_state = "dread_ipad"
 		if(invoker)
 			invoker.update_inv_hands()

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -292,7 +292,6 @@ Judgement: 12 servants, 5 caches, 300 CV, and any existing AIs are converted or 
 			else
 				progbar.update(end_time - world.time)
 		sleep(1)
-	successful = slab.slab_ability.successful
 	if(slab)
 		if(slab.slab_ability)
 			successful = slab.slab_ability.successful


### PR DESCRIPTION
The fixes from #22897!

Three bugs fixed here:
1. A few scriptures didn't actually set themselves as successful on doing stuff.
2. Even for scriptures that DID, it'd exit out of the loop that set if it was successful before managing to set it, meaning none of them were considered successful ever.
3. run_scripture() always returned TRUE, even for failed scripture recital, meaning anything relying on it returning FALSE for anything would be very disappointed.