### PR TITLE
Makes firedoors adjacent to areas with fire alarms close

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -43,6 +43,13 @@
 		areas |= T.loc
 	return areas
 
+/proc/get_adjacent_areas(atom/center)
+	. = list(get_area(get_ranged_target_turf(center, NORTH, 1)))
+	. |= list(get_area(get_ranged_target_turf(center, SOUTH, 1)))
+	. |= list(get_area(get_ranged_target_turf(center, EAST, 1)))
+	. |= list(get_area(get_ranged_target_turf(center, WEST, 1)))
+	listclearnulls(.)
+
 // Like view but bypasses luminosity check
 
 /proc/get_hear(range, atom/source)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -44,10 +44,10 @@
 	return areas
 
 /proc/get_adjacent_areas(atom/center)
-	. = list(get_area(get_ranged_target_turf(center, NORTH, 1)))
-	. |= list(get_area(get_ranged_target_turf(center, SOUTH, 1)))
-	. |= list(get_area(get_ranged_target_turf(center, EAST, 1)))
-	. |= list(get_area(get_ranged_target_turf(center, WEST, 1)))
+	. = list(get_area(get_ranged_target_turf(center, NORTH, 1)),
+			get_area(get_ranged_target_turf(center, SOUTH, 1)),
+			get_area(get_ranged_target_turf(center, EAST, 1)),
+			get_area(get_ranged_target_turf(center, WEST, 1)))
 	listclearnulls(.)
 
 /proc/get_open_turf_in_dir(atom/center, dir)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -50,6 +50,18 @@
 	. |= list(get_area(get_ranged_target_turf(center, WEST, 1)))
 	listclearnulls(.)
 
+/proc/get_open_turf_in_dir(atom/center, dir)
+	var/turf/open/T = get_ranged_target_turf(center, dir, 1)
+	if(istype(T))
+		return T
+
+/proc/get_adjacent_open_areas(atom/center)
+	. = list(get_open_turf_in_dir(center, NORTH),
+			get_open_turf_in_dir(center, SOUTH),
+			get_open_turf_in_dir(center, EAST),
+			get_open_turf_in_dir(center, WEST))
+	listclearnulls(.)
+
 // Like view but bypasses luminosity check
 
 /proc/get_hear(range, atom/source)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -55,12 +55,18 @@
 	if(istype(T))
 		return T
 
-/proc/get_adjacent_open_areas(atom/center)
+/proc/get_adjacent_open_turfs(atom/center)
 	. = list(get_open_turf_in_dir(center, NORTH),
 			get_open_turf_in_dir(center, SOUTH),
 			get_open_turf_in_dir(center, EAST),
 			get_open_turf_in_dir(center, WEST))
 	listclearnulls(.)
+
+/proc/get_adjacent_open_areas(atom/center)
+	. = list()
+	var/list/adjacent_turfs = get_adjacent_open_turfs(center)
+	for(var/I in adjacent_turfs)
+		. |= get_area(I)
 
 // Like view but bypasses luminosity check
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -59,8 +59,9 @@
 									'sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg',\
 									'sound/ambience/ambigen12.ogg','sound/ambience/ambigen14.ogg')
 	flags = CAN_BE_DIRTY
-	var/firedoors_last_closed_on = 0
 
+	var/list/firedoors
+	var/firedoors_last_closed_on = 0
 
 /*Adding a wizard area teleport list because motherfucking lag -- Urist*/
 /*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
@@ -186,14 +187,23 @@ var/list/teleportlocs = list()
 		return 1
 	return 0
 
-/area/proc/CloseFiredoors()
-	firedoors_last_closed_on = world.time
-	for(var/obj/machinery/door/firedoor/D in src)
-		if(!D.welded)
-			if(D.operating)
-				D.nextstate = CLOSED
-			else if(!D.density)
-				INVOKE_ASYNC(D, /obj/machinery/door/firedoor.proc/close)
+/area/proc/ModifyFiredoors(opening)
+	if(firedoors)
+		firedoors_last_closed_on = world.time
+		for(var/FD in firedoors)
+			var/obj/machinery/door/firedoor/D = FD
+			var/cont = !D.welded
+			if(cont && opening)	//don't open if adjacent area is on fire
+				for(var/I in D.affecting_areas)
+					var/area/A = I
+					if(A.fire)
+						cont = FALSE
+						break
+			if(cont)
+				if(D.operating)
+					D.nextstate = opening ? OPEN : CLOSED
+				else if(!(D.density ^ opening))
+					INVOKE_ASYNC(D, (opening ? /obj/machinery/door/firedoor.proc/open : /obj/machinery/door/firedoor.proc/close))
 
 /area/proc/firealert(obj/source)
 	if(always_unpowered == 1) //no fire alarms in space/asteroid
@@ -204,7 +214,7 @@ var/list/teleportlocs = list()
 	for(var/area/RA in related)
 		if (!( RA.fire ))
 			RA.set_fire_alarm_effect()
-			RA.CloseFiredoors()
+			RA.ModifyFiredoors(FALSE)
 			for(var/obj/machinery/firealarm/F in RA)
 				F.update_icon()
 		for (var/obj/machinery/camera/C in RA)
@@ -227,14 +237,7 @@ var/list/teleportlocs = list()
 			RA.fire = 0
 			RA.mouse_opacity = 0
 			RA.updateicon()
-			for(var/obj/machinery/door/firedoor/D in RA)
-				if(!D.welded)
-					if(D.operating)
-						D.nextstate = OPEN
-					else if(D.density)
-						INVOKE_ASYNC(D, /obj/machinery/door/firedoor.proc/open)
-			for(var/obj/machinery/firealarm/F in RA)
-				F.update_icon()
+			RA.ModifyFiredoors(TRUE)
 
 	for (var/mob/living/silicon/aiPlayer in player_list)
 		aiPlayer.cancelAlarm("Fire", src, source)
@@ -250,7 +253,7 @@ var/list/teleportlocs = list()
 /area/process()
 	if(firedoors_last_closed_on + 100 < world.time)	//every 10 seconds
 		for(var/area/RA in related)
-			RA.CloseFiredoors()
+			RA.ModifyFiredoors(FALSE)
 
 /area/proc/burglaralert(obj/trigger)
 	if(always_unpowered == 1) //no burglar alarms in space/asteroid

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -35,7 +35,7 @@
 
 /obj/machinery/door/firedoor/proc/CalculateAffectingAreas()
 	remove_from_areas()
-	affecting_areas = get_adjacent_areas(src) | get_area(src)
+	affecting_areas = get_adjacent_open_areas(src) | get_area(src)
 	for(var/I in affecting_areas)
 		var/area/A = I
 		LAZYADD(A.firedoors, src)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -40,6 +40,8 @@
 		var/area/A = I
 		LAZYADD(A.firedoors, src)
 
+//see also turf/ChangeTurf for adjacency shennanigans
+
 /obj/machinery/door/firedoor/proc/remove_from_areas()
 	if(affecting_areas)
 		for(var/I in affecting_areas)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -27,6 +27,29 @@
 	armor = list(melee = 30, bullet = 30, laser = 20, energy = 20, bomb = 10, bio = 100, rad = 100, fire = 95, acid = 70)
 	CanAtmosPass = ATMOS_PASS_PROC
 	var/boltslocked = TRUE
+	var/list/affecting_areas
+
+/obj/machinery/door/firedoor/Initialize()
+	..()
+	CalculateAffectingAreas()
+
+/obj/machinery/door/firedoor/proc/CalculateAffectingAreas()
+	remove_from_areas()
+	affecting_areas = get_adjacent_areas(src) | get_area(src)
+	for(var/I in affecting_areas)
+		var/area/A = I
+		LAZYADD(A.firedoors, src)
+
+/obj/machinery/door/firedoor/proc/remove_from_areas()
+	if(affecting_areas)
+		for(var/I in affecting_areas)
+			var/area/A = I
+			LAZYREMOVE(A.firedoors, src)
+
+/obj/machinery/door/firedoor/Destroy()
+	remove_from_areas()
+	affecting_areas.Cut()
+	return ..()
 
 /obj/machinery/door/firedoor/Bumped(atom/AM)
 	if(panel_open || operating)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -40,7 +40,7 @@
 		var/area/A = I
 		LAZYADD(A.firedoors, src)
 
-//see also turf/ChangeTurf for adjacency shennanigans
+//see also turf/AfterChange for adjacency shennanigans
 
 /obj/machinery/door/firedoor/proc/remove_from_areas()
 	if(affecting_areas)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -228,9 +228,15 @@
 		A.contents += turfs
 		A.SetDynamicLighting()
 	A.has_gravity = old_gravity
+
+	for(var/area/RA in old.related)
+		if(RA.firedoors)
+			for(var/D in RA.firedoors)
+				var/obj/machinery/door/firedoor/FD = D
+				FD.CalculateAffectingAreas()
+
 	creator << "<span class='notice'>You have created a new area, named [str]. It is now weather proof, and constructing an APC will allow it to be powered.</span>"
 	return 1
-
 
 /obj/item/areaeditor/proc/edit_area()
 	var/area/A = get_area()
@@ -244,6 +250,10 @@
 	set_area_machinery_title(A,str,prevname)
 	for(var/area/RA in A.related)
 		RA.name = str
+		if(RA.firedoors)
+			for(var/D in RA.firedoors)
+				var/obj/machinery/door/firedoor/FD = D
+				FD.CalculateAffectingAreas()
 	usr << "<span class='notice'>You rename the '[prevname]' to '[str]'.</span>"
 	interact()
 	return 1

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -189,13 +189,6 @@
 	W.explosion_level = old_ex_level
 	W.explosion_id = old_ex_id
 
-	//update firedoor adjacency
-	var/list/turfs_to_check = get_adjacent_open_turfs() | src
-	for(var/I in turfs_to_check)
-		var/turf/T = I
-		for(var/obj/machinery/door/firedoor/FD in T)
-			FD.CalculateAffectingAreas()
-
 	if(!defer_change)
 		W.AfterChange(ignore_air)
 	W.blueprint_data = old_blueprint_data
@@ -208,6 +201,13 @@
 	if(!can_have_cabling())
 		for(var/obj/structure/cable/C in contents)
 			C.deconstruct()
+
+	//update firedoor adjacency
+	var/list/turfs_to_check = get_adjacent_open_turfs(src) | src
+	for(var/I in turfs_to_check)
+		var/turf/T = I
+		for(var/obj/machinery/door/firedoor/FD in T)
+			FD.CalculateAffectingAreas()
 
 	queue_smooth_neighbors(src)
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -189,6 +189,12 @@
 	W.explosion_level = old_ex_level
 	W.explosion_id = old_ex_id
 
+	//update firedoor adjacency
+	var/list/turfs_to_check = get_adjacent_open_turfs() | src
+	for(var/I in turfs_to_check)
+		var/turf/T = I
+		for(var/obj/machinery/door/firedoor/FD in T)
+			FD.CalculateAffectingAreas()
 
 	if(!defer_change)
 		W.AfterChange(ignore_air)


### PR DESCRIPTION
Title gore I know, see here:

Before:
![before](https://cloud.githubusercontent.com/assets/8171642/22629375/b4712ae2-ebb2-11e6-8bc2-97640ff49c0f.png)
After:
![after](https://cloud.githubusercontent.com/assets/8171642/22629378/b87983c8-ebb2-11e6-9499-1a50e59ab015.png)

:cl: Cyberboss
fix: Certain firedoors that should have closed during an alarm now actually close
/:cl: