### PR TITLE
Fixes a dismemberment runtime

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -35,6 +35,8 @@
 	var/turf/target_turf = get_turf(src)
 	for(var/i in 1 to t_range-1)
 		var/turf/new_turf = get_step(target_turf, direction)
+		if(!new_turf)
+			break
 		target_turf = new_turf
 		if(new_turf.density)
 			break


### PR DESCRIPTION
```
The following runtime has occurred 23 time(s).
runtime error: Cannot read null.density
proc name: dismember (/obj/item/bodypart/proc/dismember)
  source file: dismemberment.dm,39
  usr: MrGear (/mob/living/carbon/human)
  src: the left leg (/obj/item/bodypart/l_leg)
```