### PR TITLE
Mousetrap will kill mice again, mousetraps description is a bit clearer

### DIFF
--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -9,7 +9,6 @@
 
 
 /obj/item/device/assembly/mousetrap/examine(mob/user)
-	..()
 	if(armed)
 		user << "It looks like it's armed."
 
@@ -113,6 +112,8 @@
 						triggered(H)
 						H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
 										  "<span class='warning'>You accidentally step on [src]</span>")
+				else if(ismouse(MM))
+					triggered(MM)
 		else if(AM.density) // For mousetrap grenades, set off by anything heavy
 			triggered(AM)
 	..()

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -9,8 +9,11 @@
 
 
 /obj/item/device/assembly/mousetrap/examine(mob/user)
+	..()
 	if(armed)
-		user << "It looks like it's armed."
+		user << "The mousetrap is armed!"
+	else
+		user << "The mousetrap is not armed."
 
 /obj/item/device/assembly/mousetrap/activate()
 	if(..())


### PR DESCRIPTION
[it was kevinz000](https://github.com/tgstation/tgstation/commit/87dbd658118c0ce28cd42b16818fd2fef708e8f0#diff-906844658a489c41bd3b43397ad21e47)

Also I removed the "is secured and ready to be used" message from the mousetraps description because it dosen't really apply in the case of the mosuetrap and is somewhat confusing with respect to the `armed` state of the trap.

fixes #23020