### PR TITLE
Fixes floors flashing red after doomsday stops

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -10,7 +10,6 @@ var/global/list/teleportbeacons = list()			//list of all tracking beacons used b
 var/global/list/deliverybeacons = list()			//list of all MULEbot delivery beacons.
 var/global/list/deliverybeacontags = list()			//list of all tags associated with delivery beacons.
 var/global/list/nuke_list = list()
-var/global/list/nuke_tiles = list()					//list of all turfs that turn to animated red grids when a nuke is triggered
 var/global/list/alarmdisplay = list()				//list of all machines or programs that can display station alerts
 
 var/global/list/chemical_reactions_list				//list of all /datum/chemical_reaction datums. Used during chemical reactions

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -6,6 +6,9 @@ var/datum/subsystem/mapping/SSmapping
 	flags = SS_NO_FIRE
 	display_order = 50
 
+	var/list/nuke_tiles = list()
+	var/list/nuke_threats = list()
+
 
 /datum/subsystem/mapping/New()
 	NEW_SS_GLOBAL(SSmapping)
@@ -39,6 +42,29 @@ var/datum/subsystem/mapping/SSmapping
 	// Set up Z-level transistions.
 	setup_map_transitions()
 	..()
+
+/* Nuke threats, for making the blue tiles on the station go RED
+   Used by the AI doomsday and the self destruct nuke.
+*/
+
+/datum/subsystem/mapping/proc/add_nuke_threat(datum/nuke)
+	nuke_threats[nuke] = TRUE
+	check_nuke_threats()
+
+/datum/subsystem/mapping/proc/remove_nuke_threat(datum/nuke)
+	nuke_threats -= nuke
+	check_nuke_threats()
+
+/datum/subsystem/mapping/proc/check_nuke_threats()
+	for(var/datum/d in nuke_threats)
+		if(!istype(d) || qdeleted(d))
+			nuke_threats -= d
+
+	var/threats = nuke_threats.len
+
+	for(var/N in nuke_tiles)
+		var/turf/open/floor/T = N
+		T.icon_state = (threats ? "rcircuitanim" : T.icon_regular_floor)
 
 /datum/subsystem/mapping/Recover()
 	flags |= SS_NO_INIT

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -28,10 +28,6 @@
 	set category = "Malfunction"
 	set name = "Doomsday Device"
 
-	for(var/N in nuke_tiles)
-		var/turf/T = N
-		T.icon_state = "rcircuitanim" //This causes all blue "circuit" tiles on the map to change to animated red icon state.
-
 	src << "<span class='notice'>Nuclear device armed.</span>"
 	priority_announce("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", "Anomaly Alert", 'sound/AI/aimalf.ogg')
 	set_security_level("delta")
@@ -67,6 +63,7 @@
 		countdown = null
 	STOP_PROCESSING(SSfastprocess, src)
 	SSshuttle.clearHostileEnvironment(src)
+	SSmapping.remove_nuke_threat(src)
 	for(var/A in ai_list)
 		var/mob/living/silicon/ai/Mlf = A
 		if(Mlf.doomsday_device == src)
@@ -79,6 +76,7 @@
 	countdown.start()
 	START_PROCESSING(SSfastprocess, src)
 	SSshuttle.registerHostileEnvironment(src)
+	SSmapping.add_nuke_threat(src) //This causes all blue "circuit" tiles on the map to change to animated red icon state.
 
 /obj/machinery/doomsday_device/proc/seconds_remaining()
 	. = max(0, (round((detonation_timer - world.time) / 10)))
@@ -96,7 +94,6 @@
 	if(sec_left <= 0)
 		timing = FALSE
 		detonate(T.z)
-		qdel(src)
 	else
 		var/key = num2text(sec_left)
 		if(!(sec_left % 60) && !(key in milestones))
@@ -114,7 +111,7 @@
 			continue
 		if(issilicon(L))
 			continue
-		L << "<span class='danger'><B>The blast wave from the [src] tears you atom from atom!</B></span>"
+		L << "<span class='userdanger'>The blast wave from [src] tears you atom from atom!</span>"
 		L.dust()
 	world << "<B>The AI cleansed the station of life with the doomsday device!</B>"
 	ticker.force_ending = 1

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -465,22 +465,22 @@ var/bomb_set
 This is here to make the tiles around the station mininuke change when it's armed.
 */
 
-/obj/machinery/nuclearbomb/selfdestruct/proc/SetTurfs()
-	if(loc == initial(loc))
-		for(var/N in nuke_tiles)
-			var/turf/open/floor/T = N
-			T.icon_state = (timing ? "rcircuitanim" : T.icon_regular_floor)
-
 /obj/machinery/nuclearbomb/selfdestruct/set_anchor()
 	return
 
 /obj/machinery/nuclearbomb/selfdestruct/set_active()
 	..()
-	SetTurfs()
+	if(timing)
+		SSmapping.add_nuke_threat(src)
+	else
+		SSmapping.remove_nuke_threat(src)
 
 /obj/machinery/nuclearbomb/selfdestruct/set_safety()
 	..()
-	SetTurfs()
+	if(timing)
+		SSmapping.add_nuke_threat(src)
+	else
+		SSmapping.remove_nuke_threat(src)
 
 //==========DAT FUKKEN DISK===============
 /obj/item/weapon/disk

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -15,10 +15,10 @@
 
 /turf/open/floor/bluegrid/New()
 	..()
-	nuke_tiles += src
+	SSmapping.nuke_tiles += src
 
 /turf/open/floor/bluegrid/Destroy()
-	nuke_tiles -= src
+	SSmapping.nuke_tiles -= src
 	return ..()
 
 /turf/open/floor/greengrid


### PR DESCRIPTION
:cl: coiax
bugfix: Blue circuit floors are now restored to their normal colour if
an AI doomsday device is disabled.
/:cl:

Put a nuke tracker on SSmapping, because we need a tiny bit of state to
track this, in case you have two concurrent things running.