### PR TITLE
[Meta] Fixes Atmospherics Freezer Spawning As A Heater

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -46647,9 +46647,8 @@
 /turf/open/floor/plasteel,
 /area/atmos)
 "bAL" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 2;
-	on = 1
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/atmos)
@@ -47562,11 +47561,11 @@
 /turf/open/floor/plasteel,
 /area/atmos)
 "bCt" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	color = "purple";
-	dir = 1
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	color = "purple";
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/atmos)
 "bCu" = (
@@ -137232,7 +137231,7 @@ bvo
 bvr
 bxh
 bzb
-bAK
+bDW
 bCr
 bDW
 bFQ
@@ -137490,7 +137489,7 @@ bvv
 bxi
 bzc
 bAL
-bCs
+bCi
 bDX
 bFR
 bHx

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -46647,9 +46647,7 @@
 /turf/open/floor/plasteel,
 /area/atmos)
 "bAL" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel,
 /area/atmos)
 "bAM" = (
@@ -47562,9 +47560,9 @@
 /area/atmos)
 "bCt" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	color = "purple";
-	dir = 6
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/atmos)
@@ -94441,6 +94439,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"ddF" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	color = "purple";
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/atmos)
 
 (1,1,1) = {"
 aaa
@@ -137231,7 +137236,7 @@ bvo
 bvr
 bxh
 bzb
-bDW
+bAK
 bCr
 bDW
 bFQ
@@ -137489,7 +137494,7 @@ bvv
 bxi
 bzc
 bAL
-bCi
+ddF
 bDX
 bFR
 bHx


### PR DESCRIPTION
## **Fixes Atmospherics Freezer Spawning As A Heater On MetaStation**
This Pull Request fixes the freezer that spawns as a heater at roundstart on metastation in atmospherics. This should allow Atmospherics Technicians more easier use of the freezer without having to deconstruct the heater and reconstruct it into a freezer.

## **Images**
![capture](https://cloud.githubusercontent.com/assets/24999255/22910228/ab32aa9a-f2ac-11e6-8744-9afbc82cac59.PNG)



## **Changelog**
:cl: Tofa01
Fix: [Meta] Fixes Atmospherics Freezer Spawning As A Heater
/:cl:

## **Fixes #23950**

