### PR TITLE
You can now pull things past the Ark

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -164,7 +164,7 @@
 			var/turf/T = t
 			T.ChangeTurf(/turf/open/floor/clockwork)
 	for(var/obj/O in orange(1, src))
-		if(!istype(O, /obj/effect) && O.density)
+		if(!O.pulledby && !istype(O, /obj/effect) && O.density)
 			if(!step_away(O, src, 2) || get_dist(O, src) < 2)
 				O.take_damage(50, BURN, "bomb")
 			O.update_icon()


### PR DESCRIPTION
:cl: Joan
add: You can now pull objects past the Ark of the Clockwork Justicar without them being moved and or destroyed by its power.
/:cl:

edict: avoid_clunky