### PR TITLE
Changes Command departmental channel back to blue

### DIFF
--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -30,7 +30,7 @@ em						{font-style: normal;	font-weight: bold;}
 .deadsay				{color: #5c00e6;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #948f02;}
+.comradio				{color: #193a7a;}
 .secradio				{color: #a30000;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}


### PR DESCRIPTION
Reverts tgstation/tgstation#23987

:cl: coiax
del: Command chat is now blue, rather than gold.
/:cl:

Because the blue was better and the yellow is ugly.