### PR TITLE
Lobby timer won't be delayed by subsystem initializations

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -2,7 +2,7 @@ var/datum/subsystem/mapping/SSmapping
 
 /datum/subsystem/mapping
 	name = "Mapping"
-	init_order = 13
+	init_order = 12
 	flags = SS_NO_FIRE
 	display_order = 50
 

--- a/code/controllers/subsystem/processing/objects.dm
+++ b/code/controllers/subsystem/processing/objects.dm
@@ -6,7 +6,7 @@ var/datum/subsystem/objects/SSobj
 
 /datum/subsystem/objects
 	name = "Objects"
-	init_order = 12
+	init_order = 11
 	priority = 40
 
 	var/initialized = INITIALIZATION_INSSOBJ

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -4,7 +4,7 @@ var/datum/subsystem/ticker/ticker
 
 /datum/subsystem/ticker
 	name = "Ticker"
-	init_order = 0
+	init_order = 13
 
 	priority = 200
 	flags = SS_FIRE_IN_LOBBY|SS_KEEP_TIMING
@@ -39,7 +39,8 @@ var/datum/subsystem/ticker/ticker
 	var/tipped = 0							//Did we broadcast the tip of the day yet?
 	var/selected_tip						// What will be the tip of the day?
 
-	var/timeLeft = 1200						//pregame timer
+	var/timeLeft						//pregame timer
+	var/start_at
 
 	var/totalPlayers = 0					//used for pregame stats on statpanel
 	var/totalPlayersReady = 0				//used for pregame stats on statpanel
@@ -66,19 +67,19 @@ var/datum/subsystem/ticker/ticker
 	if(!syndicate_code_response)
 		syndicate_code_response	= generate_code_phrase()
 	..()
+	start_at = world.time + (config.lobby_countdown * 10)
+	world << "<span class='boldnotice'>Welcome to [station_name()]!</span>"
+	world << "Please set up your character and select \"Ready\". The game will start in about [config.lobby_countdown] seconds."
+	current_state = GAME_STATE_PREGAME
+	for(var/client/C in clients)
+		window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
 
 /datum/subsystem/ticker/fire()
 	switch(current_state)
-		if(GAME_STATE_STARTUP)
-			timeLeft = config.lobby_countdown * 10
-			world << "<span class='boldnotice'>Welcome to [station_name()]!</span>"
-			world << "Please set up your character and select \"Ready\". The game will start in [config.lobby_countdown] seconds."
-			current_state = GAME_STATE_PREGAME
-			for(var/client/C in clients)
-				window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
-
 		if(GAME_STATE_PREGAME)
 				//lobby stats for statpanels
+			if(isnull(timeLeft))
+				timeLeft = max(0,start_at - world.time)
 			totalPlayers = 0
 			totalPlayersReady = 0
 			for(var/mob/new_player/player in player_list)
@@ -707,3 +708,15 @@ var/datum/subsystem/ticker/ticker
 
 	if(news_message)
 		send2otherserver(news_source, news_message,"News_Report")
+
+/datum/subsystem/ticker/proc/GetTimeLeft()
+	if(isnull(ticker.timeLeft))
+		return max(0, start_at - world.time)
+	return timeLeft
+
+/datum/subsystem/ticker/proc/SetTimeLeft(newtime)
+	if(newtime >= 0 && isnull(timeLeft))	//remember, negative means delayed
+		start_at = world.time + newtime
+	else
+		timeLeft = newtime
+		

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -569,11 +569,11 @@ var/global/BSACooldown = 0
 	set desc="Delay the game start"
 	set name="Delay pre-game"
 
-	var/newtime = input("Set a new time in seconds. Set -1 for indefinite delay.","Set Delay",round(ticker.timeLeft/10)) as num|null
+	var/newtime = input("Set a new time in seconds. Set -1 for indefinite delay.","Set Delay",round(ticker.GetTimeLeft()/10)) as num|null
 	if(ticker.current_state > GAME_STATE_PREGAME)
 		return alert("Too late... The game has already started!")
 	if(newtime)
-		ticker.timeLeft = newtime * 10
+		ticker.SetTimeLeft(newtime * 10)
 		if(newtime < 0)
 			world << "<b>The game start has been delayed.</b>"
 			log_admin("[key_name(usr)] delayed the round start.")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -75,7 +75,10 @@
 		stat("Map:", MAP_NAME)
 
 		if(ticker.current_state == GAME_STATE_PREGAME)
-			stat("Time To Start:", (ticker.timeLeft >= 0) ? "[round(ticker.timeLeft / 10)]s" : "DELAYED")
+			var/time_remaining = ticker.GetTimeLeft()
+			if(time_remaining >= 0)
+				time_remaining /= 10
+			stat("Time To Start:", (time_remaining >= 0) ? "[round(time_remaining)]s" : "DELAYED")
 
 			stat("Players:", "[ticker.totalPlayers]")
 			if(client.holder)


### PR DESCRIPTION
If we want longer roundstarts we can change the config.

If initialization isn't complete by the time the timer is up, it will wait until it's done before starting.

Moved ticker initialization to second (after jobs). So, it all works out.

:cl: Cyberboss
tweak: The round start timer will count down during subsystem initialization
/:cl: