### PR TITLE
Resets client skin on connect

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -301,7 +301,7 @@ var/next_external_rsc = 0
 	if(!tooltips)
 		tooltips = new /datum/tooltip(src)
 	
-	winset(usr, null, "reset=true")
+	winset(src, null, "reset=true")
 
 //////////////
 //DISCONNECT//

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -300,7 +300,8 @@ var/next_external_rsc = 0
 	//This is down here because of the browse() calls in tooltip/New()
 	if(!tooltips)
 		tooltips = new /datum/tooltip(src)
-
+	
+	winset(usr, null, "reset=true")
 
 //////////////
 //DISCONNECT//


### PR DESCRIPTION
This still keeps most saved skin shit, but it does force the client's skin to re-align with the server

This will fix clients not getting the test merged goonchat until they close and re-open their client @lzimann 

(it also would fix issues clients had during the 64x64 merge, or when clients are redirected too quickly after connecting)