### PR TITLE
Moves linebreak in testmerge MOTD message

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -293,9 +293,10 @@ var/inerror = 0
 
 /world/proc/load_motd()
 	join_motd = file2text("config/motd.txt")
+	join_motd += "<br>"
 	for(var/line in revdata.testmerge)
 		if(line)
-			join_motd += "<br>Test merge active of PR <a href='[config.githuburl]/pull/[line]'>#[line]</a>"
+			join_motd += "Test merge active of PR <a href='[config.githuburl]/pull/[line]'>#[line]</a><br>"
 
 /world/proc/load_configuration()
 	protected_config = new /datum/protected_configuration()


### PR DESCRIPTION
Previous version was causing this.
![line](http://puu.sh/tswED/2061393e2b.png)