### PR TITLE
Clicking item slot now clicks the item in it

### DIFF
--- a/code/_onclick/hud/generic_dextrous.dm
+++ b/code/_onclick/hud/generic_dextrous.dm
@@ -32,11 +32,11 @@
 	zone_select.icon = ui_style
 	zone_select.update_icon(mymob)
 
-	using = new /obj/screen/inventory/craft
+	using = new /obj/screen/craft
 	using.icon = ui_style
 	static_inventory += using
 
-	using = new /obj/screen/inventory/area_creator
+	using = new /obj/screen/area_creator
 	using.icon = ui_style
 	static_inventory += using
 

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -90,7 +90,7 @@
 	var/obj/screen/using
 	var/obj/screen/inventory/inv_box
 
-	using = new /obj/screen/inventory/craft
+	using = new /obj/screen/craft
 	using.icon = ui_style
 	static_inventory += using
 
@@ -99,7 +99,7 @@
 	wheels += using
 	static_inventory += using
 
-	using = new /obj/screen/inventory/area_creator
+	using = new /obj/screen/area_creator
 	using.icon = ui_style
 	static_inventory += using
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -53,25 +53,25 @@
 		M.swap_hand()
 	return 1
 
-/obj/screen/inventory/craft
+/obj/screen/craft
 	name = "crafting menu"
 	icon = 'icons/mob/screen_midnight.dmi'
 	icon_state = "craft"
 	screen_loc = ui_crafting
 
-/obj/screen/inventory/craft/Click()
+/obj/screen/craft/Click()
 	var/mob/living/M = usr
 	if(isobserver(usr))
 		return
 	M.OpenCraftingMenu()
 
-/obj/screen/inventory/area_creator
+/obj/screen/area_creator
 	name = "create new area"
 	icon = 'icons/mob/screen_midnight.dmi'
 	icon_state = "area_edit"
 	screen_loc = ui_building
 
-/obj/screen/inventory/area_creator/Click()
+/obj/screen/area_creator/Click()
 	if(usr.incapacitated())
 		return 1
 	var/area/A = get_area(usr)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -150,7 +150,7 @@
 			add_overlay(active_overlay)
 
 
-/obj/screen/inventory/hand/Click()
+/obj/screen/inventory/hand/Click(location, control, params)
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
 	// We don't even know if it's a middle click
 	if(world.time <= usr.next_move)
@@ -160,9 +160,12 @@
 	if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
 		return 1
 
-	if(ismob(usr))
-		var/mob/M = usr
-		M.swap_hand(held_index)
+	if(hud.mymob.active_hand_index == held_index)
+		var/obj/item/I = hud.mymob.get_active_held_item()
+		if(I)
+			I.Click(location, control, params)
+	else
+		hud.mymob.swap_hand(held_index)
 	return 1
 
 /obj/screen/close

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -87,7 +87,7 @@
 	layer = HUD_LAYER
 	plane = HUD_PLANE
 
-/obj/screen/inventory/Click()
+/obj/screen/inventory/Click(location, control, params)
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
 	// We don't even know if it's a middle click
 	if(world.time <= usr.next_move)
@@ -95,8 +95,14 @@
 
 	if(usr.incapacitated())
 		return 1
-	if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
+	if(istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
 		return 1
+
+	if(hud && hud.mymob && slot_id)
+		var/obj/item/inv_item = hud.mymob.get_item_by_slot(slot_id)
+		if(inv_item)
+			return inv_item.Click(location, control, params)
+
 	if(usr.attack_ui(slot_id))
 		usr.update_inv_hands()
 	return 1


### PR DESCRIPTION
95% less pixel hunting with tiny sprite items in pockets.

It also includes a rider commit with small path consistency change.

:cl: CoreOverload
tweak: Clicking item slot now clicks the item in it.
/:cl: