### PR TITLE
Fix supermatter consumed in a closet by a singulo

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -438,3 +438,7 @@
 	for(var/atom/A in contents)
 		A.ex_act(severity, target)
 		CHECK_TICK
+
+/obj/structure/closet/singularity_act()
+	dump_contents()
+	..()


### PR DESCRIPTION
Fixes #23301

:cl: Cyberboss
fix: Supermatter in a closet/crate will now properly fee the singulo
/:cl:
