### PR TITLE
Fixes freon/ice causing lag

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -307,12 +307,17 @@ proc/addtimer(datum/callback/callback, wait, flags)
 
 		var/datum/timedevent/hash_timer = SStimer.hashes[hash]
 		if(hash_timer)
-			if (flags & TIMER_OVERRIDE)
-				qdel(hash_timer)
+			if (hash_timer.spent) //it's pending deletion, pretend it doesn't exist.
+				hash_timer.hash = null
+				SStimer.hashes -= hash
 			else
-				if (hash_timer.flags & TIMER_STOPPABLE)
-					. = hash_timer.id
-				return
+
+				if (flags & TIMER_OVERRIDE)
+					qdel(hash_timer)
+				else
+					if (hash_timer.flags & TIMER_STOPPABLE)
+						. = hash_timer.id
+					return
 
 
 	var/timeToRun = world.time + wait

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -258,4 +258,4 @@
 	if(!wet && wet_time)
 		wet_time = 0
 	if(wet)
-		addtimer(CALLBACK(src, .proc/HandleWet), 15)
+		addtimer(CALLBACK(src, .proc/HandleWet), 15, TIMER_UNIQUE)


### PR DESCRIPTION
Yes, these were stacking. so a turf would have a bunch of "handle wet" timers running on it, every 1.5 seconds, all checking the same shit.

I found this trying to fix timers crashing the server.