### PR TITLE
Botany Fixes

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -352,8 +352,8 @@
 		if(!master.vines.len)
 			var/obj/item/seeds/kudzu/KZ = new(loc)
 			KZ.mutations |= mutations
-			KZ.potency = min(100, master.mutativeness * 10)
-			KZ.production = (master.spread_cap / initial(master.spread_cap)) * 5
+			KZ.set_potency(master.mutativeness * 10)
+			KZ.set_production((master.spread_cap / initial(master.spread_cap)) * 5)
 	mutations = list()
 	SetOpacity(0)
 	if(has_buckled_mobs())

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -146,10 +146,10 @@
 
 /datum/spacevine_mutation/explosive/on_explosion(explosion_severity, target, obj/structure/spacevine/holder)
 	if(explosion_severity < 3)
-		qdel(src)
+		qdel(holder)
 	else
 		. = 1
-		QDEL_IN(src, 5)
+		QDEL_IN(holder, 5)
 
 /datum/spacevine_mutation/explosive/on_death(obj/structure/spacevine/holder, mob/hitter, obj/item/I)
 	explosion(holder.loc, 0, 0, severity, 0, 0)

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -62,7 +62,7 @@
 		for(var/datum/spacevine_mutation/SM in mutations)
 			if(SM.quality == POSITIVE)
 				temp_mut_list += SM
-		if(prob(20)&& temp_mut_list.len)
+		if(prob(20) && temp_mut_list.len)
 			mutations.Remove(pick(temp_mut_list))
 		temp_mut_list.Cut()
 
@@ -70,7 +70,7 @@
 		for(var/datum/spacevine_mutation/SM in mutations)
 			if(SM.quality == MINOR_NEGATIVE)
 				temp_mut_list += SM
-		if(prob(20)&& temp_mut_list.len)
+		if(prob(20) && temp_mut_list.len)
 			mutations.Remove(pick(temp_mut_list))
 		temp_mut_list.Cut()
 

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -54,7 +54,7 @@
 		for(var/datum/spacevine_mutation/SM in mutations)
 			if(SM.quality == NEGATIVE)
 				temp_mut_list += SM
-		if(prob(20))
+		if(prob(20) && temp_mut_list.len)
 			mutations.Remove(pick(temp_mut_list))
 		temp_mut_list.Cut()
 
@@ -62,7 +62,7 @@
 		for(var/datum/spacevine_mutation/SM in mutations)
 			if(SM.quality == POSITIVE)
 				temp_mut_list += SM
-		if(prob(20))
+		if(prob(20)&& temp_mut_list.len)
 			mutations.Remove(pick(temp_mut_list))
 		temp_mut_list.Cut()
 
@@ -70,21 +70,21 @@
 		for(var/datum/spacevine_mutation/SM in mutations)
 			if(SM.quality == MINOR_NEGATIVE)
 				temp_mut_list += SM
-		if(prob(20))
+		if(prob(20)&& temp_mut_list.len)
 			mutations.Remove(pick(temp_mut_list))
 		temp_mut_list.Cut()
 
 	if(S.has_reagent("blood", 15))
-		production = Clamp(production + rand(15, -5),1,10)
+		adjust_production(rand(15, -5))
 
 	if(S.has_reagent("amatoxin", 5))
-		production = Clamp(production + rand(5, -15),1,10)
+		adjust_production(rand(5, -15))
 
 	if(S.has_reagent("plasma", 5))
-		potency = Clamp(potency + rand(5, -15),0,100)
+		adjust_potency(rand(5, -15))
 
 	if(S.has_reagent("holywater", 10))
-		potency = Clamp(potency + rand(15, -5),0,100)
+		adjust_potency(rand(15, -5))
 
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/kudzupod

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -210,7 +210,7 @@
 	species = "glowshroom"
 	plantname = "Glowshrooms"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom
-	lifespan = 120 //ten times that is the delay
+	lifespan = 100 //ten times that is the delay
 	endurance = 30
 	maturation = 15
 	production = 1

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -211,7 +211,7 @@
 		C.value = weed_rate
 
 /obj/item/seeds/proc/adjust_weed_chance(adjustamt)
-	weed_chance = Clamp(weed_chance + adjustamt, 0, 100)
+	weed_chance = Clamp(weed_chance + adjustamt, 0, 67)
 	var/datum/plant_gene/core/C = get_gene(/datum/plant_gene/core/weed_chance)
 	if(C)
 		C.value = weed_chance
@@ -242,7 +242,7 @@
 
 /obj/item/seeds/proc/set_production(adjustamt)
 	if(yield != -1)
-		production = Clamp(adjustamt, 2, 10)
+		production = Clamp(adjustamt, 1, 10)
 		var/datum/plant_gene/core/C = get_gene(/datum/plant_gene/core/production)
 		if(C)
 			C.value = production
@@ -255,13 +255,13 @@
 			C.value = potency
 
 /obj/item/seeds/proc/set_weed_rate(adjustamt)
-	weed_rate = Clamp(adjustamt, 0, 100)
+	weed_rate = Clamp(adjustamt, 0, 10)
 	var/datum/plant_gene/core/C = get_gene(/datum/plant_gene/core/weed_rate)
 	if(C)
 		C.value = weed_rate
 
 /obj/item/seeds/proc/set_weed_chance(adjustamt)
-	weed_chance = Clamp(adjustamt, 0, 100)
+	weed_chance = Clamp(adjustamt, 0, 67)
 	var/datum/plant_gene/core/C = get_gene(/datum/plant_gene/core/weed_chance)
 	if(C)
 		C.value = weed_chance

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -211,7 +211,7 @@
 		C.value = weed_rate
 
 /obj/item/seeds/proc/adjust_weed_chance(adjustamt)
-	weed_chance = Clamp(weed_chance + adjustamt, 0, 67)
+	weed_chance = Clamp(weed_chance + adjustamt, 0, 100)
 	var/datum/plant_gene/core/C = get_gene(/datum/plant_gene/core/weed_chance)
 	if(C)
 		C.value = weed_chance


### PR DESCRIPTION
Just a few botany fixes

- Fixes a runtime with Kudzu being impacted by certain chemicals
- Fixes Kudzu seeds created from vines not having their potency and production genes properly set
- Fixes reagent application to Kudzu seeds not properly altering gene stats
- Fixes `set_production`  to clamp to 1 and 10 instead of 2 and 10
- Fixes `set_weed_chance` to clamp to 0 and 67 instead of 0 and 100
- Fixes `set_weed_rate` to clamp to 0 and 10 instead of 0 and 100
- Fixes glowshrooms having an invalidly high lifespan (120->100)
- Fixes explosive vines deleting their own datum
  - Impact of this is that chain reactions now properly work


:cl: Fox McCloud
fix: Fixes Kudzu seed gene stats not being properly altered by certain reagents
fix: Fixes Kudzu vine dropped seeds not properly having gene stats set
fix: Fixes glowshrooms having an invalidly high lifespan
fix: Fixes explosive vines not properly chaining
/:cl: