### PR TITLE
Removes world start lag

### DIFF
--- a/code/__DEFINES/tick.dm
+++ b/code/__DEFINES/tick.dm
@@ -1,7 +1,7 @@
 #define TICK_LIMIT_RUNNING 80
 #define TICK_LIMIT_TO_RUN 78
 #define TICK_LIMIT_MC 70
-#define TICK_LIMIT_MC_INIT 98
+#define TICK_LIMIT_MC_INIT_DEFAULT 98
 
 #define TICK_CHECK ( world.tick_usage > CURRENT_TICKLIMIT ? stoplag() : 0 )
 #define CHECK_TICK if (world.tick_usage > CURRENT_TICKLIMIT)  stoplag()

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -49,6 +49,7 @@
 	var/popup_admin_pm = 0				//adminPMs to non-admins show in a pop-up 'reply' window when set to 1.
 	var/fps = 20
 	var/allow_holidays = 0				//toggles whether holiday-specific content should be used
+	var/tick_limit_mc_init = TICK_LIMIT_MC_INIT_DEFAULT	//SSinitialization throttling
 
 	var/hostedby = null
 	var/respawn = 1
@@ -385,6 +386,8 @@
 					var/ticklag = text2num(value)
 					if(ticklag > 0)
 						fps = 10 / ticklag
+				if("tick_limit_mc_init")
+					tick_limit_mc_init = text2num(value)
 				if("fps")
 					fps = text2num(value)
 				if("automute_on")

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -127,7 +127,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	sortTim(subsystems, /proc/cmp_subsystem_init)
 
 	// Initialize subsystems.
-	CURRENT_TICKLIMIT = TICK_LIMIT_MC_INIT
+	CURRENT_TICKLIMIT = config.tick_limit_mc_init
 	for (var/datum/subsystem/SS in subsystems)
 		if (SS.flags & SS_NO_INIT)
 			continue

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -28,8 +28,8 @@ var/datum/subsystem/air/SSair
 	var/list/hotspots = list()
 	var/list/networks = list()
 	var/list/obj/machinery/atmos_machinery = list()
-	
-	
+
+
 
 	//Special functions lists
 	var/list/turf/active_super_conductivity = list()
@@ -269,6 +269,7 @@ var/datum/subsystem/air/SSair
 		if (T.blocks_air)
 			continue
 		T.Initalize_Atmos(times_fired)
+		CHECK_TICK
 
 	if(active_turfs.len)
 		var/starting_ats = active_turfs.len
@@ -284,6 +285,7 @@ var/datum/subsystem/air/SSair
 			var/list/new_turfs_to_check = list()
 			for(var/turf/open/T in turfs_to_check)
 				new_turfs_to_check += T.resolve_active_graph()
+			CHECK_TICK
 
 			active_turfs += new_turfs_to_check
 			turfs_to_check = new_turfs_to_check
@@ -294,6 +296,7 @@ var/datum/subsystem/air/SSair
 			var/datum/excited_group/EG = thing
 			EG.self_breakdown(space_is_all_consuming = 1)
 			EG.dismantle()
+			CHECK_TICK
 
 		var/msg = "HEY! LISTEN! [(world.timeofday - timer)/10] Seconds were wasted processing [starting_ats] turf(s) (connected to [ending_ats] other turfs) with atmos differences at round start."
 		world << "<span class='boldannounce'>[msg]</span>"

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -32,5 +32,6 @@ var/datum/subsystem/icon_smooth/SSicon_smooth
 		if(!A || A.z <= 2)
 			continue
 		smooth_icon(A)
+		CHECK_TICK
 
 	..()

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -69,14 +69,17 @@ var/datum/subsystem/lighting/SSlighting
 			if (A.lighting_use_dynamic == DYNAMIC_LIGHTING_IFSTARLIGHT)
 				A.luminosity = 0
 
+	CHECK_TICK
 	for(var/thing in changed_lights)
 		var/datum/light_source/LS = thing
 		LS.check()
+		CHECK_TICK
 	changed_lights.Cut()
 
 	for(var/thing in turfs_to_init)
 		var/turf/T = thing
 		T.init_lighting()
+		CHECK_TICK
 	changed_turfs.Cut()
 
 	..()

--- a/config/config.txt
+++ b/config/config.txt
@@ -187,6 +187,9 @@ ALLOW_HOLIDAYS
 ##Uncomment to show the names of the admin sending a pm from IRC instead of showing as a stealthmin.
 #SHOW_IRC_NAME
 
+##Defines the ticklimit for subsystem initialization. Lower makes world start smoother. Higher makes it faster
+TICK_LIMIT_MC_INIT 500
+
 ##Defines the ticklag for the world.  0.9 is the normal one, 0.5 is smoother.
 TICKLAG 0.5
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -187,7 +187,8 @@ ALLOW_HOLIDAYS
 ##Uncomment to show the names of the admin sending a pm from IRC instead of showing as a stealthmin.
 #SHOW_IRC_NAME
 
-##Defines the ticklimit for subsystem initialization. Lower makes world start smoother. Higher makes it faster
+##Defines the ticklimit for subsystem initialization (In percents of a byond tick). Lower makes world start smoother. Higher makes it faster.
+##This is currently a testing optimized setting. A good value for production would be 98.
 TICK_LIMIT_MC_INIT 500
 
 ##Defines the ticklag for the world.  0.9 is the normal one, 0.5 is smoother.


### PR DESCRIPTION
Someone yell at me if sleeping in lighting/Initialize breaks stuff

:cl: Cyberboss
fix: World start will no longer lag
/:cl:

- [x] TODO

```
3:34:08 PM +MrStonedOne https://github.com/tgstation/tgstation/blob/master/code/controllers/master.dm#L130 you see this bit 
3:34:50 PM Cyberboss yea 
3:34:51 PM +MrStonedOne make this a config, default it to 500, and on the server, i'll set it to something like 150 or 200 or maybe 100, i can play with that 
3:36:06 PM +MrStonedOne this way the server starts up quickly for debugging, (with some hanging) but doesn't block ooc convos on production 
```