### PR TITLE
Fixes secbots dropping the wrong baton types

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -430,6 +430,7 @@
 		var/mob/living/simple_animal/bot/secbot/S = new /mob/living/simple_animal/bot/secbot
 		S.loc = get_turf(src)
 		S.name = created_name
+		S.baton_type = I.type
 		qdel(I)
 		qdel(src)
 

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -15,6 +15,7 @@
 	bot_type = SEC_BOT
 	model = "Securitron"
 	bot_core_type = /obj/machinery/bot_core/secbot
+	var/baton_type = /obj/item/weapon/melee/baton
 	window_id = "autosec"
 	window_name = "Automatic Security Unit v1.6"
 	allow_pai = 0
@@ -380,7 +381,7 @@ Auto Patrol: []"},
 	Sa.add_overlay("hs_hole")
 	Sa.created_name = name
 	new /obj/item/device/assembly/prox_sensor(Tsec)
-	new /obj/item/weapon/melee/baton(Tsec)
+	new baton_type(Tsec)
 
 	if(prob(50))
 		new /obj/item/bodypart/l_arm/robot(Tsec)


### PR DESCRIPTION
:cl: Cyberboss
fix: Secbots will now drop the baton type they were constructed with
/:cl:

Fixes #23217 