### PR TITLE
Adds distinct server sql name config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -20,8 +20,8 @@
 	var/name = "Configuration"			// datum name
 
 	var/server_name = null				// server name (the name of the game window)
+	var/server_sql_name = null			// short form server name used for the DB
 	var/station_name = null				// station name (the name of the station in-game)
-	var/server_suffix = 0				// generate numeric suffix based on server port
 	var/lobby_countdown = 120			// In between round countdown.
 	var/round_end_countdown = 25		// Post round murder death kill countdown
 	var/hub = 0
@@ -351,10 +351,10 @@
 					config.respawn = 0
 				if("servername")
 					config.server_name = value
+				if("serversqlname")
+					config.server_sql_name = 1
 				if("stationname")
 					config.station_name = value
-				if("serversuffix")
-					config.server_suffix = 1
 				if("hostedby")
 					config.hostedby = value
 				if("server")

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -35,8 +35,8 @@
 	if(!timestamp)
 		timestamp = SQLtime()
 	if(!server)
-		if (config && config.server_name)
-			server = config.server_name
+		if (config && config.server_sql_name)
+			server = config.server_sql_name
 	server = sanitizeSQL(server)
 	if(isnull(secret))
 		switch(alert("Hide note from being viewed by players?", "Secret note?","Yes","No","Cancel"))
@@ -352,8 +352,8 @@ proc/get_message_output(type, target_ckey)
 		var/notetext
 		notesfile >> notetext
 		var/server
-		if(config && config.server_name)
-			server = config.server_name
+		if(config && config.server_sql_name)
+			server = config.server_sql_name
 		var/regex/note = new("^(\\d{2}-\\w{3}-\\d{4}) \\| (.+) ~(\\w+)$", "i")
 		note.Find(notetext)
 		var/timestamp = note.group[1]

--- a/code/world.dm
+++ b/code/world.dm
@@ -47,9 +47,6 @@ var/list/map_transition_config = MAP_TRANSITION_CONFIG
 	LoadBans()
 	investigate_reset()
 
-	if(config && config.server_name != null && config.server_suffix && world.port > 0)
-		config.server_name += " #[(world.port % 1000) / 100]"
-
 	timezoneOffset = text2num(time2text(0,"hh")) * 36000
 
 	if(config.sql_enabled)

--- a/config/config.txt
+++ b/config/config.txt
@@ -1,5 +1,8 @@
-## Server name: This appears at the top of the screen in-game. Remove the # infront of SERVERNAME and replace 'tgstation' with the name of your choice
+## Server name: This appears at the top of the screen in-game and in the BYOND hub. Remove the # infront of SERVERNAME and replace 'tgstation' with the name of your choice.
 # SERVERNAME tgstation
+
+## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
+# SERVERSQLNAME tgstation
 
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
 STATIONNAME Space Station 13


### PR DESCRIPTION
This config is used just to identify the server in SQL because the name used to advertise to the hub, `server_name`, is oft more than the 32 character length of the `server` column in the schema, which is going to be increased in a different PR. `server_name` is unchanged so someone forgetting to change the config doesn't cause problems. See for example https://github.com/tgstation/tgstation/pull/23327#issuecomment-278540986, our servers are 41 chars but truncate the input.

Also removes a config variable that, as far as I can tell, has been depreceated since at least the first googlecode commit and its only use in the code: to append `server_name` with the connection port mod 1000 divided by 100; I can't fathom as to why.