### PR TITLE
Removes minimum round time from abductor event

### DIFF
--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -5,7 +5,6 @@
 	max_occurrences = 1
 
 	min_players = 5
-	earliest_start = 18000 // 30 min
 
 	gamemode_blacklist = list("nuclear","wizard","revolution","abduction")
 


### PR DESCRIPTION
:cl: coiax
add: The Abductor event can now happen at any time, rather than thirty
(30) minute plus rounds.
/:cl:

- We have the xeno event that can fire at any time, and that's way more
round affecting than ayys. Ayys are fun, and we don't get to see them
except with admin memes.