### PR TITLE
Moves SSjob initialization to first

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -2,7 +2,7 @@ var/datum/subsystem/job/SSjob
 
 /datum/subsystem/job
 	name = "Jobs"
-	init_order = 5
+	init_order = 14
 	flags = SS_NO_FIRE
 
 	var/list/occupations = list()		//List of all jobs

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -2,7 +2,7 @@ var/datum/subsystem/mapping/SSmapping
 
 /datum/subsystem/mapping
 	name = "Mapping"
-	init_order = 100000
+	init_order = 13
 	flags = SS_NO_FIRE
 	display_order = 50
 


### PR DESCRIPTION
WHAT COULD GO WRONG?

Legit though. This lets people choose jobs almost immediately. Also, by looking over job datums (which is all that is created during initialization, it seems that it does no fuckery which would require lavaland or atoms to be `Initialize`d. SSobj will soon take longer and longer to initialize and Mapping already takes forever.

Preliminary test locally went fine. Time for a testmerge?

:cl: Cyberboss
add: The job subsystem now loads instantly. No more waiting to set your occupation prefs!
/:cl: