### PR TITLE
Fixes ID Access For Player Sleepers & Fixes Space Bar Access To Kitchen Freezer 

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -147,7 +147,9 @@
 /turf/closed/wall,
 /area/ruin/powered/spacebar/bar)
 "aG" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = null
+	},
 /turf/open/floor/wood,
 /area/ruin/powered/spacebar/bar)
 "aH" = (

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -349,7 +349,7 @@
 	glasses = /obj/item/clothing/glasses/sunglasses/reagent
 	has_id = 1
 	id_job = "Bartender"
-	id_access = "Bartender"
+	id_access_list = list(access_bar)
 
 /obj/effect/mob_spawn/human/bartender/alive
 	death = FALSE
@@ -386,7 +386,7 @@
 	glasses = /obj/item/clothing/glasses/sunglasses
 	has_id = 1
 	id_job = "Bridge Officer"
-	id_access = "Captain"
+	id_access_list = list(access_cent_captain)
 
 /obj/effect/mob_spawn/human/commander
 	name = "Commander"
@@ -401,7 +401,7 @@
 	pocket1 = /obj/item/weapon/lighter
 	has_id = 1
 	id_job = "Commander"
-	id_access = "Captain"
+	id_access_list = list(access_cent_captain)
 
 /obj/effect/mob_spawn/human/nanotrasensoldier
 	name = "Nanotrasen Private Security Officer"
@@ -414,7 +414,7 @@
 	back = /obj/item/weapon/storage/backpack/security
 	has_id = 1
 	id_job = "Private Security Force"
-	id_access = "Security Officer"
+	id_access_list = list(access_cent_specops)
 
 /obj/effect/mob_spawn/human/commander/alive
 	death = FALSE


### PR DESCRIPTION
## **Fixes ID Access For Player Sleepers & Fixes Space Bar Access To Kitchen Freezer** 
Changes ID Access for the kitchen freezer to null to allow for anyone including the space barman to access the freezer. This Pull Request also fixes id_access in corpse.dm to id_access_list so that people who spawn on a ruin via a player sleeper/spawner get proper access for their ID that they spawn in with.

## **Changelog**
:cl: Tofa01
Fix: Fixes space bar kitchen freezer access level
Fix: Fixes giving IDs proper access for players who spawn on a ruin via a player sleeper/spawners
/:cl:

## **Fixes #24416**