### PR TITLE
Reduces cost of NES Port shuttle (Shuttle changes #5)

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -160,8 +160,8 @@
 /datum/map_template/shuttle/emergency/goon
 	suffix = "goon"
 	name = "NES Port"
-	description = "The Nanotrasen Emergency Shuttle Port(NES Port for short) is a shuttle used at other less known nanotrasen facilities and has a more open inside for larger crowds."
-	credit_cost = 3000
+	description = "The Nanotrasen Emergency Shuttle Port(NES Port for short) is a shuttle used at other less known Nanotrasen facilities and has a more open inside for larger crowds, but fewer onboard shuttle facilities."
+	credit_cost = 500
 
 /datum/map_template/shuttle/emergency/wabbajack
 	suffix = "wabbajack"


### PR DESCRIPTION
:cl: coiax
add: The NES Port shuttle now costs 500 credits.
/:cl:

It's large, but lacking in a lot of the basic supplies that nearly all
other mainline shuttles have. Its current cost is too much.