### PR TITLE
Prevents enchanted boltaction/arcanebarrages from being unloaded

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -165,7 +165,7 @@
 /obj/item/weapon/gun/ballistic/shotgun/boltaction/enchanted/arcane_barrage/discard_gun(mob/user)
 	return
 
-/obj/item/weapon/gun/ballistic/shotgun/boltaction/attack_self()
+/obj/item/weapon/gun/ballistic/shotgun/boltaction/enchanted/attack_self()
 	return
 
 /obj/item/weapon/gun/ballistic/shotgun/boltaction/enchanted/shoot_live_shot(mob/living/user as mob|obj, pointblank = 0, mob/pbtarget = null, message = 1)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -165,6 +165,9 @@
 /obj/item/weapon/gun/ballistic/shotgun/boltaction/enchanted/arcane_barrage/discard_gun(mob/user)
 	return
 
+/obj/item/weapon/gun/ballistic/shotgun/boltaction/attack_self()
+	return
+
 /obj/item/weapon/gun/ballistic/shotgun/boltaction/enchanted/shoot_live_shot(mob/living/user as mob|obj, pointblank = 0, mob/pbtarget = null, message = 1)
 	..()
 	if(guns_left)


### PR DESCRIPTION
Makes attack_self do nothing so wizards don't lose their enchanted weapon's uses by using inhand.
makes no sense to remove a magic casing from a glowing hand either.