### PR TITLE
Fixed colourful morphs

### DIFF
--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -121,6 +121,7 @@
 	morphed = 0
 	form = null
 	alpha = initial(alpha)
+	color = initial(color)
 
 	visible_message("<span class='warning'>[src] suddenly collapses in on itself, dissolving into a pile of green flesh!</span>", \
 					"<span class='notice'>You reform to your normal body.</span>")


### PR DESCRIPTION
:cl: Thunder12345
fix: Morphs will no longer retain the colour of the last thing mimicked when reverting to their true form
/:cl:

Fixes #22973 
