### PR TITLE
Combat Shotgun Price Increase

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -345,7 +345,7 @@
 
 /datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
-	cost = 4000
+	cost = 8000
 	contains = list(/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,
 					/obj/item/weapon/gun/ballistic/shotgun/automatic/combat,


### PR DESCRIPTION
Not a complete solution, but its at least a step towards better balance. 

Price is now 8,000 up from 4,000. 

Next Step: Balancing exports. 