### PR TITLE
[s]Prepares the Codebase for April Fools

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -72,3 +72,6 @@
 #ifndef SERVERTOOLS
 #define SERVERTOOLS 0
 #endif
+
+//Enables the dedicate April Fools Day code. Don't expect this to be well maintained or even compile if it's not near april fools...
+//#define APRIL_FOOLS_MODE

--- a/code/modules/april_fools/_april_fools_includes.dm
+++ b/code/modules/april_fools/_april_fools_includes.dm
@@ -1,0 +1,10 @@
+//Stick some #include s here for normally uncompiled code stored in this folder that should be run only during april fools day.
+//You can #define APRIL_FOOLS_MODE in _compile_options.dm
+//Every March review these files. Remove the ones that no longer work if people don't intend to update them.
+//Also remove the ones that just weren't funny last year. :honkman:
+
+//REMEMBER: One really bad and overbearing april fools day gimmick can spoil the whole experience. DON'T MEME TOO HARD!!!
+
+#ifdef APRIL_FOOLS_MODE
+
+#endif


### PR DESCRIPTION
Well it's March, and that means April Fools Day is within striking distance. Rather than use a separate branch this year I figured what we could do is set up a little preprocessor safe zone for meme code.

By uncommenting #define APRIL_FOOLS_MODE in _compile_options.dm  we can selectively run a version of the game with a bunch of  features that don't have to be actively maintained for 11 months out of the year.

The game plan goes like this:

1. This pull gets merged.
2. People add (unchecked) files to the April Fools folder to either tie in with existing features or add completely new ones.
3. They #define the path of their April Fools work in _april_fools_includes.dm
4. Those pulls get merged.
5. Late on March 31st we merge a pull that uncomments #define APRIL_FOOLS_MODE and get the servers up to date.
6. 🤡 Everyone gets pranked hard 🤡 
7. Late on April 1st we merge a pull that comments out #define APRIL_FOOLS_MODE and get the servers up to date.
8. Nothing happens for 11 months
9. Come March 2018 our decedents test to see what joke features still run, fix up the good ones that don't run anymore, and throw out the rest.
10. GOTO 2

A note to people thinking of writing/merging April Fools code:

<b>TRAVIS WILL AUTOMATICALLY PASS YOUR WORK UNTIL WE TURN ON APRIL_FOOLS_MODE.</b>
Test locally by temporarily uncommenting #define APRIL_FOOLS_MODE in _compile_options.dm
Don't test by just including YOUR work, because it has to play nice with everyone else's april fools code too.

Also always [s] april fools day pull requests to try and persevere some of the surprise #