### PR TITLE
Sigils of Transmission can be accessed by clockwork structures in a larger range

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -90,5 +90,6 @@ var/global/list/all_scripture = list() //a list containing scripture instances; 
 #define CLOCKCULT_SILICONS "silicons"
 
 //misc clockcult stuff
-
 #define MARAUDER_EMERGE_THRESHOLD 65 //marauders cannot emerge unless host is at this% or less health
+
+#define SIGIL_ACCESS_RANGE 2 //range at which transmission sigils can access power

--- a/code/game/gamemodes/clock_cult/clock_structure.dm
+++ b/code/game/gamemodes/clock_cult/clock_structure.dm
@@ -132,7 +132,9 @@
 	..()
 	if(is_servant_of_ratvar(user) || isobserver(user))
 		var/powered = total_accessable_power()
-		user << "<span class='[powered ? "brass":"alloy"]'>It has access to <b>[powered == INFINITY ? "INFINITY":"[powered]"]W</b> of power.</span>"
+		var/sigil_number = LAZYLEN(check_apc_and_sigils())
+		user << "<span class='[powered ? "brass":"alloy"]'>It has access to <b>[powered == INFINITY ? "INFINITY":"[powered]"]W</b> of power, \
+		and <b>[sigil_number]</b> Sigil[sigil_number == 1 ? "s":""] of Transmission [sigil_number == 1 ? "is":"are"] in range.</span>"
 
 /obj/structure/destructible/clockwork/powered/Destroy()
 	SSfastprocess.processing -= src
@@ -213,7 +215,7 @@
 
 /obj/structure/destructible/clockwork/powered/proc/accessable_sigil_power()
 	var/power = 0
-	for(var/obj/effect/clockwork/sigil/transmission/T in range(1, src))
+	for(var/obj/effect/clockwork/sigil/transmission/T in range(SIGIL_ACCESS_RANGE, src))
 		power += T.power_charge
 	return power
 
@@ -231,8 +233,8 @@
 /obj/structure/destructible/clockwork/powered/proc/use_power(amount) //we've made sure we had power, so now we use it
 	var/sigilpower = accessable_sigil_power()
 	var/list/sigils_in_range = list()
-	for(var/obj/effect/clockwork/sigil/transmission/T in range(1, src))
-		sigils_in_range |= T
+	for(var/obj/effect/clockwork/sigil/transmission/T in range(SIGIL_ACCESS_RANGE, src))
+		sigils_in_range += T
 	while(sigilpower && amount >= MIN_CLOCKCULT_POWER)
 		for(var/S in sigils_in_range)
 			var/obj/effect/clockwork/sigil/transmission/T = S
@@ -278,8 +280,8 @@
 
 /obj/structure/destructible/clockwork/powered/proc/check_apc_and_sigils() //checks for sigils and an APC, returning FALSE if it finds neither, and a list of sigils otherwise
 	. = list()
-	for(var/obj/effect/clockwork/sigil/transmission/T in range(1, src))
-		. |= T
+	for(var/obj/effect/clockwork/sigil/transmission/T in range(SIGIL_ACCESS_RANGE, src))
+		. += T
 	var/list/L = .
 	if(!L.len && (!target_apc || !target_apc.cell))
 		return FALSE

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -53,7 +53,7 @@
 		if(POWER_REQ_ALL)
 			return !T || !A || ((!A.master.power_equip || isspaceturf(T)) && !is_type_in_list(loc, list(/obj/item, /obj/mecha)))
 		if(POWER_REQ_CLOCKCULT)
-			for(var/obj/effect/clockwork/sigil/transmission/ST in range(src, 1))
+			for(var/obj/effect/clockwork/sigil/transmission/ST in range(src, SIGIL_ACCESS_RANGE))
 				return FALSE
 			return !T || !A || (!istype(T, /turf/open/floor/clockwork) && (!A.master.power_equip || isspaceturf(T)) && !is_type_in_list(loc, list(/obj/item, /obj/mecha)))
 


### PR DESCRIPTION
:cl: Joan
rscadd: Sigils of Transmission can be accessed by clockwork structures in a larger range.
tweak: You can see, when examining a clockwork structure, how many sigils are in range of it.
/:cl:

A buff, but not much of one? Usability is probably better than straight buffs anyway.