### PR TITLE
Improves the sql death report

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,3 +1,13 @@
+30 January 2017, by Lzimann
+
+Modified table 'death', adding the columns 'mapname' and 'server'.
+
+ALTER TABLE `death` ADD COLUMN `mapname` TEXT NOT NULL AFTER `coord`, ADD COLUMN `server` TEXT NOT NULL AFTER `mapname`
+
+Remember to add a prefix to the table name if you use them
+
+----------------------------------------------------
+
 1 September 2016, by Jordie0608
 
 Modified table 'notes', adding column 'secret'.

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -135,6 +135,8 @@ CREATE TABLE `death` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pod` text NOT NULL COMMENT 'Place of death',
   `coord` text NOT NULL COMMENT 'X, Y, Z POD',
+  `mapname` text NOT NULL,
+  `server` text NOT NULL,
   `tod` datetime NOT NULL COMMENT 'Time of death',
   `job` text NOT NULL,
   `special` text NOT NULL,
@@ -147,6 +149,7 @@ CREATE TABLE `death` (
   `brainloss` int(11) NOT NULL,
   `fireloss` int(11) NOT NULL,
   `oxyloss` int(11) NOT NULL,
+  
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -135,6 +135,8 @@ CREATE TABLE `SS13_death` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pod` text NOT NULL COMMENT 'Place of death',
   `coord` text NOT NULL COMMENT 'X, Y, Z POD',
+  `mapname` text NOT NULL,
+  `server` text NOT NULL,
   `tod` datetime NOT NULL COMMENT 'Time of death',
   `job` text NOT NULL,
   `special` text NOT NULL,

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -30,4 +30,4 @@
 
 	update_icons()
 
-	sql_report_cyborg_death(src)
+	sql_report_death(src)

--- a/code/orphaned_procs/statistics.dm
+++ b/code/orphaned_procs/statistics.dm
@@ -40,77 +40,40 @@
 	if(!config.sql_enabled)
 		return
 
-/proc/sql_report_death(mob/living/carbon/human/H)
+/proc/sql_report_death(mob/living/L)
 	if(!config.sql_enabled)
 		return
-	if(!H)
+	if(!L)
 		return
-	if(!H.key || !H.mind)
+	if(!L.key || !L.mind)
 		return
 
-	var/turf/T = H.loc
+	var/turf/T = get_turf(L)
 	var/area/placeofdeath = get_area(T.loc)
 	var/podname = placeofdeath.name
 
-	var/sqlname = sanitizeSQL(H.real_name)
-	var/sqlkey = sanitizeSQL(H.key)
+	var/sqlname = sanitizeSQL(L.real_name)
+	var/sqlkey = sanitizeSQL(L.key)
 	var/sqlpod = sanitizeSQL(podname)
-	var/sqlspecial = sanitizeSQL(H.mind.special_role)
-	var/sqljob = sanitizeSQL(H.mind.assigned_role)
+	var/sqlspecial = sanitizeSQL(L.mind.special_role)
+	var/sqljob = sanitizeSQL(L.mind.assigned_role)
 	var/laname
 	var/lakey
-	if(H.lastattacker)
-		laname = sanitizeSQL(H.lastattacker:real_name)
-		lakey = sanitizeSQL(H.lastattacker:key)
+	if(L.lastattacker)
+		laname = sanitizeSQL(L.lastattacker:real_name)
+		lakey = sanitizeSQL(L.lastattacker:key)
 	var/sqltime = time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")
-	var/coord = "[H.x], [H.y], [H.z]"
-	//world << "INSERT INTO death (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss) VALUES ('[sqlname]', '[sqlkey]', '[sqljob]', '[sqlspecial]', '[sqlpod]', '[sqltime]', '[laname]', '[lakey]', '[H.gender]', [H.bruteloss], [H.getFireLoss()], [H.brainloss], [H.getOxyLoss()])"
+	var/coord = "[L.x], [L.y], [L.z]"
+	var/map = MAP_NAME
+	var/server = "[world.address]:[world.port]"
 	establish_db_connection()
 	if(!dbcon.IsConnected())
 		log_game("SQL ERROR during death reporting. Failed to connect.")
 	else
-		var/DBQuery/query = dbcon.NewQuery("INSERT INTO [format_table_name("death")] (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord) VALUES ('[sqlname]', '[sqlkey]', '[sqljob]', '[sqlspecial]', '[sqlpod]', '[sqltime]', '[laname]', '[lakey]', '[H.gender]', [H.getBruteLoss()], [H.getFireLoss()], [H.brainloss], [H.getOxyLoss()], '[coord]')")
+		var/DBQuery/query = dbcon.NewQuery("INSERT INTO [format_table_name("death")] (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord, mapname, server) VALUES ('[sqlname]', '[sqlkey]', '[sqljob]', '[sqlspecial]', '[sqlpod]', '[sqltime]', '[laname]', '[lakey]', '[L.gender]', [L.getBruteLoss()], [L.getFireLoss()], [L.brainloss], [L.getOxyLoss()], '[coord]', '[map]', [server]')")
 		if(!query.Execute())
 			var/err = query.ErrorMsg()
 			log_game("SQL ERROR during death reporting. Error : \[[err]\]\n")
-
-
-/proc/sql_report_cyborg_death(mob/living/silicon/robot/H)
-	if(!config.sql_enabled)
-		return
-	if(!H)
-		return
-	if(!H.key || !H.mind)
-		return
-
-	var/turf/T = H.loc
-	var/area/placeofdeath = get_area(T.loc)
-	var/podname = placeofdeath.name
-
-	var/sqlname = sanitizeSQL(H.real_name)
-	var/sqlkey = sanitizeSQL(H.key)
-	var/sqlpod = sanitizeSQL(podname)
-	var/sqlspecial = sanitizeSQL(H.mind.special_role)
-	var/sqljob = sanitizeSQL(H.mind.assigned_role)
-	var/laname
-	var/lakey
-	if(H.lastattacker)
-		laname = sanitizeSQL(H.lastattacker:real_name)
-		lakey = sanitizeSQL(H.lastattacker:key)
-	var/sqltime = time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")
-	var/coord = "[H.x], [H.y], [H.z]"
-	//world << "INSERT INTO death (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss) VALUES ('[sqlname]', '[sqlkey]', '[sqljob]', '[sqlspecial]', '[sqlpod]', '[sqltime]', '[laname]', '[lakey]', '[H.gender]', [H.bruteloss], [H.getFireLoss()], [H.brainloss], [H.getOxyLoss()])"
-	establish_db_connection()
-	if(!dbcon.IsConnected())
-		log_game("SQL ERROR during death reporting. Failed to connect.")
-	else
-		var/DBQuery/query = dbcon.NewQuery("INSERT INTO [format_table_name("death")] (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord) VALUES ('[sqlname]', '[sqlkey]', '[sqljob]', '[sqlspecial]', '[sqlpod]', '[sqltime]', '[laname]', '[lakey]', '[H.gender]', [H.getBruteLoss()], [H.getFireLoss()], [H.brainloss], [H.getOxyLoss()], '[coord]')")
-		if(!query.Execute())
-			var/err = query.ErrorMsg()
-			log_game("SQL ERROR during death reporting. Error : \[[err]\]\n")
-
-
-
 
 //This proc is used for feedback. It is executed at round end.
 /proc/sql_commit_feedback()


### PR DESCRIPTION
As requested before, now the death report will also include the map name and server's address and port. 
I also removed the `sql_report_cyborg_death`, it was a copypasta of the proc above for some reason.

Closes #23413
