### PR TITLE
Places a cap on the bluespace mining bag

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -94,9 +94,10 @@
 
 /obj/item/weapon/storage/bag/ore/holding //miners, your messiah has arrived
 	name = "mining satchel of holding"
-	desc = "A revolution in convenience, this satchel allows for infinite ore storage. It's been outfitted with anti-malfunction safety measures."
-	storage_slots = INFINITY
-	max_combined_w_class = INFINITY
+	desc = "A revolution in convenience, this satchel allows for huge amounts of ore storage. It's been outfitted with anti-malfunction safety measures."
+	storage_slots = 100
+	//100 * 2 (WEIGHT_CLASS_SMALL)
+	max_combined_w_class =  300
 	origin_tech = "bluespace=4;materials=3;engineering=3"
 	icon_state = "satchel_bspace"
 


### PR DESCRIPTION
This causes problems if you collect a huge number of ores and then
move them around into crates or dump them to the ground

This is currently capped at about 2x the normal bag, which should still
be an upgrade on the current ore bag.

Naturally the value is somewhat up for debate but cannot rise too high.

Fixes #24220
