### PR TITLE
Adds support for simple mobs changing intents

### DIFF
--- a/code/_onclick/hud/generic_dextrous.dm
+++ b/code/_onclick/hud/generic_dextrous.dm
@@ -28,9 +28,21 @@
 	using.screen_loc = ui_swaphand_position(owner,2)
 	static_inventory += using
 
+	if(mymob.possible_a_intents)
+		if(mymob.possible_a_intents.len == 4)
+			// All possible intents - full intent selector
+			action_intent = new /obj/screen/act_intent/segmented
+		else
+			action_intent = new /obj/screen/act_intent
+			action_intent.icon = ui_style
+		action_intent.icon_state = mymob.a_intent
+		static_inventory += action_intent
+
+
 	zone_select = new /obj/screen/zone_sel()
 	zone_select.icon = ui_style
 	zone_select.update_icon(mymob)
+	static_inventory += zone_select
 
 	using = new /obj/screen/inventory/craft
 	using.icon = ui_style

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -103,12 +103,11 @@
 	using.icon = ui_style
 	static_inventory += using
 
-	using = new /obj/screen/act_intent()
-	using.icon_state = mymob.a_intent
-	static_inventory += using
-	action_intent = using
+	action_intent = new /obj/screen/act_intent/segmented
+	action_intent.icon_state = mymob.a_intent
+	static_inventory += action_intent
 
-	using = new /obj/screen/mov_intent()
+	using = new /obj/screen/mov_intent
 	using.icon = ui_style
 	using.icon_state = (mymob.m_intent == MOVE_INTENT_RUN ? "running" : "walking")
 	using.screen_loc = ui_movi

--- a/code/_onclick/hud/monkey.dm
+++ b/code/_onclick/hud/monkey.dm
@@ -3,12 +3,11 @@
 	var/obj/screen/using
 	var/obj/screen/inventory/inv_box
 
-	using = new /obj/screen/act_intent()
-	using.icon = ui_style
-	using.icon_state = mymob.a_intent
-	using.screen_loc = ui_acti
-	static_inventory += using
-	action_intent = using
+	action_intent = new /obj/screen/act_intent()
+	action_intent.icon = ui_style
+	action_intent.icon_state = mymob.a_intent
+	action_intent.screen_loc = ui_acti
+	static_inventory += action_intent
 
 	using = new /obj/screen/mov_intent()
 	using.icon = ui_style

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -151,10 +151,9 @@
 	mymobR.thruster_button = using
 
 //Intent
-	using = new /obj/screen/act_intent/robot()
-	using.icon_state = mymob.a_intent
-	static_inventory += using
-	action_intent = using
+	action_intent = new /obj/screen/act_intent/robot()
+	action_intent.icon_state = mymob.a_intent
+	static_inventory += action_intent
 
 //Health
 	healths = new /obj/screen/healths/robot()

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -185,8 +185,10 @@
 	screen_loc = ui_acti
 
 /obj/screen/act_intent/Click(location, control, params)
-	if(ishuman(usr) && (usr.client.prefs.toggles & INTENT_STYLE))
+	usr.a_intent_change(INTENT_HOTKEY_RIGHT)
 
+/obj/screen/act_intent/segmented/Click(location, control, params)
+	if(usr.client.prefs.toggles & INTENT_STYLE)
 		var/_x = text2num(params2list(params)["icon-x"])
 		var/_y = text2num(params2list(params)["icon-y"])
 
@@ -201,9 +203,8 @@
 
 		else if(_x>=17 && _y>=17)
 			usr.a_intent_change(INTENT_DISARM)
-
 	else
-		usr.a_intent_change(INTENT_HOTKEY_RIGHT)
+		return ..()
 
 /obj/screen/act_intent/alien
 	icon = 'icons/mob/screen_alien.dmi'

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -3,6 +3,7 @@
 	icon_state = "alien_s"
 	pass_flags = PASSTABLE
 	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab/xeno = 5, /obj/item/stack/sheet/animalhide/xeno = 1)
+	possible_a_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
 	limb_destroyer = 1
 	var/obj/item/r_store = null
 	var/obj/item/l_store = null

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -1,6 +1,7 @@
 /mob/living/carbon
 	gender = MALE
 	pressure_resistance = 15
+	possible_a_intents = list(INTENT_HELP, INTENT_HARM)
 	var/list/stomach_contents		= list()
 	var/list/internal_organs		= list()	//List of /obj/item/organ in the mob. They don't go in the contents for some reason I don't want to know.
 	var/list/internal_organs_slot	= list()	//Same as above, but stores "slot ID" - "organ" pairs for easy access.

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -3,6 +3,7 @@ var/global/default_martial_art = new/datum/martial_art
 	languages_spoken = HUMAN
 	languages_understood = HUMAN
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD,ANTAG_HUD)
+	possible_a_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
 	pressure_resistance = 25
 	//Hair colour and style
 	var/hair_color = "000"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -11,6 +11,7 @@
 	see_in_dark = 8
 	bubble_icon = "machine"
 	weather_immunities = list("ash")
+	possible_a_intents = list(INTENT_HELP, INTENT_HARM)
 
 	var/syndicate = 0
 	var/datum/ai_laws/laws = null//Now... THEY ALL CAN ALL HAVE LAWS

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -73,6 +73,7 @@
 	var/weakened = 0
 	var/losebreath = 0//Carbon
 	var/a_intent = INTENT_HELP//Living
+	var/list/possible_a_intents = null//Living
 	var/m_intent = MOVE_INTENT_RUN//Living
 	var/lastKnownIP = null
 	var/atom/movable/buckled = null//Living

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -298,8 +298,10 @@ var/static/regex/firstname = new("^\[^\\s-\]+") //First word before whitespace o
 		a_intent = input
 	else
 		var/current_intent = possible_a_intents.Find(a_intent)
+
 		if(!current_intent)
-			return
+			// Failsafe. Just in case some badmin was playing with VV.
+			current_intent = 1
 
 		if(input == INTENT_HOTKEY_RIGHT)
 			current_intent += 1

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -291,49 +291,32 @@ var/static/regex/firstname = new("^\[^\\s-\]+") //First word before whitespace o
 	set name = "a-intent"
 	set hidden = 1
 
-	if(ishuman(src) || isalienadult(src) || isbrain(src))
-		switch(input)
-			if(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
-				a_intent = input
-			if(INTENT_HOTKEY_RIGHT)
-				switch (a_intent)
-					if(INTENT_HELP)
-						a_intent = INTENT_DISARM
-					if(INTENT_DISARM)
-						a_intent = INTENT_GRAB
-					if(INTENT_GRAB)
-						a_intent = INTENT_HARM
-					if(INTENT_HARM)
-						a_intent = INTENT_HELP
-			if(INTENT_HOTKEY_LEFT)
-				switch (a_intent)
-					if(INTENT_HELP)
-						a_intent = INTENT_HARM
-					if(INTENT_DISARM)
-						a_intent = INTENT_HELP
-					if(INTENT_GRAB)
-						a_intent = INTENT_DISARM
-					if(INTENT_HARM)
-						a_intent = INTENT_GRAB
+	if(!possible_a_intents || !possible_a_intents.len)
+		return
 
-		if(hud_used && hud_used.action_intent)
-			hud_used.action_intent.icon_state = "[a_intent]"
+	if(input in possible_a_intents)
+		a_intent = input
+	else
+		var/current_intent = possible_a_intents.Find(a_intent)
+		if(!current_intent)
+			return
 
-	else if(iscyborg(src) || ismonkey(src) || islarva(src))
-		switch(input)
-			if(INTENT_HELP)
-				a_intent = INTENT_HELP
-			if(INTENT_HARM)
-				a_intent = INTENT_HARM
-			if(INTENT_HOTKEY_RIGHT, INTENT_HOTKEY_LEFT)
-				switch (a_intent)
-					if(INTENT_HELP)
-						a_intent = INTENT_HARM
-					if(INTENT_HARM)
-						a_intent = INTENT_HELP
+		if(input == INTENT_HOTKEY_RIGHT)
+			current_intent += 1
+		if(input == INTENT_HOTKEY_LEFT)
+			current_intent -= 1
 
-		if(hud_used && hud_used.action_intent)
-			hud_used.action_intent.icon_state = "[a_intent]"
+		// Handle looping
+		if(current_intent < 1)
+			current_intent = possible_a_intents.len
+		if(current_intent > possible_a_intents.len)
+			current_intent = 1
+
+		a_intent = possible_a_intents[current_intent]
+
+	if(hud_used && hud_used.action_intent)
+		hud_used.action_intent.icon_state = "[a_intent]"
+
 
 /proc/is_blind(A)
 	if(ismob(A))


### PR DESCRIPTION
This PR refactors action intent selectors to make them more flexible.

New mob var: `possible_a_intents`, defaults to `null`. 

When set to a list of possible intents, it allows said mob to use listed intents, both by selecting directly and in cycling mode. The var itself doesn't add intent selector to HUD, but "dexterous simple animal" HUD now supports it. It will display appropriate intent selector if the mob has `possible_a_intents` var at HUD creation.
