### PR TITLE
Gives our engineers more love by adding black gloves to their closets so they be no longer why cant insulated gloves touch lightning?

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -67,6 +67,7 @@
 	new /obj/item/device/radio/headset/headset_eng(src)
 	new /obj/item/weapon/storage/toolbox/mechanical(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen/engi(src)
+	new /obj/item/clothing/gloves/color/black(src)
 	new /obj/item/weapon/holosign_creator/engineering(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/clothing/glasses/meson/engine(src)


### PR DESCRIPTION
we must

:cl: optional name here
add: Adds black gloves to engineering locker
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)to fix lights when somoene stole the thingy...
