### PR TITLE
Vehicles now ignore lube, except for the scooter and skateboard

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -147,7 +147,7 @@
 		var/obj/buckled_obj
 		if(C.buckled)
 			buckled_obj = C.buckled
-			if(!(lube&GALOSHES_DONT_HELP)) //can't slip while buckled unless it's lube.
+			if(!(lube&GALOSHES_DONT_HELP) || buckled_obj.ignore_lube) //can't slip while buckled unless it's lube.
 				return 0
 		else
 			if(C.lying || !(C.status_flags & CANWEAKEN)) // can't slip unbuckled mob if they're lying or can't fall.

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -2,6 +2,7 @@
 	name = "scooter"
 	desc = "A fun way to get around."
 	icon_state = "scooter"
+	ignore_lube = FALSE
 
 /obj/vehicle/scooter/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/wrench))

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -14,6 +14,7 @@
 	var/auto_door_open = TRUE
 	var/view_range = 7
 	var/datum/riding/riding_datum = null
+	var/ignore_lube = TRUE
 
 /obj/vehicle/update_icon()
 	return


### PR DESCRIPTION
:cl: Lzimann
tweak: Vehicles now ignore lube, except for the scooter and skateboard
/:cl:

Or if you prefer I could make all vehicles slide like it was ice instead of straight ignoring.

Closes #23558