### PR TITLE
You can now emag the escape pods to launch them

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -387,12 +387,9 @@
 	launch_status = UNLAUNCHED
 
 /obj/docking_port/mobile/pod/request()
-	var/emagged = FALSE
 	var/obj/machinery/computer/shuttle/S = getControlConsole()
-	if(S)
-		emagged = S.emagged
 
-	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA || emagged)
+	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA || (S && S.emagged))
 		if(launch_status == UNLAUNCHED)
 			launch_status = EARLY_LAUNCHED
 			return ..()
@@ -424,7 +421,7 @@
 /obj/machinery/computer/shuttle/pod/emag_act(mob/user)
 	if(!emagged)
 		emagged = TRUE
-		user << "<span class='notice'>You fried the pod's alert level checking system.</span>"
+		user << "<span class='warning'>You fry the pod's alert level checking system.</span>"
 
 /obj/docking_port/stationary/random
 	name = "escape pod"

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -387,7 +387,12 @@
 	launch_status = UNLAUNCHED
 
 /obj/docking_port/mobile/pod/request()
-	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA)
+	var/emagged = FALSE
+	var/obj/machinery/computer/shuttle/S = getControlConsole()
+	if(S)
+		emagged = S.emagged
+
+	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA || emagged)
 		if(launch_status == UNLAUNCHED)
 			launch_status = EARLY_LAUNCHED
 			return ..()
@@ -415,6 +420,11 @@
 
 /obj/machinery/computer/shuttle/pod/update_icon()
 	return
+
+/obj/machinery/computer/shuttle/pod/emag_act(mob/user)
+	if(!emagged)
+		emagged = TRUE
+		user << "<span class='notice'>You fried the pod's alert level checking system.</span>"
 
 /obj/docking_port/stationary/random
 	name = "escape pod"
@@ -467,6 +477,7 @@
 	density = 0
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "safe"
+	var/unlocked = FALSE
 
 /obj/item/weapon/storage/pod/New()
 	..()
@@ -486,13 +497,18 @@
 	return
 
 /obj/item/weapon/storage/pod/MouseDrop(over_object, src_location, over_location)
-	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA)
+	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA || unlocked)
 		. = ..()
 	else
 		usr << "The storage unit will only unlock during a Red or Delta security alert."
 
 /obj/item/weapon/storage/pod/attack_hand(mob/user)
-	return
+	return MouseDrop(user)
+
+/obj/item/weapon/storage/pod/onShuttleMove()
+	unlocked = TRUE
+	// If the pod was launched, the storage will always open.
+	return ..()
 
 
 /obj/docking_port/mobile/emergency/backup

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -697,4 +697,13 @@
 		else
 			dst = destination
 		. += " towards [dst ? dst.name : "unknown location"] ([timeLeft(600)] minutes)"
+
+
+// attempts to locate /obj/machinery/computer/shuttle with matching ID inside the shuttle
+/obj/docking_port/mobile/proc/getControlConsole()
+	for(var/obj/machinery/computer/shuttle/S in areaInstance)
+		if(S.shuttleId == id)
+			return S
+	return null
+
 #undef DOCKING_PORT_HIGHLIGHT


### PR DESCRIPTION
Now you can emag the control panel, press the button and enjoy your trip to lavaland.

This adds a new fun way to get rid of targets, and makes it possible to sabotage pods and force people to use the shuttle.

Complimentary changes:
* The pod storage will permanently unlock when the pod is launched. This fixes a corner case when the pod is launched in Code Red, but then alert level gets dropped and storage stops working.
* The pod storage will now also open on click, just like it does on click-drag.

:cl: CoreOverload
add: You can now emag the escape pods to launch them under any alert code.
/:cl: