### PR TITLE
Nerfs Volt Void

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_cyborg.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_cyborg.dm
@@ -40,5 +40,5 @@
 
 //Volt Void, but with a different quickbind desc
 /datum/clockwork_scripture/channeled/volt_void/cyborg
-	quickbind_desc = "Allows you to fire energy rays at target locations using your own power.<br><b>Maximum 4 chants.</b>"
+	quickbind_desc = "Allows you to fire energy rays at target locations using your own power. Failing to fire causes backlash.<br><b>Maximum 4 chants.</b>"
 	tier = SCRIPTURE_PERIPHERAL

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_cyborg.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_cyborg.dm
@@ -40,5 +40,5 @@
 
 //Volt Void, but with a different quickbind desc
 /datum/clockwork_scripture/channeled/volt_void/cyborg
-	quickbind_desc = "Allows you to fire energy rays at target locations using your own power.<br><b>Maximum 5 chants.</b>"
+	quickbind_desc = "Allows you to fire energy rays at target locations using your own power.<br><b>Maximum 4 chants.</b>"
 	tier = SCRIPTURE_PERIPHERAL

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
@@ -272,12 +272,12 @@
 /datum/clockwork_scripture/channeled/volt_void
 	descname = "Channeled, Targeted Energy Blasts"
 	name = "Volt Void" //Alternative name: "On all levels but physical, I am a power sink"
-	desc = "Allows you to fire energy rays at target locations; more power consumed causes more damage. Channeled every fourth of a second for a maximum of ten seconds."
-	channel_time = 20
+	desc = "Allows you to fire energy rays at target locations; more power consumed causes more damage. Channeled every fifth of a second for a maximum of ten seconds."
+	channel_time = 30
 	invocations = list("Amperage...", "...grant me your power!")
 	chant_invocations = list("Use charge to kill!", "Slay with power!", "Hunt with energy!")
-	chant_amount = 5
-	chant_interval = 4
+	chant_amount = 4
+	chant_interval = 5
 	required_components = list(GEIS_CAPACITOR = 1, HIEROPHANT_ANSIBLE = 2)
 	consumed_components = list(GEIS_CAPACITOR = 1, HIEROPHANT_ANSIBLE = 1)
 	usage_tip = "Though it requires you to stand still, this scripture can do massive damage."
@@ -285,7 +285,7 @@
 	primary_component = HIEROPHANT_ANSIBLE
 	sort_priority = 10
 	quickbind = TRUE
-	quickbind_desc = "Allows you to fire energy rays at target locations. Failing to fire causes backlash.<br><b>Maximum 5 chants.</b>"
+	quickbind_desc = "Allows you to fire energy rays at target locations. Failing to fire causes backlash.<br><b>Maximum 4 chants.</b>"
 	var/static/list/nzcrentr_insults = list("You're not very good at aiming.", "You hunt badly.", "What a waste of energy.", "Almost funny to watch.",
 	"Boss says </span><span class='heavy_brass'>\"Click something, you idiot!\"</span><span class='nzcrentr'>.", "Stop wasting components if you can't aim.")
 
@@ -324,7 +324,7 @@
 	ranged_type = /obj/effect/proc_holder/slab/volt
 	ranged_message = "<span class='nzcrentr_small'><i>You charge the clockwork slab with shocking might.</i>\n\
 	<b>Left-click a target to fire, quickly!</b></span>"
-	timeout_time = 16
+	timeout_time = 20
 
 /obj/structure/destructible/clockwork/powered/volt_checker
 	invisibility = INVISIBILITY_ABSTRACT

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
@@ -297,13 +297,20 @@
 	var/turf/T = get_turf(invoker)
 	if(!ray.run_scripture() && slab && invoker)
 		if(can_recite() && T == get_turf(invoker))
-			if(!ratvar_awakens && !iscyborg(invoker) && !isclockmob(invoker) && !isdrone(invoker))
+			if(!ratvar_awakens)
 				var/obj/structure/destructible/clockwork/powered/volt_checker/VC = new/obj/structure/destructible/clockwork/powered/volt_checker(get_turf(invoker))
-				var/multiplier = 0.4
+				var/multiplier = 0.5
 				var/usable_power = min(Floor(VC.total_accessable_power() * 0.2, MIN_CLOCKCULT_POWER), 1000)
 				if(VC.try_use_power(usable_power))
-					multiplier += (usable_power * 0.0004) //at maximum power, should be 0.8 multiplier
+					multiplier += (usable_power * 0.0005) //at maximum power, should be 1 multiplier
 				qdel(VC)
+				if(iscyborg(invoker))
+					var/mob/living/silicon/robot/C = invoker
+					if(C.cell)
+						var/prev_power = usable_power //we don't want to increase the multiplier past 1
+						usable_power = min(Floor(C.cell.charge * 0.2, MIN_CLOCKCULT_POWER), 1000) - prev_power
+						if(usable_power > 0 && C.cell.use(usable_power))
+							multiplier += (usable_power * 0.0005)
 				var/obj/effect/overlay/temp/ratvar/volt_hit/VH = new /obj/effect/overlay/temp/ratvar/volt_hit(get_turf(invoker), null, multiplier)
 				invoker.visible_message("<span class='warning'>[invoker] is struck by [invoker.p_their()] own [VH.name]!</span>", "<span class='userdanger'>You're struck by your own [VH.name]!</span>")
 				invoker.adjustFireLoss(VH.damage) //you have to fail all five blasts to die to this

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -317,7 +317,7 @@
 	duration = 5
 	icon_state = "volt_hit"
 	var/mob/user
-	var/damage = 25
+	var/damage = 20
 
 /obj/effect/overlay/temp/ratvar/volt_hit/New(loc, caster, multiplier)
 	if(multiplier)


### PR DESCRIPTION
:cl: Joan
tweak: Volt Void now only allows you to fire 4 volt rays instead of 5, and the damage of each ray has been reduced to 20, from 25.
rscdel: Cyborgs using Volt Void now take damage if they fail to fire.
/:cl:
