### PR TITLE
[READY]DATUM VERBS AND TOP MENUS!

### DIFF
--- a/code/__DEFINES/menu.dm
+++ b/code/__DEFINES/menu.dm
@@ -1,0 +1,3 @@
+#define CHECKBOX_NONE 0
+#define CHECKBOX_GROUP 1
+#define CHECKBOX_TOGGLE 2

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -457,6 +457,7 @@
 #define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= L.len ? L[I] : null) : L[I]) : null)
 #define LAZYLEN(L) length(L)
 #define LAZYCLEARLIST(L) if(L) L.Cut()
+#define SANITIZE_LIST(L) ( islist(L) ? L : list() )
 
 /* Definining a counter as a series of key -> numeric value entries
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -4,18 +4,12 @@ GLOBAL_PROTECT(admin_verbs_default)
 GLOBAL_LIST_INIT(admin_verbs_default, world.AVerbsDefault())
 /world/proc/AVerbsDefault()
 	return list(
-	/client/proc/toggleadminhelpsound,	/*toggles whether we hear a sound when adminhelps/PMs are used*/
-	/client/proc/toggleannouncelogin, /*toggles if an admin's login is announced during a round*/
 	/client/proc/deadmin,				/*destroys our own admin datum so we can play as a regular player*/
 	/client/proc/cmd_admin_say,			/*admin-only ooc chat*/
 	/client/proc/hide_verbs,			/*hides all our adminverbs*/
 	/client/proc/hide_most_verbs,		/*hides all our hideable adminverbs*/
 	/client/proc/debug_variables,		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
-	/client/proc/deadchat,				/*toggles deadchat on/off*/
 	/client/proc/dsay,					/*talk in deadchat using our ckey/fakekey*/
-	/client/proc/toggleprayers,			/*toggles prayers on/off*/
-	/client/verb/toggleprayersounds,	/*Toggles prayer sounds (HALLELUJAH!)*/
-	/client/proc/toggle_hear_radio,		/*toggles whether we hear the radio*/
 	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
 	/client/proc/secrets,
 	/client/proc/reload_admins,
@@ -29,7 +23,6 @@ GLOBAL_PROTECT(admin_verbs_admin)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 /world/proc/AVerbsAdmin()
 	return list(
-	/client/proc/player_panel_new,		/*shows an interface for all players, with links to various panels*/
 	/client/proc/invisimin,				/*allows our mob to go invisible/visible*/
 //	/datum/admins/proc/show_traitor_panel,	/*interface which shows a mob's mind*/ -Removed due to rare practical use. Moved to debug verbs ~Errorage
 	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
@@ -172,9 +165,6 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	/client/proc/set_ooc,
 	/client/proc/reset_ooc,
 	/client/proc/deadmin,
-	/client/proc/deadchat,
-	/client/proc/toggleprayers,
-	/client/proc/toggle_hear_radio,
 	/datum/admins/proc/show_traitor_panel,
 	/datum/admins/proc/toggleenter,
 	/datum/admins/proc/toggleguests,
@@ -386,13 +376,6 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 		else
 			mob.invisibility = INVISIBILITY_OBSERVER
 			to_chat(mob, "<span class='adminnotice'><b>Invisimin on. You are now as invisible as a ghost.</b></span>")
-
-/client/proc/player_panel_new()
-	set name = "Player Panel"
-	set category = "Admin"
-	if(holder)
-		holder.player_panel_new()
-	SSblackbox.add_details("admin_verb","Player Panel New") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/check_antagonists()
 	set name = "Check Antagonists"

--- a/code/modules/admin/adminmenu.dm
+++ b/code/modules/admin/adminmenu.dm
@@ -1,0 +1,11 @@
+/datum/menu/Admin/Generate_list(client/C)
+	if (C.holder)
+		. = ..()
+
+/datum/menu/Admin/verb/playerpanel()
+	set name = "Player Panel"
+	set desc = "Player Panel"
+	set category = "Admin"
+	usr.client.holder.player_panel_new()
+	SSblackbox.add_details("admin_verb","Player Panel New") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -328,6 +328,26 @@ GLOBAL_LIST(external_rsc_urls)
 	if(!tooltips)
 		tooltips = new /datum/tooltip(src)
 
+	var/list/topmenus = GLOB.menulist[/datum/menu]
+	for (var/thing in topmenus)
+		var/datum/menu/topmenu = thing
+		var/topmenuname = "[topmenu]"
+		if (topmenuname == "[topmenu.type]")
+			var/list/tree = splittext(topmenuname, "/")
+			topmenuname = tree[tree.len]
+		winset(src, "[topmenu.type]", "parent=menu;name=[url_encode(topmenuname)]")
+		var/list/entries = topmenu.Generate_list(src)
+		for (var/child in entries)
+			winset(src, "[url_encode(child)]", "[entries[child]]")
+			if (!ispath(child, /datum/menu))
+				var/atom/verb/verbpath = child
+				if (copytext(verbpath.name,1,2) != "@")
+					new child(src)
+
+	for (var/thing in prefs.menuoptions)
+		var/datum/menu/menuitem = GLOB.menulist[thing]
+		if (menuitem)
+			menuitem.Load_checked(src)
 
 //////////////
 //DISCONNECT//

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -102,6 +102,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/uplink_spawn_loc = UPLINK_PDA
 
+	var/list/menuoptions
+
 /datum/preferences/New(client/C)
 	parent = C
 	custom_names["ai"] = pick(GLOB.ai_names)
@@ -124,6 +126,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(!loaded_preferences_successfully)
 		save_preferences()
 	save_character()		//let's save this new random character so it doesn't keep generating new ones.
+	menuoptions = list()
 	return
 
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,5 +1,5 @@
 //This is the lowest supported version, anything below this is completely obsolete and the entire savefile will be wiped.
-#define SAVEFILE_VERSION_MIN	10
+#define SAVEFILE_VERSION_MIN	15
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
 #define SAVEFILE_VERSION_MAX	17
@@ -88,15 +88,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 
 /datum/preferences/proc/update_preferences(current_version, savefile/S)
-	if(current_version < 10)
-		toggles |= MEMBER_PUBLIC
-	if(current_version < 11)
-		chat_toggles = TOGGLES_DEFAULT_CHAT
-		toggles = TOGGLES_DEFAULT
-	if(current_version < 12)
-		ignoring = list()
-	if(current_version < 15)
-		toggles |= SOUND_ANNOUNCEMENTS
 
 
 //should this proc get fairly long (say 3 versions long),
@@ -106,16 +97,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 //It's only really meant to avoid annoying frequent players
 //if your savefile is 3 months out of date, then 'tough shit'.
 /datum/preferences/proc/update_character(current_version, savefile/S)
-	if(pref_species && !(pref_species.id in GLOB.roundstart_species))
-		var/rando_race = pick(config.roundstart_races)
-		pref_species = new rando_race()
-
-	if(current_version < 13 || !istext(backbag))
-		switch(backbag)
-			if(2)
-				backbag = DSATCHEL
-			else
-				backbag = DBACKPACK
 	if(current_version < 16)
 		var/berandom
 		S["userandomjob"] >> berandom
@@ -156,12 +137,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["tgui_fancy"]			>> tgui_fancy
 	S["tgui_lock"]			>> tgui_lock
 	S["windowflash"]		>> windowflashing
+	S["be_special"] 		>> be_special
 
-	if(islist(S["be_special"]))
-		S["be_special"] 	>> be_special
-	else //force update and store the old bitflag version of be_special
-		needs_update = 11
-		S["be_special"] 	>> old_be_special
 
 	S["default_slot"]		>> default_slot
 	S["chat_toggles"]		>> chat_toggles
@@ -177,6 +154,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["uses_glasses_colour"]>> uses_glasses_colour
 	S["clientfps"]			>> clientfps
 	S["parallax"]			>> parallax
+	S["menuoptions"]			>> menuoptions
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
@@ -199,6 +177,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	ghost_orbit 	= sanitize_inlist(ghost_orbit, GLOB.ghost_orbits, initial(ghost_orbit))
 	ghost_accs		= sanitize_inlist(ghost_accs, GLOB.ghost_accs_options, GHOST_ACCS_DEFAULT_OPTION)
 	ghost_others	= sanitize_inlist(ghost_others, GLOB.ghost_others_options, GHOST_OTHERS_DEFAULT_OPTION)
+	menuoptions		= SANITIZE_LIST(menuoptions)
+	be_special		= SANITIZE_LIST(be_special)
+
 
 	return 1
 
@@ -235,6 +216,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["uses_glasses_colour"]<< uses_glasses_colour
 	S["clientfps"]			<< clientfps
 	S["parallax"]			<< parallax
+	S["menuoptions"]		<< menuoptions
 
 	return 1
 
@@ -444,7 +426,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 #undef SAVEFILE_VERSION_MAX
 #undef SAVEFILE_VERSION_MIN
-/*
+
 //DEBUG
 //Some crude tools for testing savefiles
 //path is the savefile path
@@ -455,4 +437,4 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 /client/verb/savefile_import(path as text)
 	var/savefile/S = new /savefile(path)
 	S.ImportText("/",file("[path].txt"))
-*/
+

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -427,6 +427,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 #undef SAVEFILE_VERSION_MAX
 #undef SAVEFILE_VERSION_MIN
 
+#ifdef TESTING
 //DEBUG
 //Some crude tools for testing savefiles
 //path is the savefile path
@@ -438,3 +439,4 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	var/savefile/S = new /savefile(path)
 	S.ImportText("/",file("[path].txt"))
 
+#endif

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -1,162 +1,249 @@
+//this works as is to create a single checked item, but has no back end code for toggleing the check yet
+#define TOGGLE_CHECKBOX(PARENT, CHILD) PARENT/CHILD/abstract = TRUE;PARENT/CHILD/checkbox = CHECKBOX_TOGGLE;PARENT/CHILD/verb/CHILD
+
+//Example usage TOGGLE_CHECKBOX(datum/menu/Settings/Ghost/chatterbox, toggle_ghost_ears)()
+
+//override because we don't want to save preferences twice.
+/datum/menu/Settings/Set_checked(client/C, verbpath)
+	if (checkbox == CHECKBOX_GROUP)
+		C.prefs.menuoptions[type] = verbpath
+	else if (checkbox == CHECKBOX_TOGGLE)
+		var/checked = Get_checked(C)
+		C.prefs.menuoptions[type] = !checked
+		winset(C, "[verbpath]", "is-checked = [!checked]")
+
+/datum/menu/Settings/verb/setup_character()
+	set name = "Game Preferences"
+	set category = "Preferences"
+	set desc = "Open Game Preferences Window"
+	usr.client.prefs.current_tab = 1
+	usr.client.prefs.ShowChoices(usr)
+
 //toggles
-/client/verb/toggle_ghost_ears()
+/datum/menu/Settings/Ghost/chatterbox
+	name = "Chat Box Spam"
+
+TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_ears)()
 	set name = "Show/Hide GhostEars"
-	set category = "Preferences"
-	set desc = ".Toggle Between seeing all mob speech, and only speech of nearby mobs"
-	prefs.chat_toggles ^= CHAT_GHOSTEARS
-	to_chat(src, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTEARS) ? "see all speech in the world" : "only see speech from nearby mobs"].")
-	prefs.save_preferences()
-	SSblackbox.add_details("preferences_verb","Toggle Ghost Ears|[prefs.chat_toggles & CHAT_GHOSTEARS]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	set category = ""
+	set desc = "See All Speech"
+	usr.client.prefs.chat_toggles ^= CHAT_GHOSTEARS
+	to_chat(usr, "As a ghost, you will now [(usr.client.prefs.chat_toggles & CHAT_GHOSTEARS) ? "see all speech in the world" : "only see speech from nearby mobs"].")
+	usr.client.prefs.save_preferences()
+	SSblackbox.add_details("preferences_verb","Toggle Ghost Ears|[usr.client.prefs.chat_toggles & CHAT_GHOSTEARS]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Ghost/chatterbox/toggle_ghost_ears/Get_checked(client/C)
+	return C.prefs.chat_toggles & CHAT_GHOSTEARS
 
-/client/verb/toggle_ghost_sight()
+TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_sight)()
 	set name = "Show/Hide GhostSight"
-	set category = "Preferences"
-	set desc = ".Toggle Between seeing all mob emotes, and only emotes of nearby mobs"
-	prefs.chat_toggles ^= CHAT_GHOSTSIGHT
-	to_chat(src, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTSIGHT) ? "see all emotes in the world" : "only see emotes from nearby mobs"].")
-	prefs.save_preferences()
-	SSblackbox.add_details("preferences_verb","Toggle Ghost Sight|[prefs.chat_toggles & CHAT_GHOSTSIGHT]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	set category = ""
+	set desc = "See All Emotes"
+	usr.client.prefs.chat_toggles ^= CHAT_GHOSTSIGHT
+	to_chat(usr, "As a ghost, you will now [(usr.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) ? "see all emotes in the world" : "only see emotes from nearby mobs"].")
+	usr.client.prefs.save_preferences()
+	SSblackbox.add_details("preferences_verb","Toggle Ghost Sight|[usr.client.prefs.chat_toggles & CHAT_GHOSTSIGHT]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Ghost/chatterbox/toggle_ghost_sight/Get_checked(client/C)
+	return C.prefs.chat_toggles & CHAT_GHOSTSIGHT
 
-/client/verb/toggle_ghost_whispers()
+TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_whispers)()
 	set name = "Show/Hide GhostWhispers"
-	set category = "Preferences"
-	set desc = ".Toggle between hearing all whispers, and only whispers of nearby mobs"
-	prefs.chat_toggles ^= CHAT_GHOSTWHISPER
-	to_chat(src, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTWHISPER) ? "see all whispers in the world" : "only see whispers from nearby mobs"].")
-	prefs.save_preferences()
-	SSblackbox.add_details("preferences_verb","Toggle Ghost Whispers|[prefs.chat_toggles & CHAT_GHOSTWHISPER]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	set category = ""
+	set desc = "See All Whispers"
+	usr.client.prefs.chat_toggles ^= CHAT_GHOSTWHISPER
+	to_chat(usr, "As a ghost, you will now [(usr.client.prefs.chat_toggles & CHAT_GHOSTWHISPER) ? "see all whispers in the world" : "only see whispers from nearby mobs"].")
+	usr.client.prefs.save_preferences()
+	SSblackbox.add_details("preferences_verb","Toggle Ghost Whispers|[usr.client.prefs.chat_toggles & CHAT_GHOSTWHISPER]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Ghost/chatterbox/toggle_ghost_whispers/Get_checked(client/C)
+	return C.prefs.chat_toggles & CHAT_GHOSTWHISPER
 
-/client/verb/toggle_ghost_radio()
+TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_radio)()
 	set name = "Show/Hide GhostRadio"
-	set category = "Preferences"
-	set desc = ".Enable or disable hearing radio chatter as a ghost"
-	prefs.chat_toggles ^= CHAT_GHOSTRADIO
-	to_chat(src, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTRADIO) ? "see radio chatter" : "not see radio chatter"].")
-	prefs.save_preferences()
-	SSblackbox.add_details("preferences_verb","Toggle Ghost Radio|[prefs.chat_toggles & CHAT_GHOSTRADIO]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc! //social experiment, increase the generation whenever you copypaste this shamelessly GENERATION 1
+	set category = ""
+	set desc = "See All Radio Chatter"
+	usr.client.prefs.chat_toggles ^= CHAT_GHOSTRADIO
+	to_chat(usr, "As a ghost, you will now [(usr.client.prefs.chat_toggles & CHAT_GHOSTRADIO) ? "see radio chatter" : "not see radio chatter"].")
+	usr.client.prefs.save_preferences()
+	SSblackbox.add_details("preferences_verb","Toggle Ghost Radio|[usr.client.prefs.chat_toggles & CHAT_GHOSTRADIO]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc! //social experiment, increase the generation whenever you copypaste this shamelessly GENERATION 1
+/datum/menu/Settings/Ghost/chatterbox/toggle_ghost_radio/Get_checked(client/C)
+	return C.prefs.chat_toggles & CHAT_GHOSTRADIO
 
-/client/verb/toggle_ghost_pda()
+TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_pda)()
 	set name = "Show/Hide GhostPDA"
-	set category = "Preferences"
-	set desc = ".Toggle Between seeing all mob pda messages, and only pda messages of nearby mobs"
-	prefs.chat_toggles ^= CHAT_GHOSTPDA
-	to_chat(src, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTPDA) ? "see all pda messages in the world" : "only see pda messages from nearby mobs"].")
-	prefs.save_preferences()
-	SSblackbox.add_details("preferences_verb","Toggle Ghost PDA|[prefs.chat_toggles & CHAT_GHOSTPDA]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	set category = ""
+	set desc = "See All PDA Messages"
+	usr.client.prefs.chat_toggles ^= CHAT_GHOSTPDA
+	to_chat(usr, "As a ghost, you will now [(usr.client.prefs.chat_toggles & CHAT_GHOSTPDA) ? "see all pda messages in the world" : "only see pda messages from nearby mobs"].")
+	usr.client.prefs.save_preferences()
+	SSblackbox.add_details("preferences_verb","Toggle Ghost PDA|[usr.client.prefs.chat_toggles & CHAT_GHOSTPDA]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Ghost/chatterbox/toggle_ghost_pda/Get_checked(client/C)
+	return C.prefs.chat_toggles & CHAT_GHOSTPDA
+
+/datum/menu/Settings/Ghost/chatterbox/Events
+	name = "Events"
 
 //please be aware that the following two verbs have inverted stat output, so that "Toggle Deathrattle|1" still means you activated it
-/client/verb/toggle_deathrattle()
+TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox/Events, toggle_deathrattle)()
 	set name = "Toggle Deathrattle"
-	set category = "Preferences"
-	set desc = "Toggle recieving a message in deadchat when sentient mobs die."
-	prefs.toggles ^= DISABLE_DEATHRATTLE
-	prefs.save_preferences()
-	to_chat(usr, "You will [(prefs.toggles & DISABLE_DEATHRATTLE) ? "no longer" : "now"] get messages when a sentient mob dies.")
-	SSblackbox.add_details("preferences_verb", "Toggle Deathrattle|[!(prefs.toggles & DISABLE_DEATHRATTLE)]") //If you are copy-pasting this, maybe you should spend some time reading the comments.
+	set category = ""
+	set desc = "Death"
+	usr.client.prefs.toggles ^= DISABLE_DEATHRATTLE
+	usr.client.prefs.save_preferences()
+	to_chat(usr, "You will [(usr.client.prefs.toggles & DISABLE_DEATHRATTLE) ? "no longer" : "now"] get messages when a sentient mob dies.")
+	SSblackbox.add_details("preferences_verb", "Toggle Deathrattle|[!(usr.client.prefs.toggles & DISABLE_DEATHRATTLE)]") //If you are copy-pasting this, maybe you should spend some time reading the comments.
+/datum/menu/Settings/Ghost/chatterbox/Events/toggle_deathrattle/Get_checked(client/C)
+	return !(C.prefs.toggles & DISABLE_DEATHRATTLE)
 
-/client/verb/toggle_arrivalrattle()
+TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox/Events, toggle_arrivalrattle)()
 	set name = "Toggle Arrivalrattle"
-	set category = "Preferences"
-	set desc = "Toggle recieving a message in deadchat when someone joins the station."
-	prefs.toggles ^= DISABLE_ARRIVALRATTLE
-	to_chat(usr, "You will [(prefs.toggles & DISABLE_ARRIVALRATTLE) ? "no longer" : "now"] get messages when someone joins the station.")
-	prefs.save_preferences()
-	SSblackbox.add_details("preferences_verb", "Toggle Arrivalrattle|[!(prefs.toggles & DISABLE_ARRIVALRATTLE)]") //If you are copy-pasting this, maybe you should rethink where your life went so wrong.
+	set category = ""
+	set desc = "New Player Arrival"
+	usr.client.prefs.toggles ^= DISABLE_ARRIVALRATTLE
+	to_chat(usr, "You will [(usr.client.prefs.toggles & DISABLE_ARRIVALRATTLE) ? "no longer" : "now"] get messages when someone joins the station.")
+	usr.client.prefs.save_preferences()
+	SSblackbox.add_details("preferences_verb", "Toggle Arrivalrattle|[!(usr.client.prefs.toggles & DISABLE_ARRIVALRATTLE)]") //If you are copy-pasting this, maybe you should rethink where your life went so wrong.
+/datum/menu/Settings/Ghost/chatterbox/Events/toggle_arrivalrattle/Get_checked(client/C)
+	return !(C.prefs.toggles & DISABLE_ARRIVALRATTLE)
 
-/client/verb/togglemidroundantag()
+TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost, togglemidroundantag)()
 	set name = "Toggle Midround Antagonist"
-	set category = "Preferences"
-	set desc = "Toggles whether or not you will be considered for antagonist status given during a round."
-	prefs.toggles ^= MIDROUND_ANTAG
-	prefs.save_preferences()
-	to_chat(src, "You will [(prefs.toggles & MIDROUND_ANTAG) ? "now" : "no longer"] be considered for midround antagonist positions.")
-	SSblackbox.add_details("preferences_verb","Toggle Midround Antag|[prefs.toggles & MIDROUND_ANTAG]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	set category = ""
+	set desc = "Midround Antagonist"
+	usr.client.prefs.toggles ^= MIDROUND_ANTAG
+	usr.client.prefs.save_preferences()
+	to_chat(usr, "You will [(usr.client.prefs.toggles & MIDROUND_ANTAG) ? "now" : "no longer"] be considered for midround antagonist positions.")
+	SSblackbox.add_details("preferences_verb","Toggle Midround Antag|[usr.client.prefs.toggles & MIDROUND_ANTAG]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Ghost/togglemidroundantag/Get_checked(client/C)
+	return C.prefs.toggles & MIDROUND_ANTAG
 
-/client/verb/toggletitlemusic()
+TOGGLE_CHECKBOX(/datum/menu/Settings/Sound, toggletitlemusic)()
 	set name = "Hear/Silence LobbyMusic"
 	set category = "Preferences"
-	set desc = "Toggles hearing the GameLobby music"
-	prefs.toggles ^= SOUND_LOBBY
-	prefs.save_preferences()
-	if(prefs.toggles & SOUND_LOBBY)
-		to_chat(src, "You will now hear music in the game lobby.")
-		if(isnewplayer(mob))
-			playtitlemusic()
+	set desc = "Hear Music In Lobby"
+	usr.client.prefs.toggles ^= SOUND_LOBBY
+	usr.client.prefs.save_preferences()
+	if(usr.client.prefs.toggles & SOUND_LOBBY)
+		to_chat(usr, "You will now hear music in the game lobby.")
+		if(isnewplayer(usr))
+			usr.client.playtitlemusic()
 	else
-		to_chat(src, "You will no longer hear music in the game lobby.")
-		mob.stop_sound_channel(CHANNEL_LOBBYMUSIC)
-	SSblackbox.add_details("preferences_verb","Toggle Lobby Music|[prefs.toggles & SOUND_LOBBY]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		to_chat(usr, "You will no longer hear music in the game lobby.")
+		usr.stop_sound_channel(CHANNEL_LOBBYMUSIC)
+	SSblackbox.add_details("preferences_verb","Toggle Lobby Music|[usr.client.prefs.toggles & SOUND_LOBBY]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Sound/toggletitlemusic/Get_checked(client/C)
+	return C.prefs.toggles & SOUND_LOBBY
 
-/client/verb/togglemidis()
+
+TOGGLE_CHECKBOX(/datum/menu/Settings/Sound, togglemidis)()
 	set name = "Hear/Silence Midis"
 	set category = "Preferences"
-	set desc = "Toggles hearing sounds uploaded by admins"
-	prefs.toggles ^= SOUND_MIDI
-	prefs.save_preferences()
-	if(prefs.toggles & SOUND_MIDI)
-		to_chat(src, "You will now hear any sounds uploaded by admins.")
+	set desc = "Hear Admin Triggered Sounds (Midis)"
+	usr.client.prefs.toggles ^= SOUND_MIDI
+	usr.client.prefs.save_preferences()
+	if(usr.client.prefs.toggles & SOUND_MIDI)
+		to_chat(usr, "You will now hear any sounds uploaded by admins.")
 	else
-		to_chat(src, "You will no longer hear sounds uploaded by admins")
-		mob.stop_sound_channel(CHANNEL_ADMIN)
-	SSblackbox.add_details("preferences_verb","Toggle Hearing Midis|[prefs.toggles & SOUND_MIDI]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		to_chat(usr, "You will no longer hear sounds uploaded by admins")
+		usr.stop_sound_channel(CHANNEL_ADMIN)
+	SSblackbox.add_details("preferences_verb","Toggle Hearing Midis|[usr.client.prefs.toggles & SOUND_MIDI]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Sound/togglemidis/Get_checked(client/C)
+	return C.prefs.toggles & SOUND_MIDI
 
-/client/verb/stop_client_sounds()
-	set name = "Stop Sounds"
-	set category = "Preferences"
-	set desc = "Kills all currently playing sounds, use if admin taste in midis a shite"
-	src << sound(null)
-	SSblackbox.add_details("preferences_verb","Stop Self Sounds") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/verb/listen_ooc()
-	set name = "Show/Hide OOC"
-	set category = "Preferences"
-	set desc = "Toggles seeing OutOfCharacter chat"
-	prefs.chat_toggles ^= CHAT_OOC
-	prefs.save_preferences()
-	to_chat(src, "You will [(prefs.chat_toggles & CHAT_OOC) ? "now" : "no longer"] see messages on the OOC channel.")
-	SSblackbox.add_details("preferences_verb","Toggle Seeing OOC|[prefs.chat_toggles & CHAT_OOC]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/client/verb/Toggle_Soundscape() //All new ambience should be added here so it works with this verb until someone better at things comes up with a fix that isn't awful
-	set name = "Hear/Silence Ambience"
-	set category = "Preferences"
-	set desc = "Toggles hearing ambient sound effects"
-	prefs.toggles ^= SOUND_AMBIENCE
-	prefs.save_preferences()
-	if(prefs.toggles & SOUND_AMBIENCE)
-		to_chat(src, "You will now hear ambient sounds.")
-	else
-		to_chat(src, "You will no longer hear ambient sounds.")
-		src << sound(null, repeat = 0, wait = 0, volume = 0, channel = 1)
-		src << sound(null, repeat = 0, wait = 0, volume = 0, channel = 2)
-	SSblackbox.add_details("preferences_verb","Toggle Ambience|[prefs.toggles & SOUND_AMBIENCE]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-// This needs a toggle because you people are awful and spammed terrible music
-/client/verb/toggle_instruments()
+TOGGLE_CHECKBOX(/datum/menu/Settings/Sound, toggle_instruments)()
 	set name = "Hear/Silence Instruments"
 	set category = "Preferences"
-	set desc = "Toggles hearing musical instruments like the violin and piano"
-	prefs.toggles ^= SOUND_INSTRUMENTS
-	prefs.save_preferences()
-	if(prefs.toggles & SOUND_INSTRUMENTS)
-		to_chat(src, "You will now hear people playing musical instruments.")
+	set desc = "Hear In-game Instruments"
+	usr.client.prefs.toggles ^= SOUND_INSTRUMENTS
+	usr.client.prefs.save_preferences()
+	if(usr.client.prefs.toggles & SOUND_INSTRUMENTS)
+		to_chat(usr, "You will now hear people playing musical instruments.")
 	else
-		to_chat(src, "You will no longer hear musical instruments.")
-	SSblackbox.add_details("preferences_verb","Toggle Instruments|[prefs.toggles & SOUND_INSTRUMENTS]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		to_chat(usr, "You will no longer hear musical instruments.")
+	SSblackbox.add_details("preferences_verb","Toggle Instruments|[usr.client.prefs.toggles & SOUND_INSTRUMENTS]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Sound/toggle_instruments/Get_checked(client/C)
+	return C.prefs.toggles & SOUND_INSTRUMENTS
 
-//Lots of people get headaches from the normal ship ambience, this is to prevent that
-/client/verb/toggle_ship_ambience()
+
+TOGGLE_CHECKBOX(/datum/menu/Settings/Sound, Toggle_Soundscape)()
+	set name = "Hear/Silence Ambience"
+	set category = "Preferences"
+	set desc = "Hear Ambient Sound Effects"
+	usr.client.prefs.toggles ^= SOUND_AMBIENCE
+	usr.client.prefs.save_preferences()
+	if(usr.client.prefs.toggles & SOUND_AMBIENCE)
+		to_chat(usr, "You will now hear ambient sounds.")
+	else
+		to_chat(usr, "You will no longer hear ambient sounds.")
+		usr << sound(null, repeat = 0, wait = 0, volume = 0, channel = 1)
+		usr << sound(null, repeat = 0, wait = 0, volume = 0, channel = 2)
+	SSblackbox.add_details("preferences_verb","Toggle Ambience|[usr.client.prefs.toggles & SOUND_AMBIENCE]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Sound/Toggle_Soundscape/Get_checked(client/C)
+	return C.prefs.toggles & SOUND_AMBIENCE
+
+
+TOGGLE_CHECKBOX(/datum/menu/Settings/Sound, toggle_ship_ambience)()
 	set name = "Hear/Silence Ship Ambience"
 	set category = "Preferences"
-	set desc = "Toggles hearing generalized ship ambience, no matter your area."
-	prefs.toggles ^= SOUND_SHIP_AMBIENCE
-	prefs.save_preferences()
-	if(prefs.toggles & SOUND_SHIP_AMBIENCE)
-		to_chat(src, "You will now hear ship ambience.")
+	set desc = "Hear Ship Ambience Roar"
+	usr.client.prefs.toggles ^= SOUND_SHIP_AMBIENCE
+	usr.client.prefs.save_preferences()
+	if(usr.client.prefs.toggles & SOUND_SHIP_AMBIENCE)
+		to_chat(usr, "You will now hear ship ambience.")
 	else
-		to_chat(src, "You will no longer hear ship ambience.")
-		src << sound(null, repeat = 0, wait = 0, volume = 0, channel = 2)
-		src.ambience_playing = 0
-	SSblackbox.add_details("preferences_verb", "Toggle Ship Ambience|[prefs.toggles & SOUND_SHIP_AMBIENCE]") //If you are copy-pasting this, I bet you read this comment expecting to see the same thing :^)
+		to_chat(usr, "You will no longer hear ship ambience.")
+		usr << sound(null, repeat = 0, wait = 0, volume = 0, channel = 2)
+		usr.client.ambience_playing = 0
+	SSblackbox.add_details("preferences_verb", "Toggle Ship Ambience|[usr.client.prefs.toggles & SOUND_SHIP_AMBIENCE]") //If you are copy-pasting this, I bet you read this comment expecting to see the same thing :^)
+/datum/menu/Settings/Sound/toggle_ship_ambience/Get_checked(client/C)
+	return C.prefs.toggles & SOUND_SHIP_AMBIENCE
+
+
+TOGGLE_CHECKBOX(/datum/menu/Settings/Sound, toggle_announcement_sound)()
+	set name = "Hear/Silence Announcements"
+	set category = "Preferences"
+	set desc = "Hear Announcement Sound"
+	usr.client.prefs.toggles ^= SOUND_ANNOUNCEMENTS
+	to_chat(usr, "You will now [(usr.client.prefs.toggles & SOUND_ANNOUNCEMENTS) ? "hear announcement sounds" : "no longer hear announcements"].")
+	usr.client.prefs.save_preferences()
+	SSblackbox.add_details("preferences_verb","Toggle Announcement Sound|[usr.client.prefs.toggles & SOUND_ANNOUNCEMENTS]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Sound/toggle_announcement_sound/Get_checked(client/C)
+	return C.prefs.toggles & SOUND_ANNOUNCEMENTS
+
+
+TOGGLE_CHECKBOX(/datum/menu/Settings/Sound, toggleprayersounds)()
+	set name = "Hear/Silence Prayer Sounds"
+	set category = "Preferences"
+	set desc = "Hear Prayer Sounds"
+	usr.client.prefs.toggles ^= SOUND_PRAYERS
+	usr.client.prefs.save_preferences()
+	if(usr.client.prefs.toggles & SOUND_PRAYERS)
+		to_chat(usr, "You will now hear prayer sounds.")
+	else
+		to_chat(usr, "You will no longer prayer sounds.")
+	SSblackbox.add_details("admin_toggle", "Toggle Prayer Sounds|[usr.client.prefs.toggles & SOUND_PRAYERS]")
+/datum/menu/Settings/Sound/toggleprayersounds/Get_checked(client/C)
+	return C.prefs.toggles & SOUND_PRAYERS
+
+
+/datum/menu/Settings/Sound/verb/stop_client_sounds()
+	set name = "Stop Sounds"
+	set category = "Preferences"
+	set desc = "Stop Current Sounds"
+	usr << sound(null)
+	SSblackbox.add_details("preferences_verb","Stop Self Sounds") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+
+TOGGLE_CHECKBOX(/datum/menu/Settings, listen_ooc)()
+	set name = "Show/Hide OOC"
+	set category = "Preferences"
+	set desc = "Show OOC Chat"
+	usr.client.prefs.chat_toggles ^= CHAT_OOC
+	usr.client.prefs.save_preferences()
+	to_chat(usr, "You will [(usr.client.prefs.chat_toggles & CHAT_OOC) ? "now" : "no longer"] see messages on the OOC channel.")
+	SSblackbox.add_details("preferences_verb","Toggle Seeing OOC|[usr.client.prefs.chat_toggles & CHAT_OOC]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/listen_ooc/Get_checked(client/C)
+	return C.prefs.chat_toggles & CHAT_OOC
+
 
 GLOBAL_LIST_INIT(ghost_forms, list("ghost","ghostking","ghostian2","skeleghost","ghost_red","ghost_black", \
 							"ghost_blue","ghost_yellow","ghost_green","ghost_pink", \
@@ -246,13 +333,6 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 	prefs.save_preferences()
 	SSblackbox.add_details("preferences_verb","Toggle Intent Selection|[prefs.toggles & INTENT_STYLE]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/verb/setup_character()
-	set name = "Game Preferences"
-	set category = "Preferences"
-	set desc = "Allows you to access the Setup Character screen. Changes to your character won't take effect until next round, but other changes will."
-	prefs.current_tab = 1
-	prefs.ShowChoices(usr)
-
 /client/verb/toggle_ghost_hud_pref()
 	set name = "Toggle Ghost HUD"
 	set category = "Preferences"
@@ -277,15 +357,6 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 	else
 		to_chat(src, "<span class='notice'>You will no longer examine things you click on.</span>")
 	SSblackbox.add_details("preferences_verb","Toggle Ghost Inquisitiveness|[prefs.inquisitive_ghost]")
-
-/client/verb/toggle_announcement_sound()
-	set name = "Hear/Silence Announcements"
-	set category = "Preferences"
-	set desc = ".Toggles hearing Central Command, Captain, VOX, and other announcement sounds"
-	prefs.toggles ^= SOUND_ANNOUNCEMENTS
-	to_chat(src, "You will now [(prefs.toggles & SOUND_ANNOUNCEMENTS) ? "hear announcement sounds" : "no longer hear announcements"].")
-	prefs.save_preferences()
-	SSblackbox.add_details("preferences_verb","Toggle Announcement Sound|[prefs.toggles & SOUND_ANNOUNCEMENTS]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 //Admin Preferences
 /client/proc/toggleadminhelpsound()
@@ -338,14 +409,3 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 	to_chat(src, "You will [(prefs.chat_toggles & CHAT_PRAYER) ? "now" : "no longer"] see prayerchat.")
 	SSblackbox.add_details("admin_toggle","Toggle Prayer Visibility|[prefs.chat_toggles & CHAT_PRAYER]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/verb/toggleprayersounds()
-	set name = "Hear/Silence Prayer Sounds"
-	set category = "Preferences"
-	set desc = "Toggles hearing pray sounds."
-	prefs.toggles ^= SOUND_PRAYERS
-	prefs.save_preferences()
-	if(prefs.toggles & SOUND_PRAYERS)
-		to_chat(src, "You will now hear prayer sounds.")
-	else
-		to_chat(src, "You will no longer prayer sounds.")
-	SSblackbox.add_details("admin_toggle", "Toggle Prayer Sounds|[prefs.toggles & SOUND_PRAYERS]")

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -25,7 +25,7 @@
 
 TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_ears)()
 	set name = "Show/Hide GhostEars"
-	set category = ""
+	set category = "Preferences"
 	set desc = "See All Speech"
 	usr.client.prefs.chat_toggles ^= CHAT_GHOSTEARS
 	to_chat(usr, "As a ghost, you will now [(usr.client.prefs.chat_toggles & CHAT_GHOSTEARS) ? "see all speech in the world" : "only see speech from nearby mobs"].")
@@ -36,7 +36,7 @@ TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_ears)()
 
 TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_sight)()
 	set name = "Show/Hide GhostSight"
-	set category = ""
+	set category = "Preferences"
 	set desc = "See All Emotes"
 	usr.client.prefs.chat_toggles ^= CHAT_GHOSTSIGHT
 	to_chat(usr, "As a ghost, you will now [(usr.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) ? "see all emotes in the world" : "only see emotes from nearby mobs"].")
@@ -47,7 +47,7 @@ TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_sight)()
 
 TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_whispers)()
 	set name = "Show/Hide GhostWhispers"
-	set category = ""
+	set category = "Preferences"
 	set desc = "See All Whispers"
 	usr.client.prefs.chat_toggles ^= CHAT_GHOSTWHISPER
 	to_chat(usr, "As a ghost, you will now [(usr.client.prefs.chat_toggles & CHAT_GHOSTWHISPER) ? "see all whispers in the world" : "only see whispers from nearby mobs"].")
@@ -58,7 +58,7 @@ TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_whispers)()
 
 TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_radio)()
 	set name = "Show/Hide GhostRadio"
-	set category = ""
+	set category = "Preferences"
 	set desc = "See All Radio Chatter"
 	usr.client.prefs.chat_toggles ^= CHAT_GHOSTRADIO
 	to_chat(usr, "As a ghost, you will now [(usr.client.prefs.chat_toggles & CHAT_GHOSTRADIO) ? "see radio chatter" : "not see radio chatter"].")
@@ -69,7 +69,7 @@ TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_radio)()
 
 TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_pda)()
 	set name = "Show/Hide GhostPDA"
-	set category = ""
+	set category = "Preferences"
 	set desc = "See All PDA Messages"
 	usr.client.prefs.chat_toggles ^= CHAT_GHOSTPDA
 	to_chat(usr, "As a ghost, you will now [(usr.client.prefs.chat_toggles & CHAT_GHOSTPDA) ? "see all pda messages in the world" : "only see pda messages from nearby mobs"].")
@@ -84,7 +84,7 @@ TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox, toggle_ghost_pda)()
 //please be aware that the following two verbs have inverted stat output, so that "Toggle Deathrattle|1" still means you activated it
 TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox/Events, toggle_deathrattle)()
 	set name = "Toggle Deathrattle"
-	set category = ""
+	set category = "Preferences"
 	set desc = "Death"
 	usr.client.prefs.toggles ^= DISABLE_DEATHRATTLE
 	usr.client.prefs.save_preferences()
@@ -95,7 +95,7 @@ TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox/Events, toggle_deathrattle
 
 TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox/Events, toggle_arrivalrattle)()
 	set name = "Toggle Arrivalrattle"
-	set category = ""
+	set category = "Preferences"
 	set desc = "New Player Arrival"
 	usr.client.prefs.toggles ^= DISABLE_ARRIVALRATTLE
 	to_chat(usr, "You will [(usr.client.prefs.toggles & DISABLE_ARRIVALRATTLE) ? "no longer" : "now"] get messages when someone joins the station.")
@@ -106,7 +106,7 @@ TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost/chatterbox/Events, toggle_arrivalratt
 
 TOGGLE_CHECKBOX(/datum/menu/Settings/Ghost, togglemidroundantag)()
 	set name = "Toggle Midround Antagonist"
-	set category = ""
+	set category = "Preferences"
 	set desc = "Midround Antagonist"
 	usr.client.prefs.toggles ^= MIDROUND_ANTAG
 	usr.client.prefs.save_preferences()

--- a/code/world.dm
+++ b/code/world.dm
@@ -59,6 +59,7 @@
 	load_mode()
 	load_motd()
 	load_admins()
+	load_menu()
 	if(config.usewhitelist)
 		load_whitelist()
 	LoadBans()
@@ -68,6 +69,7 @@
 	GLOB.data_core = new /datum/datacore()
 
 	Master.Initialize(10, FALSE)
+	return
 
 #define IRC_STATUS_THROTTLE 50
 /world/Topic(T, addr, master, key)
@@ -341,5 +343,10 @@
 
 	status = s
 
+
 /world/proc/has_round_started()
 	return SSticker.HasRoundStarted()
+
+/world/proc/load_menu()
+	for (var/typepath in (typesof(/datum/menu)-/datum/menu))
+		new typepath()

--- a/code/world.dm
+++ b/code/world.dm
@@ -69,7 +69,6 @@
 	GLOB.data_core = new /datum/datacore()
 
 	Master.Initialize(10, FALSE)
-	return
 
 #define IRC_STATUS_THROTTLE 50
 /world/Topic(T, addr, master, key)

--- a/code/world.dm
+++ b/code/world.dm
@@ -346,7 +346,3 @@
 
 /world/proc/has_round_started()
 	return SSticker.HasRoundStarted()
-
-/world/proc/load_menu()
-	for (var/typepath in (typesof(/datum/menu)-/datum/menu))
-		new typepath()

--- a/interface/menu.dm
+++ b/interface/menu.dm
@@ -6,6 +6,11 @@
 */
 
 GLOBAL_LIST_EMPTY(menulist)
+
+/world/proc/load_menu()
+	for (var/typepath in subtypesof(/datum/menu))
+		new typepath()
+
 /datum/menu
 	var/name
 	var/list/children

--- a/interface/menu.dm
+++ b/interface/menu.dm
@@ -1,0 +1,198 @@
+/*
+/datum/menu/Example/verb/Example()
+	set name = "" //if this starts with @ the verb is not created and name becomes the command to invoke.
+	set desc = "" //desc is the text given to this entry in the menu
+	//You can not use src in these verbs. It will be the menu at compile time, but the client at runtime.
+*/
+
+GLOBAL_LIST_EMPTY(menulist)
+/datum/menu
+	var/name
+	var/list/children
+	var/datum/menu/myparent
+	var/list/verblist
+	var/checkbox = CHECKBOX_NONE //checkbox type.
+	var/default //default checked type.
+	//Set to true to append our children to our parent,
+	//Rather then add us as a node (used for having more then one checkgroups in the same menu)
+	var/abstract = FALSE
+
+/datum/menu/New()
+	var/ourentry = GLOB.menulist[type]
+	children = list()
+	verblist = list()
+	if (ourentry)
+		if (islist(ourentry)) //some of our childern already loaded
+			Add_children(ourentry)
+		else
+			stack_trace("Menu item double load: [type]")
+			qdel(src)
+			return
+
+	GLOB.menulist[type] = src
+
+	Load_verbs(type, typesof("[type]/verb"))
+
+	var/datum/menu/parent = GLOB.menulist[parent_type]
+	if (!parent)
+		GLOB.menulist[parent_type] = list(src)
+	else if (islist(parent))
+		parent += src
+	else
+		parent.Add_children(list(src))
+
+/datum/menu/proc/Set_parent(datum/menu/parent)
+	myparent = parent
+	if (abstract)
+		myparent.Add_children(children)
+		var/list/verblistoftypes = list()
+		for(var/thing in verblist)
+			LAZYADD(verblistoftypes[verblist[thing]], thing)
+
+		for(var/verbparenttype in verblistoftypes)
+			myparent.Load_verbs(verbparenttype, verblistoftypes[verbparenttype])
+
+/datum/menu/proc/Add_children(list/kids)
+	if (abstract && myparent)
+		myparent.Add_children(kids)
+		return
+
+	for(var/thing in kids)
+		var/datum/menu/menuitem = thing
+		menuitem.Set_parent(src)
+		if (!menuitem.abstract)
+			children += menuitem
+
+/datum/menu/proc/Load_verbs(verb_parent_type, list/verbs)
+	if (abstract && myparent)
+		myparent.Load_verbs(verb_parent_type, verbs)
+		return
+
+	for (var/verbpath in verbs)
+		verblist[verbpath] = verb_parent_type
+
+/datum/menu/proc/Generate_list(client/C)
+	. = list()
+	if (length(children))
+		for (var/thing in children)
+			var/datum/menu/child = thing
+			var/list/childlist = child.Generate_list(C)
+			if (childlist)
+				var/childname = "[child]"
+				if (childname == "[child.type]")
+					var/list/tree = splittext(childname, "/")
+					childname = tree[tree.len]
+				.[child.type] = "parent=[url_encode(type)];name=[url_encode(childname)]"
+				. += childlist
+
+
+
+	for (var/thing in verblist)
+		var/atom/verb/verbpath = thing
+		if (!verbpath)
+			stack_trace("Bad VERB in [type] verblist: [english_list(verblist)]")
+		var/list/entry = list()
+		entry["parent"] = "[type]"
+		entry["name"] = verbpath.desc
+		if (copytext(verbpath.name,1,2) == "@")
+			entry["command"] = copytext(verbpath.name,2)
+		else
+			entry["command"] = replacetext(verbpath.name, " ", "-")
+		var/datum/menu/verb_true_parent = GLOB.menulist[verblist[verbpath]]
+		var/true_checkbox = verb_true_parent.checkbox
+		if (true_checkbox != CHECKBOX_NONE)
+			var/checkedverb = verb_true_parent.Get_checked(C)
+			if (true_checkbox == CHECKBOX_GROUP)
+				if (verbpath == checkedverb)
+					entry["is-checked"] = TRUE
+				else
+					entry["is-checked"] = FALSE
+			else if (true_checkbox == CHECKBOX_TOGGLE)
+				entry["is-checked"] = checkedverb
+
+			entry["command"] = ".updatemenuchecked \"[verb_true_parent.type]\" \"[verbpath]\"\n[entry["command"]]"
+			entry["can-check"] = TRUE
+			entry["group"] = "[verb_true_parent.type]"
+		.[verbpath] = list2params(entry)
+
+/datum/menu/proc/Get_checked(client/C, default)
+	return C.prefs.menuoptions[type] || default || FALSE
+
+/datum/menu/proc/Load_checked(client/C) //Loads the checked menu item into a new client. Used by icon menus to invoke the checked item.
+	return
+
+/datum/menu/proc/Set_checked(client/C, verbpath)
+	if (checkbox == CHECKBOX_GROUP)
+		C.prefs.menuoptions[type] = verbpath
+		C.prefs.save_preferences()
+	else if (checkbox == CHECKBOX_TOGGLE)
+		var/checked = Get_checked(C)
+		C.prefs.menuoptions[type] = !checked
+		C.prefs.save_preferences()
+		winset(C, "[verbpath]", "is-checked = [!checked]")
+
+/client/verb/updatemenuchecked(menutype as text, verbpath as text)
+	set name = ".updatemenuchecked"
+	menutype = text2path(menutype)
+	verbpath = text2path(verbpath)
+	if (!menutype || !verbpath)
+		return
+	var/datum/menu/M = GLOB.menulist[menutype]
+	if (!M)
+		return
+	if (!(verbpath in typesof("[menutype]/verb")))
+		return
+	M.Set_checked(src, verbpath)
+
+
+/datum/menu/Icon/Load_checked(client/C) //So we can be lazy, we invoke the "checked" menu item on menu load.
+	var/atom/verb/verbpath = Get_checked(C)
+	if (!verbpath || !(verbpath in typesof("[type]/verb")))
+		return
+	if (copytext(verbpath.name,1,2) == "@")
+		winset(C, null, "command = [copytext(verbpath.name,2)]")
+	else
+		winset(C, null, "command = [replacetext(verbpath.name, " ", "-")]")
+
+/datum/menu/Icon/Size
+	checkbox = CHECKBOX_GROUP
+	default = /datum/menu/Icon/Size/verb/iconstretchtofit
+
+/datum/menu/Icon/Size/verb/iconstretchtofit()
+	set name = "@.winset \"mapwindow.map.icon-size=0\""
+	set desc = "&Auto (stretch-to-fit)"
+
+/datum/menu/Icon/Size/verb/icon96()
+	set name = "@.winset \"mapwindow.map.icon-size=96\""
+	set desc = "&96x96 (3x)"
+
+/datum/menu/Icon/Size/verb/icon64()
+	set name = "@.winset \"mapwindow.map.icon-size=64\""
+	set desc = "&64x64 (2x)"
+
+/datum/menu/Icon/Size/verb/icon48()
+	set name = "@.winset \"mapwindow.map.icon-size=48\""
+	set desc = "&48x48 (1.5x)"
+
+/datum/menu/Icon/Size/verb/icon32()
+	set name = "@.winset \"mapwindow.map.icon-size=32\""
+	set desc = "&32x32 (1x)"
+
+
+/datum/menu/Icon/Scaling
+	checkbox = CHECKBOX_GROUP
+	name = "Scaling Mode"
+	default = /datum/menu/Icon/Scaling/verb/NN
+
+/datum/menu/Icon/Scaling/verb/NN()
+	set name = "@.winset \"mapwindow.map.zoom-mode=distort\""
+	set desc = "Nearest Neighbor"
+
+/datum/menu/Icon/Scaling/verb/PS()
+	set name = "@.winset \"mapwindow.map.zoom-mode=normal\""
+	set desc = "Point Sampling"
+
+/datum/menu/Icon/Scaling/verb/BL()
+	set name = "@.winset \"mapwindow.map.zoom-mode=blur\""
+	set desc = "Bilinear"
+

--- a/interface/menu.dm
+++ b/interface/menu.dm
@@ -120,7 +120,7 @@ GLOBAL_LIST_EMPTY(menulist)
 			entry["group"] = "[verb_true_parent.type]"
 		.[verbpath] = list2params(entry)
 
-/datum/menu/proc/Get_checked(client/C, default)
+/datum/menu/proc/Get_checked(client/C)
 	return C.prefs.menuoptions[type] || default || FALSE
 
 /datum/menu/proc/Load_checked(client/C) //Loads the checked menu item into a new client. Used by icon menus to invoke the checked item.

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1039,60 +1039,6 @@ menu "menu"
 		is-disabled = false
 		saved-params = "is-checked"
 	elem 
-		name = "&Icons"
-		command = ""
-		category = ""
-		is-checked = false
-		can-check = false
-		group = ""
-		is-disabled = false
-		saved-params = "is-checked"
-	elem "auto"
-		name = "&Auto (stretch-to-fit)"
-		command = ".winset \"mapwindow.map.icon-size=0\""
-		category = "&Icons"
-		is-checked = true
-		can-check = true
-		group = "size"
-		is-disabled = false
-		saved-params = "is-checked"
-	elem "icon96"
-		name = "&96x96 (3x)"
-		command = ".winset \"mapwindow.map.icon-size=96\""
-		category = "&Icons"
-		is-checked = false
-		can-check = true
-		group = "size"
-		is-disabled = false
-		saved-params = "is-checked"
-	elem "icon64"
-		name = "&64x64 (2x)"
-		command = ".winset \"mapwindow.map.icon-size=64\""
-		category = "&Icons"
-		is-checked = false
-		can-check = true
-		group = "size"
-		is-disabled = false
-		saved-params = "is-checked"
-	elem "icon48"
-		name = "&48x48 (1.5x)"
-		command = ".winset \"mapwindow.map.icon-size=48\""
-		category = "&Icons"
-		is-checked = false
-		can-check = true
-		group = "size"
-		is-disabled = false
-		saved-params = "is-checked"
-	elem "icon32"
-		name = "&32x32"
-		command = ".winset \"mapwindow.map.icon-size=32\""
-		category = "&Icons"
-		is-checked = false
-		can-check = true
-		group = "size"
-		is-disabled = false
-		saved-params = "is-checked"
-	elem 
 		name = "&Help"
 		command = ""
 		category = ""
@@ -1359,6 +1305,7 @@ window "mapwindow"
 		on-show = ""
 		on-hide = ""
 		style = ""
+		zoom-mode = "distort"
 
 window "infowindow"
 	elem "infowindow"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -45,6 +45,7 @@
 #include "code\__DEFINES\maps.dm"
 #include "code\__DEFINES\math.dm"
 #include "code\__DEFINES\MC.dm"
+#include "code\__DEFINES\menu.dm"
 #include "code\__DEFINES\misc.dm"
 #include "code\__DEFINES\mobs.dm"
 #include "code\__DEFINES\monkeys.dm"
@@ -968,6 +969,7 @@
 #include "code\modules\admin\admin_investigate.dm"
 #include "code\modules\admin\admin_ranks.dm"
 #include "code\modules\admin\admin_verbs.dm"
+#include "code\modules\admin\adminmenu.dm"
 #include "code\modules\admin\banjob.dm"
 #include "code\modules\admin\create_mob.dm"
 #include "code\modules\admin\create_object.dm"
@@ -2093,6 +2095,7 @@
 #include "code\modules\zombie\items.dm"
 #include "code\modules\zombie\organs.dm"
 #include "interface\interface.dm"
+#include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
 // END_INCLUDE


### PR DESCRIPTION
:cl:
add: Moved to a new system to make top menu items easier to edit.
tweak: Moved icon size stuff to a sub menu
add: Added option to change icon scaling mode.
fix: Byond added fancy shader supported scaling(Point Sampling), this sucks because it's blurry, the default for /tg/station has changed back to the old nearest neighbor scaling.
/:cl:

This allows you to define a top menu item by just defining a verb. the verb's type path will be used to figure out hierarchy.

eg: `/datum/menu/Icon/Size/verb/iconstretchtofit()` will create the menu entry `Icon`->`Size`->`Auto (stretch-to-fit)` (assuming `desc` is set to `Auto (stretch-to-fit)`)

@pjb3005
@Fox-McCloud 

Todo:
- [x] Testing
- [x] ~~Add admin verbs to this system (bonus points, we can remove the admin verb lists entirely with just a bit more boilerplate, the example i put in was mainly a proof of concept.) (even better, we can make a seperate system and move all of admin/topic to it.)~~ Todo for another pr.
- [x] Add example admin modular verbs/topic system based off of this one.
- [x] Moar Testing
- [x] Add preference verbs to this system
- [x] Add a toggle system for the toggle preferences so users can see whats on/off.
- [x] Add some of the ghost display/vision verbs
- [x] More Testing
- [x] Add the rest of the pref toggle verbs
- [x] Look at other tabs for inspiration
- [x] Checkboxes don't save on dynamic menus. Find some way around this limitation.
- [x] Testing.
- [x] Remove debug lines

Screen:
![](https://cloud.githubusercontent.com/assets/7069733/22173862/843eae34-df83-11e6-9554-785fe2a09c89.png)