### PR TITLE
Mania Motors are slightly less instant at conversion

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
@@ -66,8 +66,8 @@
 		if(is_servant_of_ratvar(H) || H.null_rod_check() || H.stat == DEAD)
 			continue
 		if(!H.Adjacent(src))
-			 H << "<span class='sevtug'>\"[text2ratvar(pick(close_messages))]\"</span>"
-			 continue
+			H << "<span class='sevtug'>\"[text2ratvar(pick(close_messages))]\"</span>"
+			continue
 		if(try_use_power(convert_cost))
 			H.playsound_local(T, hum, 80, 1)
 			if(!H.stat)

--- a/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
@@ -14,9 +14,8 @@
 	debris = list(/obj/item/clockwork/alloy_shards/large = 1, \
 	/obj/item/clockwork/alloy_shards/small = 3, \
 	/obj/item/clockwork/component/geis_capacitor/antennae = 1)
-	var/mania_cost = 200
-	var/convert_attempt_cost = 500
-	var/convert_cost = 500
+	var/mania_cost = 150
+	var/convert_cost = 150
 	var/static/list/mania_messages = list("Go nuts.", "Take a crack at crazy.", "Make a bid for insanity.", "Get kooky.", "Move towards mania.", "Become bewildered.", "Wax wild.", \
 	"Go round the bend.", "Land in lunacy.", "Try dementia.", "Strive to get a screw loose.")
 	var/static/list/compel_messages = list("Come closer.", "Approach the transmitter.", "Touch the antennae.", "I always have to deal with idiots. Move towards the mania motor.", \
@@ -28,11 +27,10 @@
 	"Amazing. You somehow managed to wedge yourself somewhere you can't actually reach the motor from.", "Such a show of idiocy is unparalleled. Perhaps I should put you on display?", \
 	"Did you do this on purpose? I can't imagine you doing so accidentally. Oh, wait, I can.", "How is it that such smart creatures can still do something AS STUPID AS THIS!")
 
-
 /obj/structure/destructible/clockwork/powered/mania_motor/examine(mob/user)
 	..()
 	if(is_servant_of_ratvar(user) || isobserver(user))
-		user << "<span class='sevtug_small'>It requires <b>[mania_cost]W</b> to run, and <b>[convert_attempt_cost + convert_cost]W</b> to convert humans adjecent to it.</span>"
+		user << "<span class='sevtug_small'>It requires <b>[mania_cost]W</b> to run, and at least <b>[convert_cost]W</b> to attempt to convert humans adjecent to it.</span>"
 
 /obj/structure/destructible/clockwork/powered/mania_motor/forced_disable(bad_effects)
 	if(active)
@@ -58,94 +56,88 @@
 		SetLuminosity(0)
 
 /obj/structure/destructible/clockwork/powered/mania_motor/process()
-	if(try_use_power(mania_cost))
-		var/turf/T = get_turf(src)
-		var/hum = get_sfx('sound/effects/screech.ogg') //like playsound, same sound for everyone affected
-		var/efficiency = get_efficiency_mod()
-		for(var/mob/living/carbon/human/H in view(1, src))
-			if(is_servant_of_ratvar(H) || H.null_rod_check())
-				continue
-			if(H.Adjacent(src) && try_use_power(convert_attempt_cost))
-				if(is_eligible_servant(H) && try_use_power(convert_cost))
-					H << "<span class='sevtug'>\"[text2ratvar("You are mine and his, now.")]\"</span>"
-					H.playsound_local(T, hum, 80, 1)
-					add_servant_of_ratvar(H)
-					H.Paralyse(5)
-				else if(!H.stat)
-					if(H.getBrainLoss() >= 100)
-						H.Paralyse(5)
-						H << "<span class='sevtug'>\"[text2ratvar(pick(convert_messages))]\"</span>"
-					else
-						H.adjustBrainLoss(100 * efficiency)
-						H.visible_message("<span class='warning'>[H] reaches out and touches [src].</span>", "<span class='sevtug'>You touch [src] involuntarily.</span>")
-			else
-				visible_message("<span class='warning'>[src]'s antennae fizzle quietly.</span>")
-				playsound(src, 'sound/effects/light_flicker.ogg', 50, 1)
-		for(var/mob/living/carbon/human/H in range(10, src))
-			if(is_servant_of_ratvar(H))
-				if(H.getBrainLoss() || H.hallucination || H.druggy || H.dizziness || H.confused)
-					H.adjustBrainLoss(-H.getBrainLoss()) //heals servants of braindamage, hallucination, druggy, dizziness, and confusion
-					H.hallucination = 0
-					H.adjust_drugginess(-H.druggy)
-					H.dizziness = 0
-					H.confused = 0
-			else if(!H.null_rod_check() && H.stat == CONSCIOUS)
-				var/distance = get_dist(T, get_turf(H))
-				var/falloff_distance = min((110) - distance * 10, 80)
-				var/sound_distance = falloff_distance * 0.5
-				var/targetbrainloss = H.getBrainLoss()
-				if(distance >= 4 && prob(falloff_distance * 0.5))
-					H << "<span class='sevtug_small'>\"[text2ratvar(pick(mania_messages))]\"</span>"
-				H.playsound_local(T, hum, sound_distance, 1)
-				switch(distance)
-					if(2 to 3)
-						if(prob(falloff_distance * 0.5))
-							if(prob(falloff_distance))
-								H << "<span class='sevtug_small'>\"[text2ratvar(pick(mania_messages))]\"</span>"
-							else
-								H << "<span class='sevtug'>\"[text2ratvar(pick(compel_messages))]\"</span>"
-						if(targetbrainloss <= 50)
-							H.adjustBrainLoss((50 * efficiency) - targetbrainloss) //got too close had brain eaten
-						H.adjust_drugginess(Clamp(7 * efficiency, 0, 100 - H.druggy))
-						H.hallucination = min(H.hallucination + (7 * efficiency), 100)
-						H.dizziness = min(H.dizziness + (3 * efficiency), 45)
-						H.confused = min(H.confused + (3 * efficiency), 45)
-					if(4 to 5)
-						if(targetbrainloss <= 50)
-							H.adjustBrainLoss(1 * efficiency)
-						H.adjust_drugginess(Clamp(5 * efficiency, 0, 80 - H.druggy))
-						H.hallucination = min(H.hallucination + (5 * efficiency), 80)
-						H.dizziness = min(H.dizziness + (2 * efficiency), 30)
-						H.confused = min(H.confused + (2 * efficiency), 30)
-					if(6 to 7)
-						if(targetbrainloss <= 30)
-							H.adjustBrainLoss(1 * efficiency)
-						H.adjust_drugginess(Clamp(2 * efficiency, 0, 60 - H.druggy))
-						H.hallucination = min(H.hallucination + (2 * efficiency), 60)
-						H.dizziness = min(H.dizziness + (2 * efficiency), 15)
-						H.confused = min(H.confused + (2 * efficiency), 15)
-					if(8 to 9)
-						if(targetbrainloss <= 10)
-							H.adjustBrainLoss(1 * efficiency)
-						H.adjust_drugginess(Clamp(2 * efficiency, 0, 40 - H.druggy))
-						H.hallucination = min(H.hallucination + (2 * efficiency), 40)
-					if(10 to INFINITY)
-						H.adjust_drugginess(Clamp(2 * efficiency, 0, 20 - H.druggy))
-						H.hallucination = min(H.hallucination + (2 * efficiency), 20)
-					else //if it's a distance of 1 and they can't see it/aren't adjacent or they're on top of it(how'd they get on top of it and still trigger this???)
-						if(prob(falloff_distance * 0.5))
-							if(prob(falloff_distance))
-								H << "<span class='sevtug'>\"[text2ratvar(pick(compel_messages))]\"</span>"
-							else if(prob(falloff_distance * 0.5))
-								H << "<span class='sevtug'>\"[text2ratvar(pick(close_messages))]\"</span>"
-							else
-								H << "<span class='sevtug_small'>\"[text2ratvar(pick(mania_messages))]\"</span>"
-						if(targetbrainloss <= 99)
-							H.adjustBrainLoss((99 * efficiency) - targetbrainloss)
-						H.adjust_drugginess(Clamp(10 * efficiency, 0, 150 - H.druggy))
-						H.hallucination = min(H.hallucination + (10 * efficiency), 150)
-						H.dizziness = min(H.dizziness + (5 * efficiency), 60)
-						H.confused = min(H.confused + (5 * efficiency), 60)
-
-	else
+	if(!try_use_power(mania_cost))
 		forced_disable(FALSE)
+		return
+	var/turf/T = get_turf(src)
+	var/hum = get_sfx('sound/effects/screech.ogg') //like playsound, same sound for everyone affected
+	var/efficiency = get_efficiency_mod()
+	for(var/mob/living/carbon/human/H in view(1, src))
+		if(is_servant_of_ratvar(H) || H.null_rod_check() || H.stat == DEAD)
+			continue
+		if(!H.Adjacent(src))
+			 H << "<span class='sevtug'>\"[text2ratvar(pick(close_messages))]\"</span>"
+			 continue
+		if(try_use_power(convert_cost))
+			H.playsound_local(T, hum, 80, 1)
+			if(!H.stat)
+				if(H.getBrainLoss() < 100)
+					H.adjustBrainLoss(15 * efficiency)
+					H.visible_message("<span class='warning'>[H] reaches out and touches [src].</span>", "<span class='sevtug'>You touch [src] involuntarily.</span>")
+				else
+					H.Paralyse(3)
+			else if(is_eligible_servant(H))
+				H << "<span class='sevtug'>\"[text2ratvar("You are mine and his, now.")]\"</span>"
+				add_servant_of_ratvar(H)
+				H.Paralyse(5)
+			else
+				H << "<span class='sevtug'>\"[text2ratvar(pick(convert_messages))]\"</span>"
+		else
+			visible_message("<span class='warning'>[src]'s antennae fizzle quietly.</span>")
+			playsound(src, 'sound/effects/light_flicker.ogg', 50, 1)
+	for(var/mob/living/carbon/human/H in range(10, src))
+		if(is_servant_of_ratvar(H)) //heals servants of braindamage, hallucination, druggy, dizziness, and confusion
+			var/brainloss = H.getBrainLoss()
+			if(brainloss)
+				H.adjustBrainLoss(-brainloss)
+			if(H.hallucination)
+				H.hallucination = 0
+			if(H.druggy)
+				H.adjust_drugginess(-H.druggy)
+			if(H.dizziness)
+				H.dizziness = 0
+			if(H.confused)
+				H.confused = 0
+		else if(!H.null_rod_check() && H.stat == CONSCIOUS)
+			var/distance = 0 + get_dist(T, get_turf(H))
+			var/falloff_distance = min((110) - distance * 10, 80)
+			var/sound_distance = falloff_distance * 0.5
+			var/targetbrainloss = H.getBrainLoss()
+			if(distance >= 4 && prob(falloff_distance * 0.5))
+				H << "<span class='sevtug_small'>\"[text2ratvar(pick(mania_messages))]\"</span>"
+			H.playsound_local(T, hum, sound_distance, 1)
+			switch(distance)
+				if(0 to 3)
+					if(prob(falloff_distance * 0.5))
+						if(prob(falloff_distance))
+							H << "<span class='sevtug_small'>\"[text2ratvar(pick(mania_messages))]\"</span>"
+						else
+							H << "<span class='sevtug'>\"[text2ratvar(pick(compel_messages))]\"</span>"
+					if(targetbrainloss <= 50)
+						H.adjustBrainLoss((50 * efficiency) - targetbrainloss) //got too close had brain eaten
+					H.adjust_drugginess(Clamp(7 * efficiency, 0, 100 - H.druggy))
+					H.hallucination = min(H.hallucination + (7 * efficiency), 100)
+					H.dizziness = min(H.dizziness + (3 * efficiency), 45)
+					H.confused = min(H.confused + (3 * efficiency), 45)
+				if(4 to 5)
+					if(targetbrainloss <= 50)
+						H.adjustBrainLoss(1 * efficiency)
+					H.adjust_drugginess(Clamp(5 * efficiency, 0, 80 - H.druggy))
+					H.hallucination = min(H.hallucination + (5 * efficiency), 80)
+					H.dizziness = min(H.dizziness + (2 * efficiency), 30)
+					H.confused = min(H.confused + (2 * efficiency), 30)
+				if(6 to 7)
+					if(targetbrainloss <= 30)
+						H.adjustBrainLoss(1 * efficiency)
+					H.adjust_drugginess(Clamp(2 * efficiency, 0, 60 - H.druggy))
+					H.hallucination = min(H.hallucination + (2 * efficiency), 60)
+					H.dizziness = min(H.dizziness + (2 * efficiency), 15)
+					H.confused = min(H.confused + (2 * efficiency), 15)
+				if(8 to 9)
+					if(targetbrainloss <= 10)
+						H.adjustBrainLoss(1 * efficiency)
+					H.adjust_drugginess(Clamp(2 * efficiency, 0, 40 - H.druggy))
+					H.hallucination = min(H.hallucination + (2 * efficiency), 40)
+				if(10 to INFINITY)
+					H.adjust_drugginess(Clamp(2 * efficiency, 0, 20 - H.druggy))
+					H.hallucination = min(H.hallucination + (2 * efficiency), 20)

--- a/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
@@ -30,7 +30,7 @@
 /obj/structure/destructible/clockwork/powered/mania_motor/examine(mob/user)
 	..()
 	if(is_servant_of_ratvar(user) || isobserver(user))
-		user << "<span class='sevtug_small'>It requires <b>[mania_cost]W</b> to run, and at least <b>[convert_cost]W</b> to attempt to convert humans adjecent to it.</span>"
+		user << "<span class='sevtug_small'>It requires <b>[mania_cost]W</b> to run, and at least <b>[convert_cost]W</b> to attempt to convert humans adjacent to it.</span>"
 
 /obj/structure/destructible/clockwork/powered/mania_motor/forced_disable(bad_effects)
 	if(active)
@@ -72,7 +72,7 @@
 			H.playsound_local(T, hum, 80, 1)
 			if(!H.stat)
 				if(H.getBrainLoss() < 100)
-					H.adjustBrainLoss(15 * efficiency)
+					H.adjustBrainLoss(20 * efficiency)
 					H.visible_message("<span class='warning'>[H] reaches out and touches [src].</span>", "<span class='sevtug'>You touch [src] involuntarily.</span>")
 				else
 					H.Paralyse(3)

--- a/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
@@ -72,7 +72,7 @@
 			H.playsound_local(T, hum, 80, 1)
 			if(!H.stat)
 				if(H.getBrainLoss() < 100)
-					H.adjustBrainLoss(20 * efficiency)
+					H.adjustBrainLoss(30 * efficiency)
 					H.visible_message("<span class='warning'>[H] reaches out and touches [src].</span>", "<span class='sevtug'>You touch [src] involuntarily.</span>")
 				else
 					H.Paralyse(3)


### PR DESCRIPTION
:cl: Joan
rscdel: Mania Motors no longer instantly convert people next to them.
rscadd: Instead, you have to remain next to them for several seconds, after which you will be knocked out, then converted if possible.
tweak: Mania Motors now cost slightly less power to run.
/:cl:

This is from 200W run cost to 150W run cost, and 1000W insta-convert to 600W delayed-over-6~-second convert.