### PR TITLE
Puts files in single quotes like they belong

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -4,10 +4,10 @@
 
 /area/CATEGORY/OR/DESCRIPTOR/NAME 	(you can make as many subdivisions as you want)
 	name = "NICE NAME" 				(not required but makes things really nice)
-	icon = "ICON FILENAME" 			(defaults to areas.dmi)
+	icon = 'ICON FILENAME' 			(defaults to 'icons/turf/areas.dmi')
 	icon_state = "NAME OF ICON" 	(defaults to "unknown" (blank))
 	requires_power = 0 				(defaults to 1)
-	music = "music/music.ogg"		(defaults to "music/music.ogg")
+	music = null					(defaults to nothing, look in sound/ambience for music)
 
 NOTE: there are two lists of areas in the end of this file: centcom and station itself. Please maintain these lists valid. --rastaf0
 

--- a/code/game/area/areas/away_content.dm
+++ b/code/game/area/areas/away_content.dm
@@ -126,32 +126,32 @@
 
 /area/awaymission/centcomAway/general
 	name = "XCC-P5831"
-	music = "music/ambigen3.ogg"
+	music = 'sound/ambience/ambigen3.ogg'
 
 /area/awaymission/centcomAway/maint
 	name = "XCC-P5831 Maintenance"
 	icon_state = "away1"
-	music = "music/ambisin1.ogg"
+	music = 'sound/ambience/ambisin1.ogg'
 
 /area/awaymission/centcomAway/thunderdome
 	name = "XCC-P5831 Thunderdome"
 	icon_state = "away2"
-	music = "music/ambisin2.ogg"
+	music = 'sound/ambience/ambisin2.ogg'
 
 /area/awaymission/centcomAway/cafe
 	name = "XCC-P5831 Kitchen Arena"
 	icon_state = "away3"
-	music = "music/ambisin3.ogg"
+	music = 'sound/ambience/ambisin3.ogg'
 
 /area/awaymission/centcomAway/courtroom
 	name = "XCC-P5831 Courtroom"
 	icon_state = "away4"
-	music = "music/ambisin4.ogg"
+	music = 'sound/ambience/ambisin4.ogg'
 
 /area/awaymission/centcomAway/hangar
 	name = "XCC-P5831 Hangars"
 	icon_state = "away4"
-	music = "music/ambigen5.ogg"
+	music = 'sound/ambience/ambigen5.ogg'
 
 
 /*Cabin areas*/

--- a/code/game/area/areas/misc.dm
+++ b/code/game/area/areas/misc.dm
@@ -5,7 +5,6 @@
 	//icon = "ICON FILENAME"
 	//icon_state = "NAME OF ICON"
 	requires_power = 0
-	music = "music/music.ogg"
 
 /area/hell/trial1
 	name = "Hell Trial1"

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -286,7 +286,7 @@
 		var/timer = SSshuttle.emergency.timeLeft(1) + cursetime
 		SSshuttle.emergency.setTimer(timer)
 		user << "<span class='danger'>You shatter the orb! A dark essence spirals into the air, then disappears.</span>"
-		playsound(user.loc, "sound/effects/Glassbr1.ogg", 50, 1)
+		playsound(user.loc, 'sound/effects/Glassbr1.ogg', 50, 1)
 		qdel(src)
 		sleep(20)
 		var/global/list/curses

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -507,7 +507,7 @@
 	feedback_add_details("wizard_spell_learned",log_name)
 	rightandwrong(0, user, 25)
 	active = 1
-	playsound(get_turf(user),"sound/magic/CastSummon.ogg",50,1)
+	playsound(get_turf(user), 'sound/magic/CastSummon.ogg', 50, 1)
 	user << "<span class='notice'>You have cast summon guns!</span>"
 	return 1
 
@@ -525,7 +525,7 @@
 	feedback_add_details("wizard_spell_learned",log_name)
 	rightandwrong(1, user, 25)
 	active = 1
-	playsound(get_turf(user),"sound/magic/CastSummon.ogg",50,1)
+	playsound(get_turf(user), 'sound/magic/CastSummon.ogg', 50, 1)
 	user << "<span class='notice'>You have cast summon magic!</span>"
 	return 1
 
@@ -545,7 +545,7 @@
 	feedback_add_details("wizard_spell_learned",log_name)
 	summonevents()
 	times++
-	playsound(get_turf(user),"sound/magic/CastSummon.ogg",50,1)
+	playsound(get_turf(user), 'sound/magic/CastSummon.ogg', 50, 1)
 	user << "<span class='notice'>You have cast summon events.</span>"
 	return 1
 

--- a/code/game/machinery/computer/gulag_teleporter.dm
+++ b/code/game/machinery/computer/gulag_teleporter.dm
@@ -144,7 +144,7 @@
 /obj/machinery/computer/gulag_teleporter_computer/proc/teleport(mob/user)
 	log_game("[user]([user.ckey] teleported [prisoner]([prisoner.ckey]) to the Labor Camp ([beacon.x], [beacon.y], [beacon.z]) for [id.goal] points.")
 	teleporter.handle_prisoner(id, temporary_record)
-	playsound(loc, "sound/weapons/emitter.ogg", 50, 1)
+	playsound(loc, 'sound/weapons/emitter.ogg', 50, 1)
 	prisoner.forceMove(get_turf(beacon))
 	prisoner.Weaken(2) // small travel dizziness
 	prisoner << "<span class='warning'>The teleportation makes you a little dizzy.</span>"

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -245,7 +245,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/silenced
 	name = "\improper S.H.H. \"Quietus\" Carbine"
 	desc = "A weapon for combat exosuits. A mime invention, field tests have shown that targets cannot even scream before going down."
-	fire_sound = "sound/weapons/Gunshot_silenced.ogg"
+	fire_sound = 'sound/weapons/Gunshot_silenced.ogg'
 	icon_state = "mecha_mime"
 	equip_cooldown = 30
 	projectile = /obj/item/projectile/bullet/mime

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -297,7 +297,7 @@
 	return (BRUTELOSS)
 
 /obj/item/weapon/wirecutters/power/attack_self(mob/user)
-	playsound(get_turf(user),"sound/items/change_jaws.ogg",50,1)
+	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
 	var/obj/item/weapon/crowbar/power/pryjaws = new /obj/item/weapon/crowbar/power
 	user << "<span class='notice'>You attach the pry jaws to [src].</span>"
 	qdel(src)
@@ -735,7 +735,7 @@
 	return (BRUTELOSS)
 
 /obj/item/weapon/crowbar/power/attack_self(mob/user)
-	playsound(get_turf(user),"sound/items/change_jaws.ogg",50,1)
+	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
 	var/obj/item/weapon/wirecutters/power/cutjaws = new /obj/item/weapon/wirecutters/power
 	user << "<span class='notice'>You attach the cutting jaws to [src].</span>"
 	qdel(src)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -496,7 +496,7 @@
 /obj/item/weapon/twohanded/required/chainsaw/doomslayer/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
 	if(attack_type == PROJECTILE_ATTACK)
 		owner.visible_message("<span class='danger'>Ranged attacks just make [owner] angrier!</span>")
-		playsound(src, pick("sound/weapons/bulletflyby.ogg","sound/weapons/bulletflyby2.ogg","sound/weapons/bulletflyby3.ogg"), 75, 1)
+		playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
 		return 1
 	return 0
 
@@ -613,7 +613,7 @@
 		if(prob(final_block_chance))
 			if(attack_type == PROJECTILE_ATTACK)
 				owner.visible_message("<span class='danger'>[owner] deflects [attack_text] with [src]!</span>")
-				playsound(src, pick("sound/weapons/bulletflyby.ogg","sound/weapons/bulletflyby2.ogg","sound/weapons/bulletflyby3.ogg"), 75, 1)
+				playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
 				return 1
 			else
 				owner.visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -388,7 +388,7 @@ var/highlander_claymores = 0
 	throw_speed = 0
 	sharpness = IS_SHARP
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
-	hitsound = "sound/weapons/chainsawhit.ogg"
+	hitsound = 'sound/weapons/chainsawhit.ogg'
 
 /obj/item/weapon/mounted_chainsaw/dropped()
 	..()

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -73,7 +73,7 @@
 	if(alert)
 		var/area/alarmed = get_area(src)
 		alarmed.burglaralert(src)
-		playsound(src, "sound/effects/alert.ogg", 50, 1)
+		playsound(src, 'sound/effects/alert.ogg', 50, 1)
 
 /*
 

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -81,7 +81,7 @@
 				return
 			if(user.pulling != L)
 				return
-			playsound(src.loc, "sound/effects/splat.ogg", 25, 1)
+			playsound(src.loc, 'sound/effects/splat.ogg', 25, 1)
 			L.visible_message("<span class='danger'>[user] slams [L] onto the meat spike!</span>", "<span class='userdanger'>[user] slams you onto the meat spike!</span>", "<span class='italics'>You hear a squishy wet noise.</span>")
 			L.loc = src.loc
 			L.emote("scream")

--- a/code/modules/clothing/shoes/bananashoes.dm
+++ b/code/modules/clothing/shoes/bananashoes.dm
@@ -15,7 +15,7 @@
 /obj/item/clothing/shoes/clown_shoes/banana_shoes/step_action()
 	if(on)
 		if(footstep > 1)//honks when its on
-			playsound(src, "sound/items/bikehorn.ogg", 75, 1)
+			playsound(src, 'sound/items/bikehorn.ogg', 75, 1)
 			footstep = 0
 		else
 			footstep++

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -69,7 +69,7 @@ insert ascii eagle on american flag background here
 	if(frying)
 		cook_time++
 		if(cook_time == 30)
-			playsound(src.loc, "sound/machines/ding.ogg", 50, 1)
+			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 			visible_message("[src] dings!")
 		else if (cook_time == 60)
 			visible_message("[src] emits an acrid smell!")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -63,7 +63,7 @@
 		if(prob(martial_art.deflection_chance))
 			if(!lying && dna && !dna.check_mutation(HULK)) //But only if they're not lying down, and hulks can't do it
 				visible_message("<span class='danger'>[src] deflects the projectile; [p_they()] can't be hit with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
-				playsound(src, pick("sound/weapons/bulletflyby.ogg","sound/weapons/bulletflyby2.ogg","sound/weapons/bulletflyby3.ogg"), 75, 1)
+				playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
 				return 0
 
 	if(!(P.original == src && P.firer == src)) //can't block or reflect when shooting yourself

--- a/code/modules/mob/living/carbon/human/species_types/corporate.dm
+++ b/code/modules/mob/living/carbon/human/species_types/corporate.dm
@@ -12,7 +12,7 @@
 	punchdamagehigh = 30//they are inhumanly strong
 	punchstunthreshold = 25
 	attack_verb = "smash"
-	attack_sound = "sound/weapons/resonator_blast.ogg"
+	attack_sound = 'sound/weapons/resonator_blast.ogg'
 	blacklisted = 1
 	use_skintones = 0
 	species_traits = list(RADIMMUNE,VIRUSIMMUNE,NOBLOOD,PIERCEIMMUNE,EYECOLOR,NODISMEMBER,NOHUNGER)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -98,7 +98,7 @@
 	meat = /obj/item/weapon/ore/iron
 	info_text = "As a <span class='danger'>Plasteel Golem</span>, you are slower, but harder to stun, and hit very hard when punching."
 	attack_verb = "smash"
-	attack_sound = "sound/effects/meteorimpact.ogg" //hits pretty hard
+	attack_sound = 'sound/effects/meteorimpact.ogg' //hits pretty hard
 
 //Immune to ash storms
 /datum/species/golem/titanium
@@ -231,7 +231,7 @@
 	burnmod = 3 //melts easily
 	brutemod = 0.25
 	info_text = "As a <span class='danger'>Sand Golem</span>, you are immune to physical bullets and take very little brute damage, but are extremely vulnerable to burn damage. You will also turn to sand when dying, preventing any form of recovery."
-	attack_sound = "sound/effects/shovel_dig.ogg"
+	attack_sound = 'sound/effects/shovel_dig.ogg'
 
 /datum/species/golem/sand/spec_death(gibbed, mob/living/carbon/human/H)
 	H.visible_message("<span class='danger'>[H] turns into a pile of sand!</span>")
@@ -244,7 +244,7 @@
 /datum/species/golem/sand/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
 	if(!(P.original == H && P.firer == H))
 		if(P.flag == "bullet" || P.flag == "bomb")
-			playsound(H, "sound/effects/shovel_dig.ogg", 70, 1)
+			playsound(H, 'sound/effects/shovel_dig.ogg', 70, 1)
 			H.visible_message("<span class='danger'>The [P.name] sinks harmlessly in [H]'s sandy body!</span>", \
 			"<span class='userdanger'>The [P.name] sinks harmlessly in [H]'s sandy body!</span>")
 			return 2
@@ -260,7 +260,7 @@
 	brutemod = 3 //very fragile
 	burnmod = 0.25
 	info_text = "As a <span class='danger'>Glass Golem</span>, you reflect lasers and energy weapons, and are very resistant to burn damage, but you are extremely vulnerable to brute damage. On death, you'll shatter beyond any hope of recovery."
-	attack_sound = "sound/effects/Glassbr2.ogg"
+	attack_sound = 'sound/effects/Glassbr2.ogg'
 
 /datum/species/golem/glass/spec_death(gibbed, mob/living/carbon/human/H)
 	playsound(H, "shatter", 70, 1)
@@ -300,7 +300,7 @@
 	meat = /obj/item/weapon/ore/bluespace_crystal
 	info_text = "As a <span class='danger'>Bluespace Golem</span>, are spatially unstable: you will teleport when hit, and you can teleport manually at a long distance."
 	attack_verb = "bluespace punch"
-	attack_sound = "sound/effects/phasein.ogg"
+	attack_sound = 'sound/effects/phasein.ogg'
 
 	var/datum/action/innate/unstable_teleport/unstable_teleport
 	var/teleport_cooldown = 100
@@ -393,7 +393,7 @@
 	meat = /obj/item/weapon/ore/bananium
 	info_text = "As a <span class='danger'>Bananium Golem</span>, you are made for pranking. Your body emits natural honks, and you cannot hurt people when punching them. Your skin also emits bananas when damaged."
 	attack_verb = "honk"
-	attack_sound = "sound/items/AirHorn2.ogg"
+	attack_sound = 'sound/items/AirHorn2.ogg'
 
 	var/last_honk = 0
 	var/honkooldown = 0

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -147,16 +147,16 @@
 					break
 				else if(toner >= 5 && !busy && check_ass()) //You have to be sitting on the copier and either be a xeno or a human without clothes on.
 					if(isalienadult(ass) || istype(ass,/mob/living/simple_animal/hostile/alien)) //Xenos have their own asses, thanks to Pybro.
-						temp_img = icon("icons/ass/assalien.png")
+						temp_img = icon('icons/ass/assalien.png')
 					else if(ishuman(ass)) //Suit checks are in check_ass
 						if(ass.gender == MALE)
-							temp_img = icon("icons/ass/assmale.png")
+							temp_img = icon('icons/ass/assmale.png')
 						else if(ass.gender == FEMALE)
-							temp_img = icon("icons/ass/assfemale.png")
+							temp_img = icon('icons/ass/assfemale.png')
 						else 									//In case anyone ever makes the generic ass. For now I'll be using male asses.
-							temp_img = icon("icons/ass/assmale.png")
+							temp_img = icon('icons/ass/assmale.png')
 					else if(isdrone(ass)) //Drones are hot
-						temp_img = icon("icons/ass/assdrone.png")
+						temp_img = icon('icons/ass/assdrone.png')
 					else
 						break
 					var/obj/item/weapon/photo/p = new /obj/item/weapon/photo (loc)

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -116,7 +116,7 @@
 	projectile_type = /obj/item/projectile/beam/disabler
 	select_name  = "disable"
 	e_cost = 50
-	fire_sound = "sound/weapons/taser2.ogg"
+	fire_sound = 'sound/weapons/taser2.ogg'
 
 /obj/item/ammo_casing/energy/plasma
 	projectile_type = /obj/item/projectile/plasma
@@ -133,7 +133,7 @@
 /obj/item/ammo_casing/energy/wormhole
 	projectile_type = /obj/item/projectile/beam/wormhole
 	e_cost = 0
-	fire_sound = "sound/weapons/pulse3.ogg"
+	fire_sound = 'sound/weapons/pulse3.ogg'
 	var/obj/item/weapon/gun/energy/wormhole_projector/gun = null
 	select_name = "blue"
 
@@ -184,7 +184,7 @@
 /obj/item/ammo_casing/energy/gravityrepulse
 	projectile_type = /obj/item/projectile/gravityrepulse
 	e_cost = 0
-	fire_sound = "sound/weapons/wave.ogg"
+	fire_sound = 'sound/weapons/wave.ogg'
 	select_name = "repulse"
 	delay = 50
 	var/obj/item/weapon/gun/energy/gravity_gun/gun = null
@@ -195,7 +195,7 @@
 /obj/item/ammo_casing/energy/gravityattract
 	projectile_type = /obj/item/projectile/gravityattract
 	e_cost = 0
-	fire_sound = "sound/weapons/wave.ogg"
+	fire_sound = 'sound/weapons/wave.ogg'
 	select_name = "attract"
 	delay = 50
 	var/obj/item/weapon/gun/energy/gravity_gun/gun = null
@@ -207,7 +207,7 @@
 /obj/item/ammo_casing/energy/gravitychaos
 	projectile_type = /obj/item/projectile/gravitychaos
 	e_cost = 0
-	fire_sound = "sound/weapons/wave.ogg"
+	fire_sound = 'sound/weapons/wave.ogg'
 	select_name = "chaos"
 	delay = 50
 	var/obj/item/weapon/gun/energy/gravity_gun/gun = null

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -4,7 +4,7 @@
 /obj/item/weapon/gun/magic/staff/change
 	name = "staff of change"
 	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself"
-	fire_sound = "sound/magic/Staff_Change.ogg"
+	fire_sound = 'sound/magic/Staff_Change.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/change
 	icon_state = "staffofchange"
 	item_state = "staffofchange"
@@ -12,7 +12,7 @@
 /obj/item/weapon/gun/magic/staff/animate
 	name = "staff of animation"
 	desc = "An artefact that spits bolts of life-force which causes objects which are hit by it to animate and come to life! This magic doesn't affect machines."
-	fire_sound = "sound/magic/Staff_animation.ogg"
+	fire_sound = 'sound/magic/Staff_animation.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/animate
 	icon_state = "staffofanimation"
 	item_state = "staffofanimation"
@@ -20,7 +20,7 @@
 /obj/item/weapon/gun/magic/staff/healing
 	name = "staff of healing"
 	desc = "An artefact that spits bolts of restoring magic which can remove ailments of all kinds and even raise the dead."
-	fire_sound = "sound/magic/Staff_Healing.ogg"
+	fire_sound = 'sound/magic/Staff_Healing.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/heal
 	icon_state = "staffofhealing"
 	item_state = "staffofhealing"
@@ -31,7 +31,7 @@
 /obj/item/weapon/gun/magic/staff/chaos
 	name = "staff of chaos"
 	desc = "An artefact that spits bolts of chaotic magic that can potentially do anything."
-	fire_sound = "sound/magic/Staff_Chaos.ogg"
+	fire_sound = 'sound/magic/Staff_Chaos.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/chaos
 	icon_state = "staffofchaos"
 	item_state = "staffofchaos"
@@ -49,7 +49,7 @@
 /obj/item/weapon/gun/magic/staff/door
 	name = "staff of door creation"
 	desc = "An artefact that spits bolts of transformative magic that can create doors in walls."
-	fire_sound = "sound/magic/Staff_Door.ogg"
+	fire_sound = 'sound/magic/Staff_Door.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/door
 	icon_state = "staffofdoor"
 	item_state = "staffofdoor"
@@ -60,7 +60,7 @@
 /obj/item/weapon/gun/magic/staff/honk
 	name = "staff of the honkmother"
 	desc = "Honk"
-	fire_sound = "sound/items/airhorn.ogg"
+	fire_sound = 'sound/items/airhorn.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/honk
 	icon_state = "honker"
 	item_state = "honker"
@@ -70,7 +70,7 @@
 /obj/item/weapon/gun/magic/staff/spellblade
 	name = "spellblade"
 	desc = "A deadly combination of laziness and boodlust, this blade allows the user to dismember their enemies without all the hard work of actually swinging the sword."
-	fire_sound = "sound/magic/Fireball.ogg"
+	fire_sound = 'sound/magic/Fireball.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/spellblade
 	icon_state = "spellblade"
 	item_state = "spellblade"

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -60,7 +60,7 @@
 /obj/item/weapon/gun/magic/wand/death
 	name = "wand of death"
 	desc = "This deadly wand overwhelms the victim's body with pure energy, slaying them without fail."
-	fire_sound = "sound/magic/WandoDeath.ogg"
+	fire_sound = 'sound/magic/WandoDeath.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/death
 	icon_state = "deathwand"
 	max_charges = 3 //3, 2, 2, 1
@@ -82,7 +82,7 @@
 	name = "wand of healing"
 	desc = "This wand uses healing magics to heal and revive. They are rarely utilized within the Wizard Federation for some reason."
 	ammo_type = /obj/item/ammo_casing/magic/heal
-	fire_sound = "sound/magic/Staff_Healing.ogg"
+	fire_sound = 'sound/magic/Staff_Healing.ogg'
 	icon_state = "revivewand"
 	max_charges = 10 //10, 5, 5, 4
 
@@ -105,7 +105,7 @@
 	desc = "This wand is attuned to chaos and will radically alter the victim's form."
 	ammo_type = /obj/item/ammo_casing/magic/change
 	icon_state = "polywand"
-	fire_sound = "sound/magic/Staff_Change.ogg"
+	fire_sound = 'sound/magic/Staff_Change.ogg'
 	max_charges = 10 //10, 5, 5, 4
 
 /obj/item/weapon/gun/magic/wand/polymorph/zap_self(mob/living/user)
@@ -121,7 +121,7 @@
 	name = "wand of teleportation"
 	desc = "This wand will wrench targets through space and time to move them somewhere else."
 	ammo_type = /obj/item/ammo_casing/magic/teleport
-	fire_sound = "sound/magic/Wand_Teleport.ogg"
+	fire_sound = 'sound/magic/Wand_Teleport.ogg'
 	icon_state = "telewand"
 	max_charges = 10 //10, 5, 5, 4
 	no_den_usage = 1
@@ -143,7 +143,7 @@
 	desc = "This particular wand can create doors in any wall for the unscrupulous wizard who shuns teleportation magics."
 	ammo_type = /obj/item/ammo_casing/magic/door
 	icon_state = "doorwand"
-	fire_sound = "sound/magic/Staff_Door.ogg"
+	fire_sound = 'sound/magic/Staff_Door.ogg'
 	max_charges = 20 //20, 10, 10, 7
 	no_den_usage = 1
 
@@ -159,7 +159,7 @@
 /obj/item/weapon/gun/magic/wand/fireball
 	name = "wand of fireball"
 	desc = "This wand shoots scorching balls of fire that explode into destructive flames."
-	fire_sound = "sound/magic/Fireball.ogg"
+	fire_sound = 'sound/magic/Fireball.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/fireball
 	icon_state = "firewand"
 	max_charges = 8 //8, 4, 4, 3

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -239,7 +239,7 @@
 	name = "repulsion bolt"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "chronofield"
-	hitsound = "sound/weapons/wave.ogg"
+	hitsound = 'sound/weapons/wave.ogg'
 	damage = 0
 	damage_type = BRUTE
 	nodamage = 1
@@ -267,7 +267,7 @@
 	name = "attraction bolt"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "chronofield"
-	hitsound = "sound/weapons/wave.ogg"
+	hitsound = 'sound/weapons/wave.ogg'
 	damage = 0
 	damage_type = BRUTE
 	nodamage = 1
@@ -294,7 +294,7 @@
 	name = "gravitational blast"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "chronofield"
-	hitsound = "sound/weapons/wave.ogg"
+	hitsound = 'sound/weapons/wave.ogg'
 	damage = 0
 	damage_type = BRUTE
 	nodamage = 1

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -110,7 +110,7 @@
 	projectile_type = /obj/item/projectile/magic/aoe/fireball
 	base_icon_state = "fireball"
 	action_icon_state = "fireball0"
-	sound = "sound/magic/Fireball.ogg"
+	sound = 'sound/magic/Fireball.ogg'
 	active_msg = "You prepare to cast your fireball spell!"
 	deactive_msg = "You extinguish your fireball... for now."
 	active = FALSE

--- a/code/modules/spells/spell_types/area_teleport.dm
+++ b/code/modules/spells/spell_types/area_teleport.dm
@@ -5,8 +5,8 @@
 
 	var/randomise_selection = 0 //if it lets the usr choose the teleport loc or picks it from the list
 	var/invocation_area = 1 //if the invocation appends the selected area
-	var/sound1 = "sound/weapons/ZapBang.ogg"
-	var/sound2 = "sound/weapons/ZapBang.ogg"
+	var/sound1 = 'sound/weapons/ZapBang.ogg'
+	var/sound2 = 'sound/weapons/ZapBang.ogg'
 
 /obj/effect/proc_holder/spell/targeted/area_teleport/perform(list/targets, recharge = 1,mob/living/user = usr)
 	var/thearea = before_cast(targets)

--- a/code/modules/spells/spell_types/barnyard.dm
+++ b/code/modules/spells/spell_types/barnyard.dm
@@ -32,7 +32,7 @@
 		return
 
 	var/list/masks = list(/obj/item/clothing/mask/spig, /obj/item/clothing/mask/cowmask, /obj/item/clothing/mask/horsehead)
-	var/list/mSounds = list("sound/magic/PigHead_curse.ogg", "sound/magic/CowHead_Curse.ogg", "sound/magic/HorseHead_curse.ogg")
+	var/list/mSounds = list('sound/magic/PigHead_curse.ogg', 'sound/magic/CowHead_Curse.ogg', 'sound/magic/HorseHead_curse.ogg')
 	var/randM = rand(1,3)
 
 

--- a/code/modules/spells/spell_types/charge.dm
+++ b/code/modules/spells/spell_types/charge.dm
@@ -95,5 +95,5 @@
 		else if(burnt_out)
 			L << "<span class='caution'>[charged_item] doesn't seem to be reacting to the spell...</span>"
 		else
-			playsound(get_turf(L), "sound/magic/Charge.ogg", 50, 1)
+			playsound(get_turf(L), 'sound/magic/Charge.ogg', 50, 1)
 			L << "<span class='notice'>[charged_item] suddenly feels very warm!</span>"

--- a/code/modules/spells/spell_types/emplosion.dm
+++ b/code/modules/spells/spell_types/emplosion.dm
@@ -6,7 +6,7 @@
 	var/emp_light = 3
 
 	action_icon_state = "emp"
-	sound = "sound/weapons/ZapBang.ogg"
+	sound = 'sound/weapons/ZapBang.ogg'
 
 /obj/effect/proc_holder/spell/targeted/emplosion/cast(list/targets,mob/user = usr)
 	playsound(get_turf(user), sound, 50,1)

--- a/code/modules/spells/spell_types/forcewall.dm
+++ b/code/modules/spells/spell_types/forcewall.dm
@@ -6,7 +6,7 @@
 	clothes_req = 0
 	invocation = "TARCOL MINTI ZHERI"
 	invocation_type = "shout"
-	sound =  "sound/magic/ForceWall.ogg"
+	sound = 'sound/magic/ForceWall.ogg'
 	action_icon_state = "shield"
 	range = -1
 	include_user = 1

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -42,7 +42,7 @@
 	name = "\improper disintegrating touch"
 	desc = "This hand of mine glows with an awesome power!"
 	catchphrase = "EI NATH!!"
-	on_use_sound = "sound/magic/Disintegrate.ogg"
+	on_use_sound = 'sound/magic/Disintegrate.ogg'
 	icon_state = "disintegrate"
 	item_state = "disintegrate"
 
@@ -60,7 +60,7 @@
 	name = "\improper petrifying touch"
 	desc = "That's the bottom line, because flesh to stone said so!"
 	catchphrase = "STAUN EI!!"
-	on_use_sound = "sound/magic/FleshToStone.ogg"
+	on_use_sound = 'sound/magic/FleshToStone.ogg'
 	icon_state = "fleshtostone"
 	item_state = "fleshtostone"
 

--- a/code/modules/spells/spell_types/knock.dm
+++ b/code/modules/spells/spell_types/knock.dm
@@ -13,7 +13,7 @@
 	action_icon_state = "knock"
 
 /obj/effect/proc_holder/spell/aoe_turf/knock/cast(list/targets,mob/user = usr)
-	user << sound("sound/magic/Knock.ogg")
+	user << sound('sound/magic/Knock.ogg')
 	for(var/turf/T in targets)
 		for(var/obj/machinery/door/door in T.contents)
 			INVOKE_ASYNC(src, .proc/open_door, door)

--- a/code/modules/spells/spell_types/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/spacetime_distortion.dm
@@ -7,7 +7,7 @@
 	var/list/effects
 	var/ready = TRUE
 	centcom_cancast = FALSE
-	sound = "sound/effects/magic.ogg"
+	sound = 'sound/effects/magic.ogg'
 	cooldown_min = 300
 	level_max = 0
 

--- a/code/modules/spells/spell_types/summonitem.dm
+++ b/code/modules/spells/spell_types/summonitem.dm
@@ -103,10 +103,10 @@
 			if(!L.put_in_hands(item_to_retrieve))
 				item_to_retrieve.loc = L.loc
 				item_to_retrieve.loc.visible_message("<span class='caution'>The [item_to_retrieve.name] suddenly appears!</span>")
-				playsound(get_turf(L),"sound/magic/SummonItems_generic.ogg",50,1)
+				playsound(get_turf(L), 'sound/magic/SummonItems_generic.ogg', 50, 1)
 			else
 				item_to_retrieve.loc.visible_message("<span class='caution'>The [item_to_retrieve.name] suddenly appears in [L]'s hand!</span>")
-				playsound(get_turf(L),"sound/magic/SummonItems_generic.ogg",50,1)
+				playsound(get_turf(L), 'sound/magic/SummonItems_generic.ogg', 50, 1)
 
 
 		if(message)

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -58,4 +58,4 @@
 	cooldown_min = 200 //100 deciseconds reduction per rank
 
 	action_icon_state = "statue"
-	sound = "sound/magic/FleshToStone.ogg"
+	sound = 'sound/magic/FleshToStone.ogg'

--- a/code/modules/spells/spell_types/turf_teleport.dm
+++ b/code/modules/spells/spell_types/turf_teleport.dm
@@ -8,8 +8,8 @@
 
 	var/include_space = 0 //whether it includes space tiles in possible teleport locations
 	var/include_dense = 0 //whether it includes dense tiles in possible teleport locations
-	var/sound1 = "sound/weapons/ZapBang.ogg"
-	var/sound2 = "sound/weapons/ZapBang.ogg"
+	var/sound1 = 'sound/weapons/ZapBang.ogg'
+	var/sound2 = 'sound/weapons/ZapBang.ogg'
 
 /obj/effect/proc_holder/spell/targeted/turf_teleport/cast(list/targets,mob/user = usr)
 	playsound(get_turf(user), sound1, 50,1)

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -25,11 +25,11 @@
 	proj_trail_icon_state = "magicmd"
 
 	action_icon_state = "magicm"
-	sound = "sound/magic/MAGIC_MISSILE.ogg"
+	sound = 'sound/magic/MAGIC_MISSILE.ogg'
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/magic_missile
 	amt_weakened = 3
-	sound = "sound/magic/MM_Hit.ogg"
+	sound = 'sound/magic/MM_Hit.ogg'
 
 /obj/effect/proc_holder/spell/targeted/genetic/mutate
 	name = "Mutate"
@@ -48,7 +48,7 @@
 	cooldown_min = 300 //25 deciseconds reduction per rank
 
 	action_icon_state = "mutate"
-	sound = "sound/magic/Mutate.ogg"
+	sound = 'sound/magic/Mutate.ogg'
 
 
 /obj/effect/proc_holder/spell/targeted/smoke
@@ -82,7 +82,7 @@
 
 	emp_heavy = 6
 	emp_light = 10
-	sound = "sound/magic/Disable_Tech.ogg"
+	sound = 'sound/magic/Disable_Tech.ogg'
 
 /obj/effect/proc_holder/spell/targeted/turf_teleport/blink
 	name = "Blink"
@@ -105,8 +105,8 @@
 	outer_tele_radius = 6
 
 	action_icon_state = "blink"
-	sound1="sound/magic/blink.ogg"
-	sound2="sound/magic/blink.ogg"
+	sound1 = 'sound/magic/blink.ogg'
+	sound2 = 'sound/magic/blink.ogg'
 
 /obj/effect/proc_holder/spell/targeted/turf_teleport/blink/cult
 	name = "quickstep"
@@ -130,8 +130,8 @@
 
 	smoke_spread = 1
 	smoke_amt = 2
-	sound1="sound/magic/Teleport_diss.ogg"
-	sound2="sound/magic/Teleport_app.ogg"
+	sound1 = 'sound/magic/Teleport_diss.ogg'
+	sound2 = 'sound/magic/Teleport_app.ogg'
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop
 	name = "Stop Time"
@@ -159,7 +159,7 @@
 	range = 1
 
 	summon_type = list(/mob/living/simple_animal/hostile/carp)
-	cast_sound = "sound/magic/Summon_Karp.ogg"
+	cast_sound = 'sound/magic/Summon_Karp.ogg'
 
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/construct
@@ -176,7 +176,7 @@
 	summon_type = list(/obj/structure/constructshell)
 
 	action_icon_state = "artificer"
-	cast_sound = "sound/magic/SummonItems_generic.ogg"
+	cast_sound = 'sound/magic/SummonItems_generic.ogg'
 
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/creature
@@ -192,7 +192,7 @@
 	range = 3
 
 	summon_type = list(/mob/living/simple_animal/hostile/creature)
-	cast_sound = "sound/magic/SummonItems_generic.ogg"
+	cast_sound = 'sound/magic/SummonItems_generic.ogg'
 
 /obj/effect/proc_holder/spell/targeted/trigger/blind
 	name = "Blind"
@@ -221,12 +221,12 @@
 /obj/effect/proc_holder/spell/targeted/inflict_handler/blind
 	amt_eye_blind = 10
 	amt_eye_blurry = 20
-	sound="sound/magic/Blind.ogg"
+	sound = 'sound/magic/Blind.ogg'
 
 /obj/effect/proc_holder/spell/targeted/genetic/blind
 	mutations = list(BLINDMUT)
 	duration = 300
-	sound="sound/magic/Blind.ogg"
+	sound = 'sound/magic/Blind.ogg'
 /obj/effect/proc_holder/spell/aoe_turf/repulse
 	name = "Repulse"
 	desc = "This spell throws everything around the user away."
@@ -305,7 +305,7 @@
 	include_user = 1
 	selection_type = "view"
 	action_icon_state = "sacredflame"
-	sound = "sound/magic/Fireball.ogg"
+	sound = 'sound/magic/Fireball.ogg'
 
 /obj/effect/proc_holder/spell/targeted/sacred_flame/cast(list/targets, mob/user = usr)
 	for(var/mob/living/L in targets)

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -507,7 +507,7 @@ var/static/regex/multispin_words = regex("like a record baby|right round")
 	//HONK
 	else if((findtext(message, honk_words)))
 		next_command = world.time + cooldown_meme
-		addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, get_turf(owner), "sound/items/bikehorn.ogg", 300, 1), 25)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, get_turf(owner), 'sound/items/bikehorn.ogg', 300, 1), 25)
 		if(owner.mind && owner.mind.assigned_role == "Clown")
 			for(var/mob/living/carbon/C in listeners)
 				C.slip(0,7 * power_multiplier)


### PR DESCRIPTION
This means they're included into the rsc and sent out although almost all of these files were already included elsewhere. Also DM will yell if the file couldn't be found for whatever reason like if someone moves or renames it.

I left out some file types for various reasons
dmis used in overlays: I have another pr I'll do later which will fix all of them and I don't want to conflict with myself
text files: they would get included in the rsc, which is completely unnecessary. However they're small, so they might be worth including anyway for the reasons above.