### PR TITLE
Fixed research disks magically staying in sync with the research they copied

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -188,8 +188,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			if(t_disk)
 				if(!n)
 					for(var/tech in t_disk.tech_stored)
-						if(tech)
-							files.AddTech2Known(tech)
+						files.AddTech2Known(tech)
 				else
 					files.AddTech2Known(t_disk.tech_stored[n])
 				updateUsrDialog()
@@ -212,7 +211,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	else if(href_list["copy_tech"]) //Copy some technology data from the research holder to the disk.
 		var/slot = text2num(href_list["copy_tech"])
-		t_disk.tech_stored[slot] = files.known_tech[href_list["copy_tech_ID"]]
+		var/datum/tech/T = files.known_tech[href_list["copy_tech_ID"]]
+		if(T)
+			t_disk.tech_stored[slot] = T.copy()
 		screen = 1.2
 
 	else if(href_list["updt_design"]) //Updates the research holder with design data from the design disk.

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -84,12 +84,14 @@ research holder datum.
 //Adds a tech to known_tech list. Checks to make sure there aren't duplicates and updates existing tech's levels if needed.
 //Input: datum/tech; Output: Null
 /datum/research/proc/AddTech2Known(datum/tech/T)
+	if(!T)
+		return
 	if(known_tech[T.id])
 		var/datum/tech/known = known_tech[T.id]
 		if(T.level > known.level)
 			known.level = T.level
 		return
-	known_tech[T.id] = T
+	known_tech[T.id] = T.copy()
 
 /datum/research/proc/AddDesign2Known(datum/design/D)
 	if(known_designs[D.id])
@@ -297,6 +299,11 @@ research holder datum.
 		cost += i*rare
 
 	return cost
+
+/datum/tech/proc/copy()
+	var/datum/tech/T = new type()
+	T.level = level
+	return T
 
 /obj/item/weapon/disk/tech_disk
 	name = "technology disk"


### PR DESCRIPTION
Unlike designs, tech is mutable, so you cannot just copy the reference. The fact that no one has noticed this yet proves that no one ever uses the tech storage disks.