### PR TITLE
Fixes Mop Cleaning Tile Under Janitorial Cart Fix

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -42,7 +42,7 @@
 
 	var/turf/T = get_turf(A)
 
-	if(istype(A, /obj/item/weapon/reagent_containers/glass/bucket))
+	if(istype(A, /obj/item/weapon/reagent_containers/glass/bucket | /obj/structure/janitorialcart))
 		return
 
 	if(T)


### PR DESCRIPTION
## **Mop Cleaning Tile Under Janitorial Cart Fix**
The Mop will no longer try and clean the tile under the janitorial cart when the player tries to wet the mop from the janitorial cart. This should help janitors needing to move to cancel the mop from cleaning the tile under the janitorial cart.

## **Changelog**
:cl: Tofa01
Fix: Mop will no longer try and clean tile under janitorial cart when wetting the mop.
/:cl:
