### PR TITLE
Invoking Nezbere will now properly affect objects created after Nezbere was invoked

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -12,7 +12,8 @@ var/global/list/clockwork_generals_invoked = list("nezbere" = FALSE, "sevtug" = 
 var/global/list/all_clockwork_objects = list() //All clockwork items, structures, and effects in existence
 var/global/list/all_clockwork_mobs = list() //All clockwork SERVANTS (not creatures) in existence
 var/global/list/clockwork_component_cache = list(BELLIGERENT_EYE = 0, VANGUARD_COGWHEEL = 0, GEIS_CAPACITOR = 0, REPLICANT_ALLOY = 0, HIEROPHANT_ANSIBLE = 0) //The pool of components that caches draw from
-var/global/ratvar_awakens = 0 //If Ratvar has been summoned; not a boolean, for proper handling of multiple ratvars
+var/global/ratvar_awakens = 0 //If Ratvar has been summoned; not a boolean, for proper handling of multiple Ratvars
+var/global/nezbere_invoked = 0 //If Nezbere has been invoked; not a boolean, for proper handling of multiple Nezberes
 var/global/clockwork_gateway_activated = FALSE //if a gateway to the celestial derelict has ever been successfully activated
 var/global/list/all_scripture = list() //a list containing scripture instances; not used to track existing scripture
 

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_proselytizer.dm
@@ -113,6 +113,10 @@
 		charge_delay = 2
 
 /obj/item/clockwork/clockwork_proselytizer/ratvar_act()
+	if(nezbere_invoked)
+		charge_rate = 1250
+	else
+		charge_rate = initial(charge_rate)
 	if(ratvar_awakens)
 		uses_power = FALSE
 		speed_multiplier = initial(speed_multiplier) * 0.25

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_revenant.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_revenant.dm
@@ -133,31 +133,13 @@
 	hierophant_message("<span class='nezbere_large'>[text2ratvar("Armorer: \"I heed your call, champions. May your artifacts bring ruin upon the heathens that oppose our master!")]\"</span>", FALSE, invoker)
 	clockwork_generals_invoked["nezbere"] = world.time + CLOCKWORK_GENERAL_COOLDOWN
 	playsound(invoker, 'sound/magic/clockwork/invoke_general.ogg', 50, 0)
-	for(var/obj/structure/destructible/clockwork/ocular_warden/W in all_clockwork_objects) //Ocular wardens have increased damage and radius
-		W.damage_per_tick = 5
-		W.sight_range = 5
-	for(var/obj/item/clockwork/clockwork_proselytizer/P in all_clockwork_objects) //Proselytizers no longer require power
-		P.charge_rate = 1250
-	for(var/obj/structure/destructible/clockwork/powered/M in all_clockwork_objects) //Powered clockwork structures no longer need power
-		M.needs_power = FALSE
-		if(istype(M, /obj/structure/destructible/clockwork/powered/tinkerers_daemon)) //Daemons produce components twice as quickly
-			var/obj/structure/destructible/clockwork/powered/tinkerers_daemon/D = M
-			D.production_time = 0
-			D.production_cooldown *= 0.5
+	nezbere_invoked++
+	for(var/obj/O in all_clockwork_objects)
+		O.ratvar_act()
 	spawn(600)
-		for(var/obj/structure/destructible/clockwork/ocular_warden/W in all_clockwork_objects)
-			if(W.damage_per_tick == 5)
-				W.damage_per_tick = initial(W.damage_per_tick)
-			if(W.sight_range == 5)
-				W.sight_range = initial(W.sight_range)
-		for(var/obj/item/clockwork/clockwork_proselytizer/P in all_clockwork_objects)
-			if(P.charge_rate == 1250)
-				P.charge_rate = initial(P.charge_rate)
-		for(var/obj/structure/destructible/clockwork/powered/M in all_clockwork_objects)
-			M.needs_power = initial(M.needs_power)
-			if(istype(M, /obj/structure/destructible/clockwork/powered/tinkerers_daemon))
-				var/obj/structure/destructible/clockwork/powered/tinkerers_daemon/D = M
-				D.production_cooldown = initial(D.production_cooldown)
+		nezbere_invoked--
+		for(var/obj/O in all_clockwork_objects)
+			O.ratvar_act()
 	return TRUE
 
 

--- a/code/game/gamemodes/clock_cult/clock_structure.dm
+++ b/code/game/gamemodes/clock_cult/clock_structure.dm
@@ -154,6 +154,13 @@
 	SSobj.processing -= src
 	return ..()
 
+/obj/structure/destructible/clockwork/powered/ratvar_act()
+	..()
+	if(nezbere_invoked)
+		needs_power = FALSE
+	else
+		needs_power = initial(needs_power)
+
 /obj/structure/destructible/clockwork/powered/process()
 	var/powered = total_accessable_power()
 	return powered == PROCESS_KILL ? 25 : powered //make sure we don't accidentally return the arbitrary PROCESS_KILL define

--- a/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
@@ -50,6 +50,9 @@
 	if(ratvar_awakens)
 		damage_per_tick = 10
 		sight_range = 6
+	else if(nezbere_invoked)
+		damage_per_tick = 5
+		sight_range = 5
 	else
 		damage_per_tick = initial(damage_per_tick)
 		sight_range = initial(sight_range)

--- a/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
@@ -28,6 +28,16 @@
 	clockwork_daemons--
 	return ..()
 
+/obj/structure/destructible/clockwork/powered/ratvar_act()
+	..()
+	if(nezbere_invoked)
+		production_time = 0
+		production_cooldown = initial(production_cooldown) * 0.5
+		if(!active)
+			toggle(0)
+	else
+		production_cooldown = initial(production_cooldown)
+
 /obj/structure/destructible/clockwork/powered/tinkerers_daemon/examine(mob/user)
 	..()
 	if(is_servant_of_ratvar(user) || isobserver(user))

--- a/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
@@ -28,7 +28,7 @@
 	clockwork_daemons--
 	return ..()
 
-/obj/structure/destructible/clockwork/powered/ratvar_act()
+/obj/structure/destructible/clockwork/powered/tinkerers_daemon/ratvar_act()
 	..()
 	if(nezbere_invoked)
 		production_time = 0


### PR DESCRIPTION
A very important buff fix?

This means making a proselytizer after Nezbere was invoked will make that proselytizer charge faster, which is cool and good.