### PR TITLE
Plant Analyzer Info Tweak

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -61,20 +61,12 @@
 		var/msg = "<span class='info'>*---------*\n This is \a <span class='name'>[src]</span>.\n"
 		if(seed)
 			msg += seed.get_analyzer_text()
-		msg += "\n- Nutritional value: [reagents.get_reagent_amount("nutriment")]\n"
-		msg += "- Other substances: [reagents.total_volume-reagents.get_reagent_amount("nutriment")]\n"
-		msg += "*---------*</span>"
-
-		var/list/scannable_reagents = list("charcoal" = "Anti-Toxin", "morphine" = "Morphine", "amatoxin" = "Amatoxins",
-			"toxin" = "Toxins", "mushroomhallucinogen" = "Mushroom Hallucinogen", "condensedcapsaicin" = "Condensed Capsaicin",
-			"capsaicin" = "Capsaicin", "frostoil" = "Frost Oil", "gold" = "Mineral Content", "glycerol" = "Glycerol",
-			"radium" = "Highly Radioactive Material", "uranium" = "Radioactive Material")
 		var/reag_txt = ""
 		if(seed)
-			for(var/reagent_id in scannable_reagents)
-				if(reagent_id in seed.reagents_add)
-					var/amt = reagents.get_reagent_amount(reagent_id)
-					reag_txt += "\n<span class='info'>- [scannable_reagents[reagent_id]]: [amt*100/reagents.maximum_volume]%</span>"
+			for(var/reagent_id in seed.reagents_add)
+				var/datum/reagent/R  = chemical_reagents_list[reagent_id]
+				var/amt = reagents.get_reagent_amount(reagent_id)
+				reag_txt += "\n<span class='info'>- [R.name]: [amt]</span>"
 
 		if(reag_txt)
 			msg += reag_txt

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -290,6 +290,12 @@
 	text += "- Weed Vulnerability: [weed_chance]\n"
 	if(rarity)
 		text += "- Species Discovery Value: [rarity]\n"
+	var/all_traits = ""
+	for(var/datum/plant_gene/trait/traits in genes)
+		if(istype(traits, /datum/plant_gene/trait/plant_type))
+			continue
+		all_traits += " [traits.get_name()]"
+	text += "- Plant Traits:[all_traits]\n"
 
 	text += "*---------*"
 


### PR DESCRIPTION
Plant analyzers will now display a seed's traits (liquid contents, separated chemicals, slippery skin, etc.); additionally, using a plant analyzer on a grown will display its *genetic* reagents and how much of that reagent exists (in units).

This should make a botanist's life a bit easier, especially when he has multiple of a same plant growing and the only differences are traits; it'll also let them be able to see if a hard mutate added an additional trait or not.

The reagents display is mostly just a quality of life thing; the nutritional substances vs total volume wasn't particularly useful, and limited amount of reagents that could be seen was a bit silly. Please note this does **not** work on all reagents; only the *genetic reagents*; injecting a grown with a new reagent (via syringe) will ***not*** show up on a scanner. 

![img](https://i.gyazo.com/f08a191547f9c27d7d26753e510b48fa.png)


:cl: Fox McCloud
tweak: Plant analyzers will now display plant traits
tweak: Plant analyzers will now display all of a grown's genetic reagents
/:cl:
