### PR TITLE
Makes hulk unobtainable by genetics

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -114,9 +114,9 @@
 	return list()
 
 /datum/mutation/human/hulk
-
 	name = "Hulk"
 	quality = POSITIVE
+	dna_block = NON_SCANNABLE
 	get_chance = 15
 	lowest_value = 256 * 12
 	text_gain_indication = "<span class='notice'>Your muscles hurt!</span>"


### PR DESCRIPTION
:cl: XDTM
del: Hulk cannot be obtained by genetics anymore. It can still be spawned by admins.
/:cl:

## Why
Not because i've had my round ruined by a hulk as antag, but because when hulk spreads through the greytide there are no rules anymore and the station gets ruined to the point that a shuttle call is needed. This is seen is most rounds where enough people get hulk. I've seen an **extended** round thrown to chaos today by a hulk tide.  
And stopping them is, first of all, harder than normal, requiring either lethals or mutadone, and usually won't be done before significant damage and a shuttle call. Plus the whole "having to stop a nonantag before it destroys the station".