### PR TITLE
Fixes all overlays being compiled twice at roundstart

### DIFF
--- a/code/controllers/subsystem/processing/overlays.dm
+++ b/code/controllers/subsystem/processing/overlays.dm
@@ -22,6 +22,7 @@ var/datum/subsystem/processing/overlays/SSoverlays
 		var/atom/A = I
 		A.compile_overlays()
 		CHECK_TICK
+	processing.Cut()
 	..()
 
 /datum/subsystem/processing/overlays/Recover()


### PR DESCRIPTION
NobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviewsNobodyReviews

# S P E E D M E R G E