### PR TITLE
Fixes portable chem dispensers unwrenching

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -281,7 +281,6 @@
 	dispensable_reagents = sortList(dispensable_reagents)
 
 /obj/machinery/chem_dispenser/constructable/attackby(obj/item/I, mob/user, params)
-	..()
 	if(default_deconstruction_screwdriver(user, "minidispenser-o", "minidispenser", I))
 		return
 


### PR DESCRIPTION
:cl: XDTM
fix: Wrenching portable chem dispensers won't cause you to immediately try unwrenching them.
/:cl:

Fixes #22302.