### PR TITLE
Changes Command departmental channel back to gold

### DIFF
--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -28,7 +28,7 @@ em						{font-style: normal;	font-weight: bold;}
 .deadsay				{color: #5c00e6;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #193a7a;}
+.comradio				{color: #aca82d;}
 .secradio				{color: #a30000;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -28,7 +28,7 @@ em						{font-style: normal;	font-weight: bold;}
 .deadsay				{color: #5c00e6;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #aca82d;}
+.comradio				{color: #948f02;}
 .secradio				{color: #a30000;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}


### PR DESCRIPTION
_Changes the Command departmental radio channel's colour from its current navy back to gold (a darker one than before)_, changing a similar tweak in November. Images attached; edited together from uraniummeltdown's PR, which added the Bay colours, showing the original gold, navy and Medbay blue, plus one of my own that shows the darker gold. Thanks, MSO.
![command3](https://cloud.githubusercontent.com/assets/6266927/22859185/58586fa4-f0cb-11e6-88e8-58be1059c45c.png)
![comnewoldmed](https://cloud.githubusercontent.com/assets/6266927/22859186/585a272c-f0cb-11e6-88e7-06853cc04f85.png)

It suits the setting better (was blue/navy ever particularly associated with command? It was usually green or gold, unless you're focusing on the captain's outfit), and makes it more distinct from Medical's lighter blue. If I have trouble telling the difference on the fly, with my above-average colour vision and relatively high saturation setting on my screen, then what've other people been doing?

