### PR TITLE
PA now warns when activated for an incomplete containment field

### DIFF
--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -21,11 +21,12 @@
 	var/powered = 0
 	mouse_opacity = 2
 
-/obj/machinery/particle_accelerator/control_box/New()
+/obj/machinery/particle_accelerator/control_box/Initialize()
 	wires = new /datum/wires/particle_accelerator/control_box(src)
 	connected_parts = list()
 	radio = new(src)
 	radio.listening = 0
+	radio.frequency = 1357
 	..()
 
 /obj/machinery/particle_accelerator/control_box/Destroy()
@@ -215,7 +216,6 @@
 	message_admins("PA Control Computer turned [active ?"ON":"OFF"] by [usr ? key_name_admin(usr) : "outside forces"](<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[usr]'>FLW</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 	log_game("PA Control Computer turned [active ?"ON":"OFF"] by [usr ? "[key_name(usr)]" : "outside forces"] in ([x],[y],[z])")
 	if(active)
-		radio.frequency = 1357
 		for (var/obj/machinery/field/containment/C in range(30, src))
 			fieldcount += C		
 		if (fieldcount.len<24)

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -12,6 +12,8 @@
 	var/strength_upper_limit = 2
 	var/interface_control = 1
 	var/list/obj/structure/particle_accelerator/connected_parts
+	var/obj/item/device/radio/radio
+	var/list/fieldcount = list()
 	var/assembled = 0
 	var/construction_state = PA_CONSTRUCTION_UNSECURED
 	var/active = 0
@@ -22,11 +24,16 @@
 /obj/machinery/particle_accelerator/control_box/New()
 	wires = new /datum/wires/particle_accelerator/control_box(src)
 	connected_parts = list()
+	radio = new(src)
+	radio.listening = 0
 	..()
 
 /obj/machinery/particle_accelerator/control_box/Destroy()
 	if(active)
 		toggle_power()
+	if(radio)
+		qdel(radio)
+		radio = null
 	for(var/CP in connected_parts)
 		var/obj/structure/particle_accelerator/part = CP
 		part.master = null
@@ -208,6 +215,11 @@
 	message_admins("PA Control Computer turned [active ?"ON":"OFF"] by [usr ? key_name_admin(usr) : "outside forces"](<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[usr]'>FLW</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 	log_game("PA Control Computer turned [active ?"ON":"OFF"] by [usr ? "[key_name(usr)]" : "outside forces"] in ([x],[y],[z])")
 	if(active)
+		radio.frequency = 1357
+		for (var/obj/machinery/field/containment/C in range(30, src))
+			fieldcount += C		
+		if (fieldcount.len<24)
+			radio.talk_into(src,"ALERT: Particle Accelerator has been activated while the containment field is incomplete. A Class 5 Extinction Event is probable unless the issue is immediately remedied!", ENG_FREQ)
 		use_power = 2
 		for(var/CP in connected_parts)
 			var/obj/structure/particle_accelerator/part = CP

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -219,7 +219,7 @@
 		for (var/obj/machinery/field/containment/C in range(30, src))
 			fieldcount += C		
 		if (fieldcount.len<24)
-			radio.talk_into(src,"ALERT: Particle Accelerator has been activated while the containment field is incomplete. A Class 5 Extinction Event is probable unless the issue is immediately remedied!", ENG_FREQ)
+			radio.talk_into(src,"ALERT: Particle Accelerator has been activated with a non-standard containment field configuration. Please inspect containment status to ensure that a Class 5 Extinction Event is not imminent!", ENG_FREQ)
 		use_power = 2
 		for(var/CP in connected_parts)
 			var/obj/structure/particle_accelerator/part = CP


### PR DESCRIPTION
This PR is primarily designed to create a safeguard against Engineering incompetence. Nobody benefits when a new engineer dooms the station 60 seconds into the round. Since the warning only goes out upon activation, it is still relatively easy to sabotage the engine. It will also have the effect of eliminating low/med pop engi-antags doing low effort releases at roundstart (since there may not even be other engineers around to notice/prevent a roundstart PA activation). 

This is especially necessary now that we have 2 engine devices sitting in front of the PA. I enjoy watching the occasional mass-destruction from a loose engine but when it becomes a regular occurrence we need measures to stop it from becoming routine. 

Speaking from personal experience I've released the engine at least once due to containment issues. It was resolved by https://github.com/tgstation/tgstation/pull/17734, but it probably won't be the last time containment acts up.

:cl: Robustin
add: The PA now issues a warning on Engineering radio channel when the particle accelerator is activated but the containment field is incomplete. 
/:cl:

