### PR TITLE
Using a welder to repair a mining drone now follows standard behaviour

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -180,6 +180,7 @@
 		if("Mining Drone")
 			new /mob/living/simple_animal/hostile/mining_drone(src.loc)
 			new /obj/item/weapon/weldingtool/hugetank(src.loc)
+			new /obj/item/clothing/glasses/welding(src.loc)
 		if("Extraction and Rescue Kit")
 			new /obj/item/weapon/extraction_pack(loc)
 			new /obj/item/fulton_core(loc)

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -75,7 +75,7 @@
 			if(maxHealth == health)
 				user << "<span class='info'>[src] is at full integrity.</span>"
 			else
-				if(W.remove_fuel(1, user))
+				if(W.remove_fuel(0, user))
 					adjustBruteLoss(-10)
 					user << "<span class='info'>You repair some of the armor on [src].</span>"
 			return

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -75,8 +75,9 @@
 			if(maxHealth == health)
 				user << "<span class='info'>[src] is at full integrity.</span>"
 			else
-				adjustBruteLoss(-10)
-				user << "<span class='info'>You repair some of the armor on [src].</span>"
+				if(W.remove_fuel(1, user))
+					adjustBruteLoss(-10)
+					user << "<span class='info'>You repair some of the armor on [src].</span>"
 			return
 	if(istype(I, /obj/item/device/mining_scanner) || istype(I, /obj/item/device/t_scanner/adv_mining_scanner))
 		user << "<span class='info'>You instruct [src] to drop any collected ore.</span>"


### PR DESCRIPTION
:cl: Mervill
fix: Using a welder to repair a mining drone now follows standard behaviour
fix: Redeeming the mining voucher for a mining drone now also provides welding goggles
/:cl:

Note that this also fixes an undiscovered bug where _repairing the mining drone was free_.

fixes #23019