### PR TITLE
Syndiborg costs reduced and split

### DIFF
--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -137,7 +137,6 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "locator"
 	var/borg_to_spawn
-	var/list/possible_types = list("Assault", "Medical")
 
 /obj/item/weapon/antag_spawner/nuke_ops/proc/check_usability(mob/user)
 	if(used)
@@ -189,12 +188,13 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "locator"
 
+/obj/item/weapon/antag_spawner/nuke_ops/borg_tele/assault
+	name = "syndicate assault cyborg teleporter"
+	borg_to_spawn = "Assault"
 
-/obj/item/weapon/antag_spawner/nuke_ops/borg_tele/attack_self(mob/user)
-	borg_to_spawn = input("What type?", "Cyborg Type", type) as null|anything in possible_types
-	if(!borg_to_spawn)
-		return
-	..()
+/obj/item/weapon/antag_spawner/nuke_ops/borg_tele/medical
+	name = "syndicate medical teleporter"
+	borg_to_spawn = "Medical"
 
 /obj/item/weapon/antag_spawner/nuke_ops/borg_tele/spawn_antag(client/C, turf/T)
 	var/mob/living/silicon/robot/R

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -544,11 +544,19 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 25
 	refundable = TRUE
 
-/datum/uplink_item/support/reinforcement/syndieborg
-	name = "Syndicate Cyborg"
+/datum/uplink_item/support/reinforcement/assault_borg
+	name = "Syndicate Assault Cyborg"
 	desc = "A cyborg designed and programmed for systematic extermination of non-Syndicate personnel."
-	item = /obj/item/weapon/antag_spawner/nuke_ops/borg_tele
-	cost = 80
+	item = /obj/item/weapon/antag_spawner/nuke_ops/borg_tele/assault
+	refundable = TRUE
+	cost = 65
+
+/datum/uplink_item/support/reinforcement/medical_borg
+	name = "Syndicate Medical Cyborg"
+	desc = "A combat medic cyborg, with potent healing reagents and a medical beam gun, but limited offensive potential."
+	item = /obj/item/weapon/antag_spawner/nuke_ops/borg_tele/medical
+	refundable = TRUE
+	cost = 35
 
 /datum/uplink_item/support/gygax
 	name = "Gygax Exosuit"


### PR DESCRIPTION
:cl: coiax
add: Nuke ops syndicate cyborgs have been split into two seperate uplink
items. Medical cyborgs now cost 35 TC, assault cyborgs now cost 65 TC.
/:cl:

- Reasons for the reduction in price: syndiborgs are too fragile for
their high cost, and although they have a lot of offensive potential, a
flashbang, a flash, a laser pointer, and that's a huge investment gone.

- Splitting them is because no one picks medical syndiborg, and it's
strong, but not as strong as an assault borg.