### PR TITLE
Fixes various networks traversing transit space

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -14,7 +14,7 @@
 /obj/machinery/atmospherics/onShuttleMove()
 	. = ..()
 	for(DEVICE_TYPE_LOOP)
-		if(get_area(node[I]) != get_area(src))
+		if(get_area(nodes[I]) != get_area(src))
 			nullifyNode(I)
 
 /obj/structure/cable/onShuttleMove()
@@ -24,6 +24,13 @@
 #define DIR_CHECK_TURF_AREA(X) (get_ranged_target_turf(src, X, 1) != A)
 	if(DIR_CHECK_TURF_AREA(NORTH) || DIR_CHECK_TURF_AREA(SOUTH) || DIR_CHECK_TURF_AREA(EAST) || DIR_CHECK_TURF_AREA(WEST))
 		cut_cable_from_powernet()
+
+/obj/structure/disposalpipe/onShuttleMove()
+	. = ..()
+	var/A = get_area(src)
+	//break pipes on the edge
+	if(DIR_CHECK_TURF_AREA(NORTH) || DIR_CHECK_TURF_AREA(SOUTH) || DIR_CHECK_TURF_AREA(EAST) || DIR_CHECK_TURF_AREA(WEST))
+		deconstruct(FALSE)
 #undef DIR_CHECK_TURF_AREA
 
 /atom/movable/light/onShuttleMove()

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -17,6 +17,15 @@
 		if(get_area(node[I]) != get_area(src))
 			nullifyNode(I)
 
+/obj/structure/cable/onShuttleMove()
+	. = ..()
+	var/A = get_area(src)
+	//cut cables on the edge
+#define DIR_CHECK_TURF_AREA(X) (get_ranged_target_turf(src, X, 1) != A)
+	if(DIR_CHECK_TURF_AREA(NORTH) || DIR_CHECK_TURF_AREA(SOUTH) || DIR_CHECK_TURF_AREA(EAST) || DIR_CHECK_TURF_AREA(WEST))
+		cut_cable_from_powernet()
+#undef DIR_CHECK_TURF_AREA
+
 /atom/movable/light/onShuttleMove()
 	return 0
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -17,7 +17,7 @@
 		if(get_area(nodes[I]) != get_area(src))
 			nullifyNode(I)
 
-#define DIR_CHECK_TURF_AREA(X) (get_ranged_target_turf(src, X, 1) != A)
+#define DIR_CHECK_TURF_AREA(X) (get_area(get_ranged_target_turf(src, X, 1)) != A)
 /obj/structure/cable/onShuttleMove()
 	. = ..()
 	var/A = get_area(src)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -17,11 +17,11 @@
 		if(get_area(nodes[I]) != get_area(src))
 			nullifyNode(I)
 
+#define DIR_CHECK_TURF_AREA(X) (get_ranged_target_turf(src, X, 1) != A)
 /obj/structure/cable/onShuttleMove()
 	. = ..()
 	var/A = get_area(src)
 	//cut cables on the edge
-#define DIR_CHECK_TURF_AREA(X) (get_ranged_target_turf(src, X, 1) != A)
 	if(DIR_CHECK_TURF_AREA(NORTH) || DIR_CHECK_TURF_AREA(SOUTH) || DIR_CHECK_TURF_AREA(EAST) || DIR_CHECK_TURF_AREA(WEST))
 		cut_cable_from_powernet()
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -11,6 +11,12 @@
 		return 0
 	. = ..()
 
+/obj/machinery/atmospherics/onShuttleMove()
+	. = ..()
+	for(DEVICE_TYPE_LOOP)
+		if(get_area(node[I]) != get_area(src))
+			nullifyNode(I)
+
 /atom/movable/light/onShuttleMove()
 	return 0
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -24,13 +24,6 @@
 	//cut cables on the edge
 	if(DIR_CHECK_TURF_AREA(NORTH) || DIR_CHECK_TURF_AREA(SOUTH) || DIR_CHECK_TURF_AREA(EAST) || DIR_CHECK_TURF_AREA(WEST))
 		cut_cable_from_powernet()
-
-/obj/structure/disposalpipe/onShuttleMove()
-	. = ..()
-	var/A = get_area(src)
-	//break pipes on the edge
-	if(DIR_CHECK_TURF_AREA(NORTH) || DIR_CHECK_TURF_AREA(SOUTH) || DIR_CHECK_TURF_AREA(EAST) || DIR_CHECK_TURF_AREA(WEST))
-		deconstruct(FALSE)
 #undef DIR_CHECK_TURF_AREA
 
 /atom/movable/light/onShuttleMove()


### PR DESCRIPTION
Fixes #11183

:cl: Cyberboss
fix: Wire, atmos, and disposal networks no longer work across hyperspace when on the border of a shuttle
/:cl:
