### PR TITLE
Fixes the fire overlay never being cut

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -206,7 +206,7 @@ var/global/image/acid_overlay = image("icon" = 'icons/effects/effects.dmi', "ico
 /obj/proc/extinguish()
 	if(resistance_flags & ON_FIRE)
 		resistance_flags &= ~ON_FIRE
-		cut_overlay(fire_overlay)
+		cut_overlay(fire_overlay, TRUE)
 		SSfire_burning.processing -= src
 
 


### PR DESCRIPTION
Fixes #24350

:cl: Cyberboss
fix: Fixed a bug where the fire overlay wasn't getting removed from objects
/:cl:

I forgot it's a priority overlay