### PR TITLE
Redo's #23247 adding more TOOLS to the TOOLBELT

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -33,7 +33,9 @@
 		/obj/item/device/analyzer,
 		/obj/item/weapon/extinguisher/mini,
 		/obj/item/device/radio,
-		/obj/item/clothing/gloves
+		/obj/item/clothing/gloves,
+		/obj/item/device/geiger_counter,
+		/obj/item/weapon/airlock_painter
 		)
 
 /obj/item/weapon/storage/belt/utility/chief

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -67,7 +67,6 @@
 	new /obj/item/device/radio/headset/headset_eng(src)
 	new /obj/item/weapon/storage/toolbox/mechanical(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen/engi(src)
-	new /obj/item/clothing/gloves/color/black(src)
 	new /obj/item/weapon/holosign_creator/engineering(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/clothing/glasses/meson/engine(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -67,6 +67,7 @@
 	new /obj/item/device/radio/headset/headset_eng(src)
 	new /obj/item/weapon/storage/toolbox/mechanical(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen/engi(src)
+	new /obj/item/clothing/gloves/color/black(src)
 	new /obj/item/weapon/holosign_creator/engineering(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/clothing/glasses/meson/engine(src)


### PR DESCRIPTION
i only love the geiger and airlock painter anyways

:cl: Hyena
tweak:Toolbelts now can fit geiger_counters and airlock painters
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)they are tools DUH
