### PR TITLE
Makes hulk unable to destroy walls and airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -698,6 +698,9 @@ var/list/airlock_overlays = list()
 /obj/machinery/door/airlock/attack_paw(mob/user)
 	return src.attack_hand(user)
 
+/obj/machinery/door/airlock/hulk_damage()
+	return 15
+
 /obj/machinery/door/airlock/attack_hand(mob/user)
 	if(!(issilicon(user) || IsAdminGhost(user)))
 		if(src.isElectrified())

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -107,15 +107,7 @@
 		return
 
 /turf/closed/wall/attack_hulk(mob/user, does_attack_animation = 0)
-	..(user, 1)
-	if(prob(hardness))
-		playsound(src, 'sound/effects/meteorimpact.ogg', 100, 1)
-		user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
-		dismantle_wall(1)
-	else
-		playsound(src, 'sound/effects/bang.ogg', 50, 1)
-		user << text("<span class='notice'>You punch the wall.</span>")
-	return 1
+	return
 
 /turf/closed/wall/attack_hand(mob/user)
 	user.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
:cl: XDTM
del: Hulks are no longer able to destroy walls and doors.
/:cl:

A less drastic alternative to #23468, but it will also affect hulk mutations given through alternative means, like the wish granter or devil.

## Why

Not because i've had my round ruined by a hulk as antag, but because when hulk spreads through the greytide there are no rules anymore and the station gets ruined to the point that a shuttle call is needed. This is seen is most rounds where enough people get hulk. I've seen an extended round thrown to chaos today by a hulk tide.
And stopping them is, first of all, harder than normal, requiring either lethals or mutadone, and usually won't be done before significant damage and a shuttle call. Plus the whole "having to stop a nonantag before it destroys the station".
