### PR TITLE
Transit shuttles will now give an audible warning when departing.

### DIFF
--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -64,7 +64,7 @@
 				return
 		switch(SSshuttle.moveShuttle(shuttleId, href_list["move"], 1))
 			if(0)
-				usr << "<span class='notice'>Shuttle received message and will be sent shortly.</span>"
+				say("Shuttle departing. Please stand away from the doors.")
 			if(1)
 				usr << "<span class='warning'>Invalid shuttle requested.</span>"
 			else


### PR DESCRIPTION
Why this is a worthwhile addition to the game: Because we get too many adminhelps and/or bad bans due to accidental spacing off the mining shuttle.

The warning is now essentially what the teleporter calibration message does. The next step after this is having the shuttle doors automatically close and bolt aka Bay. I don't think we want that.