### PR TITLE
Minor syndicate tweak

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -8,6 +8,7 @@
 	density = 1
 	obj_integrity = 250
 	max_integrity = 250
+	emagged = FALSE
 
 	var/obj/item/clothing/suit/space/suit = null
 	var/obj/item/clothing/head/helmet/space/helmet = null
@@ -389,3 +390,11 @@
 					storage = null
 			. = TRUE
 	update_icon()
+
+/obj/machinery/suit_storage_unit/emag_act(mob/user)
+	if(emagged)
+		return
+	emagged = TRUE
+	safeties = FALSE
+	visible_message("<span class='warning'>WARNING! SAFETY PROTOCOLS DISENGAGED</span>")
+	playsound(src.loc, 'sound/effects/sparks4.ogg', 50, 1)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -8,7 +8,6 @@
 	density = 1
 	obj_integrity = 250
 	max_integrity = 250
-	emagged = FALSE
 
 	var/obj/item/clothing/suit/space/suit = null
 	var/obj/item/clothing/head/helmet/space/helmet = null
@@ -390,11 +389,3 @@
 					storage = null
 			. = TRUE
 	update_icon()
-
-/obj/machinery/suit_storage_unit/emag_act(mob/user)
-	if(emagged)
-		return
-	emagged = TRUE
-	safeties = FALSE
-	visible_message("<span class='warning'>WARNING! SAFETY PROTOCOLS DISENGAGED</span>")
-	playsound(src.loc, 'sound/effects/sparks4.ogg', 50, 1)

--- a/code/game/objects/items/dehy_carp.dm
+++ b/code/game/objects/items/dehy_carp.dm
@@ -52,3 +52,7 @@
 	else
 		visible_message("<span class='notice'>The newly grown [M.name] looks up at you with friendly eyes.</span>")
 	qdel(src)
+
+/obj/item/toy/carpplushie/dehy_carp/greytide
+	mobtype = /mob/living/carbon/human/interactive/greytide/ //viva
+	icon_state = "assistant"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -325,3 +325,8 @@
 	for(var/i in 1 to 3)
 		new/obj/item/cardboard_cutout/adaptive(src)
 	new/obj/item/toy/crayon/rainbow(src)
+
+/obj/item/weapon/storage/box/syndie_kit/greytide/New()
+	..()
+	for(var/i in 1 to 5)
+		new/obj/item/toy/carpplushie/dehy_carp/greytide

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -12,6 +12,7 @@
 	item_state = "space_suit_syndicate"
 	desc = "Has a tag on it: Totally not property of of a hostile corporation, honest!"
 	w_class = WEIGHT_CLASS_NORMAL
+	slowdown = 0
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
 	armor = list(melee = 40, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30, fire = 80, acid = 85)
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -133,6 +133,18 @@
 				SetScore(BOSS_SCORE,C,1)
 				SetScore(score_type,C,1)
 
+//NO MORE MEGAFAUNA ON THE STATION YOU SHITTERS
+/mob/living/simple_animal/hostile/megafauna/process()
+	var/turf/mobturf = get_turf(src)
+	if(mobturf && (mobturf.z == ZLEVEL_LAVALAND))
+		return
+	else
+		if(!src.admin_spawned)
+			src.visible_message("<span class='danger'>[src] collapses in on itself as it is severed from the hell energy that protected it's abominable body from falling apart. Whew!</span>")
+			spawn_gibs()
+			qdel(src)
+
+
 /proc/UnlockMedal(medal,client/player)
 
 	if(!player || !medal)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -653,6 +653,14 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	surplus = 10
 	exclude_modes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/stealthy_weapons/greytide
+	name = "GT bundle"
+	desc = "Rejected androids developed for a secret initiative, dehydrated for portability. Useful for distractions. \
+	Just add water."
+	item = /obj/item/weapon/storage/box/syndie_kit/greytide
+	cost = 15
+
+
 // Stealth Items
 /datum/uplink_item/stealthy_tools
 	category = "Stealth and Camouflage Items"
@@ -754,14 +762,14 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/storage/box/syndie_kit/cutouts
 	cost = 1
 	surplus = 20
-	
+
 /datum/uplink_item/stealthy_tools/fakenucleardisk
 	name = "Decoy Nuclear Authentication Disk"
 	desc = "It's just a normal disk. Visually it's identical to the real deal, but it won't hold up under closer scrutiny. Don't try to give this to us to complete your objective, we know better!"
 	item = /obj/item/weapon/disk/fakenucleardisk
 	cost = 1
 	surplus = 1
-	
+
 //Space Suits and Hardsuits
 /datum/uplink_item/suits
 	category = "Space Suits and Hardsuits"


### PR DESCRIPTION
Adds dehydrated assistant kits to syndicate uplinks. A child of dehydrated carp, it spawns greytide SNPCs. You get 5 in a bundle that costs 15tc. Useful for a distraction, not much else.

The syndicate soft suits now have no slowdown, giving reason to actually use them instead of completely disregarding them.


:cl:
add: Added new item to syndicate uplinks.
tweak: small buff to syndicate soft suit
/:cl:
