### PR TITLE
Hardens borg radios against EMPs

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -541,6 +541,8 @@
 	subspace_switchable = 1
 	dog_fashion = null
 
+/obj/item/device/radio/borg/emp_act(severity)	//keeps bad things from happening
+
 /obj/item/device/radio/borg/syndicate
 	syndie = 1
 	keyslot = new /obj/item/device/encryptionkey/syndicate


### PR DESCRIPTION
:cl: Cyberboss
fix: Borg radios are now immune to EMP effects, this fixes a bug with a radio being always on after being EMPed
/:cl:
