### PR TITLE
Makes "Flash burnt out!" Message Bigger

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -47,13 +47,12 @@
 	if(!crit_fail)
 		crit_fail = 1
 		update_icon()
+	if(ismob(loc))
+		var/mob/M = loc
+		M.visible_message("<span class='danger'>[src] burns out!</span>","<span class='userdanger'>[src] burns out!</span>")
+	else
 		var/turf/T = get_turf(src)
-		if(T)
-			T.visible_message("[src] burns out!")
-
-		var/mob/living/L = loc
-		if(loc)
-			L << "<span class='userdanger'>[src] burns out!</span>"
+		T.visible_message("<span class='danger'>[src] burns out!</span>")
 
 
 /obj/item/device/assembly/flash/proc/flash_recharge(interval=10)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -51,6 +51,10 @@
 		if(T)
 			T.visible_message("[src] burns out!")
 
+		var/mob/living/L = loc
+		if(loc)
+			L << "<span class='userdanger'>[src] burns out!</span>"
+
 
 /obj/item/device/assembly/flash/proc/flash_recharge(interval=10)
 	if(prob(times_used * 3)) //The more often it's used in a short span of time the more likely it will burn out


### PR DESCRIPTION
Makes "Flash burnt out" message bigger so that during combat it is now more obvious to the user that the flash has been burnt out when fighting.

I am also very new to coding for TG station and coding in general so any suggestions on how i should do anything are very welcome.

:cl:
Tweak: tweaked a few things
:cl:

Fixes #22963

Sorry i had to close the previous PR and open this one, i broke my branch when i tried to overwrite the commit i made.