### PR TITLE
Observers are announced in deadchat when joining

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -124,7 +124,7 @@
 			var/obj/O = locate("landmark*Observer-Start")
 			src << "<span class='notice'>Now teleporting.</span>"
 			if (O)
-				observer.loc = O.loc
+				observer.forceMove(get_turf(O))
 			else
 				src << "<span class='notice'>Teleporting failed. You should be able to use ghost verbs to teleport somewhere useful</span>"
 			observer.key = key
@@ -135,6 +135,8 @@
 				observer.name = observer.real_name
 			observer.update_icon()
 			observer.stopLobbySound()
+			var/message = "<span class='game deadsay'><span class='name'>[observer.real_name]</span> has started observing the round.</span>"
+			deadchat_broadcast(message, follow_target = observer, message_type=DEADCHAT_ARRIVALRATTLE)
 			qdel(mind)
 
 			qdel(src)


### PR DESCRIPTION
:cl: coiax
add: Observers are announced in deadchat when joining.
/:cl:

- Because regular players get announced, and sometimes it's nice to say
hi to people. Arrivalrattle is a pref that can be disabled if people
don't like it.