### PR TITLE
Fixes a division by zero runtime

### DIFF
--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -32,9 +32,10 @@
 			"gases" = list()
 		)
 		var/total_moles = air_sample.total_moles()
-		for(var/gas_id in air_sample.gases)
-			var/gas_name = air_sample.gases[gas_id][GAS_META][META_GAS_NAME]
-			signal.data["gases"][gas_name] = air_sample.gases[gas_id][MOLES] / total_moles * 100
+		if(total_moles)
+			for(var/gas_id in air_sample.gases)
+				var/gas_name = air_sample.gases[gas_id][GAS_META][META_GAS_NAME]
+				signal.data["gases"][gas_name] = air_sample.gases[gas_id][MOLES] / total_moles * 100
 
 		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 


### PR DESCRIPTION
```
The following runtime has occurred 77 time(s).
runtime error: Division by zero
proc name: process atmos (/obj/machinery/air_sensor/process_atmos)
  source file: atmos_control.dm,37
  usr: null
  src: the gas sensor (/obj/machinery/air_sensor)
  src.loc: the plating (139,100,1) (/turf/open/floor/plating)
```