### PR TITLE
As usual, I fucked up

### DIFF
--- a/code/controllers/subsystem/processing/objects.dm
+++ b/code/controllers/subsystem/processing/objects.dm
@@ -26,12 +26,14 @@ var/datum/subsystem/objects/SSobj
 /datum/subsystem/objects/Initialize(timeofdayl)
 	fire_overlay.appearance_flags = RESET_COLOR
 	setupGenetics() //to set the mutations' place in structural enzymes, so monkey.initialize() knows where to put the monkey mutation.
+	initialized = INITIALIZATION_INNEW_MAPLOAD
 	InitializeAtoms()
 	. = ..()
 
 /datum/subsystem/objects/proc/InitializeAtoms(list/objects = null)
+	if(initialized == INITIALIZATION_INSSOBJ)
+		return
 	initialized = INITIALIZATION_INNEW_MAPLOAD
-
 	if(objects)
 		for(var/thing in objects)
 			var/atom/A = thing
@@ -45,7 +47,6 @@ var/datum/subsystem/objects/SSobj
 				if(start_tick != world.time)
 					WARNING("[A]: [A.type] slept during it's Initialize!")
 				CHECK_TICK
-
 	initialized = INITIALIZATION_INNEW_REGULAR
 
 /datum/subsystem/objects/proc/map_loader_begin()


### PR DESCRIPTION
```
runtime error: 
[23:46:17]Warning: the plating(/turf/open/floor/plating) initialized multiple times!
runtime error: 
[23:46:17]Warning: the plating(/turf/open/floor/plating/airless) initialized multiple times!
runtime error: 
[23:46:17]Warning: the plating(/turf/open/floor/plating/airless) initialized multiple times!
runtime error: 
[23:46:17]Warning: the plating(/turf/open/floor/plating/airless) initialized multiple times!
runtime error: 
[23:46:17]Warning: the plating(/turf/open/floor/plating/airless) initialized multiple times!
runtime error: 
[23:46:17]Warning: the plating(/turf/open/floor/plating/airless) initialized multiple times!
runtime error: 
[23:46:17]Warning: the plating(/turf/open/floor/plating/airless) initialized multiple times!
```
TL;DR Mapping subsystem was calling Initialize, which it should never do
WTF is subsystem initialization order
Fixes critical bug caused by #23274 
@optimumtact speedmerbeg