### PR TITLE
Force checkouts to always be CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,5 @@
 # force changelog merging to use union
 html/changelog.html merge=union
 
-
+# force CRLF checkouts
+text eol=crlf


### PR DESCRIPTION
https://help.github.com/articles/dealing-with-line-endings/#per-repository-settings

Note that the majority of the code tree is LF

Closes #24105 