### PR TITLE
You can make a damp rag out of medical gauze + other sink refactors

### DIFF
--- a/code/game/objects/items/dehy_carp.dm
+++ b/code/game/objects/items/dehy_carp.dm
@@ -16,16 +16,7 @@
 		user << "<span class='notice'>You pet [src]. You swear it looks up at you.</span>"
 		owner = user
 		owned = 1
-	return ..()
-
-
-/obj/item/toy/carpplushie/dehy_carp/afterattack(obj/O, mob/user,proximity)
-	if(!proximity) return
-	if(istype(O,/obj/structure/sink))
-		user.drop_item()
-		loc = get_turf(O)
-		return Swell()
-	..()
+	else return ..()
 
 /obj/item/toy/carpplushie/dehy_carp/proc/Swell()
 	desc = "It's growing!"

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -503,7 +503,7 @@
 		O.clean_blood()
 		O.acid_level = 0
 		create_reagents(5)
-		reagents.add_reagent("[dispensedreagents]", 5)
+		reagents.add_reagent("[dispensedreagent]", 5)
 		reagents.reaction(O, TOUCH)
 		user.visible_message("<span class='notice'>[user] washes [O] using [src].</span>", \
 							"<span class='notice'>You wash [O] using [src].</span>")

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -406,6 +406,7 @@
 	desc = "A sink used for washing one's hands and face."
 	anchored = 1
 	var/busy = 0 	//Something's being washed at the moment
+	var/dispensedreagent = "water" // for whenever plumbing happens
 
 
 /obj/structure/sink/attack_hand(mob/living/user)
@@ -455,7 +456,7 @@
 	if(istype(O, /obj/item/weapon/reagent_containers))
 		var/obj/item/weapon/reagent_containers/RG = O
 		if(RG.container_type & OPENCONTAINER)
-			RG.reagents.add_reagent("water", min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
+			RG.reagents.add_reagent("[dispensedreagent]", min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
 			user << "<span class='notice'>You fill [RG] from [src].</span>"
 			return 1
 
@@ -475,16 +476,16 @@
 				return
 
 	if(istype(O, /obj/item/weapon/mop))
-		O.reagents.add_reagent("water", 5)
+		O.reagents.add_reagent("[dispensedreagent]", 5)
 		user << "<span class='notice'>You wet [O] in [src].</span>"
 		playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
+		return
 
-	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/monkeycube))
-		var/obj/item/weapon/reagent_containers/food/snacks/monkeycube/M = O
-		user << "<span class='notice'>You place [O] under a stream of water...</span>"
-		user.drop_item()
-		M.loc = get_turf(src)
-		M.Expand()
+	if(istype(O, /obj/item/stack/medical/gauze))
+		var/obj/item/stack/medical/gauze/G = O
+		new /obj/item/weapon/reagent_containers/glass/rag(src.loc)
+		user << "<span class='notice'>You tear off a strip of gauze and make a rag.</span>"
+		G.use(1)
 		return
 
 	if(!istype(O))
@@ -501,6 +502,9 @@
 		busy = 0
 		O.clean_blood()
 		O.acid_level = 0
+		create_reagents(5)
+		reagents.add_reagent("water", 5)
+		reagents.reaction(O, TOUCH)
 		user.visible_message("<span class='notice'>[user] washes [O] using [src].</span>", \
 							"<span class='notice'>You wash [O] using [src].</span>")
 		return 1

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -503,7 +503,7 @@
 		O.clean_blood()
 		O.acid_level = 0
 		create_reagents(5)
-		reagents.add_reagent("water", 5)
+		reagents.add_reagent("[dispensedreagents]", 5)
 		reagents.reaction(O, TOUCH)
 		user.visible_message("<span class='notice'>[user] washes [O] using [src].</span>", \
 							"<span class='notice'>You wash [O] using [src].</span>")


### PR DESCRIPTION
- You can make a damp rag out of gauze. Uses up one stack.
- Refactored sinks and wetting a bit to remove some duplicated code. Also added a "dispensedreagent" variable to put down a tiny piece of framework for if plumbing ever happens.
- Fixed a bug with dehydrated carp getting double messages since I was in there already

To do:
- Currently this doesn't show the messages one gets upon monkeycubes/carp swelling up. I have no idea why, zero.
- Things other than gauze making a rag. We don't have cutting up clothes yet though...
- Showers / the toilet?
- The damp rag sprite blows