### PR TITLE
bumps bluespace ore thingy up to 500 ores

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -95,9 +95,8 @@
 /obj/item/weapon/storage/bag/ore/holding //miners, your messiah has arrived
 	name = "mining satchel of holding"
 	desc = "A revolution in convenience, this satchel allows for huge amounts of ore storage. It's been outfitted with anti-malfunction safety measures."
-	storage_slots = 100
-	//100 * 2 (WEIGHT_CLASS_SMALL)
-	max_combined_w_class =  300
+	storage_slots = 500
+	max_combined_w_class =  1000
 	origin_tech = "bluespace=4;materials=3;engineering=3"
 	icon_state = "satchel_bspace"
 


### PR DESCRIPTION
\>going from infinite to 2x

\>not 10x

like come on. a 50dev bomb on lava produces 10 to 20k ore items and the server handles **throwing** them just fine, I think it can handle dumping more than 100 ores.

:cl: 
tweak: bluespace ore cap changed from 100 ores to 500
/:cl:

Closes #24228
Closes #24279