### PR TITLE
Buffs the valentines event

### DIFF
--- a/code/modules/events/holiday/vday.dm
+++ b/code/modules/events/holiday/vday.dm
@@ -19,6 +19,47 @@
 		var/obj/item/weapon/storage/backpack/b = locate() in H.contents
 		new /obj/item/weapon/reagent_containers/food/snacks/candyheart(b)
 
+
+	var/list/valentines = list()
+	for(var/mob/living/M in player_list)
+		if(!M.stat && M.client && M.mind)
+			valentines |= M
+
+
+	for(var/mob/living/L in valentines)
+		valentines -= L
+		if(valentines.len)
+			var/mob/living/date = pick(valentines)
+
+			valentines -= date
+
+			forge_valentines_objective(L, date)
+
+			forge_valentines_objective(date, L)
+
+
+
+		else
+			L << "<span class='warning'><B>You didn't get a date! They're all having fun without you! you'll show them though...</B></span>"
+			var/datum/objective/martyr/normiesgetout = new
+			normiesgetout.owner = L.mind
+			ticker.mode.traitors |= L.mind
+			L.mind.objectives += normiesgetout
+
+
+/proc/forge_valentines_objective(mob/living/lover,mob/living/date)
+
+	ticker.mode.traitors |= lover.mind
+	lover.mind.special_role = "valentine"
+
+	var/datum/objective/protect/protect_objective = new /datum/objective/protect
+	protect_objective.owner = lover.mind
+	protect_objective.target = date.mind
+	protect_objective.explanation_text = "Protect [date.real_name], your date."
+	lover.mind.objectives += protect_objective
+	lover << "<span class='warning'><B>You're on a date with [date]! Protect them at all costs. This takes priority over all other loyalties.</B></span>"
+
+
 /datum/round_event/valentines/announce()
 	priority_announce("It's Valentine's Day! Give a valentine to that special someone!")
 

--- a/code/modules/events/holiday/vday.dm
+++ b/code/modules/events/holiday/vday.dm
@@ -26,12 +26,11 @@
 			valentines |= M
 
 
-	for(var/mob/living/L in valentines)
-		valentines -= L
+	while(valentines.len)
+		var/mob/living/L = pick_n_take(valentines)
 		if(valentines.len)
-			var/mob/living/date = pick(valentines)
+			var/mob/living/date = pick_n_take(valentines)
 
-			valentines -= date
 
 			forge_valentines_objective(L, date)
 
@@ -45,7 +44,6 @@
 			normiesgetout.owner = L.mind
 			ticker.mode.traitors |= L.mind
 			L.mind.objectives += normiesgetout
-
 
 /proc/forge_valentines_objective(mob/living/lover,mob/living/date)
 


### PR DESCRIPTION
:cl: Kor
add: Valentines day will now randomly pair up crew members on dates. The paired crewmembers will get an objective to protect each other at all costs.
/:cl:

The valentines holiday event will pair up crew members, giving them objectives to protect each other above all other loyalties.

If there is an odd one out with no valentine they get the martyr objective

I think randomly assigning crew to each other like this will lead to some memorable stories, especially if the nuke op is paired with the captain or something. It will be silly, but will only last a couple days a year.

