### PR TITLE
[s]Fixes race condition with unreadying at start

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -103,8 +103,6 @@
 	if(href_list["ready"])
 		if(!ticker || ticker.current_state <= GAME_STATE_PREGAME) // Make sure we don't ready up after the round has started
 			ready = text2num(href_list["ready"])
-		else
-			ready = 0
 
 	if(href_list["refresh"])
 		src << browse(null, "window=playersetup") //closes the player setup window


### PR DESCRIPTION
Fixes bugs exposed by #23552 

You can't just arbitrarily set someone as unready while the game is starting! Of course that'll fuck with shit!

@MrStonedOne 

:cl: Cyberboss
fix: The rare case of duping your inventory at roundstart has been fixed
/:cl:
