### PR TITLE
Allows more mobs to use advanced camera consoles

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -4,7 +4,7 @@
 	icon_screen = "cameras"
 	icon_keyboard = "security_key"
 	var/mob/camera/aiEye/remote/eyeobj
-	var/mob/living/carbon/human/current_user = null
+	var/mob/living/current_user = null
 	var/list/networks = list("SS13")
 	var/datum/action/innate/camera_off/off_action = new
 	var/datum/action/innate/camera_jump/jump_action = new
@@ -13,7 +13,7 @@
 	eyeobj = new()
 	eyeobj.origin = src
 
-/obj/machinery/computer/camera_advanced/proc/GrantActions(mob/living/carbon/user)
+/obj/machinery/computer/camera_advanced/proc/GrantActions(mob/living/user)
 	off_action.target = user
 	off_action.Grant(user)
 	jump_action.target = user
@@ -38,11 +38,9 @@
 	if(current_user)
 		user << "The console is already in use!"
 		return
-	if(!iscarbon(user))
-		return
 	if(..())
 		return
-	var/mob/living/carbon/L = user
+	var/mob/living/L = user
 
 	if(!eyeobj)
 		CreateEye()
@@ -65,6 +63,14 @@
 		give_eye_control(L)
 		eyeobj.setLoc(eyeobj.loc)
 
+/obj/machinery/computer/camera_advanced/attack_robot(mob/user)
+	if(!Adjacent(user)) //Borgs can use the console without issue so long as they remain next to it.
+		user << "<span class='warning'>You must be adjacent to the console in order to interact with it.</span>"
+		return
+	return attack_hand(user)
+
+//obj/machinery/computer/camera_advanced/attack_ai(mob/user)
+//	return //AIs would need to disable their own camera procs to use the console safely.
 
 
 /obj/machinery/computer/camera_advanced/proc/give_eye_control(mob/user)
@@ -80,7 +86,7 @@
 	var/sprint = 10
 	var/cooldown = 0
 	var/acceleration = 1
-	var/mob/living/carbon/human/eye_user = null
+	var/mob/living/eye_user = null
 	var/obj/machinery/computer/camera_advanced/origin
 	var/eye_initialized = 0
 	var/visible_icon = 0
@@ -132,9 +138,9 @@
 	button_icon_state = "camera_off"
 
 /datum/action/innate/camera_off/Activate()
-	if(!target || !iscarbon(target))
+	if(!target || !isliving(target))
 		return
-	var/mob/living/carbon/C = target
+	var/mob/living/C = target
 	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
 	remote_eye.origin.current_user = null
 	remote_eye.origin.jump_action.Remove(C)
@@ -155,9 +161,9 @@
 	button_icon_state = "camera_jump"
 
 /datum/action/innate/camera_jump/Activate()
-	if(!target || !iscarbon(target))
+	if(!target || !isliving(target))
 		return
-	var/mob/living/carbon/C = target
+	var/mob/living/C = target
 	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
 	var/obj/machinery/computer/camera_advanced/origin = remote_eye.origin
 

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -20,7 +20,7 @@
 	jump_action.Grant(user)
 
 /obj/machinery/computer/camera_advanced/check_eye(mob/user)
-	if( (stat & (NOPOWER|BROKEN)) || !Adjacent(user) || user.eye_blind || user.incapacitated() )
+	if( (stat & (NOPOWER|BROKEN)) || (!Adjacent(user) && !user.has_unlimited_silicon_privilege) || user.eye_blind || user.incapacitated() )
 		user.unset_machine()
 
 /obj/machinery/computer/camera_advanced/Destroy()
@@ -64,13 +64,10 @@
 		eyeobj.setLoc(eyeobj.loc)
 
 /obj/machinery/computer/camera_advanced/attack_robot(mob/user)
-	if(!Adjacent(user)) //Borgs can use the console without issue so long as they remain next to it.
-		user << "<span class='warning'>You must be adjacent to the console in order to interact with it.</span>"
-		return
 	return attack_hand(user)
 
-//obj/machinery/computer/camera_advanced/attack_ai(mob/user)
-//	return //AIs would need to disable their own camera procs to use the console safely.
+obj/machinery/computer/camera_advanced/attack_ai(mob/user)
+	return //AIs would need to disable their own camera procs to use the console safely. Bugs happen otherwise.
 
 
 /obj/machinery/computer/camera_advanced/proc/give_eye_control(mob/user)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -42,7 +42,7 @@
 	eyeobj.icon = 'icons/obj/abductor.dmi'
 	eyeobj.icon_state = "camera_target"
 
-/obj/machinery/computer/camera_advanced/xenobio/GrantActions(mob/living/carbon/user)
+/obj/machinery/computer/camera_advanced/xenobio/GrantActions(mob/living/user)
 	off_action.target = user
 	off_action.Grant(user)
 
@@ -60,12 +60,6 @@
 
 	monkey_recycle_action.target = src
 	monkey_recycle_action.Grant(user)
-
-
-/obj/machinery/computer/camera_advanced/xenobio/attack_hand(mob/user)
-	if(!ishuman(user)) //AIs using it might be weird
-		return
-	return ..()
 
 /obj/machinery/computer/camera_advanced/xenobio/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/monkeycube))
@@ -88,9 +82,9 @@
 	..()
 
 /datum/action/innate/camera_off/xenobio/Activate()
-	if(!target || !ishuman(target))
+	if(!target || !isliving(target))
 		return
-	var/mob/living/carbon/C = target
+	var/mob/living/C = target
 	var/mob/camera/aiEye/remote/xenobio/remote_eye = C.remote_control
 	var/obj/machinery/computer/camera_advanced/xenobio/origin = remote_eye.origin
 	origin.current_user = null
@@ -116,9 +110,9 @@
 	button_icon_state = "slime_down"
 
 /datum/action/innate/slime_place/Activate()
-	if(!target || !ishuman(owner))
+	if(!target || !isliving(owner))
 		return
-	var/mob/living/carbon/human/C = owner
+	var/mob/living/C = owner
 	var/mob/camera/aiEye/remote/xenobio/remote_eye = C.remote_control
 	var/obj/machinery/computer/camera_advanced/xenobio/X = target
 
@@ -135,9 +129,9 @@
 	button_icon_state = "slime_up"
 
 /datum/action/innate/slime_pick_up/Activate()
-	if(!target || !ishuman(owner))
+	if(!target || !isliving(owner))
 		return
-	var/mob/living/carbon/human/C = owner
+	var/mob/living/C = owner
 	var/mob/camera/aiEye/remote/xenobio/remote_eye = C.remote_control
 	var/obj/machinery/computer/camera_advanced/xenobio/X = target
 
@@ -160,9 +154,9 @@
 	button_icon_state = "monkey_down"
 
 /datum/action/innate/feed_slime/Activate()
-	if(!target || !ishuman(owner))
+	if(!target || !isliving(owner))
 		return
-	var/mob/living/carbon/human/C = owner
+	var/mob/living/C = owner
 	var/mob/camera/aiEye/remote/xenobio/remote_eye = C.remote_control
 	var/obj/machinery/computer/camera_advanced/xenobio/X = target
 
@@ -181,9 +175,9 @@
 	button_icon_state = "monkey_up"
 
 /datum/action/innate/monkey_recycle/Activate()
-	if(!target || !ishuman(owner))
+	if(!target || !isliving(owner))
 		return
-	var/mob/living/carbon/human/C = owner
+	var/mob/living/C = owner
 	var/mob/camera/aiEye/remote/xenobio/remote_eye = C.remote_control
 	var/obj/machinery/computer/camera_advanced/xenobio/X = target
 


### PR DESCRIPTION
:cl: Gun Hog
tweak: Advanced camera, Slime Management, and Base Construction consoles may now be operated by drones and cyborgs.
/:cl:

Lessened mob type restrictions on advanced camera consoles, specifically affecting drones and cyborgs. This is intended to allow drones and cyborgs to work on the aux mining base, and for cyborgs be able to use the slime console (drones are usually forbidden by their laws).

Affected consoles ingame:
- Syndicate Lavaland base. Largely irrelevant, as it is rare for mining borgs to enter the base.
- Abductor console. Cyborgs and drones that have been abducted may now use them to attempt escaping the saucer. (Only abductors can use the console properly)
- Slime management console - Cyborgs and drones may use these consoles. <s>Cyborgs are required to be adjacent to the console to use it.</s>
- Base construction console - Same as Slime console.

Fixes https://github.com/tgstation/tgstation/issues/24482

I did not see any issues when testing the consoles with drones and cyborgs, so there does not seem to be a code reason to forbid them. AIs, however do have bugs regarding their own camera functions conflicting with the console's. As such, they remain entirely restricted from interacting with them.