### PR TITLE
Fixes the cyborg hugging module self targeting

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -66,6 +66,8 @@
 			user << "ERROR: ARM ACTUATORS OVERLOADED."
 
 /obj/item/borg/cyborghug/attack(mob/living/M, mob/living/silicon/robot/user)
+	if(M == user)
+		return
 	switch(mode)
 		if(0)
 			if(M.health >= 0)


### PR DESCRIPTION
Fixes #23388 

:cl: Cyberboss
tweak: The cyborg hugging module can no longer self target
/:cl:
