### PR TITLE
Adds a way for admins to load new zlevels

### DIFF
--- a/code/datums/helper_datums/map_template.dm
+++ b/code/datums/helper_datums/map_template.dm
@@ -17,7 +17,9 @@
 		name = rename
 
 /datum/map_template/proc/preload_size(path)
+	var/dmm_suite/maploader = new
 	var/bounds = maploader.load_map(file(path), 1, 1, 1, cropMap=FALSE, measureOnly=TRUE)
+	qdel(maploader)
 	if(bounds)
 		width = bounds[MAP_MAXX] // Assumes all templates are rectangular, have a single Z level, and begin at 1,1,1
 		height = bounds[MAP_MAXY]
@@ -54,7 +56,9 @@
 	if(T.y+height > world.maxy)
 		return
 
+	var/dmm_suite/maploader = new
 	var/list/bounds = maploader.load_map(get_file(), T.x, T.y, T.z, cropMap=TRUE)
+	qdel(maploader)
 	if(!bounds)
 		return 0
 

--- a/code/datums/helper_datums/map_template.dm
+++ b/code/datums/helper_datums/map_template.dm
@@ -46,7 +46,7 @@
 	SSmachine.setup_template_powernets(cables)
 	SSair.setup_template_machinery(atmos_machines)
 
-/datum/map_template/proc/load(turf/T, centered = FALSE)
+/datum/map_template/proc/load(turf/T = null, centered = FALSE)
 	if(centered)
 		T = locate(T.x - round(width/2) , T.y - round(height/2) , T.z)
 	if(T)

--- a/code/datums/helper_datums/map_template.dm
+++ b/code/datums/helper_datums/map_template.dm
@@ -49,15 +49,24 @@
 /datum/map_template/proc/load(turf/T, centered = FALSE)
 	if(centered)
 		T = locate(T.x - round(width/2) , T.y - round(height/2) , T.z)
-	if(!T)
-		return
-	if(T.x+width > world.maxx)
-		return
-	if(T.y+height > world.maxy)
-		return
+	if(T)
+		if(T.x+width > world.maxx)
+			return
+		if(T.y+height > world.maxy)
+			return
+	else
+		if(width > world.maxx)
+			return
+		if(height > world.maxy)
+			return
 
 	var/dmm_suite/maploader = new
-	var/list/bounds = maploader.load_map(get_file(), T.x, T.y, T.z, cropMap=TRUE)
+	var/list/bounds
+	if(T)
+		bounds = maploader.load_map(get_file(), T.x, T.y, T.z, cropMap=TRUE)
+	else
+		bounds = maploader.load_map(get_file())
+		smooth_zlevel(world.maxz)
 	qdel(maploader)
 	if(!bounds)
 		return 0

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -100,7 +100,8 @@ var/list/admin_verbs_fun = list(
 	/client/proc/mass_zombie_infection,
 	/client/proc/mass_zombie_cure,
 	/client/proc/polymorph_all,
-	/client/proc/show_tip
+	/client/proc/show_tip,
+	/client/proc/load_new_z_level
 	)
 var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_atom,		/*allows us to spawn instances*/

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -259,3 +259,14 @@ var/global/say_disabled = 0
 		message_admins("[src.ckey] used 'Disable all communication verbs', killing all communication methods.")
 	else
 		message_admins("[src.ckey] used 'Disable all communication verbs', restoring all communication methods.")
+
+/client/proc/load_new_z_level()
+	set category = "Special Verbs"
+	set name = "Load New Z-Level"
+
+	var/path = input("Path of the map to load","") as text
+	if(!path)
+		return
+
+	load_z_level(path)
+	message_admins("[src.ckey] loaded new zlevel ([world.maxz]): [path]")

--- a/code/modules/awaymissions/maploader/dmm_suite.dm
+++ b/code/modules/awaymissions/maploader/dmm_suite.dm
@@ -1,5 +1,3 @@
-var/global/dmm_suite/maploader = new
-
 dmm_suite{
 	/*
 

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -26,10 +26,9 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 		SortAreas() //To add recently loaded areas
 
 /proc/load_z_level(file)
-	var/dmm_suite/maploader = new
-	maploader.load_map(file)
-	qdel(maploader)
-	smooth_zlevel(world.maxz)
+	var/datum/map_template/loader = new(file)
+	loader.load()
+	qdel(loader)
 
 /proc/generateMapList(filename)
 	var/list/potentialMaps = list()

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -11,7 +11,9 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 		var/map = pick(potentialRandomZlevels)
 		var/file = file(map)
 		if(isfile(file))
+			var/dmm_suite/maploader = new
 			maploader.load_map(file)
+			qdel(maploader)
 			smooth_zlevel(world.maxz)
 			world.log << "away mission loaded: [map]"
 

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -11,10 +11,7 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 		var/map = pick(potentialRandomZlevels)
 		var/file = file(map)
 		if(isfile(file))
-			var/dmm_suite/maploader = new
-			maploader.load_map(file)
-			qdel(maploader)
-			smooth_zlevel(world.maxz)
+			load_z_level(file)
 			world.log << "away mission loaded: [map]"
 
 		map_transition_config.Add(AWAY_MISSION_LIST)
@@ -27,6 +24,12 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 		world << "<span class='boldannounce'>Away mission loaded.</span>"
 
 		SortAreas() //To add recently loaded areas
+
+/proc/load_z_level(file)
+	var/dmm_suite/maploader = new
+	maploader.load_map(file)
+	qdel(maploader)
+	smooth_zlevel(world.maxz)
 
 /proc/generateMapList(filename)
 	var/list/potentialMaps = list()


### PR DESCRIPTION
Also refactors zlevel/away mission loading to use `map_template`

This, together with #22778 will fix #23125 

Removes @kevinz000's ghetto way of doing it