### PR TITLE
Makes pAIs slower than humans

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai_shell.dm
+++ b/code/modules/mob/living/silicon/pai/pai_shell.dm
@@ -99,3 +99,7 @@
 	else
 		SetLuminosity(0)
 		src << "<span class='notice'>You disable your integrated light.</span>"
+
+/mob/living/silicon/pai/movement_delay()
+	. = ..()
+	. += 1 //A bit slower than humans, so they're easier to smash


### PR DESCRIPTION
:cl: Kor
add: Mobile pAIs are now slower than humans.
/:cl:

They're annoying and difficult to smash when they're running around at maxspeed with a tiny sprite and no collision.