### PR TITLE
Fixes Backpack: 1 in Character Creation

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -17,7 +17,6 @@
 	if(!pref_species)
 		var/rando_race = pick(config.roundstart_races)
 		pref_species = new rando_race()
-	backbag = 1
 	features = random_features()
 	age = rand(AGE_MIN,AGE_MAX)
 
@@ -66,7 +65,7 @@
 	preview_icon.Scale(48+32, 16+32)
 	CHECK_TICK
 	mannequin.setDir(NORTH)
-	
+
 	var/icon/stamp = getFlatIcon(mannequin)
 	CHECK_TICK
 	preview_icon.Blend(stamp, ICON_OVERLAY, 25, 17)


### PR DESCRIPTION
:cl: TalkingCactus
fix: New characters will now have their backpack preference correctly set to "Department Backpack".
/:cl:

Backpack preferences for new characters were being overwritten incorrectly in `random_character()`. This simply removes the overwrite since a valid backpack is already set as the default variable in `code/modules/client/preferences.dm`.
![picture](http://image.prntscr.com/image/79b20822ff7047ada14a68c755291a73.png)
