### PR TITLE
Revert "[READY]Asay and dsay radio keys"

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -2,21 +2,9 @@
 /mob/verb/say_verb(message as text)
 	set name = "Say"
 	set category = "IC"
-
-	if(findtext(message, ":p", 1, 3))
-		if(client)
-			client.cmd_admin_say(trim(replacetext(message, ":p", 1, 3)))
-		return
-
 	if(say_disabled)	//This is here to try to identify lag problems
 		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
 		return
-
-	if(findtext(message, ":d", 1, 3))
-		if(client)
-			client.dsay(trim(replacetext(message, ":d", 1, 3)))
-		return
-
 	usr.say(message)
 
 /mob/verb/whisper(message as text)


### PR DESCRIPTION
Reverts tgstation/tgstation#24341

@Cyberboss 

do it right or not at all.

doesn't include the alt formats like . or #

doesn't remove the key from the message.