### PR TITLE
Updates parallax space default toggle to be disabled temporarily

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -98,7 +98,7 @@ var/list/preferences_datums = list()
 
 	var/clientfps = 0
 
-	var/parallax = PARALLAX_HIGH
+	var/parallax = PARALLAX_DISABLE
 
 	var/uplink_spawn_loc = UPLINK_PDA
 


### PR DESCRIPTION
Until a feature works consistently it shouldn't be the default because brand new players can come in, have the feature not work correctly and then either leave forever or go into a frustrating "how do I fix this?" troubleshooting hunt.

This does not affect anyone who's ever saved their settings, only to brand new players going forward until we fix these problems and/or byond gets their shit together.

:cl: incoming5643: Lord of the potato computers
tweak: The default setting for parallax space (pretty space) has been set to off pending it becoming a more stable feature. New players should check to see if they can run it. Old players are completely unaffected.
/:cl:
