### PR TITLE
Removes ventcrawl from PAI

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -6,7 +6,6 @@
 	icon_state = "repairbot"
 	mouse_opacity = 2
 	density = 0
-	ventcrawler = 2
 	luminosity = 0
 	pass_flags = PASSTABLE | PASSMOB
 	mob_size = MOB_SIZE_TINY


### PR DESCRIPTION
PAIs shouldn't have pseudo all access, they should be sticking by their master instead of going anywhere on the station.
 In the PR that added them, it was stated that they wouldn't have any innate access. Well, ventcrawl is basically all access for the PAI.


:cl:
del: PAIs can no longer ventcrawl
/:cl: