### PR TITLE
Removes most roundstart belts with a exception on medical, engineering and Hos

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -26,7 +26,6 @@
 	new /obj/item/weapon/storage/box/beanbag(src)
 	new /obj/item/clothing/suit/armor/vest/alt(src)
 	new /obj/item/clothing/glasses/sunglasses/reagent(src)
-	new /obj/item/weapon/storage/belt/bandolier(src)
 
 /obj/structure/closet/chefcloset
 	name = "\proper chef's closet"

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -73,7 +73,6 @@
 	new /obj/item/weapon/storage/bag/trash(src)
 	new /obj/item/clothing/shoes/galoshes(src)
 	new /obj/item/weapon/watertank/janitor(src)
-	new /obj/item/weapon/storage/belt/janitor(src)
 
 
 /obj/structure/closet/lawcloset

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -101,7 +101,7 @@
 	new /obj/item/clothing/mask/gas/sechailer(src)
 	new /obj/item/weapon/storage/box/zipties(src)
 	new /obj/item/weapon/storage/box/flashbangs(src)
-	new /obj/item/weapon/storage/belt/security/full(src)
+	new /obj/item/weapon/melee/baton/loaded(src)
 	new /obj/item/device/flashlight/seclite(src)
 	new /obj/item/clothing/gloves/krav_maga/sec(src)
 	new /obj/item/weapon/door_remote/head_of_security(src)
@@ -125,7 +125,7 @@
 
 /obj/structure/closet/secure_closet/security/sec/New()
 	..()
-	new /obj/item/weapon/storage/belt/security/full(src)
+	new /obj/item/weapon/melee/baton/loaded(src)
 
 /obj/structure/closet/secure_closet/security/cargo
 

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -135,7 +135,7 @@
 	name = "Utility Belt"
 	id = "toolbelt"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 500)
+	materials = list(MAT_BIOMASS = 300)
 	build_path = /obj/item/weapon/storage/belt/utility
 	category = list("initial","Leather and Cloth")
 
@@ -143,7 +143,7 @@
 	name = "Security belt"
 	id = "secbelt"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 500)
+	materials = list(MAT_BIOMASS = 300)
 	build_path = /obj/item/weapon/storage/belt/security
 	category = list("initial","Leather and Cloth")
 
@@ -151,7 +151,7 @@
 	name = "Medical belt"
 	id = "medbel"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 500)
+	materials = list(MAT_BIOMASS = 300)
 	build_path = /obj/item/weapon/storage/belt/medical
 	category = list("initial","Leather and Cloth")
 
@@ -159,7 +159,7 @@
 	name = "Janitorial belt"
 	id = "janibelt"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 500)
+	materials = list(MAT_BIOMASS = 300)
 	build_path = /obj/item/weapon/storage/belt/janitor
 	category = list("initial","Leather and Cloth")
 
@@ -167,7 +167,7 @@
 	name = "Bandolier belt"
 	id = "bandolier"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 500)
+	materials = list(MAT_BIOMASS = 300)
 	build_path = /obj/item/weapon/storage/belt/bandolier
 	category = list("initial","Leather and Cloth")
 

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -135,7 +135,7 @@
 	name = "Utility Belt"
 	id = "toolbelt"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 300)
+	materials = list(MAT_BIOMASS = 500)
 	build_path = /obj/item/weapon/storage/belt/utility
 	category = list("initial","Leather and Cloth")
 
@@ -143,7 +143,7 @@
 	name = "Security belt"
 	id = "secbelt"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 300)
+	materials = list(MAT_BIOMASS = 500)
 	build_path = /obj/item/weapon/storage/belt/security
 	category = list("initial","Leather and Cloth")
 
@@ -151,7 +151,7 @@
 	name = "Medical belt"
 	id = "medbel"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 300)
+	materials = list(MAT_BIOMASS = 500)
 	build_path = /obj/item/weapon/storage/belt/medical
 	category = list("initial","Leather and Cloth")
 
@@ -159,7 +159,7 @@
 	name = "Janitorial belt"
 	id = "janibelt"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 300)
+	materials = list(MAT_BIOMASS = 500)
 	build_path = /obj/item/weapon/storage/belt/janitor
 	category = list("initial","Leather and Cloth")
 
@@ -167,7 +167,7 @@
 	name = "Bandolier belt"
 	id = "bandolier"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 300)
+	materials = list(MAT_BIOMASS = 500)
 	build_path = /obj/item/weapon/storage/belt/bandolier
 	category = list("initial","Leather and Cloth")
 


### PR DESCRIPTION
This is mostly a test because kor said we dont really need belts with the new storage system altough this pr doesnt remove belts entirely you can get them from the biogenerator requiring you to do departmental cooperation or just do it yourself at the public garden 

engineering of course keep their belts for quick access to tools same with medical
and hos keeps his belt for better management


:cl: hyena
tweak: Removes some roundstart belts
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)Because i think this atleast worth a try to lower the storagecreep 
