### PR TITLE
Changes And Makes Shuttle Authorization Repeal Message Work Properly  

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -85,14 +85,13 @@
 				. = TRUE
 
 	if((old_len != authorized.len) && !ENGINES_STARTED)
-		var/alert = (authorized.len > old_len)
-		var/repeal = (authorized.len < old_len)
+		var/alert = (authorized.len > old_len), var/repeal = (authorized.len < old_len)
 		var/remaining = auth_need - authorized.len
 		if(authorized.len && remaining)
 			minor_announce("[remaining] authorizations \
 				needed until shuttle is launched early", null, alert)
 		if(repeal)
-			minor_announce("Early launch authorization revoked [remaining] authorizations needed")
+			minor_announce("Early launch authorization revoked, [remaining] authorizations needed")
 
 /obj/machinery/computer/emergency_shuttle/proc/authorize(mob/user, source)
 	var/obj/item/weapon/card/id/ID = user.get_idcard()

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -86,13 +86,14 @@
 
 	if((old_len != authorized.len) && !ENGINES_STARTED)
 		var/alert = (authorized.len > old_len)
+		var/repeal = (authorized.len < old_len)
 		var/remaining = auth_need - authorized.len
 		if(authorized.len && remaining)
 			minor_announce("[remaining] authorizations \
 				needed until shuttle is launched early", null, alert)
-		else
-			minor_announce("All authorizations to launch the shuttle \
-				early have been revoked.")
+		if(repeal)
+			minor_announce("Authorization repeal detecteds \
+				[remaining] authorizations needed")
 
 /obj/machinery/computer/emergency_shuttle/proc/authorize(mob/user, source)
 	var/obj/item/weapon/card/id/ID = user.get_idcard()

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -85,11 +85,11 @@
 				. = TRUE
 
 	if((old_len != authorized.len) && !ENGINES_STARTED)
-		var/alert = (authorized.len > old_len), var/repeal = (authorized.len < old_len)
+		var/alert = (authorized.len > old_len)
+		var/repeal = (authorized.len < old_len)
 		var/remaining = auth_need - authorized.len
 		if(authorized.len && remaining)
-			minor_announce("[remaining] authorizations \
-				needed until shuttle is launched early", null, alert)
+			minor_announce("[remaining] authorizations needed until shuttle is launched early", null, alert)
 		if(repeal)
 			minor_announce("Early launch authorization revoked, [remaining] authorizations needed")
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -92,8 +92,7 @@
 			minor_announce("[remaining] authorizations \
 				needed until shuttle is launched early", null, alert)
 		if(repeal)
-			minor_announce("Authorization repeal detected \
-				[remaining] authorizations needed")
+			minor_announce("Early launch authorization revoked [remaining] authorizations needed")
 
 /obj/machinery/computer/emergency_shuttle/proc/authorize(mob/user, source)
 	var/obj/item/weapon/card/id/ID = user.get_idcard()

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -92,7 +92,7 @@
 			minor_announce("[remaining] authorizations \
 				needed until shuttle is launched early", null, alert)
 		if(repeal)
-			minor_announce("Authorization repeal detecteds \
+			minor_announce("Authorization repeal detected \
 				[remaining] authorizations needed")
 
 /obj/machinery/computer/emergency_shuttle/proc/authorize(mob/user, source)


### PR DESCRIPTION
## **Changes Message And Fixes Shuttle Authorization Repeal Announcement**
Fixes shuttle repeal message so it actually works also changes shuttle repeal message to "Authorization repeal detected [remaining] authorizations needed" This means the shuttle will send a alert anytime an Authorization repeal is detected on the shuttle computer this should also help crew understand the status of the shuttle and if its going to blast off land leave them behind. 

## **Changelog**

:cl: Tofa01
Tweak: Changed alert message on early launch Authorization shuttle repeal message.
Fix: Makes the repeal message work and push a alert to the crew properly, also reports every Authorization repeal now.
/:cl:

## **Fixes #23123**

