### PR TITLE
Fixed pai bots not having data huds

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -89,7 +89,6 @@
 			var/datum/antagonist/D = i
 			D.transfer_to_new_body(new_character)
 	var/datum/atom_hud/antag/hud_to_transfer = antag_hud//we need this because leave_hud() will clear this list
-	leave_all_huds()									//leave all the huds in the old body, so it won't get huds if somebody else enters it
 	current = new_character								//associate ourself with our new body
 	new_character.mind = src							//and associate our new body with ourself
 	if(iscarbon(new_character))

--- a/code/game/gamemodes/antag_hud.dm
+++ b/code/game/gamemodes/antag_hud.dm
@@ -42,19 +42,15 @@
 //MIND PROCS
 //these are called by mind.transfer_to()
 /datum/mind/proc/transfer_antag_huds(datum/atom_hud/antag/newhud)
-	leave_all_huds()
+	leave_all_antag_huds()
 	ticker.mode.set_antag_hud(current, antag_hud_icon_state)
 	if(newhud)
 		newhud.join_hud(current)
 
-/datum/mind/proc/leave_all_huds()
+/datum/mind/proc/leave_all_antag_huds()
 	for(var/datum/atom_hud/antag/hud in huds)
 		if(current in hud.hudusers)
 			hud.leave_hud(current)
-
-	for(var/datum/atom_hud/data/hud in huds)
-		if(current in hud.hudusers)
-			hud.remove_hud_from(current)
 
 /datum/atom_hud/antag/gang
 	var/color = null


### PR DESCRIPTION
/datum/mind/proc/transfer_to() was removing data huds as well as antag huds from the mob the mind was leaving. This also fixes the same bug with mindswap and anything else that used mind/transfer_to().

Fixes #15134