### PR TITLE
Reduces Plasmaman Heat-Based Damage Multiplier from 2x to 1.5x

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -10,8 +10,8 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 	mutantlungs = /obj/item/organ/lungs/plasmaman
 	dangerous_existence = 1 //So so much
 	blacklisted = 1 //See above
-	burnmod = 2
-	heatmod = 2
+	burnmod = 1.5
+	heatmod = 1.5
 	breathid = "tox"
 	speedmod = 1
 	damage_overlay_type = ""//let's not show bloody wounds or burns over bones.


### PR DESCRIPTION
## Reduces Heat-damage Multiplier ##

When Plasmamen were first released, they were riddled with bugs, and quite a few quick-fixes were applied by the coder who was maintaining them at the time. One of those hotfixes was causing Plasmamen to take double damage from burn/heat, as griefers were taking off their suits to run around on fire and cause chaos.

As Plasmamen have settled into a nice niche, I feel safe in giving them a moderate buff to their damage multiplier. Enough hopefully that taking off their suit should still be incredibly dangerous, but not so much that it only takes a few laser blasts to kill them.

## Changelog ##
:cl: Sweaterkittens
tweak: Plasmamen burn damage multiplier reduced to 1.5x from 2x
/:cl:
