### PR TITLE
Voice of God Tweak

### DIFF
--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -75,6 +75,21 @@ var/static/regex/multispin_words = regex("like a record baby|right round")
 	var/base_multiplier = 1
 	spans = list("colossus","yell")
 
+/obj/item/organ/vocal_cords/colossus/attack(mob/living/carbon/human/H, mob/living/carbon/human/user, obj/target)
+	if(H == user && istype(H))
+		user.drop_item()
+		Insert(user)
+	else
+		return ..()
+
+/obj/item/organ/vocal_cords/colossus/Insert(mob/living/carbon/M, special = 0)
+	..()
+	if(owner)
+		owner << "<span class ='notice'>Your vocal chords have been replaced with [src], you feel a strange sensation of power overcome you!</span>"
+
+/obj/item/organ/vocal_cords/colossus/prepare_eat()
+	return
+
 /datum/action/item_action/organ_action/colossus
 	name = "Voice of God"
 	var/obj/item/organ/vocal_cords/colossus/cords = null


### PR DESCRIPTION
The Voice of God is ridiculously hard to get your hands on; it rarely happens, and..even after you do so, you have to get the vocal chords manually installed on you...meaning it's subject to theft or someone just not willing to do it--this should be the case for something so difficult to acquire.

As such, the Voice of God can now be inserted into yourself by clicking it onto yourself; additionally, you can no longer "oops" consume it and eat it.

:cl: Fox McCloud
tweak: Voice of God can now be self-inserted by clicking on yourself; you can no longer accidentally eat it, either
/:cl:
