### PR TITLE
Makes a thing use a better define

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -208,8 +208,7 @@ var/datum/subsystem/timer/SStimer
 		SStimer.timer_id_dict["timerid[id]"] = src
 
 	if (callBack.object != GLOBAL_PROC)
-		LAZYINITLIST(callBack.object.active_timers)
-		callBack.object.active_timers += src
+		LAZYADD(callBack.object.active_timers, src)
 
 	if (flags & TIMER_CLIENT_TIME)
 		SStimer.clienttime_timers += src


### PR DESCRIPTION
For reference:

```
#define LAZYINITLIST(L) if (!L) L = list()
#define LAZYADD(L, I) if(!L) { L = list(); } L += I;
```