### PR TITLE
Alters Dried Jerky and Raisins

### DIFF
--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -6,7 +6,7 @@
 	name = "meat"
 	desc = "A slab of meat"
 	icon_state = "meat"
-	dried_type = /obj/item/weapon/reagent_containers/food/snacks/sosjerky
+	dried_type = /obj/item/weapon/reagent_containers/food/snacks/sosjerky/healthy
 	bitesize = 3
 	list_reagents = list("nutriment" = 3)
 	cooked_type = /obj/item/weapon/reagent_containers/food/snacks/meat/steak/plain

--- a/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -47,7 +47,6 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/no_raisin/healthy
 	name = "homemade raisins"
-	icon_state = "4no_raisins"
 	desc = "homemade raisins, the best in all of spess."
 	list_reagents = list("nutriment" = 3, "vitamin" = 2)
 	junkiness = 0

--- a/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -20,6 +20,12 @@
 	junkiness = 25
 	filling_color = "#8B0000"
 
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky/healthy
+	name = "homemade beef jerky"
+	desc = "Homemade beef jerky made from the finest space cows."
+	list_reagents = list("nutriment" = 3, "vitamin" = 1)
+	junkiness = 0
+
 /obj/item/weapon/reagent_containers/food/snacks/chips
 	name = "chips"
 	desc = "Commander Riker's What-The-Crisps"
@@ -38,6 +44,13 @@
 	list_reagents = list("nutriment" = 2, "sugar" = 4)
 	junkiness = 25
 	filling_color = "#8B0000"
+
+/obj/item/weapon/reagent_containers/food/snacks/no_raisin/healthy
+	name = "homemade raisins"
+	icon_state = "4no_raisins"
+	desc = "homemade raisins, the best in all of spess."
+	list_reagents = list("nutriment" = 3, "vitamin" = 2)
+	junkiness = 0
 
 /obj/item/weapon/reagent_containers/food/snacks/spacetwinkie
 	name = "space twinkie"

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -164,7 +164,7 @@
 	name = "bunch of grapes"
 	desc = "Nutritious!"
 	icon_state = "grapes"
-	dried_type = /obj/item/weapon/reagent_containers/food/snacks/no_raisin
+	dried_type = /obj/item/weapon/reagent_containers/food/snacks/no_raisin/healthy
 	filling_color = "#FF1493"
 	bitesize_mod = 2
 


### PR DESCRIPTION
Alters the dried type of meat slabs and grapes to have a healthier option.

Reason being something that requires this much effort (growing it+making the drying rack+time to dry it) shouldn't discourage/punish those who want to eat it from doing so...as it was effectively still junkfood. With this change, it becomes a viable food option that actually has incentive to be made.

:cl: Fox McCloud
tweak: drying meat slabs and grapes now yields a healthy non-junkfood snack
/:cl: