### PR TITLE
Makes the shuttle harder to call (2017 edition)

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -139,6 +139,10 @@
 	var/list/midround_antag = list() 	// which roundtypes use the midround antagonist system
 	var/midround_antag_time_check = 60  // How late (in minutes) you want the midround antag system to stay on, setting this to 0 will disable the system
 	var/midround_antag_life_check = 0.7 // A ratio of how many people need to be alive in order for the round not to immediately end in midround antagonist
+	var/shuttle_boredom_check = 60 		// """Optimal""" round length time (in minutes), used as a guide for calling the shuttle in the abscence of any other issue to face
+	var/shuttle_life_check = 0.7		// A ratio of how many people need to be alive in order for the shuttle to not justify that as a reason for coming.
+	var/shuttle_antag_overrun = 0.5		// A ratio of dirty traitors to all living crew. If this is achieved the shuttle can come (most likely in revolution/gang/quick moving low pop cults).
+	var/shuttle_infrastructure_check = 0.7 // A ratio of "how blown up / singulo'd / tesla'd the station is", again to gauge shuttle calls.
 	var/shuttle_refuel_delay = 12000
 	var/show_game_type_odds = 0			//if set this allows players to see the odds of each roundtype on the get revision screen
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
@@ -588,6 +592,14 @@
 					config.midround_antag_time_check = text2num(value)
 				if("midround_antag_life_check")
 					config.midround_antag_life_check = text2num(value)
+				if("shuttle_boredom_check")
+					config.shuttle_boredom_check	= text2num(value)
+				if("shuttle_life_check")
+					config.shuttle_life_check 		= text2num(value)
+				if("shuttle_antag_overrun")
+					config.shuttle_antag_overrun 	= text2num(value)
+				if("shuttle_infrastructure_check")
+					config.shuttle_infrastructure_check = text2num(value)
 				if("min_pop")
 					var/pop_pos = findtext(value, " ")
 					var/mode_name = null

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -25,6 +25,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	var/area/emergencyLastCallLoc
 	var/emergencyCallAmount = 0		//how many times the escape shuttle was called
 	var/emergencyNoEscape
+	var/force_shuttle = 0			//Even in abscence of danger, the shuttle will come.
 	var/list/hostileEnvironments = list()
 
 		//supply shuttle stuff

--- a/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
@@ -24,6 +24,7 @@
 	var/image/alert_overlay = image('icons/effects/clockwork_effects.dmi', "ratvar_alert")
 	var/area/A = get_area(src)
 	notify_ghosts("The Justiciar's light calls to you! Reach out to Ratvar in [A.name] to be granted a shell to spread his glory!", null, source = src, alert_overlay = alert_overlay)
+	SSshuttle.force_shuttle = 1
 	addtimer(CALLBACK(SSshuttle.emergency, /obj/docking_port/mobile/emergency..proc/request, null, 0.1), 50)
 
 /obj/structure/destructible/clockwork/massive/ratvar/Destroy()

--- a/code/game/gamemodes/gang/gang_datum.dm
+++ b/code/game/gamemodes/gang/gang_datum.dm
@@ -95,6 +95,7 @@
 	set_domination_time(determine_domination_time(src) * modifier)
 	is_dominating = TRUE
 	set_security_level("delta")
+	SSshuttle.force_shuttle = 1
 
 /datum/gang/proc/set_domination_time(d)
 	domination_timer = world.time + (10 * d)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -21,6 +21,7 @@
 	var/nukes_left = 1 // Call 3714-PRAY right now and order more nukes! Limited offer!
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level
+	var/syndies_made_contact = 0 //Used for tracking when (if?) the syndicates actually manage to step foot on space station 13
 
 /datum/game_mode/nuclear/pre_setup()
 	var/n_players = num_players()
@@ -164,6 +165,14 @@
 		return 1
 	return ..()
 
+/datum/game_mode/nuclear/proc/are_operatives_onsite()
+	for(var/datum/mind/operative_mind in syndicates)
+		if(ismob(operative_mind.current))
+			var/mob/M = operative_mind.current
+			if(!M.stat && isarea(M.loc) && M.loc in the_station_areas)
+				syndies_made_contact = 1
+				SSshuttle.force_shuttle = 1
+
 /datum/game_mode/proc/are_operatives_dead()
 	for(var/datum/mind/operative_mind in syndicates)
 		if(ishuman(operative_mind.current) && (operative_mind.current.stat!=2))
@@ -175,6 +184,8 @@
 		return replacementmode.check_finished()
 	if((SSshuttle.emergency.mode == SHUTTLE_ENDGAME) || station_was_nuked)
 		return 1
+	if(!syndies_made_contact)
+		are_operatives_onsite()
 	if(are_operatives_dead())
 		if(bomb_set) //snaaaaaaaaaake! It's not over yet!
 			return 0

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -381,6 +381,7 @@ var/bomb_set
 		for(var/obj/item/weapon/pinpointer/syndicate/S in pinpointer_list)
 			S.switch_mode_to(TRACK_INFILTRATOR)
 		countdown.start()
+		SSshuttle.force_shuttle = 1
 	else
 		bomb_set = FALSE
 		detonation_timer = null

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -299,6 +299,13 @@
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] edited the Emergency Shuttle's timeleft to [timer] seconds.</span>")
 		href_list["secrets"] = "check_antagonist"
 
+	else if(href_list["force_shuttle"])
+		if(!check_rights(R_ADMIN) || SSshuttle.force_shuttle)	return
+
+		SSshuttle.force_shuttle = 1
+		log_admin("[key_name(usr)] allowed the Emergency Shuttle to come.")
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] allowed the Emergency Shuttle to come.</span>")
+
 	else if(href_list["toggle_continuous"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -640,6 +640,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(confirm != "Yes")
 		return
 
+	SSshuttle.force_shuttle = 1
 	SSshuttle.emergency.request()
 	feedback_add_details("admin_verb","CSHUT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	log_admin("[key_name(usr)] admin-called the emergency shuttle.")

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -36,6 +36,7 @@
 	narsie_spawn_animation()
 
 	sleep(70)
+	SSshuttle.force_shuttle = 1
 	SSshuttle.emergency.request(null, 0.1) // Cannot recall
 
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -209,6 +209,25 @@
 		if(SHUTTLE_RECALL, SHUTTLE_IDLE, SHUTTLE_CALL)
 			mode = SHUTTLE_CALL
 			setTimer(call_time)
+			if(!legitimize_call())
+				var/time_to_recall = rand(600,1200) //Values selected so call is before the point of no return even in code red
+				var/old_timer = timer
+				spawn(time_to_recall)
+					if(mode == SHUTTLE_CALL && timer == old_timer && !SSshuttle.force_shuttle)
+						cancel(/area/centcom)
+						var/intercepttext = "<FONT size = 3><b>NanoTrasen Update</b>: Request For Shuttle.</FONT><HR>\
+											To whom it may concern:<BR><BR>\
+											We have taken note of the situation upon [station_name()] and have come to the \
+											conclusion that it does not warrant the abandonment of the station.<BR>\
+											If you do not agree with our opinion we suggest that you open a direct \
+											line with us and explain the nature of your crisis.<BR><BR>\
+											<i>This message has been automatically generated based upon readings from long \
+											range diagnostic tools. To assure the quality of your request every finalized report \
+											is reviewed by an on-call rear admiral.<BR>\
+											<b>Rear Admiral's Notes:</b> \
+											[pick("Do you know how expensive these stations are?","Stop wasting my time.","I was sleeping, thanks a lot.","Stand and fight you cowards!","You knew the risks coming in.","Stop being paranoid.","Whatever's broken just build a new one.","No.", "<i>null</i>","<i>Error: No comment given.</i>")]"
+						print_command_report(intercepttext,"Classified [command_name()] Update")
+						priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
 		else
 			return
 
@@ -220,6 +239,44 @@
 		SSshuttle.emergencyLastCallLoc = null
 
 	priority_announce("The emergency shuttle has been called. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/AI/shuttlecalled.ogg', "Priority")
+
+/obj/docking_port/mobile/emergency/proc/legitimize_call() //Checks are sorted in rough order of processing cost
+	if(SSshuttle.force_shuttle) //Set manually by certain "Oh shit" events, like narsie.
+		message_admins("Shuttle will arrive due to you know what.")
+		return 1
+
+	if(world.time >= (config.shuttle_boredom_check * 600)) //Extended mercy and/or boring/ineffective antags
+		message_admins("Shuttle will arrive due to long round length.")
+		return 1
+
+	var/list/living_crew_bodies = list()
+	var/list/living_crew_minds	= list()
+	for(var/mob/Player in mob_list)
+		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player))
+			living_crew_bodies	+= Player
+			living_crew_minds	+= Player.mind
+
+	if(living_crew_bodies.len / joined_player_list.len <= config.shuttle_life_check) //Dead people everywhere
+		message_admins("Shuttle will arrive due to rampant death.")
+		return 1
+
+	var/list/antagonist_crew_minds	= list()
+	for(var/datum/mind/M in living_crew_minds)
+		if(M.special_role)
+			antagonist_crew_minds += M
+
+	if(antagonist_crew_minds.len / living_crew_minds.len >= config.shuttle_antag_overrun) //Station ruled by antags
+		message_admins("Shuttle will arrive due to antagonist infestation.")
+		return 1
+
+	var/datum/station_state/current_state = new /datum/station_state()
+	current_state.count()
+	if((start_state.score(current_state)) < config.shuttle_infrastructure_check) //Station bombed to hell/singulo'd
+		message_admins("Shuttle will arrive due to badly damaged station.")
+		return 1
+
+	message_admins("Shuttle will recall automatically. If you feel the shuttle should come, <A HREF='?_src_=holder;force_shuttle=\ref[usr]'>click here</A>.")
+	return 0
 
 /obj/docking_port/mobile/emergency/cancel(area/signalOrigin)
 	if(mode != SHUTTLE_CALL)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -141,6 +141,18 @@ MIDROUND_ANTAG BLOB
 #MIDROUND_ANTAG  RAGINMAGES
 #MIDROUND_ANTAG  MONKEY
 
+##A time in minutes a round must progress before a shuttle call can be successful without anything being very wrong with the station.
+SHUTTLE_BOREDOM_CHECK 60
+
+##A ratio (living crew/all crew) used to determine if mass crewmember death is a valid reason to call the shuttle
+SHUTTLE_LIFE_CHECK 0.7
+
+##A ratio (living antag crew/all living crew) used to determine if mass antags is a valid reason to call the shuttle
+SHUTTLE_ANTAG_OVERRUN 0.5
+
+##A ratio (current station/initial station) used to determine if a badly damaged station is a valid reason to call the shuttle
+SHUTTLE_INFRASTRUCTURE_CHECK 0.7
+
 ## Uncomment for overrides of the minimum / maximum number of players in a round type. 
 ## If you set any of these occasionally check to see if you still need them as the modes
 ## will still be actively rebalanced around the SUGGESTED populations, not your overrides.


### PR DESCRIPTION
Resurrects a pull of mine from 2015 (#13190) at the suggestion of @Cheridan

Code is still essentially the same, only addition is that I've added a command report on recall to give the crew some feedback.

Original PR description follows:
---
I've seen it happen far too often, the station passes the 25 minute mark, the antags are lurking in secret, the round is developing... Then someone demands a law 2 shuttle call for no real reason and everyone's forced to scramble and rush to finish their objectives in time in the name of 40 minute rounds.

Well no more. This adds actual checks to assure that a round has ACTUALLY GONE TO POT before the shuttle can be called.

The shuttle will auto recall if ALL the following are true:

1. A certain percentage of players are still alive (Defaults to 70%)
2. A certain percentage of players alive aren't antags (Defaults to 50%)
3. The station isn't damaged more than a certain rating (Defaults to 70% integrity)
4. The round hasn't gone over a certain length of time (Defaults to 1 hour)

Beyond this certain traumatic events will also always allow the shuttle to come at any point afterwards:

1. Code Delta AI
2. Live Nuke
3. Gang Takeover Attempt
4. Nar-Nar and/or Ratvar
5. Admin Shuttle Call
6. Nuke ops on the station

(2017 note: I've added Ratvar to this list obviously, tell me if there's any other new situations that warrant this treatment)

Beyond this if a shuttle call WOULD recall, the admins will also get a message that allows them to have the shuttle come anyway according to their judgment.

If all this is avoided, the shuttle will autorecall at some random point between one and two minutes after calling. If the recall is traced, it's labeled as coming from centcom

This makes running from threats a less viable strategy. Stand and fight!

:cl:
rscadd: Citing frustrations at the seemingly constant abandonment of 'like new' space stations, centcom has clamped down on flighty shuttle calls made on flimsy pretenses.
/:cl: