### PR TITLE
Makes the reviver implant heal enough to be useful

### DIFF
--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -102,6 +102,7 @@
 		var/mob/living/carbon/human/H = owner
 		if(H.stat != DEAD && prob(50 / severity))
 			H.heart_attack = TRUE
+			H << "<span class='userdanger'>You feel a horrible agony in your chest!</span>"
 			addtimer(CALLBACK(src, .proc/undo_heart_attack), 600 / severity)
 
 /obj/item/organ/cyberimp/chest/reviver/proc/undo_heart_attack()

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -61,6 +61,7 @@
 		else
 			cooldown = revive_cost + world.time
 			reviving = FALSE
+			owner << "<span class='notice'>Your reviver implant shuts down and starts recharging. It will be ready again in [revive_cost/10] seconds.</span>"
 		return
 
 	if(cooldown > world.time)
@@ -72,20 +73,21 @@
 
 	revive_cost = 0
 	reviving = TRUE
+	owner << "<span class='notice'>You feel a faint buzzing as your reviver implant starts patching your wounds...</span>"
 
 /obj/item/organ/cyberimp/chest/reviver/proc/heal()
-	if(prob(90) && owner.getOxyLoss())
-		owner.adjustOxyLoss(-3)
+	if(owner.getOxyLoss())
+		owner.adjustOxyLoss(-5)
 		revive_cost += 5
-	if(prob(75) && owner.getBruteLoss())
-		owner.adjustBruteLoss(-1)
-		revive_cost += 20
-	if(prob(75) && owner.getFireLoss())
-		owner.adjustFireLoss(-1)
-		revive_cost += 20
-	if(prob(40) && owner.getToxLoss())
+	if(owner.getBruteLoss())
+		owner.adjustBruteLoss(-2)
+		revive_cost += 40
+	if(owner.getFireLoss())
+		owner.adjustFireLoss(-2)
+		revive_cost += 40
+	if(owner.getToxLoss())
 		owner.adjustToxLoss(-1)
-		revive_cost += 50
+		revive_cost += 40
 
 /obj/item/organ/cyberimp/chest/reviver/emp_act(severity)
 	if(!owner)


### PR DESCRIPTION
:cl: XDTM
tweak: Reviver implants now warn you when they're turning on or off, or when giving a heart attack due to EMP.
/:cl:

Fixes #23053

Healing is now constant and not reliant on RNG, oxyloss healing has been increased overall, all other damages heal at an increased rate, but with double the previous cost per heal. It's still fairly slow, so nobody will get up from crit while getting beaten up.
