### PR TITLE
Musical instruments will no longer generate a pop up each time a song finishes

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -113,8 +113,6 @@
 				else
 					sleep(tempo)
 		repeat--
-		if(repeat >= 0) // don't show the last -1 repeat
-			updateDialog(user)
 	playing = 0
 	repeat = 0
 	updateDialog(user)


### PR DESCRIPTION
:cl: Kor

tweak: Instruments will only create a pop up when the song has run out of repeats, rather than at the end of each playthrough.

/:cl:

I personally find it annoying to have control taken away by a pop up each time a song finishes. I set it to 10 repeats so I can forget about it and go about doing other things, not be continuously bugged by the instrument.
