### PR TITLE
Makes ore satchels of holding hold 8x the mining satchel amount

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -95,9 +95,9 @@
 /obj/item/weapon/storage/bag/ore/holding //miners, your messiah has arrived
 	name = "mining satchel of holding"
 	desc = "A revolution in convenience, this satchel allows for huge amounts of ore storage. It's been outfitted with anti-malfunction safety measures."
-	storage_slots = 100
+	storage_slots = 400
 	//100 * 2 (WEIGHT_CLASS_SMALL)
-	max_combined_w_class =  300
+	max_combined_w_class =  1200
 	origin_tech = "bluespace=4;materials=3;engineering=3"
 	icon_state = "satchel_bspace"
 


### PR DESCRIPTION
This amount probably won't cause lag, but is it too high for balance purposes?
I felt like it would be good because it should be a significant upgrade over normal satchels as they used to hold infinite.
**THIS IS A BUFF FROM @optimumtact 's INITIAL VALUES OF 2x THE MINING SATCHEL'S CAPACITY (100 ores), THIS MAKES IT 400 ORES.**