### PR TITLE
Changeling power "Anatomic Panacea" removes zombie infections

### DIFF
--- a/code/game/gamemodes/changeling/powers/panacea.dm
+++ b/code/game/gamemodes/changeling/powers/panacea.dm
@@ -8,7 +8,7 @@
 
 //Heals the things that the other regenerative abilities don't.
 /obj/effect/proc_holder/changeling/panacea/sting_action(mob/user)
-	user << "<span class='notice'>We begin cleansing impurities from our form.</span>"
+	user << "<span class='notice'>We cleanse impurities from our form.</span>"
 
 	var/mob/living/simple_animal/borer/B = user.has_brain_worms()
 	if(B)
@@ -19,13 +19,20 @@
 			var/mob/living/carbon/C = user
 			C.vomit(0)
 			user << "<span class='notice'>A parasite exits our form.</span>"
-	var/obj/item/organ/body_egg/egg = user.getorgan(/obj/item/organ/body_egg)
-	if(egg)
-		egg.Remove(user)
+	var/list/bad_organs = list(
+		user.getorgan(/obj/item/organ/body_egg),
+		user.getorgan(/obj/item/organ/zombie_infection))
+
+	for(var/o in bad_organs)
+		var/obj/item/organ/O = o
+		if(!istype(O))
+			continue
+
+		O.Remove(user)
 		if(iscarbon(user))
 			var/mob/living/carbon/C = user
 			C.vomit(0)
-		egg.loc = get_turf(user)
+		O.forceMove(get_turf(user))
 
 	user.reagents.add_reagent("mutadone", 10)
 	user.reagents.add_reagent("pen_acid", 20)


### PR DESCRIPTION
:cl: coiax
add: The changeling power "Anatomic Panacea" now causes the changeling
to vomit out zombie infections, along with headslugs and xeno
infections, as before.
/:cl:

Closes #24063.