### PR TITLE
Removes kicking of afk clients in lobby

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -225,7 +225,7 @@ var/last_irc_status = 0
 /world/proc/OnReboot(reason, feedback_c, feedback_r, round_end_sound_sent)
 	feedback_set_details("[feedback_c]","[feedback_r]")
 	log_game("<span class='boldannounce'>Rebooting World. [reason]</span>")
-	kick_clients_in_lobby("<span class='boldannounce'>The round came to an end with you in the lobby.</span>", 1) //second parameter ensures only afk clients are kicked
+
 #ifdef dellogging
 	var/log = file("data/logs/del.log")
 	log << time2text(world.realtime)


### PR DESCRIPTION
iirc the afk variable on clients is preserved on world reboot, so this really isn't needed since afk admins would still stop showing in adminwho or preventing the irc relay of admin helps

and not kicking them would allow us to increase our perceived player count for that sweet sweet epeen

:cl:
experiment: Removed the kicking of clients in the lobby on round end.
/:cl:
