### PR TITLE
Fixes lube slipping people when they are buckled, excluding when buckled on a scooter or skateboard

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -147,8 +147,7 @@
 		var/obj/buckled_obj
 		if(C.buckled)
 			buckled_obj = C.buckled
-			if(!(lube&GALOSHES_DONT_HELP)) //can't slip while buckled unless it's lube.
-				return 0
+			return 0
 		else
 			if(C.lying || !(C.status_flags & CANWEAKEN)) // can't slip unbuckled mob if they're lying or can't fall.
 				return 0

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -147,7 +147,8 @@
 		var/obj/buckled_obj
 		if(C.buckled)
 			buckled_obj = C.buckled
-			return 0
+			if(!(istype(C.buckled,/obj/vehicle/scooter) && lube))
+				return 0
 		else
 			if(C.lying || !(C.status_flags & CANWEAKEN)) // can't slip unbuckled mob if they're lying or can't fall.
 				return 0

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -122,3 +122,4 @@ kevinz000 = Game Master
 Tacolizard = Game Master
 TrustyGun = Game Master
 Cyberboss = Game Master
+Sometinyprick = Game Master


### PR DESCRIPTION
It doesn't really make sense to slip while buckled
fixes #23183
:cl:
fix: you can no longer slip while buckled, except on scooters and skateboards
/:cl:
