### PR TITLE
Mc refactor to fix timers crashing shit.

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -1,4 +1,4 @@
-#define MC_TICK_CHECK ( world.tick_usage > CURRENT_TICKLIMIT ? pause() : 0 )
+#define MC_TICK_CHECK ( ( world.tick_usage > CURRENT_TICKLIMIT || src.state != SS_RUNNING ) ? pause() : 0 )
 // Used to smooth out costs to try and avoid oscillation.
 #define MC_AVERAGE_FAST(average, current) (0.7 * (average) + 0.3 * (current))
 #define MC_AVERAGE(average, current) (0.8 * (average) + 0.2 * (current))
@@ -43,6 +43,15 @@
 //	(IE: if a 5ds wait SS takes 2ds to run, its next fire should be 5ds away, not 3ds like it normally would be)
 //	This flag overrides SS_KEEP_TIMING
 #define SS_POST_FIRE_TIMING 128
+
+//SUBSYSTEM STATES
+#define SS_IDLE 0		//aint doing shit.
+#define SS_QUEUED 1		//queued to run
+#define SS_RUNNING 2	//actively running
+#define SS_PAUSED 3		//paused by mc_tick_check
+#define SS_SLEEPING 4	//fire() slept.
+#define SS_PAUSING 5 	//in the middle of pausing
+
 
 //Timing subsystem
 //Don't run if there is an identical unique timer active

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -198,6 +198,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		SS.queued_time = 0
 		SS.queue_next = null
 		SS.queue_prev = null
+		SS.state = SS_IDLE
 		if (SS.flags & SS_TICKER)
 			tickersubsystems += SS
 			timer += world.tick_lag * rand(1, 5)
@@ -303,6 +304,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 // This is what decides if something should run.
 /datum/controller/master/proc/CheckQueue(list/subsystemstocheck)
 	. = 0 //so the mc knows if we runtimed
+
 	//we create our variables outside of the loops to save on overhead
 	var/datum/subsystem/SS
 	var/SS_flags
@@ -311,7 +313,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		if (!thing)
 			subsystemstocheck -= thing
 		SS = thing
-		if (SS.queued_time) //already in the queue
+		if (SS.state != SS_IDLE)
 			continue
 		if (SS.can_fire <= 0)
 			continue
@@ -322,10 +324,6 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 			subsystemstocheck -= SS
 		if (!(SS_flags & SS_TICKER) && (SS_flags & SS_KEEP_TIMING) && SS.last_fire + (SS.wait * 0.75) > world.time)
 			continue
-
-		//Queue it to run.
-		//	(we loop thru a linked list until we get to the end or find the right point)
-		//	(this lets us sort our run order correctly without having to re-sort the entire already sorted list)
 		SS.enqueue()
 	. = 1
 
@@ -356,9 +354,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		while (queue_node)
 			if (ran && world.tick_usage > TICK_LIMIT_RUNNING)
 				break
-			if (!istype(queue_node))
-				world.log << "[__FILE__]:[__LINE__] queue_node bad, now equals: [queue_node](\ref[queue_node])"
-				return
+
 			queue_node_flags = queue_node.flags
 			queue_node_priority = queue_node.queued_priority
 
@@ -373,9 +369,6 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 					queue_priority_count -= queue_node_priority
 					queue_priority_count += queue_node.queued_priority
 					current_tick_budget -= queue_node_priority
-					if (!istype(queue_node))
-						world.log << "[__FILE__]:[__LINE__] queue_node bad, now equals: [queue_node](\ref[queue_node])"
-						return
 					queue_node = queue_node.queue_next
 					continue
 
@@ -396,24 +389,25 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 				ran_non_ticker = TRUE
 			ran = TRUE
 			tick_usage = world.tick_usage
-			queue_node_paused = queue_node.paused
-			queue_node.paused = FALSE
+			queue_node_paused = (queue_node.state == SS_PAUSED || queue_node.state == SS_PAUSING)
 			last_type_processed = queue_node
 
-			queue_node.fire(queue_node_paused)
+			queue_node.state = SS_RUNNING
 
+			var/state = queue_node.ignite(queue_node_paused)
+			if (state == SS_RUNNING)
+				state = SS_IDLE
 			current_tick_budget -= queue_node_priority
 			tick_usage = world.tick_usage - tick_usage
 
 			if (tick_usage < 0)
 				tick_usage = 0
 
-			if (queue_node.paused)
+			queue_node.state = state
+
+			if (state == SS_PAUSED)
 				queue_node.paused_ticks++
 				queue_node.paused_tick_usage += tick_usage
-				if (!istype(queue_node))
-					world.log << "[__FILE__]:[__LINE__] queue_node bad, now equals: [queue_node](\ref[queue_node])"
-					return
 				queue_node = queue_node.queue_next
 				continue
 
@@ -447,9 +441,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 
 			//remove from queue
 			queue_node.dequeue()
-			if (!istype(queue_node))
-				world.log << "[__FILE__]:[__LINE__] queue_node bad, now equals: [queue_node](\ref[queue_node])"
-				return
+
 			queue_node = queue_node.queue_next
 
 	. = 1
@@ -482,7 +474,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		SS.queue_prev = null
 		SS.queued_priority = 0
 		SS.queued_time = 0
-		SS.paused = 0
+		SS.state = SS_IDLE
 	if (queue_head && !istype(queue_head))
 		world.log << "MC: SoftReset: Found bad data in subsystem queue, queue_head = '[queue_head]'"
 	queue_head = null

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -19,13 +19,13 @@
 	var/next_fire = 0		//scheduled world.time for next fire()
 	var/cost = 0			//average time to execute
 	var/tick_usage = 0		//average tick usage
-	var/paused = 0			//was this subsystem paused mid fire.
+	var/state = SS_IDLE		//tracks the current state of the ss, running, paused, etc.
 	var/paused_ticks = 0	//ticks this ss is taking to run right now.
 	var/paused_tick_usage	//total tick_usage of all of our runs while pausing this run
 	var/ticks = 1			//how many ticks does this ss take to run on avg.
 	var/times_fired = 0		//number of times we have called fire()
 	var/queued_time = 0		//time we entered the queue, (for timing and priority reasons)
-	var/queued_priority //we keep a running total to make the math easier, if it changes mid-fire that would break our running total, so we store it here
+	var/queued_priority 	//we keep a running total to make the math easier, if priority changes mid-fire that would break our running total, so we store it here
 	//linked list stuff for the queue
 	var/datum/subsystem/queue_next
 	var/datum/subsystem/queue_prev
@@ -41,13 +41,24 @@
 /datum/subsystem/proc/Shutdown()
 	return
 
+//This is used so the mc knows when the subsystem sleeps. do not override.
+/datum/subsystem/proc/ignite(resumed = 0)
+	set waitfor = 0
+	. = SS_SLEEPING
+	fire(resumed)
+	. = state
+	if (state == SS_SLEEPING)
+		state = SS_IDLE
+	if (state == SS_PAUSING)
+		var/QT = queued_time
+		enqueue()
+		state = SS_PAUSED
+		queued_time = QT
+
 //previously, this would have been named 'process()' but that name is used everywhere for different things!
 //fire() seems more suitable. This is the procedure that gets called every 'wait' deciseconds.
-//fire(), and the procs it calls, SHOULD NOT HAVE ANY SLEEP OPERATIONS in them!
-//YE BE WARNED!
+//Sleeping in here prevents future fires until returned.
 /datum/subsystem/proc/fire(resumed = 0)
-	set waitfor = 0 //this should not be depended upon, this is just to solve issues with sleeps messing up tick tracking
-	can_fire = 0
 	flags |= SS_NO_FIRE
 	throw EXCEPTION("Subsystem [src]([type]) does not fire() but did not set the SS_NO_FIRE flag. Please add the SS_NO_FIRE flag to any subsystem that doesn't fire so it doesn't get added to the processing list and waste cpu.")
 
@@ -57,6 +68,10 @@
 	flags |= SS_NO_FIRE
 	Master.subsystems -= src
 
+
+//Queue it to run.
+//	(we loop thru a linked list until we get to the end or find the right point)
+//	(this lets us sort our run order correctly without having to re-sort the entire already sorted list)
 /datum/subsystem/proc/enqueue()
 	var/SS_priority = priority
 	var/SS_flags = flags
@@ -90,6 +105,7 @@
 
 	queued_time = world.time
 	queued_priority = SS_priority
+	state = SS_QUEUED
 	if (SS_flags & SS_BACKGROUND) //update our running total
 		Master.queue_priority_count_bg += SS_priority
 	else
@@ -124,12 +140,17 @@
 	if (src == Master.queue_head)
 		Master.queue_head = queue_next
 	queued_time = 0
+	if (state == SS_QUEUED)
+		state = SS_IDLE
 
 
 /datum/subsystem/proc/pause()
 	. = 1
-	paused = TRUE
-	paused_ticks++
+	if (state == SS_RUNNING)
+		state = SS_PAUSED
+	else if (state == SS_SLEEPING)
+		state = SS_PAUSING
+
 
 //used to initialize the subsystem AFTER the map has loaded
 /datum/subsystem/proc/Initialize(start_timeofday)
@@ -143,12 +164,31 @@
 	if(!statclick)
 		statclick = new/obj/effect/statclick/debug("Initializing...", src)
 
+
+
 	if(can_fire)
 		msg = "[round(cost,1)]ms|[round(tick_usage,1)]%|[round(ticks,0.1)]\t[msg]"
 	else
 		msg = "OFFLINE\t[msg]"
 
-	stat(name, statclick.update(msg))
+	var/title = name
+	if (can_fire)
+		title = "\[[state_letter()]][title]"
+
+	stat(title, statclick.update(msg))
+
+/datum/subsystem/proc/state_letter()
+	switch (state)
+		if (SS_RUNNING)
+			. = "R"
+		if (SS_QUEUED)
+			. = "Q"
+		if (SS_PAUSED, SS_PAUSING)
+			. = "P"
+		if (SS_SLEEPING)
+			. = "S"
+		if (SS_IDLE)
+			. = "  "
 
 //could be used to postpone a costly subsystem for (default one) var/cycles, cycles
 //for instance, during cpu intensive operations like explosions
@@ -160,10 +200,10 @@
 //should attempt to salvage what it can from the old instance of subsystem
 /datum/subsystem/proc/Recover()
 
-//this is so the subsystem doesn't rapid fire to make up missed ticks causing more lag
 /datum/subsystem/vv_edit_var(var_name, var_value)
 	switch (var_name)
 		if ("can_fire")
+			//this is so the subsystem doesn't rapid fire to make up missed ticks causing more lag
 			if (var_value)
 				next_fire = world.time + wait
 		if ("queued_priority") //editing this breaks things.

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -73,7 +73,7 @@ var/datum/subsystem/air/SSair
 	if(currentpart == SSAIR_PIPENETS || !resumed)
 		process_pipenets(resumed)
 		cost_pipenets = MC_AVERAGE(cost_pipenets, TICK_DELTA_TO_MS(world.tick_usage - timer))
-		if(paused)
+		if(state != SS_RUNNING)
 			return
 		resumed = 0
 		currentpart = SSAIR_ATMOSMACHINERY
@@ -82,7 +82,7 @@ var/datum/subsystem/air/SSair
 		timer = world.tick_usage
 		process_atmos_machinery(resumed)
 		cost_atmos_machinery = MC_AVERAGE(cost_atmos_machinery, TICK_DELTA_TO_MS(world.tick_usage - timer))
-		if(paused)
+		if(state != SS_RUNNING)
 			return
 		resumed = 0
 		currentpart = SSAIR_ACTIVETURFS
@@ -91,7 +91,7 @@ var/datum/subsystem/air/SSair
 		timer = world.tick_usage
 		process_active_turfs(resumed)
 		cost_turfs = MC_AVERAGE(cost_turfs, TICK_DELTA_TO_MS(world.tick_usage - timer))
-		if(paused)
+		if(state != SS_RUNNING)
 			return
 		resumed = 0
 		currentpart = SSAIR_EXCITEDGROUPS
@@ -100,7 +100,7 @@ var/datum/subsystem/air/SSair
 		timer = world.tick_usage
 		process_excited_groups(resumed)
 		cost_groups = MC_AVERAGE(cost_groups, TICK_DELTA_TO_MS(world.tick_usage - timer))
-		if(paused)
+		if(state != SS_RUNNING)
 			return
 		resumed = 0
 		currentpart = SSAIR_HIGHPRESSURE
@@ -109,7 +109,7 @@ var/datum/subsystem/air/SSair
 		timer = world.tick_usage
 		process_high_pressure_delta(resumed)
 		cost_highpressure = MC_AVERAGE(cost_highpressure, TICK_DELTA_TO_MS(world.tick_usage - timer))
-		if(paused)
+		if(state != SS_RUNNING)
 			return
 		resumed = 0
 		currentpart = SSAIR_HOTSPOTS
@@ -118,7 +118,7 @@ var/datum/subsystem/air/SSair
 		timer = world.tick_usage
 		process_hotspots(resumed)
 		cost_hotspots = MC_AVERAGE(cost_hotspots, TICK_DELTA_TO_MS(world.tick_usage - timer))
-		if(paused)
+		if(state != SS_RUNNING)
 			return
 		resumed = 0
 		currentpart = SSAIR_SUPERCONDUCTIVITY
@@ -127,7 +127,7 @@ var/datum/subsystem/air/SSair
 		timer = world.tick_usage
 		process_super_conductivity(resumed)
 		cost_superconductivity = MC_AVERAGE(cost_superconductivity, TICK_DELTA_TO_MS(world.tick_usage - timer))
-		if(paused)
+		if(state != SS_RUNNING)
 			return
 		resumed = 0
 	currentpart = SSAIR_PIPENETS

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -54,7 +54,7 @@ var/datum/subsystem/garbage_collector/SSgarbage
 
 /datum/subsystem/garbage_collector/fire()
 	HandleToBeQueued()
-	if (!paused)
+	if(state == SS_RUNNING)
 		HandleQueue()
 
 //If you see this proc high on the profile, what you are really seeing is the garbage collection/soft delete overhead in byond.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -291,7 +291,7 @@
 		SpinAnimation(5, 1)
 
 	SSthrowing.processing[src] = TT
-	if (SSthrowing.paused && length(SSthrowing.currentrun))
+	if (SSthrowing.state == SS_PAUSED && length(SSthrowing.currentrun))
 		SSthrowing.currentrun[src] = TT
 	TT.tick()
 


### PR DESCRIPTION
Fixes the mc treating subsystems that slept in fire() improperly 

Originally I wanted to just say that such a thing is unsupported, but since byond can just randomly decide to insert a bunch of sleeps into a loop, I can't make that requirement on subsystems, so it's now supported.

This was part of what was causing timers to shit the bed.

Also fixes timers being fucky with how they deleted, removed some hacks i put in place earlier.

@pjb3005 this should look familiar.