### PR TITLE
Fixes bug with addtimer keeping old timers around, makes addtimer even faster.

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -53,4 +53,5 @@
 //	tracking this is more expensive,
 //	should only be used in conjuction with things that have to progress client side, such as animate() or sound()
 #define TIMER_CLIENT_TIME	0x4
-
+//Timer can be stopped using deltimer()
+#define TIMER_STOPPABLE		0x8

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1286,7 +1286,7 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))
 
-#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, item), time)
+#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, item), time, TIMER_STOPPABLE)
 
 /proc/check_for_cleanbot_bug()
 	var/static/admins_warned //bet you didn't know you could do this!

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -112,7 +112,8 @@
 	C.parallax_movedir = new_parallax_movedir
 	if (C.parallax_animate_timer)
 		deltimer(C.parallax_animate_timer)
-	C.parallax_animate_timer = addtimer(CALLBACK(src, .proc/update_parallax_motionblur, C, animatedir, new_parallax_movedir, newtransform), min(shortesttimer, PARALLAX_LOOP_TIME), TIMER_CLIENT_TIME)
+	C.parallax_animate_timer = addtimer(CALLBACK(src, .proc/update_parallax_motionblur, C, animatedir, new_parallax_movedir, newtransform), min(shortesttimer, PARALLAX_LOOP_TIME), TIMER_CLIENT_TIME|TIMER_STOPPABLE)
+
 
 /datum/hud/proc/update_parallax_motionblur(client/C, animatedir, new_parallax_movedir, matrix/newtransform)
 	C.parallax_animate_timer = FALSE

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -288,23 +288,6 @@ var/datum/subsystem/timer/SStimer
 	return QDEL_HINT_IWILLGC
 
 proc/addtimer(datum/callback/callback, wait, flags)
-	if (flags)
-		return addtimer_default(arglist(args))
-
-	var/static/const/num = 2
-	var/static/cur = rand(0, num-1)
-	if (prob(33))
-		cur = ((cur + 1) % num)
-
-	switch(cur)
-		if(0)
-			return addtimer_real(arglist(args))
-		if(1)
-			return addtimer_spawn(arglist(args))
-		else
-			throw EXCEPTION("invalid chain state")
-
-/proc/addtimer_default(datum/callback/callback, wait, flags)
 	if (!callback)
 		return
 
@@ -336,43 +319,6 @@ proc/addtimer(datum/callback/callback, wait, flags)
 	var/datum/timedevent/timer = new(callback, timeToRun, flags, hash)
 	if (flags & TIMER_STOPPABLE)
 		return timer.id
-
-/proc/addtimer_real(datum/callback/callback, wait, flags)
-	if (!callback)
-		return
-
-	if (wait <= 0)
-		callback.InvokeAsync()
-		return
-
-	var/hash
-
-	if (flags & TIMER_UNIQUE)
-		var/list/hashlist = list(callback.object, "(\ref[callback.object])", callback.delegate, wait, flags & TIMER_CLIENT_TIME)
-		hashlist += callback.arguments
-		hash = hashlist.Join("|||||||")
-
-		var/datum/timedevent/hash_timer = SStimer.hashes[hash]
-		if(hash_timer)
-			if (flags & TIMER_OVERRIDE)
-				qdel(hash_timer)
-			else
-				if (hash_timer & TIMER_STOPPABLE)
-					. = hash_timer.id
-				return
-
-
-	var/timeToRun = world.time + wait
-	if (flags & TIMER_CLIENT_TIME)
-		timeToRun = REALTIMEOFDAY + wait
-
-	var/datum/timedevent/timer = new(callback, timeToRun, flags, hash)
-	if (flags & TIMER_STOPPABLE)
-		return timer.id
-
-/proc/addtimer_spawn(datum/callback/callback, wait, flags)
-	spawn(wait)
-		callback.InvokeAsync()
 
 /proc/deltimer(id)
 	if (!id)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -307,7 +307,7 @@ proc/addtimer(datum/callback/callback, wait, flags)
 			if (flags & TIMER_OVERRIDE)
 				qdel(hash_timer)
 			else
-				if (hash_timer & TIMER_STOPPABLE)
+				if (hash_timer.flags & TIMER_STOPPABLE)
 					. = hash_timer.id
 				return
 

--- a/code/game/gamemodes/clock_cult/clock_items/ratvarian_spear.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/ratvarian_spear.dm
@@ -36,7 +36,7 @@
 		throwforce = initial(throwforce)
 		armour_penetration = 0
 		clockwork_desc = "A powerful spear of Ratvarian making. It's more effective against enemy cultists and silicons, though it won't last for long."
-		timerid = addtimer(CALLBACK(src, .proc/break_spear), 600)
+		timerid = addtimer(CALLBACK(src, .proc/break_spear), 600, TIMER_STOPPABLE)
 
 /obj/item/clockwork/ratvarian_spear/cyborg/ratvar_act() //doesn't break!
 	if(ratvar_awakens)

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
@@ -210,7 +210,7 @@
 	if(!ratvar_awakens)
 		R.clockwork_desc = "A powerful spear of Ratvarian making. It's more effective against enemy cultists and silicons, though it won't last for long."
 		owner << "<span class='warning'>Your spear begins to break down in this plane of existence. You can't use it for long!</span>"
-		R.timerid = addtimer(CALLBACK(R, /obj/item/clockwork/ratvarian_spear.proc/break_spear), base_cooldown)
+		R.timerid = addtimer(CALLBACK(R, /obj/item/clockwork/ratvarian_spear.proc/break_spear), base_cooldown, TIMER_STOPPABLE)
 	cooldown = base_cooldown + world.time
 	owner.update_action_buttons_icon()
 	addtimer(CALLBACK(src, .proc/update_actions), base_cooldown)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -762,7 +762,7 @@ var/list/wall_runes = list()
 			W.density = TRUE
 			W.update_state()
 			W.spread_density()
-	density_timer = addtimer(CALLBACK(src, .proc/lose_density), 900)
+	density_timer = addtimer(CALLBACK(src, .proc/lose_density), 900, TIMER_STOPPABLE)
 
 /obj/effect/rune/wall/proc/lose_density()
 	if(density)

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -272,7 +272,7 @@ var/total_borer_hosts_needed = 10
 					else
 						src << "<span class='warning'>You start shaking off your lethargy as the sugar leaves your host's blood. This will take about 10 seconds...</span>"
 
-					waketimerid = addtimer(CALLBACK(src, "wakeup"), 10)
+					waketimerid = addtimer(CALLBACK(src, "wakeup"), 10, TIMER_STOPPABLE)
 			if(controlling)
 
 				if(docile)

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -59,7 +59,7 @@
 
 	user << "Your name has been sent to your employers for approval."
 	// Autoapproves after a certain time
-	response_timer_id = addtimer(CALLBACK(src, .proc/rename_station, new_name, user), approval_time)
+	response_timer_id = addtimer(CALLBACK(src, .proc/rename_station, new_name, user), approval_time, TIMER_STOPPABLE)
 	admins << "<span class='adminnotice'><b><font color=orange>CUSTOM STATION RENAME:</font></b>[key_name_admin(user)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) proposes to rename the station to [new_name] (will autoapprove in [approval_time / 10] seconds). (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[user]'>BSA</A>) (<A HREF='?_src_=holder;reject_custom_name=\ref[src]'>REJECT</A>) (<a href='?_src_=holder;CentcommReply=\ref[user]'>RPLY</a>)</span>"
 
 /obj/item/station_charter/proc/reject_proposed(user)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -100,7 +100,7 @@
 
 	//remove our adminhelp verb temporarily to prevent spamming of admins.
 	src.verbs -= /client/verb/adminhelp
-	adminhelptimerid = addtimer(CALLBACK(src, .proc/giveadminhelpverb), 1200) //2 minute cooldown of admin helps
+	adminhelptimerid = addtimer(CALLBACK(src, .proc/giveadminhelpverb), 1200, TIMER_STOPPABLE) //2 minute cooldown of admin helps
 
 	msg = keywords_lookup(msg)
 

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -147,12 +147,12 @@
 		user.Stun(INFINITY)
 
 		animate(user, color = "#00ccee", time = 3)
-		phase_timer_id = addtimer(CALLBACK(src, .proc/phase_2, user, to_turf, phase_in_ds), 3)
+		phase_timer_id = addtimer(CALLBACK(src, .proc/phase_2, user, to_turf, phase_in_ds), 3, TIMER_STOPPABLE)
 
 /obj/item/clothing/suit/space/chronos/proc/phase_2(mob/living/carbon/human/user, turf/to_turf, phase_in_ds)
 	if(teleporting && activated && user)
 		animate(user, alpha = 0, time = 2)
-		phase_timer_id = addtimer(CALLBACK(src, .proc/phase_3, user, to_turf, phase_in_ds), 2)
+		phase_timer_id = addtimer(CALLBACK(src, .proc/phase_3, user, to_turf, phase_in_ds), 2, TIMER_STOPPABLE)
 	else
 		finish_chronowalk(user, to_turf)
 
@@ -160,14 +160,14 @@
 	if(teleporting && activated && user)
 		user.forceMove(to_turf)
 		animate(user, alpha = 255, time = phase_in_ds)
-		phase_timer_id = addtimer(CALLBACK(src, .proc/phase_4, user, to_turf), phase_in_ds)
+		phase_timer_id = addtimer(CALLBACK(src, .proc/phase_4, user, to_turf), phase_in_ds, TIMER_STOPPABLE)
 	else
 		finish_chronowalk(user, to_turf)
 
 /obj/item/clothing/suit/space/chronos/proc/phase_4(mob/living/carbon/human/user, turf/to_turf)
 	if(teleporting && activated && user)
 		animate(user, color = "#ffffff", time = 3)
-		phase_timer_id = addtimer(CALLBACK(src, .proc/finish_chronowalk, user, to_turf), 3)
+		phase_timer_id = addtimer(CALLBACK(src, .proc/finish_chronowalk, user, to_turf), 3, TIMER_STOPPABLE)
 	else
 		finish_chronowalk(user, to_turf)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -421,7 +421,7 @@
 /mob/living/simple_animal/hostile/proc/GainPatience()
 	if(lose_patience_timeout)
 		LosePatience()
-		lose_patience_timer_id = addtimer(CALLBACK(src, .proc/LoseTarget), lose_patience_timeout)
+		lose_patience_timer_id = addtimer(CALLBACK(src, .proc/LoseTarget), lose_patience_timeout, TIMER_STOPPABLE)
 
 
 /mob/living/simple_animal/hostile/proc/LosePatience()
@@ -432,7 +432,7 @@
 /mob/living/simple_animal/hostile/proc/LoseSearchObjects()
 	search_objects = 0
 	deltimer(search_objects_timer_id)
-	search_objects_timer_id = addtimer(CALLBACK(src, .proc/RegainSearchObjects), search_objects_regain_time)
+	search_objects_timer_id = addtimer(CALLBACK(src, .proc/RegainSearchObjects), search_objects_regain_time, TIMER_STOPPABLE)
 
 
 /mob/living/simple_animal/hostile/proc/RegainSearchObjects(value)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -842,7 +842,7 @@
 		return
 	malf << "Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process."
 	malf.malfhack = src
-	malf.malfhacking = addtimer(CALLBACK(malf, /mob/living/silicon/ai/.proc/malfhacked, src), 600)
+	malf.malfhacking = addtimer(CALLBACK(malf, /mob/living/silicon/ai/.proc/malfhacked, src), 600, TIMER_STOPPABLE)
 
 	var/obj/screen/alert/hackingapc/A
 	A = malf.throw_alert("hackingapc", /obj/screen/alert/hackingapc)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -124,7 +124,7 @@
 	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime"), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
 /datum/chemical_reaction/slime/slimecritlesser
 	name = "Slime Crit Lesser"
@@ -140,7 +140,7 @@
 	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", "neutral"), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
 /datum/chemical_reaction/slime/slimecritfriendly
 	name = "Slime Crit Friendly"
@@ -156,7 +156,7 @@
 	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", "neutral"), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
 //Silver
 /datum/chemical_reaction/slime/slimebork
@@ -292,7 +292,7 @@
 	addtimer(CALLBACK(src, .proc/freeze, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
 /datum/chemical_reaction/slime/slimefreeze/proc/freeze(datum/reagents/holder)
 	if(holder && holder.my_atom)
@@ -342,7 +342,7 @@
 	addtimer(CALLBACK(src, .proc/slime_burn, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
 /datum/chemical_reaction/slime/slimefire/proc/slime_burn(datum/reagents/holder)
 	if(holder && holder.my_atom)
@@ -554,7 +554,7 @@
 	addtimer(CALLBACK(src, .proc/boom, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55)
+	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
 /datum/chemical_reaction/slime/slimeexplosion/proc/boom(datum/reagents/holder)
 	if(holder && holder.my_atom)


### PR DESCRIPTION
I messed up removing from `timer_id_dict` so timers never got removed from that list. Noticing this made me notice that inserting was needlessly O(logn) when it could be O(1) like it was suppose to be, so here's my solution:

This adds a new flag, `TIMER_STOPPABLE`. you must use this flag in order for addtimer to return an id that can be used to delete it with deltimer(). without this flag addtimer returns null. Most(80%) of the overhead for addtimer() was in adding the timer to the associated lookup list for deltimer() to use. Moving that functionality to a flag so it wouldn't slow down the 80% of things calling timers was a massive improvement.

This shaved about 2 orders of magnitude off of the overhead.

I left some debugging/profiling procs in, because i want to test merge to see some real-use profiles since all of this is finicky and the overheads are based on how much exactly is going on.