### PR TITLE
Cult and clockwork structures have less duplicate messages in their desc

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structure.dm
+++ b/code/game/gamemodes/clock_cult/clock_structure.dm
@@ -44,18 +44,19 @@
 		desc = clockwork_desc
 	..()
 	desc = initial(desc)
-	if(!(resistance_flags & INDESTRUCTIBLE))
+	if(unanchored_icon)
+		user << "<span class='notice'>[src] is [anchored ? "":"not "]secured to the floor.</span>"
+
+/obj/structure/destructible/clockwork/examine_status(mob/user)
+	if(is_servant_of_ratvar(user) || isobserver(user))
 		var/t_It = p_they(TRUE)
 		var/t_is = p_are()
-		var/servant_message = "[t_It] [t_is] at <b>[obj_integrity]/[max_integrity]</b> integrity"
 		var/heavily_damaged = FALSE
 		var/healthpercent = (obj_integrity/max_integrity) * 100
 		if(healthpercent < 50)
 			heavily_damaged = TRUE
-		if(can_see_clockwork)
-			user << "<span class='[heavily_damaged ? "alloy":"brass"]'>[servant_message][heavily_damaged ? "!":"."]</span>"
-	if(unanchored_icon)
-		user << "<span class='notice'>[src] is [anchored ? "":"not "]secured to the floor.</span>"
+		return "<span class='[heavily_damaged ? "alloy":"brass"]'>[t_It] [t_is] at <b>[obj_integrity]/[max_integrity]</b> integrity[heavily_damaged ? "!":"."]</span>"
+	return ..()
 
 /obj/structure/destructible/clockwork/hulk_damage()
 	return 20

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -8,14 +8,9 @@
 
 /obj/structure/destructible/cult/examine(mob/user)
 	..()
-	var/t_It = p_they(TRUE)
-	var/t_is = p_are()
-	if(!(resistance_flags & INDESTRUCTIBLE))
-		if(can_see_cult)
-			user << "<span class='cult'>[t_It] [t_is] at <b>[round(obj_integrity * 100 / max_integrity)]%</b> stability.</span>"
 	user << "<span class='notice'>\The [src] is [anchored ? "":"not "]secured to the floor.</span>"
 	if((iscultist(user) || isobserver(user)) && cooldowntime > world.time)
-		user << "<span class='cultitalic'>The magic in [src] is too weak, [t_It] will be ready to use again in [getETA()].</span>"
+		user << "<span class='cultitalic'>The magic in [src] is too weak, [p_they()] will be ready to use again in [getETA()].</span>"
 
 /obj/structure/destructible/cult/examine_status(mob/user)
 	if(iscultist(user) || isobserver(user))

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -8,15 +8,21 @@
 
 /obj/structure/destructible/cult/examine(mob/user)
 	..()
-	var/can_see_cult = iscultist(user) || isobserver(user)
 	var/t_It = p_they(TRUE)
 	var/t_is = p_are()
 	if(!(resistance_flags & INDESTRUCTIBLE))
 		if(can_see_cult)
 			user << "<span class='cult'>[t_It] [t_is] at <b>[round(obj_integrity * 100 / max_integrity)]%</b> stability.</span>"
 	user << "<span class='notice'>\The [src] is [anchored ? "":"not "]secured to the floor.</span>"
-	if(can_see_cult && cooldowntime > world.time)
+	if((iscultist(user) || isobserver(user)) && cooldowntime > world.time)
 		user << "<span class='cultitalic'>The magic in [src] is too weak, [t_It] will be ready to use again in [getETA()].</span>"
+
+/obj/structure/destructible/cult/examine_status(mob/user)
+	if(iscultist(user) || isobserver(user))
+		var/t_It = p_they(TRUE)
+		var/t_is = p_are()
+		return "<span class='cult'>[t_It] [t_is] at <b>[round(obj_integrity * 100 / max_integrity)]%</b> stability.</span>"
+	return ..()
 
 /obj/structure/destructible/cult/attack_animal(mob/living/simple_animal/M)
 	if(istype(M, /mob/living/simple_animal/hostile/construct/builder))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -99,11 +99,11 @@
 			user << "<span class='warning'>It's on fire!</span>"
 		if(broken)
 			user << "<span class='notice'>It looks broken.</span>"
-		var/examine_status = examine_status()
+		var/examine_status = examine_status(user)
 		if(examine_status)
 			user << examine_status
 
-/obj/structure/proc/examine_status() //An overridable proc, mostly for falsewalls.
+/obj/structure/proc/examine_status(mob/user) //An overridable proc, mostly for falsewalls.
 	var/healthpercent = (obj_integrity/max_integrity) * 100
 	switch(healthpercent)
 		if(100 to INFINITY)

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -141,7 +141,7 @@
 /obj/structure/falsewall/storage_contents_dump_act(obj/item/weapon/storage/src_object, mob/user)
 	return 0
 
-/obj/structure/falsewall/examine_status() //So you can't detect falsewalls by examine.
+/obj/structure/falsewall/examine_status(mob/user) //So you can't detect falsewalls by examine.
 	return null
 
 /*

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -42,7 +42,7 @@
 
 		H.update_hair()
 
-/obj/structure/mirror/examine_status()
+/obj/structure/mirror/examine_status(mob/user)
 	if(broken)
 		return // no message spam
 	..()


### PR DESCRIPTION
Instead of "It is pristine and undamaged." AND "It is at 100/100 integrity." you only get the appropriate message