### PR TITLE
Clockwork fulltile windows actually work like fulltile windows

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -495,5 +495,6 @@
 	fulltile = 1
 	dir = FULLTILE_WINDOW_DIR
 	max_integrity = 150
+	level = 3
 	glass_amount = 2
 	made_glow = TRUE


### PR DESCRIPTION
And will properly block explosions for things under them.