### PR TITLE
Increases minimum bomb countdown to 90 seconds

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -21,8 +21,8 @@ var/bomb_set
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 	var/timer_set = 60
-	var/default_timer_set = 60
-	var/minimum_timer_set = 60
+	var/default_timer_set = 90
+	var/minimum_timer_set = 90
 	var/maximum_timer_set = 3600
 	var/ui_style = "nanotrasen"
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -11,8 +11,8 @@
 	layer = BELOW_MOB_LAYER //so people can't hide it and it's REALLY OBVIOUS
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
-	var/minimum_timer = 60
-	var/timer_set = 60
+	var/minimum_timer = 90
+	var/timer_set = 90
 	var/maximum_timer = 60000
 
 	var/can_unanchor = TRUE


### PR DESCRIPTION
:cl: coiax
add: Syndicate bombs and nuclear devices now have a minimum timer of 90 seconds.
/:cl:

Okay, so when I converted it from 60 processses to 60 actual world
seconds, that SERIOUSLY buffed syndibombs and nukes, because in practice there was
a lot less time to disarm them. I think they're a bit too fast to
detonate now.