### PR TITLE
Feedback tracking testmerged prs

### DIFF
--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -27,6 +27,7 @@ var/global/datum/getrev/revdata = new()
 		for(var/line in testmerge)
 			if(line)
 				log_world("Test merge active of PR #[line]")
+				feedback_add_details("testmerged_prs","[line]")
 		log_world("Based off master commit [parentcommit]")
 	else
 		log_world(parentcommit)


### PR DESCRIPTION
@nfreader
Fixes #24039
Only thing to note is when a PR is re-testmerged it'll increment the existing feedback detail rather than add a new one, but I doubt that'll matter here for you.