### PR TITLE
Autoshuttle timer reduced to 15 minutes

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -270,7 +270,7 @@ var/datum/subsystem/shuttle/SSshuttle
 
 	if(callShuttle)
 		if(EMERGENCY_IDLE_OR_RECALLED)
-			emergency.request(null, 1.2)
+			emergency.request(null, 1.5)
 			log_game("There is no means of calling the shuttle anymore. Shuttle automatically called.")
 			message_admins("All the communications consoles were destroyed and all AIs are inactive. Shuttle called.")
 

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -270,7 +270,7 @@ var/datum/subsystem/shuttle/SSshuttle
 
 	if(callShuttle)
 		if(EMERGENCY_IDLE_OR_RECALLED)
-			emergency.request(null, 2.5)
+			emergency.request(null, 1.2)
 			log_game("There is no means of calling the shuttle anymore. Shuttle automatically called.")
 			message_admins("All the communications consoles were destroyed and all AIs are inactive. Shuttle called.")
 


### PR DESCRIPTION
Absolutely no reason for a round to go on for 30 minutes when the station is fucked. 

Edit: To clarify when both consoles + the AI are destroyed, a 25 minute shuttle is called. That shuttle will now be 15 minutes. 

Edit2: I'm a reasonable guy. I absolutely do not understand the people who want to drag out finished rounds but 15 minutes is my new compromise number, up from 12. 