### PR TITLE
adds ion rifle to cargo for 8000 points without vcordie's memery

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -361,6 +361,13 @@
 					/obj/item/weapon/gun/energy/e_gun)
 	crate_name = "energy gun crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
+	
+/datum/supply_pack/security/armory/ionrifle
+	name = Ion Rifle Crate"
+	cost = 8000
+	contains = list(/obj/item/weapon/gun/energy/ionrifle)
+	crate_name = "ion rifle crate"
+	crate_type = /obj/structure/closet/crate/secure/plasma
 
 /datum/supply_pack/security/armory/fire
 	name = "Incendiary Weapons Crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -363,7 +363,7 @@
 	crate_type = /obj/structure/closet/crate/secure/plasma
 	
 /datum/supply_pack/security/armory/ionrifle
-	name = Ion Rifle Crate"
+	name = "Ion Rifle Crate"
 	cost = 8000
 	contains = list(/obj/item/weapon/gun/energy/ionrifle)
 	crate_name = "ion rifle crate"


### PR DESCRIPTION
A EXPENSIVE RIFLE


:cl: Hyena
rscadd:Adds ion rifle crate to cargo for 8000 points
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)apperantly people dont use the TONS of counters and want this i guess...
