### PR TITLE
Adds option of unique timers ignoring wait

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -64,3 +64,6 @@
 #define TIMER_CLIENT_TIME	0x4
 //Timer can be stopped using deltimer()
 #define TIMER_STOPPABLE		0x8
+//To be used with TIMER_UNIQUE
+//prevents distinguishing identical timers with the wait variable
+#define TIMER_NO_HASH_WAIT  0x10

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -299,7 +299,11 @@ proc/addtimer(datum/callback/callback, wait, flags)
 	var/hash
 
 	if (flags & TIMER_UNIQUE)
-		var/list/hashlist = list(callback.object, "(\ref[callback.object])", callback.delegate, wait, flags & TIMER_CLIENT_TIME)
+		var/list/hashlist
+		if(flags & TIMER_NO_HASH_WAIT)
+			hashlist = list(callback.object, "(\ref[callback.object])", callback.delegate, flags & TIMER_CLIENT_TIME)
+		else
+			hashlist = list(callback.object, "(\ref[callback.object])", callback.delegate, wait, flags & TIMER_CLIENT_TIME)
 		hashlist += callback.arguments
 		hash = hashlist.Join("|||||||")
 


### PR DESCRIPTION
For timers that may have variable length but should still replace each other (e.g. airlocks)