### PR TITLE
Adds a way to change your view range as a ghost

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -275,6 +275,10 @@ var/global/list/ghost_accs_options = list(GHOST_ACCS_NONE, GHOST_ACCS_DIR, GHOST
 
 #define GHOST_OTHERS_DEFAULT_OPTION			GHOST_OTHERS_THEIR_SETTING
 
+#define GHOST_MAX_VIEW_RANGE_DEFAULT 10
+#define GHOST_MAX_VIEW_RANGE_MEMBER 14
+
+
 var/global/list/ghost_others_options = list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DEFAULT_SPRITE, GHOST_OTHERS_THEIR_SETTING) //Same as ghost_accs_options.
 
 //Color Defines

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -388,7 +388,7 @@
 	if(modifier["shift"])
 		var/view = 0
 		if(delta_y > 0)
-			view = 1
-		else
 			view = -1
+		else
+			view = 1
 		add_view_range(view)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -32,8 +32,12 @@
 */
 /atom/Click(location,control,params)
 	usr.ClickOn(src, params)
+
 /atom/DblClick(location,control,params)
 	usr.DblClickOn(src,params)
+
+/atom/MouseWheel(delta_x,delta_y,location,control,params)
+	usr.MouseWheelOn(src, delta_y)
 
 /*
 	Standard mob ClickOn()
@@ -372,3 +376,17 @@
 		if(T)
 			T.Click(location, control, params)
 	. = 1
+
+
+/* MouseWheelOn */
+
+/mob/proc/MouseWheelOn(atom/A, delta_y)
+	return
+
+/mob/dead/observer/MouseWheelOn(atom/A, delta_y)
+	var/view = 0
+	if(delta_y > 0)
+		view = 1
+	else
+		view = -1
+	add_view_range(view)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -37,7 +37,7 @@
 	usr.DblClickOn(src,params)
 
 /atom/MouseWheel(delta_x,delta_y,location,control,params)
-	usr.MouseWheelOn(src, delta_y)
+	usr.MouseWheelOn(src, delta_x, delta_y, params)
 
 /*
 	Standard mob ClickOn()
@@ -380,13 +380,15 @@
 
 /* MouseWheelOn */
 
-/mob/proc/MouseWheelOn(atom/A, delta_y)
+/mob/proc/MouseWheelOn(atom/A, delta_x, delta_y, params)
 	return
 
-/mob/dead/observer/MouseWheelOn(atom/A, delta_y)
-	var/view = 0
-	if(delta_y > 0)
-		view = 1
-	else
-		view = -1
-	add_view_range(view)
+/mob/dead/observer/MouseWheelOn(atom/A, delta_x, delta_y, params)
+	var/list/modifier = params2list(params)
+	if(modifier["shift"])
+		var/view = 0
+		if(delta_y > 0)
+			view = 1
+		else
+			view = -1
+		add_view_range(view)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -449,7 +449,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/verb/change_view_range()
 	set category = "Ghost"
-	set name = "Modify View Range"
+	set name = "Set Zoom"
 	set desc = "Change your view range."
 
 	var/max_view = client.prefs.unlock_content ? GHOST_MAX_VIEW_RANGE_MEMBER : GHOST_MAX_VIEW_RANGE_DEFAULT

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -323,6 +323,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(mind.current.key && copytext(mind.current.key,1,2)!="@")	//makes sure we don't accidentally kick any clients
 		usr << "<span class='warning'>Another consciousness is in your body...It is resisting you.</span>"
 		return
+	client.view = world.view
 	SStgui.on_transfer(src, mind.current) // Transfer NanoUIs.
 	mind.current.key = key
 	return 1
@@ -445,6 +446,29 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 				A.update_parallax_contents()
 			else
 				A << "This mob is not located in the game world."
+
+/mob/dead/observer/verb/change_view_range()
+	set category = "Ghost"
+	set name = "Modify View Range"
+	set desc = "Change your view range."
+
+	var/max_view = client.prefs.unlock_content ? GHOST_MAX_VIEW_RANGE_MEMBER : GHOST_MAX_VIEW_RANGE_DEFAULT
+	if(client.view == world.view)
+		var/list/views = list()
+		for(var/i in 1 to max_view)
+			views |= i
+		var/new_view = input("Choose your new view", "Modify view range", 7) as null|anything in views
+		if(new_view)
+			client.view = Clamp(new_view, 1, max_view)
+	else
+		client.view = world.view
+
+/mob/dead/observer/verb/add_view_range(input as text)
+	set name = "Add View Range"
+
+	var/max_view = client.prefs.unlock_content ? 14 : 10
+	if(input)
+		client.view = Clamp(client.view + text2num(input), 1, max_view)
 
 /mob/dead/observer/verb/boo()
 	set category = "Ghost"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -463,12 +463,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else
 		client.view = world.view
 
-/mob/dead/observer/verb/add_view_range(input as text)
+/mob/dead/observer/verb/add_view_range(input as num)
 	set name = "Add View Range"
-
-	var/max_view = client.prefs.unlock_content ? 14 : 10
+	set hidden = TRUE
+	var/max_view = client.prefs.unlock_content ? GHOST_MAX_VIEW_RANGE_MEMBER : GHOST_MAX_VIEW_RANGE_DEFAULT
 	if(input)
-		client.view = Clamp(client.view + text2num(input), 1, max_view)
+		client.view = Clamp(client.view + input, 1, max_view)
 
 /mob/dead/observer/verb/boo()
 	set category = "Ghost"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -449,7 +449,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/verb/change_view_range()
 	set category = "Ghost"
-	set name = "Set Zoom"
+	set name = "View Range"
 	set desc = "Change your view range."
 
 	var/max_view = client.prefs.unlock_content ? GHOST_MAX_VIEW_RANGE_MEMBER : GHOST_MAX_VIEW_RANGE_DEFAULT

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -71,3 +71,5 @@
 	update_client_colour()
 	if(client)
 		client.click_intercept = null
+
+	client.view = world.view // Resets the client.view in case it was changed.

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -167,6 +167,14 @@ macro "default"
 		name = "CTRL+NUMPAD8"
 		command = "body-toggle-head"
 		is-disabled = false
+	elem
+		name = "CTRL+ADD"
+		command = "Add-View-Range 1"
+		is-disabled = false
+	elem
+		name = "CTRL+SUBTRACT"
+		command = "Add-View-Range -1"
+		is_disabled = false
 	elem 
 		name = "F1"
 		command = "adminhelp"
@@ -461,6 +469,14 @@ macro "hotkeys"
 		name = "NUMPAD8"
 		command = "body-toggle-head"
 		is-disabled = false
+	elem
+		name = "CTRL+ADD"
+		command = "Add-View-Range 1"
+		is-disabled = false
+	elem
+		name = "CTRL+SUBTRACT"
+		command = "Add-View-Range -1"
+		is_disabled = false
 	elem 
 		name = "F1"
 		command = "adminhelp"


### PR DESCRIPTION
:cl: Lzimann
add: You can now change your view range as ghost. To do so, either use the View Range verb in the ghost tab, the mouse scroll up/down or control + "+"/"-". The verb also works as a reset if you changed your view.
/:cl:

This keeps the admin verb, but allows ghosts to change the view range up to 10(or 14 if they are a byond member!).