### PR TITLE
Replace delta brig cell chairs with beds

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -47865,9 +47865,6 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "bHb" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
 	on = 1;
@@ -47878,14 +47875,13 @@
 	},
 /area/security/brig)
 "bHc" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	tag = "icon-intact (SOUTHWEST)";
 	icon_state = "intact";
 	dir = 10
 	},
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
@@ -52217,10 +52213,9 @@
 	},
 /area/hallway/primary/starboard)
 "bOO" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},


### PR DESCRIPTION
:cl: ChemicalRascal
tweak: Delta station brig cell chairs have been replaced with beds. One bed per cell, no funny business.
/:cl:

The fundamental difference between chairs and beds in this situation is that chairs can be picked up and used to break windows. Beds can't be. This makes managing brigged people on Delta significantly more time-intensive. Compounding this issue is that the Delta brig only has two cells, and one of the is completely out of the line-of-sight of the Warden's desk.

This PR aims to move this situation a little in sec's favor, by giving them furniture to buckle prisoners to, but which can't be used to break out of the cell with. Not all is lost, however, prospective greyshits: Bedsheets abound. Truly, a silver lining to every cloud.