### PR TITLE
Disables Sound Variance On Cryo Tube Alert Sound

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -114,7 +114,7 @@
 		if(occupant.health >= 100) // Don't bother with fully healed people.
 			on = FALSE
 			update_icon()
-			playsound(T, 'sound/machines/cryo_warning.ogg', volume, 1) // Bug the doctors.
+			playsound(T, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
 			radio.talk_into(src, "Patient fully restored", radio_channel)
 			if(autoeject) // Eject if configured.
 				radio.talk_into(src, "Auto ejecting patient now", radio_channel)


### PR DESCRIPTION
## **Disables Sound Variance On Cryo Tube Alert Sound**
Disables the sound/frequency variance on the cryo tube alert sound this is to make the sound more standard and not play at weird and random pitches every time. When i was implementing this sound i did not know at the time what the value meant so i left it alone but now that i do know what it means i am fixing this myself.

## **Changelog**
:cl: Tofa01
Fix: Disables sound/frequency variance on cryo tube alert sound
/:cl:

