### PR TITLE
fix parallax

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -235,6 +235,7 @@
 			var/image/I = image(icon, null, icon_state)
 			I.transform = matrix(1, 0, x*480, 0, 1, y*480)
 			new_overlays += I
+	cut_overlays()
 	add_overlay(new_overlays)
 	view_sized = view
 


### PR DESCRIPTION
also fixes some client lag with parallax since the overlay update.

before the overlay update, this would have set the overlay list to the new overlay list (basically doing what the overlay update does for all overlays, but manually). @Cyberboss added in the add_overlay but didn't add a cut_overlays

Speaking of that, we need a replace_overlays or set_overlays function.

fixes #24404