### PR TITLE
Fixes a runtime with sec huds

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -223,7 +223,7 @@
 	var/icon/I = icon(icon, icon_state, dir)
 	holder.pixel_y = I.Height() - world.icon_size
 	var/perpname = get_face_name(get_id_name(""))
-	if(perpname)
+	if(perpname && data_core)
 		var/datum/data/record/R = find_record("name", perpname, data_core.security)
 		if(R)
 			switch(R.fields["criminal"])


### PR DESCRIPTION
```
The following runtime has occurred 2 time(s).
runtime error: Cannot read null.security
proc name: sec hud set security status (/mob/living/carbon/human/proc/sec_hud_set_security_status)
  source file: data_huds.dm,227
  usr: (src)
  src: Courtney Wardle (/mob/living/carbon/human/dummy)
  src.loc: null
```

TL;DR World loaded, player observed, tried to turn on data huds.

...I think