### PR TITLE
Fixes an AI click runtime

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -35,12 +35,14 @@
 		return
 
 	var/turf/pixel_turf = get_turf_pixel(A)
-	var/turf_visible = cameranet.checkTurfVis(pixel_turf)
-	if(pixel_turf && !turf_visible)
-		log_admin("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(pixel_turf)])")
-		message_admins("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([ADMIN_COORDJMP(pixel_turf)]))")
-		send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(pixel_turf)]))")
-		return
+	var/turf_visible
+	if(pixel_turf)
+		turf_visible = cameranet.checkTurfVis(pixel_turf)
+		if(!turf_visible)
+			log_admin("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(pixel_turf)])")
+			message_admins("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([ADMIN_COORDJMP(pixel_turf)]))")
+			send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(pixel_turf)]))")
+			return
 
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] && modifiers["ctrl"])


### PR DESCRIPTION
```
[00:14:23]Cannot read null.x
[00:14:23]proc name: checkTurfVis (/datum/cameranet/proc/checkTurfVis)
[00:14:23]  source file: cameranet.dm,142
[00:14:23]  usr: S.O.S. (/mob/living/silicon/ai)
[00:14:23]  src: Camera Net (/datum/cameranet)
[00:14:23]  usr.loc: the floor (214,143,1) (/turf/open/floor/greengrid)
[00:14:23]  call stack:
[00:14:23]Camera Net (/datum/cameranet): checkTurfVis(null)
[00:14:23]S.O.S. (/mob/living/silicon/ai): ClickOn(the floor (112,80,1) (/turf/open/floor/plasteel/white), "icon-x=9;icon-y=23;left=1;scre...")
[00:14:23]the floor (112,80,1) (/turf/open/floor/plasteel/white): Click(the floor (112,80,1) (/turf/open/floor/plasteel/white), "mapwindow.map", "icon-x=9;icon-y=23;left=1;scre...")
runtime error: 
```