### PR TITLE
Fixes pyroclastic anomaly slime colour

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -266,8 +266,8 @@
 	if(istype(T))
 		T.atmos_spawn_air("o2=500;plasma=500;TEMP=1000") //Make it hot and burny for the new slime
 
-	var/mob/living/simple_animal/slime/S = new/mob/living/simple_animal/slime(T)
-	S.colour = pick("red", "orange")
+	var/new_colour = pick("red", "orange")
+	var/mob/living/simple_animal/slime/S = new(T, new_colour)
 	S.rabid = 1
 
 /////////////////////


### PR DESCRIPTION
The pyro anomaly was setting the color of the slime incorrectly, meaning
it had a red or orange color but had the wrong name (and probably core
type).