### PR TITLE
Main CTF gun disappears when dropped on the floor

### DIFF
--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -360,6 +360,14 @@
 	desc = "This looks like it could really hurt in melee."
 	force = 50
 
+/obj/item/weapon/gun/ballistic/automatic/laser/ctf/dropped()
+	. = ..()
+	addtimer(CALLBACK(src, .proc/floor_vanish), 1)
+
+/obj/item/weapon/gun/ballistic/automatic/laser/ctf/proc/floor_vanish()
+	if(isturf(loc))
+		qdel(src)
+
 /obj/item/ammo_box/magazine/recharge/ctf
 	ammo_type = /obj/item/ammo_casing/caseless/laser/ctf
 


### PR DESCRIPTION
:cl: coiax
fix: The main CTF laser gun disappears when dropped on the floor.
/:cl:

Brings it in line with all the other ammo and guns, I wanted the only
source of ammo to be the deathdrop ammo pickups. Also, it prevents the
red team from shooting blue team's guns.