### PR TITLE
Prevents SDQL2-query "SELECT /datum" from destroying the server

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -121,6 +121,7 @@
 
 					else
 						text += ": [t]<br>"
+					CHECK_TICK
 
 				usr << browse(text, "window=SDQL-result")
 


### PR DESCRIPTION
SELECT needs a tick_check for sure.