### PR TITLE
Makes effects immune to spacewind

### DIFF
--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -39,3 +39,6 @@
 
 /obj/effect/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
 	return 0
+
+/obj/effect/experience_pressure_difference()
+	return


### PR DESCRIPTION
Fixes #23072 

:cl: Cyberboss
fix: Various abstract entities will no longer be affected by spacewind
/:cl:

We only just realize this now?