### PR TITLE
Moving won't drain hunger when the mob has no gravity

### DIFF
--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -54,7 +54,7 @@ var/const/SLIDE_ICE = 8
 
 /mob/living/carbon/Move(NewLoc, direct)
 	. = ..()
-	if(.)
+	if(. && mob_has_gravity()) //floating is easy
 		if(dna && dna.species && (NOHUNGER in dna.species.species_traits))
 			nutrition = NUTRITION_LEVEL_FED - 1	//just less than feeling vigorous
 		else if(nutrition && stat != DEAD)


### PR DESCRIPTION
:cl: XDTM
fix: Floating without gravity won't drain hunger.
/:cl:

Fixes #23030.

Won't cover flightsuits on station, i think, but otherwise it should get rid of most cases of senseless starvation.