### PR TITLE
Tweaks some prices of cargo exports

### DIFF
--- a/code/modules/cargo/exports/organs.dm
+++ b/code/modules/cargo/exports/organs.dm
@@ -13,7 +13,7 @@
 	export_types = list(/obj/item/organ/brain/alien)
 
 /datum/export/organ/alien/acid
-	cost = 3000
+	cost = 5000
 	unit_name = "alien acid gland"
 	export_types = list(/obj/item/organ/alien/acid)
 

--- a/code/modules/cargo/exports/organs.dm
+++ b/code/modules/cargo/exports/organs.dm
@@ -8,31 +8,31 @@
 		. *= 2
 
 /datum/export/organ/alien/brain
-	cost = 2000
+	cost = 5000
 	unit_name = "alien brain"
 	export_types = list(/obj/item/organ/brain/alien)
 
 /datum/export/organ/alien/acid
-	cost = 1500
+	cost = 3000
 	unit_name = "alien acid gland"
 	export_types = list(/obj/item/organ/alien/acid)
 
 /datum/export/organ/alien/hivenode
-	cost = 2000
+	cost = 5000
 	unit_name = "alien hive node"
 	export_types = list(/obj/item/organ/alien/hivenode)
 
 /datum/export/organ/alien/neurotoxin
-	cost = 2000
+	cost = 5000
 	unit_name = "alien neurotoxin gland"
 	export_types = list(/obj/item/organ/alien/neurotoxin)
 
 /datum/export/organ/alien/resinspinner
-	cost = 1000
+	cost = 5000
 	unit_name = "alien resin spinner"
 
 /datum/export/organ/alien/plasmavessel
-	cost = 1000
+	cost = 5000
 	unit_name = "alien plasma vessel"
 	export_types = list(/obj/item/organ/alien/plasmavessel)
 

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -113,10 +113,9 @@
 // Alien Alloy. Like plasteel, but better.
 // Major players would pay a lot to get some, so you can get a lot of money from producing and selling those.
 // Just don't forget to fire all your production staff before the end of month.
-
 /datum/export/stack/abductor
 	cost = 5000
-        message = "of alien alloy"
+	message = "of alien alloy"
 	export_types = list(/obj/item/stack/sheet/mineral/abductor)
 
 // Adamantine. Does not occur naurally.

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -113,11 +113,11 @@
 // Alien Alloy. Like plasteel, but better.
 // Major players would pay a lot to get some, so you can get a lot of money from producing and selling those.
 // Just don't forget to fire all your production staff before the end of month.
-// Abductor alloy is too rewarding for 5 sheets plasma and 5 sheets metal for some alien alloy where you can get the abductor tools easily from mining
-// /datum/export/stack/abductor
-//	cost = 10000
-//	message = "of alien alloy"
-//	export_types = list(/obj/item/stack/sheet/mineral/abductor)
+
+/datum/export/stack/abductor
+	cost = 5000
+        message = "of alien alloy"
+	export_types = list(/obj/item/stack/sheet/mineral/abductor)
 
 // Adamantine. Does not occur naurally.
 /datum/export/stack/adamantine

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -59,7 +59,7 @@
 
 // Alien hide. Extremely expensive.
 /datum/export/stack/skin/xeno
-	cost = 15000
+	cost = 3000
 	unit_name = "alien hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/xeno)
 
@@ -113,10 +113,11 @@
 // Alien Alloy. Like plasteel, but better.
 // Major players would pay a lot to get some, so you can get a lot of money from producing and selling those.
 // Just don't forget to fire all your production staff before the end of month.
-/datum/export/stack/abductor
-	cost = 10000
-	message = "of alien alloy"
-	export_types = list(/obj/item/stack/sheet/mineral/abductor)
+// Abductor alloy is too rewarding for 5 sheets plasma and 5 sheets metal for some alien alloy where you can get the abductor tools easily from mining
+// /datum/export/stack/abductor
+//	cost = 10000
+//	message = "of alien alloy"
+//	export_types = list(/obj/item/stack/sheet/mineral/abductor)
 
 // Adamantine. Does not occur naurally.
 /datum/export/stack/adamantine


### PR DESCRIPTION
I tweaked the exports for the following reasons

-Alien organs:i buffed the price since alien organs arent in NPC alien mobs and auctally are rare and need effort to get them
-Alien Hide:nerfed to 3000 because its kinda stupid how they are worth 15000 points which would make a alien hive at mining make up for points for 13 supermatters without really any effort since NPC mobs are weak
-Alien Alloy:nerfed from 10000 to 5000 since science can pretty much mass produce them for cargo when they get alien tools (which is quite common at mining since theres a ruin that gives the tools) alien alloy required 5 plasma which is 2500 points so i nerfed the price just a little above that so they still give profit just not horrible amounts of it



:cl:
tweak: Changes some cargo export prices
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)
![image](https://cloud.githubusercontent.com/assets/14280283/22397244/c70fea26-e56d-11e6-8159-7518c340644a.png)

