### PR TITLE
Fix walk/run not toggling properly.

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -423,7 +423,8 @@
 
 /client/verb/toggle_walk_run()
 	set name = "toggle-walk-run"
-	set hidden = 1
+	set hidden = TRUE
+	set instant = TRUE 
 	if(mob)
 		mob.toggle_move_intent()
 


### PR DESCRIPTION
Basically, if you press and release alt within 1 game tick, the latter is ignored because of byond's verb limits. this fixes that.