### PR TITLE
Fixes Grammar Issue When Using Xeno Tongue

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -618,7 +618,7 @@
 	name = "alien tongue"
 	desc = "According to leading xenobiologists the evolutionary benefit of having a second mouth in your mouth is \"that it looks badass\"."
 	icon_state = "tonguexeno"
-	say_mod = "hiss"
+	say_mod = "hisses"
 
 /obj/item/organ/tongue/alien/TongueSpeech(var/message)
 	playsound(owner, "hiss", 25, 1, 1)


### PR DESCRIPTION
## **Grammar Issue Fixed**

The current say mod would look something like this Zion Murphy hiss, "Xeno round confirmed" With this change the sentence will look more grammatically correct and follow the grammar standard as set by previous code Zion Murphy hisses, "Xeno round confirmed"

## **Fixes #23041**