### PR TITLE
Syndicate Nuke Detonating On Ruins Will Count As Missing The Station

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -442,6 +442,8 @@ var/bomb_set
 		off_station = NUKE_SYNDICATE_BASE
 	else
 		off_station = NUKE_NEAR_MISS
+	if (istype(A, /area/ruin))
+		off_station = NUKE_MISS_STATION
 
 	if(istype(ticker.mode, /datum/game_mode/nuclear))
 		var/obj/docking_port/mobile/Shuttle = SSshuttle.getShuttle("syndicate")


### PR DESCRIPTION
## **Syndicate Nuke Detonating On Ruins**
The Syndicate Nuke detonating on a ruin will now count as missing the station resulting in the Syndicate Operatives failing. This is to eliminate cheap tactics such as detonating the nuke on space hotel counting as a major victory for the operatives as mentioned in the issue below. If the Station Z level is not nuked the Syndicate Operatives fail basically.

## **Changelog**
:cl: Tofa01
Fix: Detonating the Syndicate Nuke on a ruin will now count as missing the station.
/:cl:

## **Fixes #23609**