### PR TITLE
Comments out some debugging code

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -110,9 +110,11 @@ var/global/datum/crewmonitor/crewmonitor = new
 			hi = src.interfaces["[z]"]
 			src.update(z,TRUE)
 
+		/*
 		// Debugging purposes
 		mob << browse_rsc(file("code/game/machinery/computer/crew.js"), "crew.js")
 		mob << browse_rsc(file("code/game/machinery/computer/crew.css"), "crew.css")
+		*/
 
 		hi = src.interfaces["[z]"]
 		hi.show(mob)


### PR DESCRIPTION
It does nothing but creates unnecessary load. Actual resources are sent to client in other places, this just makes them reload all the time.

Commented out and not removed because it could be useful for debugging, if someone would ever try to change something in crew monitor JS/CSS.