### PR TITLE
Makes travis compile all the maps in one step so it doesn't get overloaded and backlogged as often.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,8 @@ env:
     - DM_MAPFILE=""
     matrix:
     - BUILD_TOOLS=true
-    - DM_MAPFILE="tgstation2"
-    - DM_MAPFILE="metastation"
-    - DM_MAPFILE="birdstation"
-    - DM_MAPFILE="pubbystation"
     - DM_MAPFILE="templates"
-    - DM_MAPFILE="omegastation"
-    - DM_MAPFILE="deltastation"
+    - DM_MAPFILE="loadallmaps"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
     - DM_MAPFILE=""
     matrix:
     - BUILD_TOOLS=true
-    - DM_MAPFILE="templates"
     - DM_MAPFILE="loadallmaps"
 
 cache:

--- a/_maps/birdstation.dm
+++ b/_maps/birdstation.dm
@@ -13,6 +13,7 @@ A small map intended for lowpop(40 players and less).
 		#define MINETYPE "lavaland"
 
 		#include "map_files\BirdStation\BirdStation.dmm"
+#ifndef TRAVIS_MASS_MAP_BUILD
 		#include "map_files\generic\z2.dmm"
 		#include "map_files\generic\z3.dmm"
 		#include "map_files\generic\z4.dmm"
@@ -29,7 +30,7 @@ A small map intended for lowpop(40 players and less).
 		#define MAP_NAME "BirdboatStation"
 
 		#define MAP_TRANSITION_CONFIG DEFAULT_MAP_TRANSITION_CONFIG
-
+#endif
 		#if !defined(MAP_OVERRIDE_FILES)
 				#define MAP_OVERRIDE_FILES
 			#include "map_files\BirdStation\job\job_changes.dm"

--- a/_maps/deltastation.dm
+++ b/_maps/deltastation.dm
@@ -5,6 +5,7 @@
 		#define MINETYPE "lavaland"
 
 		#include "map_files\DeltaStation\DeltaStation2.dmm"
+#ifndef TRAVIS_MASS_MAP_BUILD
 		#include "map_files\generic\z2.dmm"
 		#include "map_files\generic\z3.dmm"
 		#include "map_files\generic\z4.dmm"
@@ -21,7 +22,7 @@
 		#define MAP_NAME "Delta Station"
 
 		#define MAP_TRANSITION_CONFIG DEFAULT_MAP_TRANSITION_CONFIG
-
+#endif
 #elif !defined(MAP_OVERRIDE)
 
 	#warn a map has already been included, deltastation.

--- a/_maps/loadallmaps.dm
+++ b/_maps/loadallmaps.dm
@@ -44,6 +44,10 @@
 
 #undef TRAVIS_MASS_MAP_BUILD
 
+#ifdef TRAVISBUILDING
+#include "templates.dm"
+#endif
+
 #include "runtimestation.dm"
 
 #define BYOND_WHY_YOU_NO_ALLOW_INCLUDE_LAST_LINE //because byond fails to compile if the last thing in a file is an include.

--- a/_maps/loadallmaps.dm
+++ b/_maps/loadallmaps.dm
@@ -1,0 +1,49 @@
+#define TRAVIS_MASS_MAP_BUILD
+#define MAP_TRANSITION_CONFIG DEFAULT_MAP_TRANSITION_CONFIG
+
+#include "birdstation.dm"
+#ifdef MAP_OVERRIDE_FILES
+	#undef MAP_OVERRIDE_FILES
+#endif
+
+#include "deltastation.dm"
+#ifdef MAP_OVERRIDE_FILES
+	#undef MAP_OVERRIDE_FILES
+#endif
+
+#include "metastation.dm"
+#ifdef MAP_OVERRIDE_FILES
+	#undef MAP_OVERRIDE_FILES
+#endif
+
+#include "omegastation.dm"
+#ifdef MAP_OVERRIDE_FILES
+	#undef MAP_OVERRIDE_FILES
+#endif
+
+#include "pubbystation.dm"
+#ifdef MAP_OVERRIDE_FILES
+	#undef MAP_OVERRIDE_FILES
+#endif
+
+#include "tgstation2.dm"
+#ifdef MAP_OVERRIDE_FILES
+	#undef MAP_OVERRIDE_FILES
+#endif
+
+#include "map_files\generic\z2.dmm"
+#include "map_files\generic\z3.dmm"
+#include "map_files\generic\z4.dmm"
+#include "map_files\generic\lavaland.dmm"
+#include "map_files\generic\z6.dmm"
+#include "map_files\generic\z7.dmm"
+#include "map_files\generic\z8.dmm"
+#include "map_files\generic\z9.dmm"
+#include "map_files\generic\z10.dmm"
+#include "map_files\generic\z11.dmm"
+
+#undef TRAVIS_MASS_MAP_BUILD
+
+#include "runtimestation.dm"
+
+#define BYOND_WHY_YOU_NO_ALLOW_INCLUDE_LAST_LINE //because byond fails to compile if the last thing in a file is an include.

--- a/_maps/metastation.dm
+++ b/_maps/metastation.dm
@@ -5,6 +5,7 @@
 		#define MINETYPE "lavaland"
 
 		#include "map_files\MetaStation\MetaStation.dmm"
+#ifndef TRAVIS_MASS_MAP_BUILD
 		#include "map_files\generic\z2.dmm"
 		#include "map_files\generic\z3.dmm"
 		#include "map_files\generic\z4.dmm"
@@ -21,7 +22,7 @@
 		#define MAP_NAME "MetaStation"
 
 		#define MAP_TRANSITION_CONFIG DEFAULT_MAP_TRANSITION_CONFIG
-
+#endif
 #elif !defined(MAP_OVERRIDE)
 
 	#warn a map has already been included, ignoring MetaStation.

--- a/_maps/omegastation.dm
+++ b/_maps/omegastation.dm
@@ -5,6 +5,7 @@
 		#define MINETYPE "lavaland"
 
 		#include "map_files\OmegaStation\OmegaStation.dmm"
+#ifndef TRAVIS_MASS_MAP_BUILD
 		#include "map_files\generic\z2.dmm"
 		#include "map_files\generic\z3.dmm"
 		#include "map_files\generic\z4.dmm"
@@ -21,7 +22,7 @@
 		#define MAP_NAME "OmegaStation"
 
 		#define MAP_TRANSITION_CONFIG DEFAULT_MAP_TRANSITION_CONFIG
-
+#endif
 		#if !defined(MAP_OVERRIDE_FILES)
 			#define MAP_OVERRIDE_FILES
 			#include "map_files\OmegaStation\job\job_changes.dm"

--- a/_maps/pubbystation.dm
+++ b/_maps/pubbystation.dm
@@ -5,6 +5,7 @@
 		#define MINETYPE "lavaland"
 
 		#include "map_files\PubbyStation\PubbyStation.dmm"
+#ifndef TRAVIS_MASS_MAP_BUILD
 		#include "map_files\generic\z2.dmm"
 		#include "map_files\generic\z3.dmm"
 		#include "map_files\generic\z4.dmm"
@@ -21,7 +22,7 @@
 		#define MAP_NAME "PubbyStation"
 
 		#define MAP_TRANSITION_CONFIG DEFAULT_MAP_TRANSITION_CONFIG
-
+#endif
 		#if !defined(MAP_OVERRIDE_FILES)
 			#define MAP_OVERRIDE_FILES
 			#include "map_files\PubbyStation\job\job_changes.dm"

--- a/_maps/tgstation2.dm
+++ b/_maps/tgstation2.dm
@@ -5,6 +5,7 @@
 		#define MINETYPE "lavaland"
 
         #include "map_files\TgStation\tgstation.2.1.3.dmm"
+#ifndef TRAVIS_MASS_MAP_BUILD
         #include "map_files\generic\z2.dmm"
         #include "map_files\generic\z3.dmm"
         #include "map_files\generic\z4.dmm"
@@ -21,7 +22,7 @@
         #define MAP_NAME "Box Station"
 
 		#define MAP_TRANSITION_CONFIG DEFAULT_MAP_TRANSITION_CONFIG
-
+#endif
 #elif !defined(MAP_OVERRIDE)
 
 	#warn a map has already been included, ignoring /tg/station 2.

--- a/tools/travis/before_build_tools.sh
+++ b/tools/travis/before_build_tools.sh
@@ -5,6 +5,6 @@ if [ "$BUILD_TOOLS" = true ]; then
     cd tgui && source ~/.nvm/nvm.sh && npm install && cd ..
 fi;
 
-if [ "$DM_MAPFILE" = "templates" ]; then
+if [ "$DM_MAPFILE" = "loadallmaps" ]; then
     python tools/travis/template_dm_generator.py
 fi;

--- a/tools/travis/build_byond.sh
+++ b/tools/travis/build_byond.sh
@@ -7,5 +7,5 @@ shopt -s globstar
 if [ "$BUILD_TOOLS" = false ]; then
     (! grep 'step_[xy]' _maps/**/*.dmm)
     source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
-    tools/travis/dm.sh -M${DM_MAPFILE} tgstation.dme
+    tools/travis/dm.sh -DTRAVISBUILDING -M${DM_MAPFILE} tgstation.dme
 fi;


### PR DESCRIPTION
We compile all the maps as one step now so that travis only uses 2 jobs, build tools, and maps.

@tgstation/commit-access 
