### PR TITLE
[READY]SDQL2 update: In which admins get more power than they deserve.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -25,7 +25,10 @@
 	appearance_flags = TILE_BOUND
 	var/datum/forced_movement/force_moving = null	//handled soley by forced_movement.dm
 
-
+/atom/movable/SDQL_update(const/var_name, new_value)
+	if(var_name == "step_x" || var_name == "step_y" || var_name == "step_size" || var_name == "bound_x" || var_name == "bound_y" || var_name == "bound_width" || var_name == "bound_height")
+		return FALSE	//PLEASE no.
+	. = ..()
 
 /atom/movable/Move(atom/newloc, direct = 0)
 	if(!loc || !newloc) return 0

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -24,7 +24,7 @@
 
 	var/list/decals
 
-/turf/SDQL_update(var/list/vars_list)
+/turf/SDQL_update(list/vars_list)
 	if(("x" in vars_list) || ("y" in vars_list) || ("z" in vars_list))
 		return FALSE
 	. = ..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -21,8 +21,13 @@
 
 	var/explosion_level = 0	//for preventing explosion dodging
 	var/explosion_id = 0
-	
+
 	var/list/decals
+
+/turf/SDQL_update(var/const/var_name, var/new_value)
+	if(var_name == "x" || var_name == "y" || var_name == "z")
+		return FALSE
+	. = ..()
 
 /turf/New()
 	..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -24,8 +24,8 @@
 
 	var/list/decals
 
-/turf/SDQL_update(var/const/var_name, var/new_value)
-	if(var_name == "x" || var_name == "y" || var_name == "z")
+/turf/SDQL_update(var/list/vars_list)
+	if(("x" in vars_list) || ("y" in vars_list) || ("z" in vars_list))
 		return FALSE
 	. = ..()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -24,8 +24,8 @@
 
 	var/list/decals
 
-/turf/SDQL_update(list/vars_list)
-	if(("x" in vars_list) || ("y" in vars_list) || ("z" in vars_list))
+/turf/SDQL_update(const/var_name, new_value)
+	if(var_name == "x" || var_name == "y" || var_name == "z")
 		return FALSE
 	. = ..()
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -823,3 +823,7 @@ var/global/BSACooldown = 0
 				"Admin login: [key_name(src)]")
 		if(string)
 			message_admins("[string]")
+
+
+/datum/admins/SDQL_update(var/const/var_name, var/new_value)
+	return FALSE	//No.

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -825,5 +825,5 @@ var/global/BSACooldown = 0
 			message_admins("[string]")
 
 
-/datum/admins/SDQL_update(var/const/var_name, var/new_value)
+/datum/admins/SDQL_update()
 	return FALSE	//No.

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -6,6 +6,9 @@ var/list/admin_ranks = list()								//list of all admin_rank datums
 	var/list/adds
 	var/list/subs
 
+/datum/admin_rank/SDQL_update()
+	return FALSE	//Nice try trivialadmin!
+
 /datum/admin_rank/New(init_name, init_rights, list/init_adds, list/init_subs)
 	name = init_name
 	switch(name)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -147,7 +147,7 @@
 								set_vals[v] = SDQL_expression(d, set_list[v])
 							d.SDQL_update(set_vals)
 							CHECK_TICK
-	catch(var/exception/e)
+	catch(exception/e)
 		usr << "<span class='boldwarning'>A runtime error has occured in your SDQL2-query.</span>"
 		usr << "\[NAME\][e.name]"
 		usr << "\[FILE\][e.file]"

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -106,7 +106,7 @@
 						for(var/v in call_list)
 							if(copytext(v,1,8) == "global.")
 								v = "/proc/[copytext(v,8)]"
-								call(v)(arglist(new_args))
+								SDQL_callproc_global(v,new_args)
 							else
 								SDQL_callproc(d, v, new_args)
 						CHECK_TICK
@@ -153,8 +153,12 @@
 		usr << "\[FILE\][e.file]"
 		usr << "\[LINE\][e.line]"
 
+/proc/SDQL_callproc_global(procname,args_list)
+	set waitfor = FALSE
+	call(procname)(arglist(args_list))
+
 /proc/SDQL_callproc(thing, procname, args_list)
-	set waitfor = 0
+	set waitfor = FALSE
 	if(hascall(thing, procname))
 		call(thing, procname)(arglist(args_list))
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -22,7 +22,7 @@
 	vars[var_name] = new_value
 	return TRUE
 
-/client/proc/SDQL_update(var/const/var_name, var/new_value)
+/client/SDQL_update(var/const/var_name, var/new_value)
 	vars[var_name] = new_value
 	return TRUE
 
@@ -136,14 +136,10 @@
 				if("set" in query_tree)
 					var/list/set_list = query_tree["set"]
 					for(var/datum/d in objs)
-						var/list/vals = list()
 						for(var/v in set_list)
 							v = SDQL_expression(d, v)
-							d.SDQL_update(v.name, v)
+							d.SDQL_update(set_list[v.name], set_list[v])
 						CHECK_TICK
-
-
-
 
 /proc/SDQL_callproc(thing, procname, args_list)
 	set waitfor = 0

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -400,7 +400,8 @@
 		var/list/expressions_list = expression[++i]
 		val = list()
 		for(var/list/expression_list in expressions_list)
-			val[++val.len] = SDQL_expression(object, expression_list)
+			val.len++
+			val[val.len] = SDQL_expression(object, expression_list)
 
 	else
 		val = SDQL_var(object, expression, i)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -18,12 +18,9 @@
 
 */
 
-/datum/proc/SDQL_update(var/const/var_name, var/new_value)
-	vars[var_name] = new_value
-	return TRUE
-
-/client/SDQL_update(var/const/var_name, var/new_value)
-	vars[var_name] = new_value
+/datum/proc/SDQL_update(var/list/vars_list)
+	for(var/v in vars_list)
+		vars[v] = vars_list[v]
 	return TRUE
 
 /client/proc/SDQL2_query(query_text as message)
@@ -136,13 +133,10 @@
 				if("set" in query_tree)
 					var/list/set_list = query_tree["set"]
 					for(var/datum/d in objs)
-						var/list/set_vals = list()
-						for(var/v in set_list)
-							if(v in d.vars)
-								vals += v
-								vals[v] = SDQL_expression(d, set_list[v])
-						for(var/v in vals)
-							d.SDQL_update(set_list[v.name], set_list[v])
+						var/list/set_vals = set_list.Copy()
+						for(var/v in set_vals)
+							set_vals[v] = SDQL_expression(d, set_list[v])
+						d.SDQL_update(set_vals)
 						CHECK_TICK
 
 /proc/SDQL_callproc(thing, procname, args_list)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -18,11 +18,26 @@
 
 */
 
+/datum/proc/SDQL_update(var/const/var_name, var/new_value)
+	vars[var_name] = new_value
+	return TRUE
+
+/client/proc/SDQL_update(var/const/var_name, var/new_value)
+	vars[var_name] = new_value
+	return TRUE
+
 /client/proc/SDQL2_query(query_text as message)
 	set category = "Debug"
 	if(!check_rights(R_DEBUG))  //Shouldn't happen... but just to be safe.
 		message_admins("<span class='danger'>ERROR: Non-admin [key_name(usr, usr.client)] attempted to execute a SDQL query!</span>")
 		log_admin("Non-admin [usr.ckey]([usr]) attempted to execute a SDQL query!")
+		return FALSE
+
+	var/query_log = "executed SDQL query: \"[query_text]\"."
+	message_admins("[key_name_admin(usr)] [query_log]")
+	query_log = "[usr.ckey]([usr]) [query_log]"
+	log_game(query_log)
+	NOTICE(query_log)
 
 	if(!query_text || length(query_text) < 1)
 		return
@@ -38,14 +53,6 @@
 
 	if(!querys || querys.len < 1)
 		return
-
-
-	var/query_log = "executed SDQL query: \"[query_text]\"."
-	message_admins("[key_name_admin(usr)] [query_log]")
-	query_log = "[usr.ckey]([usr]) [query_log]"
-	log_game(query_log)
-	NOTICE(query_log)
-
 
 	for(var/list/query_tree in querys)
 		var/list/from_objs = list()
@@ -131,20 +138,8 @@
 					for(var/datum/d in objs)
 						var/list/vals = list()
 						for(var/v in set_list)
-							if(v in d.vars)
-								vals += v
-								vals[v] = SDQL_expression(d, set_list[v])
-
-						if(isturf(d))
-							for(var/v in vals)
-								if(v == "x" || v == "y" || v == "z")
-									continue
-
-								d.vars[v] = vals[v]
-
-						else
-							for(var/v in vals)
-								d.vars[v] = vals[v]
+							v = SDQL_expression(d, v)
+							d.SDQL_update(v.name, v)
 						CHECK_TICK
 
 
@@ -248,7 +243,7 @@
 
 	type = text2path(type)
 	var/typecache = typecacheof(type)
-	
+
 	if(ispath(type, /mob))
 		for(var/mob/d in location)
 			if(typecache[d.type])

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -398,11 +398,10 @@
 
 	else if(expression[i] == "\[")
 		var/list/expressions_list = expression[++i]
-		val = list()
+		var/list/val2 = list()
 		for(var/list/expression_list in expressions_list)
-			val.len++
-			val[val.len] = SDQL_expression(object, expression_list)
-
+			val2[++val2.len] = SDQL_expression(object, expression_list)
+		val = val2
 	else
 		val = SDQL_var(object, expression, i)
 		i = expression.len

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -18,7 +18,7 @@
 
 */
 
-/datum/proc/SDQL_update(var/list/vars_list)
+/datum/proc/SDQL_update(list/vars_list)
 	for(var/v in vars_list)
 		vars[v] = vars_list[v]
 	return TRUE

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -136,8 +136,12 @@
 				if("set" in query_tree)
 					var/list/set_list = query_tree["set"]
 					for(var/datum/d in objs)
+						var/list/set_vals = list()
 						for(var/v in set_list)
-							v = SDQL_expression(d, v)
+							if(v in d.vars)
+								vals += v
+								vals[v] = SDQL_expression(d, set_list[v])
+						for(var/v in vals)
 							d.SDQL_update(set_list[v.name], set_list[v])
 						CHECK_TICK
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -400,7 +400,7 @@
 		var/list/expressions_list = expression[++i]
 		val = list()
 		for(var/list/expression_list in expressions_list)
-			val += SDQL_expression(object, expression_list)
+			val[++val.len] = SDQL_expression(object, expression_list)
 
 	else
 		val = SDQL_var(object, expression, i)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -51,93 +51,107 @@
 	if(!querys || querys.len < 1)
 		return
 
-	for(var/list/query_tree in querys)
-		var/list/from_objs = list()
-		var/list/select_types = list()
+	try
 
-		switch(query_tree[1])
-			if("explain")
-				SDQL_testout(query_tree["explain"])
-				return
+		for(var/list/query_tree in querys)
+			var/list/from_objs = list()
+			var/list/select_types = list()
 
-			if("call")
-				if("on" in query_tree)
-					select_types = query_tree["on"]
-				else
+			switch(query_tree[1])
+				if("explain")
+					SDQL_testout(query_tree["explain"])
 					return
 
-			if("select", "delete", "update")
-				select_types = query_tree[query_tree[1]]
+				if("call")
+					if("on" in query_tree)
+						select_types = query_tree["on"]
+					else
+						return
 
-		from_objs = SDQL_from_objs(query_tree["from"])
+				if("select", "delete", "update")
+					select_types = query_tree[query_tree[1]]
 
-		var/list/objs = list()
+			from_objs = SDQL_from_objs(query_tree["from"])
 
-		for(var/type in select_types)
-			var/char = copytext(type, 1, 2)
+			var/list/objs = list()
 
-			if(char == "/" || char == "*")
-				for(var/from in from_objs)
-					objs += SDQL_get_all(type, from)
-					CHECK_TICK
+			for(var/type in select_types)
+				var/char = copytext(type, 1, 2)
 
-			else if(char == "'" || char == "\"")
-				objs += locate(copytext(type, 2, length(type)))
-
-		if("where" in query_tree)
-			var/objs_temp = objs
-			objs = list()
-			for(var/datum/d in objs_temp)
-				if(SDQL_expression(d, query_tree["where"]))
-					objs += d
-				CHECK_TICK
-
-		switch(query_tree[1])
-			if("call")
-				var/list/call_list = query_tree["call"]
-				var/list/args_list = query_tree["args"]
-
-				for(var/datum/d in objs)
-					for(var/v in call_list)
-						SDQL_callproc(d, v, args_list)
+				if(char == "/" || char == "*")
+					for(var/from in from_objs)
+						objs += SDQL_get_all(type, from)
 						CHECK_TICK
 
-			if("delete")
-				for(var/datum/d in objs)
-					qdel(d)
+				else if(char == "'" || char == "\"")
+					objs += locate(copytext(type, 2, length(type)))
+
+			if("where" in query_tree)
+				var/objs_temp = objs
+				objs = list()
+				for(var/datum/d in objs_temp)
+					if(SDQL_expression(d, query_tree["where"]))
+						objs += d
 					CHECK_TICK
 
-			if("select")
-				var/text = ""
-				for(var/datum/t in objs)
-					text += "<A HREF='?_src_=vars;Vars=\ref[t]'>\ref[t]</A>"
-					if(istype(t, /atom))
-						var/atom/a = t
+			switch(query_tree[1])
+				if("call")
+					var/list/call_list = query_tree["call"]
+					var/list/args_list = query_tree["args"]
 
-						if(a.x)
-							text += ": [t] at ([a.x], [a.y], [a.z])<br>"
+					for(var/datum/d in objs)
+						var/list/new_args = list()
+						for(var/a in args_list)
+							new_args += SDQL_expression(d,a)
+						for(var/v in call_list)
+							if(copytext(v,1,8) == "global.")
+								v = "/proc/[copytext(v,8)]"
+								call(v)(arglist(new_args))
+							else
+								SDQL_callproc(d, v, new_args)
+						CHECK_TICK
 
-						else if(a.loc && a.loc.x)
-							text += ": [t] in [a.loc] at ([a.loc.x], [a.loc.y], [a.loc.z])<br>"
+				if("delete")
+					for(var/datum/d in objs)
+						qdel(d)
+						CHECK_TICK
+
+				if("select")
+					var/text = ""
+					for(var/datum/t in objs)
+						text += "<A HREF='?_src_=vars;Vars=\ref[t]'>\ref[t]</A>"
+						if(istype(t, /atom))
+							var/atom/a = t
+
+							if(a.x)
+								text += ": [t] at ([a.x], [a.y], [a.z])<br>"
+
+							else if(a.loc && a.loc.x)
+								text += ": [t] in [a.loc] at ([a.loc.x], [a.loc.y], [a.loc.z])<br>"
+
+							else
+								text += ": [t]<br>"
 
 						else
 							text += ": [t]<br>"
-
-					else
-						text += ": [t]<br>"
-					CHECK_TICK
-
-				usr << browse(text, "window=SDQL-result")
-
-			if("update")
-				if("set" in query_tree)
-					var/list/set_list = query_tree["set"]
-					for(var/datum/d in objs)
-						var/list/set_vals = set_list.Copy()
-						for(var/v in set_vals)
-							set_vals[v] = SDQL_expression(d, set_list[v])
-						d.SDQL_update(set_vals)
 						CHECK_TICK
+
+					usr << browse(text, "window=SDQL-result")
+
+				if("update")
+					if("set" in query_tree)
+						var/list/set_list = query_tree["set"]
+						for(var/datum/d in objs)
+							var/list/set_vals = set_list.Copy()
+							for(var/v in set_vals)
+								set_vals[v] = SDQL_expression(d, set_list[v])
+							d.SDQL_update(set_vals)
+							CHECK_TICK
+	catch(var/exception/e)
+		usr << "<span class='boldwarning'>A runtime error has occured in your SDQL2-query.</span>"
+		usr << "\[NAME\][e.name]"
+		usr << "\[FILE\][e.file]"
+		usr << "\[LINE\][e.line]"
 
 /proc/SDQL_callproc(thing, procname, args_list)
 	set waitfor = 0
@@ -378,22 +392,40 @@
 	return list("val" = val, "i" = i)
 
 /proc/SDQL_var(datum/object, list/expression, start = 1)
-
+	var/v
 	if(expression[start] in object.vars)
-
-		if(start < expression.len && expression[start + 1] == ".")
-			return SDQL_var(object.vars[expression[start]], expression[start + 2])
-
-		else
-			return object.vars[expression[start]]
-
+		v = object.vars[expression[start]]
+	else if(expression[start] == "{" && start < expression.len)
+		if(lowertext(copytext(expression[start + 1], 1, 3)) != "0x")
+			usr << "<span class='danger'>Invalid pointer syntax: [expression[start + 1]]</span>"
+			return null
+		v = locate("\[[expression[start + 1]]]")
+		if(!v)
+			usr << "<span class='danger'>Invalid pointer: [expression[start + 1]]</span>"
+			return null
+		start++
 	else
-		return null
+		switch(expression[start])
+			if("usr")
+				v = usr
+			if("src")
+				v = object
+			if("marked")
+				if(usr.client && usr.client.holder && usr.client.holder.marked_datum)
+					v = usr.client.holder.marked_datum
+				else
+					return null
+			else
+				return null
+	if(start < expression.len && expression[start + 1] == ".")
+		return SDQL_var(v, expression[start + 2])
+	else
+		return v
 
 /proc/SDQL2_tokenize(query_text)
 
 	var/list/whitespace = list(" ", "\n", "\t")
-	var/list/single = list("(", ")", ",", "+", "-", ".", ";")
+	var/list/single = list("(", ")", ",", "+", "-", ".", ";", "{", "}")
 	var/list/multi = list(
 					"=" = list("", "="),
 					"<" = list("", "=", ">"),

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -147,7 +147,7 @@
 								set_vals[v] = SDQL_expression(d, set_list[v])
 							d.SDQL_update(set_vals)
 							CHECK_TICK
-	catch(exception/e)
+	catch(var/exception/e)
 		usr << "<span class='boldwarning'>A runtime error has occured in your SDQL2-query.</span>"
 		usr << "\[NAME\][e.name]"
 		usr << "\[FILE\][e.file]"

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -316,29 +316,29 @@
 
 //call_function:	<function name> ['(' [arguments] ')']
 /datum/SDQL_parser/proc/call_function(i, list/node, list/arguments)
-		if(length(tokenl(i)))
-			var/procname = ""
-			if(token(i) == "global" && token(i+1) == ".")
-				i += 2
-				procname = "global."
-			node += procname + token(i++)
-			if(token(i) != "(")
-				parse_error("Expected ( but found '[token(i)]'")
-			else if(token(i + 1) != ")")
-				var/list/expression_list_temp = list()
-				do
-					i = expression(i + 1, expression_list_temp)
-					if(token(i) == ",")
-						arguments[++arguments.len] = expression_list_temp
-						expression_list_temp = list()
-						continue
-				while(token(i) && token(i) != ")")
-				arguments[++arguments.len] = expression_list_temp
-			else
-				i++
+	if(length(tokenl(i)))
+		var/procname = ""
+		if(token(i) == "global" && token(i+1) == ".")
+			i += 2
+			procname = "global."
+		node += procname + token(i++)
+		if(token(i) != "(")
+			parse_error("Expected ( but found '[token(i)]'")
+		else if(token(i + 1) != ")")
+			var/list/expression_list_temp = list()
+			do
+				i = expression(i + 1, expression_list_temp)
+				if(token(i) == ",")
+					arguments[++arguments.len] = expression_list_temp
+					expression_list_temp = list()
+					continue
+			while(token(i) && token(i) != ")")
+			arguments[++arguments.len] = expression_list_temp
 		else
-			parse_error("Expected a function but found nothing")
-		return i + 1
+			i++
+	else
+		parse_error("Expected a function but found nothing")
+	return i + 1
 
 //select_function:	count_function
 /datum/SDQL_parser/proc/select_function(i, list/node)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -57,12 +57,8 @@
 	var/list/binary_operators = list("+", "-", "/", "*", "&", "|", "^")
 	var/list/comparitors = list("=", "==", "!=", "<>", "<", "<=", ">", ">=")
 
-
-
 /datum/SDQL_parser/New(query_list)
 	query = query_list
-
-
 
 /datum/SDQL_parser/proc/parse_error(error_message)
 	error = 1
@@ -98,443 +94,311 @@
 
 //query:	select_query | delete_query | update_query
 /datum/SDQL_parser/proc/query(i, list/node)
-		query_type = tokenl(i)
-
-		switch(query_type)
-			if("select")
-				select_query(i, node)
-
-			if("delete")
-				delete_query(i, node)
-
-			if("update")
-				update_query(i, node)
-
-			if("call")
-				call_query(i, node)
-
-			if("explain")
-				node += "explain"
-				node["explain"] = list()
-				query(i + 1, node["explain"])
+	query_type = tokenl(i)
+	switch(query_type)
+		if("select")
+			select_query(i, node)
+		if("delete")
+			delete_query(i, node)
+		if("update")
+			update_query(i, node)
+		if("call")
+			call_query(i, node)
+		if("explain")
+			node += "explain"
+			node["explain"] = list()
+			query(i + 1, node["explain"])
 
 
 //	select_query:	'SELECT' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]
 /datum/SDQL_parser/proc/select_query(i, list/node)
-		var/list/select = list()
-		i = select_list(i + 1, select)
-
-		node += "select"
-		node["select"] = select
-
-		var/list/from = list()
-		if(tokenl(i) in list("from", "in"))
-			i = from_list(i + 1, from)
-		else
-			from += "world"
-
-		node += "from"
-		node["from"] = from
-
-		if(tokenl(i) == "where")
-			var/list/where = list()
-			i = bool_expression(i + 1, where)
-
-			node += "where"
-			node["where"] = where
-
-		return i
-
+	var/list/select = list()
+	i = select_list(i + 1, select)
+	node += "select"
+	node["select"] = select
+	var/list/from = list()
+	if(tokenl(i) in list("from", "in"))
+		i = from_list(i + 1, from)
+	else
+		from += "world"
+	node += "from"
+	node["from"] = from
+	if(tokenl(i) == "where")
+		var/list/where = list()
+		i = bool_expression(i + 1, where)
+		node += "where"
+		node["where"] = where
+	return i
 
 //delete_query:	'DELETE' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]
 /datum/SDQL_parser/proc/delete_query(i, list/node)
-		var/list/select = list()
-		i = select_list(i + 1, select)
-
-		node += "delete"
-		node["delete"] = select
-
-		var/list/from = list()
-		if(tokenl(i) in list("from", "in"))
-			i = from_list(i + 1, from)
-		else
-			from += "world"
-
-		node += "from"
-		node["from"] = from
-
-		if(tokenl(i) == "where")
-			var/list/where = list()
-			i = bool_expression(i + 1, where)
-
-			node += "where"
-			node["where"] = where
-
-		return i
-
+	var/list/select = list()
+	i = select_list(i + 1, select)
+	node += "delete"
+	node["delete"] = select
+	var/list/from = list()
+	if(tokenl(i) in list("from", "in"))
+		i = from_list(i + 1, from)
+	else
+		from += "world"
+	node += "from"
+	node["from"] = from
+	if(tokenl(i) == "where")
+		var/list/where = list()
+		i = bool_expression(i + 1, where)
+		node += "where"
+		node["where"] = where
+	return i
 
 //update_query:	'UPDATE' select_list [('FROM' | 'IN') from_list] 'SET' assignments ['WHERE' bool_expression]
 /datum/SDQL_parser/proc/update_query(i, list/node)
-		var/list/select = list()
-		i = select_list(i + 1, select)
-
-		node += "update"
-		node["update"] = select
-
-		var/list/from = list()
-		if(tokenl(i) in list("from", "in"))
-			i = from_list(i + 1, from)
-		else
-			from += "world"
-
-		node += "from"
-		node["from"] = from
-
-		if(tokenl(i) != "set")
-			i = parse_error("UPDATE has misplaced SET")
-
-		var/list/set_assignments = list()
-		i = assignments(i + 1, set_assignments)
-
-		node += "set"
-		node["set"] = set_assignments
-
-		if(tokenl(i) == "where")
-			var/list/where = list()
-			i = bool_expression(i + 1, where)
-
-			node += "where"
-			node["where"] = where
-
-		return i
-
+	var/list/select = list()
+	i = select_list(i + 1, select)
+	node += "update"
+	node["update"] = select
+	var/list/from = list()
+	if(tokenl(i) in list("from", "in"))
+		i = from_list(i + 1, from)
+	else
+		from += "world"
+	node += "from"
+	node["from"] = from
+	if(tokenl(i) != "set")
+		i = parse_error("UPDATE has misplaced SET")
+	var/list/set_assignments = list()
+	i = assignments(i + 1, set_assignments)
+	node += "set"
+	node["set"] = set_assignments
+	if(tokenl(i) == "where")
+		var/list/where = list()
+		i = bool_expression(i + 1, where)
+		node += "where"
+		node["where"] = where
+	return i
 
 //call_query:	'CALL' call_function ['ON' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]]
 /datum/SDQL_parser/proc/call_query(i, list/node)
-		var/list/func = list()
-		var/list/arguments = list()
-		i = call_function(i + 1, func, arguments)
-
-		node += "call"
-		node["call"] = func
-		node["args"] = arguments
-
-		if(tokenl(i) != "on")
-			return i
-
-		var/list/select = list()
-		i = select_list(i + 1, select)
-
-		node += "on"
-		node["on"] = select
-
-		var/list/from = list()
-		if(tokenl(i) in list("from", "in"))
-			i = from_list(i + 1, from)
-		else
-			from += "world"
-
-		node += "from"
-		node["from"] = from
-
-		if(tokenl(i) == "where")
-			var/list/where = list()
-			i = bool_expression(i + 1, where)
-
-			node += "where"
-			node["where"] = where
-
+	var/list/func = list()
+	var/list/arguments = list()
+	i = call_function(i + 1, func, arguments)
+	node += "call"
+	node["call"] = func
+	node["args"] = arguments
+	if(tokenl(i) != "on")
 		return i
-
+	var/list/select = list()
+	i = select_list(i + 1, select)
+	node += "on"
+	node["on"] = select
+	var/list/from = list()
+	if(tokenl(i) in list("from", "in"))
+		i = from_list(i + 1, from)
+	else
+		from += "world"
+	node += "from"
+	node["from"] = from
+	if(tokenl(i) == "where")
+		var/list/where = list()
+		i = bool_expression(i + 1, where)
+		node += "where"
+		node["where"] = where
+	return i
 
 //select_list:	select_item [',' select_list]
 /datum/SDQL_parser/proc/select_list(i, list/node)
-		i = select_item(i, node)
-
-		if(token(i) == ",")
-			i = select_list(i + 1, node)
-
-		return i
-
+	i = select_item(i, node)
+	if(token(i) == ",")
+		i = select_list(i + 1, node)
+	return i
 
 //from_list:	from_item [',' from_list]
 /datum/SDQL_parser/proc/from_list(i, list/node)
-		i = from_item(i, node)
-
-		if(token(i) == ",")
-			i = from_list(i + 1, node)
-
-		return i
-
+	i = from_item(i, node)
+	if(token(i) == ",")
+		i = from_list(i + 1, node)
+	return i
 
 //assignments:	assignment, [',' assignments]
 /datum/SDQL_parser/proc/assignments(i, list/node)
-		i = assignment(i, node)
-
-		if(token(i) == ",")
-			i = assignments(i + 1, node)
-
-		return i
-
+	i = assignment(i, node)
+	if(token(i) == ",")
+		i = assignments(i + 1, node)
+	return i
 
 //select_item:	'*' | select_function | object_type
 /datum/SDQL_parser/proc/select_item(i, list/node)
-
-		if(token(i) == "*")
-			node += "*"
-			i++
-
-		else if(tokenl(i) in select_functions)
-			i = select_function(i, node)
-
-		else
-			i = object_type(i, node)
-
-		return i
-
+	if(token(i) == "*")
+		node += "*"
+		i++
+	else if(tokenl(i) in select_functions)
+		i = select_function(i, node)
+	else
+		i = object_type(i, node)
+	return i
 
 //from_item:	'world' | object_type
 /datum/SDQL_parser/proc/from_item(i, list/node)
-
-		if(token(i) == "world")
-			node += "world"
-			i++
-
-		else
-			i = object_type(i, node)
-
-		return i
-
+	if(token(i) == "world")
+		node += "world"
+		i++
+	else
+		i = object_type(i, node)
+	return i
 
 //bool_expression:	expression [bool_operator bool_expression]
 /datum/SDQL_parser/proc/bool_expression(i, list/node)
-
-		var/list/bool = list()
-		i = expression(i, bool)
-
-		node[++node.len] = bool
-
-		if(tokenl(i) in boolean_operators)
-			i = bool_operator(i, node)
-			i = bool_expression(i, node)
-
-		return i
-
+	var/list/bool = list()
+	i = expression(i, bool)
+	node[++node.len] = bool
+	if(tokenl(i) in boolean_operators)
+		i = bool_operator(i, node)
+		i = bool_expression(i, node)
+	return i
 
 //assignment:	<variable name> '=' expression
 /datum/SDQL_parser/proc/assignment(i, list/node)
-
-		node += token(i)
-
-		if(token(i + 1) == "=")
-			var/varname = token(i)
-			node[varname] = list()
-
-			i = expression(i + 2, node[varname])
-
-		else
-			parse_error("Assignment expected, but no = found")
-
-		return i
-
+	node += token(i)
+	if(token(i + 1) == "=")
+		var/varname = token(i)
+		node[varname] = list()
+		i = expression(i + 2, node[varname])
+	else
+		parse_error("Assignment expected, but no = found")
+	return i
 
 //variable:	<variable name> | <variable name> '.' variable
 /datum/SDQL_parser/proc/variable(i, list/node)
-		var/list/L = list(token(i))
-		node[++node.len] = L
-
-		if(token(i + 1) == ".")
-			L += "."
-			i = variable(i + 2, L)
-
-		else
-			i++
-
-		return i
-
+	var/list/L = list(token(i))
+	node[++node.len] = L
+	if(token(i + 1) == ".")
+		L += "."
+		i = variable(i + 2, L)
+	else
+		i++
+	return i
 
 //object_type:	<type path> | string
 /datum/SDQL_parser/proc/object_type(i, list/node)
-
-		if(copytext(token(i), 1, 2) == "/")
-			node += token(i)
-
-		else
-			i = string(i, node)
-
-		return i + 1
-
+	if(copytext(token(i), 1, 2) == "/")
+		node += token(i)
+	else
+		i = string(i, node)
+	return i + 1
 
 //comparitor:	'=' | '==' | '!=' | '<>' | '<' | '<=' | '>' | '>='
 /datum/SDQL_parser/proc/comparitor(i, list/node)
-
-		if(token(i) in list("=", "==", "!=", "<>", "<", "<=", ">", ">="))
-			node += token(i)
-
-		else
-			parse_error("Unknown comparitor [token(i)]")
-
-		return i + 1
-
+	if(token(i) in list("=", "==", "!=", "<>", "<", "<=", ">", ">="))
+		node += token(i)
+	else
+		parse_error("Unknown comparitor [token(i)]")
+	return i + 1
 
 //bool_operator:	'AND' | '&&' | 'OR' | '||'
 /datum/SDQL_parser/proc/bool_operator(i, list/node)
-
-		if(tokenl(i) in list("and", "or", "&&", "||"))
-			node += token(i)
-
-		else
-			parse_error("Unknown comparitor [token(i)]")
-
-		return i + 1
-
+	if(tokenl(i) in list("and", "or", "&&", "||"))
+		node += token(i)
+	else
+		parse_error("Unknown comparitor [token(i)]")
+	return i + 1
 
 //string:	''' <some text> ''' | '"' <some text > '"'
 /datum/SDQL_parser/proc/string(i, list/node)
-
-		if(copytext(token(i), 1, 2) in list("'", "\""))
-			node += copytext(token(i),2,-1)
-
-		else
-			parse_error("Expected string but found '[token(i)]'")
-
-		return i + 1
-
+	if(copytext(token(i), 1, 2) in list("'", "\""))
+		node += copytext(token(i),2,-1)
+	else
+		parse_error("Expected string but found '[token(i)]'")
+	return i + 1
 
 //call_function:	<function name> ['(' [arguments] ')']
 /datum/SDQL_parser/proc/call_function(i, list/node, list/arguments)
-		if(length(tokenl(i)))
-			node += token(i++)
-			if(token(i) != "(")
-				parse_error("Expected ( but found '[token(i)]'")
-			else if(token(i + 1) != ")")
-				do
-					i = expression(i + 1, arguments)
-					if(token(i) == ",")
-						continue
-				while(token(i) && token(i) != ")")
-			else
-				i++
+	if(length(tokenl(i)))
+		node += token(i++)
+		if(token(i) != "(")
+			parse_error("Expected ( but found '[token(i)]'")
+		else if(token(i + 1) != ")")
+			do
+				i = expression(i + 1, arguments)
+				if(token(i) == ",")
+					continue
+			while(token(i) && token(i) != ")")
 		else
-			parse_error("Expected a function but found nothing")
-		return i + 1
-
+			i++
+	else
+		parse_error("Expected a function but found nothing")
+	return i + 1
 
 //select_function:	count_function
 /datum/SDQL_parser/proc/select_function(i, list/node)
-
-		parse_error("Sorry, function calls aren't available yet")
-
-		return i
-
+	parse_error("Sorry, function calls aren't available yet")
+	return i
 
 //expression:	( unary_expression | '(' expression ')' | value ) [binary_operator expression]
 /datum/SDQL_parser/proc/expression(i, list/node)
-
-		if(token(i) in unary_operators)
-			i = unary_expression(i, node)
-
-		else if(token(i) == "(")
-			var/list/expr = list()
-
-			i = expression(i + 1, expr)
-
-			if(token(i) != ")")
-				parse_error("Missing ) at end of expression.")
-
-			else
-				i++
-
-			node[++node.len] = expr
-
+	if(token(i) in unary_operators)
+		i = unary_expression(i, node)
+	else if(token(i) == "(")
+		var/list/expr = list()
+		i = expression(i + 1, expr)
+		if(token(i) != ")")
+			parse_error("Missing ) at end of expression.")
 		else
-			i = value(i, node)
-
-		if(token(i) in binary_operators)
-			i = binary_operator(i, node)
-			i = expression(i, node)
-
-		else if(token(i) in comparitors)
-			i = binary_operator(i, node)
-
-			var/list/rhs = list()
-			i = expression(i, rhs)
-
-			node[++node.len] = rhs
-
-
-		return i
-
+			i++
+		node[++node.len] = expr
+	else
+		i = value(i, node)
+	if(token(i) in binary_operators)
+		i = binary_operator(i, node)
+		i = expression(i, node)
+	else if(token(i) in comparitors)
+		i = binary_operator(i, node)
+		var/list/rhs = list()
+		i = expression(i, rhs)
+		node[++node.len] = rhs
+	return i
 
 //unary_expression:	unary_operator ( unary_expression | value | '(' expression ')' )
 /datum/SDQL_parser/proc/unary_expression(i, list/node)
-
+	if(token(i) in unary_operators)
+		var/list/unary_exp = list()
+		unary_exp += token(i)
+		i++
 		if(token(i) in unary_operators)
-			var/list/unary_exp = list()
-
-			unary_exp += token(i)
-			i++
-
-			if(token(i) in unary_operators)
-				i = unary_expression(i, unary_exp)
-
-			else if(token(i) == "(")
-				var/list/expr = list()
-
-				i = expression(i + 1, expr)
-
-				if(token(i) != ")")
-					parse_error("Missing ) at end of expression.")
-
-				else
-					i++
-
-				unary_exp[++unary_exp.len] = expr
-
+			i = unary_expression(i, unary_exp)
+		else if(token(i) == "(")
+			var/list/expr = list()
+			i = expression(i + 1, expr)
+			if(token(i) != ")")
+				parse_error("Missing ) at end of expression.")
 			else
-				i = value(i, unary_exp)
-
-			node[++node.len] = unary_exp
-
-
+				i++
+			unary_exp[++unary_exp.len] = expr
 		else
-			parse_error("Expected unary operator but found '[token(i)]'")
-
-		return i
-
+			i = value(i, unary_exp)
+		node[++node.len] = unary_exp
+	else
+		parse_error("Expected unary operator but found '[token(i)]'")
+	return i
 
 //binary_operator:	comparitor | '+' | '-' | '/' | '*' | '&' | '|' | '^'
 /datum/SDQL_parser/proc/binary_operator(i, list/node)
-
-		if(token(i) in (binary_operators + comparitors))
-			node += token(i)
-
-		else
-			parse_error("Unknown binary operator [token(i)]")
-
-		return i + 1
-
+	if(token(i) in (binary_operators + comparitors))
+		node += token(i)
+	else
+		parse_error("Unknown binary operator [token(i)]")
+	return i + 1
 
 //value:	variable | string | number | 'null'
 /datum/SDQL_parser/proc/value(i, list/node)
-
-		if(token(i) == "null")
-			node += "null"
-			i++
-
-		else if(isnum(text2num(token(i))))
-			node += text2num(token(i))
-			i++
-
-		else if(copytext(token(i), 1, 2) in list("'", "\""))
-			i = string(i, node)
-
-		else
-			i = variable(i, node)
-
-		return i
-
-
-
+	if(token(i) == "null")
+		node += "null"
+		i++
+	else if(isnum(text2num(token(i))))
+		node += text2num(token(i))
+		i++
+	else if(copytext(token(i), 1, 2) in list("'", "\""))
+		i = string(i, node)
+	else
+		i = variable(i, node)
+	return i
 
 /*EXPLAIN SELECT * WHERE 42 = 6 * 9 OR val = - 5 == 7*/

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -96,11 +96,8 @@
 	return lowertext(token(i))
 
 
-
-/datum/SDQL_parser/proc
-
 //query:	select_query | delete_query | update_query
-	query(i, list/node)
+/datum/SDQL_parser/proc/query(i, list/node)
 		query_type = tokenl(i)
 
 		switch(query_type)
@@ -123,7 +120,7 @@
 
 
 //	select_query:	'SELECT' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]
-	select_query(i, list/node)
+/datum/SDQL_parser/proc/select_query(i, list/node)
 		var/list/select = list()
 		i = select_list(i + 1, select)
 
@@ -150,7 +147,7 @@
 
 
 //delete_query:	'DELETE' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]
-	delete_query(i, list/node)
+/datum/SDQL_parser/proc/delete_query(i, list/node)
 		var/list/select = list()
 		i = select_list(i + 1, select)
 
@@ -177,7 +174,7 @@
 
 
 //update_query:	'UPDATE' select_list [('FROM' | 'IN') from_list] 'SET' assignments ['WHERE' bool_expression]
-	update_query(i, list/node)
+/datum/SDQL_parser/proc/update_query(i, list/node)
 		var/list/select = list()
 		i = select_list(i + 1, select)
 
@@ -213,7 +210,7 @@
 
 
 //call_query:	'CALL' call_function ['ON' select_list [('FROM' | 'IN') from_list] ['WHERE' bool_expression]]
-	call_query(i, list/node)
+/datum/SDQL_parser/proc/call_query(i, list/node)
 		var/list/func = list()
 		var/list/arguments = list()
 		i = call_function(i + 1, func, arguments)
@@ -251,7 +248,7 @@
 
 
 //select_list:	select_item [',' select_list]
-	select_list(i, list/node)
+/datum/SDQL_parser/proc/select_list(i, list/node)
 		i = select_item(i, node)
 
 		if(token(i) == ",")
@@ -261,7 +258,7 @@
 
 
 //from_list:	from_item [',' from_list]
-	from_list(i, list/node)
+/datum/SDQL_parser/proc/from_list(i, list/node)
 		i = from_item(i, node)
 
 		if(token(i) == ",")
@@ -271,7 +268,7 @@
 
 
 //assignments:	assignment, [',' assignments]
-	assignments(i, list/node)
+/datum/SDQL_parser/proc/assignments(i, list/node)
 		i = assignment(i, node)
 
 		if(token(i) == ",")
@@ -281,7 +278,7 @@
 
 
 //select_item:	'*' | select_function | object_type
-	select_item(i, list/node)
+/datum/SDQL_parser/proc/select_item(i, list/node)
 
 		if(token(i) == "*")
 			node += "*"
@@ -297,7 +294,7 @@
 
 
 //from_item:	'world' | object_type
-	from_item(i, list/node)
+/datum/SDQL_parser/proc/from_item(i, list/node)
 
 		if(token(i) == "world")
 			node += "world"
@@ -310,7 +307,7 @@
 
 
 //bool_expression:	expression [bool_operator bool_expression]
-	bool_expression(i, list/node)
+/datum/SDQL_parser/proc/bool_expression(i, list/node)
 
 		var/list/bool = list()
 		i = expression(i, bool)
@@ -325,7 +322,7 @@
 
 
 //assignment:	<variable name> '=' expression
-	assignment(i, list/node)
+/datum/SDQL_parser/proc/assignment(i, list/node)
 
 		node += token(i)
 
@@ -342,7 +339,7 @@
 
 
 //variable:	<variable name> | <variable name> '.' variable
-	variable(i, list/node)
+/datum/SDQL_parser/proc/variable(i, list/node)
 		var/list/L = list(token(i))
 		node[++node.len] = L
 
@@ -357,7 +354,7 @@
 
 
 //object_type:	<type path> | string
-	object_type(i, list/node)
+/datum/SDQL_parser/proc/object_type(i, list/node)
 
 		if(copytext(token(i), 1, 2) == "/")
 			node += token(i)
@@ -369,7 +366,7 @@
 
 
 //comparitor:	'=' | '==' | '!=' | '<>' | '<' | '<=' | '>' | '>='
-	comparitor(i, list/node)
+/datum/SDQL_parser/proc/comparitor(i, list/node)
 
 		if(token(i) in list("=", "==", "!=", "<>", "<", "<=", ">", ">="))
 			node += token(i)
@@ -381,7 +378,7 @@
 
 
 //bool_operator:	'AND' | '&&' | 'OR' | '||'
-	bool_operator(i, list/node)
+/datum/SDQL_parser/proc/bool_operator(i, list/node)
 
 		if(tokenl(i) in list("and", "or", "&&", "||"))
 			node += token(i)
@@ -393,7 +390,7 @@
 
 
 //string:	''' <some text> ''' | '"' <some text > '"'
-	string(i, list/node)
+/datum/SDQL_parser/proc/string(i, list/node)
 
 		if(copytext(token(i), 1, 2) in list("'", "\""))
 			node += copytext(token(i),2,-1)
@@ -405,7 +402,7 @@
 
 
 //call_function:	<function name> ['(' [arguments] ')']
-	call_function(i, list/node, list/arguments)
+/datum/SDQL_parser/proc/call_function(i, list/node, list/arguments)
 		if(length(tokenl(i)))
 			node += token(i++)
 			if(token(i) != "(")
@@ -424,7 +421,7 @@
 
 
 //select_function:	count_function
-	select_function(i, list/node)
+/datum/SDQL_parser/proc/select_function(i, list/node)
 
 		parse_error("Sorry, function calls aren't available yet")
 
@@ -432,7 +429,7 @@
 
 
 //expression:	( unary_expression | '(' expression ')' | value ) [binary_operator expression]
-	expression(i, list/node)
+/datum/SDQL_parser/proc/expression(i, list/node)
 
 		if(token(i) in unary_operators)
 			i = unary_expression(i, node)
@@ -470,7 +467,7 @@
 
 
 //unary_expression:	unary_operator ( unary_expression | value | '(' expression ')' )
-	unary_expression(i, list/node)
+/datum/SDQL_parser/proc/unary_expression(i, list/node)
 
 		if(token(i) in unary_operators)
 			var/list/unary_exp = list()
@@ -507,7 +504,7 @@
 
 
 //binary_operator:	comparitor | '+' | '-' | '/' | '*' | '&' | '|' | '^'
-	binary_operator(i, list/node)
+/datum/SDQL_parser/proc/binary_operator(i, list/node)
 
 		if(token(i) in (binary_operators + comparitors))
 			node += token(i)
@@ -519,7 +516,7 @@
 
 
 //value:	variable | string | number | 'null'
-	value(i, list/node)
+/datum/SDQL_parser/proc/value(i, list/node)
 
 		if(token(i) == "null")
 			node += "null"

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -1,0 +1,174 @@
+// Wrappers for BYOND default procs which can't directly be called by call().
+
+/proc/_abs(A)
+	return abs(A)
+
+/*/proc/_animate(atom/A, set_vars, time = 10, loop = 1, easing = LINEAR_EASING, flags = null)
+	animate(A, set_vars, time, loop, easing, flags)
+	Borked. If anyone wants to fix this be my guest.*/
+
+/proc/_acrccos(A)
+	return arccos(A)
+
+/proc/_arcsin(A)
+	return arcsin(A)
+
+/proc/_ascii2text(A)
+	return ascii2text(A)
+
+/proc/_block(Start, End)
+	return block(Start, End)
+
+/proc/_ckey(Key)
+	return ckey(Key)
+
+/proc/_ckeyEx(Key)
+	return ckeyEx(Key)
+
+/proc/_copytext(T, Start = 1, End = 0)
+	return copytext(T, Start, End)
+
+/proc/_cos(X)
+	return cos(X)
+
+/proc/_get_dir(Loc1, Loc2)
+	return get_dir(Loc1, Loc2)
+
+/proc/_get_dist(Loc1, Loc2)
+	return get_dist(Loc1, Loc2)
+
+/proc/_get_step(Ref, Dir)
+	return get_step(Ref, Dir)
+
+/proc/_hearers(Depth = world.view, Center = usr)
+	return hearers(Depth, Center)
+
+/proc/_image(icon, loc, icon_state, layer, dir)
+	return image(icon, loc, icon_state, layer, dir)
+
+/proc/_length(E)
+	return length(E)
+
+/proc/_link(thing, url)
+	thing << link(url)
+
+/proc/_locate(X, Y, Z)
+	if (isnull(Y)) // Assuming that it's only a single-argument call.
+		return locate(X)
+
+	return locate(X, Y, Z)
+
+/proc/_log(X, Y)
+	return log(X, Y)
+
+/proc/_lowertext(T)
+	return lowertext(T)
+
+/proc/_matrix(a, b, c, d, e, f)
+	return matrix(a, b, c, d, e, f)
+
+/proc/_max(...)
+	return max(arglist(args))
+
+/proc/_md5(T)
+	return md5(T)
+
+/proc/_min(...)
+	return min(arglist(args))
+
+/proc/_new(type, arguments)
+	return new type (arglist(arguments))
+
+/proc/_num2text(N, SigFig = 6)
+	return num2text(N, SigFig)
+
+/proc/_ohearers(Dist, Center = usr)
+	return ohearers(Dist, Center)
+
+/proc/_orange(Dist, Center = usr)
+	return orange(Dist, Center)
+
+/proc/_output(thing, msg, control)
+	thing << output(msg, control)
+
+/proc/_oview(Dist, Center = usr)
+	return oview(Dist, Center)
+
+/proc/_oviewers(Dist, Center = usr)
+	return oviewers(Dist, Center)
+
+/proc/_params2list(Params)
+	return params2list(Params)
+
+/proc/_pick(...)
+	return pick(arglist(args))
+
+/proc/_prob(P)
+	return prob(P)
+
+/proc/_rand(L = 0, H = 1)
+	return rand(L, H)
+
+/proc/_range(Dist, Center = usr)
+	return range(Dist, Center)
+
+/proc/_regex(pattern, flags)
+	return regex(pattern, flags)
+
+/proc/_REGEX_QUOTE(text)
+	return REGEX_QUOTE(text)
+
+/proc/_REGEX_QUOTE_REPLACEMENT(text)
+	return REGEX_QUOTE_REPLACEMENT(text)
+
+/proc/_replacetext(Haystack, Needle, Replacement, Start = 1,End = 0)
+	return replacetext(Haystack, Needle, Replacement, Start, End)
+
+/proc/_replacetextEx(Haystack, Needle, Replacement, Start = 1,End = 0)
+	return replacetextEx(Haystack, Needle, Replacement, Start, End)
+
+/proc/_rgb(R, G, B)
+	return rgb(R, G, B)
+
+/proc/_rgba(R, G, B, A)
+	return rgb(R, G, B, A)
+
+/proc/_roll(dice)
+	return roll(dice)
+
+/proc/_round(A, B = 1)
+	return round(A, B)
+
+/proc/_sin(X)
+	return sin(X)
+
+/proc/_step(Ref, Dir, Speed = 0)
+	return step(Ref, Dir, Speed)
+
+/proc/_list_add(list/L, ...)
+	if (args.len < 2)
+		return
+	L += args.Copy(2)
+
+/proc/_list_copy(list/L, Start = 1, End = 0)
+	return L.Copy(Start, End)
+
+/proc/_list_cut(list/L, Start = 1, End = 0)
+	L.Cut(Start, End)
+
+/proc/_list_find(list/L, Elem, Start = 1, End = 0)
+	return L.Find(Elem, Start, End)
+
+/proc/_list_insert(list/L, Index, Item)
+	return L.Insert(Index, Item)
+
+/proc/_list_join(list/L, Glue, Start = 0, End = 1)
+	return L.Join(Glue, Start, End)
+
+/proc/_list_remove(list/L, ...)
+	if (args.len < 2)
+		return
+	L -= args.Copy(2)
+
+/proc/_list_swap(list/L, Index1, Index2)
+	L.Swap(Index1, Index2)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -985,6 +985,7 @@
 #include "code\modules\admin\verbs\tripAI.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2_parser.dm"
+#include "code\modules\admin\verbs\SDQL2\SDQL_2_wrappers.dm"
 #include "code\modules\assembly\assembly.dm"
 #include "code\modules\assembly\bomb.dm"
 #include "code\modules\assembly\doorcontrol.dm"


### PR DESCRIPTION
#23694 Credits to /vg/station and @PJB3005
:cl:
rscadd: ADMINS: SDQL2 has been given some new features!
bugfix: SDQL2 now gives you an exception on runtime instead of flooding server runtime logs.
rscadd: SDQL2 now supports usr, which makes that variable reference to whatever mob you are in, src, which targets the object it is being called on itself, and marked, which targets the datum marked by the admin calling it. Also, it supports hex references (the hex number at the top of a VV panel) in {}s, so you can target nearly anything! Also, global procs are supported by global.[procname](args), for CALL queries.
bugfix: SDQL2 can no longer edit /datum/admins or /datum/admin_rank, and is protected from changing x/y/z of a turf and anything that would cause broken movement for movable atoms.
rscadd: SDQL2 can now get list input with [arg1, arg2]!
experimental: Do '"<string>"' to put strings inside of SDQL2 or it won't work.
/:cl: