### PR TITLE
Fixes unneeded delay in smoothing mining walls

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -76,8 +76,7 @@
 			new mineralType(src)
 		feedback_add_details("ore_mined","[mineralType]|[mineralAmt]")
 	ChangeTurf(turf_type, defer_change)
-	spawn(10)
-		AfterChange()
+	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, 1) //beautiful destruction
 	return
 
@@ -466,8 +465,7 @@
 			G.icon_state = "Gibtonite ore 2"
 
 	ChangeTurf(turf_type, defer_change)
-	spawn(10)
-		AfterChange()
+	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
 
 
 /turf/closed/mineral/gibtonite/volcanic


### PR DESCRIPTION
:cl:
fix: Fixed excessive and immersion ruining delay on the smoothing of asteroid/mining rock after a neighboring rock turf was mined up.
/:cl:

1: this doesn't need to be 1 second, 1ds will do. (the point of the spawn was to fix gibtoniate/explosions leaving air less turfs because they tried to transfer air from walls that were about to become floors. adding the spawn means the afterChange part runs after all the turfs have already done changeturf) 

2: addtimer to make it faster (in theory)