### PR TITLE
Fixes simple_animals not deathrattling

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -302,18 +302,17 @@
 		if(deathmessage || !del_on_death)
 			emote("deathgasp")
 	if(del_on_death)
-		ghostize()
+		..()
 		//Prevent infinite loops if the mob Destroy() is overriden in such
 		//a manner as to cause a call to death() again
 		del_on_death = FALSE
 		qdel(src)
-		return
 	else
 		health = 0
 		icon_state = icon_dead
 		density = 0
 		lying = 1
-	..()
+		..()
 
 /mob/living/simple_animal/proc/CanAttack(atom/the_target)
 	if(see_invisible < the_target.invisibility)


### PR DESCRIPTION
Removed the ghostize cause that's handled at mob/Destroy

Fixes #23887 

:cl: Cyberboss
fix: Simple animals that are deleted when killed will now deathrattle
/:cl:
