### PR TITLE
Minebots now check for pressure

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -138,29 +138,12 @@
 			iconF = "flight_on"
 		add_overlay(image(icon = icon, icon_state = iconF, pixel_x = flight_x_offset, pixel_y = flight_y_offset))
 
-
 //Casing
 /obj/item/ammo_casing/energy/kinetic
 	projectile_type = /obj/item/projectile/kinetic
 	select_name = "kinetic"
 	e_cost = 500
 	fire_sound = 'sound/weapons/Kenetic_accel.ogg' // fine spelling there chap
-
-/obj/item/ammo_casing/energy/kinetic/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
-	..()
-	if(loc && istype(loc, /obj/item/weapon/gun/energy/kinetic_accelerator))
-		var/obj/item/weapon/gun/energy/kinetic_accelerator/KA = loc
-		KA.modify_projectile(BB)
-
-		var/turf/proj_turf = get_turf(BB)
-		if(!isturf(proj_turf))
-			return
-		var/datum/gas_mixture/environment = proj_turf.return_air()
-		var/pressure = environment.return_pressure()
-		if(pressure > 50)
-			BB.name = "weakened [BB.name]"
-			var/obj/item/projectile/kinetic/K = BB
-			K.damage *= K.pressure_decrease
 
 
 //Projectiles
@@ -177,6 +160,17 @@
 	var/turf_aoe = FALSE
 	var/mob_aoe = 0
 	var/list/hit_overlays = list()
+
+/obj/item/projectile/kinetic/prehit(atom/target)
+	var/turf/target_turf = get_turf(target)
+	if(!isturf(target_turf))
+		return
+	var/datum/gas_mixture/environment = target_turf.return_air()
+	var/pressure = environment.return_pressure()
+	if(pressure > 50)
+		name = "weakened [name]"
+		damage = damage * pressure_decrease
+	. = ..()
 
 /obj/item/projectile/kinetic/on_range()
 	strike_thing()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -145,6 +145,11 @@
 	e_cost = 500
 	fire_sound = 'sound/weapons/Kenetic_accel.ogg' // fine spelling there chap
 
+/obj/item/ammo_casing/energy/kinetic/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
+	..()
+	if(loc && istype(loc, /obj/item/weapon/gun/energy/kinetic_accelerator))
+		var/obj/item/weapon/gun/energy/kinetic_accelerator/KA = loc
+		KA.modify_projectile(BB)
 
 //Projectiles
 /obj/item/projectile/kinetic


### PR DESCRIPTION
Fixes #24136

So apparently minebots do a flat 40 damage indoors, which meant an upgraded sentient minebot could crit people in under 3 seconds. The KA pressure check was in the ammo casing and simple mob code just poops out projectiles so... no pressure check. 

Thanks to Coiax for showing me prehit and letting me escape the nightmare of gun code. 