### PR TITLE
[s]Fixes exotic_blood not being deleted or processed

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -700,7 +700,7 @@
 /datum/species/proc/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.id == exotic_blood)
 		H.blood_volume = min(H.blood_volume + round(chem.volume, 0.1), BLOOD_VOLUME_MAXIMUM)
-		H.reagents.remove_reagent(chem.id)
+		H.reagents.del_reagent(chem.id)
 		return 1
 	return 0
 


### PR DESCRIPTION
...causing slimepeople to not only never consume the slime jelly in their veins, but to gain the same amount of blood volume every tick, making it possible to split every two seconds.

Fixes #21600.