### PR TITLE
Changelings can remove pieces of their own flesh clothing

### DIFF
--- a/code/game/gamemodes/changeling/powers/transform.dm
+++ b/code/game/gamemodes/changeling/powers/transform.dm
@@ -11,35 +11,92 @@
 	name = "flesh"
 	flags = NODROP
 
+/obj/item/clothing/glasses/changeling/attack_hand(mob/user)
+	if(loc == user && user.mind && user.mind.changeling)
+		user << "<span class='notice'>You reabsorb [src] into your body.</span>"
+		qdel(src)
+		return
+	..()
+
 /obj/item/clothing/under/changeling
 	name = "flesh"
 	flags = NODROP
+
+/obj/item/clothing/under/changeling/attack_hand(mob/user)
+	if(loc == user && user.mind && user.mind.changeling)
+		user << "<span class='notice'>You reabsorb [src] into your body.</span>"
+		qdel(src)
+		return
+	..()
 
 /obj/item/clothing/suit/changeling
 	name = "flesh"
 	flags = NODROP
 	allowed = list(/obj/item/changeling)
 
+/obj/item/clothing/suit/changeling/attack_hand(mob/user)
+	if(loc == user && user.mind && user.mind.changeling)
+		user << "<span class='notice'>You reabsorb [src] into your body.</span>"
+		qdel(src)
+		return
+	..()
+
 /obj/item/clothing/head/changeling
 	name = "flesh"
 	flags = NODROP
+
+/obj/item/clothing/head/changeling/attack_hand(mob/user)
+	if(loc == user && user.mind && user.mind.changeling)
+		user << "<span class='notice'>You reabsorb [src] into your body.</span>"
+		qdel(src)
+		return
+	..()
+
 /obj/item/clothing/shoes/changeling
 	name = "flesh"
 	flags = NODROP
+
+/obj/item/clothing/shoes/changeling/attack_hand(mob/user)
+	if(loc == user && user.mind && user.mind.changeling)
+		user << "<span class='notice'>You reabsorb [src] into your body.</span>"
+		qdel(src)
+		return
+	..()
 
 /obj/item/clothing/gloves/changeling
 	name = "flesh"
 	flags = NODROP
 
+/obj/item/clothing/gloves/changeling/attack_hand(mob/user)
+	if(loc == user && user.mind && user.mind.changeling)
+		user << "<span class='notice'>You reabsorb [src] into your body.</span>"
+		qdel(src)
+		return
+	..()
+
 /obj/item/clothing/mask/changeling
 	name = "flesh"
 	flags = NODROP
+
+/obj/item/clothing/mask/changeling/attack_hand(mob/user)
+	if(loc == user && user.mind && user.mind.changeling)
+		user << "<span class='notice'>You reabsorb [src] into your body.</span>"
+		qdel(src)
+		return
+	..()
 
 /obj/item/changeling
 	name = "flesh"
 	flags = NODROP
 	slot_flags = ALL
 	allowed = list(/obj/item/changeling)
+
+/obj/item/changeling/attack_hand(mob/user)
+	if(loc == user && user.mind && user.mind.changeling)
+		user << "<span class='notice'>You reabsorb [src] into your body.</span>"
+		qdel(src)
+		return
+	..()
 
 //Change our DNA to that of somebody we've absorbed.
 /obj/effect/proc_holder/changeling/transform/sting_action(mob/living/carbon/human/user)
@@ -62,7 +119,7 @@
 	var/chosen_name = input(prompt, title, null) as null|anything in names
 	if(!chosen_name)
 		return
-	
+
 	if(chosen_name == "Drop Flesh Disguise")
 		for(var/slot in slots)
 			if(istype(user.vars[slot], slot2type[slot]))


### PR DESCRIPTION
:cl: XDTM
add: Changelings can now click their fake clothing to remove it, without needing to drop the full disguise.
/:cl:

## Why
>Changeling, i have my target's DNA and id
>Strip then assume my target's appearance
>A fake id is blocking my id slot, so i can't wear the real deal
>Remove flesh disguise
>Can't wear id due to no jumpsuit
>Scream internally

### Notes
A quirk of this is that deleting the jumpsuit won't drop flesh id or belt items due to NODROP, but it will still prevent other items from being inserted. I'd rather keep this, since it doesn't harm gameplay and it sort of makes sense, than try to find a workaround.
It doesn't change the behaviour when trying to remove a changeling's stuff from the strip panel; it still appears as stuck and unremovable. Same if somehow the clothing owner is not a changeling.
Changelings who do this by mistake can get the clothing back for 5 chemicals, and learn not to do it again.
