### PR TITLE
Gives [dead] people assurance badmins are not at work.

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -97,6 +97,7 @@ var/datum/subsystem/events/SSevent
 				continue
 			if (E.alertadmins)
 				message_admins("Random Event triggering: [E.name] ([E.typepath])")
+				deadchat_broadcast("[E.name] has just been randomly triggered!") //STOP ASSUMING IT'S BADMINS!
 			log_game("Random Event triggering: [E.name] ([E.typepath])")
 			return
 


### PR DESCRIPTION
:cl: Cobby
add: Ghosts will now be informed when an event has been triggered by our lovely RNG system.
/:cl:

Reason: People assume anything round altering was done by the work of conspiring admins and that we are simply lying to them when we say otherwise. This informs them they are wrong and their tin foil could be better placed elsewhere.

If a random event would not tell an admin, it does not tell the player. Does not inform individuals of round-start events or events triggered by admins.