### PR TITLE
[Meta] Moves AI MiniSat Tracking Beacon

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -40223,7 +40223,6 @@
 	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/device/radio/beacon,
 /turf/open/floor/plasteel/black,
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
@@ -40295,6 +40294,7 @@
 	d2 = 8
 	},
 /obj/machinery/holopad,
+/obj/item/device/radio/beacon,
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/turret_protected/tcomfoyer{
 	name = "\improper MiniSat Foyer"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -38948,7 +38948,6 @@
 	name = "\improper MiniSat Foyer"
 	})
 "bps" = (
-/obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -40224,6 +40223,7 @@
 	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/device/radio/beacon,
 /turf/open/floor/plasteel/black,
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"


### PR DESCRIPTION
## **Metastation Moves AI MiniSat Tracking Beacon**
Moves Metastation AI MiniSat Tracking Beacon to AI Minisat entrance. Through repeated testing this results in a less frequent chance of being teleported into space.

## **Changelog**
:cl: Tofa01
Tweak: Moved Meta station AI MiniSat tracking beacon to AI MiniSat entrance. Should prevent being regular teleported into space. 
/:cl:

## **Photos**
![untitled](https://cloud.githubusercontent.com/assets/24999255/22242901/4304f0ec-e279-11e6-9073-92cd548a25ff.png)
**Key: Red - New tracking beacon.
   Black - Removed previous location of tracking beacon.**

## **Fixes #23296**

