### PR TITLE
Fixes bolas stunning you for a full 10 seconds if you try to remove them

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -291,8 +291,8 @@
 			changeNext_move(CLICK_CD_BREAKOUT)
 			last_special = world.time + CLICK_CD_BREAKOUT
 		if(type == 2)
-			changeNext_move(CLICK_CD_RANGED)
-			last_special = world.time + CLICK_CD_RANGED
+			changeNext_move(CLICK_CD_RANGE)
+			last_special = world.time + CLICK_CD_RANGE
 		cuff_resist(I)
 
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -279,13 +279,20 @@
 
 /mob/living/carbon/resist_restraints()
 	var/obj/item/I = null
+	var/type = 0
 	if(handcuffed)
 		I = handcuffed
+		type = 1
 	else if(legcuffed)
 		I = legcuffed
+		type = 2
 	if(I)
-		changeNext_move(CLICK_CD_BREAKOUT)
-		last_special = world.time + CLICK_CD_BREAKOUT
+		if(type == 1)
+			changeNext_move(CLICK_CD_BREAKOUT)
+			last_special = world.time + CLICK_CD_BREAKOUT
+		if(type == 2)
+			changeNext_move(CLICK_CD_RANGED)
+			last_special = world.time + CLICK_CD_RANGED
 		cuff_resist(I)
 
 


### PR DESCRIPTION
If you try to remove a bola from yourself you're unable to click or use anything for 10 full seconds regardless of you do it, fail to do it, or get moved while trying to do it.
:cl:
bugfix: Bolas no longer restrain your hands for 10 seconds when you try to remove them and fail.
/:cl: