### PR TITLE
Fixes massive throwing runtimes

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -87,7 +87,7 @@
 				/obj/item/clothing/gloves/color/fyellow = 1,
 				/obj/item/clothing/head/hardhat = 1,
 				/obj/item/clothing/head/hardhat/red = 1,
-				/obj/item/clothing/head/that{throwforce = 1; throwing = 1} = 1,
+				/obj/item/clothing/head/that{throwforce = 1;} = 1,
 				/obj/item/clothing/head/ushanka = 1,
 				/obj/item/clothing/head/welding = 1,
 				/obj/item/clothing/mask/gas = 15,


### PR DESCRIPTION
```
The following runtime has occurred 1802 time(s).
runtime error: Cannot execute 1.hit atom().
proc name: Bump (/atom/movable/Bump)
  source file: atoms_movable.dm,133
  usr: 0
  src: the top-hat (/obj/item/clothing/head/that)
  src.loc: the floor (131,123,1) (/turf/open/floor/plasteel/cafeteria)
```