### PR TITLE
Fixes a login runtime

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -71,5 +71,4 @@
 	update_client_colour()
 	if(client)
 		client.click_intercept = null
-
-	client.view = world.view // Resets the client.view in case it was changed.
+		client.view = world.view // Resets the client.view in case it was changed.


### PR DESCRIPTION
```
The following runtime has occurred 39 time(s).
runtime error: Cannot modify null.view.
proc name: Login (/mob/Login)
  source file: login.dm,75
  usr: (src)
  src:  (/mob/living/carbon/human)
  src.loc: null
```