### PR TITLE
[Delta Station] Adds Tracking Beacon To AI Mini Satellite

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -117267,6 +117267,18 @@
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
+"ebV" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/item/device/radio/beacon,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/construction/hallway{
+	name = "\improper MiniSat Exterior"
+	})
 
 (1,1,1) = {"
 aaa
@@ -129216,7 +129228,7 @@ bJu
 bnO
 bNB
 bPu
-bRB
+ebV
 blR
 bnQ
 agg


### PR DESCRIPTION
## **Delta Station MiniSat Tracking Beacon**
Adds a tracking beacon to the AI MiniSat Exterior Hallway on Delta Station, this is to allow easier access to the MiniSat for authorised personnel such as the Research Director so they can get to the MiniSat without having to go through other departments they do not have access to such as engineering to use the AI MiniSat tube.

## **Changelog**

:cl: Tofa01
Add: [Delta Station] Adds a tracking beacon to AI MiniSat Exterior Hallway
/:cl:

### **Fixes #23098**