### PR TITLE
Megafauna won't heal while on station

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -734,6 +734,10 @@
 		user << "[choice] is already dead!"
 		used = FALSE
 		return
+	if(choice == user)
+		user << "You feel like writing your own name into a cursed death warrant would be unwise."
+		used + FALSE
+		return
 	else
 
 		var/mob/living/L = choice

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -736,7 +736,7 @@
 		return
 	if(choice == user)
 		user << "You feel like writing your own name into a cursed death warrant would be unwise."
-		used + FALSE
+		used = FALSE
 		return
 	else
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -97,7 +97,8 @@
 	visible_message(
 		"<span class='danger'>[src] devours [L]!</span>",
 		"<span class='userdanger'>You feast on [L], restoring your health!</span>")
-	adjustBruteLoss(-L.maxHealth/2)
+	if(z != ZLEVEL_STATION && !client) //NPC monsters won't heal while on station
+		adjustBruteLoss(-L.maxHealth/2)
 	L.gib()
 
 /mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)


### PR DESCRIPTION
:cl: Kor
add: Megafauna will not heal while on the station. Do not be afraid to throw your life away to get in a few toolbox hits.
/:cl:

I thought megafauna rampages were more fun when they killed like 40 people but the survivors inevitably wore it down with heroic suicide attacks. This should make them both more manageable and more exciting, rather than having infinite health from dumb assistants and simple animals.
