### PR TITLE
Ebow damage nerf

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -155,7 +155,7 @@
 /obj/item/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 15
+	damage = 8
 	damage_type = TOX
 	nodamage = 0
 	weaken = 5


### PR DESCRIPTION
Pretty simple, if your weapon has infinite stuns forever, it shouldn't be about as powerful as a laser with a harder-to-heal and much more discrete form of damage. 

Currently you've got about 15 seconds after the first shot to scream for help before the toxin spam does you in. This change will either force the traitor to use a melee weapon to finish you (more likely to leave blood, evidence, find the body, etc.), or rekindle the ancient art of stripping headsets. 
