### PR TITLE
Removes unused translate_hive var from radios

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -7,7 +7,6 @@
 	w_class = WEIGHT_CLASS_TINY
 	origin_tech = "engineering=2;bluespace=1"
 	var/translate_binary = 0
-	var/translate_hive = 0
 	var/syndie = 0
 	var/centcom = 0
 	var/list/channels = list()

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -273,9 +273,6 @@
 		if(keyslot2.translate_binary)
 			src.translate_binary = 1
 
-		if(keyslot2.translate_hive)
-			src.translate_hive = 1
-
 		if(keyslot2.syndie)
 			src.syndie = 1
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -17,7 +17,6 @@
 	var/broadcasting = 0
 	var/listening = 1
 	var/translate_binary = 0
-	var/translate_hive = 0
 	var/freerange = 0 // 0 - Sanitize frequencies, 1 - Full range
 	var/list/channels = list() //see communications.dm for full list. First channes is a "default" for :h
 	var/obj/item/device/encryptionkey/keyslot //To allow the radio to accept encryption keys.
@@ -58,7 +57,6 @@
 /obj/item/device/radio/proc/recalculateChannels()
 	channels = list()
 	translate_binary = 0
-	translate_hive = 0
 	syndie = 0
 	centcom = 0
 
@@ -71,9 +69,6 @@
 
 		if(keyslot.translate_binary)
 			translate_binary = 1
-
-		if(keyslot.translate_hive)
-			translate_hive = 1
 
 		if(keyslot.syndie)
 			syndie = 1


### PR DESCRIPTION
I'm extremely surpised that this went unnoticed for so long.
I checked back through history, and it didn't even do anything when it was first added!
https://github.com/tgstation/tgstation/commit/785eb9dcc6a4051a5ae14e60fd3dac7f96de76fd