### PR TITLE
Allows uplinks to buy more types of Martial Arts.

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -564,12 +564,12 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/mecha/combat/marauder/mauler/loaded
 	cost = 140
 
-// Stealthy Weapons
-/datum/uplink_item/stealthy_weapons
-	category = "Stealthy and Inconspicuous Weapons"
+// Martial Arts
+/datum/uplink_item/martial_arts
+	category = "Martial Arts"
 
-/datum/uplink_item/stealthy_weapons/martialarts
-	name = "Martial Arts Scroll"
+/datum/uplink_item/martial_arts/sleeping_carp
+	name = "Sleeping Carp Scroll"
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat, \
 			deflecting all ranged weapon fire, but you also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/weapon/sleeping_carp_scroll
@@ -577,13 +577,43 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 
-/datum/uplink_item/stealthy_weapons/cqc
+/datum/uplink_item/martial_arts/cqc
 	name = "CQC Manual"
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing."
 	item = /obj/item/weapon/cqc_manual
-	include_modes = list(/datum/game_mode/nuclear)
 	cost = 13
 	surplus = 0
+	exclude_modes = list(/datum/game_mode/gang)
+
+/datum/uplink_item/martial_arts/plasma_fist
+	name = "Plasma Fist Scroll"
+	desc = "An ancient scroll containing the secrets to a highly lethal martial arts simply known as 'Plasma Fist'. \
+			The punches are rumoured to be highly explosive."
+	item = /obj/item/weapon/plasma_fist_scroll
+	cost = 18
+	surplus = 0
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
+
+/datum/uplink_item/martial_arts/wrestling
+	name = "Wrestling Belt"
+	desc = "It is said that those who wears this belt, instantly gains an understanding of an old Earth fighting technique \
+			known simply as 'wrestling'."
+	item = /obj/item/weapon/storage/belt/champion/wrestling
+	cost = 16
+	surplus = 0
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
+
+/datum/uplink_item/martial_arts/bostaff
+	name = "Bo Staff"
+	desc = "This is a long wooden staff which has traditionally been used in old Earth martial arts. It is a highly effective \
+			and often dangerous weapon."
+	item = /obj/item/weapon/twohanded/bostaff
+	cost = 13
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
+
+// Stealthy Weapons
+/datum/uplink_item/stealthy_weapons
+	category = "Stealthy and Inconspicuous Weapons"
 
 /datum/uplink_item/stealthy_weapons/throwingweapons
 	name = "Box of Throwing Weapons"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -594,15 +594,6 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 
-/datum/uplink_item/martial_arts/wrestling
-	name = "Wrestling Belt"
-	desc = "It is said that those who wears this belt, instantly gains an understanding of an old Earth fighting technique \
-			known simply as 'wrestling'."
-	item = /obj/item/weapon/storage/belt/champion/wrestling
-	cost = 16
-	surplus = 0
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
-
 /datum/uplink_item/martial_arts/bostaff
 	name = "Bo Staff"
 	desc = "This is a long wooden staff which has traditionally been used in old Earth martial arts. It is a highly effective \

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -590,8 +590,9 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "An ancient scroll containing the secrets to a highly lethal martial arts simply known as 'Plasma Fist'. \
 			The punches are rumoured to be highly explosive."
 	item = /obj/item/weapon/plasma_fist_scroll
-	cost = 18
+	cost = 20
 	surplus = 0
+	cant_discount = TRUE
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 
 /datum/uplink_item/martial_arts/bostaff


### PR DESCRIPTION
Firstly, this adds a new category to the Uplink, called Martial Arts.

Now, on to the main part. This adds several new types of martial arts to the uplinks. These include:

**CQC** (Well, this actually makes it no longer be Nuke Op only. Now normal traitors can buy it aswell)
**Plasma Fist** (Yes, I know it has a move which can gib people. But honestly? It is still weaker than Sleeping Carp. Sec can just taser you, or laser you, or shotgun you. Unlike Sleeping Carp which is immune to projectiles, and if gotten on discount, can be bought alongside an Esword.)
**Bo Staff**

I am making this PR, considering we can already buy one martial arts, the martial arts which is arguably the most op of them all due to providing immunity to projectiles. And personally it would be fun and interesting to have more variety, and this would also allow these MA's to be used more, instead of just sitting in a closet, dusty, and lonely.


:cl: Firecage
add: NanoTrasen emergency bulletin: We have recently learned that the Syndicate has started training their operatives in martial arts other than Sleeping Carp. We recommend that our Security forces remains vigilant of this new threat.
/:cl: