### PR TITLE
[Pubby] Adds Modular Computer To CE office

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -45420,6 +45420,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/yellow/side{
 	tag = "icon-yellow (EAST)";
 	dir = 4


### PR DESCRIPTION
## **Pubbystation CE Office Modular Computer**
Adds a modular computer to the Cheif Engineers office on Pubby Station.  All other stations already have Modular Computers in all the necessary locations. This will be more uniform with most other maps which have modular computers already implemented.

## **Pictures**
**Computers with a green circuit board are new modular computers.**
![pubbycemodular](https://cloud.githubusercontent.com/assets/24999255/22362952/d0c5c896-e4ba-11e6-9155-a550142694da.PNG)

## **Changelog**
:cl: Tofa01
Add: Adds a modular computer to the CE office on Pubbystation.
/:cl:
