### PR TITLE
Swaps the tier of Vitality Matrix and Fellowship Armory

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -272,6 +272,7 @@
 	resist_string = "glows shimmering yellow"
 	sigil_name = "Vitality Matrix"
 	var/static/vitality = 0
+	var/base_revive_cost = 20
 	var/sigil_active = FALSE
 	var/animation_number = 3 //each cycle increments this by 1, at 4 it produces an animation and resets
 	var/static/list/damage_heal_order = list(CLONE, TOX, BURN, BRUTE, OXY) //we heal damage in this order
@@ -283,7 +284,7 @@
 		if(ratvar_awakens)
 			user << "<span class='inathneq_small'>It can revive Servants at no cost!</span>"
 		else
-			user << "<span class='inathneq_small'>It can revive Servants at a cost of vitality equal to the damage they have, in addition to being destroyed in the process.</span>"
+			user << "<span class='inathneq_small'>It can revive Servants at a cost of <b>[base_revive_cost]</b> vitality plus vitality equal to the non-oxygen damage they have, in addition to being destroyed in the process.</span>"
 
 /obj/effect/clockwork/sigil/vitality/sigil_effects(mob/living/L)
 	if((is_servant_of_ratvar(L) && L.suiciding) || sigil_active)
@@ -323,7 +324,7 @@
 				break
 		else
 			if(L.stat == DEAD)
-				var/revival_cost = L.getCloneLoss() + L.getToxLoss() + L.getFireLoss() + L.getBruteLoss() + L.getOxyLoss()
+				var/revival_cost = base_revive_cost + L.getCloneLoss() + L.getToxLoss() + L.getFireLoss() + L.getBruteLoss() //ignores oxygen damage
 				if(ratvar_awakens)
 					revival_cost = 0
 				var/mob/dead/observer/ghost = L.get_ghost(TRUE)

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_armor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_armor.dm
@@ -187,6 +187,9 @@
 	all_clockwork_objects -= src
 	return ..()
 
+/obj/item/clothing/shoes/clockwork/negates_gravity()
+	return TRUE
+
 /obj/item/clothing/shoes/clockwork/ratvar_act()
 	if(ratvar_awakens)
 		flags |= NOSLIP

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
@@ -58,8 +58,8 @@
 	/datum/clockwork_scripture/create_object/soul_vessel, /datum/clockwork_scripture/create_object/sigil_of_transmission, /datum/clockwork_scripture/create_object/interdiction_lens)
 
 /obj/item/clockwork/slab/cyborg/medical //five scriptures, plus a spear
-	quickbound = list(/datum/clockwork_scripture/ranged_ability/linked_vanguard, /datum/clockwork_scripture/ranged_ability/sentinels_compromise, /datum/clockwork_scripture/fellowship_armory, \
-	/datum/clockwork_scripture/create_object/vitality_matrix, /datum/clockwork_scripture/create_object/mending_motor)
+	quickbound = list(/datum/clockwork_scripture/ranged_ability/linked_vanguard, /datum/clockwork_scripture/ranged_ability/sentinels_compromise, \
+	/datum/clockwork_scripture/create_object/vitality_matrix, /datum/clockwork_scripture/fellowship_armory, /datum/clockwork_scripture/create_object/mending_motor)
 
 /obj/item/clockwork/slab/cyborg/security //four scriptures, plus a spear
 	quickbound = list(/datum/clockwork_scripture/channeled/belligerent, /datum/clockwork_scripture/ranged_ability/judicial_marker, /datum/clockwork_scripture/channeled/taunting_tirade, \
@@ -75,7 +75,7 @@
 
 /obj/item/clockwork/slab/cyborg/service //five scriptures, plus xray vision
 	quickbound = list(/datum/clockwork_scripture/create_object/replicant, /datum/clockwork_scripture/create_object/tinkerers_cache, \
-	/datum/clockwork_scripture/fellowship_armory, /datum/clockwork_scripture/spatial_gateway, /datum/clockwork_scripture/create_object/clockwork_obelisk)
+	/datum/clockwork_scripture/spatial_gateway, /datum/clockwork_scripture/fellowship_armory, /datum/clockwork_scripture/create_object/clockwork_obelisk)
 
 /obj/item/clockwork/slab/cyborg/miner //three scriptures, plus a spear and xray vision
 	quickbound = list(/datum/clockwork_scripture/ranged_ability/linked_vanguard, /datum/clockwork_scripture/spatial_gateway, /datum/clockwork_scripture/channeled/volt_void/cyborg)

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -24,26 +24,71 @@
 	quickbind_desc = "Creates a Sigil of Accession, which can convert a mindshielded non-Servant that remains on it."
 
 
-//Vitality Matrix: Creates a sigil which will drain health from nonservants and can use that health to heal or even revive servants.
-/datum/clockwork_scripture/create_object/vitality_matrix
-	descname = "Trap, Damage to Healing"
-	name = "Vitality Matrix"
-	desc = "Scribes a sigil beneath the invoker which drains life from any living non-Servants that cross it. Servants that cross it, however, will be healed based on how much it drained from non-Servants. \
-	Dead Servants can be revived by this sigil if it has enough stored vitality."
-	invocations = list("Divinity...", "...steal their life...", "...for these shells!")
-	channel_time = 70
-	consumed_components = list(BELLIGERENT_EYE = 1, VANGUARD_COGWHEEL = 2, HIEROPHANT_ANSIBLE = 1)
-	whispered = TRUE
-	object_path = /obj/effect/clockwork/sigil/vitality
-	creator_message = "<span class='brass'>A vitality matrix appears below you. It will drain life from non-Servants and heal Servants that cross it.</span>"
-	usage_tip = "To revive a Servant, the sigil must have 20 vitality plus the target Servant's non-oxygen damage. It will still heal dead Servants if it lacks the vitality to outright revive them."
+//Fellowship Armory: Arms the invoker and nearby servants with Ratvarian armor.
+/datum/clockwork_scripture/fellowship_armory
+	descname = "Area Servant Armor"
+	name = "Fellowship Armory"
+	desc = "Equips the invoker and all visible Servants with Ratvarian armor. This armor provides high melee resistance but a weakness to lasers. \
+	It grows faster to invoke with more adjacent Servants."
+	invocations = list("Shield us...", "...with the...", "... fragments of Engine!")
+	channel_time = 100
+	consumed_components = list(VANGUARD_COGWHEEL = 2, REPLICANT_ALLOY = 1, HIEROPHANT_ANSIBLE = 1)
+	usage_tip = "This scripture will replace all weaker armor worn by affected Servants."
 	tier = SCRIPTURE_APPLICATION
-	one_per_tile = TRUE
+	multiple_invokers_used = TRUE
+	multiple_invokers_optional = TRUE
 	primary_component = VANGUARD_COGWHEEL
 	sort_priority = 2
 	quickbind = TRUE
-	quickbind_desc = "Creates a Vitality Matrix, which drains non-Servants on it to heal Servants that cross it."
+	quickbind_desc = "Attempts to armor all nearby Servants with powerful Ratvarian armor."
+	var/static/list/ratvarian_armor_typecache = typecacheof(list(
+	/obj/item/clothing/suit/armor/clockwork,
+	/obj/item/clothing/head/helmet/clockwork,
+	/obj/item/clothing/gloves/clockwork,
+	/obj/item/clothing/shoes/clockwork)) //don't replace this ever
+	var/static/list/better_armor_typecache = typecacheof(list(
+	/obj/item/clothing/suit/space,
+	/obj/item/clothing/head/helmet/space,
+	/obj/item/clothing/shoes/magboots)) //replace this only if ratvar is up
 
+/datum/clockwork_scripture/fellowship_armory/run_scripture()
+	for(var/mob/living/L in orange(1, get_turf(invoker)))
+		if(is_servant_of_ratvar(L) && L.can_speak_vocal())
+			channel_time = max(channel_time - 10, 0)
+	return ..()
+
+/datum/clockwork_scripture/fellowship_armory/scripture_effects()
+	var/affected = 0
+	for(var/mob/living/L in view(7, invoker))
+		if(!is_servant_of_ratvar(L))
+			continue
+		var/do_message = 0
+		var/obj/item/I = L.get_item_by_slot(slot_wear_suit)
+		if(remove_item_if_better(I, L))
+			do_message += L.equip_to_slot_or_del(new/obj/item/clothing/suit/armor/clockwork(null), slot_wear_suit)
+		I = L.get_item_by_slot(slot_head)
+		if(remove_item_if_better(I, L))
+			do_message += L.equip_to_slot_or_del(new/obj/item/clothing/head/helmet/clockwork(null), slot_head)
+		I = L.get_item_by_slot(slot_gloves)
+		if(remove_item_if_better(I, L))
+			do_message += L.equip_to_slot_or_del(new/obj/item/clothing/gloves/clockwork(null), slot_gloves)
+		I = L.get_item_by_slot(slot_shoes)
+		if(remove_item_if_better(I, L))
+			do_message += L.equip_to_slot_or_del(new/obj/item/clothing/shoes/clockwork(null), slot_shoes)
+		if(do_message)
+			L.visible_message("<span class='warning'>Strange armor appears on [L]!</span>", "<span class='heavy_brass'>A bright shimmer runs down your body, equipping you with Ratvarian armor.</span>")
+			playsound(L, 'sound/magic/clockwork/fellowship_armory.ogg', 15*do_message, 1) //get sound loudness based on how much we equipped
+			affected++
+	return affected
+
+/datum/clockwork_scripture/fellowship_armory/proc/remove_item_if_better(obj/item/I, mob/user)
+	if(!I)
+		return TRUE
+	if(is_type_in_typecache(I, ratvarian_armor_typecache))
+		return FALSE
+	if(!ratvar_awakens && is_type_in_typecache(I, better_armor_typecache))
+		return FALSE
+	return user.dropItemToGround(I)
 
 //Memory Allocation: Finds a willing ghost and makes them into a clockwork marauders for the invoker.
 /datum/clockwork_scripture/memory_allocation
@@ -254,7 +299,7 @@
 	desc = "Creates a clockwork obelisk that can broadcast messages over the Hierophant Network or open a Spatial Gateway to any living servant or clockwork obelisk."
 	invocations = list("May this obelisk...", "...take us to all places!")
 	channel_time = 80
-	consumed_components = list(VANGUARD_COGWHEEL = 1, REPLICANT_ALLOY = 1, HIEROPHANT_ANSIBLE = 3)
+	consumed_components = list(BELLIGERENT_EYE = 1, VANGUARD_COGWHEEL = 1, HIEROPHANT_ANSIBLE = 3)
 	object_path = /obj/structure/destructible/clockwork/powered/clockwork_obelisk
 	creator_message = "<span class='brass'>You form a clockwork obelisk which can broadcast messages or produce Spatial Gateways.</span>"
 	observer_message = "<span class='warning'>A brass obelisk appears handing in midair!</span>"

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -52,15 +52,15 @@
 	/obj/item/clothing/shoes/magboots)) //replace this only if ratvar is up
 
 /datum/clockwork_scripture/fellowship_armory/run_scripture()
-	for(var/mob/living/L in orange(1, get_turf(invoker)))
-		if(is_servant_of_ratvar(L) && L.can_speak_vocal())
+	for(var/mob/living/L in orange(1, invoker))
+		if(is_servant_of_ratvar(L) && L.stat == CONSCIOUS && L.can_speak_vocal())
 			channel_time = max(channel_time - 10, 0)
 	return ..()
 
 /datum/clockwork_scripture/fellowship_armory/scripture_effects()
 	var/affected = 0
-	for(var/mob/living/L in view(7, invoker))
-		if(!is_servant_of_ratvar(L))
+	for(var/mob/living/L in view(7, get_turf(invoker)))
+		if(L.stat == DEAD || !is_servant_of_ratvar(L))
 			continue
 		var/do_message = 0
 		var/obj/item/I = L.get_item_by_slot(slot_wear_suit)

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
@@ -53,7 +53,7 @@
 	descname = "Trap, Damage to Healing"
 	name = "Vitality Matrix"
 	desc = "Scribes a sigil beneath the invoker which drains life from any living non-Servants that cross it. Servants that cross it, however, will be healed based on how much Vitality all \
-	Matrices have drained from non-Servants. Dead Servants can be revived by this sigil if there is vitality equal to the target Servant's damage."
+	Matrices have drained from non-Servants. Dead Servants can be revived by this sigil if there is vitality equal to the target Servant's non-oxygen damage."
 	invocations = list("Divinity...", "...steal their life...", "...for these shells!")
 	channel_time = 60
 	consumed_components = list(BELLIGERENT_EYE = 1, VANGUARD_COGWHEEL = 1)

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
@@ -48,45 +48,25 @@
 	quickbind_desc = "Creates a Cogscarab Shell, which produces a Cogscarab when filled with a Soul Vessel."
 
 
-//Fellowship Armory: Arms the invoker and nearby servants with Ratvarian armor.
-/datum/clockwork_scripture/fellowship_armory
-	descname = "Area Servant Armor"
-	name = "Fellowship Armory"
-	desc = "Equips the invoker and any nearby servants with Ratvarian armor. This armor provides high melee resistance but a weakness to lasers. \
-	It grows faster to invoke with more nearby servants."
-	invocations = list("Shield us...", "...with the...", "... fragments of Engine!")
-	channel_time = 100
-	consumed_components = list(VANGUARD_COGWHEEL = 1, REPLICANT_ALLOY = 1)
-	usage_tip = "Before using, advise adjacent allies to remove their helmets, external suits, gloves, and shoes."
+//Vitality Matrix: Creates a sigil which will drain health from nonservants and can use that health to heal or even revive servants.
+/datum/clockwork_scripture/create_object/vitality_matrix
+	descname = "Trap, Damage to Healing"
+	name = "Vitality Matrix"
+	desc = "Scribes a sigil beneath the invoker which drains life from any living non-Servants that cross it. Servants that cross it, however, will be healed based on how much Vitality all \
+	Matrices have drained from non-Servants. Dead Servants can be revived by this sigil if there is vitality equal to the target Servant's damage."
+	invocations = list("Divinity...", "...steal their life...", "...for these shells!")
+	channel_time = 60
+	consumed_components = list(BELLIGERENT_EYE = 1, VANGUARD_COGWHEEL = 1)
+	whispered = TRUE
+	object_path = /obj/effect/clockwork/sigil/vitality
+	creator_message = "<span class='brass'>A vitality matrix appears below you. It will drain life from non-Servants and heal Servants that cross it.</span>"
+	usage_tip = "The sigil will be consumed upon reviving a Servant."
 	tier = SCRIPTURE_SCRIPT
-	multiple_invokers_used = TRUE
-	multiple_invokers_optional = TRUE
+	one_per_tile = TRUE
 	primary_component = VANGUARD_COGWHEEL
-	sort_priority = 4
+	sort_priority = 3
 	quickbind = TRUE
-	quickbind_desc = "Attempts to armor all nearby Servants with powerful Ratvarian armor."
-
-/datum/clockwork_scripture/fellowship_armory/run_scripture()
-	for(var/mob/living/L in orange(1, get_turf(invoker)))
-		if(is_servant_of_ratvar(L) && L.can_speak_vocal())
-			channel_time = max(channel_time - 10, 0)
-	return ..()
-
-/datum/clockwork_scripture/fellowship_armory/scripture_effects()
-	var/affected = 0
-	for(var/mob/living/L in range(1, invoker))
-		if(!is_servant_of_ratvar(L))
-			continue
-		var/do_message = 0
-		do_message += L.equip_to_slot_or_del(new/obj/item/clothing/head/helmet/clockwork(null), slot_head)
-		do_message += L.equip_to_slot_or_del(new/obj/item/clothing/suit/armor/clockwork(null), slot_wear_suit)
-		do_message += L.equip_to_slot_or_del(new/obj/item/clothing/gloves/clockwork(null), slot_gloves)
-		do_message += L.equip_to_slot_or_del(new/obj/item/clothing/shoes/clockwork(null), slot_shoes)
-		if(do_message)
-			L.visible_message("<span class='warning'>Strange armor appears on [L]!</span>", "<span class='heavy_brass'>A bright shimmer runs down your body, equipping you with Ratvarian armor.</span>")
-			playsound(L, 'sound/magic/clockwork/fellowship_armory.ogg', 15*do_message, 1) //get sound loudness based on how much we equipped
-			affected++
-	return affected
+	quickbind_desc = "Creates a Vitality Matrix, which drains non-Servants on it to heal Servants that cross it."
 
 
 //Sigil of Submission: Creates a sigil of submission, which converts one heretic above it after a delay.

--- a/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
@@ -40,7 +40,7 @@
 			return head
 		if(slot_generic_dextrous_storage)
 			return internal_storage
-	..()
+	return ..()
 
 
 /mob/living/simple_animal/drone/equip_to_slot(obj/item/I, slot)


### PR DESCRIPTION
:cl: Joan
wip: The Vitality Matrix scripture is now a Script, from an Application. Its cost has been accordingly adjusted.
tweak: Vitality Matrices will be consumed upon successfully reviving a Servant. They also drain and heal conscious targets slightly slower.
wip: The Fellowship Armory scripture is now an Application, from a Script. Its cost has been accordingly adjusted.
tweak: Fellowship Armory now affects all Servants in view of the invoker, and will replace weaker gear and armor with its Ratvarian armor. Also, clockwork treads now allow you to move in no gravity like magboots.
/:cl:

Fellowship Armory really only shows up later, because it's really fucking obvious and makes you a big target, but it was a little difficult to use.
So, making it more obviously a later, more powerful thing!

Vitality Matrices, by contrast, are something you really want early so that you can try and get anybody who dies back up, especially given that they're reliant on having drained a lot of vitality so you can do that at all.
So, dropping them a tier and making them slower and a bit more costly for multiple revives!
