### PR TITLE
Weaker cult talismans take less time to imbue

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -233,7 +233,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	..()
 	visible_message("<span class='warning'>Dark power begins to channel into the paper!</span>")
 	rune_in_use = 1
-	if(!do_after(user, 100, target = paper_to_imbue))
+	if(!do_after(user, initial(talisman_type.creation_time), target = paper_to_imbue))
 		rune_in_use = 0
 		return
 	new talisman_type(get_turf(src))

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -4,6 +4,7 @@
 	var/invocation = "Naise meam!"
 	var/uses = 1
 	var/health_cost = 0 //The amount of health taken from the user when invoking the talisman
+	var/creation_time = 100 //how long it takes an imbue rune to make this type of talisman
 
 /obj/item/weapon/paper/talisman/examine(mob/user)
 	if(iscultist(user) || user.stat == DEAD)
@@ -119,6 +120,7 @@
 	color = "#551A8B" // purple
 	invocation = "Sas'so c'arta forbici!"
 	health_cost = 5
+	creation_time = 80
 
 /obj/item/weapon/paper/talisman/teleport/invoke(mob/living/user, successfuluse = 1)
 	var/list/potential_runes = list()
@@ -157,6 +159,7 @@
 	color = "#512727" // red-black
 	invocation = "N'ath reth sh'yro eth d'raggathnor!"
 	health_cost = 1
+	creation_time = 30
 
 /obj/item/weapon/paper/talisman/summon_tome/invoke(mob/living/user, successfuluse = 1)
 	. = ..()
@@ -172,6 +175,7 @@
 	color = "#9c9c9c" // grey
 	invocation = "Kla'atu barada nikt'o!"
 	health_cost = 1
+	creation_time = 30
 	uses = 2
 	var/revealing = FALSE //if it reveals or not
 
@@ -196,6 +200,7 @@
 	cultist_desc = "A talisman that will make nearby runes appear fake."
 	color = "#ff80d5" // honk
 	invocation = "By'o nar'nar!"
+	creation_time = 20
 
 /obj/item/weapon/paper/talisman/make_runes_fake/invoke(mob/living/user, successfuluse = 1)
 	. = ..()
@@ -273,6 +278,7 @@
 	cultist_desc = "A talisman that will equip the invoker with cultist equipment if there is a slot to equip it to."
 	color = "#33cc33" // green
 	invocation = "N'ath reth sh'yro eth draggathnor!"
+	creation_time = 80
 
 /obj/item/weapon/paper/talisman/armor/invoke(mob/living/user, successfuluse = 1)
 	. = ..()
@@ -301,6 +307,7 @@
 	cultist_desc = "A talisman that will break the mind of the victim with nightmarish hallucinations."
 	color = "#ffb366" // light orange
 	invocation = "Lo'Nab Na'Dm!"
+	creation_time = 80
 
 /obj/item/weapon/paper/talisman/horror/attack(mob/living/target, mob/living/user)
 	if(iscultist(user))
@@ -323,6 +330,7 @@
 	invocation = "Ethra p'ni dedol!"
 	color = "#000000" // black
 	uses = 25
+	creation_time = 80
 
 /obj/item/weapon/paper/talisman/construction/attack_self(mob/living/user)
 	if(iscultist(user))


### PR DESCRIPTION
:cl: Joan
tweak: Weaker cult talismans take less time to imbue.
/:cl:

New imbue times;
Stun and Shackling: 10 seconds, same as current
Teleport, Arming, Horror, and Construction: 8 seconds
Summon Tome and Hide/Reveal Runes: 3 seconds
Fake Runes: 2 seconds

Because okay, talisman spam is a problem, but it's only a problem with stun and cuff talismans really, and it taking 10 seconds to get somebody a tome for whatever reason is just a pain.
A cult buff, probably???