### PR TITLE
Fixes timers not GCing

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -284,7 +284,8 @@ var/datum/subsystem/timer/SStimer
 			prev.next = null
 		if (next && next.prev == src)
 			next.prev = null
-
+	next = null
+	prev = null
 	return QDEL_HINT_IWILLGC
 
 proc/addtimer(datum/callback/callback, wait, flags)


### PR DESCRIPTION
As an aside, this bug is also why sybil and bagil have been crashing.

