### PR TITLE
Fix riding_datum runtimes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -18,6 +18,7 @@
 	if(!magpulse)
 		return ..()
 
-/mob/living/silicon/robot/Move()
+/mob/living/silicon/robot/Moved()
 	. = ..()
-	riding_datum.on_vehicle_move()
+	if(riding_datum)
+		riding_datum.on_vehicle_move()


### PR DESCRIPTION
Also, `Move` is for checking is something CAN move. `Moved` is the event.

Fixes #23969 

@kevinz000 