### PR TITLE
Stops AI And Borgs From Interfacing With Ferry Console

### DIFF
--- a/code/modules/shuttle/ferry.dm
+++ b/code/modules/shuttle/ferry.dm
@@ -5,6 +5,15 @@
 	possible_destinations = "ferry_home;ferry_away"
 	req_access = list(access_cent_general)
 
+	var/aiControlDisabled = 1
+
+/obj/machinery/computer/shuttle/ferry/proc/canAIControl(mob/user)
+	return ((aiControlDisabled != 1));
+
+/obj/machinery/computer/shuttle/ferry/attack_ai(mob/user)
+	if(!src.canAIControl(user))
+		return
+
 /obj/machinery/computer/shuttle/ferry/request
 	name = "ferry console"
 	circuit = /obj/item/weapon/circuitboard/computer/ferry/request


### PR DESCRIPTION
## **Stops AI And Borgs From Interfacing With Ferry Console**
This pull requests prevents AI and AI Borgs from interfacing and or interacting at all with the Centcomm Ferry Console, this should stop players from charging onto the Centcomm Ferry when it has docked with a Borg, travelling to the Centcomm station and looting the entire station as Borgs have all access everywhere.

## **Changelog**
:cl: Tofa01
Fix: Stops AI And Borgs From Interfacing With Ferry Console
/:cl:

## **Fixes #24454**

_Just to clarify but this is a bug and was not intended when i re-coded the ferry shuttle to be accessed with ID's._


