### PR TITLE
Mobs pushing eachother wont change their direction

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -188,7 +188,12 @@
 					return
 		if(pulling == AM)
 			stop_pulling()
+		var/current_dir
+		if(isliving(AM))
+			current_dir = AM.dir
 		step(AM, t)
+		if(current_dir)
+			AM.dir = current_dir
 		now_pushing = 0
 
 //mob verbs are a lot faster than object verbs

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -193,7 +193,7 @@
 			current_dir = AM.dir
 		step(AM, t)
 		if(current_dir)
-			AM.dir = current_dir
+			AM.setDir(current_dir)
 		now_pushing = 0
 
 //mob verbs are a lot faster than object verbs


### PR DESCRIPTION
This will be pretty much critical if we get the vision thing merged.

Otherwise it doesn't matter much either way, but I think it makes more sense people would stumble backwards rather than two people rapidly facing back and forth as they bump into eachother.

:cl: Kor
fix: You will now retain your facing when getting pushed by another mob.
/:cl: