### PR TITLE
[Omega] Fixes ORM Input And Output Directions

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -9179,9 +9179,6 @@
 	})
 "aoh" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/mineral/ore_redemption{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9189,6 +9186,10 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 4;
+	output_dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)


### PR DESCRIPTION
## **Fixes ORM Input And Output Directions On Omegastation**
Fixes the Ore Redemption Module input and output directions so that the machine can be used without the need to move it into another position. This Pull Request should allow for the more easy use of the Ore Redemption Module on Omegastation.

## **Images**
![orm](https://cloud.githubusercontent.com/assets/24999255/23327505/615734f0-fb61-11e6-802d-917ddf43571c.PNG)
_Red box - new input and output directions_
_Green box - old input and output directions_

## **Changelog**
:cl: Tofa01
Fix: [Omega] Fixes ORM input and output directions
/:cl:
