### PR TITLE
[Meta] Replaces Orange Jumpsuit In Holding Cell With Prisoner Jumpsuit

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14995,26 +14995,11 @@
 	id = "holdingflash";
 	pixel_x = 25
 	},
-/obj/item/clothing/under/color/orange{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/under/color/orange{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/under/color/orange{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/under/color/orange{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/under/color/orange{
-	pixel_x = 1;
-	pixel_y = -1
-	},
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
 /obj/item/clothing/shoes/sneakers/orange,
 /obj/item/clothing/shoes/sneakers/orange,
 /obj/item/clothing/shoes/sneakers/orange,


### PR DESCRIPTION
## **Replaces Orange Jumpsuit In Metastation Holding Cell With Prisoner Jumpsuit**
Replaces the orange jumpsuits in the Metastation brig holding cell with proper prisoner jumpsuits, this is so that if players are wearing a orange jumpsuit for whatever reason they are not as easily mistaken as a escaped prisoner by other players or station security. Other maps also have prisoner jumpsuits so there is no reason that this map should not have these included too.

## **Changelog**
:cl: Tofa01
Tweak: [Meta] Replaces orange jumpsuit in holding cell with prisoner jumpsuits
/:cl:

## **Fixes #24242**
