### PR TITLE
Easier stripping of admin private information from public logs

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -22,9 +22,15 @@
 	if (config.log_admin)
 		diary << "\[[time_stamp()]]ADMIN: [text]"
 
+//Items using this proc are stripped from public logs - use with caution
+/proc/log_admin_private(text)
+	admin_log.Add(text)
+	if (config.log_admin)
+		diary << "\[[time_stamp()]]ADMINPRIVATE: [text]"
+
 /proc/log_adminsay(text)
 	if (config.log_adminchat)
-		log_admin("ASAY: [text]")
+		log_admin_private("ASAY: [text]")
 
 /proc/log_dsay(text)
 	if (config.log_adminchat)

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -134,11 +134,11 @@ var/savefile/Banlist
 	if (!Banlist.dir.Remove(foldername)) return 0
 
 	if(!usr)
-		log_admin("Ban Expired: [key]")
+		log_admin_private("Ban Expired: [key]")
 		message_admins("Ban Expired: [key]")
 	else
 		ban_unban_log_save("[key_name(usr)] unbanned [key]")
-		log_admin("[key_name(usr)] unbanned [key]")
+		log_admin_private("[key_name(usr)] unbanned [key]")
 		message_admins("[key_name_admin(usr)] unbanned: [key]")
 		feedback_inc("ban_unban",1)
 		usr.client.holder.DB_ban_unban( ckey(key), BANTYPE_ANY_FULLBAN)

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -52,7 +52,7 @@
 		log_game("SQL ERROR creating new [type] in messages table. Error : \[[err]\]\n")
 		return
 	if(logged)
-		log_admin("[key_name(usr)] has created a [type][(type == "note" || type == "message" || type == "watchlist entry") ? " for [target_ckey]" : ""]: [text]")
+		log_admin_private("[key_name(usr)] has created a [type][(type == "note" || type == "message" || type == "watchlist entry") ? " for [target_ckey]" : ""]: [text]")
 		message_admins("[key_name_admin(usr)] has created a [type][(type == "note" || type == "message" || type == "watchlist entry") ? " for [target_ckey]" : ""]:<br>[text]")
 		if(browse)
 			browse_messages("[type]")
@@ -84,7 +84,7 @@
 		log_game("SQL ERROR deleting [type] from messages table. Error : \[[err]\]\n")
 		return
 	if(logged)
-		log_admin("[key_name(usr)] has deleted a [type][(type == "note" || type == "message" || type == "watchlist entry") ? " for" : " made by"] [target_ckey]: [text]")
+		log_admin_private("[key_name(usr)] has deleted a [type][(type == "note" || type == "message" || type == "watchlist entry") ? " for" : " made by"] [target_ckey]: [text]")
 		message_admins("[key_name_admin(usr)] has deleted a [type][(type == "note" || type == "message" || type == "watchlist entry") ? " for" : " made by"] [target_ckey]:<br>[text]")
 		if(browse)
 			browse_messages("[type]")
@@ -119,7 +119,7 @@
 			var/err = query_edit_message.ErrorMsg()
 			log_game("SQL ERROR editing messages table. Error : \[[err]\]\n")
 			return
-		log_admin("[key_name(usr)] has edited a [type] [(type == "note" || type == "message" || type == "watchlist entry") ? " for [target_ckey]" : ""] made by [admin_ckey] from [old_text] to [new_text]")
+		log_admin_private("[key_name(usr)] has edited a [type] [(type == "note" || type == "message" || type == "watchlist entry") ? " for [target_ckey]" : ""] made by [admin_ckey] from [old_text] to [new_text]")
 		message_admins("[key_name_admin(usr)] has edited a [type] [(type == "note" || type == "message" || type == "watchlist entry") ? " for [target_ckey]" : ""] made by [admin_ckey] from<br>[old_text]<br>to<br>[new_text]")
 		if(browse)
 			browse_messages("[type]")
@@ -150,7 +150,7 @@
 			var/err = query_message_secret.ErrorMsg()
 			log_game("SQL ERROR toggling message secrecy. Error : \[[err]\]\n")
 			return
-		log_admin("[key_name(usr)] has toggled [target_ckey]'s [type] made by [admin_ckey] to [secret ? "not secret" : "secret"]")
+		log_admin_private("[key_name(usr)] has toggled [target_ckey]'s [type] made by [admin_ckey] to [secret ? "not secret" : "secret"]")
 		message_admins("[key_name_admin(usr)] has toggled [target_ckey]'s [type] made by [admin_ckey] to [secret ? "not secret" : "secret"]")
 		browse_messages(target_ckey = target_ckey)
 

--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -33,7 +33,7 @@
 
 			world.SetConfig("ban",ckey,list2stickyban(ban))
 
-			log_admin("[key_name(usr)] has stickybanned [ckey].\nReason: [ban["message"]]")
+			log_admin_private("[key_name(usr)] has stickybanned [ckey].\nReason: [ban["message"]]")
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] has stickybanned [ckey].\nReason: [ban["message"]]</span>")
 
 		if ("remove")
@@ -52,7 +52,7 @@
 				return
 			world.SetConfig("ban",ckey, null)
 
-			log_admin("[key_name(usr)] removed [ckey]'s stickyban")
+			log_admin_private("[key_name(usr)] removed [ckey]'s stickyban")
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] removed [ckey]'s stickyban</span>")
 
 		if ("remove_alt")
@@ -100,7 +100,7 @@
 
 			world.SetConfig("ban",ckey,list2stickyban(ban))
 
-			log_admin("[key_name(usr)] has disassociated [alt] from [ckey]'s sticky ban")
+			log_admin_private("[key_name(usr)] has disassociated [alt] from [ckey]'s sticky ban")
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] has disassociated [alt] from [ckey]'s sticky ban</span>")
 
 		if ("edit")
@@ -124,7 +124,7 @@
 
 			world.SetConfig("ban",ckey,list2stickyban(ban))
 
-			log_admin("[key_name(usr)] has edited [ckey]'s sticky ban reason from [oldreason] to [reason]")
+			log_admin_private("[key_name(usr)] has edited [ckey]'s sticky ban reason from [oldreason] to [reason]")
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] has edited [ckey]'s sticky ban reason from [oldreason] to [reason]</span>")
 
 		if ("revert")
@@ -142,7 +142,7 @@
 				usr << "<span class='adminnotice'>Error: No cached sticky ban for [ckey] found!"
 			world.SetConfig("ban",ckey,null)
 
-			log_admin("[key_name(usr)] has reverted [ckey]'s sticky ban to it's state at round start.")
+			log_admin_private("[key_name(usr)] has reverted [ckey]'s sticky ban to it's state at round start.")
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] has reverted [ckey]'s sticky ban to it's state at round start.</span>")
 			//revert is mostly used when shit goes rouge, so we have to set it to null
 			//	and wait a byond tick before assigning it to ensure byond clears its shit.

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -21,7 +21,7 @@
 		C << "Please try to be calm, clear, and descriptive in admin helps, do not assume the admin has seen any related events, and clearly state the names of anybody you are reporting."
 
 		message_admins("[key_name_admin(usr)] Rejected [C.key]'s admin help. [C.key]'s Adminhelp verb has been returned to them.")
-		log_admin("[key_name(usr)] Rejected [C.key]'s admin help.")
+		log_admin_private("[key_name(usr)] Rejected [C.key]'s admin help.")
 
 	else if(href_list["icissue"])
 		var/client/C = locate(href_list["icissue"]) in clients
@@ -35,7 +35,7 @@
 		C << msg
 
 		message_admins("[key_name_admin(usr)] marked [C.key]'s admin help as an IC issue.")
-		log_admin("[key_name(usr)] marked [C.key]'s admin help as an IC issue.")
+		log_admin_private("[key_name(usr)] marked [C.key]'s admin help as an IC issue.")
 
 	else if(href_list["stickyban"])
 		stickyban(href_list["stickyban"],href_list)
@@ -506,7 +506,7 @@
 				if(!reason)
 					return
 
-		log_admin("[key_name(usr)] edited [banned_key]'s ban. Reason: [reason] Duration: [duration]")
+		log_admin_private("[key_name(usr)] edited [banned_key]'s ban. Reason: [reason] Duration: [duration]")
 		ban_unban_log_save("[key_name(usr)] edited [banned_key]'s ban. Reason: [reason] Duration: [duration]")
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] edited [banned_key]'s ban. Reason: [reason] Duration: [duration]</span>")
 		Banlist.cd = "/base/[banfolder]"
@@ -536,7 +536,7 @@
 			switch(alert("Remove appearance ban?","Please Confirm","Yes","No"))
 				if("Yes")
 					ban_unban_log_save("[key_name(usr)] removed [key_name(M)]'s appearance ban.")
-					log_admin("[key_name(usr)] removed [key_name(M)]'s appearance ban.")
+					log_admin_private("[key_name(usr)] removed [key_name(M)]'s appearance ban.")
 					feedback_inc("ban_appearance_unban", 1)
 					DB_ban_unban(M.ckey, BANTYPE_ANY_JOB, "appearance")
 					if(M.client)
@@ -555,7 +555,7 @@
 				if(M.client)
 					jobban_buildcache(M.client)
 				ban_unban_log_save("[key_name(usr)] appearance banned [key_name(M)]. reason: [reason]")
-				log_admin("[key_name(usr)] appearance banned [key_name(M)]. \nReason: [reason]")
+				log_admin_private("[key_name(usr)] appearance banned [key_name(M)]. \nReason: [reason]")
 				feedback_inc("ban_appearance",1)
 				create_message("note", M.ckey, null, "Appearance banned - [reason]", null, null, 0, 0)
 				message_admins("<span class='adminnotice'>[key_name_admin(usr)] appearance banned [key_name_admin(M)].</span>")
@@ -940,7 +940,7 @@
 						if(M.client)
 							jobban_buildcache(M.client)
 						ban_unban_log_save("[key_name(usr)] temp-jobbanned [key_name(M)] from [job] for [mins] minutes. reason: [reason]")
-						log_admin("[key_name(usr)] temp-jobbanned [key_name(M)] from [job] for [mins] minutes.")
+						log_admin_private("[key_name(usr)] temp-jobbanned [key_name(M)] from [job] for [mins] minutes.")
 						feedback_inc("ban_job_tmp",1)
 						feedback_add_details("ban_job_tmp","- [job]")
 						if(!msg)
@@ -965,7 +965,7 @@
 							if(M.client)
 								jobban_buildcache(M.client)
 							ban_unban_log_save("[key_name(usr)] perma-jobbanned [key_name(M)] from [job]. reason: [reason]")
-							log_admin("[key_name(usr)] perma-banned [key_name(M)] from [job]")
+							log_admin_private("[key_name(usr)] perma-banned [key_name(M)] from [job]")
 							feedback_inc("ban_job",1)
 							feedback_add_details("ban_job","- [job]")
 							if(!msg)
@@ -993,7 +993,7 @@
 				switch(alert("Job: '[job]' Reason: '[reason]' Un-jobban?","Please Confirm","Yes","No"))
 					if("Yes")
 						ban_unban_log_save("[key_name(usr)] unjobbanned [key_name(M)] from [job]")
-						log_admin("[key_name(usr)] unbanned [key_name(M)] from [job]")
+						log_admin_private("[key_name(usr)] unbanned [key_name(M)] from [job]")
 						DB_ban_unban(M.ckey, BANTYPE_ANY_JOB, job)
 						if(M.client)
 							jobban_buildcache(M.client)
@@ -1141,7 +1141,7 @@
 					M << "<span class='danger'>To try to resolve this matter head to [config.banappeals]</span>"
 				else
 					M << "<span class='danger'>No ban appeals URL has been set.</span>"
-				log_admin("[key_name(usr)] has banned [M.ckey].\nReason: [key_name(M)]\nThis will be removed in [mins] minutes.")
+				log_admin_private("[key_name(usr)] has banned [M.ckey].\nReason: [key_name(M)]\nThis will be removed in [mins] minutes.")
 				message_admins("<span class='adminnotice'>[key_name_admin(usr)] has banned [key_name_admin(M)].\nReason: [reason]\nThis will be removed in [mins] minutes.</span>")
 
 				qdel(M.client)
@@ -1166,7 +1166,7 @@
 					usr << "<span class='danger'>Failed to apply ban.</span>"
 					return
 				ban_unban_log_save("[key_name(usr)] has permabanned [key_name(M)]. - Reason: [reason] - This is a permanent ban.")
-				log_admin("[key_name(usr)] has banned [key_name_admin(M)].\nReason: [reason]\nThis is a permanent ban.")
+				log_admin_private("[key_name(usr)] has banned [key_name_admin(M)].\nReason: [reason]\nThis is a permanent ban.")
 				message_admins("<span class='adminnotice'>[key_name_admin(usr)] has banned [key_name_admin(M)].\nReason: [reason]\nThis is a permanent ban.</span>")
 				feedback_inc("ban_perma",1)
 				qdel(M.client)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -124,7 +124,7 @@
 
 	//send it to irc if nobody is on and tell us how many were on
 	var/admin_number_present = send2irc_adminless_only(ckey,original_msg)
-	log_admin("HELP: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins who have +BAN.")
+	log_admin_private("HELP: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins who have +BAN.")
 	if(admin_number_present <= 0)
 		src << "<span class='notice'>No active admins are online, your adminhelp was sent to the admin irc.</span>"
 	feedback_add_details("admin_verb","AH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -176,12 +176,12 @@
 				return
 
 	if(irc)
-		log_admin("PM: [key_name(src)]->IRC: [rawmsg]")
+		log_admin_private("PM: [key_name(src)]->IRC: [rawmsg]")
 		for(var/client/X in admins)
 			X << "<B><font color='blue'>PM: [key_name(src, X, 0)]-&gt;IRC:</B> \blue [keywordparsedmsg]</font>" //inform X
 	else
 		window_flash(C, ignorepref = TRUE)
-		log_admin("PM: [key_name(src)]->[key_name(C)]: [rawmsg]")
+		log_admin_private("PM: [key_name(src)]->[key_name(C)]: [rawmsg]")
 		//we don't use message_admins here because the sender/receiver might get it too
 		for(var/client/X in admins)
 			if(X.key!=key && X.key!=C.key)	//check client/X is an admin and isn't the sender or recipient
@@ -208,7 +208,7 @@
 		return "No message"
 
 	message_admins("IRC message from [sender] to [key_name_admin(C)] : [msg]")
-	log_admin("IRC PM: [sender] -> [key_name(C)] : [msg]")
+	log_admin_private("IRC PM: [sender] -> [key_name(C)] : [msg]")
 	msg = emoji_parse(msg)
 
 	C << "<font color='red' size='4'><b>-- Administrator private message --</b></font>"


### PR DESCRIPTION
A new admin log proc, admin_log_private that appends a different prefix,
to make it easy to filter the logs that are shown publically