### PR TITLE
Unequip refactor fix pack

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -766,12 +766,8 @@
 
 		else if(istype(over_object, /obj/screen/inventory/hand))
 			var/obj/screen/inventory/hand/H = over_object
-			if(!remove_item_from_storage(M))
-				M.temporarilyRemoveItemFromInventory(src, TRUE)
-			if(!M.put_in_hand(src, H.held_index))
-				qdel(src)
-				return
-			usr << "<span class='notice'>You pick up the deck.</span>"
+			if(M.putItemFromInventoryInHandIfPossible(src, H.held_index))
+				usr << "<span class='notice'>You pick up the deck.</span>"
 
 	else
 		usr << "<span class='warning'>You can't reach it from here!</span>"

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -93,12 +93,13 @@
 /obj/item/weapon/defibrillator/MouseDrop(obj/over_object)
 	if(ismob(src.loc))
 		var/mob/M = src.loc
-		if(istype(over_object, /obj/screen/inventory/hand))
+		if(!M.incapacitated() && istype(over_object, /obj/screen/inventory/hand))
 			var/obj/screen/inventory/hand/H = over_object
 			if(!M.temporarilyRemoveItemFromInventory(src))
 				return
 			if(!M.put_in_hand(src, H.held_index))
 				qdel(src)	//wewie
+				CRASH("Failed to move [src] to a mob's hand")
 
 
 /obj/item/weapon/defibrillator/attackby(obj/item/weapon/W, mob/user, params)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -95,12 +95,7 @@
 		var/mob/M = src.loc
 		if(!M.incapacitated() && istype(over_object, /obj/screen/inventory/hand))
 			var/obj/screen/inventory/hand/H = over_object
-			if(!M.temporarilyRemoveItemFromInventory(src))
-				return
-			if(!M.put_in_hand(src, H.held_index))
-				qdel(src)	//wewie
-				CRASH("Failed to move [src] to a mob's hand")
-
+			M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 
 /obj/item/weapon/defibrillator/attackby(obj/item/weapon/W, mob/user, params)
 	if(W == paddles)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -140,19 +140,12 @@
 			return ..()
 		if(!M.incapacitated() && istype(over_object, /obj/screen/inventory/hand))
 			var/obj/screen/inventory/hand/H = over_object
-			if(!M.temporarilyRemoveItemFromInventory(src))
-				return
-			if(!M.put_in_hand(src,H.held_index))
-				qdel(src)
-				CRASH("Failed to move [src] to a mob's hand")
-			src.add_fingerprint(usr)
-			return
+			if(M.putItemFromInventoryInHandIfPossible(src, H.held_index))
+				add_fingerprint(usr)
 		if(over_object == usr && in_range(src, usr) || usr.contents.Find(src))
 			if(usr.s_active)
 				usr.s_active.close(usr)
 			src.show_to(usr)
-			return
-	return
 
 /obj/item/weapon/storage/box/silver_sulf
 	name = "box of silver sulfadiazine patches"

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -138,13 +138,13 @@
 		var/mob/M = usr
 		if(!istype(over_object, /obj/screen) || !Adjacent(M))
 			return ..()
-		if(!M.restrained() && !M.stat && istype(over_object, /obj/screen/inventory/hand))
+		if(!M.incapacitated() && istype(over_object, /obj/screen/inventory/hand))
 			var/obj/screen/inventory/hand/H = over_object
 			if(!M.temporarilyRemoveItemFromInventory(src))
 				return
 			if(!M.put_in_hand(src,H.held_index))
 				qdel(src)
-				return
+				CRASH("Failed to move [src] to a mob's hand")
 			src.add_fingerprint(usr)
 			return
 		if(over_object == usr && in_range(src, usr) || usr.contents.Find(src))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -45,7 +45,7 @@
 			show_to(M)
 			return
 
-		if(!M.restrained() && !M.stat && !M.weakened)
+		if(!M.incapacitated())
 			if(!istype(over_object, /obj/screen))
 				return content_can_dump(over_object, M)
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -45,7 +45,7 @@
 			show_to(M)
 			return
 
-		if(!M.restrained() && !M.stat)
+		if(!M.restrained() && !M.stat && !M.weakened)
 			if(!istype(over_object, /obj/screen))
 				return content_can_dump(over_object, M)
 
@@ -54,14 +54,13 @@
 
 			playsound(loc, "rustle", 50, 1, -5)
 
-
 			if(istype(over_object, /obj/screen/inventory/hand))
 				var/obj/screen/inventory/hand/H = over_object
 				if(!M.temporarilyRemoveItemFromInventory(src))
 					return
 				if(!M.put_in_hand(src,H.held_index))
-					qdel(src)
-					return
+					qdel(src)	//better than having it in the void
+					CRASH("Failed to move [src] to a mob's hand")
 
 			add_fingerprint(usr)
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -56,11 +56,7 @@
 
 			if(istype(over_object, /obj/screen/inventory/hand))
 				var/obj/screen/inventory/hand/H = over_object
-				if(!M.temporarilyRemoveItemFromInventory(src))
-					return
-				if(!M.put_in_hand(src,H.held_index))
-					qdel(src)	//better than having it in the void
-					CRASH("Failed to move [src] to a mob's hand")
+				M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 
 			add_fingerprint(usr)
 

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -85,10 +85,7 @@
 	var/mob/M = src.loc
 	if(istype(M) && istype(over_object, /obj/screen/inventory/hand))
 		var/obj/screen/inventory/hand/H = over_object
-		if(!M.temporarilyRemoveItemFromInventory(src))
-			return
-		M.put_in_hand(src, H.held_index)
-
+		M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 
 /obj/item/weapon/watertank/attackby(obj/item/W, mob/user, params)
 	if(W == noz)

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -93,7 +93,7 @@
 
 	M.temporarilyRemoveItemFromInventory(src, TRUE)	//Remove the tank from your character,in case you were holding it
 	if(!M.put_in_hands(R))		//Equips the bomb if possible, or puts it on the floor.
-		forceMove(M.loc)
+		forceMove(get_turf(M))
 
 	R.bombassembly = S	//Tell the bomb about its assembly part
 	S.master = R		//Tell the assembly about its new owner

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -48,12 +48,8 @@
 
 	if(!M.incapacitated() && loc == M && istype(over_object, /obj/screen/inventory/hand))
 		var/obj/screen/inventory/hand/H = over_object
-		if(!M.temporarilyRemoveItemFromInventory(src))
-			return
-		if(!M.put_in_hand(src, H.held_index))
-			qdel(src)	//better than having it in the void
-			CRASH("Failed to move [src] to a mob's hand")
-		add_fingerprint(usr)
+		if(M.putItemFromInventoryInHandIfPossible(src, H.held_index))
+			add_fingerprint(usr)
 
 /obj/item/clothing/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
 	if(pockets)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -46,7 +46,7 @@
 	if(istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
 		return
 
-	if(!M.restrained() && !M.stat && !M.weakened && loc == M && istype(over_object, /obj/screen/inventory/hand))
+	if(!M.incapacitated() && loc == M && istype(over_object, /obj/screen/inventory/hand))
 		var/obj/screen/inventory/hand/H = over_object
 		if(!M.temporarilyRemoveItemFromInventory(src))
 			return

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -46,13 +46,13 @@
 	if(istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
 		return
 
-	if(!M.restrained() && !M.stat && loc == M && istype(over_object, /obj/screen/inventory/hand))
+	if(!M.restrained() && !M.stat && !M.weakened && loc == M && istype(over_object, /obj/screen/inventory/hand))
 		var/obj/screen/inventory/hand/H = over_object
 		if(!M.temporarilyRemoveItemFromInventory(src))
 			return
 		if(!M.put_in_hand(src, H.held_index))
-			qdel(src)
-			return
+			qdel(src)	//better than having it in the void
+			CRASH("Failed to move [src] to a mob's hand")
 		add_fingerprint(usr)
 
 /obj/item/clothing/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -331,7 +331,7 @@
 		if (istype(usr.loc,/obj/mecha))
 			return
 
-		if(!M.restrained() && !M.stat)
+		if(!M.incapacitated())
 			playsound(loc, "rustle", 50, 1, -5)
 
 
@@ -341,7 +341,7 @@
 					return
 				if(!M.put_in_hand(src, H.held_index))
 					qdel(src)
-					return //fuck these things
+					CRASH("Failed to move [src] to a mob's hand")
 
 			add_fingerprint(usr)
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -337,11 +337,7 @@
 
 			if(istype(over_object, /obj/screen/inventory/hand))
 				var/obj/screen/inventory/hand/H = over_object
-				if(!M.temporarilyRemoveItemFromInventory(src))
-					return
-				if(!M.put_in_hand(src, H.held_index))
-					qdel(src)
-					CRASH("Failed to move [src] to a mob's hand")
+				M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 
 			add_fingerprint(usr)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -156,7 +156,7 @@
 	return !held_items[hand_index]
 
 /mob/proc/put_in_hand(obj/item/I, hand_index)
-	if(!can_put_in_hand(hand_index))
+	if(can_put_in_hand(hand_index))
 		I.forceMove(src)
 		held_items[hand_index] = I
 		I.layer = ABOVE_HUD_LAYER

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -156,7 +156,7 @@
 	return !held_items[hand_index]
 
 /mob/proc/put_in_hand(obj/item/I, hand_index)
-	if(can_put_in_hand(hand_index))
+	if(can_put_in_hand(I, hand_index))
 		I.forceMove(src)
 		held_items[hand_index] = I
 		I.layer = ABOVE_HUD_LAYER

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -148,14 +148,15 @@
 /mob/proc/can_equip(obj/item/I, slot, disable_warning = 0)
 	return FALSE
 
-
-/mob/proc/put_in_hand(obj/item/I, hand_index)
+/mob/proc/can_put_in_hand(I, hand_index)
 	if(!put_in_hand_check(I))
 		return FALSE
 	if(!has_hand_for_held_index(hand_index))
 		return FALSE
-	var/obj/item/curr = held_items[hand_index]
-	if(!curr)
+	return !held_items[hand_index]
+
+/mob/proc/put_in_hand(obj/item/I, hand_index)
+	if(!can_put_in_hand(hand_index))
 		I.forceMove(src)
 		held_items[hand_index] = I
 		I.layer = ABOVE_HUD_LAYER
@@ -253,6 +254,17 @@
 		return TRUE
 	if((I.flags & NODROP) && !force)
 		return FALSE
+	return TRUE
+
+/mob/proc/putItemFromInventoryInHandIfPossible(obj/item/I, hand_index, force_removal = FALSE)
+	if(!can_put_in_hand(I, hand_index))
+		return FALSE
+	if(!temporarilyRemoveItemFromInventory(I, force_removal))
+		return FALSE
+	I.remove_item_from_storage(src)
+	if(!put_in_hand(I, hand_index))
+		qdel(I)
+		CRASH("Assertion failure: putItemFromInventoryInHandIfPossible") //should never be possible
 	return TRUE
 
 //The following functions are the same save for one small difference

--- a/code/modules/modular_computers/computers/item/computer_components.dm
+++ b/code/modules/modular_computers/computers/item/computer_components.dm
@@ -24,6 +24,7 @@
 
 	user << "<span class='notice'>You install \the [H] into \the [src].</span>"
 	H.holder = src
+	H.forceMove(src)
 	H.on_install(src, user)
 
 

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -68,14 +68,18 @@
 
 	var/ejected = 0
 	if(stored_card && (!slot || slot == 1))
-		stored_card.forceMove(get_turf(src))
-		stored_card.verb_pickup()
+		if(user)
+			user.put_in_hands(stored_card)
+		else
+			stored_card.forceMove(get_turf(src))
 		stored_card = null
 		ejected++
 
 	if(stored_card2 && (!slot || slot == 2))
-		stored_card2.forceMove(get_turf(src))
-		stored_card2.verb_pickup()
+		if(user)
+			user.put_in_hands(stored_card2)
+		else
+			stored_card2.forceMove(get_turf(src))
 		stored_card2 = null
 		ejected++
 

--- a/code/modules/paperwork/paper_cutter.dm
+++ b/code/modules/paperwork/paper_cutter.dm
@@ -100,11 +100,7 @@
 
 	else if(istype(over_object, /obj/screen/inventory/hand))
 		var/obj/screen/inventory/hand/H = over_object
-		if(!remove_item_from_storage(M))
-			M.temporarilyRemoveItemFromInventory(src, TRUE)
-		if(!M.put_in_hand(src, H.held_index))
-			qdel(src)	//rip
-			return
+		M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 	add_fingerprint(M)
 
 

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -56,11 +56,7 @@
 
 	else if(istype(over_object, /obj/screen/inventory/hand))
 		var/obj/screen/inventory/hand/H = over_object
-		if(!remove_item_from_storage(M))
-			M.temporarilyRemoveItemFromInventory(src, TRUE)
-		if(!M.put_in_hand(src, H.held_index))
-			qdel(src)
-			return
+		M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 
 	add_fingerprint(M)
 

--- a/code/modules/projectiles/guns/ballistic/laser_gatling.dm
+++ b/code/modules/projectiles/guns/ballistic/laser_gatling.dm
@@ -67,11 +67,7 @@
 
 			if(istype(over_object, /obj/screen/inventory/hand))
 				var/obj/screen/inventory/hand/H = over_object
-				if(!M.temporarilyRemoveItemFromInventory(src))
-					return
-				if(!M.put_in_hand(src, H.held_index))
-					qdel(src)
-					CRASH("Failed to move [src] to a mob's hand")
+				M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 
 
 /obj/item/weapon/minigunpack/update_icon()

--- a/code/modules/projectiles/guns/ballistic/laser_gatling.dm
+++ b/code/modules/projectiles/guns/ballistic/laser_gatling.dm
@@ -63,7 +63,7 @@
 		if(!over_object)
 			return
 
-		if(!M.restrained() && !M.stat)
+		if(!M.incapacitated())
 
 			if(istype(over_object, /obj/screen/inventory/hand))
 				var/obj/screen/inventory/hand/H = over_object
@@ -71,6 +71,7 @@
 					return
 				if(!M.put_in_hand(src, H.held_index))
 					qdel(src)
+					CRASH("Failed to move [src] to a mob's hand")
 
 
 /obj/item/weapon/minigunpack/update_icon()


### PR DESCRIPTION
:cl: Cyberboss
fix: Fixed unequipping items while stunned
fix: Fixed various things deleting when unequipped
fix: Fixed tablet ID slots deleting cards
fix: Fixed water mister nozzle getting stuck in hands
/:cl:

In my defense, the real bug is that these checks weren't here before.

Fixes #23794 
Fixes #23579
Fixes #23912
Caused by #22918 

I really don't know how I broke modular id slots BUT EVEN BIGGER IS WHY DID ALL THE COMPONENTS HAVE NULL LOCS THIS WHOLE TIME REEEEEEE