### PR TITLE
Shuttle removals, costs, restrictions

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -45,6 +45,10 @@
 	admin_notes = "No brig, no medical facilities, no air."
 	credit_cost = -7500
 
+/datum/map_template/shuttle/emergency/airless/prerequisites_met()
+	// first 5 minutes only
+	return world.time - round_start_time < CHALLENGE_TIME_LIMIT
+
 /datum/map_template/shuttle/emergency/asteroid
 	suffix = "asteroid"
 	name = "Asteroid Station Emergency Shuttle"
@@ -104,7 +108,6 @@
 	\n\
 	Contains contraband armory guns, maintenance loot, and abandoned crates!"
 	admin_notes = "Due to origin as a solo piloted secure vessel, has an active GPS onboard labeled STV5."
-	credit_cost = -7500
 
 /datum/map_template/shuttle/emergency/meta
 	suffix = "meta"
@@ -155,13 +158,12 @@
 	name = "Oh, Hi Daniel"
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
-	credit_cost = -5000
 
 /datum/map_template/shuttle/emergency/goon
 	suffix = "goon"
 	name = "NES Port"
-	description = "The Nanotrasen Emergency Shuttle Port(NES Port for short) is a shuttle used at other less known nanotrasen facilities and has a more open inside for larger crowds."
-	credit_cost = 3000
+	description = "The Nanotrasen Emergency Shuttle Port(NES Port for short) is a shuttle used at other less known Nanotrasen facilities and has a more open inside for larger crowds, but fewer onboard shuttle facilities."
+	credit_cost = 500
 
 /datum/map_template/shuttle/emergency/wabbajack
 	suffix = "wabbajack"

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -100,44 +100,6 @@
 	qdel(src)
 
 
-//Luxury Shuttle Blockers
-
-/obj/effect/forcefield/luxury_shuttle
-	var/threshhold = 500
-	var/list/approved_passengers = list()
-
-/obj/effect/forcefield/luxury_shuttle/CanPass(atom/movable/mover, turf/target, height=0)
-	if(mover in approved_passengers)
-		return 1
-
-	if(!isliving(mover)) //No stowaways
-		return 0
-
-	var/total_cash = 0
-	var/list/counted_money = list()
-
-	for(var/obj/item/weapon/coin/C in mover)
-		total_cash += C.value
-		counted_money += C
-		if(total_cash >= threshhold)
-			break
-	for(var/obj/item/stack/spacecash/S in mover)
-		total_cash += S.value * S.amount
-		counted_money += S
-		if(total_cash >= threshhold)
-			break
-
-	if(total_cash >= threshhold)
-		for(var/obj/I in counted_money)
-			qdel(I)
-
-		mover << "Thank you for your payment! Please enjoy your flight."
-		approved_passengers += mover
-		return 1
-	else
-		mover << "You don't have enough money to enter the main shuttle. You'll have to fly coach."
-		return 0
-
 //Shuttle Build
 
 /obj/effect/shuttle_build

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -216,3 +216,42 @@
 	var/obj/item/weapon/card/id/ID = user.get_idcard()
 	if(ID && (access_cent_bar in ID.access))
 		return TRUE
+
+//Luxury Shuttle Blockers
+
+/obj/effect/forcefield/luxury_shuttle
+	var/threshhold = 500
+	var/static/list/approved_passengers = list()
+
+/obj/effect/forcefield/luxury_shuttle/CanPass(atom/movable/mover, turf/target, height=0)
+	if(mover in approved_passengers)
+		return 1
+
+	if(!isliving(mover)) //No stowaways
+		return 0
+
+	var/total_cash = 0
+	var/list/counted_money = list()
+
+	for(var/obj/item/weapon/coin/C in mover.GetAllContents())
+		total_cash += C.value
+		counted_money += C
+		if(total_cash >= threshhold)
+			break
+	for(var/obj/item/stack/spacecash/S in mover.GetAllContents())
+		total_cash += S.value * S.amount
+		counted_money += S
+		if(total_cash >= threshhold)
+			break
+
+	if(total_cash >= threshhold)
+		for(var/obj/I in counted_money)
+			qdel(I)
+
+		mover << "Thank you for your payment! Please enjoy your flight."
+		approved_passengers += mover
+		return 1
+	else
+		mover << "You don't have enough money to enter the main shuttle. You'll have to fly coach."
+		return 0
+


### PR DESCRIPTION
:cl: coiax
add: The Build your own shuttle kit can only be bought in the first five
minutes of the shift.
del: Removes the STV5 from purchase.
del: Removes the Oh, Hi Daniel from purchase, pending a redesign.
tweak: Reduced NES Port to 500 credits.
add: The Luxury Shuttle also grabs cash in your wallet and backpack, and
shares approval between the entrance gates.
/:cl:

- I'd like to redesign Oh Hi Daniel, Luxury Shuttle, and Meteor Shuttle,
but that's for another PR.

- BYOS restriction is to avoid grief.
- STV5 was an admin punishment shuttle, our current shuttle purchase
system doesn't allow refunds, so removing it for now.
- Oh Hai Daniel is a BIT MEMEY, gonna redesign it to make it bigger, put
some damn engines on the thing.
- NES Port is actually very sparse and is missing a decent amount of
materials and supplies that other shuttles have.
- Luxury Shuttle grabbing cash in your wallet is self explanatory,
although we lack a "proper" cash spending system on /tg/.