### PR TITLE
Ladders give the user a message if they're broken

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -66,6 +66,8 @@
 		go_up(user,is_ghost)
 	else if(down)
 		go_down(user,is_ghost)
+	else
+		user << "<span class='warning'>[src] doesn't seem to lead anywhere!</span>"
 
 	if(!is_ghost)
 		add_fingerprint(user)


### PR DESCRIPTION
Now it's clear when a ladder is just set up incorrectly. Even though
they're super old fashioned and only used for admin memes and whatnot.