### PR TITLE
nerfs hollowed out book to former glory

### DIFF
--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -5,6 +5,7 @@
 	icon_state ="book"
 	throw_speed = 2
 	throw_range = 5
+	storage_slots = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FLAMMABLE
 	var/title = "book"
@@ -21,6 +22,7 @@ var/global/list/bibleitemstates = list("bible", "koran", "scrapbook", "bible",  
 	desc = "Apply to head repeatedly."
 	icon = 'icons/obj/storage.dmi'
 	icon_state ="bible"
+	storage_slots = 7
 	var/mob/affecting = null
 	var/deity_name = "Christ"
 


### PR DESCRIPTION
Brings back hollowed out books to 1 storage slot since you can make like a superior belt with a bookbag and basically carry 7 medkits on your belt slot

bible storage are untouched and they still do fit in bookbags its just not a stealth storage


:cl: optional name here
tweak:nerfs hollowed out books to 1 storage to prevent stealth storage + bookbag inventory creeps
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)I am infact a librarian powercreep and i know how this goooooeees...
