### PR TITLE
Multitools can change the I/O dirs of ORMs

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -919,25 +919,6 @@ var/list/WALLITEMS_INVERSE = typecacheof(list(
 		return !QDELETED(D)
 	return 0
 
-
-
-//Get the dir to the RIGHT of dir if they were on a clock
-//NORTH --> NORTHEAST
-/proc/get_clockwise_dir(dir, cardinal = FALSE)
-	if(cardinal)
-		. = angle2dir(dir2angle(dir)+90)
-	else
-		. = angle2dir(dir2angle(dir)+45)
-
-//Get the dir to the LEFT of dir if they were on a clock
-//NORTH --> NORTHWEST
-/proc/get_anticlockwise_dir(dir, cardinal = FALSE)
-	if(cardinal)
-		. = angle2dir(dir2angle(dir)-90)
-	else
-		. = angle2dir(dir2angle(dir)-45)
-
-
 //Compare A's dir, the clockwise dir of A and the anticlockwise dir of A
 //To the opposite dir of the dir returned by get_dir(B,A)
 //If one of them is a match, then A is facing B
@@ -949,8 +930,8 @@ var/list/WALLITEMS_INVERSE = typecacheof(list(
 		if(LA.lying)
 			return 0
 	var/goal_dir = angle2dir(dir2angle(get_dir(B,A)+180))
-	var/clockwise_A_dir = get_clockwise_dir(A.dir)
-	var/anticlockwise_A_dir = get_anticlockwise_dir(B.dir)
+	var/clockwise_A_dir = turn(A.dir, 45)
+	var/anticlockwise_A_dir = turn(B.dir, -45)
 
 	if(A.dir == goal_dir || clockwise_A_dir == goal_dir || anticlockwise_A_dir == goal_dir)
 		return 1

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -930,8 +930,8 @@ var/list/WALLITEMS_INVERSE = typecacheof(list(
 		if(LA.lying)
 			return 0
 	var/goal_dir = angle2dir(dir2angle(get_dir(B,A)+180))
-	var/clockwise_A_dir = turn(A.dir, 45)
-	var/anticlockwise_A_dir = turn(B.dir, -45)
+	var/clockwise_A_dir = turn(A.dir, -45)
+	var/anticlockwise_A_dir = turn(B.dir, 45)
 
 	if(A.dir == goal_dir || clockwise_A_dir == goal_dir || anticlockwise_A_dir == goal_dir)
 		return 1

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -923,13 +923,19 @@ var/list/WALLITEMS_INVERSE = typecacheof(list(
 
 //Get the dir to the RIGHT of dir if they were on a clock
 //NORTH --> NORTHEAST
-/proc/get_clockwise_dir(dir)
-	. = angle2dir(dir2angle(dir)+45)
+/proc/get_clockwise_dir(dir, cardinal = FALSE)
+	if(cardinal)
+		. = angle2dir(dir2angle(dir)+90)
+	else
+		. = angle2dir(dir2angle(dir)+45)
 
 //Get the dir to the LEFT of dir if they were on a clock
 //NORTH --> NORTHWEST
-/proc/get_anticlockwise_dir(dir)
-	. = angle2dir(dir2angle(dir)-45)
+/proc/get_anticlockwise_dir(dir, cardinal = FALSE)
+	if(cardinal)
+		. = angle2dir(dir2angle(dir)-90)
+	else
+		. = angle2dir(dir2angle(dir)-45)
 
 
 //Compare A's dir, the clockwise dir of A and the anticlockwise dir of A
@@ -1371,7 +1377,7 @@ var/valid_HTTPSGet = FALSE
 			\______(_______;;; __;;;
 		*/
 	var/temp_file = "HTTPSGetOutput.txt"
-	var/command 
+	var/command
 	if(world.system_type == MS_WINDOWS)
 		command = "powershell -Command \"wget [url] -OutFile [temp_file]\""
 	else if(world.system_type == UNIX)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -110,6 +110,12 @@
 			inserted_id = I
 			interact(user)
 		return
+	if(istype(W, /obj/item/device/multitool) && panel_open)
+		input_dir = get_clockwise_dir(input_dir, TRUE)
+		output_dir = get_clockwise_dir(output_dir, TRUE)
+		user << "<span class='notice'>You change [src]'s I/O settings, setting the input to [dir2text(input_dir)] and the output to [dir2text(output_dir)].</span>"
+		return
+
 	if(exchange_parts(user, W))
 		return
 

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -111,8 +111,8 @@
 			interact(user)
 		return
 	if(istype(W, /obj/item/device/multitool) && panel_open)
-		input_dir = get_clockwise_dir(input_dir, TRUE)
-		output_dir = get_clockwise_dir(output_dir, TRUE)
+		input_dir = turn(input_dir, 90)
+		output_dir = turn(output_dir, 90)
 		user << "<span class='notice'>You change [src]'s I/O settings, setting the input to [dir2text(input_dir)] and the output to [dir2text(output_dir)].</span>"
 		return
 

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -111,8 +111,8 @@
 			interact(user)
 		return
 	if(istype(W, /obj/item/device/multitool) && panel_open)
-		input_dir = turn(input_dir, 90)
-		output_dir = turn(output_dir, 90)
+		input_dir = turn(input_dir, -90)
+		output_dir = turn(output_dir, -90)
 		user << "<span class='notice'>You change [src]'s I/O settings, setting the input to [dir2text(input_dir)] and the output to [dir2text(output_dir)].</span>"
 		return
 


### PR DESCRIPTION
:cl: XDTM
add: You can now change the input/output directons for Ore Redemption Machines by using a multitool on them with the panel open.
/:cl:

Removed get_(counter)clockwise_dir procs as they were pointless, we have turn().
