### PR TITLE
Fixes a teleportation runtime

### DIFF
--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -148,7 +148,7 @@ Frequency:
 	for(var/obj/machinery/computer/teleporter/com in machines)
 		if(com.target)
 			var/area/A = get_area(com.target)
-			if(A.noteleport)
+			if(!A || A.noteleport)
 				continue
 			if(com.power_station && com.power_station.teleporter_hub && com.power_station.engaged)
 				L["[get_area(com.target)] (Active)"] = com.target


### PR DESCRIPTION
```
The following runtime has occurred 25 time(s).
runtime error: Cannot read null.noteleport
proc name: attack self (/obj/item/weapon/hand_tele/attack_self)
  source file: teleportation.dm,151
  usr: Isaac Catimov (/mob/living/carbon/human)
  src: the hand tele (/obj/item/weapon/hand_tele)
```