### PR TITLE
Makes ash burn in lava again

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -587,7 +587,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 		var/turf/T = get_turf(src)
 		var/obj/effect/decal/cleanable/ash/A = new()
 		A.desc = "Looks like this used to be a [name] some time ago."
-		A.forceMove(T) //so the ash decal is deleted if on top of lava.
+		A.Entered(T,T) //so the ash decal is deleted if on top of lava.
 		..()
 
 /obj/item/acid_melt()


### PR DESCRIPTION
Caused by forceMoving to the same loc. #22490 Made it so Entered/Exited isn't called if that happens, anymore

:cl: Cyberboss
fix: Ash will, once again, burn in lava
/:cl: