### PR TITLE
Clones no longer gasp for air in cloning pods + Mime's Bane reagent

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -98,6 +98,8 @@ var/global/list/emote_list = list()
 			return FALSE
 		if(restraint_check && user.restrained())
 			return FALSE
+		if(user.reagents && user.reagents.has_reagent("mimesbane"))
+			return FALSE
 
 
 /datum/emote/sound

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -38,7 +38,11 @@
 
 	// The "brine" is the reagents that are automatically added in small
 	// amounts to the occupant.
-	var/static/list/brine_types = list("salbutamol", "bicaridine", "corazone")
+	var/static/list/brine_types = list(
+		"salbutamol", // anti-oxyloss
+		"bicaridine", // NOBREATHE species take brute in crit
+		"corazone", // prevents cardiac arrest damage
+		"mimesbane") // stops them gasping from lack of air.
 
 /obj/machinery/clonepod/New()
 	..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -860,3 +860,11 @@
 			M.Weaken(1, 0)
 		. = 1
 	..()
+
+/datum/reagent/toxin/mimesbane
+	name = "Mime's Bane"
+	id = "mimesbane"
+	description = "A nonlethal neurotoxin that interferes with the victim's ability to gesture."
+	color = "#F0F8FF" // rgb: 240, 248, 255
+	toxpwr = 0
+	taste_description = "stillness"


### PR DESCRIPTION
:cl: coiax
fix: Clones no longer gasp for air while in cloning pods.
add: Adds a new reagent, "Mime's Bane", that prevents all emoting while
it is in a victim's system. Currently admin only.
/:cl:

- Clones keep gasping a lot, either because they're not in an oxygenated
environment, or because they start in crit. This fixes that in a fairly
clean manner, and also adds a "fun" reagent to give to evil clowns or
something.