### PR TITLE
Fixes Auto Capitalisation With MMI Chat

### DIFF
--- a/code/modules/mob/living/brain/say.dm
+++ b/code/modules/mob/living/brain/say.dm
@@ -20,4 +20,5 @@
 	return 0
 
 /mob/living/brain/treat_message(message)
+	message = capitalize(message)
 	return message


### PR DESCRIPTION
## **Fixes Auto Capitalisation With MMIs Talking**
When a MMI talks it will now auto capitalise sentences for example a MMI will now say "Zion Murphy says, "Hello" instead of what previously happened which looked like this "Zion Murphy says, "hello" players will no longer need to capitalise their sentences while inside a MMI.

## **Changelog**

:cl: Tofa01
Fix: Auto Capitalisation will now work with all types of MMI chat
/:cl:

## **Fixes #23152**