### PR TITLE
Fixes swarmers causing breaches with shuttles

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -329,7 +329,7 @@
 
 /turf/closed/wall/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	for(var/turf/T in range(1, src))
-		if(isspaceturf(T) || istype(T.loc, /area/space))
+		if(isspaceturf(T) || istype(T.loc, /area/space) || istype(T, /turf/closed/wall/shuttle))
 			S << "<span class='warning'>Destroying this object has the potential to cause a hull breach. Aborting.</span>"
 			S.target = null
 			return TRUE


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/22834

🆑
fix: Swarmers can no longer eat walls that are adjacent to shuttle walls, as this would cause a breach once the shuttle departed.
/:cl: