### PR TITLE
ADDS A VERSION OF DETECTIVE REVOLVER BULLETS FOCUSED ON STUNNING

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -21,6 +21,9 @@
 	desc = "A .38 bullet casing."
 	caliber = "38"
 	projectile_type = /obj/item/projectile/bullet/weakbullet2
+	
+/obj/item/ammo_casing/c38/weak
+    projectile_type = /obj/item/projectile/bullet/weakbullet
 
 /obj/item/ammo_casing/c10mm
 	desc = "A 10mm bullet casing."

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -13,6 +13,14 @@
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6
 	multiple_sprites = 1
+	
+/obj/item/ammo_box/c38/weak
+   name = "Ammo box (.38S)"
+   icon_state = "10mmbox"
+   ammo_type = /obj/item/ammo_casing/c38/weak
+   origin_tech = "combat=2"
+   max_ammo = 20
+   
 
 /obj/item/ammo_box/c9mm
 	name = "ammo box (9mm)"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -566,6 +566,14 @@
 	materials = list(MAT_METAL = 500)
 	build_path = /obj/item/ammo_box/foambox
 	category = list("initial", "Misc")
+	
+/datum/design/c38S
+    name = "Ammo Box (.38S)
+	id = "c38s"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL 30000)
+	build_path = /obj/item/ammo_box/c38/weak
+	category = list("initial", "Security")
 
 //hacked autolathe recipes
 /datum/design/flamethrower


### PR DESCRIPTION
Adds ammo for the detective revolver focused on stunning it does 80 stamina damage and 5 brute like a beanbag and does 5 brute so you wont have the scenario where people are screaming DETECTIVE SHOT SOMOENE INTO CRIT and AI get all butthurt over you 
The bullets can be made in a nonhacked autolathe they dont come in a speedloader altough! you have to reload a used speedloader with the bullets


:cl: Hyena
add: Adds 38. Stun variant
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)HELP DETECTIVE SHOT SOMOENE INTO CRIT!!!
