### PR TITLE
Fixes heads not having a real name

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -214,7 +214,7 @@
 		for(var/X in list(owner.glasses, owner.ears, owner.wear_mask, owner.head))
 			var/obj/item/I = X
 			owner.unEquip(I, 1)
-	name = "[owner]'s head"
+	name = "[owner.real_name]'s head"
 	..()
 
 


### PR DESCRIPTION
Fixes #23016

:cl: Cyberboss
fix: Dismembered heads will now use a mob's real name
/:cl:
