### PR TITLE
Map merger patch - comments!

### DIFF
--- a/tools/mapmerge/map_helpers.py
+++ b/tools/mapmerge/map_helpers.py
@@ -230,6 +230,9 @@ def get_map_raw_text(mapfile):
         return reading.read()
 
 def parse_map(map_raw_text): #still does not support more than one z level per file, but should parse any format
+    in_comment_line = False
+    comment_trigger = False
+
     in_quote_block = False
     in_key_block = False
     in_data_block = False
@@ -266,9 +269,26 @@ def parse_map(map_raw_text): #still does not support more than one z level per f
 
         if not in_map_block:
 
-            if char == "\n" or char == "\t":
+            if char == "\n":
+                in_comment_line = False
+                comment_trigger = False
                 continue
 
+            if in_comment_line:
+                continue
+
+            if char == "\t":
+                continue
+
+            if char == "/" and not in_quote_block:
+                if comment_trigger:
+                    in_comment_line = True
+                    continue
+                else:
+                    comment_trigger = True
+            else:
+                comment_trigger = False
+            
             if in_data_block:
 
                 if in_varedit_block:


### PR DESCRIPTION
Added real support for map comments, the parser function will now skip over line comments. 

Everything after ``//`` is a line comment, unless these characters are inside quotes just to be safe. I don't know if byond is sensitive to quotes in this case, but I did it anyway.

A line comment ends after a line break.

This is a patch because merging a map with a trimming commentary results in a bad model being added.