### PR TITLE
Hardsuit built-in jetpacks no longer have a speed boost

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -9,6 +9,7 @@
 	var/gas_type = "o2"
 	var/on = FALSE
 	var/stabilizers = FALSE
+	var/full_speed = TRUE // If the jetpack will have a speedboost in space/nograv or not
 	var/datum/effect_system/trail_follow/ion/ion_trail
 
 /obj/item/weapon/tank/jetpack/New()
@@ -133,6 +134,7 @@
 	volume = 1
 	slot_flags = null
 	gas_type = null
+	full_speed = FALSE
 	var/datum/gas_mixture/temp_air_contents
 	var/obj/item/weapon/tank/internals/tank = null
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -863,7 +863,7 @@
 		var/obj/item/organ/cyberimp/chest/thrusters/T = H.getorganslot("thrusters")
 		if(!istype(J) && istype(C))
 			J = C.jetpack
-		if(istype(J) && J.allow_thrust(0.01, H))	//Prevents stacking
+		if(istype(J) && J.full_speed && J.allow_thrust(0.01, H))	//Prevents stacking
 			. -= 2
 		else if(istype(T) && T.allow_thrust(0.01, H))
 			. -= 2


### PR DESCRIPTION
:cl: Lzimann
tweak: Hardsuit built-in jetpacks no longer have a speed boost.
/:cl:

Why is this needed, you may ask. This is mainly because right now there's actually zero advantages in taking out your backpack(which means having LESS storage) to use a jetpack. 
This is, in my opinion, a good way to handle without straight removing it.