### PR TITLE
Fixes parallax launch animation being odd during lag

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -112,7 +112,7 @@
 	C.parallax_movedir = new_parallax_movedir
 	if (C.parallax_animate_timer)
 		deltimer(C.parallax_animate_timer)
-	C.parallax_animate_timer = addtimer(CALLBACK(src, .proc/update_parallax_motionblur, C, animatedir, new_parallax_movedir, newtransform), min(shortesttimer, PARALLAX_LOOP_TIME))
+	C.parallax_animate_timer = addtimer(CALLBACK(src, .proc/update_parallax_motionblur, C, animatedir, new_parallax_movedir, newtransform), min(shortesttimer, PARALLAX_LOOP_TIME), TIMER_CLIENT_TIME)
 
 /datum/hud/proc/update_parallax_motionblur(client/C, animatedir, new_parallax_movedir, matrix/newtransform)
 	C.parallax_animate_timer = FALSE


### PR DESCRIPTION
In another pr, i'll refactor shuttles to use clienttime at certain edge parts to fix the parallax slowdown animation and fix the sync issues with the shuttle launch sound.


:cl:
tweak: Server side timing of the parallax shuttle launch animation now runs on client time rather than byond time/server time. This will fix the odd issues it has during lag. The parallax shuttle slowdown animation will still have issues, those will be fixed in another more involved update to shuttles.
/:cl: