### PR TITLE
Fixes simple_animals NOT deathgasping

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -93,6 +93,7 @@
 	if(istype(S) && S.deathmessage)
 		message_simple = S.deathmessage
 	. = ..()
+	message_simple = initial(message_simple)
 	if(. && isalienadult(user))
 		playsound(user.loc, 'sound/voice/hiss6.ogg', 80, 1, 1)
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -299,7 +299,7 @@
 	if(!gibbed)
 		if(death_sound)
 			playsound(get_turf(src),death_sound, 200, 1)
-		if(deathmessage && !del_on_death)
+		if(deathmessage || !del_on_death)
 			emote("deathgasp")
 	if(del_on_death)
 		ghostize()


### PR DESCRIPTION
Fixes #23840 
Fixes #23887

:cl: Cyberboss
fix: Simple animals now deathgasp properly again
/:cl:

>Tfw you figure out emotes are global
