### PR TITLE
Mining Z level no longer exempt from explosion caps

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -12,7 +12,7 @@ var/explosionid = 1
 	var/orig_heavy_range = heavy_impact_range
 	var/orig_light_range = light_impact_range
 
-	if(!ignorecap && epicenter.z != ZLEVEL_MINING)
+	if(!ignorecap)
 		//Clamp all values to MAX_EXPLOSION_RANGE
 		devastation_range = min(MAX_EX_DEVESTATION_RANGE, devastation_range)
 		heavy_impact_range = min(MAX_EX_HEAVY_RANGE, heavy_impact_range)


### PR DESCRIPTION
:cl: grimreaperx15
fix: Bombs now have the maxcap applied, even on the mining Z level.
/:cl:

[]: # Setting off multiple "maxcap" bombs on the mining Z level can easily crash the server, as the explosion is significantly greater than it could be on the station. 