### PR TITLE
Meleeing someone holding a gun will make them drop their gun

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -59,6 +59,12 @@
 	var/zoom_amt = 3 //Distance in TURFs to move the user's screen forward (the "zoom" effect)
 	var/datum/action/toggle_scope_zoom/azoom
 
+/obj/item/weapon/gun/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
+	if(attack_type != PROJECTILE_ATTACK)
+		if(owner.dropItemToGround(src))
+			throw_at(pick(oview(7,get_turf(owner))),1,1)
+			owner.visible_message("<span class='warning'>[src] is knocked flying from [owner]s hands!</span>")
+	return 0
 
 /obj/item/weapon/gun/New()
 	..()


### PR DESCRIPTION
It always seemed strange to me that guns in our game are better in every way to melee weapons. Even at close range they attack twice as fast, and generally do way more damage. There isn't really the usual tradeoff you see in games, they're just flat out better.

This PR probably isn't a good idea with the way our game is balanced (it would suck for nuke ops and security to just get swarmed) so I guess I'm just more curious if other people think.

Might be interesting if we ever get our mythical "no more stuns" combat. Could flesh out the mechanic and have a chance for the attacker to be shot as the gun goes off as well, etc.

Have not even tested this properly yet, DNM