### PR TITLE
[Box] Fixes HOP Shutter Access Levels

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -29348,14 +29348,14 @@
 	name = "Privacy Shutters Control";
 	pixel_x = 6;
 	pixel_y = 25;
-	req_access_txt = "28"
+	req_access_txt = "57"
 	},
 /obj/machinery/button/door{
 	id = "hopqueue";
 	name = "Queue Shutters Control";
 	pixel_x = -4;
 	pixel_y = 25;
-	req_access_txt = "28"
+	req_access_txt = "57"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -4;
@@ -100153,7 +100153,7 @@ aRG
 aSO
 aTO
 aVG
-cCr
+cCq
 aVz
 bak
 bbz


### PR DESCRIPTION
## **Fixes HOP Shutter Access Levels On Boxstation**
Fixes the HOP shutter access levels, changes shutters from requiring chef level access to Head Of Personnel level access, this is to be consistent with other maps that require HOP level access to toggle the HOP office shutters. 

## **Changelog**
:cl: Tofa01
Fix: [Box] Fixes access levels for HOP shutters.
/:cl:

## **Fixes #23895**

