### PR TITLE
Removes mulligan from Blob and Wizard

### DIFF
--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -7,11 +7,6 @@
 			if(B.blob_core || !B.placed)
 				return 0
 	if(!blob_cores.len) //blob is dead
-		if(config.continuous["blob"])
-			message_sent = FALSE //disable the win count at this point
-			continuous_sanity_checked = 1 //Nonstandard definition of "alive" gets past the check otherwise
-			SSshuttle.clearHostileEnvironment(src)
-			return ..()
 		return 1
 	return ..()
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -166,7 +166,7 @@
 
 	for(var/datum/mind/wizard in wizards)
 		if(isliving(wizard.current) && wizard.current.stat!=DEAD)
-			return ..()
+			return 1
 
 	if(SSevent.wizardmode) //If summon events was active, turn it off
 		SSevent.toggleWizardmode()


### PR DESCRIPTION
My only regret was not doing this sooner. I got talked out of it last year with some "alternative fix" that never ended up working. 

There is absolutely no reason to punish the crew for doing exactly what we expect them to do during a solo antag mode, team up, cooperate, empower one another... just so people can get shot in the back with the gun they had just given away. 

It doesn't shake up the meta, at this point if the round doesnt end after blobs/wizards everyone knows all hell is about to break loose with random traitors and lings. 

I didn't touch the summon events exception since summon events is already "Cancer: The Mode" I wouldn't want to ruin the theming. 

[This image sums up what happens every mulligan](http://imgur.com/a/InrEN)

Post-Round Edit: [This image sums up how every mulligan ends](http://imgur.com/a/CvCM9)