### PR TITLE
Polymorph tweaks (statue + naming)

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -829,9 +829,9 @@
 	. = ..()
 
 // Called when we are hit by a bolt of polymorph and changed
-// Generally the mob we are currently in, is about to be deleted
+// Generally the mob we are currently in is about to be deleted
 /mob/living/proc/wabbajack_act(mob/living/new_mob)
-	new_mob.name = name
+	new_mob.name = real_name
 	new_mob.real_name = real_name
 
 	if(mind)
@@ -909,4 +909,3 @@
 					  "[C] topples over [src]!", \
 					  "[C] leaps out of [src]'s way!")]</span>")
 	C.Weaken(2)
-	

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -43,7 +43,6 @@
 
 	sight = SEE_SELF|SEE_MOBS|SEE_OBJS|SEE_TURFS
 	anchored = 1
-	status_flags = GODMODE // Cannot push also
 
 	var/cannot_be_seen = 1
 	var/mob/living/creator = null


### PR DESCRIPTION
:cl: coiax
del: Statues are now just incredibly tough mobs, rather than GODMODE. As a side effect, they are no longer immune to bolts of change.
fix: Fixed some issues with X (as Y) names on polymorphed mobs.
/:cl:

Reasoning: Being stuck as a statue doing wizbiz is kinda boring, and their complete invulnerability is kinda OP.