### PR TITLE
Dead things stop hallucinating

### DIFF
--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -1,6 +1,12 @@
 /mob/living/carbon/death(gibbed)
+	if(stat == DEAD)
+		return
+
 	silent = 0
 	losebreath = 0
+	
+	if(!gibbed)
+		emote("deathgasp")
 	handling_hal = 1
 	halimage.qdel()
 	halbody.qdel()
@@ -8,6 +14,8 @@
 	hal_screwyhud = 0
 	..()
 	handling_hal = 0
+	if(ticker && ticker.mode)
+		ticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 
 /mob/living/carbon/gib(no_brain, no_organs, no_bodyparts)
 	for(var/mob/M in src)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -1,7 +1,13 @@
 /mob/living/carbon/death(gibbed)
 	silent = 0
 	losebreath = 0
+	handling_hal = 1
+	halimage.qdel()
+	halbody.qdel()
+	halitem.qdel()
+	hal_screwyhud = 0
 	..()
+	handling_hal = 0
 
 /mob/living/carbon/gib(no_brain, no_organs, no_bodyparts)
 	for(var/mob/M in src)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -63,6 +63,7 @@
 	paralysis = 0
 	stunned = 0
 	weakened = 0
+	hallucination = 0
 	set_drugginess(0)
 	SetSleeping(0, 0)
 	blind_eyes(1)


### PR DESCRIPTION
:cl: 
fix: living things now stop hallucinating when dead.
/:cl:

Mr. Bones wild ride around the super-matter can't hurt you anymore.

Fun fact: all Living can hallucinate but only carbons suffer!

Fixes #22777

![GET IN!](http://gamingillustrated.com/wp-content/uploads/2015/10/Mr.-Bones.jpg)