### PR TITLE
Mobs will no longer be shown empty memories

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -248,7 +248,7 @@
 
 	if(window)
 		recipient << browse(output,"window=memory")
-	else
+	else if(objectives.len || memory)
 		recipient << "<i>[output]</i>"
 
 /datum/mind/proc/edit_memory()


### PR DESCRIPTION
:cl: Cyberboss
tweak: You will no longer be shown empty memories when the game starts
/:cl:

Extra fluff text at round start for 90% of the crew