### PR TITLE
Tesla engine no longer destroys energy ball generators

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -17,8 +17,8 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 										/obj/structure/sign,
 										/obj/machinery/gateway,
 										/obj/structure/lattice,
-										/obj/structure/grille))
-
+										/obj/structure/grille
+										/obj/machinery/the_singularitygen/tesla))
 /obj/singularity/energy_ball
 	name = "energy ball"
 	desc = "An energy ball."

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -17,7 +17,7 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 										/obj/structure/sign,
 										/obj/machinery/gateway,
 										/obj/structure/lattice,
-										/obj/structure/grille
+										/obj/structure/grille,
 										/obj/machinery/the_singularitygen/tesla))
 /obj/singularity/energy_ball
 	name = "energy ball"


### PR DESCRIPTION
:cl: 
tweak: The tesla engine no longer destroys energy ball generators.
/:cl:

This brings back multi-tesla shenanigans from before the "tesla blows up things!!1!1" pull request.

see here for reference: http://i.imgur.com/zIiyJzk.png
