### PR TITLE
Fixes afk tracker

### DIFF
--- a/code/controllers/subsystem/ping.dm
+++ b/code/controllers/subsystem/ping.dm
@@ -20,7 +20,7 @@ var/datum/subsystem/ping/SSping
 	while (length(currentrun))
 		var/client/C = currentrun[currentrun.len]
 		currentrun.len--
-		if (!C || world.time - C.connection_time < PING_BUFFER_TIME)
+		if (!C || world.time - C.connection_time < PING_BUFFER_TIME || C.inactivity >= (wait-1))
 			if (MC_TICK_CHECK)
 				return
 			continue


### PR DESCRIPTION
As a bonus, we only track pings while the client is active.
Fixes #23036