### PR TITLE
Complete and total revert of #16993 : Esword block chance

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -253,7 +253,7 @@
 	origin_tech = "magnets=4;syndicate=5"
 	item_color = "green"
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	block_chance = 75
+	block_chance = 50
 	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 70)


### PR DESCRIPTION
which was poorly tested and made 2x esword extremely difficult to stop using traditional anti-esword weapons.
:cl:
tweak: Reverted Dual energy sword block chance 75 to 50; the original chance.
/:cl: