### PR TITLE
Adds autoimplanter to R&D designs

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -326,7 +326,7 @@
 	name = "Autoimplanter"
 	desc = "A device that automatically injects a cyber-implant into the user without the hassle of extensive surgery. It has a slot to insert implants and a screwdriver slot for removing accidentally added implants."
 	id = "autoimplanter"
-	req_tech = list("materials" = 7, "biotech" = 6, "magnets" = 5, "engineering" = 7)
+	req_tech = list("materials" = 7, "biotech" = 6, "magnets" = 6, "engineering" = 7)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000, MAT_SILVER = 4500, MAT_GOLD = 2500, MAT_TITANIUM = 3000)
 	build_path = /obj/item/device/autoimplanter

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -321,6 +321,16 @@
 	materials = list(MAT_METAL = 4000, MAT_GLASS = 2000, MAT_SILVER = 1000, MAT_DIAMOND = 1000)
 	build_path = /obj/item/organ/cyberimp/chest/thrusters
 	category = list("Misc", "Medical Designs")
+	
+/datum/design/autoimplanter
+	name = "Autoimplanter"
+	desc = "A device that automatically injects a cyber-implant into the user without the hassle of extensive surgery. It has a slot to insert implants and a screwdriver slot for removing accidentally added implants."
+	id = "autoimplanter"
+	req_tech = list("materials" = 7, "biotech" = 6, "magnets" = 5, "engineering" = 7)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000, MAT_SILVER = 4500, MAT_GOLD = 2500, MAT_TITANIUM = 3000)
+	build_path = /obj/item/device/autoimplanter
+	category = list("Medical Designs")
 
 
 /////////////////////////////////////////


### PR DESCRIPTION
:cl:
add: Autoimplanter designs can now be researched at R&D.
/:cl:

Adds the possibility to print an autoimplanter at high research levels. While the ability to self-implant might seem overpowered, you're still gonna need a looot of time and cooperation from other crew to get it.