### PR TITLE
[Delta] Adds A Centcomm Ferry Shuttle & [All Maps] Changes Centcom Ferry To Better Design

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -118600,6 +118600,279 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
+"edk" = (
+/obj/structure/shuttle/engine/propulsion{
+	tag = "icon-propulsion (NORTH)";
+	icon_state = "propulsion";
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edl" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edm" = (
+/obj/structure/shuttle/engine/propulsion{
+	tag = "icon-propulsion (NORTH)";
+	icon_state = "propulsion";
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edn" = (
+/obj/structure/shuttle/engine/propulsion{
+	tag = "icon-propulsion (NORTH)";
+	icon_state = "propulsion";
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edo" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edp" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edq" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edr" = (
+/obj/structure/shuttle/engine/propulsion{
+	tag = "icon-propulsion (NORTH)";
+	icon_state = "propulsion";
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"eds" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edt" = (
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edu" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edv" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edw" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edx" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edy" = (
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edz" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edA" = (
+/obj/machinery/computer/shuttle/ferry/request,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edB" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edC" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/transport)
+"edD" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edE" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edF" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edG" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/transport)
+"edH" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edI" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edJ" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edK" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edL" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edM" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edN" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edO" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edP" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edQ" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edR" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edS" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edT" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edU" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edV" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"edW" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/transport)
+"edX" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edY" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"edZ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"eea" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/transport)
+"eeb" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"eec" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"eed" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"eee" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"eef" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"eeg" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"eeh" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"eei" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"eej" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"eek" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"eel" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"eem" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/transport)
+"een" = (
+/obj/docking_port/mobile{
+	dir = 1;
+	dwidth = 2;
+	height = 12;
+	id = "ferry";
+	name = "ferry shuttle";
+	port_angle = 0;
+	preferred_direction = 4;
+	roundstart_move = "ferry_away";
+	width = 5
+	},
+/obj/docking_port/stationary{
+	dir = 1;
+	dwidth = 2;
+	height = 12;
+	id = "ferry_home";
+	name = "port bay 2";
+	turf_type = /turf/open/space;
+	width = 5
+	},
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"eeo" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/transport)
+"eep" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
 
 (1,1,1) = {"
 aaa
@@ -152329,7 +152602,7 @@ aaa
 aaa
 aaa
 aaf
-brL
+aax
 aaD
 agn
 agN
@@ -152574,19 +152847,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+edn
+eds
+edx
+edC
+edH
+edM
+edR
+edW
+eeb
+eeg
+eel
 aaf
-ebM
+abT
 adr
 agl
 agN
@@ -152830,20 +153103,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-brL
-brL
+edk
+edo
+edt
+edy
+edD
+edI
+edN
+edS
+edX
+eec
+eeh
+eem
+aax
+aax
 aax
 agl
 agN
@@ -153087,20 +153360,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-ebL
-ebN
+edl
+edp
+edu
+edz
+edE
+edJ
+edO
+edT
+edY
+eed
+eei
+een
+acj
+aci
 acj
 agl
 agN
@@ -153344,20 +153617,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-brL
-brL
+edm
+edq
+edv
+edA
+edF
+edK
+edP
+edU
+edZ
+eee
+eej
+eeo
+aax
+aax
 aax
 agl
 agQ
@@ -153602,19 +153875,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+edr
+edw
+edB
+edG
+edL
+edQ
+edV
+eea
+eef
+eek
+eep
 aaf
-ebO
+abR
 adq
 ago
 agM
@@ -153871,7 +154144,7 @@ aaa
 aaa
 aaa
 aaf
-brL
+aax
 aaD
 agp
 agN

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -118762,7 +118762,7 @@
 /area/shuttle/transport)
 "edT" = (
 /obj/machinery/computer/shuttle/ferry/request,
-/turf/open/floor/pod/light,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "edU" = (
 /obj/structure/chair{
@@ -153170,15 +153170,15 @@ aaa
 aaa
 aaa
 aaa
-edk
+eeq
 ees
 edo
 edo
 edD
 edD
-edD
 edp
-edD
+edp
+edp
 edD
 edD
 edC
@@ -153684,15 +153684,15 @@ aaa
 aaa
 aaa
 aaa
-edk
+eeq
 eet
 edo
 edo
 edF
 edF
-edF
 edp
-edF
+edp
+edp
 edF
 edF
 edC
@@ -153948,10 +153948,10 @@ edo
 edC
 edo
 edo
-eew
+eev
 edo
 edo
-eey
+eex
 edo
 aaf
 abR

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -118606,11 +118606,16 @@
 	icon_state = "propulsion";
 	dir = 1
 	},
-/turf/closed/wall/mineral/titanium,
+/turf/open/floor/plating/airless,
 /area/shuttle/transport)
 "edl" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium/blue,
+/obj/structure/shuttle/engine/heater{
+	tag = "icon-heater (NORTH)";
+	icon_state = "heater";
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating/airless,
 /area/shuttle/transport)
 "edm" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -118632,7 +118637,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/transport)
 "edp" = (
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/light,
 /area/shuttle/transport)
 "edq" = (
 /turf/closed/wall/mineral/titanium,
@@ -118669,7 +118674,8 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "edz" = (
-/turf/open/floor/mineral/titanium/blue,
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/pod/light,
 /area/shuttle/transport)
 "edA" = (
 /obj/machinery/computer/shuttle/ferry/request,
@@ -118687,7 +118693,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "edE" = (
 /turf/open/floor/mineral/titanium/blue,
@@ -118696,7 +118702,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "edG" = (
 /obj/structure/grille,
@@ -118755,7 +118761,8 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "edT" = (
-/turf/open/floor/mineral/titanium/blue,
+/obj/machinery/computer/shuttle/ferry/request,
+/turf/open/floor/pod/light,
 /area/shuttle/transport)
 "edU" = (
 /obj/structure/chair{
@@ -118845,7 +118852,7 @@
 /obj/docking_port/mobile{
 	dir = 1;
 	dwidth = 2;
-	height = 12;
+	height = 13;
 	id = "ferry";
 	name = "ferry shuttle";
 	port_angle = 0;
@@ -118856,14 +118863,14 @@
 /obj/docking_port/stationary{
 	dir = 1;
 	dwidth = 2;
-	height = 12;
+	height = 13;
 	id = "ferry_home";
 	name = "port bay 2";
 	turf_type = /turf/open/space;
 	width = 5
 	},
 /obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "eeo" = (
 /obj/structure/grille,
@@ -118872,6 +118879,66 @@
 /area/shuttle/transport)
 "eep" = (
 /turf/closed/wall/mineral/titanium,
+/area/shuttle/transport)
+"eeq" = (
+/obj/structure/shuttle/engine/propulsion{
+	tag = "icon-propulsion (NORTH)";
+	icon_state = "propulsion";
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/transport)
+"eer" = (
+/turf/open/floor/plasteel/neutral,
+/area/shuttle/transport)
+"ees" = (
+/obj/structure/shuttle/engine/heater{
+	tag = "icon-heater (NORTH)";
+	icon_state = "heater";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/transport)
+"eet" = (
+/obj/structure/shuttle/engine/heater{
+	tag = "icon-heater (NORTH)";
+	icon_state = "heater";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/transport)
+"eeu" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/latejoin,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/shuttle/transport)
+"eev" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"eew" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"eex" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/transport)
+"eey" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/shuttle/transport)
 
 (1,1,1) = {"
@@ -152847,17 +152914,17 @@ aaa
 aaa
 aaa
 aaa
-edn
-eds
-edx
+aaa
+aaa
+edo
 edC
-edH
-edM
-edR
-edW
-eeb
-eeg
-eel
+edo
+edo
+eev
+edo
+edo
+eex
+edo
 aaf
 abT
 adr
@@ -153104,17 +153171,17 @@ aaa
 aaa
 aaa
 edk
+ees
 edo
-edt
-edy
+edo
 edD
-edI
-edN
-edS
-edX
-eec
-eeh
-eem
+edD
+edD
+edp
+edD
+edD
+edD
+edC
 aax
 aax
 aax
@@ -153359,18 +153426,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
+eeq
 edl
 edp
-edu
+edp
 edz
-edE
-edJ
-edO
+edp
+edp
+edp
 edT
-edY
-eed
-eei
+edp
+edp
+edp
 een
 acj
 aci
@@ -153617,18 +153684,18 @@ aaa
 aaa
 aaa
 aaa
-edm
-edq
-edv
-edA
+edk
+eet
+edo
+edo
 edF
-edK
-edP
-edU
-edZ
-eee
-eej
-eeo
+edF
+edF
+edp
+edF
+edF
+edF
+edC
 aax
 aax
 aax
@@ -153875,17 +153942,17 @@ aaa
 aaa
 aaa
 aaa
-edr
-edw
-edB
-edG
-edL
-edQ
-edV
-eea
-eef
-eek
-eep
+aaa
+aaa
+edo
+edC
+edo
+edo
+eew
+edo
+edo
+eey
+edo
 aaf
 abR
 adq
@@ -157475,7 +157542,7 @@ aca
 acn
 acn
 acI
-acI
+eeu
 acI
 acI
 adN
@@ -158243,7 +158310,7 @@ abp
 abF
 abW
 abZ
-acn
+eer
 acn
 acn
 acn

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -89957,9 +89957,9 @@
 "cVm" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion"
+	icon_state = "propulsion_l"
 	},
-/turf/closed/wall/mineral/titanium/overspace,
+/turf/open/floor/plating,
 /area/shuttle/transport)
 "cVn" = (
 /turf/closed/wall/mineral/titanium,
@@ -89978,8 +89978,12 @@
 /turf/closed/wall/mineral/titanium/overspace,
 /area/shuttle/transport)
 "cVr" = (
-/turf/open/floor/mineral/titanium/blue,
-/turf/closed/wall/mineral/titanium/interior,
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/shuttle/transport)
 "cVs" = (
 /obj/machinery/computer/shuttle/ferry/request,
@@ -89993,21 +89997,28 @@
 /area/shuttle/transport)
 "cVu" = (
 /obj/structure/chair,
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "cVv" = (
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/light,
 /area/shuttle/transport)
 "cVw" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium/blue,
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/plating,
 /area/shuttle/transport)
 "cVx" = (
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile{
 	dir = 8;
 	dwidth = 2;
-	height = 12;
+	height = 13;
 	id = "ferry";
 	name = "ferry shuttle";
 	port_angle = 0;
@@ -90018,13 +90029,13 @@
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 2;
-	height = 12;
+	height = 13;
 	id = "ferry_home";
 	name = "port bay 2";
 	turf_type = /turf/open/space;
 	width = 5
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/light,
 /area/shuttle/transport)
 "cVy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -90048,7 +90059,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "cVC" = (
 /mob/living/simple_animal/sloth/citrus,
@@ -94437,6 +94448,36 @@
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
+"ddH" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"ddI" = (
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"ddJ" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"ddK" = (
+/obj/machinery/computer/shuttle/ferry/request,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"ddL" = (
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/transport)
+"ddM" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
 
 (1,1,1) = {"
 aaa
@@ -103304,11 +103345,11 @@ aaa
 aaa
 aaa
 aaf
-aaf
 aaa
 aaa
+cVm
 aaa
-aaf
+aaa
 aaf
 aaa
 aaa
@@ -103818,11 +103859,11 @@ aWS
 bvB
 aWT
 aWS
-cVm
+aaa
 cVr
 cVv
-cVr
-cVm
+ddL
+aaa
 aWS
 bKS
 aWT
@@ -104075,11 +104116,11 @@ aYC
 aVu
 aWU
 aRA
+aaa
 cVn
-cVt
 cVv
-cVA
 cVn
+aaa
 aRA
 btS
 aWU
@@ -104333,9 +104374,9 @@ aVw
 aWU
 aWS
 cVn
-cVs
-cVv
-cVA
+cVn
+ddJ
+cVn
 cVn
 aWS
 aVw
@@ -104589,11 +104630,11 @@ aRA
 bvC
 bxt
 aYC
-cVo
+cVp
 cVu
 cVv
 cVB
-cVo
+cVp
 aYC
 bKT
 aWU
@@ -105360,11 +105401,11 @@ aWS
 aVu
 bxv
 aWS
-cVn
-cVu
+ddH
+ddI
+ddK
 cVv
-cVB
-cVn
+ddM
 aWS
 aVu
 bMu
@@ -105617,11 +105658,11 @@ btO
 bvE
 bxw
 aWS
-cVp
+cVn
 cVu
 cVv
 cVB
-cVp
+cVn
 aWS
 bKU
 bMv
@@ -106131,11 +106172,11 @@ btP
 aWX
 bxx
 aRA
-cVn
+cVp
 cVu
 cVv
 cVB
-cVn
+cVp
 aRA
 btS
 bxw
@@ -106388,11 +106429,11 @@ btQ
 bvG
 bxw
 aWS
-cVq
-cVo
+cVn
+cVp
 cVx
-cVo
-cVq
+cVp
+cVn
 aWS
 aVu
 bxw

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -94450,18 +94450,18 @@
 /area/shuttle/auxillary_base)
 "ddH" = (
 /obj/machinery/door/airlock/external,
-/turf/open/floor/pod/light,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "ddI" = (
 /turf/open/floor/pod/light,
-/area/shuttle/transport)
+/area/space)
 "ddJ" = (
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
 "ddK" = (
 /obj/machinery/computer/shuttle/ferry/request,
-/turf/open/floor/pod/light,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "ddL" = (
 /obj/structure/shuttle/engine/heater{
@@ -94478,6 +94478,9 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
+"ddN" = (
+/turf/open/floor/pod/light,
+/area/space)
 
 (1,1,1) = {"
 aaa
@@ -105145,9 +105148,9 @@ aVu
 bxu
 aRA
 cVn
-cVu
 cVv
-cVB
+cVv
+cVv
 cVn
 aRA
 aVu
@@ -105402,7 +105405,7 @@ aVu
 bxv
 aWS
 ddH
-ddI
+cVv
 ddK
 cVv
 ddM
@@ -105659,9 +105662,9 @@ bvE
 bxw
 aWS
 cVn
-cVu
 cVv
-cVB
+cVv
+cVv
 cVn
 aWS
 bKU

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -55448,7 +55448,7 @@
 /area/shuttle/transport)
 "cie" = (
 /obj/machinery/computer/shuttle/ferry/request,
-/turf/open/floor/pod/light,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "cif" = (
 /obj/structure/shuttle/engine/heater{
@@ -55464,6 +55464,10 @@
 "cig" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/pod/light,
+/area/shuttle/transport)
+"cih" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 
 (1,1,1) = {"
@@ -74617,9 +74621,9 @@ aVm
 bhz
 aTr
 bjZ
-blv
 blt
-boa
+blt
+blt
 bjZ
 aaa
 aaa
@@ -74873,8 +74877,8 @@ aWm
 aVm
 bhz
 aTr
-cib
-cic
+cih
+blt
 cie
 blt
 cig
@@ -75131,9 +75135,9 @@ aVn
 bhz
 aTr
 bjZ
-blv
 blt
-boa
+blt
+blt
 bjZ
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -30928,9 +30928,9 @@
 "bjY" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion"
+	icon_state = "propulsion_l"
 	},
-/turf/closed/wall/mineral/titanium,
+/turf/open/floor/plating,
 /area/shuttle/transport)
 "bjZ" = (
 /turf/closed/wall/mineral/titanium,
@@ -31721,11 +31721,15 @@
 /turf/open/floor/plating,
 /area/maintenance/apmaint)
 "bls" = (
-/turf/open/floor/mineral/titanium/blue,
-/turf/closed/wall/mineral/titanium/interior,
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/shuttle/transport)
 "blt" = (
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/light,
 /area/shuttle/transport)
 "blu" = (
 /obj/machinery/computer/shuttle/ferry/request,
@@ -31733,7 +31737,7 @@
 /area/shuttle/transport)
 "blv" = (
 /obj/structure/chair,
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "blw" = (
 /obj/structure/grille,
@@ -32371,15 +32375,22 @@
 /turf/open/floor/plating,
 /area/maintenance/apmaint)
 "bmM" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium/blue,
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/plating,
 /area/shuttle/transport)
 "bmN" = (
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile{
 	dir = 8;
 	dwidth = 2;
-	height = 12;
+	height = 13;
 	id = "ferry";
 	name = "ferry shuttle";
 	port_angle = 0;
@@ -32390,13 +32401,13 @@
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 2;
-	height = 12;
+	height = 13;
 	id = "ferry_home";
 	name = "port bay 2";
 	turf_type = /turf/open/space;
 	width = 5
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/light,
 /area/shuttle/transport)
 "bmO" = (
 /obj/machinery/door/airlock/external{
@@ -33077,7 +33088,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "bob" = (
 /turf/open/floor/plasteel/neutral/corner,
@@ -55424,6 +55435,36 @@
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
 	})
+"cib" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"cic" = (
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"cid" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"cie" = (
+/obj/machinery/computer/shuttle/ferry/request,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"cif" = (
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/transport)
+"cig" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
 
 (1,1,1) = {"
 aaa
@@ -72778,7 +72819,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bjY
 aaa
 aaa
 aaa
@@ -73290,11 +73331,11 @@ aaa
 aaa
 aaa
 aaa
-bjY
+aaa
 bls
 blt
-bls
-bjY
+cif
+aaa
 aaa
 aaa
 aaa
@@ -73547,11 +73588,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
 bjZ
 blt
-blt
-bnZ
 bjZ
+aaa
 aaa
 aaa
 aaa
@@ -73805,9 +73846,9 @@ aTr
 aTr
 aTr
 bjZ
-blu
-blt
-bnZ
+bjZ
+cid
+bjZ
 bjZ
 aaa
 aaa
@@ -74061,11 +74102,11 @@ aTr
 aVl
 bhz
 aTr
-bka
+bkb
 blv
 blt
 boa
-bka
+bkb
 aaa
 aaa
 aaa
@@ -74832,11 +74873,11 @@ aWm
 aVm
 bhz
 aTr
-bjZ
-blv
+cib
+cic
+cie
 blt
-boa
-bjZ
+cig
 aaa
 aaa
 aaa
@@ -75089,11 +75130,11 @@ aVm
 aVn
 bhz
 aTr
-bkb
+bjZ
 blv
 blt
 boa
-bkb
+bjZ
 aaa
 aaa
 aaa
@@ -75603,11 +75644,11 @@ aTr
 bgE
 bhA
 aTr
-bjZ
+bkb
 blv
 blt
 boa
-bjZ
+bkb
 aaa
 aaa
 aaa
@@ -75861,9 +75902,9 @@ aXs
 bhz
 aTr
 bjZ
-bka
+bkb
 bmN
-bka
+bkb
 bjZ
 aaa
 aaa

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -59095,9 +59095,9 @@
 "cxt" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion"
+	icon_state = "propulsion_l"
 	},
-/turf/closed/wall/mineral/titanium,
+/turf/open/floor/plating,
 /area/shuttle/transport)
 "cxu" = (
 /turf/closed/wall/mineral/titanium,
@@ -59127,8 +59127,12 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "cxy" = (
-/turf/open/floor/mineral/titanium/blue,
-/turf/closed/wall/mineral/titanium/interior,
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/shuttle/transport)
 "cxz" = (
 /obj/machinery/computer/shuttle/ferry/request,
@@ -59142,21 +59146,28 @@
 /area/ai_monitored/security/armory)
 "cxB" = (
 /obj/structure/chair,
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "cxC" = (
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/light,
 /area/shuttle/transport)
 "cxD" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium/blue,
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/plating,
 /area/shuttle/transport)
 "cxE" = (
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile{
 	dir = 8;
 	dwidth = 2;
-	height = 12;
+	height = 13;
 	id = "ferry";
 	name = "ferry shuttle";
 	port_angle = 0;
@@ -59167,13 +59178,13 @@
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 2;
-	height = 12;
+	height = 13;
 	id = "ferry_home";
 	name = "port bay 2";
 	turf_type = /turf/open/space;
 	width = 5
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/light,
 /area/shuttle/transport)
 "cxF" = (
 /obj/machinery/door/airlock/titanium{
@@ -59203,7 +59214,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "cxJ" = (
 /obj/machinery/door/airlock/external{
@@ -61235,6 +61246,36 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
+"cCu" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"cCv" = (
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"cCw" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"cCx" = (
+/obj/machinery/computer/shuttle/ferry/request,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
+"cCy" = (
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/transport)
+"cCz" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/pod/light,
+/area/shuttle/transport)
 
 (1,1,1) = {"
 aaa
@@ -69583,7 +69624,7 @@ cwU
 aaa
 aaa
 aaa
-aaa
+cxt
 aaa
 aaa
 aaf
@@ -70095,11 +70136,11 @@ auO
 auP
 cxY
 arB
-cxt
+aaa
 cxy
 cxC
-cxy
-cxt
+cCy
+aaa
 aaf
 aaa
 aaf
@@ -70352,11 +70393,11 @@ asE
 cyb
 avP
 arB
+aaa
 cxu
 cxC
-cxC
-cxH
 cxu
+aaa
 arB
 awW
 awW
@@ -70610,9 +70651,9 @@ aQG
 aRX
 arB
 cxu
-cxz
-cxC
-cxH
+cxu
+cCw
+cxu
 cxu
 arB
 awY
@@ -70866,11 +70907,11 @@ azy
 ayl
 aRY
 awW
-cxv
+cxw
 cxB
 cxC
 cxI
-cxv
+cxw
 awW
 awZ
 ayl
@@ -71637,11 +71678,11 @@ ayl
 ayl
 aRY
 awW
-cxu
-cxB
+cCu
+cCv
+cCx
 cxC
-cxI
-cxu
+cCz
 awW
 awZ
 ayl
@@ -71894,11 +71935,11 @@ ayl
 ayl
 aRY
 awW
-cxw
+cxu
 cxB
 cxC
 cxI
-cxw
+cxu
 awW
 awZ
 ayl
@@ -72408,11 +72449,11 @@ awW
 awV
 aRY
 awW
-cxu
+cxw
 cxB
 cxC
 cxI
-cxu
+cxw
 awW
 awZ
 ayk
@@ -72666,9 +72707,9 @@ ayl
 aRY
 awW
 cxu
-cxv
+cxw
 cxE
-cxv
+cxw
 cxu
 awW
 awZ

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -61248,18 +61248,18 @@
 /area/shuttle/auxillary_base)
 "cCu" = (
 /obj/machinery/door/airlock/external,
-/turf/open/floor/pod/light,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "cCv" = (
 /turf/open/floor/pod/light,
-/area/shuttle/transport)
+/area/space)
 "cCw" = (
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
 "cCx" = (
 /obj/machinery/computer/shuttle/ferry/request,
-/turf/open/floor/pod/light,
+/turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "cCy" = (
 /obj/structure/shuttle/engine/heater{
@@ -61276,6 +61276,9 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
+"cCA" = (
+/turf/open/floor/pod/light,
+/area/space)
 
 (1,1,1) = {"
 aaa
@@ -71422,9 +71425,9 @@ aPu
 aRY
 awW
 cxu
-cxB
 cxC
-cxI
+cxC
+cxC
 cxu
 awW
 awZ
@@ -71679,7 +71682,7 @@ ayl
 aRY
 awW
 cCu
-cCv
+cxC
 cCx
 cxC
 cCz
@@ -71936,9 +71939,9 @@ ayl
 aRY
 awW
 cxu
-cxB
 cxC
-cxI
+cxC
+cxC
 cxu
 awW
 awZ

--- a/_maps/map_files/generic/z2.dmm
+++ b/_maps/map_files/generic/z2.dmm
@@ -8289,7 +8289,7 @@
 	dwidth = 2;
 	height = 13;
 	id = "ferry_away";
-	name = "unknown";
+	name = "Centcom Ferry Dock";
 	width = 5
 	},
 /turf/open/space,

--- a/_maps/map_files/generic/z2.dmm
+++ b/_maps/map_files/generic/z2.dmm
@@ -8287,7 +8287,7 @@
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 2;
-	height = 12;
+	height = 13;
 	id = "ferry_away";
 	name = "unknown";
 	width = 5


### PR DESCRIPTION
##  **Adds Centcomm Ferry Shuttle Version 2.0 To All Maps**
Adds a Centcomm new and improved ferry V2.0 to the all arrivals docks. Due to the orientation of the the arrivals dock on Delatstation the ferry had to be placed vertically on all other maps ferry's are horizontally placed. This should allow for more Admin appointed roles such as Centcom Inspector to be used on Deltastation as it previously did not have a shuttle. And this also makes the shuttle look cooler on other maps.

## **Images**
![1](https://cloud.githubusercontent.com/assets/24999255/23293871/c67a3e22-fabc-11e6-9270-915301bff309.PNG)
_Delta Station - New Centcom Ferry_

## **Changelog**
:cl: Tofa01
Add: [All Maps] The new and improved Centcom transportation ferry version 2.0 is out now!
/:cl:

## **Fixes #24320**
## **Fixes #24386**

