### PR TITLE
Admin shortcut for converting ghosts to humans

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -782,3 +782,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			SSpai.recruitWindow(src)
 	else
 		usr << "Can't become a pAI candidate while not dead!"
+
+/mob/dead/observer/CtrlShiftClick(mob/user)
+	if(isobserver(user) && check_rights(R_SPAWN))
+		change_mob_type( /mob/living/carbon/human , null, null, TRUE) //always delmob, ghosts shouldn't be left lingering
+


### PR DESCRIPTION
Used CtrlShiftClick as it's a largely (entirely?) unused combination, meaning it won't interfere with anything, but still act as a shortcut.

Requested by @PKPenguin321, I also want it as it's annoying to have to use the player panel to spawn during testing.

Coded at work.