### PR TITLE
Cyborgs can change the announcement system config

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -158,8 +158,11 @@ var/list/announcement_systems = list()
 	add_fingerprint(usr)
 	interact(usr)
 
-/obj/machinery/announcement_system/attack_ai(mob/living/silicon/ai/user)
-	if(!isAI(user))
+/obj/machinery/announcement_system/attack_robot(mob/living/silicon/user)
+	. = attack_ai(user)
+
+/obj/machinery/announcement_system/attack_ai(mob/living/silicon/user)
+	if(!issilicon(user))
 		return
 	if(stat & BROKEN)
 		user << "<span class='warning'>[src]'s firmware appears to be malfunctioning!</span>"


### PR DESCRIPTION
:cl: coiax
add: Cyborgs can now alter the messages of the announcement system.
/:cl:

Because it doesn't make sense that the AI can do it, but not the borgs.