### PR TITLE
Adds a Lizard Infestation event.

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -156,3 +156,11 @@
 	icon = 'icons/effects/tomatodecal.dmi'
 	icon_state = "salt_pile"
 	gender = NEUTER
+
+/obj/effect/decal/cleanable/filth
+	name = "filth"
+	desc = "Slime left behind by a particularly filthy animal."
+	icon = 'icons/effects/blood.dmi'
+	random_icon_states = list("xfloor2", "xfloor4", "xfloor5", "xfloor7")
+	gender = NEUTER
+

--- a/code/modules/events/vermin_migration.dm
+++ b/code/modules/events/vermin_migration.dm
@@ -1,3 +1,8 @@
+//Mice and lizards
+
+//MICE//
+//why is there an entire not easily generizable subsystem just for this one event I swear to mouse jesus
+
 /datum/round_event_control/mice_migration
 	name = "Mice Migration"
 	typepath = /datum/round_event/mice_migration
@@ -26,3 +31,32 @@
 
 /datum/round_event/mice_migration/start()
 	SSsqueak.trigger_migration(rand(minimum_mice, maximum_mice))
+
+// Lizard filth //
+
+/datum/round_event_control/lizard_infestation
+	name = "Lizard Infestation"
+	typepath = /datum/round_event/lizard_infestation
+	weight = 10
+
+/datum/round_event/lizard_infestation
+	announceWhen = 5
+	var/lizardcount = 15
+	startWhen = 10
+
+/datum/round_event/lizard_infestation/announce()
+	priority_announce("Unusual levels of vermin have been detected near [station_name()]. Please be alert for potential contamination.", "Lifesign Alert")
+
+/datum/round_event/lizard_infestation/start()
+	var/list/turfs = list()
+	for(var/area/maintenance/A in world) // to spawn lizards in maint
+		for(var/turf/open/floor/T in A)
+			turfs += T
+
+	if(turfs.len)
+		for(var/i = 1, i <= lizardcount, i++)
+			var/turf/T = pick(turfs)
+			if(prob(66))
+				new /mob/living/simple_animal/hostile/lizard/filthy(T)
+			else // #notalllizards
+				new /mob/living/simple_animal/hostile/lizard(T)

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/lizard
-	name = "Lizard"
+	name = "lizard"
 	desc = "A cute tiny lizard."
 	icon_state = "lizard"
 	icon_living = "lizard"
@@ -7,6 +7,7 @@
 	speak_emote = list("hisses")
 	health = 5
 	maxHealth = 5
+	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/lizard = 1)
 	faction = list("Lizard")
 	attacktext = "bites"
 	melee_damage_lower = 1
@@ -38,3 +39,15 @@
 		adjustBruteLoss(-2)
 	else
 		..()
+
+/mob/living/simple_animal/hostile/lizard/filthy
+	name = "lizard"
+	desc = "All lizards look alike, but this one somehow seems... filthier."
+	emote_taunt = list("hisses")
+	taunt_chance = 30
+
+/mob/living/simple_animal/hostile/lizard/filthy/Move()
+	..()
+	if (prob(15))	// same as mice chewing wires
+		var/turf/T = get_turf(src)
+		new /obj/effect/decal/cleanable/filth(T)


### PR DESCRIPTION
* An event will periodically spawn 15 lizards (amount can be changed) in maintenance. Some of these are regular lizards. Some of them leave slime trails that someone might want to clean up, especially if they find their way out of maintenance. Otherwise (so far) they are not hostile. If you have other ideas for nuisances these lizards can be let me know.

* Due to the increase of lizard corpses that will result, you can butcher them for meat.

:cl: bgobandit
add: Nanotrasen has cut its vermin extermination budget this year. This is projected to have minimal effect on station vermin levels.
/:cl: