### PR TITLE
Fixes an imaginary number

### DIFF
--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -51,7 +51,7 @@ Bonus
 	return 1
 
 /datum/symptom/fire/proc/Firestacks_stage_5(mob/living/M, datum/disease/advance/A)
-	var/get_stacks = (sqrt(20+A.totalStageSpeed()*3))-(sqrt(16+A.totalStealth()))
+	var/get_stacks = (sqrt(max(0, 20+A.totalStageSpeed()*3)))-(sqrt(max(0, 16+A.totalStealth())))
 	M.adjust_fire_stacks(get_stacks)
 	M.adjustFireLoss(get_stacks)
 	return 1


### PR DESCRIPTION
```
The following runtime has occurred 14 time(s).
runtime error: illegal: sqrt(-1.000000)
proc name: Firestacks stage 5 (/datum/symptom/fire/proc/Firestacks_stage_5)
  source file: fire.dm,54
  usr: null
  src: Spontaneous Combustion (/datum/symptom/fire)
```