### PR TITLE
[Delta] Removes SSU From Mining Equipment Room

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -30331,24 +30331,17 @@
 	icon_state = "manifold";
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock{
 	name = "\improper Mining Office"
 	})
 "bcW" = (
-/obj/machinery/suit_storage_unit/mining/eva,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock{
 	name = "\improper Mining Office"
 	})
 "bcX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/suit_storage_unit/mining/eva,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock{
 	name = "\improper Mining Office"
@@ -164185,7 +164178,7 @@ aNg
 aYO
 bar
 bbF
-bcY
+bcX
 bbF
 bgl
 bii


### PR DESCRIPTION
## **Removes SSU From Mining Equipment Room On Deltastation**
Removes the three Suit Units which provide basic space suits in the mining equipment room on Deltastation. This is because now with Lavaland using a space suit is a pretty big death sentence because of the movement speed decrease, but more importantly it provides traitor miners with a unnecessary buff and an extremely easy start along with the other equipment they have. This Pull Request should make traitor miner a bit more challenging on Deltastation and even it out compared to other maps which do not start with miner SSU's, this should also decrease the amount of break ins into cargo/mining by greytiders to get space suits. 

## **Changelog**
:cl: Tofa01
Del: [Delta] Removes SSU From Mining Equipment Room
/:cl:
