### PR TITLE
Some CTF changes

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -3,6 +3,7 @@
 
 	var/uniform = null
 	var/suit = null
+	var/toggle_helmet = TRUE
 	var/back = null
 	var/belt = null
 	var/gloves = null
@@ -76,7 +77,7 @@
 			for(var/i=0,i<number,i++)
 				H.equip_to_slot_or_del(new path(H),slot_in_backpack)
 
-	if(!H.head && istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit))
+	if(!H.head && toggle_helmet && istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit))
 		var/obj/item/clothing/suit/space/hardsuit/HS = H.wear_suit
 		HS.ToggleHelmet()
 

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -97,16 +97,20 @@
 	proj_pass_rate = 20
 	armor = list(melee = 10, bullet = 50, laser = 50, energy = 50, bomb = 10, bio = 100, rad = 100, fire = 10, acid = 0)
 
+	var/deploy_time = 40
+	var/deploy_message = TRUE
+
 
 /obj/structure/barricade/security/New()
 	..()
-	addtimer(CALLBACK(src, .proc/deploy), 40)
+	addtimer(CALLBACK(src, .proc/deploy), deploy_time)
 
 /obj/structure/barricade/security/proc/deploy()
 	icon_state = "barrier1"
 	density = 1
 	anchored = 1
-	visible_message("<span class='warning'>[src] deploys!</span>")
+	if(deploy_message)
+		visible_message("<span class='warning'>[src] deploys!</span>")
 
 
 /obj/item/weapon/grenade/barrier

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -577,11 +577,7 @@
 		if("ctfbutton")
 			if(!check_rights(R_ADMIN))
 				return
-			var/ctf_enabled = FALSE
-			for(var/obj/machinery/capture_the_flag/CTF in machines)
-				ctf_enabled = CTF.toggle_ctf()
-			message_admins("[key_name_admin(usr)] has [ctf_enabled? "enabled" : "disabled"] CTF!")
-			notify_ghosts("CTF has been [ctf_enabled? "enabled" : "disabled"]!",'sound/effects/ghost2.ogg')
+			toggle_ctf(usr)
 		if("masspurrbation")
 			if(!check_rights(R_FUN))
 				return

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -577,7 +577,7 @@
 		if("ctfbutton")
 			if(!check_rights(R_ADMIN))
 				return
-			toggle_ctf(usr)
+			toggle_all_ctf(usr)
 		if("masspurrbation")
 			if(!check_rights(R_FUN))
 				return

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -138,12 +138,14 @@
 	var/ctf_enabled = FALSE
 	var/ctf_gear = /datum/outfit/ctf
 	var/instagib_gear = /datum/outfit/ctf/instagib
-	var/list/dead_barricades = list()
+
+	var/list/obj/effect/ctf/dead_barricade/dead_barricades = list()
+	var/list/obj/structure/barricade/security/ctf/living_barricades = list()
 
 	var/static/ctf_object_typecache
 	var/static/arena_cleared = FALSE
 
-/obj/machinery/capture_the_flag/New()
+/obj/machinery/capture_the_flag/Initialize()
 	..()
 	if(!ctf_object_typecache)
 		ctf_object_typecache = typecacheof(list(
@@ -173,8 +175,8 @@
 		else
 			// The changes that you've been hit with no shield but not
 			// instantly critted are low, but have some healing.
-			M.adjustBruteLoss(-1)
-			M.adjustFireLoss(-1)
+			M.adjustBruteLoss(-5)
+			M.adjustFireLoss(-5)
 
 /obj/machinery/capture_the_flag/red
 	name = "Red CTF Controller"
@@ -192,7 +194,15 @@
 
 /obj/machinery/capture_the_flag/attack_ghost(mob/user)
 	if(ctf_enabled == FALSE)
+		if(user.client && user.client.holder)
+			var/response = alert("Enable CTF?", "CTF", "Yes", "No")
+			if(response == "Yes")
+				for(var/obj/machinery/capture_the_flag/CTF in machines)
+					CTF.start_ctf()
+				message_admins("[key_name_admin(user)] has enabled CTF!")
+				notify_ghosts("CTF has been enabled!", 'sound/effects/ghost2.ogg')
 		return
+
 	if(ticker.current_state < GAME_STATE_PLAYING)
 		return
 	if(user.ckey in team_members)
@@ -289,9 +299,16 @@
 
 /obj/machinery/capture_the_flag/proc/start_ctf()
 	ctf_enabled = TRUE
-	for(var/obj/effect/ctf/dead_barricade/ded in dead_barricades)
-		ded.respawn()
+	for(var/d in dead_barricades)
+		var/obj/effect/ctf/dead_barricade/D = d
+		D.respawn()
+
 	dead_barricades.Cut()
+
+	for(var/b in living_barricades)
+		var/obj/structure/barricade/security/ctf/B = b
+		B.obj_integrity = B.max_integrity
+
 	notify_ghosts("[name] has been activated!", enter_link="<a href=?src=\ref[src];join=1>(Click to join the [team] team!)</a> or click on the controller directly!", source = src, action=NOTIFY_ATTACK)
 
 	if(!arena_cleared)
@@ -433,6 +450,7 @@
 	ears = /obj/item/device/radio/headset
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/space/hardsuit/shielded/ctf
+	toggle_helmet = FALSE // see the whites of their eyes
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	id = /obj/item/weapon/card/id/syndicate
@@ -528,6 +546,18 @@
 /obj/structure/barricade/security/ctf
 	name = "barrier"
 	desc = "A barrier. Provides cover in fire fights."
+	deploy_time = 0
+	deploy_message = 0
+
+/obj/structure/barricade/security/ctf/Initialize(mapload)
+	..()
+	for(var/obj/machinery/capture_the_flag/CTF in machines)
+		CTF.living_barricades += src
+
+/obj/structure/barricade/security/ctf/Destroy()
+	for(var/obj/machinery/capture_the_flag/CTF in machines)
+		CTF.living_barricades -= src
+	. = ..()
 
 /obj/structure/barricade/security/ctf/make_debris()
 	new /obj/effect/ctf/dead_barricade(get_turf(src))
@@ -549,7 +579,7 @@
 	alpha = 255
 	invisibility = 0
 
-/obj/effect/ctf/ammo/New()
+/obj/effect/ctf/ammo/Initialize(mapload)
 	..()
 	QDEL_IN(src, AMMO_DROP_LIFETIME)
 
@@ -583,7 +613,8 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "barrier0"
 
-/obj/effect/ctf/dead_barricade/New()
+/obj/effect/ctf/dead_barricade/Initialize(mapload)
+	..()
 	for(var/obj/machinery/capture_the_flag/CTF in machines)
 		CTF.dead_barricades += src
 

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -117,7 +117,7 @@
 	desc = "This is where a blue banner used to play capture the flag \
 		would go."
 
-/proc/toggle_ctf(mob/user)
+/proc/toggle_all_ctf(mob/user)
 	var/ctf_enabled = FALSE
 	for(var/obj/machinery/capture_the_flag/CTF in machines)
 		ctf_enabled = CTF.toggle_ctf()
@@ -204,7 +204,7 @@
 		if(user.client && user.client.holder)
 			var/response = alert("Enable CTF?", "CTF", "Yes", "No")
 			if(response == "Yes")
-				toggle_ctf(user)
+				toggle_all_ctf(user)
 		return
 
 	if(ticker.current_state < GAME_STATE_PLAYING)

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -117,6 +117,13 @@
 	desc = "This is where a blue banner used to play capture the flag \
 		would go."
 
+/proc/toggle_ctf(mob/user)
+	var/ctf_enabled = FALSE
+	for(var/obj/machinery/capture_the_flag/CTF in machines)
+		ctf_enabled = CTF.toggle_ctf()
+	message_admins("[key_name_admin(user)] has [ctf_enabled? "enabled" : "disabled"] CTF!")
+	notify_ghosts("CTF has been [ctf_enabled? "enabled" : "disabled"]!",'sound/effects/ghost2.ogg')
+
 /obj/machinery/capture_the_flag
 	name = "CTF Controller"
 	desc = "Used for running friendly games of capture the flag."
@@ -197,10 +204,7 @@
 		if(user.client && user.client.holder)
 			var/response = alert("Enable CTF?", "CTF", "Yes", "No")
 			if(response == "Yes")
-				for(var/obj/machinery/capture_the_flag/CTF in machines)
-					CTF.start_ctf()
-				message_admins("[key_name_admin(user)] has enabled CTF!")
-				notify_ghosts("CTF has been enabled!", 'sound/effects/ghost2.ogg')
+				toggle_ctf(user)
 		return
 
 	if(ticker.current_state < GAME_STATE_PLAYING)
@@ -660,3 +664,11 @@
 					if(istype(mob_area, /area/ctf))
 						M << "<span class='userdanger'>[user.real_name] has captured \the [src], claiming it for [CTF.team]! Go take it back!</span>"
 				break
+
+#undef WHITE_TEAM
+#undef RED_TEAM
+#undef BLUE_TEAM
+#undef FLAG_RETURN_TIME
+#undef INSTAGIB_RESPAWN
+#undef DEFAULT_RESPAWN
+#undef AMMO_DROP_LIFETIME


### PR DESCRIPTION
:cl: coiax
add: CTF players start with their helmet toggled off, better to see the
whites of their opponents eyes. Very briefly.
fix: Existing CTF barricades are repaired between rounds, and deploy
instantly when replaced.
tweak: Healing non-critical CTF damage is faster. Remember though, if
you drop into crit, YOU DIE.
add: Admin ghosts can just click directly on the CTF controller to
enable them, in addition to using the Secrets panel.
/:cl:

- @Cyberboss also look at all my New->Initialize conversions.