### PR TITLE
adds a turf per ms counter to air's stat page

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -56,7 +56,7 @@ var/datum/subsystem/air/SSair
 	msg += "AT:[active_turfs.len]|"
 	msg += "EG:[excited_groups.len]|"
 	msg += "HS:[hotspots.len]|"
-	msg += "PN:[networks.len]|
+	msg += "PN:[networks.len]|"
 	msg += "HP:[high_pressure_delta.len]|"
 	msg += "AS:[active_super_conductivity.len]|"
 	msg += "AT/ms:[round(active_turfs.len/cost,0.1)]"

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -45,18 +45,21 @@ var/datum/subsystem/air/SSair
 
 /datum/subsystem/air/stat_entry(msg)
 	msg += "C:{"
-	msg += "AT:[round(cost_turfs)]|"
-	msg += "EG:[round(cost_groups)]|"
-	msg += "HP:[round(cost_highpressure)]|"
-	msg += "HS:[round(cost_hotspots)]|"
-	msg += "SC:[round(cost_superconductivity)]|"
-	msg += "PN:[round(cost_pipenets)]|"
-	msg += "AM:[round(cost_atmos_machinery)]"
+	msg += "AT:[round(cost_turfs,1)]|"
+	msg += "EG:[round(cost_groups,1)]|"
+	msg += "HP:[round(cost_highpressure,1)]|"
+	msg += "HS:[round(cost_hotspots,1)]|"
+	msg += "SC:[round(cost_superconductivity,1)]|"
+	msg += "PN:[round(cost_pipenets,1)]|"
+	msg += "AM:[round(cost_atmos_machinery,1)]"
 	msg += "} "
-	msg +=  "AT:[active_turfs.len]|"
-	msg +=  "EG:[excited_groups.len]|"
-	msg +=  "HS:[hotspots.len]|"
-	msg +=  "AS:[active_super_conductivity.len]"
+	msg += "AT:[active_turfs.len]|"
+	msg += "EG:[excited_groups.len]|"
+	msg += "HS:[hotspots.len]|"
+	msg += "PN:[networks.len]|
+	msg += "HP:[high_pressure_delta.len]|"
+	msg += "AS:[active_super_conductivity.len]|"
+	msg += "AT/ms:[round(active_turfs.len/cost,0.1)]"
 	..(msg)
 
 


### PR DESCRIPTION
I'd use the turf cost var but its broken and i don't want to take the time to fix that because it would involve a macro trick to make properly timing shit much easier on subsystems and then applying this to every subsystem.

This number makes for very good bench mark of a server's powerfulness
