### PR TITLE
Tesla balls cannot dust people near grounding rods

### DIFF
--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -100,7 +100,7 @@
 	tesla_zap(src, 10, power/shock_coeff)
 
 /obj/machinery/power/grounding_rod
-	name = "Grounding Rod"
+	name = "grounding rod"
 	desc = "Keep an area from being fried from Edison's Bane."
 	icon = 'icons/obj/tesla_engine/tesla_coil.dmi'
 	icon_state = "grounding_rod0"

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -152,9 +152,12 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 
 
 /obj/singularity/energy_ball/proc/dust_mobs(atom/A)
-	if(istype(A, /mob/living/carbon))
-		var/mob/living/carbon/C = A
-		C.dust()
+	if(!iscarbon(A))
+		return
+	for(var/obj/machinery/power/grounding_rod/GR in orange(src, 2))
+		return
+	var/mob/living/carbon/C = A
+	C.dust()
 
 /proc/tesla_zap(atom/source, zap_range = 3, power, explosive = FALSE)
 	. = source.dir

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -155,7 +155,8 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 	if(!iscarbon(A))
 		return
 	for(var/obj/machinery/power/grounding_rod/GR in orange(src, 2))
-		return
+		if(GR.anchored)
+			return
 	var/mob/living/carbon/C = A
 	C.dust()
 


### PR DESCRIPTION
:cl: coiax
del: Tesla balls cannot dust people near grounding rods.
/:cl:

- The tesla is SUPER deadly right now, anyway. If mildly charged, will
kill anyone unprotected. And people can STILL get dusted, even if
they've painstakingly set up a net of grounding rods.
- If you're hiding under only one, you're safe from the electricity and
dusting, but there are machines that explode all over the station. Only
a wide net provides any sort of cover.
- Basically, let's reward people for actually using grounding rods,
instead of getting RNG dusted if they don't cover in a locker for
however long it takes for Lady Tesla to leave.