### PR TITLE
Prevents effects from feeding the singulo

### DIFF
--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -42,3 +42,7 @@
 
 /obj/effect/experience_pressure_difference()
 	return
+
+/obj/effect/singularity_act()
+	qdel(src)
+	return 0


### PR DESCRIPTION
Fixes #23496 

:cl: Cyberboss
fix: Abstract entities no longer feed the singularity
/:cl:
