### PR TITLE
Removes shuttle STV5 from purchase (Shuttle changes #3)

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -104,7 +104,6 @@
 	\n\
 	Contains contraband armory guns, maintenance loot, and abandoned crates!"
 	admin_notes = "Due to origin as a solo piloted secure vessel, has an active GPS onboard labeled STV5."
-	credit_cost = -7500
 
 /datum/map_template/shuttle/emergency/meta
 	suffix = "meta"


### PR DESCRIPTION
:cl: coiax
del: Removes the STV5 shuttle from purchase.
/:cl:

STV5 was an admin punishment shuttle, I never envisioned the station
willingly buying it, and it serves as a horrible deathtrap inflicted by
people making poor designs. Our shuttle purchase system doesn't allow
changing, so removing it for now.