### PR TITLE
Deadchat is notified of non-CTF deaths

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -35,6 +35,7 @@
 #define NOJAUNT		1
 #define UNUSED_TRANSIT_TURF 2
 #define CAN_BE_DIRTY 4 //If a turf can be made dirty at roundstart. This is also used in areas.
+#define NO_DEATHRATTLE 16 // Do not notify deadchat about any deaths that occur on this turf.
 
 /*
 	These defines are used specifically with the atom/pass_flags bitmask

--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -105,6 +105,7 @@
 	icon_state = "yellow"
 	requires_power = 0
 	has_gravity = 1
+	flags = NO_DEATHRATTLE
 
 /area/ctf/control_room
 	name = "Control Room A"

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -49,7 +49,7 @@
 	timeofdeath = world.time
 	tod = worldtime2text()
 	var/turf/T = get_turf(src)
-	if(mind && mind.name && mind.active && (T.z != ZLEVEL_CENTCOM))
+	if(mind && mind.name && mind.active && (!(T.flags & NO_DEATHRATTLE)))
 		var/area/A = get_area(T)
 		var/rendered = "<span class='deadsay'><b>[mind.name]</b> has died at <b>[A.name]</b>.</span>"
 		deadchat_broadcast(rendered, follow_target = src, message_type=DEADCHAT_DEATHRATTLE)


### PR DESCRIPTION
:cl: coiax
fix: Deadchat is now notified of any deaths on the shuttle or on
Centcom. The CTF arena does not generate death messages, due to the high
levels of death.
/:cl:

Basically, deathrattles would not fire on shuttles, or if there's a
scuffle on an abductor UFO, or if people are beating the crap out of
each other on the thunderdome. I originally changed it to non-Z2 to
remove CTF spam, but that was too much.