### PR TITLE
You can use a spray bottle to pour chemicals into reagent containers

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -22,7 +22,7 @@
 
 
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user)
-	if(istype(A, /obj/item/weapon/reagent_containers) || istype(A, /obj/structure/sink) || istype(A, /obj/structure/janitorialcart) || istype(A, /obj/machinery/hydroponics))
+	if(istype(A, /obj/structure/sink) || istype(A, /obj/structure/janitorialcart) || istype(A, /obj/machinery/hydroponics))
 		return
 
 	if(istype(A, /obj/structure/reagent_dispensers) && get_dist(src,A) <= 1) //this block copypasted from reagent_containers/glass, for lack of a better solution


### PR DESCRIPTION
**Pouring reagents will always transfer 50 units, it's not accurate**

:cl: ma44
tweak: Nanotrasen has improved training of the crew, teaching crewmembers like you to unscrew the top off the bottle and pour it into containers like beakers. 
/:cl:

Cause if you can dump all the stuff out and have a screwable top, you should be able to pour it into reagent containers (it even has code for when it pours 50 units at a time)  also cause _muh realism_