### PR TITLE
Buffs robotic limb healing

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -409,10 +409,11 @@
 	if(affecting && affecting.status == BODYPART_ROBOTIC && user.a_intent != INTENT_HARM)
 		if(src.remove_fuel(1))
 			playsound(loc, usesound, 50, 1)
-			user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [H]'s [affecting.name].</span>", "<span class='notice'>You start fixing some of the dents on [H]'s [affecting.name].</span>")
-			if(!do_mob(user, H, 50))
-				return
-			item_heal_robotic(H, user, 5, 0)
+			if(user == H)
+				user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [H]'s [affecting.name].</span>", "<span class='notice'>You start fixing some of the dents on [H]'s [affecting.name].</span>")
+				if(!do_mob(user, H, 50))
+					return
+			item_heal_robotic(H, user, 15, 0)
 	else
 		return ..()
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -500,10 +500,11 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 
 	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
 	if(affecting && affecting.status == BODYPART_ROBOTIC)
-		user.visible_message("<span class='notice'>[user] starts to fix some of the wires in [H]'s [affecting.name].</span>", "<span class='notice'>You start fixing some of the wires in [H]'s [affecting.name].</span>")
-		if(!do_mob(user, H, 50))
-			return
-		if(item_heal_robotic(H, user, 0, 5))
+		if(user == H)
+			user.visible_message("<span class='notice'>[user] starts to fix some of the wires in [H]'s [affecting.name].</span>", "<span class='notice'>You start fixing some of the wires in [H]'s [affecting.name].</span>")
+			if(!do_mob(user, H, 50))
+				return
+		if(item_heal_robotic(H, user, 0, 15))
 			use(1)
 		return
 	else


### PR DESCRIPTION
:cl: XDTM
tweak: Repairing someone else's robotic limb is instant. Repairing your own robotic limbs will still take time.
tweak: Repairing limbs with cable or welding will now heal more.
/:cl:

Trying to heal wounds is usually extremely hard when you get augmented; only two items in the game can fix your wounds, and they take five seconds to heal, while _also_ having to target the correct limb. Add in the fact that doctors often won't notice that your limbs are robotic and that the standard bicaridine won't work, and getting your limbs augmented becomes a downgrade over normal ones.

Making others healing you instant is in line with bruise/burn packs, which share the same behaviour; overall it encourages cooperation with others.
I felt that number buff was necessary due to the huge disparity in organic and robotic healing speed. With this it'll still be a downgrade over organic, which is fair enough since robotic limbs have other benefits. To compare, cyborgs heal 30 per use.
