### PR TITLE
Made temporary martial arts not override sleeping carp

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -10,6 +10,7 @@
 	var/restraining = 0 //used in cqc's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
 	var/help_verb = null
 	var/no_guns = FALSE
+	var/allow_temp_override = TRUE //can be overriden by temporary martial arts
 
 /datum/martial_art/proc/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	return 0
@@ -76,20 +77,20 @@
 	return 1
 
 /datum/martial_art/proc/teach(mob/living/carbon/human/H,make_temporary=0)
+	if(H.martial_art && !H.martial_art.allow_temp_override)
+		return
 	if(help_verb)
 		H.verbs += help_verb
 	if(make_temporary)
 		temporary = 1
 	if(H.martial_art && temporary)
 		base = H.martial_art
-		no_guns = no_guns || base.no_guns
 	H.martial_art = src
 
 /datum/martial_art/proc/remove(mob/living/carbon/human/H)
 	if(H.martial_art != src)
 		return
 	H.martial_art = base
-	no_guns = initial(no_guns)
 	if(help_verb)
 		H.verbs -= help_verb
 
@@ -252,6 +253,7 @@
 	name = "The Sleeping Carp"
 	deflection_chance = 100
 	no_guns = TRUE
+	allow_temp_override = FALSE
 	help_verb = /mob/living/carbon/human/proc/sleeping_carp_help
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -9,6 +9,7 @@
 	var/block_chance = 0 //Chance to block melee attacks using items while on throw mode.
 	var/restraining = 0 //used in cqc's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
 	var/help_verb = null
+	var/no_guns = FALSE
 
 /datum/martial_art/proc/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	return 0
@@ -81,12 +82,14 @@
 		temporary = 1
 	if(H.martial_art && temporary)
 		base = H.martial_art
+		no_guns = no_guns || base.no_guns
 	H.martial_art = src
 
 /datum/martial_art/proc/remove(mob/living/carbon/human/H)
 	if(H.martial_art != src)
 		return
 	H.martial_art = base
+	no_guns = initial(no_guns)
 	if(help_verb)
 		H.verbs -= help_verb
 
@@ -248,6 +251,7 @@
 /datum/martial_art/the_sleeping_carp
 	name = "The Sleeping Carp"
 	deflection_chance = 100
+	no_guns = TRUE
 	help_verb = /mob/living/carbon/human/proc/sleeping_carp_help
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -10,7 +10,7 @@
 	var/restraining = 0 //used in cqc's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
 	var/help_verb = null
 	var/no_guns = FALSE
-	var/allow_temp_override = TRUE //can be overriden by temporary martial arts
+	var/allow_temp_override = TRUE //if this martial art can be overridden by temporary martial arts
 
 /datum/martial_art/proc/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	return 0
@@ -77,14 +77,14 @@
 	return 1
 
 /datum/martial_art/proc/teach(mob/living/carbon/human/H,make_temporary=0)
-	if(H.martial_art && !H.martial_art.allow_temp_override)
-		return
-	if(help_verb)
-		H.verbs += help_verb
 	if(make_temporary)
 		temporary = 1
-	if(H.martial_art && temporary)
+	if(temporary && H.martial_art)
+		if(!H.martial_art.allow_temp_override)
+			return
 		base = H.martial_art
+	if(help_verb)
+		H.verbs += help_verb
 	H.martial_art = src
 
 /datum/martial_art/proc/remove(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -145,7 +145,7 @@
 			src << "<span class='warning'>Your fingers don't fit in the trigger guard!</span>"
 			return 0
 
-	if(martial_art && martial_art.name == "The Sleeping Carp") //great dishonor to famiry
+	if(martial_art && martial_art.no_guns) //great dishonor to famiry
 		src << "<span class='warning'>Use of ranged weaponry would bring dishonor to the clan.</span>"
 		return 0
 


### PR DESCRIPTION
Alternative to #23017 to prevent sleeping carp users from using guns when they feel like it.