### PR TITLE
Bio bags won't hit the xenobio console when loading it.

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -79,6 +79,7 @@
 				qdel(G)
 		if (loaded)
 			user << "<span class='notice'>You fill [src] with the monkey cubes stored in [O]. [src] now has [monkeys] monkey cubes stored.</span>"
+		return
 	..()
 
 /datum/action/innate/camera_off/xenobio/Activate()


### PR DESCRIPTION
:cl: XDTM
fix: Loading a xenobiology console with a bio bag won't cause you to smack it with it.
/:cl:
