### PR TITLE
PDA can update their name when an agent id is inside

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -338,6 +338,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				id_check(U)
 			if("UpdateInfo")
 				ownjob = id.assignment
+				if(istype(id, /obj/item/weapon/card/id/syndicate))
+					owner = id.registered_name
 				update_label()
 			if("Eject")//Ejects the cart, only done from hub.
 				if (!isnull(cartridge))


### PR DESCRIPTION
:cl: XDTM
tweak: Updating your PDA info with an agent id card inside will also overwrite the previous name.
/:cl:

This is sorely needed for chameleon PDAs in particular, since right now they lock into a name that can't be changed, making it useless for chameleoning purposes.

Disclaimer: name is only updated manually, it won't give away anyone by itself.
