### PR TITLE
Hopefully fixes the bug where a traitor AI fails a "Nothing" objective

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -115,7 +115,7 @@
 					var/datum/objective/maroon/yandere_two = new
 					yandere_two.owner = traitor
 					yandere_two.target = yandere_one.target
-					yandere_two.update_explanation_text() // normally called in find.target()
+					yandere_two.update_explanation_text() // normally called in find_target()
 					traitor.objectives += yandere_two
 					objective_count++
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -115,6 +115,7 @@
 					var/datum/objective/maroon/yandere_two = new
 					yandere_two.owner = traitor
 					yandere_two.target = yandere_one.target
+					yandere_two.update_explanation_text() // normally called in find.target()
 					traitor.objectives += yandere_two
 					objective_count++
 


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/22967.
Fixes https://github.com/tgstation/tgstation/issues/18966.

What is happening there, if I'm right:

- The traitor AI rolls the "yandere" objective set (protect someone and maroon them). I tested this part, it's always this one that gives the Nothing (and the only way the AI can get a protect objective anyway), and the Nothing is in fact a maroon objective in VV
- The protect objective is generated normally, but the maroon objective has its target set manually (to the same person) instead of via find_target().
- update_explanation_text() gets called in find_target, which means it never happens for the Maroon objective and the text remains "Nothing" (the default). This is why it doesn't say Free Objective, which is what happens when it can't find a target
- The maroon objective works normally, but since the AI doesn't know it's supposed to be marooning someone, it probably doesn't try to maroon them, so they fail it. Maroon is set to succeed by default, this is the only way it *can* fail

haven't tested this but I'm pretty sure this is what's going on.