### PR TITLE
Fixes engraved messages being pulled by the sing

### DIFF
--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -176,6 +176,9 @@
 		persists = FALSE
 		qdel(src)
 
+/obj/structure/chisel_message/singularity_pull()
+	return
+
 /obj/structure/chisel_message/proc/register(mob/user, newmessage)
 	hidden_message = newmessage
 	creator_name = user.real_name


### PR DESCRIPTION
:cl: coiax
fix: Engraved messages can no longer be moved by a gravitational
singularity.
/:cl:

Fixes #23613.