### PR TITLE
Watchlist entries filtering, non-deleting messages

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -3,7 +3,6 @@ var/list/admins = list()							//all clients whom are admins
 var/list/deadmins = list()							//all clients who have used the de-admin verb.
 var/list/directory = list()							//all ckeys with associated client
 var/list/stealthminID = list()						//reference list with IDs that store ckeys, for stealthmins
-var/global/list/current_watchlist = list()			//stores players that are currently online and in the watchlist
 
 //Since it didn't really belong in any other category, I'm putting this here
 //This is for procs to replace all the goddamn 'in world's that are chilling around the code

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -569,7 +569,6 @@ var/datum/subsystem/garbage_collector/SSgarbage
 	SearchVar(deadmins)
 	SearchVar(directory)
 	SearchVar(stealthminID)
-	SearchVar(current_watchlist)
 	SearchVar(player_list)
 	SearchVar(mob_list)
 	SearchVar(living_mob_list)

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -9,7 +9,6 @@
 			<A href='?src=\ref[src];secrets=list_job_debug'>Show Job Debug</A><BR>
 			<A href='?src=\ref[src];secrets=admin_log'>Admin Log</A><BR>
 			<A href='?src=\ref[src];secrets=show_admins'>Show Admin List</A><BR>
-			<A href='?src=\ref[src];secrets=show_current_watchlist'>Show online players in the watchlist</A><BR>
 			<BR>
 			"}
 
@@ -119,13 +118,6 @@
 					var/datum/admins/D = admin_datums[ckey]
 					dat += "[ckey] - [D.rank.name]<br>"
 				usr << browse(dat, "window=showadmins;size=600x500")
-
-		if("show_current_watchlist")
-			var/dat = "<B>Watchlist: </B><HR>"
-			if(current_watchlist)
-				for(var/ckey in current_watchlist)
-					dat += "[ckey] - [current_watchlist[ckey]]"
-				usr << browse(dat, "window=showcurrentwatchlist;size=600x500")
 
 		if("tdomereset")
 			if(!check_rights(R_ADMIN))

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -235,7 +235,7 @@
 				data += " <a href='?_src_=holder;deletemessage=[id]'>\[Delete\]</a>"
 				if(type == "note")
 					data += " <a href='?_src_=holder;secretmessage=[id]'>[secret ? "<b>\[Secret\]</b>" : "\[Not secret\]"]</a>"
-				if(type == "message-sent")
+				if(type == "message sent")
 					data += " <font size='2'>Message has been sent</font>"
 					if(editor_ckey)
 						data += "|"
@@ -247,7 +247,7 @@
 			switch(type)
 				if("message")
 					messagedata += data
-				if("message-sent")
+				if("message sent")
 					messagedata += data
 				if("watchlist entry")
 					watchdata += data
@@ -325,7 +325,7 @@ proc/get_message_output(type, target_ckey)
 			if("message")
 				output += "<font color='red' size='3'><b>Admin message left by <span class='prefix'>[admin_ckey]</span> on [timestamp]</b></font>"
 				output += "<br><font color='red'>[text]</font><br>"
-				var/DBQuery/query_message_read = dbcon.NewQuery("UPDATE [format_table_name("messages")] SET type = 'message-sent' WHERE id = [message_id]")
+				var/DBQuery/query_message_read = dbcon.NewQuery("UPDATE [format_table_name("messages")] SET type = 'message sent' WHERE id = [message_id]")
 				if(!query_message_read.Execute())
 					var/err = query_message_read.ErrorMsg()
 					log_game("SQL ERROR updating message type. Error : \[[err]\]\n")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1087,6 +1087,9 @@
 	else if(href_list["showwatch"])
 		browse_messages("watchlist entry")
 
+	else if(href_list["showwatchfilter"])
+		browse_messages("watchlist entry", filter = 1)
+
 	else if(href_list["showmessageckey"])
 		var/target = href_list["showmessageckey"]
 		browse_messages(target_ckey = target)

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -2,7 +2,6 @@
 	SStgui.on_logout(src)
 	unset_machine()
 	player_list -= src
-	current_watchlist -= ckey
 	log_access("Logout: [key_name(src)]")
 	if(admin_datums[src.ckey])
 		if (ticker && ticker.current_state == GAME_STATE_PLAYING) //Only report this stuff if we are currently playing.


### PR DESCRIPTION
:cl:
add: Admins can now filter watchlist entries to only users who are connected.
tweak: Messages no longer delete themselves when sent.
/:cl:

Removes old `show_current_watchlist` as it's deprecated and I forgot about it before.
@lzimann This is 3 on https://dl.dropboxusercontent.com/u/169349932/quack.png