### PR TITLE
Removes the meme sloths

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1,5 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-//Model dictionary trimmed on: 02-02-2017 02:51 (UTC)
 "aaa" = (
 /turf/open/space,
 /area/space)
@@ -112031,7 +112030,7 @@ aMv
 aMv
 aKR
 aMv
-cVC
+aMv
 aXf
 aYM
 bao

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -81661,7 +81661,7 @@ bgy
 aZE
 bjr
 bjr
-ama
+bjr
 bmh
 bjr
 bjr
@@ -100153,7 +100153,7 @@ aRG
 aSO
 aTO
 aVG
-cCr
+cCq
 aVz
 bak
 bbz


### PR DESCRIPTION
>be cargo tech
>time to take the crates to the conveyor belt
>NOPE SLOTH FUCKING COCKBLOCKS YOU
>try to drag the crates around the sloth
>NOPE YOU MOTHERFUCKER
>die of frustration and salt

in all seriousness: few people like this sloth, a lot of people actively dislike it, it gets in the way of literally fucking everything a cargo tech does because a cargo tech's job involves manuevering things in a smallish space, people often kill it and/or shove it in lockers all round anyway, it exists in part due to a player reference meme, and the sprite looks fucking terrible. kill it with fire

(the alternative is moving it to the QM's office. but seriously, fuck this sloth)