### PR TITLE
Adds an editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*]
+insert_final_newline = false
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
Prevents github putting newlines at the end of files in the web editor (something that makes expanding the context on the diff annoying to do.)

Sets the default tab size to be the same as DM.
