### PR TITLE
Fixes Robotic Limb Repair Grammar Issue

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -421,7 +421,7 @@ var/static/regex/firstname = new("^\[^\\s-\]+") //First word before whitespace o
 			user.visible_message("[user] has fixed some of the [dam ? "dents on" : "burnt wires in"] [H]'s [affecting].", "<span class='notice'>You fix some of the [dam ? "dents on" : "burnt wires in"] [H]'s [affecting].</span>")
 			return 1 //successful heal
 		else
-			user << "<span class='warning'>[H]'s [affecting] is already in good condition!</span>"
+			user << "<span class='warning'>[affecting] is already in good condition!</span>"
 
 
 /proc/IsAdminGhost(var/mob/user)


### PR DESCRIPTION
## **Fixes Robotic Limb Repair Grammar Issue**
Fixes a grammar issue when repairing robotic limbs when a part is fully healed instead of saying "Zion Murphy's the cyborg right arm is already in good condition!" it will now read as "the cyborg right arm is already in good condition!" this makes more sense grammar wise.

## **Changelog**
:cl: Tofa01
Fix: Fixes robotic limb repair grammar issue
/:cl:

## **Fixes #24428**