### PR TITLE
Romerol gets its discount chance back

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -638,7 +638,6 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "A highly experimental bioterror agent which creates dormant nodules to be etched into the grey matter of the brain. On death, these nodules take control of the dead body, causing limited revivification, along with slurred speech, aggression, and the ability to infect others with this agent."
 	item = /obj/item/weapon/storage/box/syndie_kit/romerol
 	cost = 25
-	cant_discount = TRUE
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 
 /datum/uplink_item/stealthy_weapons/dart_pistol


### PR DESCRIPTION
Reverts #23801 

> We introduce first new interesting traitor item in years
>Shocker - people buy it because its new and novel
>Kneejerk PR removes its discount despite it impacting only a small percentage of rounds
>Have literally seen 0 Romerol purchases since the PR

I gave it 2 weeks to see how things would change, there's simply not enough interest in the item to get people to donate TC for it. Romerol is fun. 