### PR TITLE
Makes addtimer(..., 0) more akin to spawn(0)

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -294,6 +294,8 @@ proc/addtimer(datum/callback/callback, wait, flags)
 	if (!callback)
 		return
 
+	wait = max(wait, 0)
+
 	var/hash
 
 	if (flags & TIMER_UNIQUE)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -294,11 +294,6 @@ proc/addtimer(datum/callback/callback, wait, flags)
 	if (!callback)
 		return
 
-	if (wait <= 0)
-		spawn(0)	//This is the one legal spawn
-			callback.Invoke()
-		return
-
 	var/hash
 
 	if (flags & TIMER_UNIQUE)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -295,7 +295,8 @@ proc/addtimer(datum/callback/callback, wait, flags)
 		return
 
 	if (wait <= 0)
-		callback.InvokeAsync()
+		spawn(0)	//This is the one legal spawn
+			callback.Invoke()
 		return
 
 	var/hash


### PR DESCRIPTION
Now that we have INVOKE_ASYNC. Addtimer(..., 0) should probably adapt some differing behavior.

Just a refresher: 

`INVOKE_ASYNC` calls the proc through a `set waitfor = FALSE` proc which will run IMMEDIATELY when the call is made and let the parent proc continue running if it sleeps.

spawn(0) will queue what's under it to run AFTER the current callstack finishes running.