### PR TITLE
Clown internals box is now a box of hugs

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -581,6 +581,12 @@
 	new /obj/item/stack/medical/ointment(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 
+/obj/item/weapon/storage/box/hug/survival/New()
+	..()
+	new /obj/item/clothing/mask/breath(src)
+	new /obj/item/weapon/tank/internals/emergency_oxygen(src)
+	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
+
 /obj/item/ammo_casing/shotgun/rubbershot
 
 /obj/item/weapon/storage/box/rubbershot

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -35,11 +35,14 @@ Clown
 		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_laughter = 1
 		)
 
+	implants = list(/obj/item/weapon/implant/sad_trombone)
+
 	backpack = /obj/item/weapon/storage/backpack/clown
 	satchel = /obj/item/weapon/storage/backpack/clown
 	dufflebag = /obj/item/weapon/storage/backpack/dufflebag/clown //strangely has a duffle
 
-	implants = list(/obj/item/weapon/implant/sad_trombone)
+	box = /obj/item/weapon/storage/box/hug/survival
+
 
 /datum/outfit/job/clown/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()


### PR DESCRIPTION
:cl: coiax
add: The clown's survival/internals box is now a box of hugs. Dawww.
/:cl:

Was suggested. Means the clown revolver (coming in a box of hugs) isn't
as meta'able.