### PR TITLE
Makes chem splash based on distance

### DIFF
--- a/code/modules/reagents/chem_splash.dm
+++ b/code/modules/reagents/chem_splash.dm
@@ -46,25 +46,30 @@
 					turflist.Remove(T)
 					turflist.Add(T) // we move the purely diagonal turfs to the end of the list.
 			for(var/turf/T in turflist)
-				if(accessible[T]) continue
+				if(accessible[T])
+					continue
 				for(var/thing in T.GetAtmosAdjacentTurfs(alldir = TRUE))
 					var/turf/NT = thing
-					if(!(NT in accessible)) continue
-					if(!(get_dir(T,NT) in cardinal)) continue
+					if(!(NT in accessible))
+						continue
+					if(!(get_dir(T,NT) in cardinal))
+						continue
 					accessible[T] = 1
 					break
 		var/list/reactable = accessible
 		for(var/turf/T in accessible)
 			for(var/atom/A in T.GetAllContents())
-				if(!(A in viewable)) continue
+				if(!(A in viewable))
+					continue
 				reactable |= A
 			if(extra_heat >= 300)
 				T.hotspot_expose(extra_heat*2, 5)
 		if(!reactable.len) //Nothing to react with. Probably means we're in nullspace.
 			return
-		var/fraction = 0.5/accessible.len // In a 100u mix. A small grenade spreads ~1.5u units per affected tile. A large grenade spreads ~0.75u, and a bomb spreads ~0.4u
 		for(var/thing in reactable)
 			var/atom/A = thing
+			var/distance = max(1,get_dist(A, epicenter))
+			var/fraction = 0.5/(2 ** distance) //50/25/12/6... for a 200u splash, 25/12/6/3... for a 100u, 12/6/3/1 for a 50u
 			splash_holder.reaction(A, TOUCH, fraction)
 
 	qdel(splash_holder)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -109,11 +109,12 @@
  */
 
 /datum/reagent/water/reaction_turf(turf/open/T, reac_volume)
-	if (!istype(T)) return
+	if (!istype(T))
+		return
 	var/CT = cooling_temperature
 
 	if(reac_volume >= 5)
-		T.MakeSlippery(min_wet_time = 10, wet_time_to_add = reac_volume*1.5)
+		T.MakeSlippery(min_wet_time = 10, wet_time_to_add = min(reac_volume*1.5, 60))
 
 	for(var/mob/living/simple_animal/slime/M in T)
 		M.apply_water()
@@ -259,9 +260,10 @@
 	color = "#009CA8" // rgb: 0, 156, 168
 
 /datum/reagent/lube/reaction_turf(turf/open/T, reac_volume)
-	if (!istype(T)) return
+	if (!istype(T))
+		return
 	if(reac_volume >= 1)
-		T.MakeSlippery(wet_setting=TURF_WET_LUBE, min_wet_time=15, wet_time_to_add=reac_volume*2)
+		T.MakeSlippery(wet_setting=TURF_WET_LUBE, min_wet_time=15, min(wet_time_to_add=reac_volume*2, 120))
 
 /datum/reagent/spraytan
 	name = "Spray Tan"


### PR DESCRIPTION
:cl: XDTM
tweak: Chemical splashing is now based on distance rather than affected tiles.
fix: You can now properly wet floors by putting enough water in a grenade.
/:cl:

Fixes #19157.

Added a maximum wet time to water and lube's reaction_turf, since they are currently only balanced for small size reactions (1u = 1 second, lube multiplies amount by 2). They might have to be even lower, but for now i set it as 1 minute max (per reaction) for water, and two minutes for lube.
