### PR TITLE
You can no longer get shocked by grilles hidden under impassable objects

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -27,7 +27,15 @@
 
 /obj/structure/grille/Bumped(atom/user)
 	if(ismob(user))
-		shock(user, 70)
+		var/tile_density = FALSE
+		for(var/atom/movable/AM in get_turf(src))
+			if(AM == src)
+				continue
+			if(AM.density && AM.layer >= layer)
+				tile_density = TRUE
+				break
+		if(!tile_density)
+			shock(user, 70)
 
 
 /obj/structure/grille/attack_paw(mob/user)


### PR DESCRIPTION
Every time I walk into a blast shutter and it magically shocks me it makes me very sad and this fixes that.

If there are dense objects covering the grille that would block you from walking into that tile, you logically couldn't have bumped into the grille in the first place.
