### PR TITLE
Moves shuttle name to status screen

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -123,6 +123,8 @@
 	switch(mode)
 		if(1,2,4,5)
 			user << "The display says:<br>\t<xmp>[message1]</xmp><br>\t<xmp>[message2]</xmp>"
+	if(mode == 1 && SSshuttle.emergency)
+		user << "Current Shuttle: [SSshuttle.emergency.name]"
 
 
 /obj/machinery/status_display/proc/set_message(m1, m2)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -527,7 +527,6 @@ var/next_mob_id = 0
 			stat(null, "Next Map: [nextmap.friendlyname]")
 		stat(null, "Server Time: [time2text(world.realtime, "YYYY-MM-DD hh:mm")]")
 		if(SSshuttle.emergency)
-			stat(null, "Current Shuttle: [SSshuttle.emergency.name]")
 			var/ETA = SSshuttle.emergency.getModeStr()
 			if(ETA)
 				stat(null, "[ETA] [SSshuttle.emergency.getTimerStr()]")


### PR DESCRIPTION
No more borken immursions from shuttle name on "Status" panel.

This was added to "Status" panel by admin request. And last time I asked if the admins were against moving it, they weren't.

:cl: CoreOverload
tweak: Shuttle name is no longer displayed on "Status" panel. Instead, you can now examine a status screen to see it.
/:cl: