### PR TITLE
Adds stampedes

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -215,6 +215,13 @@
 	if(istype(MB))
 		MB.RunOver(src)
 
+	if(ishuman(AM))
+		var/mob/living/carbon/human/stampede = AM
+		visible_message("<span class='danger'>[src] is trampled by [stampede.name]!</span>", "<span class='userdanger'>You got trampled by [stampede.name]!</span>")
+		adjustBruteLoss(8)
+		if(prob(30) && stampede.m_intent == MOVE_INTENT_RUN)
+			visible_message("<span class='danger'>[src] trips over [AM]!</span>")
+			stampede.Weaken(3)
 	spreadFire(AM)
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -215,7 +215,7 @@
 	if(istype(MB))
 		MB.RunOver(src)
 
-	if(ishuman(AM))
+	if(ishuman(AM) && lying)
 		var/mob/living/carbon/human/stampede = AM
 		visible_message("<span class='danger'>[src] is trampled by [stampede.name]!</span>", "<span class='userdanger'>You got trampled by [stampede.name]!</span>")
 		adjustBruteLoss(8)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -220,7 +220,7 @@
 		visible_message("<span class='danger'>[src] is trampled by [stampede.name]!</span>", "<span class='userdanger'>You got trampled by [stampede.name]!</span>")
 		adjustBruteLoss(8)
 		if(prob(30) && stampede.m_intent == MOVE_INTENT_RUN)
-			visible_message("<span class='danger'>[src] trips over [AM]!</span>")
+			visible_message("<span class='danger'>[AM] trips over [src]!</span>")
 			stampede.Weaken(3)
 	spreadFire(AM)
 


### PR DESCRIPTION
:cl: Kor
add: When crossing over a downed person, you will deal brute damage to them.
add: When crossing over a downed person while running, there is a chance for you to trip.
/:cl:

I think this will cause panicked situations to get even more out of hand, and the accidental maiming and death that will result when people try to pile in through the broken escape shuttle window will be amusing and in the spirit of the game.

Hopline mobs fights will also be extra exciting when the clown gets stampeded to death while greyshirts are disarm spamming each other.

I should probably generalize this carbons, and I'm going to make it actually apply hits to areas instead of adjustbruteloss, but I wanted to see if this actually plays out well or not before putting more work in it.