### PR TITLE
makes disposals construction faster

### DIFF
--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -576,7 +576,7 @@ var/global/list/RPD_recipes=list(
 				return
 			user << "<span class='notice'>You start building a disposals pipe...</span>"
 			playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
-			if(do_after(user, 20, target = A))
+			if(do_after(user, 4, target = A))
 				var/obj/structure/disposalconstruct/C = new (A, queued_p_type ,queued_p_dir)
 
 				if(!C.can_place())

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -233,7 +233,7 @@
 			if(W.remove_fuel(0,user))
 				playsound(loc, 'sound/items/Welder2.ogg', 100, 1)
 				user << "<span class='notice'>You start welding the [nicetype] in place...</span>"
-				if(do_after(user, 20*I.toolspeed, target = src))
+				if(do_after(user, 8*I.toolspeed, target = src))
 					if(!loc || !W.isOn())
 						return
 					user << "<span class='notice'>The [nicetype] has been welded in place.</span>"


### PR DESCRIPTION
Buildings disposals is fun and is something that should be promoted, but currently building a pipe of any length takes a rather serious amount of time. This PR greatly reduces the delays on the RPD laying the pipe and the time needed to weld the pipe in place.

Disposals delays were re-added to prevent spam of dense objects such as bins to block movement. Since unanchored disposals objects were made not dense ages ago the delays can be removed.

🆑

tweak: Building disposal pipes is now faster

/🆑

take 2