### PR TITLE
Firedoors can be hand pried open after 5 seconds

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -44,6 +44,18 @@
 		stat |= NOPOWER
 	return
 
+/obj/machinery/door/firedoor/attack_hand(mob/user)
+	if(welded || operating || !density)
+		return
+	
+	user.visible_message("<span class='warning'>[user] struggles to activate \the [src]'s manual override.</span>",
+						 "<span class='warning'>You struggle to activate \the [src]'s manual override.</span>")
+	playsound(src, 'sound/machines/airlock_alien_prying.ogg', 10)
+
+	if(do_after(user, 50, TRUE, src))
+		if(welded || operating || !density)
+			return
+		open()
 
 /obj/machinery/door/firedoor/attackby(obj/item/weapon/C, mob/user, params)
 	add_fingerprint(user)


### PR DESCRIPTION
In response to the complaints in #23752

Probably shooting a fly with a machine gun but w/e

:cl: Cyberboss
add: Firedoors can now be opened by hand after 5 seconds
/:cl:

Again, my justification is these are meant to be hazard stoppers, not people stoppers