### PR TITLE
Removes roundstart singularity, adds roundstart supermatter, supermatter now collapes into singularity

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -7342,7 +7342,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
 	name = "Reflector Access";
-	req_access_txt = "24"
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -7365,7 +7366,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
 	name = "Reflector Access";
-	req_access_txt = "24"
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -11355,14 +11357,7 @@
 	name = "Atmospherics Engine"
 	})
 "avQ" = (
-/obj/machinery/power/supermatter_shard{
-	anchored = 1;
-	base_icon_state = "darkmatter";
-	explosion_power = 20;
-	gasefficency = 0.15;
-	icon_state = "darkmatter";
-	name = "supermatter crystal"
-	},
+/obj/machinery/power/supermatter_shard/crystal,
 /turf/open/floor/engine,
 /area/engine/gravity_generator{
 	name = "Atmospherics Engine"
@@ -12466,7 +12461,8 @@
 "axR" = (
 /obj/machinery/door/airlock/glass_atmos{
 	name = "Supermatter Chamber";
-	req_access_txt = "24"
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/engine,
 /area/engine/gravity_generator{
@@ -16800,10 +16796,6 @@
 "aFc" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
-	req_access_txt = "24"
-	},
 /obj/structure/cable/white{
 	tag = "icon-1-2";
 	icon_state = "1-2"
@@ -16811,6 +16803,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/plasteel{
 	tag = "icon-plasteel_warn_side (EAST)"
@@ -16837,13 +16834,14 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Engine Access";
-	req_access_txt = "24"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Engine Access";
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/plasteel{
 	tag = "icon-plasteel_warn_side (EAST)"
@@ -19054,12 +19052,13 @@
 "aJa" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
-	req_access_txt = "24"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/plasteel{
 	tag = "icon-plasteel_warn_side (EAST)"
@@ -19076,12 +19075,13 @@
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Engine Access";
-	req_access_txt = "24"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Engine Access";
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/plasteel{
 	tag = "icon-plasteel_warn_side (EAST)"
@@ -24868,7 +24868,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_atmos{
 	name = "Atmospherics Storage";
-	req_access_txt = "24"
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -29946,7 +29947,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_atmos{
 	name = "Atmospherics Storage";
-	req_access_txt = "24"
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -39091,16 +39093,17 @@
 /area/atmos)
 "bsB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
-	req_access_txt = "24"
-	},
 /obj/structure/cable/white{
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/plasteel{
 	tag = "icon-plasteel_warn_side (EAST)"
@@ -40723,16 +40726,17 @@
 /area/engine/break_room)
 "bvr" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
-	req_access_txt = "24"
-	},
 /obj/structure/cable/white{
 	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_access_txt = "0";
+	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/plasteel{
 	tag = "icon-plasteel_warn_side (EAST)"
@@ -58379,10 +58383,6 @@
 /area/engine/engineering)
 "bZg" = (
 /obj/structure/cable/white,
-/obj/machinery/power/emitter{
-	anchored = 1;
-	state = 2
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -58441,6 +58441,7 @@
 	},
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
+/obj/structure/barricade/wooden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZm" = (
@@ -61640,6 +61641,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ceF" = (
@@ -62295,7 +62297,6 @@
 /turf/open/space,
 /area/space)
 "cfU" = (
-/obj/machinery/power/grounding_rod,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -62308,7 +62309,6 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "cfW" = (
-/obj/machinery/power/tesla_coil,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -62316,7 +62316,6 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "cfX" = (
-/obj/machinery/power/grounding_rod,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -62353,6 +62352,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfZ" = (
@@ -63060,6 +63060,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "chu" = (
@@ -64047,7 +64048,6 @@
 /turf/open/space,
 /area/space)
 "ciY" = (
-/obj/machinery/power/tesla_coil,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -64078,6 +64078,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plasteel{
 	tag = "icon-plasteel_warn_side (EAST)"
 	},
@@ -64801,6 +64802,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ckw" = (
@@ -65459,14 +65461,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "clN" = (
-/obj/structure/particle_accelerator/particle_emitter/left{
-	tag = "icon-emitter_left (WEST)";
-	icon_state = "emitter_left";
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "clO" = (
@@ -65476,7 +65474,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "clP" = (
-/obj/machinery/particle_accelerator/control_box,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -65514,6 +65511,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "clT" = (
@@ -66147,6 +66145,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cni" = (
@@ -66215,7 +66214,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cno" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start{
+	name = "Station Engineer"
+	},
 /turf/open/floor/plasteel/yellow,
 /area/engine/engineering)
 "cnp" = (
@@ -67965,6 +67966,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqj" = (
@@ -68058,7 +68060,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqs" = (
-/obj/machinery/the_singularitygen,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -69474,6 +69475,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "csX" = (
@@ -70471,7 +70473,6 @@
 	name = "\improper Recreation Area"
 	})
 "cuI" = (
-/obj/machinery/power/grounding_rod,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -70482,7 +70483,6 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "cuK" = (
-/obj/machinery/power/tesla_coil,
 /obj/structure/cable{
 	icon_state = "0-2";
 	d2 = 2
@@ -70491,7 +70491,6 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "cuL" = (
-/obj/machinery/power/grounding_rod,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -70525,6 +70524,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cuN" = (
@@ -74202,13 +74202,6 @@
 	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
-/obj/machinery/power/emitter{
-	tag = "icon-emitter (NORTH)";
-	icon_state = "emitter";
-	dir = 1;
-	anchored = 1;
-	state = 2
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -74273,6 +74266,7 @@
 	},
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
+/obj/structure/barricade/wooden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cBb" = (
@@ -139379,15 +139373,15 @@ cbd
 aaa
 cez
 cfV
-chp
+clJ
 aaf
 aaf
-clI
+cho
 aaa
 aaH
 aaf
 aaf
-csS
+coI
 cuJ
 cez
 aaa
@@ -140150,7 +140144,7 @@ cbd
 aaH
 cez
 cfV
-chq
+cfV
 aaH
 aaH
 clJ
@@ -140410,9 +140404,9 @@ cfW
 aaa
 aaf
 aaH
-clK
+cfV
 cnd
-coJ
+cuJ
 aaH
 aaf
 aaa
@@ -140672,7 +140666,7 @@ cne
 coK
 aaH
 aaH
-csT
+cuJ
 cuJ
 cez
 aaH
@@ -141435,15 +141429,15 @@ cbd
 aaa
 cez
 cfV
-chr
+clL
 aaf
 aaf
 aaH
 aaa
-coL
+cne
 aaf
 aaf
-csU
+coK
 cuJ
 cez
 aaa
@@ -142467,8 +142461,8 @@ ceD
 ceC
 ckw
 clN
-cni
-coM
+clN
+clN
 cqj
 ceC
 csV
@@ -142723,8 +142717,8 @@ cfY
 cht
 ciZ
 ckw
-clO
-cnj
+clN
+clN
 coN
 cqk
 ciZ
@@ -142981,7 +142975,7 @@ chu
 cja
 ckx
 clP
-cnk
+clN
 coO
 cql
 cja
@@ -143238,7 +143232,7 @@ chv
 cjb
 cky
 clQ
-cnl
+clN
 coP
 cqm
 cjb

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14480,12 +14480,12 @@
 /area/engine/engineering)
 "ayW" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_access_txt = "10"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -16190,6 +16190,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBM" = (
@@ -16199,13 +16200,14 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBO" = (
@@ -16873,6 +16875,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCV" = (
@@ -16905,12 +16910,12 @@
 "aCY" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_access_txt = "10"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
@@ -17727,6 +17732,9 @@
 	dir = 9;
 	pixel_y = 0
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEr" = (
@@ -18483,7 +18491,7 @@
 "aFz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
+	name = "Supermatter Engine Room";
 	req_access_txt = "10"
 	},
 /turf/open/floor/plating,
@@ -19445,6 +19453,9 @@
 	dir = 8;
 	on = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aGY" = (
@@ -19999,6 +20010,9 @@
 /obj/item/weapon/tank/internals/emergency_oxygen/engi,
 /obj/effect/turf_decal/delivery,
 /obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
@@ -20881,6 +20895,9 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -22296,19 +22313,22 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aMg" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_access_txt = "10"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_y = 0
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -22337,9 +22357,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aMj" = (
-/obj/machinery/door/airlock/glass_atmos{
+/obj/machinery/door/airlock/engineering{
+	heat_proof = 1;
 	name = "Supermatter Chamber";
-	req_access_txt = "24"
+	req_access_txt = "10"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -23742,6 +23763,9 @@
 "aOR" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/firecloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOS" = (
@@ -24403,6 +24427,9 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQb" = (
@@ -25831,7 +25858,15 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSz" = (
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aSA" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -25850,10 +25885,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aSB" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -25861,9 +25892,9 @@
 	pixel_y = 0
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSC" = (
 /obj/structure/cable{
@@ -26549,6 +26580,9 @@
 /obj/structure/cable/white{
 	tag = "icon-4-8";
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -94271,6 +94305,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ddY" = (
@@ -94282,6 +94317,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ddZ" = (
@@ -95014,13 +95050,18 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dfC" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -135388,7 +135429,7 @@ axY
 aJm
 aKy
 aMb
-aNp
+aJu
 axY
 aPX
 aRm
@@ -136924,17 +136965,17 @@ aAr
 ddX
 aCU
 aEq
-aSz
+aTO
 aGX
 aHZ
 aJp
-aSz
-aMf
-aSz
+aTO
+aSB
+aTO
 aOR
 aQa
 aGX
-aSz
+aTO
 aTK
 aVd
 aBI
@@ -137448,7 +137489,7 @@ aIa
 aIa
 aIa
 aIa
-dfC
+aSz
 aTM
 aVe
 apc
@@ -137962,7 +138003,7 @@ aKG
 axY
 aQe
 aRv
-aSB
+dfC
 aTN
 aVe
 apc

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13956,46 +13956,29 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "axZ" = (
-/obj/structure/closet/emcloset{
-	anchored = 1;
-	desc = "It's a storage unit for emergency breath masks and O2 tanks, and is securely bolted in place.";
-	name = "anchored emergency closet"
-	},
-/turf/open/floor/plating,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "aya" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "ayb" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "ayc" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
+/obj/structure/table/reinforced,
+/obj/item/weapon/tank/internals/emergency_oxygen/engi,
+/obj/item/weapon/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
 	pixel_y = 0
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "ayd" = (
 /obj/structure/grille,
@@ -14007,9 +13990,12 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aye" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
 "ayf" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/glass{
@@ -14444,17 +14430,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ayS" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/weapon/wrench,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/weapon/hand_labeler,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
@@ -14485,55 +14469,32 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ayV" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8;
+	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ayW" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "10;13"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "10"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ayX" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = -32
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	on = 1
 	},
-/obj/machinery/light/small{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "ayY" = (
 /obj/structure/cable{
@@ -14544,15 +14505,20 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ayZ" = (
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aza" = (
-/obj/structure/cable,
-/obj/machinery/power/emitter{
-	anchored = 1;
-	state = 2
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "azb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -14579,14 +14545,13 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "azd" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
 "aze" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -15383,19 +15348,6 @@
 	},
 /area/engine/engineering)
 "aAr" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/item/device/radio/intercom{
 	freerange = 0;
 	frequency = 1459;
@@ -15408,7 +15360,9 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
@@ -15424,12 +15378,12 @@
 	},
 /area/engine/engineering)
 "aAt" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8;
+	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -15448,28 +15402,26 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aAv" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 32;
-	pixel_y = 0
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aAw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10;
+	pixel_x = 0;
+	initialize_directions = 10
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "aAx" = (
-/obj/item/device/multitool,
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aAy" = (
 /obj/item/device/radio/off,
@@ -16230,38 +16182,36 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBL" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBM" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBO" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aBP" = (
@@ -16272,14 +16222,11 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aBQ" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Fore Arm - Near";
-	dir = 4;
-	network = list("Singulo")
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
 "aBR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16908,86 +16855,64 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCT" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCU" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCV" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aCW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/engine/engineering)
-"aCX" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
+"aCW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9;
 	pixel_y = 0
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"aCX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "aCY" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "10"
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "aCZ" = (
 /obj/structure/grille,
@@ -17787,39 +17712,32 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
+/obj/structure/cable/white{
+	tag = "icon-1-4";
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEr" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 2
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aEs" = (
 /obj/structure/cable{
@@ -18548,10 +18466,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8;
+	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -18563,74 +18481,62 @@
 	},
 /area/engine/engineering)
 "aFz" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	name = "floor"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "10"
 	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aFA" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/weapon/storage/belt/utility,
-/obj/item/weapon/wrench,
-/obj/item/weapon/weldingtool,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
-/area/engine/engineering)
-"aFB" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
+/turf/open/floor/engine,
 /area/engine/engineering)
-"aFC" = (
+"aFB" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"aFC" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 4
 	},
-/obj/item/weapon/crowbar,
-/obj/item/weapon/wirecutters,
-/obj/item/stack/cable_coil,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	name = "floor"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aFD" = (
-/obj/machinery/field/generator{
-	anchored = 1;
-	state = 2
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/structure/cable/white{
+	tag = "icon-1-4";
+	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/meter,
+/obj/machinery/light,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "aFE" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
@@ -19535,63 +19441,33 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aGX" = (
-/obj/structure/table,
-/obj/machinery/light_switch{
-	pixel_x = 23
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	on = 1
 	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/obj/item/device/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/device/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aGY" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aGZ" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "External Gas to Loop"
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "aHa" = (
-/obj/item/weapon/wirecutters,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
+/obj/structure/cable/white,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aHb" = (
 /obj/machinery/camera{
 	c_tag = "Auxillary Mining Base";
@@ -20114,75 +19990,55 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHZ" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "11"
-	},
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_y = 5
-	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/weapon/tank/internals/emergency_oxygen/engi,
+/obj/item/weapon/tank/internals/emergency_oxygen/engi,
 /obj/effect/turf_decal/delivery,
+/obj/structure/table,
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
 /area/engine/engineering)
 "aIa" = (
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "11"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIb" = (
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/space)
 "aIc" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aId" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aIe" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/turf/open/floor/plating/airless,
-/area/space)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "aIf" = (
 /obj/machinery/camera{
 	c_tag = "Auxillary Base Construction";
@@ -21017,8 +20873,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/table,
+/obj/effect/turf_decal/delivery,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -21046,12 +20908,11 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aJs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aJt" = (
 /obj/effect/landmark/start{
@@ -21063,10 +20924,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aJv" = (
-/obj/structure/particle_accelerator/particle_emitter/right{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aJw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -21081,12 +20942,8 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "aJy" = (
-/obj/machinery/the_singularitygen,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
 "aJz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -21664,28 +21521,41 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aKF" = (
-/obj/structure/particle_accelerator/end_cap{
+/obj/machinery/button/door{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aKG" = (
-/obj/structure/particle_accelerator/fuel_chamber{
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aKH" = (
-/obj/structure/particle_accelerator/power_box{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Gas to Chamber"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aKI" = (
-/obj/structure/particle_accelerator/particle_emitter/center{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
-/turf/open/floor/plating,
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aKJ" = (
 /obj/structure/cable{
@@ -21698,16 +21568,23 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "aKK" = (
-/obj/item/weapon/wrench,
-/turf/open/floor/plating/airless,
-/area/space)
+/obj/structure/reflector/double/mapping,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
 "aKL" = (
-/obj/structure/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "aKM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -22410,9 +22287,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aMf" = (
@@ -22422,15 +22296,13 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aMg" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "10"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -22438,57 +22310,41 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aMh" = (
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-8";
+	tag = ""
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aMi" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Gas to Filter"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aMj" = (
-/obj/machinery/particle_accelerator/control_box,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Supermatter Chamber";
+	req_access_txt = "24"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aMk" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aMl" = (
 /obj/structure/particle_accelerator/particle_emitter/left{
@@ -22497,9 +22353,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aMm" = (
-/obj/item/weapon/weldingtool,
-/turf/open/space,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
 "aMn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -22507,12 +22364,11 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "aMo" = (
-/obj/machinery/the_singularitygen/tesla,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/obj/structure/reflector/box/mapping{
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
 "aMp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -23073,16 +22929,15 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aNu" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating{
-	icon_plating = "warnplate"
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Gas to Filter"
 	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aNv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_scrubber,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aNw" = (
 /obj/structure/window/reinforced{
@@ -23882,42 +23737,19 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOR" = (
-/obj/structure/table,
-/obj/item/weapon/book/manual/wiki/engineering_hacking{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/obj/item/weapon/book/manual/wiki/engineering_construction{
-	pixel_x = 0;
-	pixel_y = 3
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/item/weapon/book/manual/engineering_singularity_safety{
-	pixel_x = -4
-	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOS" = (
-/obj/structure/cable,
-/obj/machinery/power/tesla_coil,
-/turf/open/floor/plating/airless,
-/area/space)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "aOT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -24566,18 +24398,16 @@
 	},
 /area/engine/engineering)
 "aQa" = (
-/obj/structure/closet/secure_closet/engineering_welding,
+/obj/structure/table,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQb" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/obj/structure/sign/securearea,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aQc" = (
 /obj/structure/rack{
@@ -24602,43 +24432,21 @@
 	},
 /area/engine/engineering)
 "aQd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	dir = 1;
+	on = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aQe" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/weapon/crowbar,
-/obj/item/stack/cable_coil,
-/obj/item/weapon/screwdriver,
-/obj/item/weapon/weldingtool,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	name = "floor"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 1
 	},
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "aQf" = (
 /obj/structure/chair{
@@ -25425,14 +25233,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 2
-	},
 /obj/structure/disposalpipe/sortjunction{
 	sortType = 5
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -25475,30 +25281,15 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "aRw" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/item/weapon/tank/internals/plasma,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/obj/machinery/status_display,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aRx" = (
 /obj/structure/cable{
@@ -26043,15 +25834,26 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aSB" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -26059,9 +25861,9 @@
 	pixel_y = 0
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aSC" = (
 /obj/structure/cable{
@@ -26704,9 +26506,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -26714,6 +26513,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTI" = (
@@ -26721,18 +26521,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -26741,62 +26536,48 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable/white{
+	tag = "icon-1-4";
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTK" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/white{
+	tag = "icon-4-8";
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTL" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable/white{
+	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Engineering - Aft";
-	dir = 1;
-	network = list("SS13")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aTM" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/white{
+	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aTN" = (
-/obj/effect/landmark/start{
-	name = "Station Engineer"
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aTO" = (
 /obj/effect/turf_decal/stripes/line{
@@ -27570,13 +27351,18 @@
 /obj/item/weapon/folder/yellow,
 /obj/item/weapon/storage/firstaid/fire,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
 /area/engine/engineering)
 "aVe" = (
-/obj/machinery/light_switch,
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aVf" = (
 /obj/structure/cable/yellow{
@@ -27604,10 +27390,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aVh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aVi" = (
 /obj/item/weapon/wrench,
@@ -28470,28 +28258,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aWH" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/maintenance/starboard)
 "aWI" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -28514,16 +28285,11 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aWK" = (
-/obj/machinery/light,
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/space,
+/area/space)
 "aWL" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
@@ -29561,19 +29327,12 @@
 /obj/structure/closet/radiation,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
+/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
 /area/engine/engineering)
 "aYt" = (
-/obj/structure/closet/radiation,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 32
-	},
 /obj/item/device/radio/intercom{
 	freerange = 0;
 	frequency = 1459;
@@ -29581,6 +29340,8 @@
 	pixel_x = 29
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/closet/firecloset,
+/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel{
 	name = "floor"
 	},
@@ -29589,43 +29350,27 @@
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
 "aYv" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
 "aYw" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "aYx" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "aYy" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
@@ -30473,12 +30218,12 @@
 /turf/open/floor/wood,
 /area/library)
 "aZP" = (
-/obj/machinery/space_heater,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/area/maintenance/starboard)
+/turf/open/space,
+/area/space)
 "aZQ" = (
 /obj/effect/landmark{
 	name = "tripai"
@@ -43238,22 +42983,15 @@
 	},
 /area/maintenance/starboard)
 "buW" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Particle Accelerator";
-	dir = 2;
-	network = list("Singulo","SS13")
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "buX" = (
 /obj/structure/cable/yellow{
@@ -47598,6 +47336,7 @@
 	color = "purple";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
 "bCA" = (
@@ -53206,10 +52945,7 @@
 /turf/open/floor/plasteel,
 /area/atmos)
 "bMi" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
-	initialize_directions = 11
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
 /area/atmos)
 "bMj" = (
@@ -57559,8 +57295,12 @@
 /turf/closed/wall,
 /area/maintenance/portsolar)
 "bTq" = (
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "bTr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -58247,19 +57987,8 @@
 	},
 /area/maintenance/starboard)
 "bUw" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "10;13"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "bUx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -70987,16 +70716,23 @@
 	name = "Aft Maintenance"
 	})
 "cpR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating{
-	icon_plating = "warnplate"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Supermatter West";
+	dir = 8;
+	network = list("SS13")
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cpS" = (
 /obj/structure/cable/yellow{
@@ -91142,14 +90878,18 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "cXz" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Aft Arm - Near";
-	dir = 4;
-	network = list("Singulo")
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera{
+	c_tag = "Engineering - Supermatter South";
+	dir = 1;
+	network = list("SS13")
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cXA" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/engineering)
@@ -92851,22 +92591,14 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "daW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/meter,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "daX" = (
 /obj/structure/cable/yellow{
@@ -92881,25 +92613,17 @@
 	name = "Port Maintenance"
 	})
 "daY" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+/obj/machinery/power/rad_collector{
+	anchored = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "daZ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -92916,16 +92640,13 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dbb" = (
-/obj/item/weapon/wirecutters,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	external_pressure_bound = 101.325;
+	on = 1;
+	pressure_checks = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "dbc" = (
 /obj/structure/cable{
@@ -92955,36 +92676,36 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads)
 "dbf" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/power/tesla_coil,
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "dbg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
-	},
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plating/airless,
-/area/space)
-"dbh" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dbh" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "dbi" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -94470,6 +94191,1520 @@
 /area/shuttle/transport)
 "ddN" = (
 /turf/open/floor/pod/light,
+/area/space)
+"ddO" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"ddP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ddQ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ddR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"ddS" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Supermatter North";
+	dir = 4;
+	network = list("SS13")
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"ddT" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"ddU" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"ddV" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"ddW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ddX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ddY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ddZ" = (
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"dea" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"deb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"dec" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"ded" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1;
+	initialize_directions = 11
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dee" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"def" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"deg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"deh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dei" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dej" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dek" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	name = "Mix to Gas"
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"del" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dem" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Mix"
+	},
+/obj/structure/cable/white{
+	tag = "icon-2-8";
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"den" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"deo" = (
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"dep" = (
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"deq" = (
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"der" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"des" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"det" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Mix Bypass"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"deu" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10;
+	pixel_x = 0;
+	initialize_directions = 10
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dev" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dew" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Laser Room";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dex" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dey" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	tag = "icon-2-8";
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dez" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	tag = "icon-2-8";
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"deA" = (
+/obj/structure/cable/white{
+	tag = "icon-2-8";
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"deB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"deC" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"deD" = (
+/obj/machinery/status_display,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"deE" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chapelprivacy";
+	name = "Chapel Privacy Shutters"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"deF" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chapelprivacy";
+	name = "Chapel Privacy Shutters"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"deG" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chapelprivacy";
+	name = "Chapel Privacy Shutters"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"deH" = (
+/obj/machinery/status_display,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"deI" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1;
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"deJ" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	icon_state = "manifold";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"deK" = (
+/obj/structure/cable/white,
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 2;
+	state = 2
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"deL" = (
+/obj/structure/cable/white,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"deM" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"deN" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"deO" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"deP" = (
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"deQ" = (
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"deR" = (
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"deS" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10;
+	pixel_x = 0;
+	initialize_directions = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"deT" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1;
+	filter_type = "plasma";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"deU" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	icon_state = "manifold";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"deV" = (
+/obj/structure/sign/fire,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"deW" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Supermatter Central";
+	dir = 4;
+	network = list("SS13")
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"deX" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"deY" = (
+/obj/machinery/portable_atmospherics/canister/freon,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"deZ" = (
+/obj/machinery/power/supermatter_shard/crystal,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfa" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10;
+	pixel_x = 0;
+	initialize_directions = 10
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"dfb" = (
+/obj/structure/sign/electricshock,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"dfc" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1;
+	filter_type = "o2";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfd" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	icon_state = "manifold";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfe" = (
+/obj/structure/reflector/double/mapping{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"dff" = (
+/obj/structure/reflector/single/mapping{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfg" = (
+/obj/structure/sign/nosmoking_2,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"dfh" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfi" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"dfj" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfk" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfl" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfm" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfn" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfo" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"dfp" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfq" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfr" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfs" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1;
+	filter_type = "co2";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dft" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfu" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"dfv" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chapelprivacy";
+	name = "Chapel Privacy Shutters"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfw" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chapelprivacy";
+	name = "Chapel Privacy Shutters"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/weapon/crowbar,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfx" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chapelprivacy";
+	name = "Chapel Privacy Shutters"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfz" = (
+/obj/structure/cable/white{
+	tag = "icon-0-2";
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfA" = (
+/obj/structure/cable/white{
+	tag = "icon-0-2";
+	icon_state = "0-2"
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 1;
+	state = 2
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfB" = (
+/obj/structure/cable/white{
+	tag = "icon-0-2";
+	icon_state = "0-2"
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 1;
+	state = 2
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfE" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/meter,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfF" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfG" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfH" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Cooling Loop Bypass"
+	},
+/obj/structure/cable/white{
+	tag = "icon-2-4";
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfI" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10;
+	pixel_x = 0;
+	initialize_directions = 10
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfJ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Laser Room";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfK" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfL" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	tag = "icon-1-8";
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfM" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	tag = "icon-1-8";
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfN" = (
+/obj/structure/cable/white{
+	tag = "icon-1-8";
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfO" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Atmos to Loop"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfP" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 2;
+	on = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfQ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Gas to Cold Loop"
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfR" = (
+/obj/structure/cable/white{
+	tag = "icon-1-8";
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfS" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfT" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Cold Loop to Gas"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfU" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 2;
+	on = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"dfV" = (
+/obj/item/weapon/wrench,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"dfW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8;
+	initialize_directions = 11
+	},
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/engine/engineering)
+"dfX" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"dfY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"dfZ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"dga" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"dgb" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"dgc" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"dgd" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dge" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space,
+/area/space)
+"dgf" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dgg" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"dgh" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"dgi" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"dgj" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"dgk" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"dgl" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"dgm" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"dgn" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"dgo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"dgp" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"dgq" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/space,
+/area/space)
+"dgr" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space,
+/area/space)
+"dgs" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"dgt" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"dgu" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dgv" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgw" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"dgx" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"dgy" = (
+/obj/structure/closet/toolcloset,
+/obj/effect/turf_decal/delivery,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
+/area/engine/engineering)
+"dgz" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgA" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dgB" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dgC" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dgD" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dgE" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dgF" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dgG" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dgH" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space)
+"dgI" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"dgJ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"dgK" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"dgL" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/space,
+/area/space)
+"dgM" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgN" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgO" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgP" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgQ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/transit_tube/horizontal,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgS" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgT" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgU" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgV" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgW" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgX" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgY" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgZ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dha" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dhb" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dhc" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dhd" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10;
+	pixel_x = 0;
+	initialize_directions = 10
+	},
+/turf/open/floor/plasteel,
+/area/atmos)
+"dhe" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dhf" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/atmos)
+"dhg" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Engine";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/atmos)
+"dhh" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	icon_state = "left";
+	name = "Inner Pipe Access";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/atmos)
+"dhi" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/atmos)
+"dhj" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/atmos)
+"dhk" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/space,
 /area/space)
 
 (1,1,1) = {"
@@ -133895,7 +135130,7 @@ aGS
 axY
 aJl
 aKx
-aMb
+deY
 aNo
 axY
 aPW
@@ -134152,7 +135387,7 @@ aGT
 axY
 aJm
 aKy
-aJu
+aMb
 aNp
 axY
 aPX
@@ -135428,23 +136663,23 @@ avt
 awJ
 axS
 atm
-aAq
-aBK
+aCO
+ddW
 aCT
 aEp
+aKC
 aFx
-aFx
-aFx
-aJo
+aKC
+aKC
 aKC
 aMe
-aFx
+aKC
 aOQ
-aFx
+aKC
 aRr
 aSx
 aTJ
-aVc
+dfW
 aWD
 aVc
 aZJ
@@ -135686,27 +136921,27 @@ atm
 axT
 atm
 aAr
-aBK
+ddX
 aCU
 aEq
-aFy
+aSz
 aGX
 aHZ
 aJp
-aKD
+aSz
 aMf
-aNs
+aSz
 aOR
 aQa
-aRs
-aSy
+aGX
+aSz
 aTK
 aVd
 aBI
 aYt
 aZK
 bbA
-bcJ
+dgy
 aBI
 byK
 bhZ
@@ -135942,24 +137177,24 @@ avv
 atm
 axU
 ayS
-aAs
-aBK
-aCU
-aEq
+aCP
+ddY
+deb
+deh
 aFz
+aCZ
+deM
 axY
-axY
-aJq
-axY
+aCZ
 aMg
-axY
-axY
+aCZ
+dfg
 aQb
-aRt
-aSz
+aCZ
+aFz
 aTL
 aVe
-aBI
+axY
 aYu
 aYu
 aYu
@@ -136198,25 +137433,25 @@ auu
 avw
 atf
 axV
-ayT
+ddP
 aAt
 aBL
-aCU
-aEq
+dec
+dei
 aFA
-axY
+deB
 aIa
-aJr
-aKE
+aIa
+aIa
 aMh
-aNt
-axY
-aQc
-aRt
-aSz
+aIa
+aIa
+aIa
+aIa
+dfC
 aTM
-aEi
-aWE
+aVe
+apc
 aYu
 aZL
 bbB
@@ -136455,8 +137690,8 @@ auv
 avx
 awK
 axW
-ayU
 aAu
+ddQ
 aBM
 aCV
 aEr
@@ -136467,13 +137702,13 @@ aJs
 aKF
 aMi
 cpR
-aGY
+dfh
 aQd
-aRu
+aJs
 aSA
 aTN
-aVf
-aWF
+ayW
+apc
 aYu
 aZM
 bbC
@@ -136716,21 +137951,21 @@ ayV
 aAv
 aBN
 aCW
-aEs
+aEr
 aFC
 aGZ
-daV
-aJt
+aGZ
+axY
 aKG
 aMj
-aNu
-aGZ
+aKG
+axY
 aQe
 aRv
 aSB
-aTO
-aVg
-aWG
+aTN
+aVe
+apc
 aYu
 aZN
 bbD
@@ -136970,24 +138205,24 @@ avz
 atm
 axY
 ayW
-axY
+ddR
 aBO
 aCX
-aCX
-aCX
-axY
+dej
+aFC
+deC
 buW
-aJu
+axY
 aKH
 aMk
 aNu
 axY
-aCX
-aCX
-aCX
-aBO
-axY
-ayW
+dfo
+dfu
+dfD
+dfO
+dfX
+dgb
 aYu
 cXA
 cXA
@@ -137227,26 +138462,26 @@ avA
 atm
 axZ
 ayX
+ddS
+bUw
+aCY
+dek
+der
+deD
 axY
-aBP
-aCY
-aCY
-aCY
-aCZ
-daV
 aJv
 aKI
-aMl
-aNu
-aCZ
-aCY
-aRw
-aCY
-aTP
+aMj
+dfa
+dfi
 axY
+aRw
+dfE
+aTN
+aVe
 aWH
-axZ
-atm
+dgh
+dgm
 aqq
 aqr
 aWu
@@ -137482,28 +138717,28 @@ ati
 ajb
 avB
 atm
-axY
+ddO
 bUw
-axY
-axY
-aCZ
-aCZ
-aCZ
-aCZ
+ddT
+ddZ
+ded
+del
+des
+deE
 daY
 daZ
 dbb
-aJw
+aMk
 aNv
-aCZ
-aCZ
-aCZ
-aCZ
-axY
-axY
-bUw
-axY
-atm
+dfj
+dfp
+dfv
+dfF
+dfP
+dfY
+apc
+apc
+dgn
 apc
 cXZ
 atm
@@ -137740,27 +138975,27 @@ ajb
 avC
 atm
 aya
-ayY
-aaf
+bUw
+ddU
 aBQ
-aaf
-anS
-aCZ
-aCZ
-aCZ
-aCZ
-dba
-aCZ
-aCZ
-aCZ
-aCZ
-anS
-aaf
+dee
+aEr
+det
+deF
+daY
+daZ
+dbb
+deZ
+aNv
+dfk
+dfq
+dfw
+dfG
 cXz
-aaf
-aWI
-aYw
+aVe
 atm
+alr
+dgo
 cXI
 cYj
 atm
@@ -137997,30 +139232,30 @@ apf
 avD
 atm
 ayb
-ayZ
-anS
-aaf
+bUw
+ddV
+aBQ
 aId
+aEr
 aKL
-aKL
-aKL
-aKL
-aKL
-dbc
-aKL
-aKL
-aKL
-aKL
-aKL
+deG
+daY
+deS
+dbb
+aMk
+aNv
+dfl
+dfr
+dfx
 dbg
-aaf
-anS
-ayZ
-ayb
+dfQ
+dfZ
+dgc
+dgi
+dgp
+alr
 atm
-atd
-cYk
-bpu
+atm
 bgb
 cTu
 bgb
@@ -138039,8 +139274,8 @@ bFT
 bHz
 bIW
 bKD
-bMj
-bCi
+dhd
+dhf
 bPu
 bPu
 bPu
@@ -138256,28 +139491,28 @@ atm
 ayc
 aza
 aAw
-aaf
-aIc
-anS
+bUw
+aCY
+dem
 aFD
-aaa
-aaa
-aFD
-aaa
-aaa
-aaa
-aaa
-aFD
-anS
-aIc
-aaf
+deH
+axY
+axY
+deV
+aCZ
+dfb
+axY
+axY
+aRw
+dfH
+dfR
 aVh
-aWJ
+aaf
 aYx
-atm
-apc
-alq
-bpu
+dgq
+dgv
+dgz
+dgH
 bgb
 cTi
 bgb
@@ -138297,7 +139532,7 @@ bHy
 bIX
 bKE
 bKE
-bKE
+dhg
 bPv
 bKE
 bKE
@@ -138510,31 +139745,31 @@ apm
 apc
 avB
 atm
-ayb
+axY
 bTq
 aAx
-aaa
+aBO
 aIe
 aOS
-aaa
-aaa
-aaa
-aaf
-aaa
+deu
+deI
+deN
+deT
+deW
 aMm
-aaa
-aaa
-aaa
+dfc
+dfm
+dfs
 dbf
 dbh
+dfS
+aVh
 aaa
-aVi
-bTq
-ayb
-atm
-aqr
-alq
-aaa
+aYx
+dgr
+dgw
+ack
+dgI
 bgb
 bij
 bgb
@@ -138554,7 +139789,7 @@ bHA
 bIY
 bKF
 bMk
-bNV
+dhh
 bPw
 bQW
 bSj
@@ -138767,31 +140002,31 @@ atk
 aux
 avF
 atm
-ayd
-aYw
-ayZ
-aaa
+axY
+aaf
+ack
+dea
 aIc
-anS
-aaa
-aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaa
-aaa
-anS
-aIc
-aaa
+den
+dev
+deJ
+deO
+deU
+deX
+aMm
+dfd
+dfn
+dft
+dfy
+dfI
+dfT
 ayZ
-aya
+dgd
 azd
-atm
-cXI
-alq
-aaf
+azd
+azd
+dgA
+dgJ
 aaa
 cUL
 aaa
@@ -138811,7 +140046,7 @@ bHB
 bIZ
 bKG
 bMl
-bKG
+dhi
 bIZ
 bKG
 bMl
@@ -139025,31 +140260,31 @@ auy
 apc
 atm
 atm
-ayb
-ayZ
-aaa
-aIc
-anS
-aaa
-aaa
 aaf
-aJx
-cDu
-aMn
-aaf
-aaf
-aFD
-anS
-aIc
-aaa
-ayZ
-ayb
+ack
+ack
+def
+aCZ
+dew
+aCZ
 axY
-atm
-apc
-alq
-aaf
-aaf
+axY
+aCZ
+aCZ
+aCZ
+axY
+axY
+aCZ
+dfJ
+aCZ
+aVe
+dge
+dgj
+dgs
+aYw
+dgB
+dgK
+anT
 aaf
 aaf
 aaf
@@ -139068,7 +140303,7 @@ bza
 bJa
 bza
 bFX
-bza
+dhj
 bJa
 bza
 bFX
@@ -139282,50 +140517,50 @@ alq
 apc
 anM
 atm
-azc
-ayZ
 aaf
-aIe
-aOS
-aaa
-aaa
 aaf
+aaf
+deg
+deo
+dex
+aJu
+deP
 aJy
 aKK
 aMo
-aaf
-aaa
-aaa
-dbf
-dbh
-aaa
-ayZ
+dfe
+aJy
+aJy
+aJu
+dfK
+aJy
+aVe
 aWK
-axY
+dgk
 aZP
-apc
-alq
-aaf
-aaa
-aaa
-aaa
-aaf
-aaa
-bpw
-aaa
-aaa
-aaf
-aaf
-aaf
-aaf
+aYw
+dgC
+dgL
+dgM
+dgN
+dgO
+dgP
+dgQ
+dgR
+dgS
+dgT
+dgU
+dgV
+dgW
+dgX
 bCz
-aaf
-bFY
-aaf
-bJb
-aaf
-bFY
-aaf
+dgY
+dgZ
+dha
+dhb
+dhc
+dhe
+dhk
 bJb
 aaf
 bFY
@@ -139539,31 +140774,31 @@ auz
 avr
 atm
 atm
-ayb
-ayZ
-aaf
-aIc
-anS
-aFD
+aaa
+aaa
+aaa
+bTq
+dep
+dey
 aHa
+deQ
+aJy
+aJy
+aJy
+aJy
+aJy
+aJy
+dfz
+dfL
+dfU
+dga
+dgf
+azd
+azd
+azd
+dgD
 aaf
-aJz
-aKM
-aMp
-aaf
-aaa
-aaa
-anS
-aIc
-aaf
-ayZ
-ayb
-axY
-atm
-avr
-alq
-aaf
-aaa
+anT
 aaa
 aaa
 aaf
@@ -139795,32 +141030,32 @@ alr
 auA
 apc
 atm
-aya
-azd
-ayZ
-aaa
-aIc
-anS
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
 aaa
 aaa
-anS
-aIc
-aaa
-ayZ
-ayd
+axY
+deq
+dez
+deK
+deR
+aJy
+aJy
+aMo
+aJy
+aJy
+aJy
+dfA
+dfM
+dfV
+axY
+aWK
 aYw
-atm
-cXI
-alr
-aaf
+aZP
+aYw
+dgE
 aaa
+anT
 aaa
 aaa
 aaf
@@ -140052,32 +141287,32 @@ alq
 auB
 avG
 atm
-ayb
-bTq
-aAy
-aaa
-aIe
-aOS
 aaa
 aaa
 aaa
-aJA
 aaa
+axY
+aJu
+deA
+deL
+aJu
+aJu
+aJu
+axY
+dff
+aJu
+aJu
+dfB
+dfN
+aJy
+axY
+dgg
+aYw
+aYw
+aYw
+dgF
 aaf
-aaa
-aaa
-aaa
-dbf
-dbh
-aaa
-ayZ
-bTq
-ayb
-atm
-bbE
-alq
-aaf
-aaf
+anT
 aaa
 aaa
 aaf
@@ -140309,32 +141544,32 @@ alq
 alq
 atn
 atm
-ayd
-aza
-aAw
 aaf
-aIc
-anS
-aFD
 aaa
 aaa
 aaa
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+aWK
+dgl
+dgt
+dgx
+dgG
 aaa
-aFD
-aaa
-aaa
-aFD
-anS
-aIc
-aaf
-aVh
-aWJ
-azd
-atm
-atn
-alq
-alq
-aaf
+anT
 aaa
 aaa
 aaf
@@ -140566,33 +141801,33 @@ atn
 bOY
 avG
 atm
-aye
-ayZ
-ayZ
 aaf
-aIc
-anS
-anS
-daU
-anS
-anS
-daU
-anS
-anS
-daU
-anS
-anS
-aIc
+aaa
+aaa
+aaa
+aaa
 aaf
-ayZ
-ayZ
+aaa
+aaf
+aaa
+aaa
+aaf
+aaa
+aaf
+aaa
+aaf
+aaa
+aaf
+aaf
+aaf
+aaf
 aye
-atm
-avG
+dgu
+aye
 aYv
-atn
-ack
-ack
+aaf
+anT
+aaf
 aaf
 aaf
 aaa
@@ -140823,31 +142058,31 @@ alq
 alq
 atn
 atm
-aye
-aye
-ayZ
-aaa
-aKJ
-aRx
-aRx
-aSC
-aRx
-aRx
-aSC
-aRx
-aRx
-aSC
-aRx
-aRx
-dbi
 aaf
-aVj
-aye
-aye
-atm
-atn
-alq
-alq
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaf
+aaa
+aaa
+aaf
+aaa
+aaf
+aaa
+aaf
+aaa
+aaa
+aaf
+aaf
+aaf
+aaa
+aaa
+ack
+aaa
+aaa
 aaf
 aaa
 aaa
@@ -141080,31 +142315,31 @@ aaa
 aaf
 ack
 atm
-axY
-axY
-axY
-aaa
-cmq
-anS
+aaf
+anT
+anT
+anT
+anT
+aaf
+anT
+anT
+anT
+anT
+anT
+anT
+aaf
+anT
+anT
+anT
+anT
+anT
+anT
 aaf
 aaa
 aaa
-aaf
-anS
-aaf
-aaa
-aaa
-aaf
-anS
-cXd
-aaa
-axY
-axY
-axY
-axY
 ack
-aaf
-aaf
+aaa
+aaa
 aaf
 aaa
 aaa
@@ -141337,25 +142572,25 @@ aaf
 aaf
 ack
 aaf
-aaf
-aaf
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaf
 aaf
 aaf
@@ -141595,24 +142830,24 @@ aaa
 aaa
 aaa
 aaa
-aaf
-axY
-azf
-azf
-azf
-aGZ
-azf
-azf
-azf
-cCh
-azf
-azf
-azf
-aGZ
-azf
-azf
-azf
-axY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaf
 aaa
 aaf
@@ -141852,24 +143087,24 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaf
 aaa
 aaa
@@ -142113,17 +143348,17 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaa
-aaa
-aaf
-aaf
 aaa
 aaa
 aaa
-aaf
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -142371,15 +143606,15 @@ aaa
 aaa
 aaa
 aaa
-aaf
 aaa
 aaa
 aaa
-aaf
 aaa
 aaa
 aaa
-aaf
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -142628,7 +143863,6 @@ aaa
 aaa
 aaa
 aaa
-aaf
 aaa
 aaa
 aaa
@@ -142636,7 +143870,8 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21588,9 +21588,9 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "aKK" = (
-/obj/structure/reflector/double/mapping,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
+/obj/item/weapon/wrench,
+/turf/open/floor/plating/airless,
+/area/space)
 "aKL" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	icon_state = "intact";
@@ -22388,7 +22388,8 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "aMo" = (
-/obj/structure/reflector/box/mapping{
+/obj/structure/reflector/box{
+	anchored = 1;
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -22960,7 +22961,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aNv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber,
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 2;
+	on = 1
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aNw" = (
@@ -23774,6 +23778,13 @@
 "aOS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	freerange = 0;
+	frequency = 1459;
+	name = "Station Intercom (General)";
+	pixel_x = 0;
+	pixel_y = 21
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -25266,10 +25277,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	sortType = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRs" = (
@@ -94269,6 +94277,11 @@
 	dir = 4;
 	network = list("SS13")
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "ddT" = (
@@ -94471,6 +94484,13 @@
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "deq" = (
+/obj/item/device/radio/intercom{
+	freerange = 0;
+	frequency = 1459;
+	name = "Station Intercom (General)";
+	pixel_x = 0;
+	pixel_y = 21
+	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "der" = (
@@ -94788,14 +94808,23 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "deY" = (
-/obj/machinery/portable_atmospherics/canister/freon,
+/obj/structure/reflector/single{
+	anchored = 1;
+	dir = 1;
+	icon_state = "reflector";
+	tag = "icon-reflector (NORTH)"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "deZ" = (
+/obj/machinery/portable_atmospherics/canister/freon,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfa" = (
 /obj/machinery/power/supermatter_shard/crystal,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfa" = (
+"dfb" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
 	pixel_x = 0;
@@ -94804,11 +94833,11 @@
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"dfb" = (
+"dfc" = (
 /obj/structure/sign/electricshock,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"dfc" = (
+"dfd" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1;
 	filter_type = "o2";
@@ -94819,7 +94848,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfd" = (
+"dfe" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	icon_state = "manifold";
 	dir = 4
@@ -94829,23 +94858,29 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfe" = (
-/obj/structure/reflector/double/mapping{
-	dir = 1
+"dff" = (
+/obj/structure/reflector/double{
+	anchored = 1;
+	dir = 1;
+	icon_state = "reflector_double";
+	tag = "icon-reflector_double (NORTH)"
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"dff" = (
-/obj/structure/reflector/single/mapping{
-	dir = 8
+"dfg" = (
+/obj/structure/reflector/single{
+	anchored = 1;
+	dir = 8;
+	icon_state = "reflector";
+	tag = "icon-reflector (WEST)"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"dfg" = (
+"dfh" = (
 /obj/structure/sign/nosmoking_2,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"dfh" = (
+"dfi" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -94856,18 +94891,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfi" = (
+"dfj" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
-"dfj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plating,
 /area/engine/engineering)
 "dfk" = (
 /obj/structure/grille,
@@ -94878,19 +94907,25 @@
 "dfl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfm" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"dfm" = (
+"dfn" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfn" = (
+"dfo" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -94901,7 +94936,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfo" = (
+"dfp" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -94911,16 +94946,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"dfp" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/turf/open/floor/engine,
 /area/engine/engineering)
 "dfq" = (
 /obj/machinery/power/rad_collector{
@@ -94943,6 +94968,16 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dfs" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dft" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1;
 	filter_type = "co2";
@@ -94953,7 +94988,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dft" = (
+"dfu" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
@@ -94962,7 +94997,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfu" = (
+"dfv" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -94972,18 +95007,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"dfv" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chapelprivacy";
-	name = "Chapel Privacy Shutters"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
 /area/engine/engineering)
 "dfw" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -94995,7 +95018,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/weapon/crowbar,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dfx" = (
@@ -95008,22 +95030,35 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/weapon/crowbar,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dfy" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chapelprivacy";
+	name = "Chapel Privacy Shutters"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfz" = (
+"dfA" = (
 /obj/structure/cable/white{
 	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"dfA" = (
+"dfB" = (
 /obj/structure/cable/white{
 	tag = "icon-0-2";
 	icon_state = "0-2"
@@ -95035,7 +95070,7 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"dfB" = (
+"dfC" = (
 /obj/structure/cable/white{
 	tag = "icon-0-2";
 	icon_state = "0-2"
@@ -95051,7 +95086,7 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"dfC" = (
+"dfD" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	icon_state = "intact";
 	dir = 4
@@ -95067,7 +95102,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfD" = (
+"dfE" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -95078,26 +95113,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfE" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/meter,
-/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -95113,10 +95128,11 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/meter,
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -95141,6 +95157,25 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dfH" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dfI" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
 	name = "Cooling Loop Bypass"
@@ -95157,7 +95192,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfI" = (
+"dfJ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
 	pixel_x = 0;
@@ -95172,7 +95207,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfJ" = (
+"dfK" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
 	tag = "icon-4-8";
@@ -95184,21 +95219,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"dfK" = (
-/obj/structure/cable/white{
-	tag = "icon-4-8";
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "dfL" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
 	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	tag = "icon-1-8";
-	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -95215,12 +95239,23 @@
 /area/engine/engineering)
 "dfN" = (
 /obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
 	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dfO" = (
+/obj/structure/cable/white{
+	tag = "icon-1-8";
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"dfP" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
 	icon_state = "4-8"
@@ -95232,7 +95267,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfP" = (
+"dfQ" = (
 /obj/structure/cable/white{
 	tag = "icon-4-8";
 	icon_state = "4-8"
@@ -95248,7 +95283,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfQ" = (
+"dfR" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Gas to Cold Loop"
 	},
@@ -95259,7 +95294,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfR" = (
+"dfS" = (
 /obj/structure/cable/white{
 	tag = "icon-1-8";
 	icon_state = "1-8"
@@ -95267,11 +95302,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfS" = (
+"dfT" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfT" = (
+"dfU" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Cold Loop to Gas"
@@ -95281,7 +95316,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dfU" = (
+"dfV" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -95293,11 +95328,11 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"dfV" = (
+"dfW" = (
 /obj/item/weapon/wrench,
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"dfW" = (
+"dfX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -95315,81 +95350,73 @@
 	dir = 1
 	},
 /area/engine/engineering)
-"dfX" = (
+"dfY" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"dfY" = (
+"dfZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"dfZ" = (
+"dga" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"dga" = (
+"dgb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9;
 	pixel_y = 0
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"dgb" = (
+"dgc" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"dgc" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
 "dgd" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
 "dge" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
 "dgf" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
 "dgg" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
 "dgh" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"dgi" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+	dir = 6
 	},
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
+"dgi" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "dgj" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+	dir = 5
 	},
 /obj/structure/lattice,
 /turf/open/space,
@@ -95403,6 +95430,14 @@
 /turf/open/space,
 /area/space)
 "dgl" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"dgm" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
@@ -95410,21 +95445,13 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
-"dgm" = (
+"dgn" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"dgn" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "dgo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
@@ -95439,52 +95466,60 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dgq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"dgr" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
 /turf/open/space,
 /area/space)
-"dgr" = (
+"dgs" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
 /turf/open/space,
 /area/space)
-"dgs" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
 "dgt" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
 /area/space)
 "dgu" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"dgv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
-"dgv" = (
+"dgw" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
-"dgw" = (
+"dgx" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
-"dgx" = (
+"dgy" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
@@ -95492,7 +95527,7 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
-"dgy" = (
+"dgz" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/delivery,
 /obj/item/clothing/glasses/meson/engine,
@@ -95500,99 +95535,95 @@
 	name = "floor"
 	},
 /area/engine/engineering)
-"dgz" = (
+"dgA" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
-"dgA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space)
 "dgB" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+	dir = 5
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
 "dgC" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+	dir = 9
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
 "dgD" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+	dir = 5
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
 "dgE" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+	dir = 9
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
 "dgF" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+	dir = 5
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
 "dgG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+	dir = 9
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
 "dgH" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dgI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
 	},
 /turf/open/space,
 /area/space)
-"dgI" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space)
 "dgJ" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
 /area/space)
 "dgK" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
 /area/space)
 "dgL" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"dgM" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
 /turf/open/space,
 /area/space)
-"dgM" = (
+"dgN" = (
 /obj/structure/lattice,
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space)
-"dgN" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
@@ -95601,15 +95632,19 @@
 /turf/open/space,
 /area/space)
 "dgP" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
 "dgQ" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
 "dgR" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dgS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -95624,16 +95659,11 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
-"dgS" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space)
 "dgT" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
 "dgU" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
@@ -95659,18 +95689,23 @@
 /area/space)
 "dgZ" = (
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space)
+"dha" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
-"dha" = (
+"dhb" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
-"dhb" = (
+"dhc" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -95678,12 +95713,12 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
-"dhc" = (
+"dhd" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
-"dhd" = (
+"dhe" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
 	pixel_x = 0;
@@ -95691,7 +95726,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/atmos)
-"dhe" = (
+"dhf" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -95699,13 +95734,13 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space)
-"dhf" = (
+"dhg" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/atmos)
-"dhg" = (
+"dhh" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -95714,7 +95749,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/atmos)
-"dhh" = (
+"dhi" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/door/window/northleft{
 	dir = 8;
@@ -95727,14 +95762,14 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/atmos)
-"dhi" = (
+"dhj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/atmos)
-"dhj" = (
+"dhk" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -95742,7 +95777,7 @@
 	},
 /turf/open/floor/plating,
 /area/atmos)
-"dhk" = (
+"dhl" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
@@ -135173,7 +135208,7 @@ aGS
 axY
 aJl
 aKx
-deY
+deZ
 aNo
 axY
 aPW
@@ -136722,7 +136757,7 @@ aKC
 aRr
 aSx
 aTJ
-dfW
+dfX
 aWD
 aVc
 aZJ
@@ -136984,7 +137019,7 @@ aBI
 aYt
 aZK
 bbA
-dgy
+dgz
 aBI
 byK
 bhZ
@@ -137231,7 +137266,7 @@ axY
 aCZ
 aMg
 aCZ
-dfg
+dfh
 aQb
 aCZ
 aFz
@@ -137745,7 +137780,7 @@ aJs
 aKF
 aMi
 cpR
-dfh
+dfi
 aQd
 aJs
 aSA
@@ -138005,7 +138040,7 @@ aKG
 axY
 aQe
 aRv
-dfC
+dfD
 aTN
 aVe
 apc
@@ -138260,12 +138295,12 @@ aKH
 aMk
 aNu
 axY
-dfo
-dfu
-dfD
-dfO
-dfX
-dgb
+dfp
+dfv
+dfE
+dfP
+dfY
+dgc
 aYu
 cXA
 cXA
@@ -138515,16 +138550,16 @@ axY
 aJv
 aKI
 aMj
-dfa
-dfi
+dfb
+dfj
 axY
 aRw
-dfE
+dfF
 aTN
 aVe
 aWH
-dgh
-dgm
+dgi
+dgn
 aqq
 aqr
 aWu
@@ -138773,15 +138808,15 @@ daZ
 dbb
 aMk
 aNv
-dfj
-dfp
-dfv
-dfF
-dfP
-dfY
+dfk
+dfq
+dfw
+dfG
+dfQ
+dfZ
 apc
 apc
-dgn
+dgo
 apc
 cXZ
 atm
@@ -139028,17 +139063,17 @@ deF
 daY
 daZ
 dbb
-deZ
+dfa
 aNv
-dfk
-dfq
-dfw
-dfG
+dfl
+dfr
+dfx
+dfH
 cXz
 aVe
 atm
 alr
-dgo
+dgp
 cXI
 cYj
 atm
@@ -139287,15 +139322,15 @@ deS
 dbb
 aMk
 aNv
-dfl
-dfr
-dfx
+dfm
+dfs
+dfy
 dbg
-dfQ
-dfZ
-dgc
-dgi
-dgp
+dfR
+dga
+dgd
+dgj
+dgq
 alr
 atm
 atm
@@ -139317,8 +139352,8 @@ bFT
 bHz
 bIW
 bKD
-dhd
-dhf
+dhe
+dhg
 bPu
 bPu
 bPu
@@ -139543,19 +139578,19 @@ axY
 axY
 deV
 aCZ
-dfb
+dfc
 axY
 axY
 aRw
-dfH
-dfR
+dfI
+dfS
 aVh
 aaf
 aYx
-dgq
-dgv
-dgz
-dgH
+dgr
+dgw
+dgA
+dgI
 bgb
 cTi
 bgb
@@ -139575,7 +139610,7 @@ bHy
 bIX
 bKE
 bKE
-dhg
+dhh
 bPv
 bKE
 bKE
@@ -139800,19 +139835,19 @@ deN
 deT
 deW
 aMm
-dfc
-dfm
-dfs
+dfd
+dfn
+dft
 dbf
 dbh
-dfS
+dfT
 aVh
 aaa
 aYx
-dgr
-dgw
+dgs
+dgx
 ack
-dgI
+dgJ
 bgb
 bij
 bgb
@@ -139832,7 +139867,7 @@ bHA
 bIY
 bKF
 bMk
-dhh
+dhi
 bPw
 bQW
 bSj
@@ -140057,19 +140092,19 @@ deO
 deU
 deX
 aMm
-dfd
-dfn
-dft
-dfy
-dfI
-dfT
+dfe
+dfo
+dfu
+dfz
+dfJ
+dfU
 ayZ
-dgd
+dge
 azd
 azd
 azd
-dgA
-dgJ
+dgB
+dgK
 aaa
 cUL
 aaa
@@ -140089,7 +140124,7 @@ bHB
 bIZ
 bKG
 bMl
-dhi
+dhj
 bIZ
 bKG
 bMl
@@ -140318,15 +140353,15 @@ aCZ
 axY
 axY
 aCZ
-dfJ
+dfK
 aCZ
 aVe
-dge
-dgj
-dgs
+dgf
+dgk
+dgt
 aYw
-dgB
-dgK
+dgC
+dgL
 anT
 aaf
 aaf
@@ -140346,7 +140381,7 @@ bza
 bJa
 bza
 bFX
-dhj
+dhk
 bJa
 bza
 bFX
@@ -140569,21 +140604,20 @@ dex
 aJu
 deP
 aJy
-aKK
+aJy
 aMo
-dfe
+dff
 aJy
 aJy
 aJu
-dfK
+dfL
 aJy
 aVe
 aWK
-dgk
+dgl
 aZP
 aYw
-dgC
-dgL
+dgD
 dgM
 dgN
 dgO
@@ -140596,14 +140630,15 @@ dgU
 dgV
 dgW
 dgX
-bCz
 dgY
+bCz
 dgZ
 dha
 dhb
 dhc
-dhe
-dhk
+dhd
+dhf
+dhl
 bJb
 aaf
 bFY
@@ -140831,15 +140866,15 @@ aJy
 aJy
 aJy
 aJy
-dfz
-dfL
-dfU
-dga
-dgf
+dfA
+dfM
+dfV
+dgb
+dgg
 azd
 azd
 azd
-dgD
+dgE
 aaf
 anT
 aaa
@@ -141088,15 +141123,15 @@ aMo
 aJy
 aJy
 aJy
-dfA
-dfM
-dfV
+dfB
+dfN
+dfW
 axY
 aWK
 aYw
 aZP
 aYw
-dgE
+dgF
 aaa
 anT
 aaa
@@ -141340,20 +141375,20 @@ deA
 deL
 aJu
 aJu
-aJu
+deY
 axY
-dff
+dfg
 aJu
 aJu
-dfB
-dfN
+dfC
+dfO
 aJy
 axY
-dgg
+dgh
 aYw
 aYw
 aYw
-dgF
+dgG
 aaf
 anT
 aaa
@@ -141607,10 +141642,10 @@ axY
 axY
 axY
 aWK
-dgl
-dgt
-dgx
-dgG
+dgm
+dgu
+dgy
+dgH
 aaa
 anT
 aaa
@@ -141862,10 +141897,10 @@ aaf
 aaa
 aaf
 aaf
-aaf
-aaf
+ack
+ack
 aye
-dgu
+dgv
 aye
 aYv
 aaf
@@ -142123,7 +142158,7 @@ aaf
 aaf
 aaa
 aaa
-ack
+aaf
 aaa
 aaa
 aaf
@@ -142370,7 +142405,7 @@ anT
 anT
 anT
 anT
-aaf
+aqB
 anT
 anT
 anT
@@ -142380,7 +142415,7 @@ anT
 aaf
 aaa
 aaa
-ack
+aaf
 aaa
 aaa
 aaf
@@ -142618,26 +142653,26 @@ aaf
 aaa
 aaa
 aaa
+aaf
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bpu
+bpu
+bpu
+bpu
+bpu
+bpu
+bpu
+bpu
+bpu
+bpu
 aaa
 aaa
 aaa
 aaf
 aaf
 aaf
-ack
+aaf
 aaa
 aaa
 aaa
@@ -142875,22 +142910,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+aaf
+aaf
+anT
+anT
+anT
+anT
+aqB
+anT
+anT
+anT
+anT
+aqB
+aaf
+aaf
+aaf
 aaf
 aaa
 aaf

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14483,8 +14483,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/engineering{
-	name = "Supermatter Engine Room";
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Supermatter Engine";
 	req_access_txt = "10"
 	},
 /turf/open/floor/plating,
@@ -16913,8 +16913,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/engineering{
-	name = "Supermatter Engine Room";
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Supermatter Engine";
 	req_access_txt = "10"
 	},
 /turf/open/floor/plasteel/black,
@@ -18490,8 +18490,8 @@
 /area/engine/engineering)
 "aFz" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Supermatter Engine Room";
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Supermatter Engine";
 	req_access_txt = "10"
 	},
 /turf/open/floor/plating,
@@ -20899,6 +20899,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/item/weapon/pipe_dispenser,
+/obj/item/weapon/pipe_dispenser,
+/obj/item/weapon/pipe_dispenser,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJq" = (
@@ -22326,8 +22329,8 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/machinery/door/airlock/engineering{
-	name = "Supermatter Engine Room";
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Supermatter Engine";
 	req_access_txt = "10"
 	},
 /turf/open/floor/plating,
@@ -22357,7 +22360,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aMj" = (
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/glass_engineering{
 	heat_proof = 1;
 	name = "Supermatter Chamber";
 	req_access_txt = "10"
@@ -27399,16 +27402,15 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aVf" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	on = 1
+/obj/machinery/door/airlock/engineering{
+	name = "Supermatter Engine";
+	req_access_txt = "10"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aVg" = (
 /obj/structure/sign/securearea{
@@ -94555,7 +94557,7 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/glass_engineering{
 	name = "Laser Room";
 	req_access_txt = "10"
 	},
@@ -95176,7 +95178,7 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/glass_engineering{
 	name = "Laser Room";
 	req_access_txt = "10"
 	},
@@ -137748,7 +137750,7 @@ aQd
 aJs
 aSA
 aTN
-ayW
+aVf
 apc
 aYu
 aZM

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -56940,9 +56940,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ctv" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/closed/wall/r_wall,
+/area/space)
 "ctw" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -62375,15 +62374,11 @@
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cEX" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/open/space,
+/turf/closed/wall/r_wall,
 /area/space)
 "cEY" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+	dir = 6
 	},
 /obj/structure/lattice,
 /turf/open/space,
@@ -62396,6 +62391,13 @@
 /turf/open/space,
 /area/space)
 "cFa" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1;
 	on = 1;
@@ -62404,7 +62406,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFb" = (
+"cFc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -62420,7 +62422,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFc" = (
+"cFd" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
 	},
@@ -62430,7 +62432,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFd" = (
+"cFe" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -62438,7 +62440,7 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cFe" = (
+"cFf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
 	on = 1;
@@ -62446,14 +62448,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFf" = (
+"cFg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	on = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFg" = (
+"cFh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -62461,7 +62463,7 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cFh" = (
+"cFi" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
 	},
@@ -62471,7 +62473,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFi" = (
+"cFj" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
@@ -62487,7 +62489,7 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cFj" = (
+"cFk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -62503,22 +62505,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFk" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "cFl" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/space,
+/turf/closed/wall/r_wall,
 /area/space)
 "cFm" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
@@ -62558,6 +62549,20 @@
 /turf/open/space,
 /area/space)
 "cFs" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFt" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space,
+/area/space)
+"cFu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -62567,19 +62572,19 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFt" = (
+"cFv" = (
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cFu" = (
+"cFw" = (
 /obj/structure/sign/electricshock,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cFv" = (
+"cFx" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cFw" = (
+"cFy" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
@@ -62589,33 +62594,21 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFx" = (
+"cFz" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cFy" = (
+"cFA" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cFz" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
-"cFA" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
 "cFB" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
+/turf/closed/wall/r_wall,
 /area/space)
 "cFC" = (
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
 /area/space)
@@ -62630,12 +62623,27 @@
 /turf/open/space,
 /area/space)
 "cFF" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFG" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFH" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFG" = (
+"cFJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -62645,7 +62653,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFH" = (
+"cFK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62654,7 +62662,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFI" = (
+"cFL" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4;
 	filter_type = "co2";
@@ -62665,7 +62673,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFJ" = (
+"cFM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62677,7 +62685,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFK" = (
+"cFN" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4;
 	filter_type = "o2";
@@ -62688,7 +62696,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFL" = (
+"cFO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62703,7 +62711,7 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cFM" = (
+"cFP" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4;
 	filter_type = "plasma";
@@ -62714,7 +62722,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFN" = (
+"cFQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62726,7 +62734,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFO" = (
+"cFR" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4;
 	filter_type = "";
@@ -62737,7 +62745,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFP" = (
+"cFS" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
@@ -62746,7 +62754,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFQ" = (
+"cFT" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -62755,32 +62763,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cFR" = (
+"cFU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cFS" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cFT" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space)
-"cFU" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "cFV" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
+/turf/closed/wall/r_wall,
 /area/space)
 "cFW" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -62798,13 +62789,33 @@
 /turf/open/space,
 /area/space)
 "cFZ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cGa" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGb" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cGc" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGd" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGa" = (
+"cGe" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -62813,11 +62824,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGb" = (
+"cGf" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGc" = (
+"cGg" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -62825,7 +62836,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGd" = (
+"cGh" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -62834,101 +62845,69 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGe" = (
+"cGi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGf" = (
+"cGj" = (
 /obj/structure/table,
 /obj/item/weapon/pipe_dispenser,
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGg" = (
+"cGk" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGh" = (
+"cGl" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGi" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGj" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGk" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"cGl" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "cGm" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cGn" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGo" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGp" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGq" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cGn" = (
+"cGs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cGo" = (
+"cGt" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGp" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGr" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGs" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGt" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cGu" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -62938,20 +62917,55 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGw" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGx" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGy" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGz" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGB" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGC" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
@@ -62961,7 +62975,7 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGy" = (
+"cGD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -62970,7 +62984,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGz" = (
+"cGE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -62978,13 +62992,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGA" = (
+"cGF" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cGG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cGB" = (
+"cGH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -62992,7 +63009,7 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGC" = (
+"cGI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Laser Room";
@@ -63005,7 +63022,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGD" = (
+"cGJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Laser Room";
@@ -63018,7 +63035,7 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGE" = (
+"cGK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63026,7 +63043,7 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGF" = (
+"cGL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63034,32 +63051,35 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGG" = (
+"cGM" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cGH" = (
+"cGN" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cGO" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
-"cGI" = (
+"cGP" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
-"cGJ" = (
+"cGQ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
-"cGK" = (
+"cGR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1;
 	on = 1;
@@ -63068,64 +63088,61 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGN" = (
-/obj/structure/reflector/double/mapping,
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGO" = (
-/obj/structure/reflector/box/mapping{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGP" = (
-/obj/structure/reflector/double/mapping{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cGR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cGS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGU" = (
+/obj/structure/reflector/double{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGV" = (
+/obj/structure/reflector/box{
+	anchored = 1;
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGT" = (
+"cGZ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cGU" = (
+"cHa" = (
 /obj/machinery/airalarm{
 	dir = 4;
 	icon_state = "alarm0";
@@ -63133,97 +63150,30 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGW" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGX" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGZ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engineering)
-"cHa" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cHb" = (
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 4;
-	icon_state = "emitter";
-	state = 2;
-	tag = "icon-emitter (NORTH)"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHc" = (
-/obj/structure/reflector/box/mapping{
-	dir = 1
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/black,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cHd" = (
 /obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4
-	},
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 8;
-	icon_state = "emitter";
-	state = 2;
-	tag = "icon-emitter (NORTH)"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -63241,10 +63191,81 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHf" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cHg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHh" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 4;
+	icon_state = "emitter";
+	state = 2;
+	tag = "icon-emitter (NORTH)"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHi" = (
+/obj/structure/reflector/box{
+	anchored = 1;
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cHj" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 8;
+	icon_state = "emitter";
+	state = 2;
+	tag = "icon-emitter (NORTH)"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cHg" = (
+"cHm" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHn" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -63253,20 +63274,32 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHh" = (
-/obj/structure/reflector/single/mapping{
-	dir = 1
+"cHo" = (
+/obj/structure/reflector/single{
+	anchored = 1;
+	dir = 1;
+	icon_state = "reflector";
+	tag = "icon-reflector (NORTH)"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHi" = (
+"cHp" = (
+/obj/structure/reflector/single{
+	anchored = 1;
+	dir = 4;
+	icon_state = "reflector";
+	tag = "icon-reflector (NORTH)"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHq" = (
 /obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHj" = (
+"cHr" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -63275,10 +63308,37 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHk" = (
+"cHs" = (
 /obj/item/weapon/crowbar/large,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cHt" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHu" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHv" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHw" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHx" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHy" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHz" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHA" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cHB" = (
+/turf/closed/wall/r_wall,
+/area/space)
 
 (1,1,1) = {"
 aaa
@@ -86611,8 +86671,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+abY
+abY
 aaa
 aaa
 aaa
@@ -86857,20 +86917,20 @@ aaa
 aaa
 crn
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abY
+abY
+abY
+abY
+abY
+abY
+abY
+abY
+abY
 aaa
 aaf
-aaa
-aaa
-aaa
+cHu
+abY
+abY
 aaa
 aaa
 aaa
@@ -87114,20 +87174,20 @@ aaa
 aaa
 crn
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abY
+cEX
+cFl
+cFB
+cFV
+cGm
+cGF
+cGN
+abY
 aaa
 aaf
-aaa
-aaa
-aaa
+cHv
+ctv
+abY
 aaa
 aaa
 aaa
@@ -87371,7 +87431,6 @@ aaf
 aaf
 cig
 aaf
-aaf
 aaT
 aaT
 aaT
@@ -87379,7 +87438,8 @@ aaT
 aaT
 aaT
 aaT
-aaf
+aaT
+aaT
 aaf
 aaf
 aaf
@@ -87895,9 +87955,9 @@ aaf
 aaa
 aaa
 aaa
-aaf
-aaa
-aaa
+aaT
+abY
+abY
 aaa
 aaa
 aaa
@@ -88143,18 +88203,18 @@ cqN
 cro
 cEl
 cEE
-cEX
-cFk
-cFz
-cFS
-cGi
+cEY
+cFm
+cFC
+cFW
+cGn
 csx
-cGH
+cGO
 aaa
 aaa
 aaT
-aaa
-aaa
+cHw
+abY
 aaa
 aaa
 aaa
@@ -88401,17 +88461,17 @@ crr
 cEm
 cEF
 crJ
-cFl
-cFA
-cFT
+cFn
+cFD
+cFX
 csx
 css
 csb
 aaf
 aaf
 aaT
-aaa
-aaa
+cHx
+abY
 aaa
 aaa
 aaa
@@ -88657,18 +88717,18 @@ cqP
 crq
 cEn
 cEG
-cEY
-cFm
-cFB
-cFU
-cGj
+cEZ
+cFo
+cFE
+cFY
+cGo
 css
-cGI
+cGP
 aaa
 aaa
 aaT
-aaa
-aaa
+cHy
+abY
 aaa
 aaa
 aaa
@@ -88915,17 +88975,17 @@ crp
 cEo
 cEH
 crJ
-cFn
-cFC
-cFV
+cFp
+cFF
+cFZ
 csx
 css
 csb
 aaf
 aaf
 aaT
-aaa
-aaa
+cHz
+abY
 aaa
 aaa
 aaa
@@ -89171,18 +89231,18 @@ cqQ
 ccw
 cEp
 cEI
-cEZ
-cFo
-cFD
-cFW
-cGk
+cFa
+cFq
+cFG
+cGa
+cGp
 css
-cGJ
+cGQ
 aaa
 aaa
 aaT
-aaa
-aaa
+cHA
+abY
 aaa
 aaa
 aaa
@@ -89429,17 +89489,17 @@ ccw
 cEq
 cEJ
 crJ
-cFp
-cFE
-cFX
+cFr
+cFH
+cGb
 csx
 css
 csb
 aaf
 aaf
 aaT
-aaa
-aaa
+cHB
+abY
 aaa
 aaa
 aaa
@@ -89686,19 +89746,19 @@ ccw
 crH
 crT
 crZ
-cFq
+cFs
 css
-cFY
-cGl
+cGc
+cGq
 css
 csv
 aaa
 aaa
 aaT
+ctv
+abY
 aaa
-aaa
-aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -89943,7 +90003,7 @@ czh
 crJ
 crU
 csb
-cFr
+cFt
 css
 csx
 csx
@@ -89952,11 +90012,11 @@ csb
 aaf
 aaf
 aaT
-aaa
-aaa
-aaa
-aaa
-aaa
+aaT
+aaT
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -90203,7 +90263,7 @@ csa
 csj
 csa
 csa
-cGm
+cGr
 aaa
 aaa
 aaa
@@ -90212,7 +90272,7 @@ aaf
 aaa
 aaa
 aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -90456,12 +90516,12 @@ cqc
 cEd
 cEr
 cEL
-cFa
-cFs
-cFF
-cFZ
-cGn
-cGA
+cFb
+cFu
+cFI
+cGd
+cGs
+cGG
 aaa
 aaf
 aaa
@@ -90469,7 +90529,7 @@ aaf
 aaa
 aaa
 aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -90717,7 +90777,7 @@ cqb
 cAp
 cqb
 cAo
-cGo
+cGt
 cgx
 ccw
 ccw
@@ -90726,7 +90786,7 @@ ccw
 ccw
 aaa
 aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -90970,21 +91030,21 @@ cqB
 cEe
 csP
 cAl
-cFb
+cFc
 cAq
-cFG
+cFJ
 cpx
-cGp
-cGB
-cGK
-cGU
+cGu
+cGH
+cGR
+cHa
 csd
 ciZ
 ccw
 aaa
-aaa
-aaa
-aaa
+abY
+ctv
+abY
 aaa
 aaa
 aaa
@@ -91228,21 +91288,21 @@ cEf
 cEt
 cEM
 csA
-cFt
-cFH
-cGa
-cGq
-cGC
-cGL
-cGV
-cHa
+cFv
+cFK
+cGe
+cGv
+cGI
+cGS
+cHb
 cHg
+cHn
 ccw
 aaf
 aaT
+ctv
+aaT
 aaf
-aaf
-aaa
 aaa
 aaa
 aaa
@@ -91484,21 +91544,21 @@ cqU
 ccw
 cEu
 cEN
-cFc
+cFd
 ccw
-cFI
-cGb
-cGr
+cFL
+cGf
+cGw
 cqY
 ciZ
-cGW
-cHb
+cHc
+cHh
 cAu
 ccw
 aaa
 abY
-aaa
-aaa
+ctv
+abY
 aaa
 aaa
 aaa
@@ -91741,21 +91801,21 @@ ccw
 crs
 cEv
 cEO
-cFd
+cFe
 ccw
-cFJ
+cFM
 czE
-cGs
+cGx
 ccw
-cGM
+cGT
 csd
 csd
 ciZ
 ccw
 aaf
 aaT
-aaa
-aaa
+ctv
+abY
 aaa
 aaa
 aaa
@@ -91998,21 +92058,21 @@ cra
 crI
 cEw
 cEP
-cFe
-cFu
-cFK
+cFf
+cFw
+cFN
 csH
 csR
 cqY
-cGN
+cGU
 csd
 csd
-cHh
+cHo
 ccw
 aaa
 abY
-aaa
-aaa
+ctv
+abY
 aaa
 aaa
 aae
@@ -92257,19 +92317,19 @@ czE
 cAm
 czE
 cqY
-cFL
+cFO
 csC
 csQ
 cqY
-cGO
+cGV
 csd
-cHc
+cHi
 ccw
 ccw
 aaa
-aaa
-aaa
-aaa
+abY
+ctv
+abY
 aaa
 aaa
 aaa
@@ -92512,21 +92572,21 @@ crb
 cru
 cEx
 cEQ
-cFf
+cFg
 cAP
-cFM
+cFP
 csI
 cAt
 cqY
-cGP
 csd
 csd
-ciZ
+csd
+cHp
 ccw
 aaf
 abY
-aaa
-aaa
+ctv
+abY
 aaa
 aaa
 aaa
@@ -92769,21 +92829,21 @@ cAP
 crv
 cEy
 cER
-cFg
+cFh
 ccw
-cFN
+cFQ
 czE
-cGt
+cGy
 ccw
-cGQ
+cGW
 csd
 csd
 ciZ
 ccw
 aaf
 aaS
-aaa
-aaa
+ctv
+abY
 aaa
 aaa
 aaa
@@ -93026,21 +93086,21 @@ cEa
 ccw
 cEz
 cES
-cFh
+cFi
 ccw
-cFO
+cFR
 csJ
-cGu
+cGz
 cqY
 ciZ
-cGX
 cHd
-cHi
+cHj
+cHq
 ccw
 aaa
 abY
-aaa
-aaa
+ctv
+abY
 aaa
 aaa
 aaa
@@ -93283,21 +93343,21 @@ cEb
 cEg
 cEA
 cET
-cFi
-cFv
-cFP
-cGc
-cGv
-cGD
-cGR
-cGY
+cFj
+cFx
+cFS
+cGg
+cGA
+cGJ
+cGX
 cHe
-cHj
+cHk
+cHr
 ccw
 aaf
 aaT
-aaf
-aaf
+ctv
+aaT
 aaf
 aaa
 aaa
@@ -93540,21 +93600,21 @@ cEc
 cEh
 cEB
 cEU
-cFj
+cFk
 cAs
-cFQ
+cFT
 cpx
-cGw
-cGE
-cGS
-cGZ
+cGB
+cGK
+cGY
+cHf
 csd
-cHk
+cHs
 ccw
 aaf
-aaa
-aaa
-aaa
+abY
+ctv
+abY
 aaa
 aaa
 aaa
@@ -93800,18 +93860,18 @@ cqb
 cqb
 cAr
 cqb
-cGd
-cGx
+cGh
+cGC
 cey
 ccw
 ccw
-cHf
+cHl
 ccw
 ccw
+aaf
+abY
 aaT
-aaa
-aaa
-aaa
+abY
 aaa
 aaa
 aaa
@@ -94055,11 +94115,11 @@ cEi
 cED
 crc
 crc
-cFw
+cFy
 cBR
-cGe
-cGy
-cGF
+cGi
+cGD
+cGL
 aag
 aag
 aaf
@@ -94067,7 +94127,7 @@ aaf
 aaf
 aaf
 aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -94312,19 +94372,19 @@ ccw
 czF
 cEV
 csd
-cFx
-cFR
-cGf
-cGz
-cGG
-cGT
+cFz
+cFU
+cGj
+cGE
+cGM
+cGZ
 aag
 aaa
-aaT
+aaf
 aaa
 aaa
 aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -94569,21 +94629,21 @@ cEj
 crM
 crV
 crV
-cFy
+cFA
 csd
-cGg
+cGk
 ccw
 aag
 aag
 aag
 aaf
-aaT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -94828,17 +94888,17 @@ cEW
 cse
 cse
 csu
-cGh
+cGl
 ccw
 aaa
 aaa
 aaf
 aaa
-aaT
+aaf
+ctv
+abY
 aaa
-aaa
-aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -95088,14 +95148,14 @@ cqY
 cqY
 ccw
 aaf
-aaT
-aaT
-aaT
-aaT
+aaf
+aaf
+aaf
+aaf
+ctv
+abY
 aaa
-aaa
-aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -95347,10 +95407,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cHm
+cHt
+ctv
+abY
 aaa
 aaa
 aaa
@@ -95604,10 +95664,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+abY
+abY
+abY
+abY
 aaa
 aaa
 aae

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -46313,6 +46313,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Engine";
+	on = 0
+	},
 /turf/open/floor/plasteel,
 /area/atmos)
 "bWV" = (
@@ -47475,6 +47480,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bZx" = (
@@ -47906,6 +47912,7 @@
 /area/tcommsat/computer)
 "cap" = (
 /obj/machinery/light,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 6
 	},
@@ -49447,6 +49454,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdo" = (
@@ -50247,6 +50255,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
@@ -50585,7 +50594,7 @@
 /area/atmos)
 "cfR" = (
 /obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4;
+	dir = 1;
 	filter_type = "o2";
 	on = 1
 	},
@@ -50891,13 +50900,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgx" = (
-/obj/effect/landmark/start{
-	name = "Station Engineer"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cgy" = (
 /obj/machinery/light/small{
@@ -50993,46 +50999,34 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cgI" = (
-/obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/obj/item/weapon/pen,
-/obj/item/weapon/storage/firstaid/fire,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cgJ" = (
-/obj/structure/closet/radiation,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cgK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cgL" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engine Room";
+	req_access_txt = "32"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cgM" = (
 /obj/machinery/computer/atmos_alert,
@@ -51480,30 +51474,32 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chF" = (
-/obj/structure/table,
-/obj/item/weapon/book/manual/wiki/engineering_hacking{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/book/manual/wiki/engineering_construction,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"chG" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/clothing/gloves/color/black,
-/obj/item/weapon/extinguisher{
-	pixel_x = 8
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"chG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "chH" = (
 /obj/structure/closet/firecloset,
@@ -51633,10 +51629,26 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "chV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/tank/internals/emergency_oxygen/engi{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/meson/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "chW" = (
 /obj/machinery/camera{
@@ -51654,14 +51666,18 @@
 /area/engine/engineering)
 "chX" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "chY" = (
 /obj/machinery/shieldgen,
@@ -51714,6 +51730,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cid" = (
@@ -51765,10 +51783,25 @@
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cii" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/device/geiger_counter,
+/obj/item/device/geiger_counter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cij" = (
 /obj/machinery/computer/station_alert,
@@ -51848,8 +51881,13 @@
 	},
 /area/engine/chiefs_office)
 "cip" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "ciq" = (
 /obj/structure/grille,
@@ -51858,22 +51896,15 @@
 /turf/open/floor/plating,
 /area/engine/chiefs_office)
 "cir" = (
-/obj/structure/table,
-/obj/item/weapon/book/manual/wiki/engineering_guide,
-/obj/item/weapon/book/manual/engineering_particle_accelerator{
-	pixel_y = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cis" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cit" = (
@@ -52027,16 +52058,17 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ciO" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "ciP" = (
 /obj/structure/cable{
@@ -52208,7 +52240,9 @@
 	},
 /area/engine/chiefs_office)
 "cjh" = (
-/obj/structure/closet/firecloset,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cji" = (
@@ -52813,6 +52847,7 @@
 /obj/structure/table,
 /obj/item/weapon/book/manual/engineering_singularity_safety,
 /obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ckH" = (
@@ -53352,6 +53387,8 @@
 /obj/structure/table,
 /obj/item/weapon/crowbar/large,
 /obj/item/weapon/storage/box/lights/mixed,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 9
 	},
@@ -53382,6 +53419,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/book/manual/wiki/engineering_construction,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
@@ -53677,13 +53721,11 @@
 	},
 /area/shuttle/syndicate)
 "cmF" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
 /area/engine/engineering)
 "cmG" = (
-/obj/structure/closet/secure_closet/engineering_welding,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -54074,6 +54116,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start{
+	name = "Station Engineer"
+	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 1
 	},
@@ -54084,20 +54129,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate)
 "cnv" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the singularity chamber.";
-	dir = 1;
-	layer = 4;
-	name = "Singularity Engine Telescreen";
-	network = list("Singularity");
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnw" = (
@@ -54109,12 +54142,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnx" = (
-/obj/structure/cable/yellow{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "2-8";
+	tag = ""
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cny" = (
 /obj/effect/landmark/start{
@@ -54452,25 +54492,27 @@
 "cob" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "coc" = (
-/obj/effect/landmark/start{
-	name = "Station Engineer"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engine Room";
+	req_access_txt = "32"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cod" = (
 /obj/structure/table,
@@ -54815,22 +54857,20 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "coK" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "coL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -54839,14 +54879,27 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "coM" = (
-/obj/machinery/holopad,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "coN" = (
 /obj/machinery/door/window/westright{
@@ -54970,6 +55023,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpa" = (
@@ -54980,6 +55034,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpb" = (
@@ -55152,28 +55207,36 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpu" = (
-/obj/effect/landmark/start{
-	name = "Station Engineer"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cpv" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engine Room";
+	req_access_txt = "32"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cpv" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cpw" = (
 /obj/structure/table,
@@ -55182,44 +55245,26 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/syndicate)
 "cpx" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cpy" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cpy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	on = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cpz" = (
 /obj/structure/particle_accelerator/end_cap,
@@ -55253,17 +55298,16 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "cpD" = (
-/obj/structure/cable/yellow{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cpE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -55460,165 +55504,134 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqa" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cqb" = (
-/obj/item/clothing/glasses/meson,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cqc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cqd" = (
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "11"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cqe" = (
-/obj/structure/chair/stool,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cqf" = (
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "11"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cqg" = (
-/obj/structure/particle_accelerator/fuel_chamber,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cqh" = (
-/obj/machinery/particle_accelerator/control_box,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cqi" = (
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "11"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cqj" = (
-/obj/effect/landmark/start{
-	name = "Station Engineer"
+"cqb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cqc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cqd" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cqe" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cqf" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cqg" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Gas to Filter";
+	on = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cqh" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter North";
+	dir = 1;
+	pixel_x = 23
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cqi" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cqj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_y = -24;
+	req_access_txt = "24"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cqk" = (
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "11"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cql" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cqm" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqn" = (
@@ -55729,11 +55742,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 2;
 	name = "Engineering External Access";
@@ -55743,51 +55751,43 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqB" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cqC" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cqD" = (
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/weapon/crowbar,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/obj/structure/sign/radiation,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cqE" = (
-/obj/structure/particle_accelerator/power_box,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Supermatter Chamber";
+	req_access_txt = "24"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cqF" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cqG" = (
 /obj/structure/rack,
@@ -55897,11 +55897,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
@@ -55912,14 +55907,12 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqU" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cqV" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -55956,30 +55949,46 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqZ" = (
-/obj/structure/particle_accelerator/particle_emitter/center,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cra" = (
-/obj/structure/particle_accelerator/particle_emitter/left,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Filter"
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "crb" = (
-/obj/structure/particle_accelerator/particle_emitter/right,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	icon_state = "pump_map";
+	name = "Gas to Chamber"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "crc" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"crd" = (
-/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"crd" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engine Room";
+	req_access_txt = "32"
+	},
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cre" = (
 /obj/structure/cable{
@@ -56097,36 +56106,31 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crs" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4";
-	d1 = 1;
-	d2 = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"crt" = (
-/obj/item/weapon/wirecutters,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cru" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"crv" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"crt" = (
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Supermatter Chamber";
+	req_access_txt = "24"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cru" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"crv" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "crw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56250,57 +56254,43 @@
 /turf/open/space,
 /area/solar/starboard)
 "crH" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/space,
+/area/space)
 "crI" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "crJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/space,
+/area/space)
 "crK" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Singularity North-West";
-	dir = 2;
-	network = list("Singularity")
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
 	},
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plating/airless,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "crL" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "crM" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "crN" = (
 /obj/structure/table,
@@ -56335,20 +56325,24 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard)
 "crT" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/space,
+/area/space)
 "crU" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/space,
+/area/space)
 "crV" = (
-/obj/item/weapon/wrench,
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "crW" = (
 /obj/machinery/light/small{
@@ -56373,61 +56367,38 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crZ" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "csa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "csb" = (
-/obj/machinery/power/emitter{
-	anchored = 1;
-	dir = 4;
-	state = 2
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/space,
+/area/space)
 "csc" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/space,
 /area/maintenance/asmaint)
 "csd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cse" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "csf" = (
 /obj/machinery/power/emitter{
@@ -56463,8 +56434,11 @@
 /turf/open/space,
 /area/space)
 "csj" = (
-/obj/item/device/multitool,
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "csk" = (
 /obj/structure/disposalpipe/segment,
@@ -56534,14 +56508,10 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/incinerator)
 "css" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
 "cst" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -56552,37 +56522,26 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "csv" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
 	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "csw" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space,
 /area/space)
 "csx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
 "csy" = (
 /obj/structure/table,
 /obj/item/weapon/weldingtool,
@@ -56599,23 +56558,30 @@
 /turf/open/space,
 /area/space/nearstation)
 "csA" = (
-/obj/machinery/field/generator{
-	anchored = 1;
-	state = 2
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "csB" = (
 /obj/item/weapon/wirecutters,
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
 "csC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
 "csD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -56652,21 +56618,23 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csH" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "csI" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "csJ" = (
-/obj/item/weapon/crowbar,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "csK" = (
 /obj/machinery/light{
 	dir = 4;
@@ -56702,20 +56670,39 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "csP" = (
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"csQ" = (
-/obj/item/weapon/wrench,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"csR" = (
-/obj/machinery/the_singularitygen,
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/cable/yellow{
+	icon_state = "1-4";
+	d1 = 1;
+	d2 = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4;
+	initialize_directions = 11
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"csQ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"csR" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "csS" = (
 /obj/item/weapon/weldingtool,
 /turf/open/space,
@@ -59777,11 +59764,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "czh" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 1;
 	name = "Engineering External Access";
@@ -59926,23 +59908,14 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "czE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "czF" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Singularity North East";
-	dir = 2;
-	network = list("Singularity")
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plating/airless,
+/obj/machinery/meter,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "czG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -60237,29 +60210,33 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAl" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cAm" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4";
-	tag = "90Curve"
+	d1 = 1;
+	d2 = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cAm" = (
+/obj/machinery/power/supermatter_shard{
+	anchored = 1;
+	base_icon_state = "darkmatter";
+	explosion_power = 20;
+	gasefficency = 0.15;
+	icon_state = "darkmatter";
+	name = "supermatter crystal"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cAn" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -60270,71 +60247,90 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAo" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cAp" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4";
-	d1 = 1;
-	d2 = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Cooling Loop to Gas";
+	on = 1
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cAq" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/tesla_coil,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cAr" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cAs" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/tesla_coil,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cAt" = (
-/obj/machinery/the_singularitygen/tesla,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cAu" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2";
-	d2 = 2
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
-/obj/machinery/power/tesla_coil,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4;
+	initialize_directions = 11
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cAr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Gas to Mix";
+	on = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cAs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cAt" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cAu" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 4;
+	icon_state = "emitter";
+	state = 2;
+	tag = "icon-emitter (NORTH)"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cAv" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -60511,10 +60507,8 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cAP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/structure/sign/fire,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cAQ" = (
 /obj/structure/chair,
@@ -61008,9 +61002,12 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cBR" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/space,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cBS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61279,6 +61276,2008 @@
 "cCA" = (
 /turf/open/floor/pod/light,
 /area/space)
+"cCB" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10;
+	pixel_x = 0;
+	initialize_directions = 10
+	},
+/turf/open/floor/plasteel,
+/area/atmos)
+"cCC" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/atmos)
+"cCD" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/atmos)
+"cCE" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/atmos)
+"cCF" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/atmos)
+"cCG" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cCH" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCI" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCJ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCK" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCL" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCM" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCN" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCO" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCP" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cCQ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cCR" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cCS" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
+"cCT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cCU" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
+"cCV" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCW" = (
+/obj/machinery/portable_atmospherics/canister/freon,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cCX" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cCY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start{
+	name = "Station Engineer"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cCZ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDa" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDb" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDc" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDd" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDf" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/flashlight,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDi" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDj" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cDl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/vending/engivend,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDn" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDp" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDs" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDu" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDv" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	tag = "icon-filter_off_f (EAST)";
+	icon_state = "filter_off_f";
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDw" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Atmos to Loop";
+	on = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDz" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDA" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space,
+/area/space/nearstation)
+"cDB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Station Engineer"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDC" = (
+/obj/item/weapon/wrench,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cDD" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	tag = "icon-manifold (EAST)";
+	name = "scrubbers pipe";
+	icon_state = "manifold";
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cDE" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "External Gas to Loop"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cDF" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "External Gas to Loop"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cDG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cDH" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDI" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDL" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cDM" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cDN" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/engineering)
+"cDO" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/engineering)
+"cDP" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/engineering)
+"cDQ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/engineering)
+"cDR" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cDS" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cDT" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cDU" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cDV" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cDW" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cDX" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cDY" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cDZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cEa" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cEb" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cEc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter West";
+	dir = 4;
+	network = list("SS13")
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEf" = (
+/obj/machinery/ai_status_display,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cEg" = (
+/obj/machinery/status_display,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cEh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter East";
+	dir = 8;
+	network = list("SS13");
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEj" = (
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cEk" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cEl" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cEm" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEn" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cEo" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEp" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEq" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEs" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Gas to Cooling Loop";
+	on = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEt" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEu" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEv" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	icon_state = "manifold";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEz" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEA" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Gas";
+	on = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cED" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEE" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space,
+/area/space)
+"cEF" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEG" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEH" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEI" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEJ" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space)
+"cEK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cEL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEM" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/item/weapon/tank/internals/plasma,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEN" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cER" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	icon_state = "manifold";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cES" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cET" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cEV" = (
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cEW" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cEX" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cEY" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cEZ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4";
+	d1 = 1;
+	d2 = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	icon_state = "pump_map";
+	name = "Cooling Loop Bypass"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFc" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFd" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cFe" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cFh" = (
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFi" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cFj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix Bypass"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFk" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFl" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space,
+/area/space)
+"cFm" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFn" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space,
+/area/space)
+"cFo" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFp" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space,
+/area/space)
+"cFq" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFr" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space,
+/area/space)
+"cFs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFt" = (
+/obj/machinery/status_display,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cFu" = (
+/obj/structure/sign/electricshock,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cFv" = (
+/obj/machinery/ai_status_display,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cFw" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFx" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cFy" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cFz" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFA" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFB" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFC" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFD" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFE" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFG" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFI" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4;
+	filter_type = "co2";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFK" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4;
+	filter_type = "o2";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Center";
+	dir = 2;
+	pixel_x = 23
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cFM" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4;
+	filter_type = "plasma";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFO" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4;
+	filter_type = "";
+	on = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFP" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFQ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cFS" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFT" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFU" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFV" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFW" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFX" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space)
+"cFY" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cFZ" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGa" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGb" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGc" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGe" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGf" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGg" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGh" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGi" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGj" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGk" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cGm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cGn" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGo" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGq" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGr" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGs" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGt" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGv" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGw" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGx" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cGA" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGB" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Laser Room";
+	req_access_txt = "32"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Laser Room";
+	req_access_txt = "32"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGF" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cGG" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGH" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGI" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGL" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGM" = (
+/obj/structure/reflector/double/mapping,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGN" = (
+/obj/structure/reflector/box/mapping{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGO" = (
+/obj/structure/reflector/double/mapping{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGP" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGS" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cGT" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGV" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGW" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cGY" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cGZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHa" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 4;
+	icon_state = "emitter";
+	state = 2;
+	tag = "icon-emitter (NORTH)"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHb" = (
+/obj/structure/reflector/box/mapping{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"cHc" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 8;
+	icon_state = "emitter";
+	state = 2;
+	tag = "icon-emitter (NORTH)"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHe" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cHf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHg" = (
+/obj/structure/reflector/single/mapping{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHh" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHi" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cHj" = (
+/obj/item/weapon/crowbar/large,
+/turf/open/floor/plating,
+/area/engine/engineering)
 
 (1,1,1) = {"
 aaa
@@ -84856,6 +86855,7 @@ cjJ
 aaa
 aaa
 crn
+aaf
 aaa
 aaa
 aaa
@@ -84866,8 +86866,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -85113,6 +87112,7 @@ cjJ
 aaa
 aaa
 crn
+aaf
 aaa
 aaa
 aaa
@@ -85123,8 +87123,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -85370,20 +87369,20 @@ cjJ
 aaf
 aaf
 cig
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+aaf
+aaT
+aaT
+aaT
+aaT
+aaT
+aaT
+aaT
+aaf
+aaf
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -85628,17 +87627,17 @@ ccw
 ccw
 ccw
 aaa
+aaf
+aaa
+aaa
+aaf
+aaa
+aaa
+aaf
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -85885,17 +87884,17 @@ cqw
 cqO
 crp
 aaa
+aaf
+aaa
+aaa
+aaf
+aaa
+aaa
+aaf
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -86141,18 +88140,18 @@ cgR
 cgR
 cqN
 cro
+cEl
+cEE
+cEX
+cFk
+cFz
+cFS
+cGh
+csx
+cGG
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaT
 aaa
 aaa
 aaa
@@ -86396,20 +88395,20 @@ chE
 ciN
 ciN
 cji
-ckH
+cDZ
 crr
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cEm
+cEF
+crJ
+cFl
+cFA
+cFT
+csx
+css
+csb
+aaf
+aaf
+aaT
 aaa
 aaa
 aaa
@@ -86652,21 +88651,21 @@ cfL
 coH
 cBO
 cgR
-cqx
+cDB
 cqP
 crq
+cEn
+cEG
+cEY
+cFm
+cFB
+cFU
+cGi
+css
+cGH
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaT
 aaa
 aaa
 aaa
@@ -86912,18 +88911,18 @@ cgR
 cqx
 cqR
 crp
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cEo
+cEH
+crJ
+cFn
+cFC
+cFV
+csx
+css
+csb
+aaf
+aaf
+aaT
 aaa
 aaa
 aaa
@@ -87156,8 +89155,8 @@ bVI
 cay
 ccw
 chY
+cCW
 ciW
-ciZ
 ckB
 ckB
 ckC
@@ -87169,18 +89168,18 @@ cpX
 cqz
 cqQ
 ccw
+cEp
+cEI
+cEZ
+cFo
+cFD
+cFW
+cGj
+css
+cGI
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+aaT
 aaa
 aaa
 aaa
@@ -87426,22 +89425,22 @@ clJ
 cig
 cig
 ccw
-ccw
-ccw
-ccw
-ccw
-ccw
-ccw
-csF
-ccw
-ccw
-ccw
-ccw
-ccw
-ccw
-cjZ
+cEq
+cEJ
+crJ
+cFp
+cFE
+cFX
+csx
+css
+csb
 aaf
 aaf
+aaT
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87686,17 +89685,17 @@ ccw
 crH
 crT
 crZ
-crT
+cFq
 css
-ccw
-ccw
-ccw
+cFY
+cGk
+css
 csv
-crT
-ctl
-ctv
-ctv
-ccw
+aaa
+aaa
+aaT
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87935,26 +89934,26 @@ cmG
 cnt
 cob
 coL
-ckH
-ckH
+cDo
+cgR
 cqA
 cqT
 czh
 crJ
 crU
 csb
-crU
-cst
+cFr
+css
 csx
-csG
 csx
-csu
-crU
+css
 csb
-crU
-crU
-ccw
-ctv
+aaf
+aaf
+aaT
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88193,26 +90192,26 @@ cfG
 cgw
 coK
 cpu
-cqa
+clJ
 ccw
 ccw
 ccw
 crK
-crU
+cEK
 csa
 csj
-crU
-crU
-crU
-crU
-crU
-cte
 csa
-crU
-ctC
-ccw
-ccw
-ctv
+csa
+cGl
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88445,31 +90444,31 @@ cgR
 cen
 ckG
 clJ
-cmI
+cmF
 cgR
 cgI
 chF
 ciO
 cqc
-cqC
-cqV
-ccw
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-apQ
-aoV
-aoV
-crU
-ccw
-ctv
+cqc
+cqc
+cEd
+cEr
+cEL
+cFa
+cFs
+cFF
+cFZ
+cGm
+cGz
+aaa
+aaf
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88702,31 +90701,31 @@ cBO
 cjN
 cgR
 ceu
-cff
+clQ
 cgR
 cgx
 coM
 cpv
 cqb
-cqB
-cqU
-cqY
-aaH
-cAk
-cAo
+cqb
+cqb
+cqb
+cEs
+cqb
+cqb
 cAp
+cqb
 cAo
-cAo
-cAp
-cAo
-cAo
-cAp
-cAo
-cAo
-cAv
-apQ
-cig
-ctv
+cGn
+cgx
+ccw
+ccw
+ccw
+ccw
+ccw
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88962,29 +90961,29 @@ ceZ
 ckF
 ckF
 cgK
-cjS
-cpv
+cDg
+cDp
 cqe
 cqB
-cqW
-cqY
+cqB
+cEe
 csP
 cAl
-aaH
+cFb
 cAq
-aaH
-aaH
-cAq
-aaH
-aaH
-cAq
-aaH
-aaH
-cAl
-apQ
-cig
-ctv
-aaf
+cFG
+cpx
+cGo
+cGA
+cGJ
+cGT
+csd
+ciZ
+ccw
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89213,37 +91212,37 @@ caB
 ccw
 cie
 cdT
-cnA
+cCY
 cnA
 cev
 cfg
 cgU
 cgJ
 chG
-cpv
+cDq
 cqd
-cqB
+cDC
 cqU
-cqY
-cqY
-cAl
+cEf
+cEt
+cEM
 csA
-aoV
-aoV
-csA
-aoV
-aoV
-aoV
-aoV
-csA
-aaH
-cAl
-apQ
-cig
-ctR
+cFt
+cFH
+cGa
+cGp
+cGB
+cGK
+cGU
+cGZ
+cHf
+ccw
+aaf
+aaT
 aaf
 aaf
-aaf
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89475,30 +91474,30 @@ ckJ
 clJ
 cmL
 cgR
-csF
 ccw
+cDh
 cpy
+cDv
+cDD
+cqU
 ccw
+cEu
+cEN
+cFc
 ccw
+cFI
+cGb
+cGq
 cqY
-cqY
-cqY
-cAl
-aoV
-aoV
-aoV
-apQ
-aoV
-csS
-aoV
-aoV
-aoV
+ciZ
+cGV
+cHa
 cAu
-cAw
-apQ
-cig
-ctv
-aaf
+ccw
+aaa
+abY
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89737,24 +91736,24 @@ chV
 cpx
 cqf
 cqD
-cqX
+ccw
 crs
-cqY
-cAl
-aoV
-aoV
-apQ
-apQ
-apQ
-apQ
-apQ
-aoV
-aoV
-aaH
-cAl
-aoV
-cig
-ctv
+cEv
+cEO
+cFd
+ccw
+cFJ
+czE
+cGr
+ccw
+cGL
+csd
+csd
+ciZ
+ccw
+aaf
+aaT
+aaa
 aaa
 aaa
 aaa
@@ -89988,30 +91987,30 @@ cgR
 ckK
 clJ
 cmL
-cnw
+cgR
 cgL
 chX
-cAO
+cpx
 cqh
 cqF
 cra
 crI
-cqY
-cAl
-aoV
-aoV
-apQ
+cEw
+cEP
+cFe
+cFu
+cFK
 csH
 csR
-ctm
-apQ
-apQ
-csA
-aaH
-cAl
-aoV
-cig
-ctv
+cqY
+cGM
+csd
+csd
+cHg
+ccw
+aaa
+abY
+aaa
 aaa
 aaa
 aaa
@@ -90246,29 +92245,29 @@ ckK
 clJ
 cmL
 cnv
-ccw
-chW
-cpz
+clJ
+chX
+cpx
 cqg
 cqE
 cqZ
 crt
 czE
 cAm
-aoV
-aoV
-apQ
+czE
+cqY
+cFL
 csC
 csQ
-ctf
-apQ
-aoV
-aoV
-cAu
-cAw
-aoV
-cig
-ctv
+cqY
+cGN
+csd
+cHb
+ccw
+ccw
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90502,30 +92501,30 @@ cfb
 cfb
 cig
 cmN
-cnx
+cgR
 cgL
 chX
-cBQ
+cpx
 cqj
-cqH
+cqF
 crb
 cru
-cqY
-cAl
-csA
-csB
-apQ
+cEx
+cEQ
+cFf
+cAP
+cFM
 csI
 cAt
-czD
-apQ
-aoV
-aoV
-aaH
-cAl
-aoV
-cig
-ctv
+cqY
+cGO
+csd
+csd
+ciZ
+ccw
+aaf
+abY
+aaa
 aaa
 aaa
 aaa
@@ -90762,28 +92761,28 @@ cfz
 cgR
 ccw
 cii
-cpB
+cpx
 cqi
-cAP
+cqD
 cAP
 crv
-cqY
-cAl
-aoV
-aoV
-apQ
-apQ
-apQ
-apQ
-apQ
-aoV
-aoV
-aaH
-cAl
-aoV
-cig
-ctv
+cEy
+cER
+cFg
+ccw
+cFN
+czE
+cGs
+ccw
+cGP
+csd
+csd
+ciZ
+ccw
 aaf
+aaS
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91017,30 +93016,30 @@ ceq
 cfa
 cmQ
 cgR
-csF
 ccw
-cpy
+cDi
+cDr
+cDw
+cDE
+cEa
 ccw
+cEz
+cES
+cFh
 ccw
-cqY
-cqY
-cqY
-cAl
-aoV
-aoV
-aoV
+cFO
 csJ
-aoV
-apQ
-aoV
-aoV
-aoV
-cAu
-cAw
-apQ
-cig
-ctv
-aaf
+cGt
+cqY
+ciZ
+cGW
+cHc
+cHh
+ccw
+aaa
+abY
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91274,33 +93273,33 @@ ceq
 clQ
 cmQ
 cgR
-cgN
-cil
+clJ
+chX
 cpD
 cqk
-cqB
-cqU
-cqY
-cqY
-cAl
-csA
-aoV
-aoV
-aoV
-aoV
-csA
-aoV
-aoV
-csA
-aaH
-cAl
-apQ
-cig
-ctR
+cDF
+cEb
+cEg
+cEA
+cET
+cFi
+cFv
+cFP
+cGc
+cGu
+cGC
+cGQ
+cGX
+cHd
+cHi
+ccw
+aaf
+aaT
 aaf
 aaf
 aaf
-aaf
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91529,32 +93528,32 @@ cio
 cjY
 ckP
 ckH
-cmR
+cja
 cgR
-cgR
-cgR
-cpD
+clJ
+cDj
+cDs
 cql
-cqB
-cqU
-cqY
-csP
-cAl
-aaH
+cDG
+cEc
+cEh
+cEB
+cEU
+cFj
 cAs
-aaH
-aaH
-cAs
-aaH
-aaH
-cAs
-aaH
-aaH
-cAl
-apQ
-cig
-ctv
+cFQ
+cpx
+cGv
+cGD
+cGR
+cGY
+csd
+cHj
+ccw
 aaf
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91786,31 +93785,31 @@ cjj
 cjX
 ckO
 clP
-cmQ
-cny
 cgR
+cny
+ccw
 cip
 cnx
-cql
-cqB
-cqU
-cqY
-aaH
-cAn
-cAo
+cDx
+cqb
+cqb
+cqb
+cEC
+cqb
+cqb
 cAr
-cAo
-cAo
-cAr
-cAo
-cAo
-cAr
-cAo
-cAo
-cAx
-apQ
-cig
-ctv
+cqb
+cGd
+cGw
+cey
+ccw
+ccw
+cHe
+ccw
+ccw
+aaT
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92043,31 +94042,31 @@ cfb
 cfb
 ckR
 clR
-cmQ
 cgR
-cgP
+cgR
+clJ
 cir
-cen
-cqc
+cDt
+cDy
 cqC
 crc
-ccw
-aoV
-aoV
-aoV
-aoV
+cEi
+cED
+crc
+crc
+cFw
 cBR
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-crU
-ccw
-ctv
+cGe
+cGx
+cGE
+aag
+aag
+aaf
+aaf
+aaf
+aaf
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92294,37 +94293,37 @@ bXN
 bZt
 bZE
 cbs
-ccm
+cCT
 cdn
 cej
 cep
 ces
 clN
-cfA
+ccm
 ckF
-ckF
-ckF
+cDe
+cDk
 coc
 cqa
-ccw
+cig
 ccw
 ccw
 czF
-crU
+cEV
 csd
-crU
-crU
-crU
-crU
-crU
-crU
-crU
+cFx
+cFR
 csd
-crU
-ctD
-ccw
-ccw
-ctv
+cGy
+cGF
+cGS
+aag
+aaa
+aaT
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92557,30 +94556,30 @@ cel
 cyM
 ckT
 cgU
-cfC
-cnA
-cnA
+cco
+cgU
+cgU
 cis
-ciV
-ckH
-cqA
-cre
-czh
+cjN
+cDz
+cDH
+clJ
+cEj
 crM
 crV
-csf
-crU
-csv
-csx
-csK
-csx
-css
-crU
-csf
-crU
-crU
+crV
+cFy
+csd
+cGf
 ccw
-ctv
+aag
+aag
+aag
+aaf
+aaT
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92811,7 +94810,7 @@ ctR
 ccn
 cdo
 cek
-csF
+ccw
 cet
 cfd
 cfB
@@ -92820,24 +94819,24 @@ cgQ
 cjS
 cjN
 cqm
-cig
+cgR
 crd
-ccw
+cEk
 crL
-crT
+cEW
 cse
-crT
+cse
 csu
+cGg
 ccw
-ccw
-ccw
-cst
-crT
-ctn
-ctv
-ctv
-ccw
+aaa
+aaa
 aaf
+aaa
+aaT
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93074,29 +95073,29 @@ ccw
 ccw
 ccw
 ccw
-cjS
+cDl
 cjN
 cjh
-cig
+cDI
 ccw
 ccw
 ccw
 ccw
 ccw
+cqY
+cqY
+cqY
 ccw
-ccw
-ccw
-csF
-ccw
-ccw
-ccw
-ccw
-ccw
-ccw
-cjZ
 aaf
-aaf
-aaf
+aaT
+aaT
+aaT
+aaT
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93331,10 +95330,10 @@ bOh
 bOh
 bOh
 ccw
-cjS
+cDm
 cjP
 ckF
-ckF
+cDJ
 ckF
 cpE
 cjR
@@ -93591,7 +95590,7 @@ ccw
 coZ
 cgU
 cgU
-cgU
+cDK
 crw
 cjO
 ccw
@@ -93848,7 +95847,7 @@ ccw
 cpa
 cjc
 cqo
-ccw
+cDL
 cjk
 cjm
 ccw
@@ -94105,7 +96104,7 @@ ccw
 ccw
 cpI
 ccw
-ccw
+cDM
 cjl
 cjQ
 cjV
@@ -94362,7 +96361,7 @@ cig
 cpb
 ciZ
 cqp
-cig
+cDN
 cjT
 cgR
 crP
@@ -94619,7 +96618,7 @@ cig
 cig
 czg
 cig
-cig
+cDO
 crh
 crA
 crR
@@ -94876,7 +96875,7 @@ cig
 cpc
 cpJ
 cpc
-cig
+cDP
 cqY
 cqY
 cqY
@@ -95109,7 +97108,7 @@ bRF
 bSM
 bTS
 bUQ
-bWa
+agd
 bUO
 bVZ
 bVZ
@@ -95133,7 +97132,7 @@ cig
 cpd
 czM
 cpd
-cig
+cDQ
 aaa
 aaa
 aaa
@@ -95366,8 +97365,8 @@ bRE
 bSL
 bPe
 bOd
-bOd
-bOd
+cCB
+cCC
 bXT
 bXT
 bXT
@@ -95390,7 +97389,7 @@ ccw
 cpd
 czL
 cpd
-ccw
+cDR
 aaf
 aaa
 aaa
@@ -95624,7 +97623,7 @@ bSO
 bTU
 bUS
 bUS
-bUS
+cCD
 bXU
 bUS
 bUS
@@ -95647,7 +97646,7 @@ aaa
 cpd
 cpM
 cpd
-aaa
+cDS
 aaf
 aaa
 aaa
@@ -95881,7 +97880,7 @@ bSN
 bTT
 bUR
 bWb
-bUR
+cCE
 bTT
 bUR
 bZJ
@@ -95904,7 +97903,7 @@ aaa
 aaa
 czN
 aaa
-aaa
+cDT
 aaf
 aaa
 aaa
@@ -96161,7 +98160,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cDU
 aaf
 aaa
 aaa
@@ -96395,7 +98394,7 @@ bSP
 bPh
 bQy
 bRI
-bQy
+cCF
 bPh
 bQy
 bRI
@@ -96418,7 +98417,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cDV
 aaf
 aaa
 aaa
@@ -96652,16 +98651,16 @@ apQ
 bRK
 apQ
 bVv
-apQ
-bRK
-apQ
-bVv
-apQ
-bRK
-apQ
-bVv
-apQ
-apQ
+cCG
+cCH
+cCI
+cCJ
+cCK
+cCL
+cCM
+cCN
+cCO
+cCP
 bLK
 chg
 bLK
@@ -96675,7 +98674,7 @@ aoV
 aoV
 aoV
 aoV
-aoV
+cDW
 aoV
 aaa
 aaa
@@ -96918,7 +98917,7 @@ bPj
 bQA
 bPj
 bOh
-apQ
+cCQ
 bLK
 cyG
 bLK
@@ -96932,7 +98931,7 @@ aoV
 aoV
 aoV
 aoV
-aoV
+cDX
 aoV
 aaa
 aaa
@@ -97175,24 +99174,24 @@ cbI
 ccC
 cdD
 bOh
+cCR
+cCS
+cCU
+cCV
+cCX
+cCZ
+cDa
+cDb
+cDc
+cDd
+cDf
+cDn
+cDu
+cDA
+cDY
 apQ
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-apQ
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-aaa
-aaa
+aaf
+aaf
 aaf
 aaf
 cso
@@ -97446,7 +99445,7 @@ aoV
 aoV
 aoV
 aoV
-aoV
+apQ
 aoV
 aaa
 aaa
@@ -97703,7 +99702,7 @@ aoV
 aoV
 aoV
 csz
-aoV
+apQ
 aoV
 aaa
 aaa
@@ -97960,7 +99959,7 @@ aoV
 aoV
 aoV
 aoV
-aoV
+apQ
 aoV
 aaa
 aaa
@@ -98217,7 +100216,7 @@ bVu
 bVu
 bVu
 bVu
-bVu
+apQ
 bVu
 csw
 csw

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -51021,8 +51021,8 @@
 "cgL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
-	name = "Engine Room";
-	req_access_txt = "32"
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -54507,8 +54507,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
-	name = "Engine Room";
-	req_access_txt = "32"
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -55213,8 +55213,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
-	name = "Engine Room";
-	req_access_txt = "32"
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -55777,11 +55777,12 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cqE" = (
-/obj/machinery/door/airlock/glass_atmos{
-	name = "Supermatter Chamber";
-	req_access_txt = "24"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass_engineering{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cqF" = (
@@ -55984,8 +55985,8 @@
 "crd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
-	name = "Engine Room";
-	req_access_txt = "32"
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
@@ -56112,9 +56113,10 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "crt" = (
-/obj/machinery/door/airlock/glass_atmos{
+/obj/machinery/door/airlock/glass_engineering{
+	heat_proof = 1;
 	name = "Supermatter Chamber";
-	req_access_txt = "24"
+	req_access_txt = "10"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -62832,7 +62834,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGe" = (
-/obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -62844,7 +62845,7 @@
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cGg" = (
-/obj/structure/table/reinforced,
+/obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cGh" = (
@@ -62989,7 +62990,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Laser Room";
-	req_access_txt = "32"
+	req_access_txt = "10"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -63002,7 +63003,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Laser Room";
-	req_access_txt = "32"
+	req_access_txt = "10"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -89405,7 +89406,7 @@ ced
 bVI
 cay
 ccw
-chZ
+ciZ
 ciZ
 ciZ
 ckC

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -46313,10 +46313,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Engine";
-	on = 0
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/atmos)
@@ -55601,7 +55599,8 @@
 /obj/machinery/button/door{
 	id = "engsm";
 	name = "Radiation Shutters Control";
-	pixel_y = -24;
+	pixel_x = 24;
+	pixel_y = 0;
 	req_access_txt = "24"
 	},
 /turf/open/floor/engine,
@@ -60227,14 +60226,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cAm" = (
-/obj/machinery/power/supermatter_shard{
-	anchored = 1;
-	base_icon_state = "darkmatter";
-	explosion_power = 20;
-	gasefficency = 0.15;
-	icon_state = "darkmatter";
-	name = "supermatter crystal"
-	},
+/obj/machinery/power/supermatter_shard/crystal,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cAn" = (
@@ -61292,14 +61284,16 @@
 /area/atmos)
 "cCD" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Engine";
+	on = 0
 	},
 /turf/open/floor/plasteel,
 /area/atmos)
 "cCE" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -55599,8 +55599,8 @@
 /obj/machinery/button/door{
 	id = "engsm";
 	name = "Radiation Shutters Control";
-	pixel_x = 24;
-	pixel_y = 0;
+	pixel_x = 0;
+	pixel_y = -24;
 	req_access_txt = "24"
 	},
 /turf/open/floor/engine,
@@ -61505,6 +61505,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/weapon/pipe_dispenser,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDi" = (
@@ -62841,18 +62842,18 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGf" = (
-/obj/machinery/light,
+/obj/structure/table,
+/obj/item/weapon/pipe_dispenser,
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cGg" = (
-/obj/structure/closet/secure_closet/engineering_personal,
+/obj/machinery/light,
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cGh" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
 "cGi" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
@@ -62869,29 +62870,34 @@
 /turf/open/space,
 /area/space)
 "cGl" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cGm" = (
+"cGn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cGn" = (
+"cGo" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGo" = (
+"cGp" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGp" = (
+"cGq" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -62900,16 +62906,9 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGq" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cGr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
@@ -62922,23 +62921,23 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGt" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"cGu" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cGv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
@@ -62949,13 +62948,20 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGx" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cGx" = (
+"cGy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -62964,7 +62970,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGy" = (
+"cGz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -62972,32 +62978,19 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGz" = (
+"cGA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cGA" = (
+"cGB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
-"cGB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Laser Room";
-	req_access_txt = "10"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
 /area/engine/engineering)
 "cGC" = (
 /obj/machinery/door/firedoor,
@@ -63013,6 +63006,19 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGD" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Laser Room";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cGE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63020,7 +63026,7 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGE" = (
+"cGF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63028,17 +63034,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGF" = (
+"cGG" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cGG" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "cGH" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -63054,6 +63053,13 @@
 /turf/open/space,
 /area/space)
 "cGJ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"cGK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1;
 	on = 1;
@@ -63062,7 +63068,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGK" = (
+"cGL" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -63070,35 +63076,35 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGL" = (
+"cGM" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGM" = (
+"cGN" = (
 /obj/structure/reflector/double/mapping,
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGN" = (
+"cGO" = (
 /obj/structure/reflector/box/mapping{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGO" = (
+"cGP" = (
 /obj/structure/reflector/double/mapping{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGP" = (
+"cGQ" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGQ" = (
+"cGR" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -63106,20 +63112,20 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGR" = (
+"cGS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	on = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGS" = (
+"cGT" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cGT" = (
+"cGU" = (
 /obj/machinery/airalarm{
 	dir = 4;
 	icon_state = "alarm0";
@@ -63127,7 +63133,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGU" = (
+"cGV" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -63140,21 +63146,21 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGV" = (
+"cGW" = (
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGW" = (
+"cGX" = (
 /obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGX" = (
+"cGY" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -63167,14 +63173,14 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cGY" = (
+"cGZ" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cGZ" = (
+"cHa" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -63187,7 +63193,7 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHa" = (
+"cHb" = (
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -63201,13 +63207,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHb" = (
+"cHc" = (
 /obj/structure/reflector/box/mapping{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
-"cHc" = (
+"cHd" = (
 /obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4
@@ -63221,7 +63227,7 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHd" = (
+"cHe" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -63234,11 +63240,11 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHe" = (
+"cHf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"cHf" = (
+"cHg" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -63247,20 +63253,20 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHg" = (
+"cHh" = (
 /obj/structure/reflector/single/mapping{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHh" = (
+"cHi" = (
 /obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHi" = (
+"cHj" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -63269,7 +63275,7 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cHj" = (
+"cHk" = (
 /obj/item/weapon/crowbar/large,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -88141,9 +88147,9 @@ cEX
 cFk
 cFz
 cFS
-cGh
+cGi
 csx
-cGG
+cGH
 aaa
 aaa
 aaT
@@ -88655,9 +88661,9 @@ cEY
 cFm
 cFB
 cFU
-cGi
+cGj
 css
-cGH
+cGI
 aaa
 aaa
 aaT
@@ -89169,9 +89175,9 @@ cEZ
 cFo
 cFD
 cFW
-cGj
+cGk
 css
-cGI
+cGJ
 aaa
 aaa
 aaT
@@ -89683,7 +89689,7 @@ crZ
 cFq
 css
 cFY
-cGk
+cGl
 css
 csv
 aaa
@@ -90197,7 +90203,7 @@ csa
 csj
 csa
 csa
-cGl
+cGm
 aaa
 aaa
 aaa
@@ -90454,8 +90460,8 @@ cFa
 cFs
 cFF
 cFZ
-cGm
-cGz
+cGn
+cGA
 aaa
 aaf
 aaa
@@ -90711,7 +90717,7 @@ cqb
 cAp
 cqb
 cAo
-cGn
+cGo
 cgx
 ccw
 ccw
@@ -90968,10 +90974,10 @@ cFb
 cAq
 cFG
 cpx
-cGo
-cGA
-cGJ
-cGT
+cGp
+cGB
+cGK
+cGU
 csd
 ciZ
 ccw
@@ -91225,12 +91231,12 @@ csA
 cFt
 cFH
 cGa
-cGp
-cGB
-cGK
-cGU
-cGZ
-cHf
+cGq
+cGC
+cGL
+cGV
+cHa
+cHg
 ccw
 aaf
 aaT
@@ -91482,11 +91488,11 @@ cFc
 ccw
 cFI
 cGb
-cGq
+cGr
 cqY
 ciZ
-cGV
-cHa
+cGW
+cHb
 cAu
 ccw
 aaa
@@ -91739,9 +91745,9 @@ cFd
 ccw
 cFJ
 czE
-cGr
+cGs
 ccw
-cGL
+cGM
 csd
 csd
 ciZ
@@ -91998,10 +92004,10 @@ cFK
 csH
 csR
 cqY
-cGM
+cGN
 csd
 csd
-cHg
+cHh
 ccw
 aaa
 abY
@@ -92255,9 +92261,9 @@ cFL
 csC
 csQ
 cqY
-cGN
+cGO
 csd
-cHb
+cHc
 ccw
 ccw
 aaa
@@ -92512,7 +92518,7 @@ cFM
 csI
 cAt
 cqY
-cGO
+cGP
 csd
 csd
 ciZ
@@ -92758,7 +92764,7 @@ ccw
 cii
 cpx
 cqi
-cqD
+ccw
 cAP
 crv
 cEy
@@ -92767,9 +92773,9 @@ cFg
 ccw
 cFN
 czE
-cGs
+cGt
 ccw
-cGP
+cGQ
 csd
 csd
 ciZ
@@ -93024,12 +93030,12 @@ cFh
 ccw
 cFO
 csJ
-cGt
+cGu
 cqY
 ciZ
-cGW
-cHc
-cHh
+cGX
+cHd
+cHi
 ccw
 aaa
 abY
@@ -93281,12 +93287,12 @@ cFi
 cFv
 cFP
 cGc
-cGu
-cGC
-cGQ
-cGX
-cHd
-cHi
+cGv
+cGD
+cGR
+cGY
+cHe
+cHj
 ccw
 aaf
 aaT
@@ -93538,12 +93544,12 @@ cFj
 cAs
 cFQ
 cpx
-cGv
-cGD
-cGR
-cGY
+cGw
+cGE
+cGS
+cGZ
 csd
-cHj
+cHk
 ccw
 aaf
 aaa
@@ -93795,11 +93801,11 @@ cqb
 cAr
 cqb
 cGd
-cGw
+cGx
 cey
 ccw
 ccw
-cHe
+cHf
 ccw
 ccw
 aaT
@@ -94052,8 +94058,8 @@ crc
 cFw
 cBR
 cGe
-cGx
-cGE
+cGy
+cGF
 aag
 aag
 aaf
@@ -94308,10 +94314,10 @@ cEV
 csd
 cFx
 cFR
-csd
-cGy
-cGF
-cGS
+cGf
+cGz
+cGG
+cGT
 aag
 aaa
 aaT
@@ -94565,7 +94571,7 @@ crV
 crV
 cFy
 csd
-cGf
+cGg
 ccw
 aag
 aag
@@ -94822,7 +94828,7 @@ cEW
 cse
 cse
 csu
-cGg
+cGh
 ccw
 aaa
 aaa

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -108,3 +108,13 @@
 
 /obj/machinery/atmospherics/pipe/manifold/green/hidden
 	level = 1
+
+/obj/machinery/atmospherics/pipe/manifold/orange
+	pipe_color=rgb(255,127,39)
+	color=rgb(255,127,39)
+
+/obj/machinery/atmospherics/pipe/manifold/orange/visible
+	level = 2
+
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden
+	level = 1

--- a/code/modules/atmospherics/machinery/pipes/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold4w.dm
@@ -99,3 +99,13 @@
 
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden
 	level = 1
+
+/obj/machinery/atmospherics/pipe/manifold4w/orange
+	pipe_color=rgb(255,127,39)
+	color=rgb(255,127,39)
+
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible
+	level = 2
+
+/obj/machinery/atmospherics/pipe/manifold4w/orange/hidden
+	level = 1

--- a/code/modules/atmospherics/machinery/pipes/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple.dm
@@ -110,3 +110,13 @@ The regular pipe you see everywhere, including bent ones.
 
 /obj/machinery/atmospherics/pipe/simple/green/hidden
 	level = 1
+
+/obj/machinery/atmospherics/pipe/simple/orange
+	pipe_color=rgb(255,127,39)
+	color=rgb(255,127,39)
+
+/obj/machinery/atmospherics/pipe/simple/orange/visible
+	level = 2
+
+/obj/machinery/atmospherics/pipe/simple/orange/hidden
+	level = 1

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -868,7 +868,7 @@
 /mob/living/simple_animal/parrot/Poly
 	name = "Poly"
 	desc = "Poly the Parrot. An expert on quantum cracker theory."
-	speak = list("Poly wanna cracker!", ":e Check the singulo, you chucklefucks!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN HARDSUITS?",":e OH GOD ITS FREE CALL THE SHUTTLE")
+	speak = list("Poly wanna cracker!", ":e Check the crystal, you chucklefucks!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN HARDSUITS?",":e OH GOD ITS ABOUT TO DELAMINATE CALL THE SHUTTLE")
 	gold_core_spawnable = 0
 	speak_chance = 3
 	var/memory_saved = 0

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -129,7 +129,7 @@ var/global/list/rad_collectors = list()
 /obj/machinery/power/rad_collector/proc/receive_pulse(pulse_strength)
 	if(loaded_tank && active)
 		var/power_produced = loaded_tank.air_contents.gases["plasma"] ? loaded_tank.air_contents.gases["plasma"][MOLES] : 0
-		power_produced *= pulse_strength*20
+		power_produced *= pulse_strength*10
 		add_avail(power_produced)
 		last_power = power_produced
 		return

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -359,6 +359,7 @@
 /obj/machinery/power/supermatter_shard/crystal
 	name = "supermatter crystal"
 	desc = "A strangely translucent and iridescent crystal. <span class='danger'>You get headaches just from looking at it.</span>"
+	base_icon_state = "darkmatter"
 	icon_state = "darkmatter"
 	anchored = 1
 	gasefficency = 0.15

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -355,3 +355,12 @@
 /obj/machinery/power/supermatter_shard/hugbox
 	takes_damage = 0
 	produces_gas = 0
+
+/obj/machinery/power/supermatter_shard/crystal
+	name = "supermatter crystal"
+	desc = "A strangely translucent and iridescent crystal. <span class='danger'>You get headaches just from looking at it.</span>"
+	icon_state = "darkmatter"
+	anchored = 1
+	gasefficency = 0.15
+	explosion_power = 20
+

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -91,9 +91,12 @@
 	. = ..()
 
 /obj/machinery/power/supermatter_shard/proc/explode()
-	investigate_log("has exploded.", "supermatter")
-	explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1, 1)
+	investigate_log("has collapsed into a singularity.", "supermatter")
+	var/turf/T = get_turf(src)
 	qdel(src)
+	if(T)
+		var/obj/singularity/S = new(T)
+		S.energy = 800
 
 /obj/machinery/power/supermatter_shard/process()
 	var/turf/T = loc


### PR DESCRIPTION
🆑 Kor, Jordie and Tokiko1
add: Singularity containment has been replaced on box, meta, and delta with a supermatter room. The supermatter gives ample warning when melting down, so hopefully we'll see fewer 15 minute rounds ended by a loose singularity.
add: Supermatter crystals now collapse into singularities when they fail, rather than explode.
/🆑

As requested by @KorPhaeron 

Adds an actual supermatter crystal instead of the varedited shards that were used before.
Adds the supermatter to box.
Adds the supermatter to meta.
Removes singulo from delta and gives engineers access to some needed areas.
Adds orange pipes and manifolds for mappers.
Makes the supermatter spawn a singulo.
Rebalanced the power generation of radiation collectors by making them half as efficient as before.

Closes #24394 because it's the same thing, just a different design and some fixes.
The filesize seems a bit large for mapmerge, did I do it incorrectly?

Pictures:
Box:
![supermatter1](https://cloud.githubusercontent.com/assets/7812993/23335180/e7141f10-fbaf-11e6-97c3-b1d19b3da586.PNG)
![supermatter2](https://cloud.githubusercontent.com/assets/7812993/23335184/ebb35f22-fbaf-11e6-9441-241b77836b42.PNG)

Meta:
![metaatmos1](https://cloud.githubusercontent.com/assets/7812993/23336372/9c915a60-fbce-11e6-839a-a0c1e13b658f.PNG)

Delta:
![deltaatmos](https://cloud.githubusercontent.com/assets/7812993/23337119/ed6918a0-fbe3-11e6-9029-d0293cb10df6.PNG)

