### PR TITLE
Anima Fragments now slam into non-Servants when bumping

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_mobs/anima_fragment.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs/anima_fragment.dm
@@ -14,7 +14,7 @@
 	weather_immunities = list("lava")
 	movement_type = FLYING
 	playstyle_string = "<span class='heavy_brass'>You are an anima fragment</span><b>, a clockwork creation of Ratvar. As a fragment, you have decent health that very gradually regenerates, do \
-	decent damage, and move at extreme speed in addition to being immune to extreme temperatures and pressures. Taking damage will temporarily slow you down, however.\n\
+	decent damage, and move at extreme speed in addition to being immune to extreme temperatures and pressures. Taking damage, and slamming into non-Servants, will temporarily slow you down, however.\n\
 	Your goal is to serve the Justiciar and his servants in any way you can. You yourself are one of these servants, and will be able to utilize anything they can, assuming it doesn't require \
 	opposable thumbs.</b>"
 	var/movement_delay_time //how long the fragment is slowed after being hit
@@ -28,7 +28,9 @@
 
 /mob/living/simple_animal/hostile/clockwork/fragment/Life()
 	..()
-	if(movement_delay_time > world.time)
+	if(ratvar_awakens)
+		adjustHealth(-5)
+	else if(movement_delay_time > world.time)
 		adjustHealth(-0.2)
 	else
 		adjustHealth(-1)
@@ -46,11 +48,23 @@
 /mob/living/simple_animal/hostile/clockwork/fragment/Process_Spacemove(movement_dir = 0)
 	return 1
 
+/mob/living/simple_animal/hostile/clockwork/fragment/Bump(atom/movable/AM)
+	. = ..()
+	if(movement_delay_time <= world.time && next_move <= world.time && isliving(AM) && !is_servant_of_ratvar(AM))
+		var/mob/living/L = AM
+		if(L.stat) //we don't want to attack them if they're unconscious or dead because that feels REALLY BAD for the player
+			return
+		var/previousattacktext = attacktext
+		attacktext = "slams into"
+		UnarmedAttack(L)
+		attacktext = previousattacktext
+		changeNext_move(CLICK_CD_MELEE)
+		if(!ratvar_awakens)
+			adjustHealth(5)
+			adjust_movement_delay(22.5) //with the above, total of 35 movement delay
+
 /mob/living/simple_animal/hostile/clockwork/fragment/emp_act(severity)
-	if(movement_delay_time > world.time)
-		movement_delay_time = movement_delay_time + (50/severity)
-	else
-		movement_delay_time = world.time + (50/severity)
+	adjust_movement_delay(50/severity)
 
 /mob/living/simple_animal/hostile/clockwork/fragment/movement_delay()
 	. = ..()
@@ -59,11 +73,16 @@
 
 /mob/living/simple_animal/hostile/clockwork/fragment/adjustHealth(amount)
 	. = ..()
-	if(!ratvar_awakens && amount > 0) //if ratvar is up we ignore movement delay
-		if(movement_delay_time > world.time)
-			movement_delay_time = movement_delay_time + amount*2.5
-		else
-			movement_delay_time = world.time + amount*2.5
+	if(amount > 0)
+		adjust_movement_delay(amount*2.5)
+
+/mob/living/simple_animal/hostile/clockwork/fragment/proc/adjust_movement_delay(amount)
+	if(ratvar_awakens) //if ratvar is up we ignore movement delay
+		movement_delay_time = 0
+	else if(movement_delay_time > world.time)
+		movement_delay_time = movement_delay_time + amount
+	else
+		movement_delay_time = world.time + amount
 
 /mob/living/simple_animal/hostile/clockwork/fragment/updatehealth()
 	..()

--- a/code/game/gamemodes/clock_cult/clock_mobs/anima_fragment.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs/anima_fragment.dm
@@ -61,7 +61,7 @@
 		changeNext_move(CLICK_CD_MELEE)
 		if(!ratvar_awakens)
 			adjustHealth(4)
-			adjust_movement_delay(20) //with the above damage, total of 30 movement delay plus speed = 0 due to damage
+			adjust_movement_delay(10) //with the above damage, total of 20 movement delay plus speed = 0 due to damage
 
 /mob/living/simple_animal/hostile/clockwork/fragment/emp_act(severity)
 	adjust_movement_delay(50/severity)

--- a/code/game/gamemodes/clock_cult/clock_mobs/anima_fragment.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs/anima_fragment.dm
@@ -60,8 +60,8 @@
 		attacktext = previousattacktext
 		changeNext_move(CLICK_CD_MELEE)
 		if(!ratvar_awakens)
-			adjustHealth(5)
-			adjust_movement_delay(22.5) //with the above, total of 35 movement delay
+			adjustHealth(4)
+			adjust_movement_delay(20) //with the above damage, total of 30 movement delay plus speed = 0 due to damage
 
 /mob/living/simple_animal/hostile/clockwork/fragment/emp_act(severity)
 	adjust_movement_delay(50/severity)

--- a/code/game/gamemodes/clock_cult/clock_mobs/clockwork_marauder.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs/clockwork_marauder.dm
@@ -278,7 +278,7 @@
 				counterchance = initial(counterchance)
 				var/previousattacktext = attacktext
 				attacktext = "counters"
-				target.attack_animal(src)
+				UnarmedAttack(target)
 				attacktext = previousattacktext
 			else
 				counterchance = min(counterchance + initial(counterchance), 100)


### PR DESCRIPTION
:cl: Joan
rscadd: Anima Fragments now slam into non-Servants when bumping. This will ONLY happen if the fragment is not slowed, and slamming into someone will slightly damage the fragment and slow it severely.
/:cl:

Anima Fragments are partially kind of bad because they're so fast it can be hard to actually get next to a person to hit them.
So, the solution is to make them slam into people at the cost of brief vulnerability.