### PR TITLE
Makes frames unanchored by default

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -1,7 +1,6 @@
 /obj/structure/frame/computer
 	name = "computer frame"
 	icon_state = "0"
-	anchored = 0
 	state = 0
 
 /obj/structure/frame/computer/attackby(obj/item/P, mob/user, params)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "box_0"
 	density = 1
-	anchored = 1
 	obj_integrity = 250
 	max_integrity = 250
 	var/obj/item/weapon/circuitboard/circuit = null


### PR DESCRIPTION
Fixes #23547

:cl: Cyberboss
tweak: Machine frames will no longer be anchored when created
/:cl:
