### PR TITLE
[Delta] Fixes Areas That Are Not Radiation Proof Also Fixes Space Cleaner In Brig Medbay

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -10196,8 +10196,16 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/orange,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	step_x = -3;
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	step_x = -3;
+	pixel_x = -3;
+	pixel_y = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	tag = "icon-intact (SOUTHEAST)";
 	icon_state = "intact";
@@ -32365,7 +32373,16 @@
 	},
 /obj/item/clothing/gloves/color/latex,
 /obj/item/device/healthanalyzer,
-/obj/item/weapon/reagent_containers/spray,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	step_x = -3;
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	step_x = 0;
+	pixel_x = 5;
+	pixel_y = -1
+	},
 /turf/open/floor/plasteel/whitered/side{
 	dir = 8
 	},
@@ -34092,9 +34109,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/quartermaster/miningdock{
-	name = "\improper Mining Office"
-	})
+/area/maintenance/starboard/fore_starboard_maintenance)
 "bjL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -34112,9 +34127,7 @@
 /turf/open/floor/plasteel{
 	tag = "icon-plasteel_warn_side (EAST)"
 	},
-/area/quartermaster/miningdock{
-	name = "\improper Mining Office"
-	})
+/area/maintenance/starboard/fore_starboard_maintenance)
 "bjM" = (
 /obj/structure/cable/white{
 	tag = "icon-0-4";
@@ -34882,9 +34895,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/miningdock{
-	name = "\improper Mining Office"
-	})
+/area/maintenance/starboard/fore_starboard_maintenance)
 "blg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -34899,9 +34910,7 @@
 	icon_state = "brown";
 	dir = 8
 	},
-/area/quartermaster/miningdock{
-	name = "\improper Mining Office"
-	})
+/area/maintenance/starboard/fore_starboard_maintenance)
 "blh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -34916,9 +34925,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/quartermaster/miningdock{
-	name = "\improper Mining Office"
-	})
+/area/maintenance/starboard/fore_starboard_maintenance)
 "bli" = (
 /turf/open/floor/plating,
 /area/quartermaster/miningdock{
@@ -34929,9 +34936,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/quartermaster/miningdock{
-	name = "\improper Mining Office"
-	})
+/area/maintenance/starboard/fore_starboard_maintenance)
 "blk" = (
 /obj/structure/cable/white,
 /obj/structure/grille,
@@ -46640,7 +46645,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/maintenance/starboard)
 "bER" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -46650,7 +46655,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/maintenance/starboard)
 "bES" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -46658,7 +46663,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/maintenance/starboard)
 "bET" = (
 /obj/structure/cable/white{
 	tag = "icon-2-8";
@@ -46670,7 +46675,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/maintenance/starboard)
 "bEU" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
@@ -46690,7 +46695,7 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
 	tag = "icon-neutral (NORTHEAST)"
 	},
-/area/hallway/primary/central)
+/area/maintenance/starboard)
 "bEW" = (
 /obj/structure/table/wood,
 /obj/item/weapon/clipboard,
@@ -47697,7 +47702,7 @@
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side"
 	},
-/area/hallway/primary/central)
+/area/maintenance/starboard)
 "bGN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -47705,7 +47710,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/maintenance/starboard)
 "bGO" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Detective's Office Maintenance";
@@ -83411,7 +83416,11 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
-/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	step_x = -3;
+	pixel_x = -3;
+	pixel_y = 2
+	},
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
@@ -87265,7 +87274,11 @@
 "cXU" = (
 /obj/structure/table/wood,
 /obj/item/weapon/folder/white,
-/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	step_x = -3;
+	pixel_x = -3;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
 	},
@@ -88558,7 +88571,11 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/weapon/folder/white,
-/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	step_x = -3;
+	pixel_x = -3;
+	pixel_y = 2
+	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/medical/medbay{
@@ -112859,7 +112876,11 @@
 /obj/item/weapon/book/manual/wiki/infections,
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /obj/item/weapon/reagent_containers/dropper,
-/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	step_x = -3;
+	pixel_x = -3;
+	pixel_y = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -118571,6 +118592,14 @@
 	tag = "icon-plasteel_warn_side (WEST)"
 	},
 /area/medical/virology)
+"edh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown{
+	tag = "icon-brown (NORTH)";
+	icon_state = "brown";
+	dir = 1
+	},
+/area/maintenance/starboard/fore_starboard_maintenance)
 
 (1,1,1) = {"
 aaa
@@ -162625,9 +162654,9 @@ bcU
 bes
 bgg
 bid
-aXb
+aeX
 blf
-aXb
+aeX
 boZ
 boZ
 brQ
@@ -162637,9 +162666,9 @@ bvW
 bxR
 boZ
 boZ
-boZ
+cmX
 bEQ
-boZ
+cmX
 bIG
 bIG
 bIG
@@ -162884,7 +162913,7 @@ bgh
 bie
 bjK
 blg
-aXb
+aeX
 aaa
 aaf
 aaa
@@ -162894,9 +162923,9 @@ bvX
 aaa
 aaf
 aaa
-boZ
+cmX
 bER
-boZ
+cmX
 bIH
 bKL
 bML
@@ -163141,7 +163170,7 @@ bgi
 bif
 bjL
 blh
-aXb
+aeX
 aaa
 bqw
 bqw
@@ -163151,9 +163180,9 @@ bqw
 bqw
 bqw
 aaa
-boZ
+cmX
 bES
-boZ
+cmX
 bII
 bKM
 bMM
@@ -163396,9 +163425,9 @@ bcW
 bev
 bgj
 big
-aXb
-bbO
-aXb
+aeX
+afn
+aeX
 aaf
 bqw
 brR
@@ -163408,7 +163437,7 @@ btj
 bxS
 bqw
 aaf
-boZ
+cmX
 bET
 bGM
 bIJ
@@ -163653,9 +163682,9 @@ bcX
 bew
 bgk
 aXb
-aXb
-bli
-aXb
+aeX
+amC
+aeX
 aaa
 bqw
 brS
@@ -163665,9 +163694,9 @@ bti
 bxT
 bqw
 aaa
-boZ
+cmX
 bER
-boZ
+cmX
 bIK
 bKO
 bMO
@@ -163910,9 +163939,9 @@ bcX
 bex
 bgj
 bih
-aXb
-bar
-aXb
+aeX
+edh
+aeX
 aaa
 bqw
 brT
@@ -163922,9 +163951,9 @@ bvY
 bxU
 bqw
 aaa
-boZ
-bEU
-boZ
+cmX
+coB
+cmX
 bIL
 bKP
 bMP
@@ -164167,9 +164196,9 @@ bcY
 bbF
 bgl
 bii
-aXb
+aeX
 blj
-aXb
+aeX
 aaa
 bqw
 brU
@@ -164179,9 +164208,9 @@ bti
 bxV
 bqw
 aaa
-boZ
-bEU
-boZ
+cmX
+coB
+cmX
 bIG
 bIG
 bIG
@@ -164424,9 +164453,9 @@ bbF
 bbF
 bgm
 bij
-aXb
-aXb
-aXb
+aeX
+aeX
+aeX
 aaf
 bqw
 brV
@@ -164436,7 +164465,7 @@ btj
 brR
 bqw
 aaf
-boZ
+cmX
 bEV
 bGN
 bIM

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -10197,12 +10197,10 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/orange,
 /obj/item/weapon/reagent_containers/spray/cleaner{
-	step_x = -3;
 	pixel_x = -3;
 	pixel_y = 2
 	},
 /obj/item/weapon/reagent_containers/spray/cleaner{
-	step_x = -3;
 	pixel_x = -3;
 	pixel_y = 2
 	},
@@ -32374,12 +32372,12 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/device/healthanalyzer,
 /obj/item/weapon/reagent_containers/spray/cleaner{
-	step_x = -3;
+	pixel_x = -3;
 	pixel_x = -3;
 	pixel_y = 2
 	},
 /obj/item/weapon/reagent_containers/spray/cleaner{
-	step_x = 0;
+	pixel_x = 0;
 	pixel_x = 5;
 	pixel_y = -1
 	},
@@ -83417,7 +83415,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/weapon/reagent_containers/spray/cleaner{
-	step_x = -3;
+	pixel_x = -3;
 	pixel_x = -3;
 	pixel_y = 2
 	},
@@ -87275,7 +87273,7 @@
 /obj/structure/table/wood,
 /obj/item/weapon/folder/white,
 /obj/item/weapon/reagent_containers/spray/cleaner{
-	step_x = -3;
+	pixel_x = -3;
 	pixel_x = -3;
 	pixel_y = 2
 	},
@@ -88572,7 +88570,7 @@
 /obj/machinery/door/firedoor,
 /obj/item/weapon/folder/white,
 /obj/item/weapon/reagent_containers/spray/cleaner{
-	step_x = -3;
+	pixel_x = -3;
 	pixel_x = -3;
 	pixel_y = 2
 	},
@@ -112877,7 +112875,7 @@
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /obj/item/weapon/reagent_containers/dropper,
 /obj/item/weapon/reagent_containers/spray/cleaner{
-	step_x = -3;
+	pixel_x = -3;
 	pixel_x = -3;
 	pixel_y = 2
 	},


### PR DESCRIPTION
## **DeltaStation Fixes Areas That Are Not Radiation Proof Also Fixes Space Cleaner In Brig Medbay**
This pull request fixes the maintenance tunnels that are not Radiation Storm that are mentioned in the below issue, this also replaces the empty spray bottle that was useless in the brig with two bottles of space cleaner for space cleaning purposes.

## **Changelog**
:cl: Tofa01
Fix: [Delta] Fixes space cleaner being empty in brig medbay
Fix: [Delta] Fixes some areas that are not radiation proof
/:cl:

## **Fixes #24048**
