### PR TITLE
Fixes adjacent check for admin ghosts in the holodeck console

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -150,8 +150,6 @@
 /obj/machinery/computer/holodeck/Topic(href, list/href_list)
 	if(..())
 		return
-	if(!Adjacent(usr) && !issilicon(usr))
-		return
 	usr.set_machine(src)
 	add_fingerprint(usr)
 	if(href_list["loadarea"])


### PR DESCRIPTION
The parent call already has an adjacent check for regular mobs.
