### PR TITLE
Make pens able to un-ruin casette tapes

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -279,7 +279,7 @@
 			fix()
     else if(ruined && istype(W, /obj/item/weapon/pen))
 		user << "<span class='notice'>You start winding the tape back in...</span>"
-		if(do_after(user, 120, target = src))
+		if(do_after(user, 120*1.5, target = src))
 			user << "<span class='notice'>You wound the tape back in.</span>"
 			fix()
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -272,16 +272,17 @@
 
 
 /obj/item/device/tape/attackby(obj/item/I, mob/user, params)
-	if(ruined && istype(I, /obj/item/weapon/screwdriver))
-		user << "<span class='notice'>You start winding the tape back in...</span>"
-		if(do_after(user, 120*I.toolspeed, target = src))
-			user << "<span class='notice'>You wound the tape back in.</span>"
-			fix()
-    else if(ruined && istype(W, /obj/item/weapon/pen))
-		user << "<span class='notice'>You start winding the tape back in...</span>"
-		if(do_after(user, 120*1.5, target = src))
-			user << "<span class='notice'>You wound the tape back in.</span>"
-			fix()
+	if(ruined)
+		var/delay = -1
+		if (istype(I, /obj/item/weapon/screwdriver))
+			delay = 120*I.toolspeed
+		else if(istype(I, /obj/item/weapon/pen))
+			delay = 120*1.5
+		if (delay != -1)
+			user << "<span class='notice'>You start winding the tape back in...</span>"
+			if(do_after(user, delay, target = src))
+				user << "<span class='notice'>You wound the tape back in.</span>"
+				fix()
 
 //Random colour tapes
 /obj/item/device/tape/random/New()

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -277,7 +277,11 @@
 		if(do_after(user, 120*I.toolspeed, target = src))
 			user << "<span class='notice'>You wound the tape back in.</span>"
 			fix()
-
+    else if(ruined && istype(W, /obj/item/weapon/pen))
+		user << "<span class='notice'>You start winding the tape back in...</span>"
+		if(do_after(user, 120, target = src))
+			user << "<span class='notice'>You wound the tape back in.</span>"
+			fix()
 
 //Random colour tapes
 /obj/item/device/tape/random/New()


### PR DESCRIPTION
:cl: ChemicalRascal
tweak: Pen is able to wind up ruined tapes.
/:cl:

[]: # Ruined tapes aren't common, but when they happen, oh boy are they a nightmare! Instead of using a proper tool, players might think about how they fix ruined tapes in reality, if they were born before 1970 and thus had to do that at some point in their lives. And, of course, nobody used a screwdriver for that, stationary was typically used.

Technically a slight buff to the detective, which is, of course, the only role on-station that is even remotely interested in tapes.