### PR TITLE
[READY]Blacklists tools, part exchangers, and beakers from the deep fryer. Allows them to be unanchored, and deconstructed

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -49,6 +49,12 @@ insert ascii eagle on american flag background here
 	if(istype(I, /obj/item/weapon/reagent_containers/food/snacks/deepfryholder))
 		user << "<span class='userdanger'>Your cooking skills are not up to the legendary Doublefry technique.</span>"
 		return
+	if(default_unfasten_wrench(user, I))
+		return
+	else if(exchange_parts(user, I))
+		return
+	else if(default_deconstruction_screwdriver(user, "fryer_off", "fryer_off" ,I)	//where's the open maint panel icon?!
+		return
 	else
 		if(I.type in blacklisted_items)
 			user << "<span class='warning'>You don't think the [I] would fry very well...</span>"

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -18,8 +18,7 @@ insert ascii eagle on american flag background here
 	container_type = OPENCONTAINER
 	var/obj/item/frying = null	//What's being fried RIGHT NOW?
 	var/cook_time = 0
-	var/list/blacklisted_items = typecacheof(list(/obj/item/weapon/screwdriver, /obj/item/weapon/crowbar, /obj/item/weapon/wrench, /obj/item/weapon/wirecutters, /obj/item/device/multitool, /obj/item/weapon/weldingtool, /obj/item/nuke_core, /obj/item/nuke_core_container, /obj/item/weapon/reagent_containers/glass, /obj/item/weapon/storage/part_replacer))
-
+	var/list/blacklisted_items
 /obj/item/weapon/circuitboard/machine/deep_fryer
 	name = "circuit board (Deep Fryer)"
 	build_path = /obj/machinery/deepfryer
@@ -28,6 +27,7 @@ insert ascii eagle on american flag background here
 
 /obj/machinery/deepfryer/New()
 	..()
+	blacklisted_items = typecacheof(list(/obj/item/weapon/screwdriver, /obj/item/weapon/crowbar, /obj/item/weapon/wrench, /obj/item/weapon/wirecutters, /obj/item/device/multitool, /obj/item/weapon/weldingtool, /obj/item/nuke_core, /obj/item/nuke_core_container, /obj/item/weapon/reagent_containers/glass, /obj/item/weapon/storage/part_replacer))
 	create_reagents(50)
 	reagents.add_reagent("nutriment", 25)
 	component_parts = list()

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -52,8 +52,8 @@ insert ascii eagle on american flag background here
 	else
 		if(I.type in blacklisted_items)
 			user << "<span class='warning'>You don't think the [I] would fry very well...</span>"
-			return FALSE
-		if(user.drop_item() && !frying)
+			. = ..()
+		else if(user.drop_item() && !frying)
 			user << "<span class='notice'>You put [I] into [src].</span>"
 			frying = I
 			frying.forceMove(src)

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -27,7 +27,7 @@ insert ascii eagle on american flag background here
 
 /obj/machinery/deepfryer/New()
 	..()
-	blacklisted_items = typecacheof(list(/obj/item/weapon/screwdriver, /obj/item/weapon/crowbar, /obj/item/weapon/wrench, /obj/item/weapon/wirecutters, /obj/item/device/multitool, /obj/item/weapon/weldingtool, /obj/item/nuke_core, /obj/item/nuke_core_container, /obj/item/weapon/reagent_containers/glass, /obj/item/weapon/storage/part_replacer))
+	blacklisted_items = typecacheof(list(/obj/item/weapon/screwdriver, /obj/item/weapon/crowbar, /obj/item/weapon/wrench, /obj/item/weapon/wirecutters, /obj/item/device/multitool, /obj/item/weapon/weldingtool, /obj/item/weapon/reagent_containers/glass, /obj/item/weapon/storage/part_replacer))
 	create_reagents(50)
 	reagents.add_reagent("nutriment", 25)
 	component_parts = list()

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -19,8 +19,8 @@ insert ascii eagle on american flag background here
 	var/obj/item/frying = null	//What's being fried RIGHT NOW?
 	var/cook_time = 0
 	var/list/blacklisted_items = typecacheof(list(/obj/item/weapon/screwdriver, /obj/item/weapon/crowbar, /obj/item/weapon/wrench,
-		/obj/item/weapon/wirecutters, /obj/item/device/multitool, /obj/item/weapon/weldingtool, /obj/item/weapon/disk/nuclear,
-		/obj/item/nuke_core, /obj/item/nuke_core_container, /obj/item/organ/brain, /obj/item/weapon/reagent_containers/glass))
+		/obj/item/weapon/wirecutters, /obj/item/device/multitool, /obj/item/weapon/weldingtool,
+		/obj/item/nuke_core, /obj/item/nuke_core_container, /obj/item/weapon/reagent_containers/glass, /obj/item/weapon/storage/part_replacer))
 
 /obj/item/weapon/circuitboard/machine/deep_fryer
 	name = "circuit board (Deep Fryer)"

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -18,9 +18,7 @@ insert ascii eagle on american flag background here
 	container_type = OPENCONTAINER
 	var/obj/item/frying = null	//What's being fried RIGHT NOW?
 	var/cook_time = 0
-	var/list/blacklisted_items = typecacheof(list(/obj/item/weapon/screwdriver, /obj/item/weapon/crowbar, /obj/item/weapon/wrench,
-		/obj/item/weapon/wirecutters, /obj/item/device/multitool, /obj/item/weapon/weldingtool,
-		/obj/item/nuke_core, /obj/item/nuke_core_container, /obj/item/weapon/reagent_containers/glass, /obj/item/weapon/storage/part_replacer))
+	var/list/blacklisted_items = typecacheof(list(/obj/item/weapon/screwdriver, /obj/item/weapon/crowbar, /obj/item/weapon/wrench, /obj/item/weapon/wirecutters, /obj/item/device/multitool, /obj/item/weapon/weldingtool, /obj/item/nuke_core, /obj/item/nuke_core_container, /obj/item/weapon/reagent_containers/glass, /obj/item/weapon/storage/part_replacer))
 
 /obj/item/weapon/circuitboard/machine/deep_fryer
 	name = "circuit board (Deep Fryer)"

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -53,7 +53,7 @@ insert ascii eagle on american flag background here
 		return
 	else if(exchange_parts(user, I))
 		return
-	else if(default_deconstruction_screwdriver(user, "fryer_off", "fryer_off" ,I)	//where's the open maint panel icon?!
+	else if(default_deconstruction_screwdriver(user, "fryer_off", "fryer_off" ,I))	//where's the open maint panel icon?!
 		return
 	else
 		if(I.type in blacklisted_items)

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -56,8 +56,7 @@ insert ascii eagle on american flag background here
 	else if(default_deconstruction_screwdriver(user, "fryer_off", "fryer_off" ,I))	//where's the open maint panel icon?!
 		return
 	else
-		if(I.type in blacklisted_items)
-			user << "<span class='warning'>You don't think the [I] would fry very well...</span>"
+		if(I in blacklisted_items)
 			. = ..()
 		else if(user.drop_item() && !frying)
 			user << "<span class='notice'>You put [I] into [src].</span>"

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -18,7 +18,8 @@ insert ascii eagle on american flag background here
 	container_type = OPENCONTAINER
 	var/obj/item/frying = null	//What's being fried RIGHT NOW?
 	var/cook_time = 0
-	var/list/blacklisted_items
+	var/static/list/blacklisted_items = typecacheof(list(/obj/item/weapon/screwdriver, /obj/item/weapon/crowbar, /obj/item/weapon/wrench, /obj/item/weapon/wirecutters, /obj/item/device/multitool, /obj/item/weapon/weldingtool, /obj/item/weapon/reagent_containers/glass, /obj/item/weapon/storage/part_replacer))
+
 /obj/item/weapon/circuitboard/machine/deep_fryer
 	name = "circuit board (Deep Fryer)"
 	build_path = /obj/machinery/deepfryer
@@ -27,7 +28,6 @@ insert ascii eagle on american flag background here
 
 /obj/machinery/deepfryer/New()
 	..()
-	blacklisted_items = typecacheof(list(/obj/item/weapon/screwdriver, /obj/item/weapon/crowbar, /obj/item/weapon/wrench, /obj/item/weapon/wirecutters, /obj/item/device/multitool, /obj/item/weapon/weldingtool, /obj/item/weapon/reagent_containers/glass, /obj/item/weapon/storage/part_replacer))
 	create_reagents(50)
 	reagents.add_reagent("nutriment", 25)
 	component_parts = list()
@@ -54,7 +54,7 @@ insert ascii eagle on american flag background here
 	else if(default_deconstruction_screwdriver(user, "fryer_off", "fryer_off" ,I))	//where's the open maint panel icon?!
 		return
 	else
-		if(I in blacklisted_items)
+		if(is_type_in_typecache(I, blacklisted_items))
 			. = ..()
 		else if(user.drop_item() && !frying)
 			user << "<span class='notice'>You put [I] into [src].</span>"

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -18,6 +18,9 @@ insert ascii eagle on american flag background here
 	container_type = OPENCONTAINER
 	var/obj/item/frying = null	//What's being fried RIGHT NOW?
 	var/cook_time = 0
+	var/list/blacklisted_items = typecacheof(list(/obj/item/weapon/screwdriver, /obj/item/weapon/crowbar, /obj/item/weapon/wrench,
+		/obj/item/weapon/wirecutters, /obj/item/device/multitool, /obj/item/weapon/weldingtool, /obj/item/weapon/disk/nuclear,
+		/obj/item/nuke_core, /obj/item/nuke_core_container, /obj/item/organ/brain, /obj/item/weapon/reagent_containers/glass))
 
 /obj/item/weapon/circuitboard/machine/deep_fryer
 	name = "circuit board (Deep Fryer)"
@@ -47,6 +50,9 @@ insert ascii eagle on american flag background here
 		user << "<span class='userdanger'>Your cooking skills are not up to the legendary Doublefry technique.</span>"
 		return
 	else
+		if(I.type in blacklisted_items)
+			user << "<span class='warning'>You don't think the [I] would fry very well...</span>"
+			return FALSE
 		if(user.drop_item() && !frying)
 			user << "<span class='notice'>You put [I] into [src].</span>"
 			frying = I


### PR DESCRIPTION
Goofball, fix your shit. Yes, this is necessary.
By the way where the hell is the maint panel open icon?