### PR TITLE
Fixes runtime with burger overlays

### DIFF
--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -117,9 +117,8 @@
 		if(INGREDIENTS_STACKPLUSTOP)
 			I.pixel_x = rand(-1,1)
 			I.pixel_y = 2 * ingredients.len - 1
-			our_overlays.Cut(ingredients.len)	//???
-			//force an update here just in case
-			SSoverlays.processing[src] = src
+			if(our_overlays)
+				our_overlays.Cut(ingredients.len)	//???, add overlay calls later in this proc will queue the compile if necessary
 			var/image/TOP = new(icon, "[icon_state]_top")
 			TOP.pixel_y = 2 * ingredients.len + 3
 			add_overlay(I)


### PR DESCRIPTION
I'm not sure if this is correct still...

This was the original code:

`overlays.Cut(ingredients.len)`

Does this even work with the new system?

https://github.com/Cyberboss/tgstation/blame/2f3a8fb849594ff3caed04c7ea0ded550c232501/code/modules/food_and_drinks/food/customizables.dm#L120