### PR TITLE
Global Variables Subsystem

### DIFF
--- a/code/controllers/subsystem/globalvariable
+++ b/code/controllers/subsystem/globalvariable
@@ -1,7 +1,0 @@
-var/datum/subsystem/globalvars/SSGlobalVars
-/datum/subsystem/globalvars
-  name = "Global Variables"
-  can_fire = FALSE
-  stat_tag = "GV"
-/datum/subsystem/globalvars/New()
-	NEW_SS_GLOBAL(SSGlobalVars)

--- a/code/controllers/subsystem/globalvariable
+++ b/code/controllers/subsystem/globalvariable
@@ -1,0 +1,7 @@
+var/datum/subsystem/globalvars/SSGlobalVars
+/datum/subsystem/globalvars
+  name = "Global Variables"
+  can_fire = FALSE
+  stat_tag = "GV"
+/datum/subsystem/globalvars/New()
+	NEW_SS_GLOBAL(SSGlobalVars)

--- a/code/controllers/subsystem/globalvariable.dm
+++ b/code/controllers/subsystem/globalvariable.dm
@@ -1,0 +1,66 @@
+var/datum/subsystem/globalvars/SSGlobalVars
+
+/datum/subsystem/globalvars
+	name = "Global Variables"
+	can_fire = FALSE
+	var/global_emote_list
+	var/global_objects_portal_list
+	var/global_objects_datacore
+	var/global_objects_mech_list
+	var/global_objects_telebeacon_list
+	var/global_objects_navbeacon_list
+	var/global_objects_commsconsole_list
+	var/global_objects_chemical_reactions
+	var/global_objects_chemicals
+	var/global_objects_crafting_recipes
+	var/global_objects_rcd_list
+	var/global_objects_mulebot_beacons
+	var/global_objects_mulebot_tags
+	var/global_objects_chem_implants
+	var/global_objects_track_implants
+	var/global_objects_pointofinterest_list
+	var/global_mapping_landmarks
+	var/global_mapping_landmarks_ruins
+	var/global_mapping_landmarks_awaystart
+	var/global_mapping_globalmap
+	var/global_mapping_spawns
+	var/global_mapping_spawns_depsec
+	var/global_mapping_spawns_events
+	var/global_mapping_spawns_latejoin
+	var/global_ntnet
+	var/global_uplinks
+	var/global_maploader
+	var/global_adminsound
+
+/datum/subsystem/globalvars/New()
+	NEW_SS_GLOBAL(SSGlobalVars)
+
+/datum/subsystem/globalvars/Initialize()
+	global_emote_list = emote_list
+	global_objects_portal_list = portals
+	global_objects_datacore = data_core
+	global_objects_mech_list = mechas_list
+	global_objects_telebeacon_list = teleportbeacons
+	global_objects_navbeacon_list = navbeacons
+	global_objects_commsconsole_list = shuttle_caller_list
+	global_objects_chemical_reactions = chemical_reactions_list
+	global_objects_chemicals = chemical_reagents_list
+	global_objects_crafting_recipes = crafting_recipes
+	global_objects_rcd_list = rcd_list
+	global_objects_mulebot_beacons = deliverybeacons
+	global_objects_mulebot_tags = deliverybeacontags
+	global_objects_chem_implants = tracked_chem_implants
+	global_objects_track_implants = tracked_implants
+	global_objects_pointofinterest_list = poi_list
+	global_mapping_landmarks = landmarks_list
+	global_mapping_landmarks_ruins = ruin_landmarks
+	global_mapping_landmarks_awaystart = awaydestinations
+	global_mapping_globalmap = global_map
+	global_mapping_spawns = start_landmarks_list
+	global_mapping_spawns_depsec = department_security_spawns
+	global_mapping_spawns_events = generic_event_spawns
+	global_mapping_spawns_latejoin = latejoin
+	global_ntnet = ntnet_global
+	global_uplinks = uplinks
+	global_maploader = maploader
+	global_adminsound = admin_sound

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -153,6 +153,7 @@
 #include "code\controllers\subsystem\events.dm"
 #include "code\controllers\subsystem\fire_burning.dm"
 #include "code\controllers\subsystem\garbage.dm"
+#include "code\controllers\subsystem\globalvariable.dm"
 #include "code\controllers\subsystem\icon_smooth.dm"
 #include "code\controllers\subsystem\ipintel.dm"
 #include "code\controllers\subsystem\jobs.dm"


### PR DESCRIPTION
Puts most of the globalvars onto a non-firing subsystem for varediting purposes.
By most I mean the ones that have any interest to admins, as in nothing that would present a security risk, or things that would irreversibly fuck up the game if edited and or things that won't really help in events when edited.

Most of this can be done via SDQL but this is for when people don't want to screw around with SDQL to select things.

tl;dr enables admin aboose