### PR TITLE
Modifies the Human-level Intelligence Event

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -1,11 +1,24 @@
 /datum/round_event_control/sentience
 	name = "Random Human-level Intelligence"
 	typepath = /datum/round_event/ghost_role/sentience
-	weight = 5
+	weight = 10
 
 /datum/round_event/ghost_role/sentience
 	minimum_required = 1
 	role_name = "random animal"
+
+/datum/round_event/ghost_role/sentience/start()
+	var/sentience_report = "<font size=3><b>[command_name()] Medium-Priority Update</b></font>"
+
+	var/data = pick("scans from our long-range sensors", "our sophisticated probabilistic models", "our omnipotence", "the communications traffic on your station", "energy emissions we detected", "\[REDACTED\]")
+	var/pets = pick("animals/bots", "bots/animals", "pets", "simple animals", "lesser lifeforms", "\[REDACTED\]")
+	var/strength = pick("human", "moderate", "lizard", "security", "command", "clown", "low", "very low", "\[REDACTED\]")
+
+	sentience_report += "<br><br>Based on [data], we believe that one of the station's [pets] has developed [strength] level intelligence, and the ability to communicate."
+
+	print_command_report(sentience_report, "Classified [command_name()] Update")
+	priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
+	..()
 
 /datum/round_event/ghost_role/sentience/spawn_role()
 	var/list/mob/dead/observer/candidates


### PR DESCRIPTION
:cl: coiax
add: The Human-level Intelligence event now occurs slightly more often,
and produces a classified message.
/:cl:

- This has been harmless enough, right now the probability chance is
actually BELOW gateway swarmers, which is a bit silly.
- So the weight has been changed from 5 to 10.
- Some notification for the station so they can start looking for a
cockroach/mouse with opinions, or check the slime pens.
- Speaking of gateway swarmers, it produces the same classified message
notification, to keep people on their toes.
- Also I love madlib descriptions.