### PR TITLE
gives weapons a chance to knock away other weapons when targeting the arms

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1169,6 +1169,24 @@
 						H.w_uniform.add_mob_blood(H)
 						H.update_inv_w_uniform()
 
+			if("l_hand")//might be l_arm
+				if(H.stat == CONSCIOUS && armor_block < 50)
+					if(prob(I.force))
+						if(H.held_items[1])//left = 1, right = 2
+							var/obj/item/itemToThrow = H.held_items[1]
+							if(H.dropItemToGround(itemToThrow))
+								itemToThrow.throw_at(pick(oview(rand(3,5),get_turf(H))),1,1)
+								H.visible_message("<span class='warning'>[itemToThrow] is knocked flying from [H]s hands!</span>")
+
+			if("r_hand")
+				if(H.stat == CONSCIOUS && armor_block < 50)
+					if(prob(I.force))
+						if(H.held_items[2])//left = 1, right = 2
+							var/obj/item/itemToThrow = H.held_items[2]
+							if(H.dropItemToGround(itemToThrow))
+								itemToThrow.throw_at(pick(oview(rand(3,5),get_turf(H))),1,1)
+								H.visible_message("<span class='warning'>[itemToThrow] is knocked flying from [H]s hands!</span>")
+
 		if(Iforce > 10 || Iforce >= 5 && prob(33))
 			H.forcesay(hit_appends)	//forcesay checks stat already.
 	return TRUE


### PR DESCRIPTION
So if you target the left arm and they're holding a thing in their left hand, you have a %chance (equal to the force of the weapon you are using) to knock away their weapon 3 to 5 tiles away.

Inspired by https://github.com/tgstation/tgstation/pull/24293

DNM for now since it doesn't appear to actually work upon testing, no runtimes but the checks never pass(?) and the items are never thrown away.

🆑
add: Targeting the arms when attacking with a melee weapon now has a chance to knock whatever your opponent may be holding in that arm out of their hand.
/:cl: