### PR TITLE
Clockwork Marauders have less health

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_mobs/clockwork_marauder.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs/clockwork_marauder.dm
@@ -3,8 +3,8 @@
 	name = "clockwork marauder"
 	desc = "A stalwart apparition of a soldier, blazing with crimson flames. It's armed with a gladius and shield."
 	icon_state = "clockwork_marauder"
-	health = 400
-	maxHealth = 400
+	health = 300
+	maxHealth = 300
 	speed = 1
 	obj_damage = 40
 	melee_damage_lower = 12
@@ -262,8 +262,8 @@
 
 /mob/living/simple_animal/hostile/clockwork/marauder/proc/blockOrCounter(mob/target, atom/textobject)
 	if(ratvar_awakens) //if ratvar has woken, we block nearly everything at a very high chance
-		blockchance = 80
-		counterchance = 80
+		blockchance = 90
+		counterchance = 90
 	if(prob(blockchance))
 		. = TRUE
 		if(target)
@@ -285,8 +285,8 @@
 	else
 		blockchance = min(blockchance + initial(blockchance), 100)
 	if(ratvar_awakens)
-		blockchance = 80
-		counterchance = 80
+		blockchance = 90
+		counterchance = 90
 
 //COMMUNICATION and EMERGENCE
 


### PR DESCRIPTION
:cl: Joan
tweak: Clockwork Marauders have 25% less health, 300 health from 400.
/:cl:

their blockchance when ratvar is up is even higher though because I think that's hilarious to watch