### PR TITLE
SM detonation singularities can grow to stage 6

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -43,7 +43,7 @@
 
 	var/emergency_issued = 0
 
-	var/explosion_power = 8
+	var/explosion_power = 320
 
 	var/lastwarning = 0				// Time in 1/10th of seconds since the last sent warning
 	var/power = 0
@@ -93,10 +93,10 @@
 /obj/machinery/power/supermatter_shard/proc/explode()
 	investigate_log("has collapsed into a singularity.", "supermatter")
 	var/turf/T = get_turf(src)
-	qdel(src)
 	if(T)
 		var/obj/singularity/S = new(T)
-		S.energy = 800
+		S.energy = explosion_power
+		S.consume(src)
 
 /obj/machinery/power/supermatter_shard/process()
 	var/turf/T = loc
@@ -142,6 +142,7 @@
 					L.rad_act(rads)
 
 			explode()
+			return
 
 	//Ok, get the air from the turf
 	var/datum/gas_mixture/env = T.return_air()
@@ -223,8 +224,6 @@
 	power -= (power/500)**3
 
 	return 1
-
-/obj/machinery/power/supermatter_shard
 
 /obj/machinery/power/supermatter_shard/bullet_act(obj/item/projectile/Proj)
 	var/turf/L = loc
@@ -363,5 +362,5 @@
 	icon_state = "darkmatter"
 	anchored = 1
 	gasefficency = 0.15
-	explosion_power = 20
+	explosion_power = 800
 


### PR DESCRIPTION
:cl: coiax
add: Singularities created by detonating supermatter can grow to stage
six, as if they had consumed a supermatter shard, because of their
origins.
/:cl:

Also makes `explosion_power` used again.