### PR TITLE
[Omega] Adds Mass Driver To Chapel

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -745,11 +745,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/bridge)
 "abl" = (
@@ -760,11 +760,11 @@
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/bridge)
 "abm" = (
@@ -802,11 +802,11 @@
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/bridge)
 "abr" = (
@@ -829,11 +829,11 @@
 	pixel_y = 0;
 	tag = "icon-doors"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/bridge)
 "abs" = (
@@ -1038,8 +1038,8 @@
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -1047,8 +1047,8 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -1066,8 +1066,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -1132,8 +1132,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -1448,8 +1448,8 @@
 	icon_state = "intact";
 	dir = 6
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -1458,8 +1458,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -1472,10 +1472,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -1491,8 +1491,8 @@
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -1502,41 +1502,41 @@
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
 "acz" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn (NORTHWEST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn (NORTHWEST)"
+	},
 /area/shuttle/supply)
 "acA" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "acB" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "acC" = (
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn (NORTHEAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn (NORTHEAST)"
 	},
 /area/shuttle/supply)
 "acD" = (
@@ -1561,10 +1561,10 @@
 "acG" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered{
 	name = "Asteroid"
 	})
@@ -1644,8 +1644,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -1772,10 +1772,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/bridge)
 "acX" = (
 /obj/structure/cable/white{
@@ -1876,10 +1876,10 @@
 	req_access = null;
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/bridge)
 "ade" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2041,26 +2041,26 @@
 /area/quartermaster/storage)
 "adr" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "ads" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "adt" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "adu" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "adv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2384,11 +2384,11 @@
 	req_access_txt = "57"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/heads)
 "adW" = (
@@ -2420,12 +2420,12 @@
 /obj/machinery/camera{
 	c_tag = "Cargo Bay North"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "aea" = (
@@ -2437,12 +2437,12 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "aeb" = (
@@ -2451,12 +2451,12 @@
 	id = "cargounload"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "aec" = (
@@ -2470,12 +2470,12 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "aed" = (
@@ -2483,12 +2483,12 @@
 	dir = 8;
 	id = "cargounload"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "aee" = (
@@ -2505,12 +2505,12 @@
 	pixel_y = 32;
 	tag = "icon-doors"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "aef" = (
@@ -2523,12 +2523,12 @@
 	name = "supply dock unloading door"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "aeg" = (
@@ -2537,12 +2537,12 @@
 	id = "cargounload"
 	},
 /obj/structure/plasticflaps,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "aeh" = (
@@ -2558,12 +2558,12 @@
 	id = "cargounload";
 	name = "supply dock unloading door"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "aei" = (
@@ -2579,14 +2579,14 @@
 /area/shuttle/supply)
 "aej" = (
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "aek" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "ael" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2617,10 +2617,10 @@
 /obj/item/weapon/extinguisher/mini,
 /obj/item/weapon/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/breath,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered{
 	name = "Asteroid"
 	})
@@ -2648,11 +2648,11 @@
 	req_access_txt = "4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/security/detectives_office)
 "aes" = (
@@ -2664,10 +2664,10 @@
 "aet" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -2697,11 +2697,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
@@ -3018,18 +3018,18 @@
 "aeR" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aeS" = (
 /obj/structure/closet/crate,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aeT" = (
 /obj/structure/closet/crate,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aeU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3041,8 +3041,8 @@
 /area/quartermaster/storage)
 "aeV" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aeW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3050,20 +3050,20 @@
 	name = "Supply Dock Airlock";
 	req_access_txt = "31"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aeX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/quartermaster/storage)
 "aeY" = (
@@ -3076,10 +3076,10 @@
 	name = "Supply Dock Airlock";
 	req_access_txt = "31"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aeZ" = (
 /obj/machinery/door/airlock/shuttle{
@@ -3090,20 +3090,20 @@
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "afa" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "afb" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/ruin/unpowered{
 	name = "Asteroid"
@@ -3180,16 +3180,16 @@
 	name = "Detective's Office Maintenance";
 	req_access_txt = "4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "afj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -3198,8 +3198,8 @@
 	pixel_x = -26
 	},
 /obj/machinery/suit_storage_unit/captain,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plasteel,
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
 	})
@@ -3391,10 +3391,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads)
 "afw" = (
 /obj/structure/cable/white{
@@ -3549,8 +3549,8 @@
 	pixel_y = -8
 	},
 /obj/machinery/computer/cargo,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "afJ" = (
 /obj/structure/cable/white{
@@ -3577,10 +3577,10 @@
 	pixel_x = -24;
 	pixel_y = -8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "afL" = (
 /obj/structure/girder/reinforced,
@@ -3675,8 +3675,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -3691,10 +3691,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
 	})
@@ -3703,8 +3703,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
 	})
@@ -4051,21 +4051,21 @@
 	name = "Supply Dock Airlock";
 	req_access_txt = "31"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "agC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/quartermaster/storage)
 "agD" = (
@@ -4103,10 +4103,10 @@
 	name = "Asteroid"
 	})
 "agH" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered{
 	name = "Asteroid"
 	})
@@ -4202,8 +4202,8 @@
 	tag = "icon-0-4";
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
 	})
@@ -4321,10 +4321,10 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
 	})
@@ -4508,8 +4508,8 @@
 	id = "hopblast";
 	name = "HoP Blast door"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads)
 "ahj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4529,12 +4529,12 @@
 	pixel_y = -24
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ahl" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ahm" = (
 /obj/machinery/light,
@@ -4554,12 +4554,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_end (WEST)";
 	icon_state = "plating_warn_end"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
 	},
 /area/quartermaster/storage)
 "aho" = (
@@ -4569,12 +4569,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "ahp" = (
@@ -4583,12 +4583,12 @@
 	id = "cargoload"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "ahq" = (
@@ -4601,12 +4601,12 @@
 	id = "cargoload";
 	name = "supply dock loading door"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "ahr" = (
@@ -4616,12 +4616,12 @@
 	},
 /obj/structure/plasticflaps,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "ahs" = (
@@ -4638,12 +4638,12 @@
 	id = "cargoload";
 	name = "supply dock loading door"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /area/quartermaster/storage)
 "aht" = (
@@ -4676,10 +4676,10 @@
 	layer = 2.4;
 	on = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "ahw" = (
 /obj/structure/reagent_dispensers/peppertank{
@@ -4688,8 +4688,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "ahx" = (
 /obj/machinery/ai_status_display{
@@ -4701,8 +4701,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "ahy" = (
 /obj/machinery/suit_storage_unit/security,
@@ -4715,18 +4715,18 @@
 	on = 1;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "ahz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered{
 	name = "Asteroid"
 	})
@@ -4737,10 +4737,10 @@
 /obj/item/clothing/head/hardhat/red,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered{
 	name = "Asteroid"
 	})
@@ -4826,8 +4826,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -4836,11 +4836,11 @@
 	pixel_x = -32
 	},
 /obj/structure/closet/secure_closet/captains,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_end (NORTH)"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_end (NORTH)"
 	},
 /area/crew_quarters/captain{
 	name = "\improper Captain's Quarters"
@@ -5012,8 +5012,8 @@
 	name = "Primary Hallway"
 	})
 "ahZ" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -5021,14 +5021,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
 "aib" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -5053,11 +5053,11 @@
 	req_one_access_txt = "48;50"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/quartermaster/storage)
 "aie" = (
@@ -5068,10 +5068,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/plasticflaps,
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plating,
 /area/quartermaster/storage)
 "aif" = (
 /obj/structure/grille,
@@ -5081,25 +5081,25 @@
 /area/quartermaster/storage)
 "aig" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "aih" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "aii" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "aij" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "aik" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5150,10 +5150,10 @@
 	c_tag = "Armoury - Internal";
 	network = list("Labor")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aio" = (
 /obj/structure/rack,
@@ -5212,11 +5212,11 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/security/brig)
 "ais" = (
@@ -5234,11 +5234,11 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/security/brig)
 "ait" = (
@@ -5273,11 +5273,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/security/detectives_office)
 "aiw" = (
@@ -5302,11 +5302,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -5323,11 +5323,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/bridge)
 "aiz" = (
@@ -5381,11 +5381,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/bridge)
 "aiD" = (
@@ -5433,11 +5433,11 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -5494,8 +5494,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating,
 /area/quartermaster/storage)
 "aiN" = (
 /obj/structure/table/reinforced,
@@ -5525,12 +5525,12 @@
 /area/quartermaster/storage)
 "aiP" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "aiQ" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/shuttle/supply)
 "aiR" = (
 /obj/structure/rack,
@@ -5552,10 +5552,10 @@
 /area/security/brig)
 "aiS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aiT" = (
 /obj/structure/rack,
@@ -5836,10 +5836,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -5902,10 +5902,10 @@
 	c_tag = "Central Hallway North";
 	dir = 2
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -5917,10 +5917,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -5929,10 +5929,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6016,10 +6016,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6109,12 +6109,12 @@
 	opacity = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ajI" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ajJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6132,8 +6132,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ajL" = (
 /obj/structure/chair/office/dark{
@@ -6170,8 +6170,8 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/shuttle/supply)
 "ajO" = (
 /obj/structure/window/reinforced{
@@ -6179,8 +6179,8 @@
 	},
 /obj/structure/shuttle/engine/heater,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/shuttle/supply)
 "ajP" = (
 /obj/structure/barricade/wooden,
@@ -6221,10 +6221,10 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "ajT" = (
 /obj/structure/rack,
@@ -6531,8 +6531,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6545,8 +6545,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6562,8 +6562,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6581,8 +6581,8 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6598,10 +6598,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6614,10 +6614,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6852,8 +6852,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6875,8 +6875,8 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6896,8 +6896,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6914,8 +6914,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6931,10 +6931,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -6979,8 +6979,8 @@
 	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -7027,20 +7027,20 @@
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "burst_l"
 	},
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/shuttle/supply)
 "akR" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/shuttle/supply)
 "akS" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "burst_r"
 	},
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/shuttle/supply)
 "akT" = (
 /obj/structure/sign/electricshock{
@@ -7073,11 +7073,11 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/security/brig)
 "akV" = (
@@ -7182,11 +7182,11 @@
 	name = "Primary Restroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -7216,11 +7216,11 @@
 	name = "Teleporter Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/teleporter{
 	name = "\improper Teleporter Room"
@@ -7236,11 +7236,11 @@
 	name = "Teleport Access";
 	req_access_txt = "17"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/teleporter{
 	name = "\improper Teleporter Room"
@@ -7404,11 +7404,11 @@
 	req_access = null;
 	req_access_txt = "18"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
@@ -7420,11 +7420,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
@@ -7481,8 +7481,8 @@
 /area/quartermaster/storage)
 "alB" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "alC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7605,10 +7605,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "alL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7731,8 +7731,8 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -7740,8 +7740,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -7754,8 +7754,8 @@
 	on = 1;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -7788,8 +7788,8 @@
 	pixel_y = 0;
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -7800,18 +7800,18 @@
 	on = 1;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
 "ama" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -7825,10 +7825,10 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -7841,8 +7841,8 @@
 /obj/machinery/camera{
 	c_tag = "Teleporter"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -7878,8 +7878,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -7903,8 +7903,8 @@
 	})
 "ami" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -7929,8 +7929,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -7990,27 +7990,27 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
 "amq" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
 "amr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
@@ -8202,8 +8202,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "amJ" = (
 /obj/machinery/computer/secure_data,
@@ -8282,8 +8282,8 @@
 	icon_state = "sink";
 	pixel_x = -12
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -8353,10 +8353,10 @@
 	})
 "amU" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -8366,8 +8366,8 @@
 /obj/item/device/radio,
 /obj/item/device/radio,
 /obj/item/device/gps,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -8377,11 +8377,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-warning (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-warning (EAST)"
 	},
 /area/teleporter{
 	name = "\improper Teleporter Room"
@@ -8409,8 +8409,8 @@
 	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -8447,8 +8447,8 @@
 	tag = "icon-1-4";
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -8460,11 +8460,11 @@
 	})
 "anf" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_end (WEST)"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_end (WEST)"
 	},
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
@@ -8479,10 +8479,10 @@
 	dir = 1;
 	on = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
@@ -8493,18 +8493,18 @@
 /obj/item/device/radio,
 /obj/item/device/flashlight/flare,
 /obj/item/device/flashlight/flare,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
 "ani" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-warning (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-warning (EAST)"
 	},
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
@@ -8519,11 +8519,11 @@
 	pixel_y = 0;
 	tag = "icon-fire0 (EAST)"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_end (EAST)"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_end (EAST)"
 	},
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
@@ -8531,11 +8531,11 @@
 "ank" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -8547,11 +8547,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -8566,8 +8566,8 @@
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ann" = (
 /obj/structure/grille,
@@ -8586,11 +8586,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/quartermaster/storage)
 "anp" = (
@@ -8605,17 +8605,17 @@
 	pixel_y = 26
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "anr" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "ans" = (
 /obj/machinery/power/apc{
@@ -8633,10 +8633,10 @@
 	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "ant" = (
 /obj/structure/grille,
@@ -8647,20 +8647,20 @@
 "anu" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/emergency,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn (NORTHWEST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn (NORTHWEST)"
 	},
 /area/shuttle/mining)
 "anv" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/mining)
 "anw" = (
 /obj/structure/table/reinforced,
@@ -8669,10 +8669,10 @@
 /obj/item/weapon/wrench,
 /obj/item/weapon/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/mining)
 "anx" = (
 /obj/structure/grille,
@@ -8814,11 +8814,11 @@
 "anH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -8830,11 +8830,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -8843,11 +8843,11 @@
 /obj/machinery/door/airlock{
 	name = "Toilet Unit"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -8857,11 +8857,11 @@
 	name = "Toilet Unit"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -8888,17 +8888,17 @@
 	name = "\improper Teleporter Room"
 	})
 "anM" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
 "anN" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -8909,10 +8909,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -8947,11 +8947,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -8961,11 +8961,11 @@
 /obj/machinery/door/airlock/glass{
 	name = "Atrium"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -8976,11 +8976,11 @@
 /obj/machinery/door/airlock/glass{
 	name = "Atrium"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -9019,17 +9019,17 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
 "anW" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
@@ -9048,10 +9048,10 @@
 	dir = 8;
 	name = "command camera"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
@@ -9095,10 +9095,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -9185,10 +9185,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aoi" = (
 /obj/machinery/light_switch{
@@ -9238,8 +9238,8 @@
 "aol" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ore_box,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aom" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9251,14 +9251,14 @@
 	c_tag = "Mining Dock External";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aon" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/mining)
 "aoo" = (
 /obj/structure/chair{
@@ -9269,10 +9269,10 @@
 "aop" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/mining)
 "aoq" = (
 /turf/open/floor/engine/vacuum,
@@ -9336,10 +9336,10 @@
 "aov" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aow" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9359,17 +9359,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aoy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aoz" = (
 /obj/machinery/light/small{
@@ -9381,10 +9381,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aoA" = (
 /obj/machinery/door/firedoor,
@@ -9396,10 +9396,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aoB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -9446,8 +9446,8 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -9465,8 +9465,8 @@
 /obj/effect/landmark/start{
 	name = "Assistant"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -9488,8 +9488,8 @@
 	})
 "aoG" = (
 /obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -9502,11 +9502,11 @@
 	dir = 1;
 	on = 1
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-warning (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-warning (EAST)"
 	},
 /area/teleporter{
 	name = "\improper Teleporter Room"
@@ -9525,10 +9525,10 @@
 "aoJ" = (
 /obj/machinery/droneDispenser,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -9546,8 +9546,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -9563,10 +9563,10 @@
 	icon_state = "intact";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -9584,8 +9584,8 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar{
 	name = "Atrium"
 	})
@@ -9647,8 +9647,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar{
 	name = "Atrium"
 	})
@@ -9665,10 +9665,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -9681,8 +9681,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -9706,10 +9706,10 @@
 /obj/machinery/shieldgen,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -9721,19 +9721,19 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_end (WEST)"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_end (WEST)"
 	},
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
 "aoX" = (
 /obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
@@ -9742,11 +9742,11 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_end (EAST)"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_end (EAST)"
 	},
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
@@ -9800,10 +9800,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -9888,8 +9888,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -9906,10 +9906,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "apj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9919,8 +9919,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "apk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9958,26 +9958,26 @@
 	req_access = null;
 	req_access_txt = "48"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "apn" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/quartermaster/miningdock)
 "apo" = (
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/quartermaster/miningdock)
 "app" = (
@@ -9985,26 +9985,26 @@
 	name = "Mining Shuttle Airlock";
 	req_access_txt = "0"
 	},
-/turf/open/floor/plasteel/white,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/mining)
 "apq" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/mining)
 "apr" = (
 /turf/open/floor/plasteel/neutral,
 /area/shuttle/mining)
 "aps" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/mining)
 "apt" = (
 /obj/docking_port/mobile{
@@ -10028,10 +10028,10 @@
 	name = "Mining Shuttle Airlock";
 	req_access_txt = "48"
 	},
-/turf/open/floor/plasteel/white,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/mining)
 "apu" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -10083,11 +10083,11 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/security/brig)
 "apy" = (
@@ -10102,10 +10102,10 @@
 	icon_state = "tube1";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "apz" = (
 /obj/effect/landmark/start{
@@ -10161,10 +10161,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "apD" = (
 /obj/structure/cable/white{
@@ -10176,8 +10176,8 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "apE" = (
 /obj/structure/cable/white{
@@ -10187,10 +10187,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "apF" = (
 /obj/machinery/door/firedoor,
@@ -10206,10 +10206,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "apG" = (
 /obj/structure/cable/white{
@@ -10266,8 +10266,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -10276,10 +10276,10 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -10294,8 +10294,8 @@
 	tag = "icon-0-4";
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -10307,10 +10307,10 @@
 	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -10325,8 +10325,8 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/teleporter{
 	name = "\improper Teleporter Room"
 	})
@@ -10366,8 +10366,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -10384,10 +10384,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -10405,8 +10405,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar{
 	name = "Atrium"
 	})
@@ -10450,8 +10450,8 @@
 	})
 "apX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar{
 	name = "Atrium"
 	})
@@ -10468,8 +10468,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -10493,10 +10493,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -10532,10 +10532,10 @@
 	tag = "icon-1-4";
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
@@ -10549,8 +10549,8 @@
 	tag = "icon-0-8";
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
@@ -10563,10 +10563,10 @@
 	on = 1;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
 	})
@@ -10618,8 +10618,8 @@
 	})
 "aqj" = (
 /obj/machinery/computer/cargo/request,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -10628,8 +10628,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -10640,8 +10640,8 @@
 /obj/effect/landmark/start{
 	name = "Assistant"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -10653,8 +10653,8 @@
 	},
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -10667,8 +10667,8 @@
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -10678,8 +10678,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -10693,8 +10693,8 @@
 	c_tag = "Fore Primary Hallway East";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -10712,8 +10712,8 @@
 	dir = 4;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aqr" = (
 /obj/structure/chair/office/dark{
@@ -10749,8 +10749,8 @@
 /area/quartermaster/miningdock)
 "aqu" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aqv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10762,19 +10762,19 @@
 /obj/item/device/flashlight/flare,
 /obj/item/weapon/stock_parts/cell/high,
 /obj/item/weapon/crowbar/red,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aqw" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_end (WEST)"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_end (WEST)"
 	},
 /area/shuttle/mining)
 "aqx" = (
@@ -10782,11 +10782,11 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/shuttle/mining)
 "aqy" = (
@@ -10794,11 +10794,11 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_end (EAST)"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_end (EAST)"
 	},
 /area/shuttle/mining)
 "aqz" = (
@@ -10941,10 +10941,10 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -11035,8 +11035,8 @@
 	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aqU" = (
 /obj/structure/table/reinforced,
@@ -11047,8 +11047,8 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aqV" = (
 /obj/structure/table/reinforced,
@@ -11065,8 +11065,8 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aqW" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -11075,16 +11075,16 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aqX" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/camera{
 	c_tag = "Primary Tool Storage"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aqY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11127,11 +11127,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/bar{
 	name = "Atrium"
@@ -11141,11 +11141,11 @@
 /obj/machinery/door/airlock/glass{
 	name = "Atrium"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/bar{
 	name = "Atrium"
@@ -11156,11 +11156,11 @@
 /obj/machinery/door/airlock/glass{
 	name = "Atrium"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/bar{
 	name = "Atrium"
@@ -11187,11 +11187,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
@@ -11239,8 +11239,8 @@
 	},
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "arl" = (
 /obj/structure/table/reinforced,
@@ -11354,8 +11354,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/pickaxe/emergency,
 /obj/item/weapon/pickaxe/emergency,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/shuttle/mining)
 "aro" = (
 /obj/structure/shuttle/engine/heater,
@@ -11368,14 +11368,14 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/shuttle/mining)
 "arp" = (
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/shuttle/mining)
 "arq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -11411,10 +11411,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "aru" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -11426,20 +11426,20 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "arv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "arw" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -11492,8 +11492,8 @@
 	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/atmos)
 "arA" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
@@ -11504,8 +11504,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "arB" = (
 /turf/open/floor/plating/astplate,
@@ -11572,10 +11572,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "arH" = (
 /obj/structure/cable/white{
@@ -11654,10 +11654,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "arM" = (
 /obj/machinery/holopad,
@@ -11788,8 +11788,8 @@
 	name = "Station Intercom";
 	pixel_x = 26
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "arV" = (
 /obj/structure/cable/white{
@@ -11818,10 +11818,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -12089,8 +12089,8 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -12106,8 +12106,8 @@
 	dir = 1;
 	layer = 2.9
 	},
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/shuttle/mining)
 "asv" = (
 /turf/open/floor/engine/n2,
@@ -12163,10 +12163,10 @@
 "asA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "asB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12176,11 +12176,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-warning (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-warning (EAST)"
 	},
 /area/atmos)
 "asD" = (
@@ -12339,10 +12339,10 @@
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asP" = (
 /obj/structure/table/reinforced,
@@ -12358,10 +12358,10 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asQ" = (
 /obj/structure/table/reinforced,
@@ -12371,10 +12371,10 @@
 	pixel_y = -32
 	},
 /obj/item/device/flashlight/seclite,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asR" = (
 /obj/machinery/computer/security,
@@ -12451,10 +12451,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "asV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12519,8 +12519,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "ata" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12535,10 +12535,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "atb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12598,11 +12598,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/theatre)
 "ath" = (
@@ -12702,10 +12702,10 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -12722,8 +12722,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -12733,8 +12733,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -12750,10 +12750,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -12769,8 +12769,8 @@
 	pixel_x = -1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -12825,25 +12825,25 @@
 	},
 /area/atmos)
 "atB" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "atC" = (
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "atD" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-warning (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-warning (EAST)"
 	},
 /area/atmos)
 "atE" = (
@@ -12936,11 +12936,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/security/brig)
 "atM" = (
@@ -12982,10 +12982,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "atP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13104,8 +13104,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "atU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13116,8 +13116,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "atV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13125,8 +13125,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -13411,10 +13411,10 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "auv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -13425,11 +13425,11 @@
 /area/atmos)
 "auw" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel{
-	tag = "icon-warning (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-warning (EAST)"
 	},
 /area/atmos)
 "aux" = (
@@ -13502,10 +13502,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -13622,10 +13622,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -13762,12 +13762,12 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "auY" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -14006,10 +14006,10 @@
 "avw" = (
 /obj/machinery/shieldgen,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -14050,10 +14050,10 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "avB" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -14162,10 +14162,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -14219,10 +14219,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -14241,10 +14241,10 @@
 	name = "2maintenance loot spawner"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -14258,10 +14258,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -14367,8 +14367,8 @@
 	pixel_x = -24;
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "avZ" = (
 /obj/machinery/vending/tool,
@@ -14377,8 +14377,8 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "awa" = (
 /obj/machinery/vending/assist,
@@ -14388,8 +14388,8 @@
 	pixel_y = -22
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "awb" = (
 /obj/structure/table/reinforced,
@@ -14400,8 +14400,8 @@
 	amount = 30
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "awc" = (
 /obj/structure/table/reinforced,
@@ -14421,16 +14421,16 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "awd" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -14579,10 +14579,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "awt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14645,10 +14645,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "awx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -14690,11 +14690,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-warning (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-warning (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -14738,10 +14738,10 @@
 /area/atmos)
 "awE" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "awF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -14825,11 +14825,11 @@
 	icon_state = "manifold";
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/atmos)
 "awN" = (
@@ -14842,8 +14842,8 @@
 	name = "Atmospherics Lockdown Blast door"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/atmos)
 "awO" = (
 /obj/machinery/door/firedoor,
@@ -14852,11 +14852,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -15016,10 +15016,10 @@
 	})
 "axf" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -15137,8 +15137,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "axr" = (
 /obj/structure/cable/white{
@@ -15151,8 +15151,8 @@
 	icon_state = "intact";
 	dir = 9
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/atmos)
 "axs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -15163,8 +15163,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "axt" = (
 /obj/structure/grille,
@@ -15178,8 +15178,8 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "axv" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -15189,20 +15189,20 @@
 /obj/structure/sign/atmosplaque{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "axw" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "axx" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "axy" = (
 /obj/item/weapon/weldingtool,
@@ -15564,10 +15564,10 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "aye" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
@@ -15591,10 +15591,10 @@
 	on = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "ayg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -15603,27 +15603,27 @@
 	name = "Waste to Filter";
 	on = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "ayh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /obj/machinery/meter,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "ayi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "ayj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -15636,10 +15636,10 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "ayk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -15650,10 +15650,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "ayl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -15664,10 +15664,10 @@
 	pixel_x = 24
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "aym" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -15677,23 +15677,23 @@
 	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/atmos)
 "ayn" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/atmos)
 "ayo" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/atmos)
 "ayp" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/atmos)
 "ayq" = (
 /obj/structure/table/reinforced,
@@ -15941,10 +15941,10 @@
 "ayQ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -15969,17 +15969,17 @@
 	pixel_x = 0;
 	pixel_y = 25
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
 "ayS" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -16004,8 +16004,8 @@
 	})
 "ayV" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -16178,10 +16178,10 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "azl" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -16232,10 +16232,10 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "azs" = (
 /obj/structure/grille,
@@ -16354,11 +16354,11 @@
 /obj/machinery/door/airlock{
 	name = "Cabin"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/sleep)
 "azE" = (
@@ -16470,8 +16470,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -16501,10 +16501,10 @@
 	})
 "azQ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -16531,10 +16531,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -16553,8 +16553,8 @@
 	})
 "azU" = (
 /obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -16584,8 +16584,8 @@
 	icon_state = "intact";
 	dir = 10
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -16629,11 +16629,11 @@
 	req_access = null;
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (NORTH)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (NORTH)"
 	},
 /area/shuttle/escape)
 "aAd" = (
@@ -16722,10 +16722,10 @@
 	icon_state = "intact";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "aAm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -16815,10 +16815,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "aAu" = (
 /obj/machinery/door/firedoor,
@@ -16838,10 +16838,10 @@
 	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "aAv" = (
 /obj/structure/cable/white{
@@ -16882,8 +16882,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aAA" = (
 /obj/structure/chair/office/dark{
@@ -16926,10 +16926,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/sleep)
 "aAE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16944,8 +16944,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/sleep)
 "aAG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16998,11 +16998,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/theatre)
 "aAN" = (
@@ -17119,10 +17119,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -17135,8 +17135,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -17169,10 +17169,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -17287,17 +17287,17 @@
 	name = "External Docking Port";
 	req_access_txt = "63"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "aBi" = (
 /obj/structure/fans/tiny,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -17306,10 +17306,10 @@
 	name = "Emergency Shuttle Airlock";
 	req_access_txt = "2"
 	},
-/turf/open/floor/plasteel/white,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "aBk" = (
 /obj/structure/table/reinforced,
@@ -17388,17 +17388,17 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBs" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBt" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -17406,34 +17406,34 @@
 	icon_state = "intact";
 	dir = 9
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBu" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBw" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
 	initialize_directions = 11
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
 	initialize_directions = 10
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -17441,8 +17441,8 @@
 	icon_state = "manifold";
 	name = "scrubbers pipe"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -17451,8 +17451,8 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -17463,8 +17463,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBB" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -17473,10 +17473,10 @@
 	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBC" = (
 /obj/structure/grille,
@@ -17517,8 +17517,8 @@
 /area/atmos)
 "aBF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aBG" = (
 /obj/structure/tank_dispenser,
@@ -17617,10 +17617,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/sleep)
 "aBN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17792,11 +17792,11 @@
 	req_access_txt = "28"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/kitchen)
 "aCe" = (
@@ -17868,11 +17868,11 @@
 	},
 /obj/item/weapon/folder/red,
 /obj/item/device/radio,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (WEST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (WEST)"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -17912,11 +17912,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (WEST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (WEST)"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -17956,11 +17956,11 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/shuttle/escape)
 "aCr" = (
@@ -18018,8 +18018,8 @@
 "aCv" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/machinery/meter,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aCw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -18031,8 +18031,8 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aCx" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -18044,8 +18044,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aCy" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -18055,8 +18055,8 @@
 	},
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aCz" = (
 /obj/structure/table/reinforced,
@@ -18074,10 +18074,10 @@
 	},
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/atmos)
 "aCA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -18130,8 +18130,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aCF" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -18144,8 +18144,8 @@
 	c_tag = "Atmospherics South East";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aCG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18188,11 +18188,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/atmos)
 "aCJ" = (
@@ -18231,8 +18231,8 @@
 	name = "Atmospherics Desk";
 	req_access_txt = "24"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/atmos)
 "aCL" = (
 /obj/machinery/airalarm{
@@ -18437,8 +18437,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -18484,8 +18484,8 @@
 	name = "\improper Departure Lounge"
 	})
 "aDh" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -18493,10 +18493,10 @@
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -18525,8 +18525,8 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aDk" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aDl" = (
 /turf/open/floor/plasteel/neutral/side{
@@ -18545,8 +18545,8 @@
 	pixel_x = 26;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aDn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -18594,11 +18594,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/atmos)
 "aDu" = (
@@ -18691,8 +18691,8 @@
 "aDC" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/airlock_painter,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -18809,10 +18809,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aDO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18873,8 +18873,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aDS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -18949,8 +18949,8 @@
 "aEa" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -18958,8 +18958,8 @@
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -18976,8 +18976,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -18991,8 +18991,8 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -19003,8 +19003,8 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aEh" = (
 /turf/open/floor/plasteel/neutral,
@@ -19013,8 +19013,8 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aEj" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -19101,8 +19101,8 @@
 	pixel_y = 9
 	},
 /obj/structure/closet/crate/internals,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aEl" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -19116,8 +19116,8 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aEn" = (
 /obj/machinery/shieldgen,
@@ -19135,41 +19135,41 @@
 	dir = 4;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEo" = (
 /obj/machinery/shieldgen,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEp" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEr" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEs" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEt" = (
 /turf/closed/wall/r_wall,
@@ -19235,10 +19235,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19254,8 +19254,8 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEz" = (
 /obj/machinery/shower{
@@ -19264,10 +19264,10 @@
 	name = "emergency shower"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -19348,10 +19348,10 @@
 /obj/machinery/door/airlock/glass{
 	name = "Engineering Foyer"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -19554,8 +19554,8 @@
 	},
 /obj/item/weapon/storage/bag/tray,
 /obj/item/weapon/kitchen/fork,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aEZ" = (
 /obj/effect/landmark/start{
@@ -19641,10 +19641,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aFg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -19691,8 +19691,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -19704,10 +19704,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -19715,8 +19715,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -19737,8 +19737,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -19771,8 +19771,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFr" = (
 /obj/machinery/power/emitter,
@@ -19782,26 +19782,26 @@
 	pixel_x = 0;
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFs" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFt" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFu" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFv" = (
 /obj/structure/closet/crate,
@@ -19818,8 +19818,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFw" = (
 /obj/structure/cable/white{
@@ -19833,11 +19833,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/engine/engineering)
 "aFx" = (
@@ -19856,11 +19856,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/engine/engineering)
 "aFy" = (
@@ -19884,11 +19884,11 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/engine/engineering)
 "aFz" = (
@@ -19899,10 +19899,10 @@
 	},
 /obj/item/clothing/glasses/meson,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFA" = (
 /obj/structure/cable/white{
@@ -19915,8 +19915,8 @@
 	layer = 2.4;
 	on = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFB" = (
 /obj/machinery/shower{
@@ -19936,10 +19936,10 @@
 	dir = 8;
 	network = list("Labor")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFC" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -20038,10 +20038,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -20152,8 +20152,8 @@
 	},
 /obj/item/weapon/storage/fancy/donut_box,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aFR" = (
 /turf/open/floor/plasteel/white,
@@ -20217,8 +20217,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -20227,10 +20227,10 @@
 /obj/machinery/door/airlock/glass{
 	name = "Departure Lounge"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -20242,8 +20242,8 @@
 "aGb" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -20293,11 +20293,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/engine/engineering)
 "aGi" = (
@@ -20336,11 +20336,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/engine/engineering)
 "aGl" = (
@@ -20381,11 +20381,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/engine/engineering)
 "aGo" = (
@@ -20470,8 +20470,8 @@
 /obj/item/weapon/stock_parts/cell/high,
 /obj/item/weapon/stock_parts/cell/high,
 /obj/machinery/cell_charger,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -20513,8 +20513,8 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -20526,8 +20526,8 @@
 	},
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -20540,8 +20540,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -20635,10 +20635,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -20654,8 +20654,8 @@
 	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -20667,10 +20667,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -20683,10 +20683,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -20700,8 +20700,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -20795,11 +20795,11 @@
 "aGS" = (
 /obj/machinery/processor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_end (NORTH)"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_end (NORTH)"
 	},
 /area/crew_quarters/kitchen)
 "aGT" = (
@@ -20886,8 +20886,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -20899,10 +20899,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -20910,8 +20910,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -20934,8 +20934,8 @@
 	icon_state = "manifold";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -20982,10 +20982,10 @@
 	icon_state = "plant-21";
 	layer = 4.1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHj" = (
 /obj/structure/cable/white{
@@ -20998,10 +20998,10 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHk" = (
 /obj/structure/cable/white{
@@ -21014,10 +21014,10 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHl" = (
 /obj/structure/cable/white{
@@ -21029,10 +21029,10 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHm" = (
 /obj/structure/cable/white{
@@ -21048,10 +21048,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHn" = (
 /obj/structure/cable/white{
@@ -21066,10 +21066,10 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHo" = (
 /obj/structure/cable/white{
@@ -21082,10 +21082,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHp" = (
 /obj/structure/cable{
@@ -21103,10 +21103,10 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHq" = (
 /obj/structure/cable/white{
@@ -21124,10 +21124,10 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHr" = (
 /obj/structure/cable/white{
@@ -21143,10 +21143,10 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHs" = (
 /obj/structure/cable/white{
@@ -21252,11 +21252,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/engine/engineering)
 "aHy" = (
@@ -21294,8 +21294,8 @@
 	name = "Engineering Desk";
 	req_access_txt = "10"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHA" = (
 /obj/structure/grille,
@@ -21366,8 +21366,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -21384,10 +21384,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -21399,11 +21399,11 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
@@ -21425,11 +21425,11 @@
 	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
@@ -21445,11 +21445,11 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
@@ -21463,10 +21463,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -21532,11 +21532,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hydroponics)
 "aHP" = (
@@ -21613,11 +21613,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/kitchen)
 "aHX" = (
@@ -21634,8 +21634,8 @@
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -21644,8 +21644,8 @@
 	icon_state = "plant-21";
 	layer = 4.1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -21688,10 +21688,10 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -21703,8 +21703,8 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -21717,8 +21717,8 @@
 	pixel_x = 0;
 	tag = ""
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIi" = (
 /obj/machinery/atmospherics/components/trinary/filter{
@@ -21734,8 +21734,8 @@
 	pixel_x = 0;
 	tag = ""
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -21754,8 +21754,8 @@
 	on = 1;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -21777,8 +21777,8 @@
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIl" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -21792,8 +21792,8 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIm" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -21815,8 +21815,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIn" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -21834,8 +21834,8 @@
 	dir = 1;
 	on = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIo" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -21848,8 +21848,8 @@
 	pixel_x = 0;
 	tag = ""
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIp" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -21865,8 +21865,8 @@
 /obj/effect/landmark/start{
 	name = "Station Engineer"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -21877,10 +21877,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIr" = (
 /obj/structure/cable/white{
@@ -21889,10 +21889,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIs" = (
 /obj/structure/table/reinforced,
@@ -21910,16 +21910,16 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIt" = (
 /obj/structure/cable/white{
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIu" = (
 /obj/machinery/firealarm{
@@ -21928,16 +21928,16 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIv" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIw" = (
 /obj/structure/chair/office/dark{
@@ -21950,8 +21950,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIx" = (
 /obj/machinery/computer/monitor{
@@ -21968,8 +21968,8 @@
 	pixel_y = 24;
 	req_access_txt = "10"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIy" = (
 /obj/structure/table/reinforced,
@@ -21981,8 +21981,8 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22024,11 +22024,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/janitor)
 "aID" = (
@@ -22043,8 +22043,8 @@
 	name = "3maintenance loot spawner"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -22055,8 +22055,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -22072,8 +22072,8 @@
 	},
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/structure/closet/crate/hydroponics,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aIH" = (
 /obj/structure/sink{
@@ -22081,8 +22081,8 @@
 	icon_state = "sink";
 	pixel_x = 12
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aII" = (
 /obj/machinery/hydroponics/constructable,
@@ -22090,18 +22090,18 @@
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aIJ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aIK" = (
 /obj/machinery/hydroponics/constructable,
@@ -22113,10 +22113,10 @@
 	pixel_x = 0;
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aIL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22124,8 +22124,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aIM" = (
 /obj/machinery/chem_master/condimaster{
@@ -22139,16 +22139,16 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aIN" = (
 /obj/machinery/vending/hydronutrients,
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aIO" = (
 /obj/machinery/vending/hydroseeds,
@@ -22163,8 +22163,8 @@
 	pixel_y = 24;
 	req_access_txt = "35"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aIP" = (
 /obj/structure/table/reinforced,
@@ -22175,8 +22175,8 @@
 	},
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aIQ" = (
 /obj/machinery/newscaster{
@@ -22189,15 +22189,15 @@
 	})
 "aIR" = (
 /obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aIS" = (
 /obj/structure/closet/chefcloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aIT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -22213,8 +22213,8 @@
 	tag = "icon-1-4";
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aIU" = (
 /obj/structure/sink/kitchen{
@@ -22229,10 +22229,10 @@
 	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aIV" = (
 /obj/machinery/gibber,
@@ -22242,8 +22242,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aIW" = (
 /obj/structure/sink/kitchen{
@@ -22254,10 +22254,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aIX" = (
 /obj/machinery/airalarm{
@@ -22312,8 +22312,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -22339,10 +22339,10 @@
 	name = "Emergency Shuttle Airlock";
 	req_access_txt = "0"
 	},
-/turf/open/floor/plasteel/white,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "aJf" = (
 /turf/open/floor/plasteel/neutral/side,
@@ -22357,8 +22357,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aJh" = (
 /obj/machinery/light{
@@ -22405,10 +22405,10 @@
 	dir = 2;
 	pixel_x = 23
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aJl" = (
 /obj/machinery/power/apc{
@@ -22425,10 +22425,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aJm" = (
 /obj/machinery/power/terminal{
@@ -22446,10 +22446,10 @@
 	icon_state = "0-2";
 	tag = "icon-0-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aJn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22464,8 +22464,8 @@
 /obj/structure/sign/electricshock{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aJo" = (
 /obj/structure/grille,
@@ -22484,10 +22484,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -22497,18 +22497,18 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJr" = (
 /obj/item/weapon/wrench,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -22518,8 +22518,8 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJt" = (
 /obj/structure/sign/radiation,
@@ -22543,8 +22543,8 @@
 	name = "External Gas to Loop"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJx" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -22553,8 +22553,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJy" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -22565,10 +22565,10 @@
 	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJz" = (
 /obj/structure/cable/white{
@@ -22578,10 +22578,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJA" = (
 /obj/structure/grille,
@@ -22652,8 +22652,8 @@
 	icon_state = "manifold";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJF" = (
 /obj/structure/cable/white{
@@ -22721,8 +22721,8 @@
 /obj/machinery/camera{
 	c_tag = "Custodial Closet"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aJJ" = (
 /obj/vehicle/janicart,
@@ -22740,8 +22740,8 @@
 	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aJK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22750,8 +22750,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aJL" = (
 /obj/structure/closet/crate/bin,
@@ -22760,8 +22760,8 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aJM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22774,11 +22774,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
@@ -22788,10 +22788,10 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aJO" = (
 /turf/open/floor/plasteel/greenblue/side{
@@ -22868,8 +22868,8 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/wheat,
 /obj/item/weapon/reagent_containers/food/snacks/grown/pumpkin,
 /obj/item/weapon/reagent_containers/food/snacks/grown/grapes,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aJW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -22908,8 +22908,8 @@
 	dir = 4;
 	network = list("MINE")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aKa" = (
 /obj/machinery/airalarm{
@@ -22968,8 +22968,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aKf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22992,8 +22992,8 @@
 	})
 "aKg" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -23013,8 +23013,8 @@
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -23025,8 +23025,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -23037,11 +23037,11 @@
 	req_access_txt = "48;50"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -23062,11 +23062,11 @@
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Cargo"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/shuttle/escape)
 "aKn" = (
@@ -23079,11 +23079,11 @@
 	name = "Escape Shuttle Infirmary";
 	req_access_txt = "0"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/shuttle/escape)
 "aKp" = (
@@ -23116,10 +23116,10 @@
 	req_access_txt = "19; 61"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aKt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23129,10 +23129,10 @@
 	icon_state = "manifold";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aKu" = (
 /obj/structure/cable{
@@ -23171,10 +23171,10 @@
 	tag = "icon-1-4";
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aKw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23190,8 +23190,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aKx" = (
 /obj/machinery/door/firedoor,
@@ -23216,10 +23216,10 @@
 	icon_state = "manifold";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aKy" = (
 /obj/structure/cable/white{
@@ -23235,18 +23235,18 @@
 	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aKz" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aKA" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -23284,8 +23284,8 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aKF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -23295,10 +23295,10 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aKG" = (
 /obj/structure/cable/white{
@@ -23314,10 +23314,10 @@
 	icon_state = "intact";
 	dir = 6
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aKH" = (
 /obj/machinery/door/firedoor,
@@ -23340,10 +23340,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aKI" = (
 /obj/structure/cable/white{
@@ -23459,8 +23459,8 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aKQ" = (
 /obj/effect/landmark/start{
@@ -23517,19 +23517,19 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
 "aKV" = (
 /obj/machinery/biogenerator,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aKW" = (
 /turf/open/floor/plasteel/greenblue/side{
@@ -23550,8 +23550,8 @@
 	pixel_y = 3
 	},
 /obj/item/weapon/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aKY" = (
 /obj/structure/table/glass,
@@ -23564,8 +23564,8 @@
 	},
 /obj/item/weapon/reagent_containers/glass/bottle/nutrient/rh,
 /obj/item/weapon/reagent_containers/dropper,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aKZ" = (
 /obj/structure/table/glass,
@@ -23573,8 +23573,8 @@
 /obj/item/weapon/reagent_containers/spray/pestspray,
 /obj/item/weapon/grenade/chem_grenade/antiweed,
 /obj/item/weapon/grenade/chem_grenade/antiweed,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aLa" = (
 /obj/machinery/holopad,
@@ -23583,8 +23583,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aLb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23605,8 +23605,8 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/wheat,
 /obj/item/seeds/wheat,
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aLd" = (
 /obj/structure/table/glass,
@@ -23620,8 +23620,8 @@
 	pixel_x = -6
 	},
 /obj/item/seeds/tower,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aLe" = (
 /obj/machinery/smartfridge,
@@ -23665,8 +23665,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aLj" = (
 /obj/machinery/icecream_vat,
@@ -23676,8 +23676,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aLk" = (
 /obj/structure/kitchenspike,
@@ -23687,8 +23687,8 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aLl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23717,8 +23717,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -23731,10 +23731,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -23770,8 +23770,8 @@
 	icon_state = "intact";
 	dir = 9
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -23797,8 +23797,8 @@
 "aLu" = (
 /obj/structure/fans/tiny,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -23807,24 +23807,24 @@
 	name = "External Docking Port"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
 "aLw" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aLx" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aLy" = (
 /obj/structure/closet/crate/medical{
@@ -23845,13 +23845,13 @@
 	},
 /obj/item/weapon/lazarus_injector,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
 /mob/living/simple_animal/bot/medbot{
 	name = "\improper emergency medibot";
 	pixel_x = -3;
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel,
-/obj/effect/turf_decal/bot,
 /area/shuttle/escape)
 "aLz" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -23889,10 +23889,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aLE" = (
 /obj/machinery/status_display{
@@ -23918,10 +23918,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aLG" = (
 /obj/structure/cable/white,
@@ -23941,10 +23941,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aLI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23956,15 +23956,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aLJ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aLK" = (
 /obj/structure/closet/radiation,
@@ -23979,8 +23979,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aLL" = (
 /obj/structure/grille,
@@ -24003,10 +24003,10 @@
 	icon_state = "manifold";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aLN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -24020,10 +24020,10 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aLO" = (
 /obj/machinery/ai_status_display,
@@ -24079,10 +24079,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aLW" = (
 /obj/structure/cable/white{
@@ -24090,10 +24090,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aLX" = (
 /obj/structure/grille,
@@ -24194,16 +24194,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aMi" = (
 /obj/machinery/shieldgen,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -24216,11 +24216,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-warning (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-warning (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
@@ -24231,10 +24231,10 @@
 	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aMl" = (
 /turf/open/floor/plasteel/greenblue/side{
@@ -24352,10 +24352,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -24369,8 +24369,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
 	})
@@ -24390,8 +24390,8 @@
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -24410,8 +24410,8 @@
 	})
 "aMA" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -24443,21 +24443,21 @@
 	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aME" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aMF" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aMG" = (
 /obj/structure/closet/crate{
@@ -24477,8 +24477,8 @@
 /obj/item/weapon/wrench,
 /obj/item/device/radio,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aMH" = (
 /obj/machinery/shower{
@@ -24523,11 +24523,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/tcommsat/server)
 "aMM" = (
@@ -24555,10 +24555,10 @@
 	dir = 4;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aMP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -24574,10 +24574,10 @@
 	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aMQ" = (
 /obj/structure/cable{
@@ -24591,10 +24591,10 @@
 	name = "Radiation Chamber Shutters"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aMR" = (
 /obj/machinery/power/rad_collector{
@@ -24663,10 +24663,10 @@
 	name = "Radiation Chamber Shutters"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aMZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -24680,10 +24680,10 @@
 	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNa" = (
 /obj/machinery/suit_storage_unit/engine,
@@ -24701,10 +24701,10 @@
 	tag = "icon-safety"
 	},
 /obj/item/clothing/glasses/meson/engine,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24713,10 +24713,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNc" = (
 /obj/machinery/suit_storage_unit/engine,
@@ -24725,10 +24725,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/meson/engine,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNd" = (
 /obj/structure/table/reinforced,
@@ -24740,18 +24740,18 @@
 	pixel_x = 2;
 	pixel_y = -2
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNe" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -24762,10 +24762,10 @@
 	pixel_y = -22
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNg" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -24773,10 +24773,10 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24820,8 +24820,8 @@
 	pixel_x = 0;
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aNk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -24829,8 +24829,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aNl" = (
 /obj/structure/closet/jcloset,
@@ -24839,14 +24839,14 @@
 	},
 /obj/item/device/flashlight,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aNm" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aNn" = (
 /obj/structure/rack,
@@ -24855,10 +24855,10 @@
 /obj/item/weapon/wrench,
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -24870,10 +24870,10 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
 	})
@@ -24887,8 +24887,8 @@
 /obj/item/weapon/paper/hydroponics,
 /obj/item/toy/figure/botanist,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aNq" = (
 /obj/machinery/hydroponics/constructable,
@@ -24898,17 +24898,17 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/white,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aNr" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aNs" = (
 /obj/machinery/hydroponics/constructable,
@@ -24919,15 +24919,15 @@
 	},
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aNt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aNu" = (
 /obj/structure/closet/crate/bin,
@@ -24937,8 +24937,8 @@
 	dir = 8;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aNv" = (
 /obj/structure/window/reinforced{
@@ -24967,11 +24967,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/bar{
 	name = "Atrium"
@@ -24982,11 +24982,11 @@
 	name = "Atrium"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/crew_quarters/bar{
 	name = "Atrium"
@@ -25106,8 +25106,8 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -25119,8 +25119,8 @@
 	pixel_y = -24
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -25130,8 +25130,8 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -25142,8 +25142,8 @@
 	pixel_x = 0;
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -25162,14 +25162,14 @@
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aNM" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aNN" = (
 /obj/structure/rack,
@@ -25185,8 +25185,8 @@
 	pixel_x = 3;
 	pixel_y = -5
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aNO" = (
 /obj/structure/table,
@@ -25196,8 +25196,8 @@
 	pixel_x = 24
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aNP" = (
 /obj/item/weapon/scalpel{
@@ -25296,10 +25296,10 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -25314,10 +25314,10 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOa" = (
 /obj/machinery/power/supermatter_shard{
@@ -25343,10 +25343,10 @@
 	},
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aOc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -25359,10 +25359,10 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOd" = (
 /obj/machinery/power/apc{
@@ -25374,10 +25374,10 @@
 /obj/structure/cable/white,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOe" = (
 /obj/structure/sign/nanotrasen,
@@ -25393,11 +25393,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/janitor)
 "aOg" = (
@@ -25410,11 +25410,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Central Port Maintenance"
@@ -25431,11 +25431,11 @@
 	req_access_txt = "35"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hydroponics)
 "aOj" = (
@@ -25528,8 +25528,8 @@
 /area/hallway/primary/central)
 "aOs" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25549,11 +25549,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/starboard{
 	name = "Central Starboard Maintenance"
@@ -25607,10 +25607,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -25620,10 +25620,10 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOB" = (
 /obj/structure/cable{
@@ -25636,10 +25636,10 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aOC" = (
 /obj/structure/grille,
@@ -25668,10 +25668,10 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aOF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -25679,10 +25679,10 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOG" = (
 /obj/machinery/firealarm{
@@ -25690,10 +25690,10 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOH" = (
 /turf/closed/wall/r_wall,
@@ -25734,10 +25734,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -25749,11 +25749,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -25767,11 +25767,11 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -25790,10 +25790,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -25912,10 +25912,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -26097,10 +26097,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -26411,8 +26411,8 @@
 "aPy" = (
 /obj/structure/table,
 /obj/item/weapon/storage/briefcase,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -26463,8 +26463,8 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "aPF" = (
 /obj/structure/window/reinforced{
@@ -26472,8 +26472,8 @@
 	},
 /obj/structure/shuttle/engine/heater,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "aPG" = (
 /obj/structure/grille,
@@ -26492,11 +26492,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/tcommsat/server)
 "aPI" = (
@@ -26509,10 +26509,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aPJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -26520,10 +26520,10 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aPK" = (
 /obj/structure/sign/electricshock,
@@ -26544,10 +26544,10 @@
 	on = 1;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aPN" = (
 /obj/machinery/newscaster{
@@ -26558,10 +26558,10 @@
 	icon_state = "manifold";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aPO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26602,8 +26602,8 @@
 	icon_state = "intact";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -26628,8 +26628,8 @@
 	icon_state = "intact";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -26644,8 +26644,8 @@
 	icon_state = "intact";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -26660,8 +26660,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -26761,10 +26761,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -26823,10 +26823,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aQi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27014,8 +27014,8 @@
 	c_tag = "Starboard Primary Hallway 3";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -27058,8 +27058,8 @@
 /area/maintenance/starboard)
 "aQE" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "aQF" = (
 /obj/machinery/light{
@@ -27100,10 +27100,10 @@
 	name = "scrubbers pipe"
 	},
 /obj/machinery/meter,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQK" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -27111,38 +27111,38 @@
 	icon_state = "pump_map";
 	name = "Gas to Loop"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQL" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQM" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
 /obj/machinery/meter,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQN" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQO" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -27162,20 +27162,20 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQR" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
@@ -27184,10 +27184,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQS" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -27195,18 +27195,18 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -27240,11 +27240,11 @@
 	name = "Library Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/library)
 "aQZ" = (
@@ -27257,11 +27257,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/library)
 "aRa" = (
@@ -27292,11 +27292,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/medical/morgue)
 "aRe" = (
@@ -27334,8 +27334,8 @@
 	},
 /obj/item/weapon/folder/yellow,
 /obj/item/weapon/pen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aRj" = (
 /obj/structure/grille,
@@ -27376,8 +27376,8 @@
 /area/hallway/primary/central)
 "aRn" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRo" = (
 /turf/open/floor/plasteel/neutral/corner,
@@ -27415,8 +27415,8 @@
 	id = "rndlab1";
 	name = "Research and Development Shutter"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aRu" = (
 /obj/machinery/door/firedoor,
@@ -27429,11 +27429,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/medical/research{
 	name = "Research Division"
@@ -27445,11 +27445,11 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/medical/research{
 	name = "Research Division"
@@ -27472,11 +27472,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -27498,11 +27498,11 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/starboard)
 "aRB" = (
@@ -27561,10 +27561,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRG" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -27627,10 +27627,10 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRL" = (
 /obj/structure/cable/white{
@@ -27648,10 +27648,10 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRN" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -27674,8 +27674,8 @@
 "aRP" = (
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -27694,10 +27694,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27856,10 +27856,10 @@
 	pixel_x = -26;
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aSk" = (
 /obj/machinery/light{
@@ -27893,10 +27893,10 @@
 /obj/machinery/chem_master{
 	density = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aSm" = (
 /obj/structure/chair/office/light{
@@ -27905,8 +27905,8 @@
 /obj/effect/landmark/start{
 	name = "Chemist"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aSn" = (
 /obj/machinery/chem_dispenser,
@@ -27917,19 +27917,19 @@
 	pixel_y = 24;
 	req_access_txt = "33"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aSo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central)
 "aSp" = (
@@ -27939,11 +27939,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central)
 "aSq" = (
@@ -27962,11 +27962,11 @@
 "aSt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central)
 "aSu" = (
@@ -28038,8 +28038,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aSz" = (
 /turf/closed/wall,
@@ -28060,12 +28060,12 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white{
 	tag = "icon-white_warn_end (WEST)";
 	icon_state = "white_warn_end"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
 	},
 /area/medical/research{
 	name = "Research Division"
@@ -28077,12 +28077,12 @@
 	name = "emergency shower"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white{
 	tag = "icon-white_warn_end (EAST)";
 	icon_state = "white_warn_end"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
 	},
 /area/medical/research{
 	name = "Research Division"
@@ -28102,24 +28102,24 @@
 "aSE" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/breath,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aSF" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aSG" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aSH" = (
 /obj/structure/sign/poster,
@@ -28188,10 +28188,10 @@
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/engineering_yellow,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSQ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -28210,8 +28210,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSS" = (
 /obj/item/clothing/gloves/color/black,
@@ -28220,8 +28220,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aST" = (
 /obj/structure/table/reinforced,
@@ -28230,17 +28230,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSV" = (
 /obj/machinery/power/emitter{
@@ -28273,10 +28273,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSX" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -28288,10 +28288,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSY" = (
 /obj/structure/table/reinforced,
@@ -28307,8 +28307,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSZ" = (
 /obj/structure/table/reinforced,
@@ -28318,8 +28318,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28329,10 +28329,10 @@
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTb" = (
 /obj/structure/cable/white{
@@ -28490,10 +28490,10 @@
 "aTq" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/window/reinforced,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aTr" = (
 /obj/structure/cable/white{
@@ -28506,14 +28506,14 @@
 /area/medical/chemistry)
 "aTs" = (
 /obj/machinery/chem_heater,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aTt" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aTu" = (
 /obj/structure/chair/office/light{
@@ -28522,10 +28522,10 @@
 /obj/effect/landmark/start{
 	name = "Chemist"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aTv" = (
 /obj/structure/table/reinforced,
@@ -28541,8 +28541,8 @@
 	name = "Chemistry Desk";
 	req_access_txt = "5; 33"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aTw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28617,8 +28617,8 @@
 	id = "rndlab1";
 	name = "Research and Development Shutter"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aTG" = (
 /obj/structure/chair/office/light{
@@ -28633,8 +28633,8 @@
 /area/toxins/lab)
 "aTH" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aTI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28653,10 +28653,10 @@
 	},
 /obj/item/weapon/stock_parts/matter_bin,
 /obj/item/weapon/stock_parts/micro_laser,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aTL" = (
 /obj/structure/grille,
@@ -28711,10 +28711,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/medical/research{
 	name = "Research Division"
 	})
@@ -28745,10 +28745,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aTR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28758,8 +28758,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aTS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28772,8 +28772,8 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aTT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28783,8 +28783,8 @@
 	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aTU" = (
 /obj/structure/table/wood,
@@ -28998,8 +28998,8 @@
 /obj/machinery/reagentgrinder{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aUt" = (
 /obj/structure/cable/white{
@@ -29025,8 +29025,8 @@
 	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aUw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -29058,24 +29058,24 @@
 /area/hallway/primary/central)
 "aUA" = (
 /obj/machinery/r_n_d/destructive_analyzer,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aUB" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aUC" = (
 /obj/machinery/r_n_d/protolathe,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aUD" = (
 /turf/open/floor/plasteel/whitepurple/side{
@@ -29101,10 +29101,10 @@
 	pixel_x = 28;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aUF" = (
 /obj/machinery/light{
@@ -29382,10 +29382,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aVg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29411,8 +29411,8 @@
 	icon_state = "manifold";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aVi" = (
 /obj/machinery/dna_scannernew,
@@ -29430,8 +29430,8 @@
 	},
 /obj/item/weapon/reagent_containers/glass/bottle/epinephrine,
 /obj/item/weapon/reagent_containers/dropper,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aVk" = (
 /obj/effect/landmark/start{
@@ -29525,10 +29525,10 @@
 	tag = "icon-0-4";
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aVu" = (
 /obj/effect/landmark/start{
@@ -29541,17 +29541,17 @@
 	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aVv" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aVw" = (
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -29563,10 +29563,10 @@
 /obj/item/weapon/stock_parts/console_screen,
 /obj/item/weapon/stock_parts/console_screen,
 /obj/item/weapon/stock_parts/console_screen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aVy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29665,8 +29665,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aVG" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -29677,10 +29677,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aVH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29901,8 +29901,8 @@
 	pixel_x = 3
 	},
 /obj/item/weapon/reagent_containers/dropper,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aWg" = (
 /obj/structure/table/glass,
@@ -29927,8 +29927,8 @@
 	pixel_y = -24
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aWh" = (
 /obj/structure/table/glass,
@@ -29946,8 +29946,8 @@
 /obj/item/weapon/grenade/chem_grenade,
 /obj/item/weapon/grenade/chem_grenade,
 /obj/item/weapon/grenade/chem_grenade,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aWi" = (
 /obj/structure/cable/white{
@@ -29955,8 +29955,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aWj" = (
 /obj/structure/table/glass,
@@ -29967,8 +29967,8 @@
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aWk" = (
 /obj/structure/table,
@@ -30020,10 +30020,10 @@
 	pixel_x = 24;
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/toxins/lab)
 "aWp" = (
 /obj/machinery/status_display,
@@ -30240,11 +30240,11 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/medical/medbay3)
 "aWM" = (
@@ -30265,11 +30265,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/medical/chemistry)
 "aWO" = (
@@ -30344,11 +30344,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/toxins/lab)
 "aWV" = (
@@ -30529,10 +30529,10 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aXn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30632,10 +30632,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/medical/research{
 	name = "Research Division"
 	})
@@ -30643,8 +30643,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/research{
 	name = "Research Division"
 	})
@@ -30756,10 +30756,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/medical/research{
 	name = "Research Division"
 	})
@@ -30828,8 +30828,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aXL" = (
 /obj/machinery/door/morgue{
@@ -30858,11 +30858,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/library)
 "aXO" = (
@@ -30894,8 +30894,8 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aXP" = (
 /obj/structure/closet/wardrobe/white/medical,
@@ -30903,8 +30903,8 @@
 	pixel_y = 32
 	},
 /obj/item/weapon/storage/backpack/satchel/med,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aXQ" = (
 /obj/structure/closet/secure_closet/medical3,
@@ -30917,8 +30917,8 @@
 	pixel_x = 24;
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aXR" = (
 /obj/structure/grille,
@@ -30931,10 +30931,10 @@
 	icon_state = "sleeper-open";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aXT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30942,10 +30942,10 @@
 /area/medical/medbay3)
 "aXU" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aXV" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -30954,10 +30954,10 @@
 	on = 1;
 	target_temperature = 80
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aXW" = (
 /obj/structure/table,
@@ -30970,10 +30970,10 @@
 	pixel_y = 6
 	},
 /obj/item/weapon/storage/pill_bottle/mannitol,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aXX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -31066,10 +31066,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/medical/research{
 	name = "Research Division"
 	})
@@ -31082,8 +31082,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/research{
 	name = "Research Division"
 	})
@@ -31243,8 +31243,8 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aYu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -31260,10 +31260,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aYv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31274,8 +31274,8 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aYw" = (
 /obj/structure/destructible/cult/tome,
@@ -31349,10 +31349,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -31364,8 +31364,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -31378,8 +31378,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -31394,8 +31394,8 @@
 	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -31407,10 +31407,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -31434,8 +31434,8 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aYH" = (
 /obj/effect/landmark/start{
@@ -31452,16 +31452,16 @@
 	name = "Medbay Storage";
 	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (WEST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (WEST)"
+	},
 /area/medical/medbay3)
 "aYK" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aYL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31487,25 +31487,25 @@
 	icon_state = "intact";
 	dir = 5
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aYO" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aYP" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aYQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -31542,10 +31542,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aYU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31625,11 +31625,11 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/assembly/chargebay)
 "aZe" = (
@@ -31640,11 +31640,11 @@
 "aZf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/medical/research{
 	name = "Research Division"
@@ -31656,11 +31656,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/medical/research{
 	name = "Research Division"
@@ -31765,10 +31765,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -31853,11 +31853,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -31894,8 +31894,8 @@
 	tag = "icon-2-4";
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aZD" = (
 /obj/structure/cable/white{
@@ -31933,11 +31933,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (WEST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (WEST)"
 	},
 /area/medical/medbay3)
 "aZG" = (
@@ -31948,8 +31948,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aZH" = (
 /obj/structure/cable/white{
@@ -32002,8 +32002,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aZL" = (
 /obj/effect/landmark/start{
@@ -32066,10 +32066,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "aZQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -32143,8 +32143,8 @@
 	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "aZV" = (
 /obj/machinery/recharge_station,
@@ -32153,20 +32153,20 @@
 	name = "Cyborg"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "aZW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "aZX" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "aZY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32215,17 +32215,17 @@
 	dir = 2;
 	network = list("SS13","RD")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bac" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_end (NORTH)"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_end (NORTH)"
 	},
 /area/assembly/robotics)
 "bad" = (
@@ -32239,16 +32239,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bae" = (
 /obj/machinery/mecha_part_fabricator,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_end (NORTH)"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_end (NORTH)"
 	},
 /area/assembly/robotics)
 "baf" = (
@@ -32276,8 +32276,8 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bag" = (
 /obj/item/weapon/paper_bin,
@@ -32304,8 +32304,8 @@
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bah" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32367,10 +32367,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -32385,8 +32385,8 @@
 	icon_state = "manifold";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -32445,8 +32445,8 @@
 	pixel_y = 0
 	},
 /obj/structure/cable/white,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "bau" = (
 /obj/structure/table/glass,
@@ -32466,8 +32466,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "bav" = (
 /obj/machinery/vending/medical,
@@ -32479,8 +32479,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "baw" = (
 /obj/structure/grille,
@@ -32506,11 +32506,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_end (EAST)"
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_end (EAST)"
 	},
 /area/medical/medbay3)
 "bay" = (
@@ -32638,8 +32638,8 @@
 /area/hallway/primary/central)
 "baM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "baN" = (
 /obj/machinery/firealarm{
@@ -32664,10 +32664,10 @@
 	c_tag = "Mech Bay";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "baO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32676,10 +32676,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "baP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32690,10 +32690,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "baQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32703,10 +32703,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "baR" = (
 /obj/machinery/door/firedoor,
@@ -32722,10 +32722,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "baS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32775,10 +32775,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "baW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -32786,10 +32786,10 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "baX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -32797,26 +32797,26 @@
 	layer = 2.4;
 	on = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "baY" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "baZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start{
 	name = "Roboticist"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bba" = (
 /obj/item/stack/sheet/plasteel{
@@ -32830,8 +32830,8 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bbb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32874,8 +32874,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -32915,10 +32915,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -32932,8 +32932,8 @@
 	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -32946,10 +32946,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -32994,11 +32994,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -33083,10 +33083,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bby" = (
 /obj/machinery/light_switch{
@@ -33113,8 +33113,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bbA" = (
 /obj/structure/cable/white{
@@ -33146,10 +33146,10 @@
 	tag = "icon-2-4";
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bbC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33160,10 +33160,10 @@
 	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "bbD" = (
 /obj/machinery/computer/mech_bay_power_console,
@@ -33190,10 +33190,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plating,
 /area/assembly/chargebay)
 "bbG" = (
 /obj/structure/grille,
@@ -33235,10 +33235,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bbJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -33250,10 +33250,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bbK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33265,8 +33265,8 @@
 	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bbL" = (
 /obj/effect/landmark/start{
@@ -33282,17 +33282,17 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bbN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bbO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -33300,8 +33300,8 @@
 	on = 1;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bbP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -33356,11 +33356,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -33388,11 +33388,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -33421,11 +33421,11 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -33442,18 +33442,18 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
 "bcc" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -33525,8 +33525,8 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "bck" = (
 /obj/machinery/door/firedoor,
@@ -33538,11 +33538,11 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/medical/medbay3)
 "bcl" = (
@@ -33611,10 +33611,10 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bcs" = (
 /obj/machinery/door/poddoor/shutters{
@@ -33622,16 +33622,16 @@
 	name = "Mech Bay Shutters"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "bct" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "bcu" = (
 /turf/open/floor/plasteel/circuit,
@@ -33661,10 +33661,10 @@
 "bcy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bcz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33673,26 +33673,26 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bcA" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bcB" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bcC" = (
 /obj/structure/closet/crate/bin,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bcD" = (
 /obj/structure/rack,
@@ -33701,18 +33701,18 @@
 /obj/item/device/assembly/voice,
 /obj/item/clothing/head/welding,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bcE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bcF" = (
 /obj/machinery/computer/slot_machine,
@@ -33832,8 +33832,8 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -33855,10 +33855,10 @@
 	pixel_x = 26;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -33973,10 +33973,10 @@
 	tag = "icon-1-4";
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bde" = (
 /obj/structure/cable/white{
@@ -34052,10 +34052,10 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bdk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34072,10 +34072,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "bdl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34084,10 +34084,10 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "bdm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34168,8 +34168,8 @@
 	tag = "icon-0-4";
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bdu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34185,8 +34185,8 @@
 	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bdv" = (
 /obj/structure/table/reinforced,
@@ -34196,8 +34196,8 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/weapon/surgical_drapes,
 /obj/item/weapon/cautery,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bdw" = (
 /obj/machinery/holopad,
@@ -34220,8 +34220,8 @@
 /obj/machinery/ai_status_display{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bdz" = (
 /obj/structure/cable/white{
@@ -34234,8 +34234,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bdA" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -34245,10 +34245,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bdB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34270,11 +34270,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/storage/box/lights/mixed,
-/turf/open/floor/plasteel{
-	tag = "icon-warning (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-warning (EAST)"
 	},
 /area/maintenance/starboard)
 "bdD" = (
@@ -34426,18 +34426,18 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
 "bdP" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -34485,10 +34485,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "bdU" = (
 /obj/machinery/firealarm{
@@ -34582,8 +34582,8 @@
 	name = "Medbay Desk";
 	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/medbay3)
 "beb" = (
 /obj/structure/grille,
@@ -34624,10 +34624,10 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "beg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34641,10 +34641,10 @@
 	on = 1;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "beh" = (
 /obj/machinery/computer/mech_bay_power_console,
@@ -34666,15 +34666,15 @@
 	icon_state = "recharge_port";
 	dir = 8
 	},
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plating,
 /area/assembly/chargebay)
 "bek" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/research{
 	name = "Research Division"
 	})
@@ -34684,8 +34684,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/medical/research{
 	name = "Research Division"
 	})
@@ -34701,8 +34701,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "ben" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34712,8 +34712,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "beo" = (
 /obj/structure/table/reinforced,
@@ -34727,8 +34727,8 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bep" = (
 /obj/machinery/computer/operating,
@@ -34761,8 +34761,8 @@
 	desc = "Mirror mirror on the wall, who is the most robust of them all?";
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/assembly/robotics)
 "bes" = (
 /obj/structure/rack,
@@ -34783,10 +34783,10 @@
 	amount = 30
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "beu" = (
 /obj/structure/table/wood,
@@ -34908,11 +34908,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -34932,11 +34932,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/medical/medbay3)
 "beG" = (
@@ -35008,11 +35008,11 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/medical/research{
 	name = "Research Division"
@@ -35031,11 +35031,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/medical/research{
 	name = "Research Division"
@@ -35058,11 +35058,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/assembly/robotics)
 "beQ" = (
@@ -35104,8 +35104,8 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -35157,8 +35157,8 @@
 	icon_state = "manifold";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -35242,8 +35242,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -35308,11 +35308,11 @@
 	name = "Security Checkpoint";
 	req_access_txt = "63"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (WEST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (WEST)"
 	},
 /area/hallway/primary/central)
 "bfg" = (
@@ -35340,8 +35340,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bfi" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -35355,10 +35355,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bfj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -35369,8 +35369,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bfk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -35394,8 +35394,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bfm" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -35416,8 +35416,8 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bfn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -35435,8 +35435,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bfo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -35493,8 +35493,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bft" = (
 /obj/structure/cable/white{
@@ -35606,11 +35606,11 @@
 	icon_state = "intact";
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (WEST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (WEST)"
 	},
 /area/chapel/main)
 "bfC" = (
@@ -35661,8 +35661,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -35676,10 +35676,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
@@ -35806,11 +35806,11 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/toxins/xenobiology)
 "bfR" = (
@@ -35831,11 +35831,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/toxins/xenobiology)
 "bfS" = (
@@ -36068,8 +36068,8 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgm" = (
 /turf/open/floor/plasteel/vault{
@@ -36104,14 +36104,14 @@
 	pixel_x = -24;
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bgq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bgr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -36119,8 +36119,8 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bgs" = (
 /obj/structure/table/reinforced,
@@ -36136,8 +36136,8 @@
 	pixel_x = 24;
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bgt" = (
 /obj/machinery/camera{
@@ -36161,22 +36161,22 @@
 "bgv" = (
 /obj/machinery/biogenerator,
 /obj/item/weapon/wrench,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bgw" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bgx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bgy" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -36191,8 +36191,8 @@
 "bgz" = (
 /obj/machinery/seed_extractor,
 /obj/item/weapon/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bgA" = (
 /obj/machinery/hydroponics/soil,
@@ -36200,8 +36200,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/reagent_containers/food/snacks/grown/cherries,
 /obj/item/weapon/shovel/spade,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bgB" = (
 /obj/structure/mirror{
@@ -36382,11 +36382,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/secondary/entry{
 	name = "Arrivals"
@@ -36418,11 +36418,11 @@
 	name = "Arrivals Port"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/secondary/entry{
 	name = "Arrivals"
@@ -36437,11 +36437,11 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/secondary/entry{
 	name = "Arrivals"
@@ -36471,11 +36471,11 @@
 	name = "Arrivals Port"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/secondary/entry{
 	name = "Arrivals"
@@ -36539,8 +36539,8 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bhc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36633,8 +36633,8 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bhk" = (
 /turf/open/floor/plasteel/hydrofloor,
@@ -36663,8 +36663,8 @@
 /obj/structure/sign/botany{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bho" = (
 /obj/machinery/door/airlock/silver{
@@ -36777,10 +36777,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/chapel/main)
 "bhz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -36892,8 +36892,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -36926,8 +36926,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -36958,8 +36958,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bhP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36982,8 +36982,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bhS" = (
 /obj/structure/disposalpipe/trunk{
@@ -37001,8 +37001,8 @@
 /obj/item/seeds/harebell,
 /obj/item/weapon/reagent_containers/food/snacks/grown/watermelon,
 /obj/item/weapon/cultivator,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bhU" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -37012,36 +37012,36 @@
 	pixel_y = 3
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bhV" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/weapon/reagent_containers/food/snacks/grown/wheat,
 /obj/item/weapon/reagent_containers/glass/bottle/nutrient/ez,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bhW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bhX" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/weapon/reagent_containers/food/snacks/grown/tea,
 /obj/item/weapon/hatchet,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bhY" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/tower,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/reagent_containers/glass/bottle/nutrient/rh,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bhZ" = (
 /obj/structure/closet/wardrobe/chaplain_black,
@@ -37392,8 +37392,8 @@
 	dir = 1;
 	name = "arrivals camera"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -37408,12 +37408,12 @@
 	name = "emergency shower"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white{
 	tag = "icon-white_warn_end (WEST)";
 	icon_state = "white_warn_end"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
 	},
 /area/toxins/xenobiology)
 "biD" = (
@@ -37427,12 +37427,12 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white{
 	tag = "icon-white_warn_end (EAST)";
 	icon_state = "white_warn_end"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
 	},
 /area/toxins/xenobiology)
 "biE" = (
@@ -37470,10 +37470,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/chapel/main)
 "biI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -37521,38 +37521,31 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/chapel/main)
 "biN" = (
 /obj/machinery/light_switch{
 	pixel_x = -24;
 	pixel_y = -24
 	},
-/obj/machinery/button/door{
-	id = "chapelprivacy";
-	name = "Chemistry Shutter Control";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "0"
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/white{
-	tag = "icon-4-8";
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
 "biO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -37607,6 +37600,13 @@
 	icon_state = "wooden_chair";
 	dir = 8
 	},
+/obj/machinery/button/door{
+	id = "chapelprivacy";
+	name = "Chapel Privacy Shutters";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "0"
+	},
 /turf/open/floor/plasteel{
 	icon_state = "chapel"
 	},
@@ -37637,11 +37637,11 @@
 "biU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/secondary/entry{
 	name = "Arrivals"
@@ -37656,11 +37656,11 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/secondary/entry{
 	name = "Arrivals"
@@ -37684,8 +37684,8 @@
 	name = "Containment Control";
 	req_access_txt = "55"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "biY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -37702,26 +37702,26 @@
 /area/toxins/xenobiology)
 "biZ" = (
 /obj/machinery/monkey_recycler,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bja" = (
 /obj/machinery/processor/slime,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bjb" = (
 /obj/machinery/smartfridge/extract,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bjc" = (
 /obj/structure/grille,
@@ -37828,19 +37828,19 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
 "bjo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -37890,8 +37890,8 @@
 	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bjs" = (
 /turf/open/floor/plasteel/whitepurple/side{
@@ -37916,8 +37916,8 @@
 	icon_state = "intact";
 	dir = 6
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bjv" = (
 /obj/machinery/door/airlock/glass_research{
@@ -37929,8 +37929,8 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bjw" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden,
@@ -37988,19 +37988,19 @@
 /area/chapel/main)
 "bjB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
 "bjC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38037,10 +38037,10 @@
 	on = 1;
 	target_temperature = 80
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bjI" = (
 /turf/open/floor/plasteel/circuit/gcircuit{
@@ -38097,10 +38097,10 @@
 	pixel_x = -26;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38110,10 +38110,10 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plating,
 /area/shuttle/arrival)
 "bjO" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -38139,10 +38139,10 @@
 	c_tag = "Xenobilogy Lab";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bjQ" = (
 /obj/structure/table/reinforced,
@@ -38151,10 +38151,10 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bjR" = (
 /obj/machinery/computer/camera_advanced/xenobio,
@@ -38188,10 +38188,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bjT" = (
 /obj/structure/table/reinforced,
@@ -38217,10 +38217,10 @@
 	tag = "icon-0-8";
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/plasteel,
 /area/toxins/xenobiology)
 "bjU" = (
 /obj/machinery/status_display{
@@ -38231,10 +38231,10 @@
 	icon_state = "manifold";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38252,10 +38252,10 @@
 	on = 1;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38266,10 +38266,10 @@
 	icon_state = "heater";
 	dir = 1
 	},
-/turf/open/floor/plating,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plating,
 /area/shuttle/arrival)
 "bjX" = (
 /obj/structure/grille,
@@ -38380,12 +38380,12 @@
 	pixel_y = 9
 	},
 /obj/structure/closet/crate/internals,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bkd" = (
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bke" = (
 /obj/structure/table/reinforced,
@@ -38394,8 +38394,8 @@
 	c_tag = "Arrivals Suttle 1";
 	network = list("Labor")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bkf" = (
 /obj/structure/table/reinforced,
@@ -38407,32 +38407,32 @@
 	pixel_y = 3
 	},
 /obj/item/weapon/storage/firstaid/regular,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bkg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bkh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
 "bki" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fans/tiny,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38440,10 +38440,10 @@
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38454,10 +38454,10 @@
 	layer = 2.4;
 	on = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38467,10 +38467,10 @@
 	icon_state = "manifold";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38479,10 +38479,10 @@
 	name = "Arrival Shuttle Airlock";
 	req_access_txt = "0"
 	},
-/turf/open/floor/plasteel/white,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/arrival)
 "bkn" = (
 /turf/open/floor/plasteel/neutral/side{
@@ -38515,8 +38515,8 @@
 /area/shuttle/arrival)
 "bkr" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bks" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -38539,8 +38539,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38549,8 +38549,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38559,16 +38559,16 @@
 	dir = 4
 	},
 /obj/effect/landmark/latejoin,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bkw" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/landmark/latejoin,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bkx" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -38582,15 +38582,15 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
 "bkz" = (
 /obj/machinery/vending/cola,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38605,15 +38605,15 @@
 /obj/effect/landmark/start{
 	name = "Assistant"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
 "bkC" = (
 /obj/item/device/radio/beacon,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38632,8 +38632,8 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38667,15 +38667,15 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/clipboard,
 /obj/item/toy/figure/assistant,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bkJ" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder,
 /obj/item/weapon/storage/pill_bottle/dice,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bkK" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -38698,8 +38698,8 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bkN" = (
 /turf/open/floor/plasteel/neutral/side,
@@ -38728,18 +38728,18 @@
 	pixel_y = 3
 	},
 /obj/item/weapon/storage/secure/briefcase,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "bkS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	on = 1
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38752,11 +38752,11 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (WEST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (WEST)"
 	},
 /area/shuttle/arrival)
 "bkV" = (
@@ -38772,10 +38772,10 @@
 	on = 1;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38787,10 +38787,10 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38815,15 +38815,15 @@
 "blb" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
 "blc" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -38858,11 +38858,11 @@
 	dir = 4;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/turf/open/floor/plasteel{
+	tag = "icon-plasteel_warn_side (EAST)"
 	},
 /area/hallway/primary/central{
 	name = "Primary Hallway"
@@ -38889,8 +38889,8 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -38934,8 +38934,8 @@
 	dir = 8;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
@@ -38946,8 +38946,8 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central{
 	name = "Primary Hallway"
 	})
@@ -38964,10 +38964,10 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "blo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -39098,10 +39098,10 @@
 	dir = 8;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -39114,10 +39114,10 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
 	})
@@ -39129,6 +39129,108 @@
 	},
 /turf/open/floor/plasteel/blue,
 /area/shuttle/arrival)
+"blA" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Mass Driver Room";
+	req_access_txt = "27"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/chapel/main)
+"blB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/chapel/main)
+"blC" = (
+/obj/machinery/mass_driver{
+	id = "chapelgun"
+	},
+/turf/open/floor/plating,
+/area/chapel/main)
+"blD" = (
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Mass Driver";
+	req_access_txt = "22"
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 140;
+	on = 1;
+	pressure_checks = 0
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/chapel/main)
+"blE" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	tag = "icon-manifold-b-f (EAST)";
+	dir = 4
+	},
+/turf/closed/wall,
+/area/chapel/main)
+"blF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 140;
+	on = 1;
+	pressure_checks = 0
+	},
+/turf/open/floor/plating,
+/area/chapel/main)
+"blG" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Chapel Mass Driver";
+	dir = 8;
+	network = list("SS13")
+	},
+/obj/machinery/light/small,
+/obj/machinery/button/massdriver{
+	id = "chapelmassdoor";
+	name = "mass driver blast door button";
+	pixel_x = 24;
+	pixel_y = -8
+	},
+/obj/machinery/button/massdriver{
+	id = "chapelgun";
+	pixel_x = 24;
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/chapel/main)
+"blH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall,
+/area/chapel/main)
+"blI" = (
+/obj/machinery/door/poddoor{
+	id = "chapelmassdoor";
+	name = "Chapel Launcher Door"
+	},
+/turf/open/floor/plating,
+/area/chapel/main)
+"blJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/chapel/main)
 
 (1,1,1) = {"
 aaa
@@ -76286,9 +76388,9 @@ bfu
 big
 biM
 bfu
-aaa
-aaa
-aaa
+blC
+blF
+blI
 aaa
 aaa
 aaa
@@ -76542,10 +76644,10 @@ bgG
 bhs
 bih
 biN
-bfu
-aaa
-aaa
-aaa
+blA
+blD
+blG
+blJ
 aaa
 aaa
 aaa
@@ -76799,10 +76901,10 @@ bgH
 bht
 bii
 biO
-bjl
-aaa
-aaa
-aaa
+blB
+blE
+blH
+bfu
 aaa
 aaa
 aaa
@@ -77827,7 +77929,7 @@ bgL
 bhw
 bim
 biS
-bjm
+bfu
 aaa
 aaa
 aaa
@@ -82709,7 +82811,7 @@ blu
 bgY
 bgm
 bfP
-blw
+blu
 bgY
 bgm
 bfP


### PR DESCRIPTION
##  **Adds Mass Driver To Chapel On Omegastation**
Adds a room for a Massdriver on Omegastation this is to allow the Chaplin to be able to more accurately play his role and it also allows Traitors a means of disposing bodies after they kill someone that is if they are able to get to the chapel without being caught. This is also to follow other map standards, most other maps contain a Massdriver so there is no reason this map should not also have one.

## **Pictures**
![capture](https://cloud.githubusercontent.com/assets/24999255/22462439/680db2f6-e801-11e6-928a-7deee1388735.PNG)

## **Changelog**
:cl: Tofa01
Add: [Omega] Adds a Massdriver room to chapel on Omegastation.
/:cl:
