### PR TITLE
Updates Names and Descriptions for Plasmamen-related Items

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -115,8 +115,8 @@
  */
 
 /obj/item/weapon/tank/internals/plasmaman
-	name = "plasmaman plasma tank"
-	desc = "A tank of plasma gas."
+	name = "plasma internals tank"
+	desc = "A tank of plasma gas designed specifically for use as internals, particularly for plasma-based lifeforms. If you're not a Plasmaman, you probably shouldn't use this."
 	icon_state = "plasmaman_tank"
 	item_state = "plasmaman_tank"
 	force = 10

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -1,9 +1,9 @@
- //Suits for the pink and grey skeletons!
+ //Suits for the pink and grey skeletons! //EVA version no longer used in favor of the Jumpsuit version
 
 
 /obj/item/clothing/suit/space/eva/plasmaman
-	name = "plasmaman suit"
-	desc = "A special containment suit designed to protect a plasmaman's volatile body from outside exposure and quickly extinguish it in emergencies."
+	name = "EVA plasma envirosuit"
+	desc = "A special plasma containment suit designed to be space-worthy, as well as worn over other clothing. Like it's smaller counterpart, it can automatically extinguish the wearer in a crisis, and holds twice as many charges."
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_casing,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank)
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 100, rad = 0, fire = 100, acid = 75)
 	resistance_flags = FIRE_PROOF
@@ -16,7 +16,7 @@
 
 /obj/item/clothing/suit/space/eva/plasmaman/examine(mob/user)
 	..()
-	user << "<span class='notice'>There are [extinguishes_left] extinguisher canisters left in this suit.</span>"
+	user << "<span class='notice'>There are [extinguishes_left] extinguisher charges left in this suit.</span>"
 
 
 /obj/item/clothing/suit/space/eva/plasmaman/proc/Extinguish(mob/living/carbon/human/H)
@@ -36,8 +36,8 @@
 
 //I just want the light feature of the hardsuit helmet
 /obj/item/clothing/head/helmet/space/plasmaman
-	name = "plasmaman helmet"
-	desc = "A special containment helmet designed to protect a plasmaman's volatile body from outside exposure and quickly extinguish it in emergencies."
+	name = "plasma envirosuit helmet"
+	desc = "A special containment helmet that allows plasma-based lifeforms to exist safely in an oxygenated environment. It is space-worthy, and may be worn in tandem with other EVA gear."
 	icon_state = "plasmaman-helm"
 	item_color = "plasma" //needed for the helmet lighting
 	item_state = "plasmaman-helm"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -587,8 +587,8 @@
 	can_adjust = 0
 
 /obj/item/clothing/under/plasmaman
-	name = "Plasma-man Jumpsuit"
-	desc = "A specially designed suit that allows Plasma based life forms to exist in an oxygenated environment."
+	name = "plasma envirosuit"
+	desc = "A special containment suit that allows plasma-based lifeforms to exist safely in an oxygenated environment, and automatically extinguishes them in a crisis. Despite being airtight, it's not spaceworthy."
 	icon_state = "plasmaman"
 	item_state = "plasmaman"
 	item_color = "plasmaman"
@@ -603,7 +603,7 @@
 
 /obj/item/clothing/under/plasmaman/examine(mob/user)
 	..()
-	user << "<span class='notice'>There are [extinguishes_left] extinguisher canisters left in this suit.</span>"
+	user << "<span class='notice'>There are [extinguishes_left] extinguisher charges left in this suit.</span>"
 
 
 /obj/item/clothing/under/plasmaman/proc/Extinguish(mob/living/carbon/human/H)
@@ -628,15 +628,15 @@
 			return
 		else
 			extinguishes_left = 5
-			user << "<span class='notice'>You refill the suits inbuilt extinguisher, using up the refill pack.</span>"
+			user << "<span class='notice'>You refill the suit's built-in extinguisher, using up the cartridge.</span>"
 			qdel(E)
 			return
 		return
 	return
 
 /obj/item/device/extinguisher_refill
-	name = "Plasma-man jumpsuit refill pack"
-	desc = "A compressed water pack used to refill plasma-man jumpsuit auto-extinguishers."
+	name = "plasma suit extinguisher cartridge"
+	desc = "A cartridge loaded with a compressed extinguisher mix, used to refill the automatic extinguisher on plasma envirosuits."
 	icon_state = "plasmarefill"
 	origin_tech = "materials=2;plasmatech=3;biotech=1"
 

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -635,7 +635,7 @@
 	return
 
 /obj/item/device/extinguisher_refill
-	name = "plasma suit extinguisher cartridge"
+	name = "envirosuit extinguisher cartridge"
 	desc = "A cartridge loaded with a compressed extinguisher mix, used to refill the automatic extinguisher on plasma envirosuits."
 	icon_state = "plasmarefill"
 	origin_tech = "materials=2;plasmatech=3;biotech=1"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -616,7 +616,6 @@
 #include "code\game\mecha\working\working.dm"
 #include "code\game\objects\buckling.dm"
 #include "code\game\objects\empulse.dm"
-#include "code\game\objects\explosion.dm"
 #include "code\game\objects\items.dm"
 #include "code\game\objects\obj_defense.dm"
 #include "code\game\objects\objs.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -616,6 +616,7 @@
 #include "code\game\mecha\working\working.dm"
 #include "code\game\objects\buckling.dm"
 #include "code\game\objects\empulse.dm"
+#include "code\game\objects\explosion.dm"
 #include "code\game\objects\items.dm"
 #include "code\game\objects\obj_defense.dm"
 #include "code\game\objects\objs.dm"


### PR DESCRIPTION
## Updated Names and Descriptions for Plasmamen Items

I noticed that there was a lack of consistency in naming for the Plasmamen items, namely switching between "Plasma-man" and "plasmaman" and other small things. I've updated the names and descriptions to be more consistent and comprehensive.

* The standard jumpsuit is now a "**plasma envirosuit**"
* The standard helmet is now a "**plasma envirosuit helmet**"
* The previous exosuit version of their jumpsuit (now unavailable) is a "**EVA plasma envirosuit**"
* The internals tanks are now "**plasma internals tanks**" to differentiate them from regular station tanks.
* The extinguisher rechargers are now a "**envirosuit extinguisher cartridge**"


:cl: Sweaterkittens
tweak: There are now updated names and descriptions for the items that your plasma-based crewmembers start with and use frequently.
/:cl: