### PR TITLE
Fixes stacks being deleted when merged in storage

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -207,7 +207,7 @@
 	update_icon()
 
 /obj/item/stack/proc/merge(obj/item/stack/S) //Merge src into S, as much as possible
-	if(S == src) //amusingly this can cause a stack to consume itself, let's not allow that.
+	if(QDELETED(S) || S == src) //amusingly this can cause a stack to consume itself, let's not allow that.
 		return
 	var/transfer = get_amount()
 	if(S.is_cyborg)


### PR DESCRIPTION
Fixes #23651 
Caused by #22918 but this time it wasn't my fault

```
<Cyberboss> fucking lol
<Cyberboss> i figgred out why stacks are deleting
...
<Cyberboss> i changed a loc assign to a forceMove
<Cyberboss> which called Crossed on the other stack
<Cyberboss> which caused it to be merged into the other stack
<Cyberboss> but that was already bieing deleted
```

:cl: Cyberboss
fix: Self deleting stackable items are fixed
/:cl: