### PR TITLE
Splits charcoal pills apart

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -60,10 +60,10 @@
 	..()
 	if(empty) return
 	icon_state = pick("antitoxin","antitoxfirstaid","antitoxfirstaid2","antitoxfirstaid3")
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 4)
 		new /obj/item/weapon/reagent_containers/syringe/charcoal(src)
-	for(var/i in 1 to 3)
-		new /obj/item/weapon/reagent_containers/pill/charcoal(src)
+	for(var/i in 1 to 2)
+		new /obj/item/weapon/storage/pill_bottle/charcoal(src)
 	new /obj/item/device/healthanalyzer(src)
 	return
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -399,7 +399,7 @@
 	desc = "A refrigerated storage unit for medicine storage."
 	var/list/spawn_meds = list(
 		/obj/item/weapon/reagent_containers/pill/epinephrine = 12,
-		/obj/item/weapon/reagent_containers/pill/charcoal = 1,
+		/obj/item/weapon/reagent_containers/pill/charcoal = 5,
 		/obj/item/weapon/reagent_containers/glass/bottle/epinephrine = 1,
 		/obj/item/weapon/reagent_containers/glass/bottle/charcoal = 1)
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -103,7 +103,7 @@
 	name = "antitoxin pill"
 	desc = "Neutralizes many common toxins."
 	icon_state = "pill17"
-	list_reagents = list("charcoal" = 50)
+	list_reagents = list("charcoal" = 10)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/epinephrine
 	name = "epinephrine pill"


### PR DESCRIPTION
:cl: RandomMarine
tweak: Pre-made charcoal pills now contain 10 units instead of 50. The amount of pills inside of toxin first aid kits and the smartfridge have been increased to compensate. Keep in mind that each ten unit pill recovers 100 points of toxin damage and purges 50 units of other reagents. 
/:cl:

Because charcoal pills found in vendors and toxin first aid kits contains 50 units.
What exactly does 50 units do?
50 units heals 500 points of toxin damage during its course. And is capable of purging 250u of other reagents.
That is absolute fucking overkill and in almost all situations, swallowing one pill means a great majority of it is wasted.

So this PR splits them apart into less wasteful amounts, and adds another syringe to the kits to compensate for the 10u lost. **Each kit holds effectively 200 units, +5 from before.**
Chemistry's smartfridges start with five 10u pills instead of a single 50u.
Vendors aren't touched because six pills in each is enough already.

If you want to discuss the balance concerns between first aid kits holding so much charcoal for how effective it is, go ahead and do it here.