### PR TITLE
Prevents Raw Telecrystals from appearing in the Traitor purchase log

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -103,7 +103,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	else
 		// Don't add /obj/item/stack/telecrystal to the purchase_log since
 		// it's just used to buy more items (including itself!)
-		if(!istype(src, /obj/item/stack/telecrystal))
+		if(!istype(src, /datum/uplink_item/device_tools/telecrystal))
 			U.purchase_log += "<big>\icon[A]</big>"
 
 	if(limited_stock > 0)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -101,7 +101,10 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 		for(var/obj/item/I in B)
 			U.purchase_log += "<big>\icon[I]</big>"
 	else
-		U.purchase_log += "<big>\icon[A]</big>"
+		// Don't add /obj/item/stack/telecrystal to the purchase_log since
+		// it's just used to buy more items (including itself!)
+		if(!istype(src, /obj/item/stack/telecrystal))
+			U.purchase_log += "<big>\icon[A]</big>"
 
 	if(limited_stock > 0)
 		limited_stock -= 1

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -77,6 +77,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	var/list/include_modes = list() // Game modes to allow this item in.
 	var/list/exclude_modes = list() // Game modes to disallow this item from.
 	var/player_minimum //The minimum crew size needed for this item to be added to uplinks.
+	var/purchase_log_vis = TRUE // Visible in the purchase log?
 
 /datum/uplink_item/proc/spawn_item(turf/loc, obj/item/device/uplink/U)
 	if(item)
@@ -101,9 +102,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 		for(var/obj/item/I in B)
 			U.purchase_log += "<big>\icon[I]</big>"
 	else
-		// Don't add /obj/item/stack/telecrystal to the purchase_log since
-		// it's just used to buy more items (including itself!)
-		if(!istype(src, /datum/uplink_item/device_tools/telecrystal))
+		if(purchase_log_vis)
 			U.purchase_log += "<big>\icon[A]</big>"
 
 	if(limited_stock > 0)
@@ -1039,6 +1038,9 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/stack/telecrystal
 	cost = 1
 	surplus = 0
+	// Don't add telecrystals to the purchase_log since
+	// it's just used to buy more items (including itself!)
+	purchase_log_vis = FALSE
 
 // Implants
 /datum/uplink_item/implants


### PR DESCRIPTION
:cl: Mervill
fix: Raw Telecrystals won't appear in the Traitor's purchase log at the end of the round
/:cl:

fixes #22628