### PR TITLE
Spirit board fixes

### DIFF
--- a/code/game/objects/structures/spirit_board.dm
+++ b/code/game/objects/structures/spirit_board.dm
@@ -6,7 +6,7 @@
 	density = 1
 	anchored = 0
 	var/virgin = 1
-	var/cooldown = 0
+	var/next_use = 0
 	var/planchette = "A"
 	var/lastuser = null
 
@@ -32,16 +32,14 @@
 		virgin = 0
 		notify_ghosts("Someone has begun playing with a [src.name] in [get_area(src)]!", source = src)
 
-	planchette = input("Choose the letter.", "Seance!") in list("A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z")
+	planchette = input("Choose the letter.", "Seance!") as null|anything in list("A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z")
+	if(!planchette || !Adjacent(M) || next_use > world.time)
+		return
 	add_logs(M, src, "picked a letter on", " which was \"[planchette]\".")
-	cooldown = world.time
+	next_use = world.time + rand(30,50)
 	lastuser = M.ckey
-
-	var/turf/T = loc
-	sleep(rand(20,30))
-	if(T == loc)
-		visible_message("<span class='notice'>The planchette slowly moves... and stops at the letter \"[planchette]\".</span>")
-
+	//blind message is the same because not everyone brings night vision to seances
+	visible_message("<span class='notice'>The planchette slowly moves... and stops at the letter \"[planchette]\".</span>","","<span class='notice'>The planchette slowly moves... and stops at the letter \"[planchette]\".</span>")
 
 /obj/structure/spirit_board/proc/spirit_board_checks(mob/M)
 	//cooldown
@@ -49,7 +47,7 @@
 	if(M.ckey == lastuser)
 		bonus = 10 //Give some other people a chance, hog.
 
-	if(cooldown > world.time - (30 + bonus))
+	if(next_use - bonus > world.time )
 		return 0 //No feedback here, hiding the cooldown a little makes it harder to tell who's really picking letters.
 
 	//lighting check

--- a/code/game/objects/structures/spirit_board.dm
+++ b/code/game/objects/structures/spirit_board.dm
@@ -39,7 +39,8 @@
 	next_use = world.time + rand(30,50)
 	lastuser = M.ckey
 	//blind message is the same because not everyone brings night vision to seances
-	visible_message("<span class='notice'>The planchette slowly moves... and stops at the letter \"[planchette]\".</span>","","<span class='notice'>The planchette slowly moves... and stops at the letter \"[planchette]\".</span>")
+	var/msg = "<span class='notice'>The planchette slowly moves... and stops at the letter \"[planchette]\".</span>"
+	visible_message(msg,"",msg)
 
 /obj/structure/spirit_board/proc/spirit_board_checks(mob/M)
 	//cooldown


### PR DESCRIPTION
Blind message is the same because some people keep forgetting about bringing nvgs to seance.
Also removed the invisible delayed action, it's just now fuzzy cooldown. These things are relatively rarely used anyway.