### PR TITLE
Slightly improves dufflebags and BoHs

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -32,8 +32,10 @@
 	desc = "A backpack that opens into a localized pocket of Blue Space."
 	origin_tech = "bluespace=5;materials=4;engineering=4;plasmatech=5"
 	icon_state = "holdingpack"
+	w_class = WEIGHT_CLASS_GIGANTIC
 	max_w_class = WEIGHT_CLASS_GIGANTIC
 	max_combined_w_class = 35
+	storage_slots = 35
 	resistance_flags = FIRE_PROOF
 	var/pshoom = 'sound/items/PSHOOM.ogg'
 	var/alt_sound = 'sound/items/PSHOOM_2.ogg'
@@ -321,6 +323,9 @@
 	item_state = "duffle"
 	slowdown = 1
 	max_combined_w_class = 30
+	storage_slots = 30
+	max_w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_GIGANTIC
 
 /obj/item/weapon/storage/backpack/dufflebag/captain
 	name = "captain's dufflebag"


### PR DESCRIPTION
@anconfuzedrock
"I'd think itd be better to keep that duffle buff but not the backpack one"
Don't blame me, someone wants a dufflebag buff and so I'm putting it here for feedback.

Dufflebags can now carry Bulky items, and also have a item limit equal to their max weight limit. This means you can now carry 30 cigarette butts instead of 21. To balance this out, they are now gigantic items (so you can't put a dufflebag in a dufflebag). BoH have gotten the same treatment, so they can carry 35 cigarette butts now.

Please contribute to the discussion and allow the community to generate a consensus on this change before taking any actions against it. This may or may not be a change desired by the community, and as such we should allow discussion to occur so that the community as a whole can contribute their opinions.