### PR TITLE
[s] Fixed wizards with mindswap being able to make people suicide

### DIFF
--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -4,7 +4,10 @@
 	set hidden = 1
 	if(!canSuicide())
 		return
+	var/oldkey = ckey
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+	if(ckey != oldkey)
+		return
 	if(!canSuicide())
 		return
 	if(confirm == "Yes")


### PR DESCRIPTION
You could do it by clicking mindswap and leaving the dialogue open, using suicide, selecting someone on the mindswap dialogue, and clicking yes on the suicide dialogue when they woke up.