### PR TITLE
Simple Export Nerf

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -112,7 +112,7 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	var/amount = get_amount(O)
 	total_cost += cost
 	total_amount += amount
-	amt_sold_inround += amount
+	amt_sold_inround += total_amount
 	
 	feedback_add_details("export_sold_amount","[O.type]|[amount]")
 	feedback_add_details("export_sold_cost","[O.type]|[cost]")

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -65,6 +65,8 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	var/list/export_types = list()	// Type of the exported object. If none, the export datum is considered base type.
 	var/include_subtypes = TRUE		// Set to FALSE to make the datum apply only to a strict type.
 	var/list/exclude_types = list()	// Types excluded from export
+	var/dim_returns = TRUE // Items give diminishing returns by default, see next line
+	var/amt_sold_inround = 0 // The more you sell the lower the price! Don't flood the market!
 
 	// Used by print-out
 	var/total_cost = 0
@@ -72,7 +74,14 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
 // Checks the cost. 0 cost items are skipped in export.
 /datum/export/proc/get_cost(obj/O, contr = 0, emag = 0)
-	return cost * get_amount(O, contr, emag)
+	var/endcost = 0
+	if(dim_returns && cost > amt_sold_inround)
+		endcost = (cost - amt_sold_inround) * get_amount(O, contr, emag)
+	if(dim_returns && cost < amt_sold_inround)
+		endcost = 0
+	else 
+		endcost = cost * get_amount(O, contr, emag)
+	return endcost
 
 // Checks the amount of exportable in object. Credits in the bill, sheets in the stack, etc.
 // Usually acts as a multiplier for a cost, so item that has 0 amount will be skipped in export.
@@ -103,6 +112,8 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	var/amount = get_amount(O)
 	total_cost += cost
 	total_amount += amount
+	amt_sold_inround += amount
+	
 	feedback_add_details("export_sold_amount","[O.type]|[amount]")
 	feedback_add_details("export_sold_cost","[O.type]|[cost]")
 


### PR DESCRIPTION
:cl: Cobby
experiment: Exports now have diminishing returns. To keep it simple, everytime you sell an item it subtracts one from the item's price.
fix: Coders or Badmins, to remove these for specific objects, set the export's dim_returns var to 0
/:cl:

# Exports
A simple way to lessen the effect of cargo flooding the market with particular items [probably what we should have done with those stupid seeds]. To keep it as atomized as possible, I didn't give exceptions yet. The only one I plan to give exceptions on myself is plasma [thematic] and manifest [logical], which will be in a separate PR should this go through.

I may make it more complicated later but I want cargo to be a pretty simple job since it's touted as the newbie job, so -1 per item sold is about as simple as I can make it. Unfortunately, because of this, It's a very minor nerf for high profile items, but it's a step in the right direction imo.

## Note
If you take a look at how this is calculated, you will see selling in bulk once is more beneficial than selling the items as you get them over the period of the round. No, i'm not playing 4d chess, but looking over this I like how it works out because now Cargo will hopefully store items they want to sell in the warehouse instead of immediately selling it [since it will affect prices negatively afterwards], giving you opportunity to steal the items and sabotage their efforts more efficiently. 