### PR TITLE
Fixes id_access_list not working on mob spawners.

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -177,17 +177,11 @@
 		if(id_icon)
 			W.icon_state = id_icon
 		if(id_access)
-			var/list/jobdatum_access = list()
-			var/datum/job/J
 			for(var/jobtype in typesof(/datum/job))
-				J = new jobtype
+				var/datum/job/J = new jobtype
 				if(J.title == id_access)
-					jobdatum_access = J.get_access()
-					qdel(J)
+					W.access = J.get_access()
 					break
-				qdel(J)
-			if(LAZYLEN(jobdatum_access))
-				W.access = jobdatum_access
 		if(id_access_list)
 			if(!islist(W.access))
 				W.access = list()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -177,20 +177,21 @@
 		if(id_icon)
 			W.icon_state = id_icon
 		if(id_access)
-			var/datum/job/jobdatum
+			var/list/jobdatum_access = list()
+			var/datum/job/J
 			for(var/jobtype in typesof(/datum/job))
-				var/datum/job/J = new jobtype
+				J = new jobtype
 				if(J.title == id_access)
-					jobdatum = J
+					jobdatum_access = J.get_access()
+					qdel(J)
 					break
-			if(jobdatum)
-				W.access = jobdatum.get_access()
-			else
+				qdel(J)
+			if(LAZYLEN(jobdatum_access))
+				W.access = jobdatum_access
+		if(id_access_list)
+			if(!islist(W.access))
 				W.access = list()
-			if(id_access_list)
-				if(!W.access)
-					W.access = list()
-				W.access |= id_access_list
+			W.access |= id_access_list
 		if(id_job)
 			W.assignment = id_job
 		W.registered_name = H.real_name


### PR DESCRIPTION
Fixes #22987

If the spawner had no `id_access`, the `id_access_list` was never being assigned. This fix and improves the code there a bit.