### PR TITLE
Possibly fixes /obj/structure/camera_assembly failing to GC?

### DIFF
--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -31,6 +31,12 @@
 	if(building)
 		setDir(ndir)
 
+/obj/structure/camera_assembly/Destroy()
+	for(var/I in upgrades)
+		qdel(I)
+	upgrades.Cut()
+	return ..()
+
 /obj/structure/camera_assembly/attackby(obj/item/W, mob/living/user, params)
 	switch(state)
 		if(1)


### PR DESCRIPTION
I'm not sure of this one

```
## TESTING: Beginning search for references to a /obj/item/device/assembly/prox_sensor.
## TESTING: Found /obj/item/device/assembly/prox_sensor [0x2009cd3] in /obj/structure/camera_assembly's upgrades list var.
## TESTING: Completed search for references to a /obj/item/device/assembly/prox_sensor.
## TESTING: GC: -- [0x2009cd3] | /obj/item/device/assembly/prox_sensor was unable to be GC'd and was deleted --
## TESTING: Beginning search for references to a /obj/machinery/camera/motion.
## TESTING: Found /obj/machinery/camera/motion [0x2009cd1] in /area/ai_monitored/turret_protected/ai_upload's motioncameras list var.
## TESTING: Completed search for references to a /obj/machinery/camera/motion.
## TESTING: GC: -- [0x2009cd1] | /obj/machinery/camera/motion was unable to be GC'd and was deleted --
## TESTING: Beginning search for references to a /obj/item/device/assembly/prox_sensor.
## TESTING: Found /obj/item/device/assembly/prox_sensor [0x2009cde] in /obj/structure/camera_assembly's upgrades list var.
Tue Jan 31 17:07:39 2017
## TESTING: Completed search for references to a /obj/item/device/assembly/prox_sensor.
## TESTING: GC: -- [0x2009cde] | /obj/item/device/assembly/prox_sensor was unable to be GC'd and was deleted --
```