### PR TITLE
Make progress bars stack vertically

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -14,7 +14,8 @@
 		EXCEPTION("Invalid target given")
 	if (goal_number)
 		goal = goal_number
-	bar = image('icons/effects/progessbar.dmi', target, "prog_bar_0")
+	bar = image('icons/effects/progessbar.dmi', target, "prog_bar_0", HUD_LAYER)
+	bar.plane = HUD_PLANE
 	bar.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 	user = User
 	if(user)

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -1,9 +1,12 @@
+#define PROGRESSBAR_HEIGHT 6
+
 /datum/progressbar
 	var/goal = 1
 	var/image/bar
 	var/shown = 0
 	var/mob/user
 	var/client/client
+	var/listindex
 
 /datum/progressbar/New(mob/User, goal_number, atom/target)
 	. = ..()
@@ -13,10 +16,16 @@
 		goal = goal_number
 	bar = image('icons/effects/progessbar.dmi', target, "prog_bar_0")
 	bar.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	bar.pixel_y = 32
 	user = User
 	if(user)
 		client = user.client
+
+	LAZYINITLIST(user.progressbars)
+	LAZYINITLIST(user.progressbars[bar.loc])
+	var/list/bars = user.progressbars[bar.loc]
+	bars.Add(src)
+	listindex = bars.len
+	bar.pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1))
 
 /datum/progressbar/proc/update(progress)
 	//world << "Update [progress] - [goal] - [(progress / goal)] - [((progress / goal) * 100)] - [round(((progress / goal) * 100), 5)]"
@@ -35,8 +44,24 @@
 		user.client.images += bar
 		shown = 1
 
+/datum/progressbar/proc/shiftDown()
+	--listindex
+	bar.pixel_y -= PROGRESSBAR_HEIGHT
+
 /datum/progressbar/Destroy()
+	for(var/I in user.progressbars[bar.loc])
+		var/datum/progressbar/P = I
+		if(P != src && P.listindex > listindex)
+			P.shiftDown()
+
+	var/list/bars = user.progressbars[bar.loc]
+	bars.Remove(src)
+	if(!bars.len)
+		LAZYREMOVE(user.progressbars, bar.loc)
+
 	if (client)
 		client.images -= bar
 	qdel(bar)
 	. = ..()
+
+#undef PROGRESSBAR_HEIGHT

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -146,3 +146,5 @@
 	var/resize = 1 //Badminnery resize
 
 	var/list/observers = null	//The list of people observing this mob.
+
+	var/list/progressbars = null	//for stacking do_after bars


### PR DESCRIPTION
Fixes #10128

:cl: Cyberboss
fix: Progress bars will now stack vertically instead of on top of each other
fix: Progress bars will no longer be affected by lighting
/:cl:
![untitled](https://cloud.githubusercontent.com/assets/8171642/22446195/5d1cb77c-e719-11e6-9071-f11e3d2a23c3.png)
