### PR TITLE
[Meta] Fixes Research Director Modular Computer

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1,5 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-//Model dictionary trimmed on: 31-01-2017 23:17 (UTC)
 "aaa" = (
 /turf/open/space,
 /area/space)
@@ -73083,7 +73082,6 @@
 	},
 /area/crew_quarters/hor)
 "ctb" = (
-/obj/machinery/computer/aifixer,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -73095,6 +73093,7 @@
 	pixel_x = 0;
 	pixel_y = 30
 	},
+/obj/machinery/modular_computer/console/preset/research,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -126198,7 +126197,7 @@ coe
 cpq
 cqJ
 crP
-cta
+cuN
 ctR
 cuN
 cvR

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1,4 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+//Model dictionary trimmed on: 31-01-2017 23:17 (UTC)
 "aaa" = (
 /turf/open/space,
 /area/space)


### PR DESCRIPTION
## **Fixes Research Director Modular Computer**
This Pull Request fixes an incorrect placement i made of the Research Directors modular computer in his office, this replaces one of the AI restoration computers with the modular computer, this is done because the modular computer is already able to download this program by default.

## **Pictures**
![capture](https://cloud.githubusercontent.com/assets/24999255/22574578/e5fcdcf6-ea03-11e6-8e6b-69288274fe92.PNG)


## **Changelog**
:cl: Tofa01
Fix: Fixes incorrect placement of RD modular computer on Metastation.
/:cl:

## **Fixes #23540**

_I would have fixed this earlier but due to school this had to come out a bit slower, sorry for any inconveniences this may have caused._