### PR TITLE
Uses deadsay span in event notification

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -97,7 +97,7 @@ var/datum/subsystem/events/SSevent
 				continue
 			if (E.alertadmins)
 				message_admins("Random Event triggering: [E.name] ([E.typepath])")
-				deadchat_broadcast("[E.name] has just been randomly triggered!") //STOP ASSUMING IT'S BADMINS!
+				deadchat_broadcast("<span class='deadsay'><b>[E.name]</b> has just been randomly triggered!</span>") //STOP ASSUMING IT'S BADMINS!
 			log_game("Random Event triggering: [E.name] ([E.typepath])")
 			return
 


### PR DESCRIPTION
:cl: coiax
tweak: The deadchat notification of randomly triggered events now uses
the deadsay span.
/:cl: