### PR TITLE
Removes Access To Virology Access From Medical Staff Who Don't Need It

### DIFF
--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -58,7 +58,7 @@ Medical Doctor
 
 	outfit = /datum/outfit/job/doctor
 
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_cloning, access_mineral_storeroom)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_genetics, access_cloning, access_mineral_storeroom)
 	minimal_access = list(access_medical, access_morgue, access_surgery, access_cloning)
 
 /datum/outfit/job/doctor
@@ -93,7 +93,7 @@ Chemist
 
 	outfit = /datum/outfit/job/chemist
 
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_cloning, access_mineral_storeroom)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_genetics, access_cloning, access_mineral_storeroom)
 	minimal_access = list(access_medical, access_chemistry, access_mineral_storeroom)
 
 /datum/outfit/job/chemist
@@ -127,7 +127,7 @@ Geneticist
 
 	outfit = /datum/outfit/job/geneticist
 
-	access = list(access_medical, access_morgue, access_chemistry, access_virology, access_genetics, access_cloning, access_research, access_xenobiology, access_robotics, access_mineral_storeroom, access_tech_storage)
+	access = list(access_medical, access_morgue, access_chemistry, access_genetics, access_cloning, access_research, access_xenobiology, access_robotics, access_mineral_storeroom, access_tech_storage)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_cloning, access_research)
 
 /datum/outfit/job/geneticist


### PR DESCRIPTION
## **Removes Access To Virology From Medical Staff Who Don't Need It**
Removes access to virology areas from staff who have no need to access virology such as geneticist, chemist and medical doctor. The only medical staff who should have access to this area are trained staff members such as the Chief Medical Officer and the Virologist themselves and there is no reason untrained staff members should have access into such a secure and possibly dangerous area of the station.

## **Chaneglog**
:cl: Tofa01
Tweak: Removes virology access to jobs including Medical Doctor, Geneticist and Chemist.  
/:cl:
