### PR TITLE
Nerfs buckshot

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -33,11 +33,11 @@
 
 /obj/item/projectile/bullet/pellet
 	name = "pellet"
-	damage = 15
+	damage = 12.5
 
-/obj/item/projectile/bullet/pellet/weak/New()
+/obj/item/projectile/bullet/pellet/weak
 	damage = 6
-	range = rand(8)
+	range = 8
 
 /obj/item/projectile/bullet/pellet/weak/on_range()
  	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
@@ -45,9 +45,9 @@
  	sparks.start()
  	..()
 
-/obj/item/projectile/bullet/pellet/overload/New()
+/obj/item/projectile/bullet/pellet/overload
 	damage = 3
-	range = rand(10)
+	range = 10
 
 /obj/item/projectile/bullet/pellet/overload/on_hit(atom/target, blocked = 0)
  	..()

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -37,7 +37,10 @@
 
 /obj/item/projectile/bullet/pellet/weak
 	damage = 6
-	range = 8
+
+/obj/item/projectile/bullet/pellet/weak/New()
+	range = rand(1, 8)
+	..()
 
 /obj/item/projectile/bullet/pellet/weak/on_range()
  	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
@@ -47,7 +50,10 @@
 
 /obj/item/projectile/bullet/pellet/overload
 	damage = 3
-	range = 10
+
+/obj/item/projectile/bullet/pellet/overload/New()
+	range = rand(1, 10)
+	..()
 
 /obj/item/projectile/bullet/pellet/overload/on_hit(atom/target, blocked = 0)
  	..()


### PR DESCRIPTION
:cl: Joan
tweak: Buckshot now does a maximum of 75 damage, from 90.
/:cl:

Welcome to the balance discussion!
I'd be nerfing this more, but small steps while I berate anyone and everything for thinking this is wise.

1. Pixel projectiles made spread weapons much more reliable, as they don't have a randomized spread anymore; if you fire the same gun in the same direction the spread is always the same.
2. With spread weapons being more reliable, the issues with jacking the damage up compared to single-projectile stuff becomes more apparent; spread is supposed to trade spikes of damage at range for reliability.
3. At all but the most extreme ranges you'd be hit with at least two pellets, which would do half the damage of a shotgun slug. This is quite clearly *too reliable*.
4. At the same range, the shotgun slug has about a 35% chance to hit(ie; does 35% damage, 21 (this is inaccurate, as it either hits or doesn't, but it gets the meaning across)) and is accordingly less effective both at long range and up close.