### PR TITLE
Removes Oh Hai Daniel shuttle from purchase, pending rework (Shuttle changes #4)

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -155,7 +155,6 @@
 	name = "Oh, Hi Daniel"
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
-	credit_cost = -5000
 
 /datum/map_template/shuttle/emergency/goon
 	suffix = "goon"


### PR DESCRIPTION
:cl: coiax
del: Removes Oh Hai Daniel shuttle from purchase, pending a rework.
/:cl:

Currently it's too small, has no engines, is a little memey.

I want to expand it, make it a little more usable/safe, while still
embracing the complex backstory that makes it so rich.