### PR TITLE
Hulks can no longer use Pneumatic Cannons or Flamethrowers

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -63,8 +63,6 @@
 /obj/item/weapon/flamethrower/afterattack(atom/target, mob/living/carbon/human/user, flag)
 	if(flag) 
 		return // too close  
-	if(!istype(user))
-		return
 	if(user.dna.check_mutation(HULK))
 		user << "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>"
 		return

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -63,12 +63,12 @@
 /obj/item/weapon/flamethrower/afterattack(atom/target, mob/user, flag)
 	if(flag) 
 		return // too close  
-	if(iscarbon)
-		mob/living/carbon/C = user
-		if(C.dna.check_mutation(HULK))
+	if(ishuman(user))
+		mob/living/carbon/human/H = user
+		if(H.dna.check_mutation(HULK))
 			user << "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>"
 			return
-		if(NOGUNS in C.dna.species.species_traits)
+		if(NOGUNS in H.dna.species.species_traits)
 			user << "<span class='warning'>Your fingers don't fit in the trigger guard!</span>"
 			return
 	if(user && user.get_active_held_item() == src) // Make sure our user is still holding us

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -64,7 +64,7 @@
 	if(flag) 
 		return // too close  
 	if(ishuman(user))
-		mob/living/carbon/human/H = user
+		var/mob/living/carbon/human/H = user
 		if(H.dna.check_mutation(HULK))
 			user << "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>"
 			return

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -60,15 +60,17 @@
 		item_state = "flamethrower_0"
 	return
 
-/obj/item/weapon/flamethrower/afterattack(atom/target, mob/living/carbon/human/user, flag)
+/obj/item/weapon/flamethrower/afterattack(atom/target, mob/user, flag)
 	if(flag) 
 		return // too close  
-	if(user.dna.check_mutation(HULK))
-		user << "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>"
-		return
-	if(NOGUNS in user.dna.species.species_traits)
-		user << "<span class='warning'>Your fingers don't fit in the trigger guard!</span>"
-		return
+	if(iscarbon)
+		mob/living/carbon/C = user
+		if(C.dna.check_mutation(HULK))
+			user << "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>"
+			return
+		if(NOGUNS in C.dna.species.species_traits)
+			user << "<span class='warning'>Your fingers don't fit in the trigger guard!</span>"
+			return
 	if(user && user.get_active_held_item() == src) // Make sure our user is still holding us
 		var/turf/target_turf = get_turf(target)
 		if(target_turf)

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -60,8 +60,9 @@
 		item_state = "flamethrower_0"
 	return
 
-/obj/item/weapon/flamethrower/afterattack(atom/target, var/mob/living/carbon/human/user, flag)
-	if(flag) return // too close  
+/obj/item/weapon/flamethrower/afterattack(atom/target, mob/living/carbon/human/user, flag)
+	if(flag) 
+		return // too close  
 	if(!istype(user))
 		return
 	if(user.dna.check_mutation(HULK))

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -61,14 +61,16 @@
 	return
 
 /obj/item/weapon/flamethrower/afterattack(atom/target, var/mob/living/carbon/human/user, flag)
-	if(flag) return // too close  // Make sure our user is still holding us
+	if(flag) return // too close  
+	if(!istype(user))
+		return
 	if(user.dna.check_mutation(HULK))
 		user << "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>"
 		return
 	if(NOGUNS in user.dna.species.species_traits)
 		user << "<span class='warning'>Your fingers don't fit in the trigger guard!</span>"
 		return
-	if(user && user.get_active_held_item() == src)
+	if(user && user.get_active_held_item() == src) // Make sure our user is still holding us
 		var/turf/target_turf = get_turf(target)
 		if(target_turf)
 			var/turflist = getline(user, target_turf)

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -60,9 +60,14 @@
 		item_state = "flamethrower_0"
 	return
 
-/obj/item/weapon/flamethrower/afterattack(atom/target, mob/user, flag)
-	if(flag) return // too close
-	// Make sure our user is still holding us
+/obj/item/weapon/flamethrower/afterattack(atom/target, var/mob/living/carbon/human/user, flag)
+	if(flag) return // too close  // Make sure our user is still holding us
+	if(user.dna.check_mutation(HULK))
+		user << "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>"
+		return
+	if(NOGUNS in user.dna.species.species_traits)
+		user << "<span class='warning'>Your fingers don't fit in the trigger guard!</span>"
+		return
 	if(user && user.get_active_held_item() == src)
 		var/turf/target_turf = get_turf(target)
 		if(target_turf)

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -81,6 +81,12 @@
 	if(!istype(user) && !target)
 		return
 	var/discharge = 0
+	if(user.dna.check_mutation(HULK))
+		user << "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>"
+		return
+	if(NOGUNS in user.dna.species.species_traits)
+		user << "<span class='warning'>Your fingers don't fit in the trigger guard!</span>"
+		return
 	if(!loadedItems || !loadedWeightClass)
 		user << "<span class='warning'>\The [src] has nothing loaded.</span>"
 		return

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -77,7 +77,7 @@
 	Fire(user, target)
 
 
-/obj/item/weapon/pneumatic_cannon/proc/Fire(var/mob/living/carbon/human/user, var/atom/target)
+/obj/item/weapon/pneumatic_cannon/proc/Fire(mob/living/carbon/human/user, var/atom/target)
 	if(!istype(user) && !target)
 		return
 	var/discharge = 0


### PR DESCRIPTION
Fixes #24081

Edit: Gave flamethrowers back to drones #ThanksKor
Edit2: This also includes the species check that locks out ash lizards and golems I think

:cl: Robustin
tweak: Hulks can no longer use pneumatic cannons or flamethrowers
/:cl:

