### PR TITLE
The Rod Form spell does not notify deadchat

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -35,6 +35,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	anchored = 1
 	var/z_original = 0
 	var/destination
+	var/notify = TRUE
 
 /obj/effect/immovablerod/New(atom/start, atom/end)
 	..()
@@ -42,9 +43,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		SSaugury.register_doom(src, 2000)
 	z_original = z
 	destination = end
-	notify_ghosts("\A [src] is inbound!",
-		enter_link="<a href=?src=\ref[src];orbit=1>(Click to orbit)</a>",
-		source=src, action=NOTIFY_ORBIT)
+	if(notify)
+		notify_ghosts("\A [src] is inbound!",
+			enter_link="<a href=?src=\ref[src];orbit=1>(Click to orbit)</a>",
+			source=src, action=NOTIFY_ORBIT)
 	poi_list += src
 	if(end && end.z==z_original)
 		walk_towards(src, destination, 1)

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -28,6 +28,7 @@
 	var/max_distance = 13
 	var/mob/living/wizard
 	var/turf/start_turf
+	notify = FALSE
 
 /obj/effect/immovablerod/wizard/Move()
 	if(get_dist(start_turf, get_turf(src)) >= max_distance)


### PR DESCRIPTION
:cl: coiax
del: The wizard spell "Rod Form" does not produce a message in deadchat
everytime it is used.
/:cl:

Because it gets spammy, and the joy of following a rod is being able to
watch its devestation. If you're following a wizard, you're already
following and need no notification.