### PR TITLE
make some hacked items from the autolathe into the non hacked autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -422,6 +422,30 @@
 	materials = list(MAT_METAL = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/rubbershot
 	category = list("initial", "Security")
+	
+/datum/design/buckshot_shell
+	name = "Buckshot shell"
+	id = "buckshot_shell"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot
+	category = list("initial", "Security")
+	
+/datum/design/handcuffs
+	name = "Handcuffs"
+	id = "handcuffs"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/weapon/restraints/handcuffs
+	category = list("initial", "Security")
+	
+/datum/design/shotgun_slug
+	name = "Shotgun slug"
+	id = "shotgun_slug"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun
+	category = list("initial", "Security")
 
 /datum/design/c38
 	name = "Speed loader (.38)"
@@ -606,31 +630,7 @@
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 70, MAT_GLASS = 60)
 	build_path = /obj/item/weapon/weldingtool/largetank
-	category = list("hacked", "Tools")
-
-/datum/design/handcuffs
-	name = "Handcuffs"
-	id = "handcuffs"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
-	build_path = /obj/item/weapon/restraints/handcuffs
-	category = list("hacked", "Security")
-
-/datum/design/shotgun_slug
-	name = "Shotgun slug"
-	id = "shotgun_slug"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun
-	category = list("hacked", "Security")
-
-/datum/design/buckshot_shell
-	name = "Buckshot shell"
-	id = "buckshot_shell"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/buckshot
-	category = list("hacked", "Security")
+	category = list("initial", "Tools")
 
 /datum/design/shotgun_dart
 	name = "Shotgun dart"


### PR DESCRIPTION
detective gameplay buff 

adds the following to non hacked autolathes from hacked ones
Buckshots, Shotgun slugs, handcuffs, industrial welders,

this would make the hacked autolathe more questionable for things like 357. ammo flamethrowers the real baddie stuff rcds etc hacking a autolathe takes like 3 seconds anyways so why not?


:cl: Hyena
tweak:changes some autolathe stuff
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)So like what does it take to hack a autolathe again? a multitool to pulse the wires and it doesnt even shock you a wirecutter to cut the wire and a screwdriver to open close it which takes like... 3-5 secs and can be made in the same autolathe?
