### PR TITLE
[Delta] Adds Air Pipes & Vents To Delta Station Maintenance Kitchen

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3558,6 +3558,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/plasteel/bot,
 /area/maintenance/starboard{
 	name = "Fore Starboard Maintenance"
@@ -3818,7 +3819,11 @@
 /turf/closed/wall,
 /area/security/checkpoint2)
 "ahO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	tag = "icon-manifold (WEST)";
+	icon_state = "manifold";
+	dir = 8
+	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8;
 	heat_capacity = 1e+006
@@ -3832,6 +3837,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel/delivery,
 /area/maintenance/starboard{
 	name = "Fore Starboard Maintenance"
@@ -3843,28 +3853,49 @@
 	req_access_txt = "12"
 	},
 /obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel/warning/side,
 /area/maintenance/starboard{
 	name = "Fore Starboard Maintenance"
 	})
 "ahR" = (
 /obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel/red,
 /area/maintenance/starboard{
 	name = "Fore Starboard Maintenance"
 	})
 "ahS" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/starboard{
 	name = "Fore Starboard Maintenance"
 	})
 "ahT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/red,
 /area/maintenance/starboard{
 	name = "Fore Starboard Maintenance"
 	})
 "ahU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/starboard{
 	name = "Fore Starboard Maintenance"
@@ -3873,6 +3904,11 @@
 /obj/machinery/newscaster{
 	pixel_x = 32;
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
 	},
 /turf/open/floor/plasteel/delivery,
 /area/maintenance/starboard{
@@ -3885,6 +3921,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel/warning/side,
 /area/maintenance/starboard{
 	name = "Fore Starboard Maintenance"
@@ -3897,7 +3938,10 @@
 	})
 "ahY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit/old,
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	on = 1
+	},
 /turf/open/floor/plasteel/red,
 /area/maintenance/starboard{
 	name = "Fore Starboard Maintenance"
@@ -4258,6 +4302,11 @@
 	})
 "aiK" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/bot,
 /area/maintenance/starboard{
 	name = "Fore Starboard Maintenance"
@@ -117280,6 +117329,38 @@
 /area/construction/hallway{
 	name = "\improper MiniSat Exterior"
 	})
+"ebW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Fore Starboard Maintenance"
+	})
+"ebX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plasteel/red,
+/area/maintenance/starboard{
+	name = "Fore Starboard Maintenance"
+	})
+"ebY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plasteel/delivery,
+/area/maintenance/starboard{
+	name = "Fore Starboard Maintenance"
+	})
 
 (1,1,1) = {"
 aaa
@@ -160522,7 +160603,7 @@ afG
 afV
 aeX
 afn
-afn
+ebW
 aiE
 ajH
 akE
@@ -161807,7 +161888,7 @@ aft
 afZ
 agD
 ahj
-ahT
+ebX
 aiI
 ajH
 akJ
@@ -162578,7 +162659,7 @@ aaH
 aaf
 aeX
 ahl
-ahX
+ebY
 aiK
 aeX
 aaf


### PR DESCRIPTION
## **Adds Air Pipes To Delta Station Maintenance Kitchen**
The Maintenance Kitchen on Delatstation was missing multiple air vents which led to the area containing no oxygen being in the area. This fix also adds a air alarm and vent in the Maintenance Kitchens back room. This should prevent random people stumbling in this area who are badly hurt from fainting and suffocating to death.

## **Pictures**
![edit](https://cloud.githubusercontent.com/assets/24999255/22324322/c0f45e3c-e3fc-11e6-837f-2a06ea32b15f.PNG)
**Red Box - Areas where pipes were not previously.**

## **Changelog**
:cl: Tofa01
Fix: Fixes no air in Deltastation maintenance kitchen. 
/:cl:

