### PR TITLE
Strobe shield now activates when attacked

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -282,3 +282,7 @@
 
 	if(holder)
 		holder.update_icon()
+
+/obj/item/device/assembly/flash/shield/hitreaction(obj/item/weapon/W, mob/user, params)
+	activate()
+	return ..()

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -283,6 +283,6 @@
 	if(holder)
 		holder.update_icon()
 
-/obj/item/device/assembly/flash/shield/hitreaction(obj/item/weapon/W, mob/user, params)
+/obj/item/device/assembly/flash/shield/hit_reaction(obj/item/weapon/W, mob/user, params)
 	activate()
 	return ..()


### PR DESCRIPTION
It activates the same way using a flash inhand does, seems to lack a stun but should give you an edge anyway.

Reason: Don't care if this doesn't happen in seige, this should make people use it in space, against unprepared tiders or cults. They can't hit what they can't seeeee!