### PR TITLE
Syndicate communication/services for sale

### DIFF
--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -1,6 +1,7 @@
 
 
 /datum/game_mode/blob/send_intercept(report = 0)
+	intercept_sent = TRUE
 	var/intercepttext = ""
 	switch(report)
 		if(1)

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -15,12 +15,10 @@
 /datum/game_mode/extended/announced
 	name = "extended"
 	config_tag = "extended"
+	send_no_threats_intercept = TRUE
 
 /datum/game_mode/extended/announced/generate_station_goals()
 	for(var/T in subtypesof(/datum/station_goal))
 		var/datum/station_goal/G = new T
 		station_goals += G
 		G.on_report()
-
-/datum/game_mode/extended/announced/send_intercept(report = 0)
-	priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", 'sound/AI/commandreport.ogg')

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -41,6 +41,8 @@
 
 	var/const/waittime_l = 600
 	var/const/waittime_h = 1800 // started at 1800
+	var/intercept_sent = FALSE
+	var/send_no_threats_intercept = FALSE
 
 	var/list/datum/station_goal/station_goals = list()
 
@@ -88,8 +90,7 @@
 		feedback_set_details("revision","[revdata.commit]")
 	feedback_set_details("server_ip","[world.internet_address]:[world.port]")
 	if(report)
-		spawn (rand(waittime_l, waittime_h))
-			send_intercept(0)
+		addtimer(CALLBACK(src, .proc/send_intercept, 0), rand(waittime_l, waittime_h))
 	generate_station_goals()
 	start_state = new /datum/station_state()
 	start_state.count(1)
@@ -266,6 +267,10 @@
 
 
 /datum/game_mode/proc/send_intercept()
+	intercept_sent = TRUE
+	if(send_no_threats_intercept)
+		priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", 'sound/AI/commandreport.ogg')
+		return
 	var/intercepttext = "<b><i>Central Command Status Summary</i></b><hr>"
 	intercepttext += "<b>Central Command has intercepted and partially decoded a Syndicate transmission with vital information regarding their movements. The following report outlines the most \
 	likely threats to appear in your sector.</b>"

--- a/code/game/objects/items/announcer.dm
+++ b/code/game/objects/items/announcer.dm
@@ -1,0 +1,65 @@
+/obj/item/announcer
+	name = "bootleg announcer"
+	desc = "Fake an announcement from Centcom! Note that it's unlikely they will back up your story if asked."
+	icon_state = "gangtool-red"
+	item_state = "walkietalkie"
+	w_class = WEIGHT_CLASS_TINY
+	throwforce = 0
+	throw_speed = 3
+	throw_range = 7
+	var/uses = 1 // -1 is infinite uses.
+
+/obj/item/announcer/attack_self(mob/user)
+	if(uses == 0)
+		user << "<span class='warning'>[src] has run out of [command_name()] encryption keys, and can send no more messages.</span>"
+		return
+
+	var/result = create_command_report(user)
+	if(result && uses != -1)
+		uses--
+
+/obj/item/announcer/unlimited
+	name = "official announcer"
+	desc = "Send an official announcement from Centcom. Since you're holding this, you MUST be a Centcom employee, so it has unlimited uses."
+	icon_state = "gangtool-white"
+	uses = -1
+
+/obj/item/announcer/fake_extended
+	name = "intel disruption device"
+	desc = "If used early enough in the shift, this device can prevent the station being informed of potential threats."
+	icon_state = "gangtool-blue"
+
+/obj/item/announcer/fake_extended/attack_self(mob/user)
+	if(ticker.mode.intercept_sent)
+		user << "<span class='warning'>[src] reports that the intel broadcast has already been recieved by the station!</span>"
+		return
+
+	user << "<span class='notice'>You use [src] to disrupt the station's communication network and to fake an \"all clear\" notice.</span>"
+
+	ticker.mode.send_no_threats_intercept = TRUE
+	// Deleting the object means we don't to worry about used ones being
+	// refunded.
+	visible_message("<span class='warning'>[src] dissolves into sparks!</span>")
+
+	var/datum/effect_system/spark_spread/sparks = new
+	sparks.set_up(2, 0, src)
+	sparks.attach(src)
+	sparks.start()
+
+	qdel(src)
+
+/proc/create_command_report(mob/user)
+	var/input = input(usr, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null
+	if(!input)
+		return
+
+	var/confirm = alert(src, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No")
+	if(confirm == "Yes")
+		priority_announce(input, null, 'sound/AI/commandreport.ogg')
+	else
+		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
+
+	print_command_report(input,"[confirm=="Yes" ? "" : "Classified "][command_name()] Update")
+	log_admin("[key_name(src)] has created a command report: [input]")
+	message_admins("[key_name_admin(src)] has created a command report")
+	return TRUE

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -467,21 +467,9 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!holder)
 		src << "Only administrators may use this command."
 		return
-	var/input = input(usr, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null
-	if(!input)
-		return
 
-	var/confirm = alert(src, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No")
-	if(confirm == "Yes")
-		priority_announce(input, null, 'sound/AI/commandreport.ogg')
-	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
-
-	print_command_report(input,"[confirm=="Yes" ? "" : "Classified "][command_name()] Update")
-
-	log_admin("[key_name(src)] has created a command report: [input]")
-	message_admins("[key_name_admin(src)] has created a command report")
-	feedback_add_details("admin_verb","CCR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	if(create_command_report(usr))
+		feedback_add_details("admin_verb","CCR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_change_command_name()
 	set category = "Special Verbs"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1202,6 +1202,23 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
 
+/datum/uplink_item/commservice
+	category = "Communications/Services"
+
+/datum/uplink_item/commservice/bootleg_announcer
+	name = "Bootleg Announcer"
+	desc = "Using a stolen encryption key, this device can fake a communication from Central Command. It only works once, and it's unlikely that Central will back up the story if asked about it. That is, if anyone bothers."
+	cost = 5
+	item = /obj/item/announcer
+
+/datum/uplink_item/commservice/intel_disrupter
+	name = "Intel Disruption Device"
+	desc = "This device can disrupt the normal intelligence report that is sent that normally informs the station of people like you. Use it to disrupt the report, and watch as members of the station commit suicide in despair. Not very useful after the intercept has already been recieved. Refundable if unused."
+	cost = 10
+	item = /obj/item/announcer/fake_extended
+	surplus = 0
+	refundable = TRUE
+
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -667,6 +667,7 @@
 #include "code\game\objects\effects\spawners\lootdrop.dm"
 #include "code\game\objects\effects\spawners\structure.dm"
 #include "code\game\objects\effects\spawners\vaultspawner.dm"
+#include "code\game\objects\items\announcer.dm"
 #include "code\game\objects\items\apc_frame.dm"
 #include "code\game\objects\items\blueprints.dm"
 #include "code\game\objects\items\body_egg.dm"


### PR DESCRIPTION
:cl: coiax
add: Central Command have reported that various communication encryption
keys have been stolen. The use of these keys could HYPOTHETICALLY allow
faking of secure Central Command messages, or disruption of intelligence
dispatches. Central Command reassure all Nanotrasen stations that the
chances of this happening are very slim.
add: Adds bootleg announcer to uplink, costs 5 TC, fake a Central
Command message!
add: Adds intel disruption device to uplink, costs 10 TC, fake an "all
clear message" to the station, and watch as the extended suicides pile up.
/:cl:

ROB ROBINSON IS JUST TOO STEALTHY, WE CAN'T FIND HIM.

This is a good idea because traitors TC trade for Centcom dispatches
already, why not formalise it?