### PR TITLE
Moves Centcom Inspector to admin-only event

### DIFF
--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -395,44 +395,13 @@
 
 
 /datum/admins/proc/makeOfficial()
-	var/mission = input("Assign a task for the official", "Assign Task", "Conduct a routine preformance review of [station_name()] and its Captain.")
-	var/list/mob/dead/observer/candidates = pollCandidates("Do you wish to be considered to be a Centcom Official?", "deathsquad")
+	var/datum/round_event/ghost_role/inspector/event = new(FALSE)
 
-	if(candidates.len)
-		var/mob/dead/observer/chosen_candidate = pick(candidates)
+	var/mission = input("Assign a task for the official", "Assign Task", event.mission)
+	event.mission = mission
 
-		//Create the official
-		var/mob/living/carbon/human/newmob = new (pick(emergencyresponseteamspawn))
-		chosen_candidate.client.prefs.copy_to(newmob)
-		newmob.real_name = newmob.dna.species.random_name(newmob.gender,1)
-		newmob.dna.update_dna_identity()
-		newmob.key = chosen_candidate.key
-		newmob.mind.assigned_role = "Centcom Official"
-		newmob.equipOutfit(/datum/outfit/centcom_official)
-
-		//Assign antag status and the mission
-		ticker.mode.traitors += newmob.mind
-		newmob.mind.special_role = "official"
-		var/datum/objective/missionobj = new
-		missionobj.owner = newmob.mind
-		missionobj.explanation_text = mission
-		missionobj.completed = 1
-		newmob.mind.objectives += missionobj
-
-		if(config.enforce_human_authority)
-			newmob.set_species(/datum/species/human)
-
-		//Greet the official
-		newmob << "<B><font size=3 color=red>You are a Centcom Official.</font></B>"
-		newmob << "<BR>Central Command is sending you to [station_name()] with the task: [mission]"
-
-		//Logging and cleanup
-		message_admins("Centcom Official [key_name_admin(newmob)] has spawned with the task: [mission]")
-		log_game("[key_name(newmob)] has been selected as a Centcom Official")
-
-		return 1
-
-	return 0
+	event.processing = TRUE
+	. = TRUE
 
 // CENTCOM RESPONSE TEAM
 /datum/admins/proc/makeEmergencyresponseteam()

--- a/code/modules/events/inspection.dm
+++ b/code/modules/events/inspection.dm
@@ -1,0 +1,55 @@
+/datum/round_event_control/inspector
+	name = "Inspector"
+	typepath = /datum/round_event/ghost_role/inspector
+	weight = 0
+
+/datum/round_event/ghost_role/inspector
+	minimum_required = 1
+	role_name = "Centcom Official"
+	var/mission
+
+/datum/round_event/ghost_role/inspector/setup()
+	mission = "Conduct a routine preformance review of [station_name()] and its Captain."
+
+/datum/round_event/ghost_role/inspector/spawn_role()
+	var/list/mob/dead/observer/candidates = get_candidates("deathsquad")
+
+	if(!candidates.len)
+		return NOT_ENOUGH_PLAYERS
+
+	var/mob/dead/observer/chosen_candidate = pick(candidates)
+
+	//Create the official
+	var/turf/T = pick(emergencyresponseteamspawn)
+	if(!T)
+		return MAP_ERROR
+
+	var/mob/living/carbon/human/newmob = new(T)
+
+	chosen_candidate.client.prefs.copy_to(newmob)
+	newmob.real_name = newmob.dna.species.random_name(newmob.gender,1)
+	newmob.dna.update_dna_identity()
+	newmob.key = chosen_candidate.key
+	newmob.mind.assigned_role = "Centcom Official"
+	newmob.equipOutfit(/datum/outfit/centcom_official)
+
+	//Assign antag status and the mission
+	ticker.mode.traitors += newmob.mind
+	newmob.mind.special_role = "official"
+	var/datum/objective/missionobj = new
+	missionobj.owner = newmob.mind
+	missionobj.explanation_text = mission
+	missionobj.completed = 1
+	newmob.mind.objectives += missionobj
+
+	if(config.enforce_human_authority)
+		newmob.set_species(/datum/species/human)
+
+	//Greet the official
+	newmob << "<B><font size=3 color=red>You are a Centcom Official.</font></B>"
+	newmob << "<BR>Central Command is sending you to [station_name()] with the task: [mission]"
+
+	//Logging and cleanup
+	message_admins("Centcom Official [key_name_admin(newmob)] has spawned with the task: [mission]")
+	log_game("[key_name(newmob)] has been selected as a Centcom Official")
+	return SUCCESSFUL_SPAWN

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1184,6 +1184,7 @@
 #include "code\modules\events\ghost_role.dm"
 #include "code\modules\events\grid_check.dm"
 #include "code\modules\events\immovable_rod.dm"
+#include "code\modules\events\inspection.dm"
 #include "code\modules\events\ion_storm.dm"
 #include "code\modules\events\major_dust.dm"
 #include "code\modules\events\mass_hallucination.dm"


### PR DESCRIPTION
No change in gameplay, Centcom Inspector is still an admin only event.

But this change will allow it to be easy to enable Centcom Inspector as
a random event, if this is decided in the future.