### PR TITLE
Roundstart Animation

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -405,10 +405,22 @@ var/datum/subsystem/ticker/ticker
 			CHECK_TICK
 
 /datum/subsystem/ticker/proc/transfer_characters()
+	var/list/livings = list()
 	for(var/mob/new_player/player in player_list)
-		if(player.transfer_character())
+		var/mob/living = player.transfer_character()
+		if(living)
 			qdel(player)
-		
+			living.notransform = TRUE
+			if(living.client)
+				new /obj/screen/splash(living.client, TRUE)	
+			livings += living
+	if(livings.len)
+		addtimer(CALLBACK(src, .proc/release_characters, livings), 30, TIMER_CLIENT_TIME)
+
+/datum/subsystem/ticker/proc/release_characters(list/livings)
+	for(var/I in livings)
+		var/mob/living/L = I
+		L.notransform = FALSE		
 
 /datum/subsystem/ticker/proc/declare_completion()
 	set waitfor = FALSE

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -412,7 +412,8 @@ var/datum/subsystem/ticker/ticker
 			qdel(player)
 			living.notransform = TRUE
 			if(living.client)
-				new /obj/screen/splash(living.client, TRUE)	
+				var/obj/screen/splash/S = new(living.client, TRUE)	
+				S.Fade(TRUE)
 			livings += living
 	if(livings.len)
 		addtimer(CALLBACK(src, .proc/release_characters, livings), 30, TIMER_CLIENT_TIME)


### PR DESCRIPTION
:cl: Cyberboss
imageadd: Added roundstart animation
/:cl:

Will record later, it's the same thing as the round end animation except it fades out the splashscreen during 'Welcome to the station crew' and locks players in place for the 3 second duration

This gives players a moment to get their bearings/catch up if they're lagging before things get hectic