### PR TITLE
Prevents mechs moving anchored mobs

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -562,8 +562,10 @@
 				var/obj/O = obstacle
 				if(!O.anchored)
 					step(obstacle, dir)
-			else if(istype(obstacle, /mob))
-				step(obstacle, dir)
+			else if(ismob(obstacle))
+				var/mob/M = obstacle
+				if(!M.anchored)
+					step(obstacle, dir)
 
 
 


### PR DESCRIPTION
:cl: XDTM
fix: Exosuits can't push anchored mobs, such as megafauna or tendrils, anymore.
/:cl:

Fixes #22107
