### PR TITLE
Disk "fridge" Machine [QoL]

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -34,7 +34,8 @@
 							/obj/machinery/smartfridge/drinks = "drinks",
 							/obj/machinery/smartfridge/extract = "slimes",
 							/obj/machinery/smartfridge/chemistry = "chems",
-							/obj/machinery/smartfridge/chemistry/virology = "viruses")
+							/obj/machinery/smartfridge/chemistry/virology = "viruses",
+							/obj/machinery/smartfridge/disks = "disks")
 
 /obj/item/weapon/circuitboard/machine/smartfridge/New(loc, new_type)
 	if(new_type)
@@ -96,13 +97,13 @@
 
 		if(contents.len >= max_n_of_items)
 			user << "<span class='warning'>\The [src] is full!</span>"
-			return 0
+			return FALSE
 
 		if(accept_check(O))
 			load(O)
 			user.visible_message("[user] has added \the [O] to \the [src].", "<span class='notice'>You add \the [O] to \the [src].</span>")
 			updateUsrDialog()
-			return 1
+			return TRUE
 
 		if(istype(O, /obj/item/weapon/storage/bag))
 			var/obj/item/weapon/storage/P = O
@@ -443,3 +444,17 @@
 		/obj/item/weapon/reagent_containers/glass/bottle/mutagen = 1,
 		/obj/item/weapon/reagent_containers/glass/bottle/plasma = 1,
 		/obj/item/weapon/reagent_containers/glass/bottle/synaptizine = 1)
+
+// ----------------------------
+// Disk """fridge"""
+// ----------------------------
+/obj/machinery/smartfridge/disks
+	name = "disk compartmentalizer"
+	description = "A machine capable of storing a variety of disks. Denoted by most as the DSU (disk storage unit)."
+	item_state = "diskstorage"
+
+/obj/machinery/smartfridge/disks/accept_check(obj/item/O)
+	if(istype(O,/obj/item/weapon/disk/))
+		return TRUE
+	else
+		return FALSE

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -450,8 +450,7 @@
 // ----------------------------
 /obj/machinery/smartfridge/disks
 	name = "disk compartmentalizer"
-	description = "A machine capable of storing a variety of disks. Denoted by most as the DSU (disk storage unit)."
-	item_state = "diskstorage"
+	desc = "A machine capable of storing a variety of disks. Denoted by most as the DSU (disk storage unit)."
 
 /obj/machinery/smartfridge/disks/accept_check(obj/item/O)
 	if(istype(O,/obj/item/weapon/disk/))

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -125,15 +125,15 @@
 										 "<span class='notice'>You load \the [src] with \the [O].</span>")
 				if(O.contents.len > 0)
 					user << "<span class='warning'>Some items are refused.</span>"
-				return 1
+				return TRUE
 			else
 				user << "<span class='warning'>There is nothing in [O] to put in [src]!</span>"
-				return 0
+				return FALSE
 
 	if(user.a_intent != INTENT_HARM)
 		user << "<span class='warning'>\The [src] smartly refuses [O].</span>"
 		updateUsrDialog()
-		return 0
+		return FALSE
 	else
 		return ..()
 
@@ -141,8 +141,8 @@
 
 /obj/machinery/smartfridge/proc/accept_check(obj/item/O)
 	if(istype(O,/obj/item/weapon/reagent_containers/food/snacks/grown/) || istype(O,/obj/item/seeds/) || istype(O,/obj/item/weapon/grown/))
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/machinery/smartfridge/proc/load(obj/item/O)
 	if(istype(O.loc,/mob))
@@ -160,7 +160,7 @@
 	return src.attack_hand(user)
 
 /obj/machinery/smartfridge/attack_ai(mob/user)
-	return 0
+	return FALSE
 
 /obj/machinery/smartfridge/attack_hand(mob/user)
 	user.set_machine(src)
@@ -172,7 +172,7 @@
 
 /obj/machinery/smartfridge/interact(mob/user)
 	if(stat)
-		return 0
+		return FALSE
 
 	var/dat = "<TT><b>Select an item:</b><br>"
 
@@ -355,9 +355,9 @@
 
 /obj/machinery/smartfridge/drinks/accept_check(obj/item/O)
 	if(!istype(O,/obj/item/weapon/reagent_containers) || !O.reagents || !O.reagents.reagent_list.len)
-		return 0
+		return FALSE
 	if(istype(O,/obj/item/weapon/reagent_containers/glass) || istype(O,/obj/item/weapon/reagent_containers/food/drinks) || istype(O,/obj/item/weapon/reagent_containers/food/condiment))
-		return 1
+		return TRUE
 
 // ----------------------------
 //  Food smartfridge
@@ -367,8 +367,8 @@
 
 /obj/machinery/smartfridge/food/accept_check(obj/item/O)
 	if(istype(O,/obj/item/weapon/reagent_containers/food/snacks/))
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 // -------------------------------------
 // Xenobiology Slime-Extract Smartfridge
@@ -379,10 +379,10 @@
 
 /obj/machinery/smartfridge/extract/accept_check(obj/item/O)
 	if(istype(O,/obj/item/slime_extract))
-		return 1
+		return TRUE
 	if(istype(O,/obj/item/device/slime_scanner))
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/machinery/smartfridge/extract/New()
 	..()
@@ -418,18 +418,18 @@
 		if(O.contents.len)
 			for(var/obj/item/I in O)
 				if(!accept_check(I))
-					return 0
-			return 1
-		return 0
+					return FALSE
+			return TRUE
+		return FALSE
 	if(!istype(O,/obj/item/weapon/reagent_containers))
-		return 0
+		return FALSE
 	if(istype(O,/obj/item/weapon/reagent_containers/pill)) // empty pill prank ok
-		return 1
+		return TRUE
 	if(!O.reagents || !O.reagents.reagent_list.len) // other empty containers not accepted
-		return 0
+		return FALSE
 	if(istype(O,/obj/item/weapon/reagent_containers/syringe) || istype(O,/obj/item/weapon/reagent_containers/glass/bottle) || istype(O,/obj/item/weapon/reagent_containers/glass/beaker) || istype(O,/obj/item/weapon/reagent_containers/spray))
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 // ----------------------------
 // Virology Medical Smartfridge


### PR DESCRIPTION
:cl: Cobby
add: You can now build a disk ''''''fridge''''''''. goes great with botany gene machines [and I guess you can put the nuclear disk in there if you want to keep it cool :shades:].
/🆑 

Reasoning: It's a pain managing disks, having them in a fridge [I think] would be easier to manage and read.

Next time someone updates the map be a bro and add this to botany. You can still build it now with just one matter bin and the board [reprogram the fridge in botany, it's not like you actually provide food to the chef].

Also replaces the return values with TRUE/FALSE defines because it makes a bit more sense.