### PR TITLE
Firefighter ripleys are no longer lava proof

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -64,7 +64,7 @@
 	max_temperature = 65000
 	obj_integrity = 250
 	max_integrity = 250
-	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 	lights_power = 7
 	armor = list(melee = 40, bullet = 30, laser = 30, energy = 30, bomb = 60, bio = 0, rad = 0, fire = 100, acid = 100)
 	max_equip = 5 // More armor, less tools


### PR DESCRIPTION
This makes no sense at all, lava damages it all.
They are still fire proof, which is the main point of a firefighter ripley.