### PR TITLE
Buffs backpacks and dufflebags

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -34,6 +34,7 @@
 	icon_state = "holdingpack"
 	max_w_class = WEIGHT_CLASS_GIGANTIC
 	max_combined_w_class = 35
+	storage_slots = 35
 	resistance_flags = FIRE_PROOF
 	var/pshoom = 'sound/items/PSHOOM.ogg'
 	var/alt_sound = 'sound/items/PSHOOM_2.ogg'

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -17,8 +17,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = SLOT_BACK	//ERROOOOO
 	max_w_class = WEIGHT_CLASS_NORMAL
-	max_combined_w_class = 21
-	storage_slots = 21
+	max_combined_w_class = 28
+	storage_slots = 28
 	resistance_flags = 0
 	obj_integrity = 300
 	max_integrity = 300
@@ -320,7 +320,10 @@
 	icon_state = "duffle"
 	item_state = "duffle"
 	slowdown = 1
-	max_combined_w_class = 30
+	max_combined_w_class = 35
+	storage_slots = 35
+	w_class = WEIGHT_CLASS_GIGANTIC
+	max_w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/weapon/storage/backpack/dufflebag/captain
 	name = "captain's dufflebag"


### PR DESCRIPTION
Given all the attempts to nerf storage, I figured I should see what people think of the opposite.

This increases the storage of normal backpacks by 1/3rd, dufflebags can carry 2/3rds more than backpacks currently can, as well as bulky items, and bags of holding can carry as much as a dufflebag except they can also carry gigantic items. Dufflebags are also now gigantic items so they can only ever be stored in a BoH, so no putting dufflebags in dufflebags.

:cl: 
Nanotrasen has just updated the station to the latest in load-bearing crew attire! Backpacks and dufflebags can now carry more items.
/:cl: