### PR TITLE
Makes robotic eyes and robotic voiceboxes robotic

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -664,6 +664,7 @@
 /obj/item/organ/tongue/robot
 	name = "robotic voicebox"
 	desc = "A voice synthesizer that can interface with organic lifeforms."
+	status = ORGAN_ROBOTIC
 	icon_state = "tonguerobot"
 	say_mod = "states"
 	attack_verb = list("beeped", "booped")
@@ -807,6 +808,7 @@
 	name = "robotic eyes"
 	icon_state = "cybernetic_eyeballs"
 	desc = "Your vision is augmented."
+	status = ORGAN_ROBOTIC
 
 /obj/item/organ/eyes/robotic/emp_act(severity)
 	if(!owner)


### PR DESCRIPTION
:cl: Swindly
fix: Robotic eyes can no longer be eaten
/:cl:

Makes the organs robotic so that they won't call prepare_eat().
Fixes https://github.com/tgstation/tgstation/issues/23738