### PR TITLE
Syndiebeacon now tracks engine

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -22,7 +22,7 @@
 	if(surplus() < 1500)
 		if(user) user << "<span class='notice'>The connected wire doesn't have enough current.</span>"
 		return
-	for(var/obj/singularity/singulo in world)
+	for(var/obj/singularity/singulo in poi_list)
 		if(singulo.z == z)
 			singulo.target = src
 	icon_state = "[icontype]1"
@@ -34,7 +34,7 @@
 
 
 /obj/machinery/power/singularity_beacon/proc/Deactivate(mob/user = null)
-	for(var/obj/singularity/singulo in world)
+	for(var/obj/singularity/singulo in poi_list)
 		if(singulo.target == src)
 			singulo.target = null
 	icon_state = "[icontype]0"
@@ -90,7 +90,7 @@
 			add_load(1500)
 			if(cooldown <= world.time)
 				cooldown = world.time + 100
-				for(var/obj/singularity/singulo in world)
+				for(var/obj/singularity/singulo in poi_list)
 					if(singulo.z == z)
 						say("The [singulo] is now [get_dist(src,singulo)] standard lengths away to the [dir2text(get_dir(src,singulo))]")
 		else

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -13,7 +13,7 @@
 	stat = 0
 	verb_say = "beeps"
 	verb_exclaim = "beeps"
-	var/cooldown = 9999
+	var/cooldown = 999999
 	var/active = 0
 	var/icontype = "beacon"
 

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -83,7 +83,6 @@
 
 //stealth direct power usage
 /obj/machinery/power/singularity_beacon/process()
-	say("Process")
 	if(!active)
 		return PROCESS_KILL
 	else

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -11,9 +11,9 @@
 	density = 1
 	layer = BELOW_MOB_LAYER //so people can't hide it and it's REALLY OBVIOUS
 	stat = 0
-	verb_say = "beeps"
-	verb_exclaim = "beeps"
-	var/cooldown = 999999
+	verb_say = "states"
+	var/cooldown = 0
+
 	var/active = 0
 	var/icontype = "beacon"
 
@@ -28,6 +28,7 @@
 	icon_state = "[icontype]1"
 	active = 1
 	machines |= src
+	START_PROCESSING(SSobj, src)
 	if(user)
 		user << "<span class='notice'>You activate the beacon.</span>"
 
@@ -82,18 +83,21 @@
 
 //stealth direct power usage
 /obj/machinery/power/singularity_beacon/process()
+	say("Process")
 	if(!active)
 		return PROCESS_KILL
 	else
 		if(surplus() > 1500)
 			add_load(1500)
-			for(var/obj/singularity/singulo in world)
-				if(singulo.z == z && (world.time < cooldown)
-					speak("The [singulo] is now [get_dist(src,singulo)] standard lengths away to the [get_dir(src,singulo)]")
-			cooldown = world.time + 1000				
+			if(cooldown <= world.time)
+				cooldown = world.time + 100
+				for(var/obj/singularity/singulo in world)
+					if(singulo.z == z)
+						say("The [singulo] is now [get_dist(src,singulo)] standard lengths away to the [dir2text(get_dir(src,singulo))]")
 		else
 			Deactivate()
-
+			say("Insufficient charge detected - powering down")
+		
 
 /obj/machinery/power/singularity_beacon/syndicate
 	icontype = "beaconsynd"

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -11,7 +11,9 @@
 	density = 1
 	layer = BELOW_MOB_LAYER //so people can't hide it and it's REALLY OBVIOUS
 	stat = 0
-
+	verb_say = "beeps"
+	verb_exclaim = "beeps"
+	var/cooldown = 9999
 	var/active = 0
 	var/icontype = "beacon"
 
@@ -85,6 +87,10 @@
 	else
 		if(surplus() > 1500)
 			add_load(1500)
+			for(var/obj/singularity/singulo in world)
+				if(singulo.z == z && (world.time < cooldown)
+					speak("The [singulo] is now [get_dist(src,singulo)] standard lengths away to the [get_dir(src,singulo)]")
+			cooldown = world.time + 1000				
 		else
 			Deactivate()
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -58,7 +58,7 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 	if(!orbiting)
 		handle_energy()
 
-		move_the_basket_ball(4)
+		move_the_basket_ball(4 + orbiting_balls.len * 1.5)
 
 		playsound(src.loc, 'sound/magic/lightningbolt.ogg', 100, 1, extrarange = 30)
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -58,7 +58,7 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 	if(!orbiting)
 		handle_energy()
 
-		move_the_basket_ball(round(2 + orbiting_balls.len * .1))
+		move_the_basket_ball(round(3 + orbiting_balls.len * .1))
 
 		playsound(src.loc, 'sound/magic/lightningbolt.ogg', 100, 1, extrarange = 30)
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -58,7 +58,7 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 	if(!orbiting)
 		handle_energy()
 
-		move_the_basket_ball(round(3 + orbiting_balls.len * .1))
+		move_the_basket_ball(4)
 
 		playsound(src.loc, 'sound/magic/lightningbolt.ogg', 100, 1, extrarange = 30)
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -58,7 +58,7 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 	if(!orbiting)
 		handle_energy()
 
-		move_the_basket_ball(4 + orbiting_balls.len * 1.5)
+		move_the_basket_ball(round(2 + orbiting_balls.len * .1))
 
 		playsound(src.loc, 'sound/magic/lightningbolt.ogg', 100, 1, extrarange = 30)
 


### PR DESCRIPTION
Syndiebeacon calling out distance and direction of the engine is just a QOL feature for an underused item. After messing around with it I just found it too frustrating when the tesla/sing can destroy it or pull it from the edge of your screen, you simply don't get enough time to move this device and use it to its full potential.

This also fixes an (unreported?) issue where the processing for the beacon never worked. Processing would stop immediately upon creation and there was nothing in the code to get it started again, so the beacon could be turned on and then have all power cut and it would still function until destroyed or turned off. 

:cl: Robustin
add: The syndicate power beacon will now announce the distance and direction of any engines every 10 seconds.
/:cl:
