### PR TITLE
Fixes a runtime qdeling hooded outfits

### DIFF
--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -11,9 +11,9 @@
 	..()
 
 /obj/item/clothing/suit/hooded/Destroy()
+	. = ..()
 	qdel(hood)
 	hood = null
-	return ..()
 
 /obj/item/clothing/suit/hooded/proc/MakeHood()
 	if(!hood)


### PR DESCRIPTION
```

[02:30:26]Cannot read null.loc
[02:30:26]proc name: RemoveHood (/obj/item/clothing/suit/hooded/proc/RemoveHood)
[02:30:26]  source file: toggles.dm,39
[02:30:26]  usr: null
[02:30:26]  src: the explorer suit (/obj/item/clothing/suit/hooded/explorer)
[02:30:26]  src.loc: Unknown (/mob/living/carbon/human)
[02:30:26]  call stack:
[02:30:26]the explorer suit (/obj/item/clothing/suit/hooded/explorer): RemoveHood()
[02:30:26]the explorer suit (/obj/item/clothing/suit/hooded/explorer): dropped(Unknown (/mob/living/carbon/human))
[02:30:26]the explorer suit (/obj/item/clothing/suit/hooded/explorer): Destroy(0)
[02:30:26]the explorer suit (/obj/item/clothing/suit/hooded/explorer): Destroy(0)
[02:30:26]qdel(the explorer suit (/obj/item/clothing/suit/hooded/explorer), 0)
[02:30:26]Unknown (/mob/living/carbon/human): Destroy(0)
[02:30:26]Unknown (/mob/living/carbon/human): Destroy(0)
[02:30:26]Unknown (/mob/living/carbon/human): Destroy(0)
[02:30:26]Unknown (/mob/living/carbon/human): Destroy(0)
[02:30:26]Unknown (/mob/living/carbon/human): Destroy(0)
[02:30:26]Unknown (/mob/living/carbon/human): Destroy(0)
[02:30:26]Unknown (/mob/living/carbon/human): Destroy(0)
[02:30:26]Unknown (/mob/living/carbon/human): Destroy(0)
[02:30:26]qdel(Unknown (/mob/living/carbon/human), 0)
[02:30:26]the chasm (63,53,5) (/turf/open/chasm/straight_down/lava_land_surface): drop(Unknown (/mob/living/carbon/human))
[02:30:26]ImmediateInvokeAsync(the chasm (63,53,5) (/turf/open/chasm/straight_down/lava_land_surface), /turf/open/chasm/proc/drop (/turf/open/chasm/proc/drop), Unknown (/mob/living/carbon/human))
runtime error: 
```
Fairly self explanatory what's happening