### PR TITLE
Bootleg announcers - Fake a central message (but only if the admins approve)

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -412,3 +412,7 @@ var/global/list/ghost_others_options = list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 
 //Error handler defines
 #define ERROR_USEFUL_LEN 2
+
+#define SPOOFER_ACCEPT "accept"
+#define SPOOFER_REJECT "reject"
+#define SPOOFER_DESTROY "destroy device"

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -1,6 +1,7 @@
 
 
 /datum/game_mode/blob/send_intercept(report = 0)
+	intercept_sent = TRUE
 	var/intercepttext = ""
 	switch(report)
 		if(1)

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -15,12 +15,10 @@
 /datum/game_mode/extended/announced
 	name = "extended"
 	config_tag = "extended"
+	send_no_threats_intercept = TRUE
 
 /datum/game_mode/extended/announced/generate_station_goals()
 	for(var/T in subtypesof(/datum/station_goal))
 		var/datum/station_goal/G = new T
 		station_goals += G
 		G.on_report()
-
-/datum/game_mode/extended/announced/send_intercept(report = 0)
-	priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", 'sound/AI/commandreport.ogg')

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -41,6 +41,8 @@
 
 	var/const/waittime_l = 600
 	var/const/waittime_h = 1800 // started at 1800
+	var/intercept_sent = FALSE
+	var/send_no_threats_intercept = FALSE
 
 	var/list/datum/station_goal/station_goals = list()
 
@@ -88,8 +90,7 @@
 		feedback_set_details("revision","[revdata.commit]")
 	feedback_set_details("server_ip","[world.internet_address]:[world.port]")
 	if(report)
-		spawn (rand(waittime_l, waittime_h))
-			send_intercept(0)
+		addtimer(CALLBACK(src, .proc/send_intercept, 0), rand(waittime_l, waittime_h))
 	generate_station_goals()
 	start_state = new /datum/station_state()
 	start_state.count(1)
@@ -266,6 +267,10 @@
 
 
 /datum/game_mode/proc/send_intercept()
+	intercept_sent = TRUE
+	if(send_no_threats_intercept)
+		priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", 'sound/AI/commandreport.ogg')
+		return
 	var/intercepttext = "<b><i>Central Command Status Summary</i></b><hr>"
 	intercepttext += "<b>Central Command has intercepted and partially decoded a Syndicate transmission with vital information regarding their movements. The following report outlines the most \
 	likely threats to appear in your sector.</b>"

--- a/code/game/objects/items/announcer.dm
+++ b/code/game/objects/items/announcer.dm
@@ -8,59 +8,92 @@
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 7
-	var/uses = 1 // -1 is infinite uses.
+	var/unlimited = FALSE
+	var/autoapprove = FALSE // admin only plox
+	var/approval_window = 1200 // 2 minutes to approve admins plz
+
+	var/compose_warning = "Compose your spoof announcement. Be warned that automatic algoritms verify incoming announcements, so something that's too crazy won't get broadcast."
+
+	var/proposed_message = ""
+	var/proposed_stealth = FALSE
+
+	var/verification_timer = FALSE
+
+/obj/item/announcer/Destroy()
+	deltimer(verification_timer)
+	. = ..()
 
 /obj/item/announcer/attack_self(mob/user)
-	if(uses == 0)
-		user << "<span class='warning'>[src] has run out of [command_name()] encryption keys, and can send no more messages.</span>"
+	if(verification_timer)
+		user << "<span class='warning'>[src] is still processing the last message. Please wait...</span>"
 		return
 
-	var/result = create_command_report(user)
-	if(result && uses != -1)
-		uses--
+	var/input = stripped_multiline_input(user, compose_warning, "Announcer Message", proposed_message) as message|null
+	if(!input || QDELETED(src) || QDELETED(user))
+		return
+
+	proposed_message = input
+
+	var/stealth_level = alert(user, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No")
+
+	proposed_stealth = stealth_level == "No" ? TRUE : FALSE
+
+	if(autoapprove)
+		accept_message(user)
+		return
+
+	user << "<span class='notice'>[src] chirps to itself while it verifies that the communication algorithms will accept this message.</span>"
+
+	verification_timer = addtimer(CALLBACK(src, .proc/reject_message), approval_window, TIMER_STOPPABLE)
+
+	admins << "<span class='adminnotice'><b><font color=orange>SPOOFED COMMAND MESSAGE:</font></b> [ADMIN_LOOKUP(user)] proposes to send [proposed_stealth ? "a classified message" : "a global message"]: <span class='italics'>[proposed_message]</span>. Will autoreject in [approval_window / 10] seconds. (<A HREF='?_src_=holder;spoof_message=\ref[src];response=[SPOOFER_ACCEPT]'>ACCEPT</a>) (<A HREF='?_src_=holder;spoof_message=\ref[src];response=[SPOOFER_REJECT]'>REJECT</a>) (<A HREF='?_src_=holder;spoof_message=\ref[src];response=[SPOOFER_DESTROY]'>DESTROY DEVICE</a>)</span>"
+
+/obj/item/announcer/proc/pop()
+	var/datum/effect_system/spark_spread/sparks = new
+	sparks.set_up(4, 4, src)
+	sparks.attach(src)
+	sparks.start()
+	visible_message("<span class='warning'>[src] dissolves into sparks!</span>")
+	qdel(src)
+
+/obj/item/announcer/proc/reject_message()
+	audible_message("<span class='warning'>[src] buzzes.</span>")
+	playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 1)
+
+	deltimer(verification_timer)
+	verification_timer = null
+
+/obj/item/announcer/proc/accept_message(mob/user)
+	audible_message("<span class='notice'>[src] chimes.</span>")
+	playsound(get_turf(src), 'sound/machines/chime.ogg', 50, 0)
+
+	sleep(30) // let the sound play
+
+	verification_timer = null
+	deltimer(verification_timer)
+
+	create_command_report(user, proposed_message, proposed_stealth)
+	proposed_message = ""
+	proposed_stealth = FALSE
+	if(!unlimited)
+		pop()
 
 /obj/item/announcer/unlimited
 	name = "official announcer"
 	desc = "Send an official announcement from Centcom. Since you're holding this, you MUST be a Centcom employee, so it has unlimited uses."
 	icon_state = "gangtool-white"
-	uses = -1
+	unlimited = TRUE
+	autoapprove = TRUE
+	compose_warning = "Please enter anything you want. Anything. Serious."
 
-/obj/item/announcer/fake_extended
-	name = "intel disruption device"
-	desc = "If used early enough in the shift, this device can prevent the station being informed of potential threats."
-	icon_state = "gangtool-blue"
 
-/obj/item/announcer/fake_extended/attack_self(mob/user)
-	if(ticker.mode.intercept_sent)
-		user << "<span class='warning'>[src] reports that the intel broadcast has already been recieved by the station!</span>"
-		return
-
-	user << "<span class='notice'>You use [src] to disrupt the station's communication network and to fake an \"all clear\" notice.</span>"
-
-	ticker.mode.send_no_threats_intercept = TRUE
-	// Deleting the object means we don't to worry about used ones being
-	// refunded.
-	visible_message("<span class='warning'>[src] dissolves into sparks!</span>")
-
-	var/datum/effect_system/spark_spread/sparks = new
-	sparks.set_up(2, 0, src)
-	sparks.attach(src)
-	sparks.start()
-
-	qdel(src)
-
-/proc/create_command_report(mob/user)
-	var/input = input(user, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null
-	if(!input)
-		return
-
-	var/confirm = alert(user, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No")
-	if(confirm == "Yes")
-		priority_announce(input, null, 'sound/AI/commandreport.ogg')
+/proc/create_command_report(mob/user, message, stealth)
+	if(!stealth)
+		priority_announce(message, null, 'sound/AI/commandreport.ogg')
 	else
 		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
 
-	print_command_report(input,"[confirm=="Yes" ? "" : "Classified "][command_name()] Update")
-	log_admin("[key_name(src)] has created a command report: [input]")
-	message_admins("[key_name_admin(src)] has created a command report")
+	print_command_report(message,"[stealth ? "Classified " : ""][command_name()] Update")
+	log_admin("[key_name(user)] has created a command report: [message]")
+	message_admins("[key_name_admin(user)] has created a command report")
 	return TRUE

--- a/code/game/objects/items/announcer.dm
+++ b/code/game/objects/items/announcer.dm
@@ -1,0 +1,65 @@
+/obj/item/announcer
+	name = "bootleg announcer"
+	desc = "Fake an announcement from Centcom! Note that it's unlikely they will back up your story if asked."
+	icon_state = "gangtool-red"
+	item_state = "walkietalkie"
+	w_class = WEIGHT_CLASS_TINY
+	throwforce = 0
+	throw_speed = 3
+	throw_range = 7
+	var/uses = 1 // -1 is infinite uses.
+
+/obj/item/announcer/attack_self(mob/user)
+	if(uses == 0)
+		user << "<span class='warning'>[src] has run out of [command_name()] encryption keys, and can send no more messages.</span>"
+		return
+
+	var/result = create_command_report(user)
+	if(result && uses != -1)
+		uses--
+
+/obj/item/announcer/unlimited
+	name = "official announcer"
+	desc = "Send an official announcement from Centcom. Since you're holding this, you MUST be a Centcom employee, so it has unlimited uses."
+	icon_state = "gangtool-white"
+	uses = -1
+
+/obj/item/announcer/fake_extended
+	name = "intel disruption device"
+	desc = "If used early enough in the shift, this device can prevent the station being informed of potential threats."
+	icon_state = "gangtool-blue"
+
+/obj/item/announcer/fake_extended/attack_self(mob/user)
+	if(ticker.mode.intercept_sent)
+		user << "<span class='warning'>[src] reports that the intel broadcast has already been recieved by the station!</span>"
+		return
+
+	user << "<span class='notice'>You use [src] to disrupt the station's communication network and to fake an \"all clear\" notice.</span>"
+
+	ticker.mode.send_no_threats_intercept = TRUE
+	// Deleting the object means we don't to worry about used ones being
+	// refunded.
+	visible_message("<span class='warning'>[src] dissolves into sparks!</span>")
+
+	var/datum/effect_system/spark_spread/sparks = new
+	sparks.set_up(2, 0, src)
+	sparks.attach(src)
+	sparks.start()
+
+	qdel(src)
+
+/proc/create_command_report(mob/user)
+	var/input = input(usr, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null
+	if(!input)
+		return
+
+	var/confirm = alert(src, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No")
+	if(confirm == "Yes")
+		priority_announce(input, null, 'sound/AI/commandreport.ogg')
+	else
+		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
+
+	print_command_report(input,"[confirm=="Yes" ? "" : "Classified "][command_name()] Update")
+	log_admin("[key_name(src)] has created a command report: [input]")
+	message_admins("[key_name_admin(src)] has created a command report")
+	return TRUE

--- a/code/game/objects/items/announcer.dm
+++ b/code/game/objects/items/announcer.dm
@@ -1,6 +1,7 @@
 /obj/item/announcer
 	name = "bootleg announcer"
 	desc = "Fake an announcement from Centcom! Note that it's unlikely they will back up your story if asked."
+	icon = 'icons/obj/device.dmi'
 	icon_state = "gangtool-red"
 	item_state = "walkietalkie"
 	w_class = WEIGHT_CLASS_TINY
@@ -49,11 +50,11 @@
 	qdel(src)
 
 /proc/create_command_report(mob/user)
-	var/input = input(usr, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null
+	var/input = input(user, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null
 	if(!input)
 		return
 
-	var/confirm = alert(src, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No")
+	var/confirm = alert(user, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No")
 	if(confirm == "Yes")
 		priority_announce(input, null, 'sound/AI/commandreport.ogg')
 	else

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1783,6 +1783,20 @@
 		var/obj/item/station_charter/charter = locate(href_list["reject_custom_name"])
 		if(istype(charter))
 			charter.reject_proposed(usr)
+
+	else if(href_list["spoof_message"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/obj/item/announcer/announcer = locate(href_list["spoof_message"])
+		var/response = href_list["response"]
+		switch(response)
+			if(SPOOFER_ACCEPT)
+				announcer.accept_message(usr)
+			if(SPOOFER_REJECT)
+				announcer.reject_message()
+			if(SPOOFER_DESTROY)
+				announcer.pop()
+
 	else if(href_list["jumpto"])
 		if(!isobserver(usr) && !check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -467,21 +467,9 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!holder)
 		src << "Only administrators may use this command."
 		return
-	var/input = input(usr, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null
-	if(!input)
-		return
 
-	var/confirm = alert(src, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No")
-	if(confirm == "Yes")
-		priority_announce(input, null, 'sound/AI/commandreport.ogg')
-	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
-
-	print_command_report(input,"[confirm=="Yes" ? "" : "Classified "][command_name()] Update")
-
-	log_admin("[key_name(src)] has created a command report: [input]")
-	message_admins("[key_name_admin(src)] has created a command report")
-	feedback_add_details("admin_verb","CCR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	if(create_command_report(usr))
+		feedback_add_details("admin_verb","CCR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_change_command_name()
 	set category = "Special Verbs"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -468,8 +468,14 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		src << "Only administrators may use this command."
 		return
 
-	if(create_command_report(usr))
-		feedback_add_details("admin_verb","CCR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	var/input = input(usr, "Please enter anything you want. Anything. Serious.", "What?") as message|null
+	if(!input)
+		return
+
+	var/stealth_level = alert(usr, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No")
+
+	create_command_report(usr, input, stealth_level == "No" ? TRUE : FALSE)
+	feedback_add_details("admin_verb","CCR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_change_command_name()
 	set category = "Special Verbs"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1210,6 +1210,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "Using a stolen encryption key, this device can fake a communication from Central Command. It only works once, and it's unlikely that Central will back up the story if asked about it. That is, if anyone bothers."
 	cost = 5
 	item = /obj/item/announcer
+	refundable = TRUE
 
 // Pointless
 /datum/uplink_item/badass

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1202,6 +1202,23 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
 
+/datum/uplink_item/commservice
+	category = "Communications/Services"
+
+/datum/uplink_item/commservice/bootleg_announcer
+	name = "Bootleg Announcer"
+	desc = "Using a stolen encryption key, this device can fake a communication from Central Command. It only works once, and it's unlikely that Central will back up the story if asked about it. That is, if anyone bothers."
+	cost = 5
+	item = /obj/item/announcer
+
+/datum/uplink_item/commservice/intel_disrupter
+	name = "Intel Disruption Device"
+	desc = "This device can disrupt the normal intelligence report that is sent that normally informs the station of people like you. Use it to disrupt the report, and watch as members of the station commit suicide in despair. Not very useful after the intercept has already been recieved. Refundable if unused."
+	cost = 10
+	item = /obj/item/announcer/fake_extended
+	surplus = 0
+	refundable = TRUE
+
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1211,14 +1211,6 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 5
 	item = /obj/item/announcer
 
-/datum/uplink_item/commservice/intel_disrupter
-	name = "Intel Disruption Device"
-	desc = "This device can disrupt the normal intelligence report that is sent that normally informs the station of people like you. Use it to disrupt the report, and watch as members of the station commit suicide in despair. Not very useful after the intercept has already been recieved. Refundable if unused."
-	cost = 10
-	item = /obj/item/announcer/fake_extended
-	surplus = 0
-	refundable = TRUE
-
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -667,6 +667,7 @@
 #include "code\game\objects\effects\spawners\lootdrop.dm"
 #include "code\game\objects\effects\spawners\structure.dm"
 #include "code\game\objects\effects\spawners\vaultspawner.dm"
+#include "code\game\objects\items\announcer.dm"
 #include "code\game\objects\items\apc_frame.dm"
 #include "code\game\objects\items\blueprints.dm"
 #include "code\game\objects\items\body_egg.dm"


### PR DESCRIPTION
:cl: coiax
add: Central Command have reported that various communication encryption keys have been stolen. The use of these keys could HYPOTHETICALLY allow faking of secure Central Command messages, or disruption of intelligence dispatches. Central Command reassure all Nanotrasen stations that the chances of this happening are very slim.
add: Adds bootleg announcer to uplink, costs 5 TC, fake a Central Command message! The messages will require admin approval, but the device is refundable if there's no one online, or the admins aren't feeling like it.
/:cl: