### PR TITLE
Soapstones can remove messages for free; empty soapstone for janitor

### DIFF
--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -277,4 +277,4 @@ Janitor
 	belt = /obj/item/device/pda/janitor
 	ears = /obj/item/device/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/janitor
-	backpack_contents = list(/obj/item/device/modular_computer/tablet/preset/advanced=1)
+	backpack_contents = list(/obj/item/device/modular_computer/tablet/preset/advanced=1, /obj/item/soapstone/empty=1)

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -58,7 +58,7 @@
 	if(already_message)
 		our_message = already_message.creator_key == user.ckey
 
-	if(!remaining_uses && !our_message)
+	if(!remaining_uses && !already_message)
 		// The dull chisel is dull.
 		user << "<span class='warning'>[src] is [w_dull].</span>"
 		return
@@ -73,15 +73,13 @@
 
 		// Removing our own messages refunds a charge
 
-		if((our_message || can_use()) && do_after(user, tool_speed, target=target) && (our_message || can_use()))
+		if(do_after(user, tool_speed, target=target))
 			user.visible_message("<span class='notice'>[user] has erased [already_message].</span>", "<span class='notice'>You erased [already_message].</span>")
 			already_message.persists = FALSE
 			qdel(already_message)
 			playsound(loc, 'sound/items/gavel.ogg', 50, 1, -1)
 			if(our_message)
 				refund_use()
-			else
-				remove_use()
 		return
 
 	var/message = stripped_input(user, "What would you like to [w_engrave]?", "[name] Message")

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -1,6 +1,6 @@
 /obj/item/soapstone
 	name = "chisel"
-	desc = "Leave informative messages for the crew, including the crew of future shifts!\n(Not suitable for engraving on shuttles, off station or on cats. Side effects may include beatings, bannings and orbital bombardment.)"
+	desc = "Leave informative messages for the crew, including the crew of future shifts!\nEven if out of uses, it can still be used to remove messages.\n(Not suitable for engraving on shuttles, off station or on cats. Side effects may include beatings, bannings and orbital bombardment.)"
 	icon = 'icons/obj/items.dmi'
 	icon_state = "soapstone"
 	throw_speed = 3
@@ -18,6 +18,7 @@
 /obj/item/soapstone/New()
 	. = ..()
 	random_name()
+	check_name() // could start empty
 
 /obj/item/soapstone/proc/random_name()
 	name = pick("soapstone", "chisel", "chalk", "magic marker")
@@ -113,18 +114,19 @@
 		return
 
 	remaining_uses--
-	if(!remaining_uses)
-		non_dull_name = name
-		name = "[w_dull] [name]"
+	check_name()
 
 /obj/item/soapstone/proc/refund_use()
 	if(remaining_uses == -1)
 		return
-	var/was_dull = !remaining_uses
 	remaining_uses++
+	check_name()
 
-	if(was_dull)
+/obj/item/soapstone/proc/check_name()
+	if(remaining_uses)
 		name = non_dull_name
+	else
+		name = "[w_dull] [name]"
 
 /* Persistent engraved messages, etched onto the station turfs to serve
    as instructions and/or memes for the next generation of spessmen.
@@ -135,6 +137,9 @@
 
 /obj/item/soapstone/infinite
 	remaining_uses = -1
+
+/obj/item/soapstone/empty
+	remaining_uses = 0
 
 /proc/good_chisel_message_location(turf/T)
 	if(!T)


### PR DESCRIPTION
:cl: coiax
add: Soapstones/chisel/magic markers/chalk can remove messages for free.
Removing one of your own messages still grants a use.
add: The Janitor starts with a dull soapstone for removing unwanted messages.
/:cl: