### PR TITLE
Makes the Hyperfractal Gigashuttle purchasable for 100,000 credits

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -149,6 +149,7 @@
 	Outside of admin intervention, it cannot explode. \
 	It does, however, still dust anything on contact, emits high levels of radiation, and induce hallucinations in anyone looking at it without protective goggles. \
 	Emitters spawn powered on, expect admin notices, they are harmless."
+	credit_cost = 100000
 
 /datum/map_template/shuttle/emergency/imfedupwiththisworld
 	suffix = "imfedupwiththisworld"


### PR DESCRIPTION
:cl: coiax
add: The Hyperfractal Gigashuttle is now purchasable for 100,000 credits. Help Centcom by testing this very safe and efficient shuttle design. (Terms and conditions apply.)
/:cl:

Because it costs a lot, and people loved it back then, they will love it
now. And it'll actually take a LOT of effort to buy, given the cost.