### PR TITLE
Mutant parts are removed if you roll a head job, as opposed to being barred from these jobs

### DIFF
--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -68,6 +68,11 @@
 	if(!visualsOnly && announce)
 		announce(H)
 
+	if(config.enforce_human_authority && src in command_positions)
+		H.dna.features["tail_human"] = "None"
+		H.dna.features["ears"] = "None"
+		H.regenerate_icons()
+
 /datum/job/proc/get_access()
 	if(!config)	//Needed for robots.
 		return src.minimal_access.Copy()

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -10,9 +10,7 @@
 
 
 /datum/species/human/qualifies_for_rank(rank, list/features)
-	if((!features["tail_human"] || features["tail_human"] == "None") && (!features["ears"] || features["ears"] == "None"))
-		return TRUE	//Pure humans are always allowed in all roles.
-	return ..()
+	return TRUE	//Pure humans are always allowed in all roles.
 
 //Curiosity killed the cat's wagging tail.
 /datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)


### PR DESCRIPTION
:cl: Kor
add: People with mutant parts (cat ears) are no longer outright barred from selecting command roles in their preferences, but will have their mutant parts removed on spawning if they are selected for that role.
/:cl:

Why: Heads of staff slots often go unfilled and forcing people to choose between cosmetics and command roles probably plays a part in that.
