### PR TITLE
Fixes a runtime with reset_perspective

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -251,7 +251,7 @@ var/next_mob_id = 0
 /mob/living/reset_perspective(atom/A)
 	if(..())
 		update_sight()
-		if(client.eye != src)
+		if(client.eye && client.eye != src)
 			var/atom/AT = client.eye
 			AT.get_remote_view_fullscreens(src)
 		else


### PR DESCRIPTION
```
The following runtime has occurred 2 time(s).
runtime error: Cannot execute null.get remote view fullscreens().
proc name: reset perspective (/mob/living/reset_perspective)
  source file: mob.dm,256
  usr: (src)
  src: R.A.I. (/mob/living/silicon/pai)
  src.loc: null
```

From what I can tell, this is probably due to AI eyes breaking all the time