### PR TITLE
Adds Gold And Silver To Appropriate Vault Crates On Delta Station

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -38609,6 +38609,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/stack/sheet/mineral/silver,
+/obj/item/stack/sheet/mineral/silver,
+/obj/item/stack/sheet/mineral/silver,
+/obj/item/stack/sheet/mineral/silver,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -42138,6 +42142,10 @@
 	pixel_y = -22
 	},
 /obj/machinery/light/small,
+/obj/item/stack/sheet/mineral/gold,
+/obj/item/stack/sheet/mineral/gold,
+/obj/item/stack/sheet/mineral/gold,
+/obj/item/stack/sheet/mineral/gold,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -137899,7 +137907,7 @@ aaf
 aaf
 aBX
 aBX
-eca
+aEN
 aBX
 aBZ
 aBZ

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -38603,16 +38603,20 @@
 /obj/structure/closet/crate{
 	name = "Silver Crate"
 	},
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c500,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/stack/sheet/mineral/silver,
-/obj/item/stack/sheet/mineral/silver,
-/obj/item/stack/sheet/mineral/silver,
-/obj/item/stack/sheet/mineral/silver,
+/obj/item/weapon/coin/silver{
+	pixel_z = -6
+	},
+/obj/item/weapon/coin/silver{
+	pixel_z = 6
+	},
+/obj/item/weapon/coin/silver{
+	pixel_x = 6
+	},
+/obj/item/weapon/coin/silver,
+/obj/item/weapon/coin/silver,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -42133,16 +42137,12 @@
 	name = "Gold Crate"
 	},
 /obj/item/weapon/storage/belt/champion,
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c1000,
-/obj/item/stack/spacecash/c500,
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/light/small,
-/obj/item/stack/sheet/mineral/gold,
 /obj/item/stack/sheet/mineral/gold,
 /obj/item/stack/sheet/mineral/gold,
 /obj/item/stack/sheet/mineral/gold,


### PR DESCRIPTION
## **Adds Gold And Silver To Vault Crates On Deltastation**
Adds three bars of gold to the gold crate located in the Vault on Deltastation, This also adds five silver coins to the silver crate this is to make the crate names correspond and match what the crates actually contain. And also follow in accordance and other maps standards with what they have inside their vault crates.

## **Changelog**
:cl: Tofa01
Add: [Delta] Removes space money from gold crate replaces with 3 Gold Bars Gold Wrestling belt is still there.
Add: [Delta] Removes space money from silver crate replaces with 5 Silver Coins.
/:cl:

## **Fixes #23607**
