### PR TITLE
>anyone with debug can still force admin the entire server

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -10,6 +10,9 @@
 	var/autoadmin = 0
 	var/autoadmin_rank = "Game Admin"
 
+/datum/protected_configuration/SDQL_update()
+	return FALSE
+
 /datum/protected_configuration/vv_get_var(var_name)
 	return debug_variable(var_name, "SECRET", 0, src)
 


### PR DESCRIPTION
thought i fixed this
wahtever
well rip this, i used to use this to autoadmin people on the testing server that pulls admins from the default admins.txt on github.

i mean this is a non issue because someone with debug can do way worse shit and i seriously don't forsee anyone abusing this as no one with debug flag on tg right now probably wants to see the server crash and burn, but whatever, a fix is a fix :P 