### PR TITLE
The shuttle can now be recalled for longer while at green alert

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -238,7 +238,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	var/security_num = seclevel2num(get_security_level())
 	switch(security_num)
 		if(SEC_LEVEL_GREEN)
-			if(emergency.timeLeft(1) < emergencyCallTime)
+			if(emergency.timeLeft(1) < emergencyCallTime * 0.5) //allow recalling for longer when at green alert
 				return
 		if(SEC_LEVEL_BLUE)
 			if(emergency.timeLeft(1) < emergencyCallTime * 0.5)

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -237,11 +237,8 @@ var/datum/subsystem/shuttle/SSshuttle
 		return
 	var/security_num = seclevel2num(get_security_level())
 	switch(security_num)
-		if(SEC_LEVEL_GREEN)
-			if(emergency.timeLeft(1) < emergencyCallTime * 0.5) //allow recalling for longer when at green alert
-				return
-		if(SEC_LEVEL_BLUE)
-			if(emergency.timeLeft(1) < emergencyCallTime * 0.5)
+		if(SEC_LEVEL_GREEN, SEC_LEVEL_BLUE)
+			if(emergency.timeLeft(1) < emergencyCallTime * 0.5) //allows recalling for longer when at green alert
 				return
 		else
 			if(emergency.timeLeft(1) < emergencyCallTime * 0.25)


### PR DESCRIPTION
:cl: Joan
tweak: When at green alert, the shuttle can be recalled until the time remaining is less than 5 minutes, from less than 10.
wip: For reference, this means changing the alert to green allows you to recall until the time is less than 2 minutes and 30 seconds at blue alert, and 1 minute and 15 seconds at red and delta alerts.
/:cl:

hey look it's that thing