### PR TITLE
Fixes accelerator cannon projectile resizing

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -97,7 +97,7 @@
 /obj/item/projectile/beam/laser/accelerator/Range()
 	..()
 	damage += 7
-	transform *= TransformUsingVariable(20 , 100, 1)
+	transform *= 1 + ((damage/7) * 0.2)//20% larger per tile
 
 /obj/item/weapon/gun/energy/xray
 	name = "xray laser gun"


### PR DESCRIPTION
:cl: XDTM
fix: Accelerator laser cannons' projectile now properly grows with distance.
/:cl:

Fixes #18645.
