### PR TITLE
Adds extra equipment for standard and engineering cyborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -240,6 +240,7 @@
 		/obj/item/device/t_scanner/adv_mining_scanner,
 		/obj/item/weapon/restraints/handcuffs/cable/zipties/cyborg,
 		/obj/item/weapon/soap/nanotrasen,
+		/obj/item/weapon/storage/bag/trash/cyborg,
 		/obj/item/borg/cyborghug)
 	emag_modules = list(/obj/item/weapon/melee/energy/sword/cyborg)
 	ratvar_modules = list(
@@ -298,6 +299,7 @@
 		/obj/item/device/t_scanner,
 		/obj/item/device/analyzer,
 		/obj/item/device/assembly/signaler/cyborg,
+		/obj/item/device/lightreplacer/cyborg,
 		/obj/item/areaeditor/blueprints/cyborg,
 		/obj/item/stack/sheet/metal/cyborg,
 		/obj/item/stack/sheet/glass/cyborg,


### PR DESCRIPTION
:cl:
add: Thanks to the recent advancements in cyborg technology, standard cyborgs can now collect trash and engineering cyborgs can replace lights. Whoa!
/:cl:

Adds cyborg trash bag to standard module and light replacer to engineering module. Has a side effect of making janitor cyborgs a rarer sight, but let's not fool ourselves - it was super rare already, except when the station is full of slaughter demons and hallways splattered with blood.