### PR TITLE
Lowers crate integrity and removes its armor

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -4,9 +4,8 @@
 	icon_state = "securecrate"
 	secure = 1
 	locked = 1
-	obj_integrity = 500
-	max_integrity = 500
-	armor = list(melee = 30, bullet = 50, laser = 50, energy = 100, bomb = 0, bio = 0, rad = 0, fire = 80, acid = 80)
+	obj_integrity = 300
+	max_integrity = 300
 	var/tamperproof = 0
 
 /obj/structure/closet/crate/secure/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)


### PR DESCRIPTION
I don't know how popular this will be but I miss being able to pop them open with stuff like the bartender's shotgun or being able to open them with an emitter in a reasonable amount of time. Them being this secure has shut cargo out of a lot of shenanigans for too long. I just want to go back to a time of more imperfect, insecure, seedy, sketchy, dangerous shit that makes this game the great thing that it is.

If it's too much, I'll compromise with just removing the armor and leaving the max integrity alone.

🆑
tweak: Crates ordered by cargo are now much easier to break open.
/:cl: