### PR TITLE
What I should have done long ago with Ctrl-Click

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -238,7 +238,7 @@
 /mob/living/carbon/human/CtrlClick(mob/user)
 	if(ishuman(user) && Adjacent(user))
 		var/mob/living/carbon/human/H = user
-		H.dna.species.grab(H, src, H.martial_art)
+		H.pulled(src)
 		H.next_click = world.time + CLICK_CD_MELEE
 	else
 		..()


### PR DESCRIPTION
:cl: Cobby
tweak: Ctrl-click can ONLY be used to pull. It will no longer act as a way to progress the grabs into things like chokeholds or strangling [you can START with ctrl-click, but you MUST continue using grab intent].
/:cl:

This is really a bugfix because EXPLOITERS keep finding ways to abuse the previous.
