### PR TITLE
Captain is no longer unconvertable by clockcult

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -52,7 +52,7 @@ Credit where due:
 	if(!istype(M))
 		return FALSE
 	if(M.mind)
-		if(ishuman(M) && (M.mind.assigned_role in list("Captain", "Chaplain")))
+		if(ishuman(M) && (M.mind.assigned_role in list("Chaplain")))
 			return FALSE
 		if(M.mind.enslaved_to && !is_servant_of_ratvar(M.mind.enslaved_to))
 			return FALSE


### PR DESCRIPTION
:cl: coiax
del: The captain is now as vulnerable to clockcult conversion as any
other mindshielded character, rather than being completely immune.
/:cl:

- Because it doesn't make sense that the captain, the derpy all access
assistant can't be converted, while the mean gun licking Hos CAN BE.
