### PR TITLE
Removes "it seems pristine and undamaged."

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -433,9 +433,7 @@ Class Procs:
 			user << "<span class='warning'>It's on fire!</span>"
 		var/healthpercent = (obj_integrity/max_integrity) * 100
 		switch(healthpercent)
-			if(100 to INFINITY)
-				user <<  "It seems pristine and undamaged."
-			if(50 to 100)
+			if(50 to 99)
 				user <<  "It looks slightly damaged."
 			if(25 to 50)
 				user <<  "It appears heavily damaged."

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -106,9 +106,7 @@
 /obj/structure/proc/examine_status(mob/user) //An overridable proc, mostly for falsewalls.
 	var/healthpercent = (obj_integrity/max_integrity) * 100
 	switch(healthpercent)
-		if(100 to INFINITY)
-			return  "It seems pristine and undamaged."
-		if(50 to 100)
+		if(50 to 99)
 			return  "It looks slightly damaged."
 		if(25 to 50)
 			return  "It appears heavily damaged."

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -97,9 +97,7 @@
 			user << "<span class='warning'>It's on fire!</span>"
 		var/healthpercent = (obj_integrity/max_integrity) * 100
 		switch(healthpercent)
-			if(100 to INFINITY)
-				user <<  "It seems pristine and undamaged."
-			if(50 to 100)
+			if(50 to 99)
 				user <<  "It looks slightly damaged."
 			if(25 to 50)
 				user <<  "It appears heavily damaged."


### PR DESCRIPTION
The grand majority of inanimate things go through the entire round without losing health, to the point where players commenting that a thing isn't damaged isn't exactly a shocking development.

This message is largely redundant and is adding extra examine lines to all over the place, The lack of a message now implies that it's undamaged.

Examine bloat is annoying, if you don't need something to be stated for people to understand the functionality it really shouldn't be stated.

The idea that if you smack something enough it breaks is a very organic concept, people can/do discover these things without seeing this message.