### PR TITLE
Fixes autoimplanters not spawning for nuke ops eye implants

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1124,7 +1124,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 
 /datum/uplink_item/cyber_implants/spawn_item(turf/loc, obj/item/device/uplink/U)
 	if(item)
-		if(istype(item, /obj/item/organ/cyberimp))
+		if(istype(item, /obj/item/organ))
 			return new /obj/item/weapon/storage/box/cyber_implants(loc, item)
 		else
 			return ..()


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/23687
🆑
fix: Nuke Ops cybernetic implants should come bundled with an autoimplanter once again.
/:cl:

Not tested, but if I read the code right this *should* work. Not sure how eye replacements will work with autoimplanter code, though.