### PR TITLE
Makes Icon Smoothing faster

### DIFF
--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -111,9 +111,11 @@
 
 //do not use, use queue_smooth(atom)
 /proc/smooth_icon(atom/A)
-	if(!A || !A.smooth || !A.z)
+	if(!A || !A.smooth)
 		return
 	A.smooth &= ~SMOOTH_QUEUED
+	if (!A.z)
+		return
 	if(qdeleted(A))
 		return
 	if((A.smooth & SMOOTH_TRUE) || (A.smooth & SMOOTH_MORE))

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -33,11 +33,12 @@
 #define N_SOUTHEAST	64
 #define N_SOUTHWEST	1024
 
-#define SMOOTH_FALSE	0 //not smooth
-#define SMOOTH_TRUE		1 //smooths with exact specified types or just itself
-#define SMOOTH_MORE		2 //smooths with all subtypes of specified types or just itself (this value can replace SMOOTH_TRUE)
-#define SMOOTH_DIAGONAL	4 //if atom should smooth diagonally, this should be present in 'smooth' var
-#define SMOOTH_BORDER	8 //atom will smooth with the borders of the map
+#define SMOOTH_FALSE	0	//not smooth
+#define SMOOTH_TRUE		1	//smooths with exact specified types or just itself
+#define SMOOTH_MORE		2	//smooths with all subtypes of specified types or just itself (this value can replace SMOOTH_TRUE)
+#define SMOOTH_DIAGONAL	4	//if atom should smooth diagonally, this should be present in 'smooth' var
+#define SMOOTH_BORDER	8	//atom will smooth with the borders of the map
+#define SMOOTH_QUEUED	16	//atom is currently queued to smooth.
 
 #define NULLTURF_BORDER 123456789
 
@@ -112,6 +113,7 @@
 /proc/smooth_icon(atom/A)
 	if(!A || !A.smooth || !A.z)
 		return
+	A.smooth &= ~SMOOTH_QUEUED
 	if(qdeleted(A))
 		return
 	if((A.smooth & SMOOTH_TRUE) || (A.smooth & SMOOTH_MORE))
@@ -376,11 +378,13 @@
 
 //SSicon_smooth
 /proc/queue_smooth(atom/A)
-	if(SSicon_smooth)
-		SSicon_smooth.smooth_queue[A] = A
-		SSicon_smooth.can_fire = 1
-	else
-		smooth_icon(A)
+	if(!A.smooth || A.smooth & SMOOTH_QUEUED)
+		return
+
+	SSicon_smooth.smooth_queue += A
+	SSicon_smooth.can_fire = 1
+	A.smooth |= SMOOTH_QUEUED
+
 
 //Example smooth wall
 /turf/closed/wall/smooth


### PR DESCRIPTION
During world init or large smoothing operations happening, doing an associated add on this list accounted for a good chunk of the overhead. (because the list had gotten so large)

Keeping track of it this way is smarter

I removed the check for if the subsystem existed because subsystems are created before atoms or the map is created.

In another branch of the code, this removed 5 seconds (out of 60) from world+SS init
