### PR TITLE
Admin only event: Station-wide Human-level Intelligence

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -3,9 +3,12 @@
 	typepath = /datum/round_event/ghost_role/sentience
 	weight = 10
 
+
 /datum/round_event/ghost_role/sentience
 	minimum_required = 1
 	role_name = "random animal"
+	var/animals = 1
+	var/one = "one"
 
 /datum/round_event/ghost_role/sentience/start()
 	var/sentience_report = "<font size=3><b>[command_name()] Medium-Priority Update</b></font>"
@@ -14,7 +17,7 @@
 	var/pets = pick("animals/bots", "bots/animals", "pets", "simple animals", "lesser lifeforms", "\[REDACTED\]")
 	var/strength = pick("human", "moderate", "lizard", "security", "command", "clown", "low", "very low", "\[REDACTED\]")
 
-	sentience_report += "<br><br>Based on [data], we believe that one of the station's [pets] has developed [strength] level intelligence, and the ability to communicate."
+	sentience_report += "<br><br>Based on [data], we believe that [one] of the station's [pets] has developed [strength] level intelligence, and the ability to communicate."
 
 	print_command_report(sentience_report, "Classified [command_name()] Update")
 	priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
@@ -36,25 +39,40 @@
 
 	if(!potential.len)
 		return WAITING_FOR_SOMETHING
-	var/mob/living/simple_animal/SA = pick(potential)
 	if(!candidates.len)
 		return NOT_ENOUGH_PLAYERS
-	var/mob/dead/observer/SG = pick(candidates)
 
-	SA.key = SG.key
-	SA.languages_spoken |= HUMAN
-	SA.languages_understood |= HUMAN
-	SA.sentience_act()
+	var/spawned_animals = 0
+	while(spawned_animals < animals && candidates.len && potential.len)
+		var/mob/living/simple_animal/SA = pick_n_take(potential)
+		var/mob/dead/observer/SG = pick_n_take(candidates)
 
-	SA.maxHealth = max(SA.maxHealth, 200)
-	SA.health = SA.maxHealth
-	SA.del_on_death = FALSE
+		spawned_animals++
 
-	spawned_mobs += SA
+		SA.key = SG.key
+		SA.languages_spoken |= HUMAN
+		SA.languages_understood |= HUMAN
+		SA.sentience_act()
 
-	SA << "<span class='userdanger'>Hello world!</span>"
-	SA << "<span class='warning'>Due to freak radiation and/or chemicals \
-		and/or lucky chance, you have gained human level intelligence \
-		and the ability to speak and understand human language!</span>"
+		SA.maxHealth = max(SA.maxHealth, 200)
+		SA.health = SA.maxHealth
+		SA.del_on_death = FALSE
+
+		spawned_mobs += SA
+
+		SA << "<span class='userdanger'>Hello world!</span>"
+		SA << "<span class='warning'>Due to freak radiation and/or chemicals \
+			and/or lucky chance, you have gained human level intelligence \
+			and the ability to speak and understand human language!</span>"
 
 	return SUCCESSFUL_SPAWN
+
+/datum/round_event_control/sentience/all
+	name = "Station-wide Human-level Intelligence"
+	typepath = /datum/round_event/ghost_role/sentience/all
+	weight = 0
+
+/datum/round_event/ghost_role/sentience/all
+	one = "all"
+	animals = INFINITY // as many as there are ghosts and animals
+	// cockroach pride, station wide


### PR DESCRIPTION
:cl: coiax
add: Added a new admin only event: Station-wide Human-level Intelligence. Like the random animal intelligence event, but affecting as many animals as there are ghosties.
/:cl:

Will lead to mouse and cockroach uprisings. Also a good solution for salty ghosts wanting to be part of an ERT. Give them a random mouse in maint, and watch them attempt to valid people anyway.