### PR TITLE
fixes watertanks in botany on meta being small

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -57874,8 +57874,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bUm" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/weapon/reagent_containers/glass/bucket,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -57884,16 +57882,18 @@
 	pixel_y = 29
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/weapon/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bUn" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/weapon/reagent_containers/glass/bucket,
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/weapon/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bUo" = (


### PR DESCRIPTION
before they were the kind that is not green now they are green, I hope I mapped the merge right. I don't even play botany, or know how to move stuff to top, so I just deleted the buckets and added new ones after adding the new tanks