### PR TITLE
[Meta] Fixes Top Left Grounding Rod From Being Destroyed

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -20179,6 +20179,7 @@
 	icon_state = "2-4";
 	tag = ""
 	},
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/space)
 "aIe" = (
@@ -21708,6 +21709,7 @@
 	icon_state = "2-8";
 	tag = ""
 	},
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/space)
 "aKK" = (
@@ -92984,6 +92986,7 @@
 	icon_state = "1-4";
 	tag = "90Curve"
 	},
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/space)
 "dbh" = (
@@ -93003,6 +93006,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/space)
 "dbj" = (
@@ -137719,7 +137723,7 @@ ayY
 aaf
 aBQ
 aaf
-aIb
+anS
 aCZ
 aCZ
 aCZ
@@ -137729,7 +137733,7 @@ aCZ
 aCZ
 aCZ
 aCZ
-aIb
+anS
 aaf
 cXz
 aaf
@@ -141060,17 +141064,17 @@ axY
 axY
 aaa
 cmq
-aIb
+anS
 aaf
 aaa
 aaa
 aaf
-aIb
+anS
 aaf
 aaa
 aaa
 aaf
-aIb
+anS
 cXd
 aaa
 axY


### PR DESCRIPTION
##  **Fixes Top Left Grounding Rod From Being Destroyed On MetaStation**
This change should fix the top left grounding rod and other grounding rods from being destroyed while in their default placement on MetaStation. This Pull Request moves the grounding rods on the left one tile to the right and the grounding rods on the right one tile to the left and should alleviate any destruction of grounding rods when the tesla engine is setup.

## **Images**
![1](https://cloud.githubusercontent.com/assets/24999255/23058886/26d80a82-f54b-11e6-9f4d-cedb358b6742.PNG)

## **Changelog**
:cl: Tofa01
Fix: [Meta] Fixes top left grounding rod from being destroyed by the Tesla engine.
/:cl:

## **Fixes #24162**


