### PR TITLE
Allows in-game proccalls to have named arguments

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -119,15 +119,18 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		return
 
 	. = list()
+	var/list/named_args = list()
 	while(argnum--)
-		var/named_arg = input("Leave blank for positional argument(it won't work if you put AFTER putting a named arg)", "Named argument") as text|null
+		var/named_arg = input("Leave blank for positional argument. Positional arguments will be considered as if they were added first.", "Named argument") as text|null
 		var/value = vv_get_value(restricted_classes = list(VV_RESTORE_DEFAULT))
 		if (!value["class"])
 			return
 		if(named_arg)
-			.[named_arg] = value["value"]
+			named_args[named_arg] = value["value"]
 		else
 			. += value["value"]
+	if(LAZYLEN(named_args))
+		. += named_args
 
 /client/proc/get_callproc_returnval(returnval,procname)
 	. = ""

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -119,9 +119,8 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		return
 
 	. = list()
-	var/arg_position = 1
 	while(argnum--)
-		var/named_arg = input("Position[arg_position++]. Leave blank for positional argument", "Named argument") as text|null
+		var/named_arg = input("Leave blank for positional argument(it won't work if you put AFTER putting a named arg)", "Named argument") as text|null
 		var/value = vv_get_value(restricted_classes = list(VV_RESTORE_DEFAULT))
 		if (!value["class"])
 			return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -118,16 +118,17 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	if(isnull(argnum))
 		return
 
-	var/list/lst = list()
-
+	. = list()
+	var/arg_position = 1
 	while(argnum--)
+		var/named_arg = input("Position[arg_position++]. Leave blank for positional argument", "Named argument") as text|null
 		var/value = vv_get_value(restricted_classes = list(VV_RESTORE_DEFAULT))
 		if (!value["class"])
 			return
-		lst += value["value"]
-
-	return lst
-
+		if(named_arg)
+			.[named_arg] = value["value"]
+		else
+			. += value["value"]
 
 /client/proc/get_callproc_returnval(returnval,procname)
 	. = ""


### PR DESCRIPTION
There's only one problem, which would be admins putting the named arg and follow it with a positional arg(it will runtime), besides that, it works fine.