### PR TITLE
Fix /obj/machinery/porta_turret failing to GC

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -68,6 +68,8 @@
 
 	var/datum/effect_system/spark_spread/spark_system	//the spark system, used for generating... sparks?
 
+	var/obj/machinery/turretid/cp = null
+
 /obj/machinery/porta_turret/New(loc)
 	..()
 	if(!base)
@@ -139,6 +141,15 @@
 	if(cover)
 		qdel(cover)
 		cover = null
+	base = null
+	if(cp)
+		cp.turrets -= src
+		cp = null
+	if(stored_gun)
+		qdel(stored_gun)
+		stored_gun = null
+	qdel(spark_system)
+	spark_system = null
 	return ..()
 
 
@@ -587,6 +598,10 @@
 		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0
 	power_change() //Checks power and initial settings
 
+/obj/machinery/turretid/Destroy()
+	turrets.Cut()
+	return ..()
+
 /obj/machinery/turretid/Initialize(mapload) //map-placed turrets autolink turrets
 	..()
 	if(!mapload)
@@ -607,6 +622,7 @@
 
 	for(var/obj/machinery/porta_turret/T in control_area)
 		turrets |= T
+		T.cp = src
 
 /obj/machinery/turretid/attackby(obj/item/I, mob/user, params)
 	if(stat & BROKEN) return


### PR DESCRIPTION
```
## TESTING: Beginning search for references to a /obj/machinery/porta_turret/ai.
## TESTING: Found /obj/machinery/porta_turret/ai [0x2009f22] in /obj/machinery/porta_turret/ai's base var.
## TESTING: Found /obj/machinery/porta_turret/ai [0x2009f22] in /obj/machinery/turretid's turrets list var.
## TESTING: Completed search for references to a /obj/machinery/porta_turret/ai.
## TESTING: GC: -- [0x2009f22] | /obj/machinery/porta_turret/ai was unable to be GC'd and was deleted --
```