### PR TITLE
Changes CentComm Ferry To Require A Centcomm ID Card To Move Between Stations

### DIFF
--- a/code/modules/shuttle/ferry.dm
+++ b/code/modules/shuttle/ferry.dm
@@ -3,15 +3,15 @@
 	circuit = /obj/item/weapon/circuitboard/computer/ferry
 	shuttleId = "ferry"
 	possible_destinations = "ferry_home;ferry_away"
-
+	req_access = list(access_cent_general)
 
 /obj/machinery/computer/shuttle/ferry/request
 	name = "ferry console"
 	circuit = /obj/item/weapon/circuitboard/computer/ferry/request
 	var/last_request //prevents spamming admins
 	var/cooldown = 600
-	possible_destinations = "ferry_home"
-	admin_controlled = 1
+	possible_destinations = "ferry_home;ferry_away"
+	req_access = list(access_cent_general)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/machinery/computer/shuttle/ferry/request/Topic(href, href_list)


### PR DESCRIPTION
## **Changes Centcomm Ferry To Require A Centcomm ID Card To Move Between Stations**
Changes the centcomm Ferry that is used by players to move between the centcomm and main station to require a centcomm ID card instead of requiring players to bug/request that the admins unlock the shuttle for them. This is for centcomm Inspectors and other people who get admins to allow them roleplay as centcomm personnel. This should also make it less annoying for admins so they don't need to go and unlock the shuttle every time someone want to go between the Main Station and the centcomm Station.

## **Changelog**
:cl: Tofa01
Tweak: Changes centcomm ferry to require centcomm general access instead of admin permission.
/:cl:

