### PR TITLE
Fixes Chemistry Windoor On Deltastation

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -90059,8 +90059,12 @@
 	},
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
-/obj/machinery/door/window/eastleft,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/southleft{
+	dir = 8;
+	name = "Chemistry Desk";
+	req_access_txt = "5; 33"
+	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "ddc" = (


### PR DESCRIPTION
## **Fixes Chemistry Windoor On Deltastation**
Fixes a weirdly placed double windoor on Deltastation. This Pull Request also adds the second Chemistry windoor in the correct position instead. This is to follow the same theme all other windoors & table setups have on the map.

## **Changelog**
:cl: Tofa01
Fix: [Delta] Fixes double windoor on chemistry windows.
/:cl:

## **Fixes #23945**


