### PR TITLE
Fixes hotspots runtiming when Destroyed in a wall

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -149,14 +149,12 @@
 /obj/effect/hotspot/Destroy()
 	SetLuminosity(0)
 	SSair.hotspots -= src
-	if(isturf(loc))
-		var/turf/open/T = loc
-		if(T.active_hotspot == src)
-			T.active_hotspot = null
+	var/turf/open/T = loc
+	if(istype(T) && T.active_hotspot == src)
+		T.active_hotspot = null
 	DestroyTurf()
 	loc = null
 	. = ..()
-
 
 /obj/effect/hotspot/proc/DestroyTurf()
 	if(isturf(loc))


### PR DESCRIPTION
```
The following runtime has occurred 9 time(s).
runtime error: undefined variable /turf/closed/wall/var/active_hotspot
proc name: Destroy (/obj/effect/hotspot/Destroy)
  source file: LINDA_fire.dm,154
  usr: null
  src: the hotspot (/obj/effect/hotspot)
  src.loc: the wall (136,127,1) (/turf/closed/wall)
```