### PR TITLE
The current round odds won't print if they are the same as the general ones

### DIFF
--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -92,8 +92,8 @@ var/global/datum/getrev/revdata = new()
 	src << "Allow Midround Antagonists: [config.midround_antag.len] of [config.modes.len] roundtypes"
 	if(config.show_game_type_odds)
 		if(ticker.current_state == GAME_STATE_PLAYING)
-			src <<"<b>Game Mode Odds for current round:</b>"
 			var/prob_sum = 0
+			var/current_odds_differ = FALSE
 			var/list/probs = list()
 			var/list/modes = config.gamemode_cache
 			for(var/mode in modes)
@@ -101,17 +101,18 @@ var/global/datum/getrev/revdata = new()
 				var/ctag = initial(M.config_tag)
 				if(!(ctag in config.probabilities))
 					continue
-				if((config.min_pop[ctag] && (config.min_pop[ctag] > ticker.totalPlayersReady)) || (initial(M.required_players) > ticker.totalPlayersReady))
-					continue
-				if(config.max_pop[ctag] && (config.max_pop[ctag] < ticker.totalPlayersReady))
+				if((config.min_pop[ctag] && (config.min_pop[ctag] > ticker.totalPlayersReady)) || (config.max_pop[ctag] && (config.max_pop[ctag] < ticker.totalPlayersReady)) || (initial(M.required_players) > ticker.totalPlayersReady))
+					current_odds_differ = TRUE
 					continue
 				probs[ctag] = 1
 				prob_sum += config.probabilities[ctag]
-			for(var/ctag in probs)
-				if(config.probabilities[ctag] > 0)
-					var/percentage = round(config.probabilities[ctag] / prob_sum * 100, 0.1)
-					src << "[ctag] [percentage]%"
-
+			if(current_odds_differ)
+				src <<"<b>Game Mode Odds for current round:</b>"
+				for(var/ctag in probs)
+					if(config.probabilities[ctag] > 0)
+						var/percentage = round(config.probabilities[ctag] / prob_sum * 100, 0.1)
+						src << "[ctag] [percentage]%"
+		
 		src <<"<b>All Game Mode Odds:</b>"
 		var/sum = 0
 		for(var/ctag in config.probabilities)


### PR DESCRIPTION
In some situations the game mode odds for a given round are the same as the general odds. This essentially keeps Show Server Revision from printing the same list twice. 