### PR TITLE
Removes the title music delay

### DIFF
--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -27,7 +27,4 @@
 		loc = pick(watch_locations)
 */
 	new_player_panel()
-
-	spawn(40)
-		if(client)
-			client.playtitlemusic()
+	client.playtitlemusic()


### PR DESCRIPTION
Preferences are loaded before so this shouldn't be a problem

:cl: Cyberboss
tweak: Title music now starts immediately upon login
/:cl: