### PR TITLE
Security Suit Sensors are maximized by default

### DIFF
--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -14,6 +14,8 @@
 	icon_state = "captain"
 	item_state = "b_suit"
 	item_color = "captain"
+	sensor_mode = 3
+	random_sensor = 0
 
 /obj/item/clothing/under/rank/cargo
 	name = "quartermaster's jumpsuit"

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -18,11 +18,14 @@
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0, fire = 30, acid = 30)
 	strip_delay = 50
 	alt_covers_chest = 1
+	sensor_mode = 3
+	random_sensor = 0
 
 /obj/item/clothing/under/rank/security/grey
 	icon_state = "security"
 	item_state = "gy_suit"
 	item_color = "security"
+	
 
 /obj/item/clothing/under/rank/warden
 	name = "security suit"
@@ -33,6 +36,8 @@
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0, fire = 30, acid = 30)
 	strip_delay = 50
 	alt_covers_chest = 1
+	sensor_mode = 3
+	random_sensor = 0
 
 /obj/item/clothing/under/rank/warden/grey
 	icon_state = "warden"
@@ -51,6 +56,8 @@
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0, fire = 30, acid = 30)
 	strip_delay = 50
 	alt_covers_chest = 1
+	sensor_mode = 3
+	random_sensor = 0
 
 /obj/item/clothing/under/rank/det/grey
 	name = "noir suit"
@@ -72,6 +79,8 @@
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 50)
 	strip_delay = 60
 	alt_covers_chest = 1
+	sensor_mode = 3
+	random_sensor = 0
 
 /obj/item/clothing/under/rank/head_of_security/grey
 	icon_state = "hos"


### PR DESCRIPTION
A simple improvement. For those going "REEEEE git gud you scrub", this isn't just about the officers who forget to set them, this is also about the security who gets ambushed by a taser because some other shitty officer didn't set his sensors and so nobody knew that he had died and gotten his shit handed out to revs/traitors/cultists/whatever. This will help sec keep tabs on their own (if they are vigilant). 

:cl: Sogui
tweak: All security (and captain) suit sensors are set to max by default
/:cl: