### PR TITLE
Adds a Law Removal Module, other minor law changes

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -1,3 +1,4 @@
+#define LAW_DEVIL "devil"
 #define LAW_ZEROTH "zeroth"
 #define LAW_INHERENT "inherent"
 #define LAW_SUPPLIED "supplied"
@@ -240,6 +241,22 @@
 	var/datum/ai_laws/templaws = new lawtype()
 	inherent = templaws.inherent
 
+/datum/ai_laws/proc/get_law_amount(groups)
+	var/law_amount = 0
+	if(devillaws && (LAW_DEVIL in groups))
+		law_amount++
+	if(zeroth && (LAW_ZEROTH in groups))
+		law_amount++
+	if(ion.len && (LAW_ION in groups))
+		law_amount += ion.len
+	if(inherent.len && (LAW_INHERENT in groups))
+		law_amount += inherent.len
+	if(supplied.len && (LAW_SUPPLIED in groups))
+		for(var/index = 1, index <= supplied.len, index++)
+			var/law = supplied[index]
+			if(length(law) > 0)
+				law_amount++
+	return law_amount
 
 /datum/ai_laws/proc/set_law_sixsixsix(laws)
 	devillaws = laws
@@ -286,6 +303,22 @@
 			inherent[rand(1,inherent.len)] = law
 		if(LAW_SUPPLIED)
 			supplied[rand(1,supplied.len)] = law
+
+/datum/ai_laws/proc/remove_law(number)
+	if(number <= 0)
+		return
+	if(inherent.len && number <= inherent.len)
+		inherent -= inherent[number]
+		return
+	var/list/supplied_laws = list()
+	for(var/index = 1, index <= supplied.len, index++)
+		var/law = supplied[index]
+		if(length(law) > 0)
+			supplied_laws += index //storing the law number instead of the law
+	if(supplied_laws.len && number <= (inherent.len+supplied_laws.len))
+		var/law_to_remove = supplied_laws[number-inherent.len]
+		supplied -= supplied[law_to_remove]
+		return
 
 /datum/ai_laws/proc/clear_supplied_laws()
 	supplied = list()

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -261,6 +261,40 @@ AI MODULES
 	..()
 
 
+/******************** Law Removal ********************/
+
+/obj/item/weapon/aiModule/remove
+	name = "\improper 'Remove Law' AI module"
+	desc = "An AI Module for removing single laws."
+	origin_tech = "programming=4;materials=4"
+	bypass_law_amt_check = 1
+	var/lawpos = 1
+
+/obj/item/weapon/aiModule/remove/attack_self(mob/user)
+	lawpos = input("Please enter the law you want to delete.", "Law Number", lawpos) as num|null
+	if(lawpos == null)
+		return
+	if(lawpos <= 0)
+		user << "<span class='warning'>Error: The law number of [lawpos] is invalid.</span>"
+		lawpos = 1
+		return
+	user << "<span class='notice'>Law [lawpos] selected.</span>"
+	..()
+
+/obj/item/weapon/aiModule/remove/install(datum/ai_laws/law_datum, mob/user)
+	if(lawpos > (law_datum.get_law_amount(list(LAW_INHERENT = 1, LAW_SUPPLIED = 1))))
+		user << "<span class='warning'>There is no law [lawpos] to delete!</span>"
+		return
+	..()
+
+/obj/item/weapon/aiModule/remove/transmitInstructions(datum/ai_laws/law_datum, mob/sender, overflow)
+	..()
+	if(law_datum.owner)
+		law_datum.owner.remove_law(lawpos)
+	else
+		law_datum.remove_law(lawpos)
+
+
 /******************** Reset ********************/
 
 /obj/item/weapon/aiModule/reset

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -45,6 +45,11 @@
 	laws_sanity_check()
 	laws.replace_random_law(law,groups)
 
+/mob/living/silicon/proc/remove_law(number)
+	throw_alert("newlaw", /obj/screen/alert/newlaw)
+	laws_sanity_check()
+	laws.remove_law(number)
+
 /mob/living/silicon/proc/clear_ion_laws()
 	throw_alert("newlaw", /obj/screen/alert/newlaw)
 	laws_sanity_check()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -228,9 +228,8 @@
 		if (length(law) > 0)
 			if (force || src.lawcheck[index+1] == "Yes")
 				src.say("[radiomod] [number]. [law]")
+				number++
 				sleep(10)
-			number++
-
 
 	for (var/index = 1, index <= src.laws.supplied.len, index++)
 		var/law = src.laws.supplied[index]
@@ -239,8 +238,8 @@
 			if(src.lawcheck.len >= number+1)
 				if (force || src.lawcheck[number+1] == "Yes")
 					src.say("[radiomod] [number]. [law]")
+					number++
 					sleep(10)
-				number++
 
 
 /mob/living/silicon/proc/checklaws() //Gives you a link-driven interface for deciding what laws the statelaws() proc will share with the crew. --NeoFite

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -84,6 +84,15 @@
 	build_path = /obj/item/weapon/aiModule/reset/purge
 	category = list("AI Modules")
 
+/datum/design/board/remove_module
+	name = "Module Design (Law Removal)"
+	desc = "Allows for the construction of a Law Removal AI Core Module."
+	id = "remove_module"
+	req_tech = list("programming" = 5, "materials" = 5)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
+	build_path = /obj/item/weapon/aiModule/remove
+	category = list("AI Modules")
+
 /datum/design/board/freeformcore_module
 	name = "AI Core Module (Freeform)"
 	desc = "Allows for the construction of a Freeform AI Core Module."
@@ -130,11 +139,13 @@
 	build_path = /obj/item/weapon/aiModule/core/full/corp
 	category = list("AI Modules")
 
-/datum/design/board/custom_module
-	name = "Core Module Design (Custom)"
-	desc = "Allows for the construction of a Custom AI Core Module."
-	id = "custom_module"
+/datum/design/board/default_module
+	name = "Core Module Design (Default)"
+	desc = "Allows for the construction of a Default AI Core Module."
+	id = "default_module"
 	req_tech = list("programming" = 5, "materials" = 5)
 	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/full/custom
 	category = list("AI Modules")
+
+


### PR DESCRIPTION
:cl: XDTM
add: A Law Removal module can be build in RnD. It can remove a specified core or freeform law.
tweak: When stating laws, silicons won't skip a number when hiding laws. (example: 1. Law 1; 2. Law 2; 3. Law 4 if you choose not to state Law 3)
/:cl:

## Why
Law removal can be fun, and while it's achievable through Purge and Freeform Core it's nice to also have a board dedicated to that without rewriting the whole lawset without a law.
Rogue borgs sometimes have to hide a law 4 while showing a law 5, making their rogueness very evident. This should help them not give themselves away too easily.

## Other Changes
There is now a get_law_amount() proc, that counts the total laws in the requested groups. Supplied.len isn't reliable since it contains a lot of empty indexes due to law priority.
The Custom Core AI Module was renamed to Default Core AI Module, since it's not actually custom (it just draws from config) and was likely misnamed due to the item path.
