### PR TITLE
[Omega] Allows Chaplain Job To Be A Selectable Job

### DIFF
--- a/_maps/map_files/OmegaStation/job/removed_jobs.dm
+++ b/_maps/map_files/OmegaStation/job/removed_jobs.dm
@@ -22,9 +22,6 @@
 /datum/job/rd/config_check()
 	return 0
 
-/datum/job/chaplain/config_check()
-	return 0
-
 /datum/job/warden/config_check()
 	return 0
 


### PR DESCRIPTION
## **OmegaStation Chaplain Job**
There is a fully functional chapel and office on the Station so there is no reason that the job itself should not be selectable. This Pull Requests removes the restriction of Chaplin job from OmegaStation and allows it to be chosen the should allow for more role play options on OmegaStation.


## **Changelog**
:cl: Tofa01
Tweak: [OmegaStation] Allows Chaplain job to be selectable.
/:cl:

