### PR TITLE
Shuttle minium time to call removed if Singularity is free

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -175,7 +175,12 @@ var/datum/subsystem/shuttle/SSshuttle
 			return
 		emergency = backup_shuttle
 
-	if(world.time - round_start_time < config.shuttle_refuel_delay)
+	var/free = 0
+	for(var/E in singulo_list)
+		var/containment = locate(/obj/machinery/field/containment) in urange(30, E, 1)
+		if(!containment)
+			free = 1
+	if(world.time - round_start_time < config.shuttle_refuel_delay && !free)
 		user << "The emergency shuttle is refueling. Please wait another [abs(round(((world.time - round_start_time) - config.shuttle_refuel_delay)/600))] minutes before trying again."
 		return
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -1,4 +1,4 @@
-
+var/singulo_list[0]
 
 /obj/singularity
 	name = "gravitational singularity"
@@ -36,6 +36,7 @@
 	..()
 	START_PROCESSING(SSobj, src)
 	poi_list |= src
+	singulo_list |= src
 	for(var/obj/machinery/power/singularity_beacon/singubeacon in machines)
 		if(singubeacon.active)
 			target = singubeacon
@@ -44,6 +45,7 @@
 
 /obj/singularity/Destroy()
 	STOP_PROCESSING(SSobj, src)
+	singulo_list.Remove(src)
 	poi_list.Remove(src)
 	return ..()
 


### PR DESCRIPTION
:cl: grimreaperx15
tweak: The shuttle can be called without delay if the Singularity/Tesla is loose.
/:cl:

[]: # If the Singularity or Tesla escape before the 20 minute mark, the station is stuck waiting around for it to kill them until the 20 minute mark and they can call the shuttle. If the engine is free that early, people shouldn't be forced to sit through however many minutes waiting to just call the shuttle to leave.