### PR TITLE
Cleans up ChangeTurf/Destroy

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -508,7 +508,11 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		log_admin("[key_name(usr)] deleted [O] at ([O.x],[O.y],[O.z])")
 		message_admins("[key_name_admin(usr)] deleted [O] at ([O.x],[O.y],[O.z])")
 		feedback_add_details("admin_verb","DEL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-		qdel(O)
+		if(isturf(O))
+			var/turf/T = O
+			T.ChangeTurf(T.baseturf)
+		else
+			qdel(O)
 
 /client/proc/cmd_admin_list_open_jobs()
 	set category = "Admin"


### PR DESCRIPTION
I revisited this because of #24075 because, eventually, qdel may have other side effects we want

But, the semantics here are annoying as fuck because of how BYOND turfs replace each other.

There are a lot of conflicting goals here

- qdel/SSgarbage should handle calling Destroy
- Destroy should be called when an object is destroyed
- Turfs should ChangeTurf to their baseturf if directly qdeleted
- Turfs requires Destroy to be called before creating the replacement turf

It's really a mixmatch of requirements. At the end of the day, I decided to give point 3 the boot. From now on, if a turf is directly qdel'd, it will be logged as an error, because it always was.

Also I removed a bunch of the old -> new assignments because T U R F P E R S I S T E N C E