### PR TITLE
Cultists gain increased blood regeneration speed

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -18,6 +18,8 @@
 
 #define STATUS_EFFECT_HISGRACE /datum/status_effect/his_grace //His Grace.
 
+#define STATUS_EFFECT_CULT_BUFF /datum/status_effect/cult_buff //Persistant blood regeneration for Blood Cultists
+
 /////////////
 // DEBUFFS //
 /////////////

--- a/code/datums/antagonists/datum_cult.dm
+++ b/code/datums/antagonists/datum_cult.dm
@@ -29,12 +29,14 @@
 /datum/antagonist/cultist/apply_innate_effects()
 	owner.faction |= "cult"
 	owner.verbs += /mob/living/proc/cult_help
+	owner.add_status_effect(STATUS_EFFECT_CULT_BUFF)
 	communion.Grant(owner)
 	..()
 
 /datum/antagonist/cultist/remove_innate_effects()
 	owner.faction -= "cult"
 	owner.verbs -= /mob/living/proc/cult_help
+	owner.remove_status_effect(STATUS_EFFECT_CULT_BUFF)
 	..()
 
 /datum/antagonist/cultist/on_remove()

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -161,6 +161,7 @@
 	if(cult_mind.current.gain_antag_datum(/datum/antagonist/cultist))
 		if(stun)
 			cult_mind.current.Paralyse(5)
+		cult_mind.current.apply_status_effect(STATUS_EFFECT_CULT_BUFF)
 		return 1
 
 /datum/game_mode/proc/remove_cultist(datum/mind/cult_mind, show_message = 1, stun)
@@ -172,6 +173,7 @@
 		cult_datum.on_remove()
 		if(stun)
 			cult_mind.current.Paralyse(5)
+		cult_mind.current.remove_status_effect(STATUS_EFFECT_CULT_BUFF)
 		return TRUE
 
 /datum/game_mode/proc/update_cult_icons_added(datum/mind/cult_mind)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -161,7 +161,6 @@
 	if(cult_mind.current.gain_antag_datum(/datum/antagonist/cultist))
 		if(stun)
 			cult_mind.current.Paralyse(5)
-		cult_mind.current.apply_status_effect(STATUS_EFFECT_CULT_BUFF)
 		return 1
 
 /datum/game_mode/proc/remove_cultist(datum/mind/cult_mind, show_message = 1, stun)
@@ -173,7 +172,6 @@
 		cult_datum.on_remove()
 		if(stun)
 			cult_mind.current.Paralyse(5)
-		cult_mind.current.remove_status_effect(STATUS_EFFECT_CULT_BUFF)
 		return TRUE
 
 /datum/game_mode/proc/update_cult_icons_added(datum/mind/cult_mind)

--- a/code/game/gamemodes/cult/cult_status_effect.dm
+++ b/code/game/gamemodes/cult/cult_status_effect.dm
@@ -2,12 +2,8 @@
 	id = "cult_buff"
 	duration = -1
 	tick_interval = 50
-	alert_type = /obj/screen/alert/status_effect/cult_buff
-  
-/obj/screen/alert/status_effect/cult_buff
-	name = "Nar-sie Empowerment"
-	desc = "The power of the Geometer of Blood flows through you."
+	alert_type = null
 
 /datum/status_effect/cult_buff/tick()
-	if(ishuman(owner) && owner.blood_volume < BLOOD_VOLUME_NORMAL)
-    owner.blood_volume += 0.4
+	if(ishuman(owner) && owner.stat != DEAD && owner.blood_volume < BLOOD_VOLUME_NORMAL)
+		owner.blood_volume += 0.4

--- a/code/game/gamemodes/cult/cult_status_effect.dm
+++ b/code/game/gamemodes/cult/cult_status_effect.dm
@@ -1,7 +1,7 @@
 /datum/status_effect/cult_buff
 	id = "cult_buff"
 	duration = -1
-	tick_interval = 10
+	tick_interval = 50
 	alert_type = /obj/screen/alert/status_effect/cult_buff
   
 /obj/screen/alert/status_effect/cult_buff

--- a/code/game/gamemodes/cult/cult_status_effect.dm
+++ b/code/game/gamemodes/cult/cult_status_effect.dm
@@ -1,0 +1,13 @@
+/datum/status_effect/cult_buff
+	id = "cult_buff"
+	duration = -1
+	tick_interval = 10
+	alert_type = /obj/screen/alert/status_effect/cult_buff
+  
+/obj/screen/alert/status_effect/cult_buff
+	name = "Nar-sie Empowerment"
+	desc = "The power of the Geometer of Blood flows through you."
+
+/datum/status_effect/cult_buff/tick()
+	if(ishuman(owner) && owner.blood_volume < BLOOD_VOLUME_NORMAL)
+    owner.blood_volume += 0.4

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -418,6 +418,7 @@
 #include "code\game\gamemodes\cult\cult.dm"
 #include "code\game\gamemodes\cult\cult_comms.dm"
 #include "code\game\gamemodes\cult\cult_items.dm"
+#include "code\game\gamemodes\cult\cult_status_effect.dm"
 #include "code\game\gamemodes\cult\cult_structures.dm"
 #include "code\game\gamemodes\cult\ritual.dm"
 #include "code\game\gamemodes\cult\runes.dm"


### PR DESCRIPTION
:cl: grimreaperx15
add: Blood Cultists will now regenerate blood passively much faster
/:cl:

[]: # For a cult based around blood, nothing really cares about blood. Hopefully rituals will use blood soon, and it only makes sense for cultists to get a passive regeneration buff for it.
