### PR TITLE
Revert "Lobby timer won't be delayed by subsystem initializations"

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -2,7 +2,7 @@ var/datum/subsystem/mapping/SSmapping
 
 /datum/subsystem/mapping
 	name = "Mapping"
-	init_order = 12
+	init_order = 13
 	flags = SS_NO_FIRE
 	display_order = 50
 

--- a/code/controllers/subsystem/processing/objects.dm
+++ b/code/controllers/subsystem/processing/objects.dm
@@ -6,7 +6,7 @@ var/datum/subsystem/objects/SSobj
 
 /datum/subsystem/objects
 	name = "Objects"
-	init_order = 11
+	init_order = 12
 	priority = 40
 
 	var/initialized = INITIALIZATION_INSSOBJ

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -6,7 +6,7 @@ var/datum/subsystem/ticker/ticker
 
 /datum/subsystem/ticker
 	name = "Ticker"
-	init_order = 13
+	init_order = 0
 
 	priority = 200
 	flags = SS_FIRE_IN_LOBBY|SS_KEEP_TIMING
@@ -41,8 +41,7 @@ var/datum/subsystem/ticker/ticker
 	var/tipped = 0							//Did we broadcast the tip of the day yet?
 	var/selected_tip						// What will be the tip of the day?
 
-	var/timeLeft						//pregame timer
-	var/start_at
+	var/timeLeft = 1200						//pregame timer
 
 	var/totalPlayers = 0					//used for pregame stats on statpanel
 	var/totalPlayersReady = 0				//used for pregame stats on statpanel
@@ -70,19 +69,19 @@ var/datum/subsystem/ticker/ticker
 	if(!syndicate_code_response)
 		syndicate_code_response	= generate_code_phrase()
 	..()
-	start_at = world.time + (config.lobby_countdown * 10)
-	world << "<span class='boldnotice'>Welcome to [station_name()]!</span>"
-	world << "Please set up your character and select \"Ready\". The game will start in about [config.lobby_countdown] seconds."
-	current_state = GAME_STATE_PREGAME
-	for(var/client/C in clients)
-		window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
 
 /datum/subsystem/ticker/fire()
 	switch(current_state)
+		if(GAME_STATE_STARTUP)
+			timeLeft = config.lobby_countdown * 10
+			world << "<span class='boldnotice'>Welcome to [station_name()]!</span>"
+			world << "Please set up your character and select \"Ready\". The game will start in [config.lobby_countdown] seconds."
+			current_state = GAME_STATE_PREGAME
+			for(var/client/C in clients)
+				window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
+
 		if(GAME_STATE_PREGAME)
 				//lobby stats for statpanels
-			if(isnull(timeLeft))
-				timeLeft = max(0,start_at - world.time)
 			totalPlayers = 0
 			totalPlayersReady = 0
 			for(var/mob/new_player/player in player_list)
@@ -717,15 +716,3 @@ var/datum/subsystem/ticker/ticker
 
 	if(news_message)
 		send2otherserver(news_source, news_message,"News_Report")
-
-/datum/subsystem/ticker/proc/GetTimeLeft()
-	if(isnull(ticker.timeLeft))
-		return max(0, start_at - world.time)
-	return timeLeft
-
-/datum/subsystem/ticker/proc/SetTimeLeft(newtime)
-	if(newtime >= 0 && isnull(timeLeft))	//remember, negative means delayed
-		start_at = world.time + newtime
-	else
-		timeLeft = newtime
-		

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -569,11 +569,11 @@ var/global/BSACooldown = 0
 	set desc="Delay the game start"
 	set name="Delay pre-game"
 
-	var/newtime = input("Set a new time in seconds. Set -1 for indefinite delay.","Set Delay",round(ticker.GetTimeLeft()/10)) as num|null
+	var/newtime = input("Set a new time in seconds. Set -1 for indefinite delay.","Set Delay",round(ticker.timeLeft/10)) as num|null
 	if(ticker.current_state > GAME_STATE_PREGAME)
 		return alert("Too late... The game has already started!")
 	if(newtime)
-		ticker.SetTimeLeft(newtime * 10)
+		ticker.timeLeft = newtime * 10
 		if(newtime < 0)
 			world << "<b>The game start has been delayed.</b>"
 			log_admin("[key_name(usr)] delayed the round start.")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -75,10 +75,7 @@
 		stat("Map:", MAP_NAME)
 
 		if(ticker.current_state == GAME_STATE_PREGAME)
-			var/time_remaining = ticker.GetTimeLeft()
-			if(time_remaining >= 0)
-				time_remaining /= 10
-			stat("Time To Start:", (time_remaining >= 0) ? "[round(time_remaining)]s" : "DELAYED")
+			stat("Time To Start:", (ticker.timeLeft >= 0) ? "[round(ticker.timeLeft / 10)]s" : "DELAYED")
 
 			stat("Players:", "[ticker.totalPlayers]")
 			if(client.holder)


### PR DESCRIPTION
Reverts tgstation/tgstation#24128

@Cyberboss 

I don't like this, its not as clean.

Before the change, if nobody joined the server, the count down timer started at 120 once the first person joined because after the mc inits everything, it sets `world`.`sleep_offline` to `TRUE` causing byond to just halt all processing while nobody is connected.

after this change if nobody joins the server the lobby count down timer starts at some random ass number around 60 once the first person joins.

Also, most people now never see the lobby entry message because it happens too soon and they aren't connected. in the above situation, the first person to join after the server inits would also not see it as it comes before `world`.`sleep_offline` is set to `TRUE`.