### PR TITLE
Disconnecting does not count as dead for rev

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -107,10 +107,10 @@
 
 /datum/objective/mutiny/check_completion()
 	if(target && target.current)
-		if(target.current.stat == DEAD || !ishuman(target.current) || !target.current.ckey || !target.current.client)
+		if(target.current.stat == DEAD || !ishuman(target.current) || !target.current.ckey)
 			return 1
 		var/turf/T = get_turf(target.current)
-		if(T && (T.z > ZLEVEL_STATION) || target.current.client.is_afk())			//If they leave the station or go afk they count as dead for this
+		if(T && (T.z > ZLEVEL_STATION) || (target.current.client && target.current.client.is_afk()))			//If they leave the station or go afk they count as dead for this
 			return 2
 		return 0
 	return 1


### PR DESCRIPTION
Random disconnects happen too often that more often then not this would falsely trigger rather then properly trigger.

Heads are not suppose to be going braindead anyways, if they have to, they inform the admins, and rev rarely happens when admins are not on because of pop cap situations and its not like restart vote isn't a thing (now that it ignores afk players) that could hand the rare edge case this annoying bit of code is poorly handling now.

fixes #24124