### PR TITLE
Fixes chameleon PDAs not being able to morph into assistant PDAs.

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -67,6 +67,12 @@
 		return 0
 	return L[A.type]
 
+/proc/is_path_in_typecache(A, list/L)
+	if(!L || !L.len || !A)
+
+		return 0
+	return L[A]
+
 //returns a new list with only atoms that are in typecache L
 /proc/typecache_filter_list(list/atoms, list/typecache)
 	. = list()

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -67,12 +67,6 @@
 		return 0
 	return L[A.type]
 
-/proc/is_path_in_typecache(A, list/L)
-	if(!L || !L.len || !A)
-
-		return 0
-	return L[A]
-
 //returns a new list with only atoms that are in typecache L
 /proc/typecache_filter_list(list/atoms, list/typecache)
 	. = list()
@@ -82,9 +76,13 @@
 			. += A
 
 //Like typesof() or subtypesof(), but returns a typecache instead of a list
-/proc/typecacheof(path, ignore_root_path)
+/proc/typecacheof(path, ignore_root_path, only_root_path = FALSE)
 	if(ispath(path))
-		var/list/types = ignore_root_path ? subtypesof(path) : typesof(path)
+		var/list/types = list()
+		if(only_root_path)
+			types = list(path)
+		else
+			types = ignore_root_path ? subtypesof(path) : typesof(path)
 		var/list/L = list()
 		for(var/T in types)
 			L[T] = TRUE
@@ -98,8 +96,11 @@
 					L[T] = TRUE
 		else
 			for(var/P in pathlist)
-				for(var/T in typesof(P))
-					L[T] = TRUE
+				if(only_root_path)
+					L[P] = TRUE
+				else
+					for(var/T in typesof(P))
+						L[T] = TRUE
 		return L
 
 //Empties the list by setting the length to 0. Hopefully the elements get garbage collected

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -69,12 +69,18 @@
 /datum/action/item_action/chameleon/change
 	name = "Chameleon Change"
 	var/list/chameleon_blacklist = list()
-	var/list/chameleon_blacklist_types = list()
+	var/list/chameleon_blacklist_with_subtypes = list()
 	var/list/chameleon_list = list()
 	var/chameleon_type = null
 	var/chameleon_name = "Item"
 
 	var/emp_timer
+
+/datum/action/item_action/chameleon/change/New()
+	..()
+	chameleon_blacklist = typecacheof(chameleon_blacklist)
+	chameleon_blacklist_with_subtypes = typecacheof(chameleon_blacklist_with_subtypes)
+	chameleon_list = typecacheof(chameleon_list)
 
 /datum/action/item_action/chameleon/change/proc/initialize_disguises()
 	if(button)
@@ -82,7 +88,7 @@
 	chameleon_blacklist += target.type
 	var/list/temp_list = typesof(chameleon_type)
 	var/list/black_list = chameleon_blacklist
-	for(var/V in chameleon_blacklist_types)
+	for(var/V in chameleon_blacklist_with_subtypes)
 		black_list += typesof(V)
 	for(var/V in temp_list - black_list)
 		if(ispath(V, /obj/item))
@@ -414,7 +420,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/weapon/gun
 	chameleon_action.chameleon_name = "Gun"
-	chameleon_action.chameleon_blacklist_types = list(/obj/item/weapon/gun/magic)
+	chameleon_action.chameleon_blacklist_with_subtypes = list(/obj/item/weapon/gun/magic)
 	chameleon_action.initialize_disguises()
 
 /obj/item/weapon/gun/energy/laser/chameleon/emp_act(severity)
@@ -458,7 +464,7 @@
 	chameleon_action.chameleon_type = /obj/item/device/pda
 	chameleon_action.chameleon_name = "PDA"
 	chameleon_action.chameleon_blacklist = list(/obj/item/device/pda/heads)
-	chameleon_action.chameleon_blacklist_types = list(/obj/item/device/pda/ai)
+	chameleon_action.chameleon_blacklist_with_subtypes = list(/obj/item/device/pda/ai)
 	chameleon_action.initialize_disguises()
 
 /obj/item/device/pda/chameleon/emp_act(severity)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -69,6 +69,7 @@
 /datum/action/item_action/chameleon/change
 	name = "Chameleon Change"
 	var/list/chameleon_blacklist = list()
+	var/list/chameleon_blacklist_types = list()
 	var/list/chameleon_list = list()
 	var/chameleon_type = null
 	var/chameleon_name = "Item"
@@ -80,7 +81,10 @@
 		button.name = "Change [chameleon_name] Appearance"
 	chameleon_blacklist += target.type
 	var/list/temp_list = typesof(chameleon_type)
-	for(var/V in temp_list - (chameleon_blacklist))
+	var/list/black_list = chameleon_blacklist
+	for(var/V in chameleon_blacklist_types)
+		black_list += typesof(V)
+	for(var/V in temp_list - black_list)
 		if(ispath(V, /obj/item))
 			var/obj/item/I = V
 			if(initial(I.flags) & ABSTRACT)
@@ -410,7 +414,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/weapon/gun
 	chameleon_action.chameleon_name = "Gun"
-	chameleon_action.chameleon_blacklist = typesof(/obj/item/weapon/gun/magic)
+	chameleon_action.chameleon_blacklist_types = list(/obj/item/weapon/gun/magic)
 	chameleon_action.initialize_disguises()
 
 /obj/item/weapon/gun/energy/laser/chameleon/emp_act(severity)
@@ -453,7 +457,8 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/device/pda
 	chameleon_action.chameleon_name = "PDA"
-	chameleon_action.chameleon_blacklist = list(/obj/item/device/pda/ai)
+	chameleon_action.chameleon_blacklist = list(/obj/item/device/pda/heads)
+	chameleon_action.chameleon_blacklist_types = list(/obj/item/device/pda/ai)
 	chameleon_action.initialize_disguises()
 
 /obj/item/device/pda/chameleon/emp_act(severity)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -68,35 +68,25 @@
 
 /datum/action/item_action/chameleon/change
 	name = "Chameleon Change"
-	var/list/chameleon_blacklist = list()
-	var/list/chameleon_blacklist_with_subtypes = list()
+	var/list/chameleon_blacklist = list() //This is a typecache
 	var/list/chameleon_list = list()
 	var/chameleon_type = null
 	var/chameleon_name = "Item"
 
 	var/emp_timer
 
-/datum/action/item_action/chameleon/change/New()
-	..()
-	chameleon_blacklist = typecacheof(chameleon_blacklist)
-	chameleon_blacklist_with_subtypes = typecacheof(chameleon_blacklist_with_subtypes)
-	chameleon_list = typecacheof(chameleon_list)
-
 /datum/action/item_action/chameleon/change/proc/initialize_disguises()
 	if(button)
 		button.name = "Change [chameleon_name] Appearance"
-	chameleon_blacklist += target.type
-	var/list/temp_list = typesof(chameleon_type)
-	var/list/black_list = chameleon_blacklist
-	for(var/V in chameleon_blacklist_with_subtypes)
-		black_list += typesof(V)
-	for(var/V in temp_list - black_list)
+
+
+	chameleon_blacklist |= typecacheof(target.type)
+	for(var/V in typesof(chameleon_type))
 		if(ispath(V, /obj/item))
 			var/obj/item/I = V
-			if(initial(I.flags) & ABSTRACT)
+			if(is_path_in_typecache(I, chameleon_blacklist) || (initial(I.flags) & ABSTRACT))
 				continue
-			else
-				chameleon_list += I
+			chameleon_list += I
 
 /datum/action/item_action/chameleon/change/proc/select_look(mob/user)
 	var/list/item_names = list()
@@ -420,7 +410,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/weapon/gun
 	chameleon_action.chameleon_name = "Gun"
-	chameleon_action.chameleon_blacklist_with_subtypes = list(/obj/item/weapon/gun/magic)
+	chameleon_action.chameleon_blacklist = typecacheof(typesof(/obj/item/weapon/gun/magic))
 	chameleon_action.initialize_disguises()
 
 /obj/item/weapon/gun/energy/laser/chameleon/emp_act(severity)
@@ -463,9 +453,8 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/device/pda
 	chameleon_action.chameleon_name = "PDA"
-	chameleon_action.chameleon_blacklist = list(/obj/item/device/pda/heads)
-	chameleon_action.chameleon_blacklist_with_subtypes = list(/obj/item/device/pda/ai)
-	chameleon_action.initialize_disguises()
+	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/device/pda/heads, /obj/item/device/pda/ai, /obj/item/device/pda/ai/pai))
+
 
 /obj/item/device/pda/chameleon/emp_act(severity)
 	chameleon_action.emp_randomise()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -214,7 +214,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/under
 	chameleon_action.chameleon_name = "Jumpsuit"
-	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/under, /obj/item/clothing/under/color, /obj/item/clothing/under/rank), only_root_path = TRUE)
+	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/under, /obj/item/clothing/under/color, /obj/item/clothing/under/rank, /obj/item/clothing/under/changeling), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/under/chameleon/emp_act(severity)
@@ -237,7 +237,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/suit
 	chameleon_action.chameleon_name = "Suit"
-	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/suit/armor/abductor, only_root_path = TRUE)
+	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/suit/armor/abductor, /obj/item/clothing/suit/changeling), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/suit/chameleon/emp_act(severity)
@@ -259,6 +259,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/glasses
 	chameleon_action.chameleon_name = "Glasses"
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/glasses/changeling, only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/glasses/chameleon/emp_act(severity)
@@ -280,7 +281,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/gloves
 	chameleon_action.chameleon_name = "Gloves"
-	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/gloves, /obj/item/clothing/gloves/color), only_root_path = TRUE)
+	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/gloves, /obj/item/clothing/gloves/color, /obj/item/clothing/gloves/changeling), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/gloves/chameleon/emp_act(severity)
@@ -302,6 +303,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/head
 	chameleon_action.chameleon_name = "Hat"
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/head/changeling, only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/head/chameleon/emp_act(severity)
@@ -345,6 +347,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/mask
 	chameleon_action.chameleon_name = "Mask"
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/mask/changeling, only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/mask/chameleon/emp_act(severity)
@@ -392,6 +395,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/shoes
 	chameleon_action.chameleon_name = "Shoes"
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/shoes/changeling, only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/shoes/chameleon/emp_act(severity)
@@ -458,7 +462,6 @@
 	chameleon_action.chameleon_name = "PDA"
 	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/device/pda/heads, /obj/item/device/pda/ai, /obj/item/device/pda/ai/pai), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
-
 
 /obj/item/device/pda/chameleon/emp_act(severity)
 	chameleon_action.emp_randomise()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -84,7 +84,7 @@
 	for(var/V in typesof(chameleon_type))
 		if(ispath(V, /obj/item))
 			var/obj/item/I = V
-			if(is_path_in_typecache(I, chameleon_blacklist) || (initial(I.flags) & ABSTRACT))
+			if(chameleon_blacklist[V] || (initial(I.flags) & ABSTRACT))
 				continue
 			chameleon_list += I
 
@@ -214,6 +214,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/under
 	chameleon_action.chameleon_name = "Jumpsuit"
+	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/under, /obj/item/clothing/under/color, /obj/item/clothing/under/rank), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/under/chameleon/emp_act(severity)
@@ -236,6 +237,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/suit
 	chameleon_action.chameleon_name = "Suit"
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/suit/armor/abductor, only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/suit/chameleon/emp_act(severity)
@@ -278,6 +280,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/gloves
 	chameleon_action.chameleon_name = "Gloves"
+	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/gloves, /obj/item/clothing/gloves/color), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/gloves/chameleon/emp_act(severity)
@@ -410,7 +413,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/weapon/gun
 	chameleon_action.chameleon_name = "Gun"
-	chameleon_action.chameleon_blacklist = typecacheof(typesof(/obj/item/weapon/gun/magic))
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/weapon/gun/magic, ignore_root_path = FALSE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/weapon/gun/energy/laser/chameleon/emp_act(severity)
@@ -453,7 +456,8 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/device/pda
 	chameleon_action.chameleon_name = "PDA"
-	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/device/pda/heads, /obj/item/device/pda/ai, /obj/item/device/pda/ai/pai))
+	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/device/pda/heads, /obj/item/device/pda/ai, /obj/item/device/pda/ai/pai), only_root_path = TRUE)
+	chameleon_action.initialize_disguises()
 
 
 /obj/item/device/pda/chameleon/emp_act(severity)


### PR DESCRIPTION
:cl: XDTM
fix: Chameleon PDAs can now morph into assistant PDAs.
fix: A few iconless items have been blacklisted from chameleon clothing.
/:cl:

Fixes #23044
Fixes #22900

The pAI PDA and later, the generic heads PDA were hijacking the name "PDA", hiding the assistant PDA.

I also reworked the list to be a typecache, and since for some reason typecaches automatically grabbed typesof or subtypesof the types you inserted, i added an option not to.
Also added a few iconless items to the blacklists.
