### PR TITLE
 Tweaks Flash Burnt Out Message So It Is Bigger

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -48,8 +48,14 @@
 		crit_fail = 1
 		update_icon()
 		var/turf/T = get_turf(src)
+		var/mob/living/L = loc
 		if(T)
 			T.visible_message("[src] burns out!")
+		if(loc)
+			return
+
+		if(loc)
+			L << "<span class='userdanger'>[src] burns out!</span>"
 
 
 /obj/item/device/assembly/flash/proc/flash_recharge(interval=10)


### PR DESCRIPTION
## **Flash Tweak**
Makes "Flash burnt out" message bigger so that during combat it is now more obvious to the user that the flash has been burnt out when fighting as there is a lot of chat spam and it can be easily missed at the moment.


:cl: 
Tweak: Added span class='userdanger' to "Flash burnt out" message to make message bigger.
:cl:


### **Fixes #22963**
