### PR TITLE
Adds "secondary flags"; stops cyborg radio EMP wires

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -31,6 +31,10 @@
 #define DROPDEL			16384 // When dropped, it calls qdel on itself
 #define HOLOGRAM		32768	// HOlodeck shit should not be used in any fucking things
 
+/* Secondary atom flags, access using the SECONDARY_FLAG macros */
+
+#define NO_EMP_WIRES "no_emp_wires"
+
 //turf-only flags
 #define NOJAUNT		1
 #define UNUSED_TRANSIT_TURF 2

--- a/code/__HELPERS/flags.dm
+++ b/code/__HELPERS/flags.dm
@@ -1,0 +1,3 @@
+#define HAS_SECONDARY_FLAG(atom, sflag) (atom.secondary_flags ? atom.secondary_flags[sflag] : FALSE)
+#define SET_SECONDARY_FLAG(atom, sflag) if(!atom.secondary_flags) { atom.secondary_flags = list(); } atom.secondary_flags[sflag] = TRUE;
+#define CLEAR_SECONDARY_FLAG(atom, sflag) if(atom.secondary_flags) atom.secondary_flags[sflag] = null

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -2,7 +2,10 @@
 	layer = TURF_LAYER
 	plane = GAME_PLANE
 	var/level = 2
+
 	var/flags = 0
+	var/list/secondary_flags
+
 	var/list/fingerprints
 	var/list/fingerprintshidden
 	var/list/blood_DNA
@@ -165,16 +168,6 @@
 /atom/proc/is_transparent()
 	return container_type & TRANSPARENT
 
-/*//Convenience proc to see whether a container can be accessed in a certain way.
-
-/atom/proc/can_subract_container()
-	return flags & EXTRACT_CONTAINER
-
-/atom/proc/can_add_container()
-	return flags & INSERT_CONTAINER
-*/
-
-
 /atom/proc/allow_drop()
 	return 1
 
@@ -185,7 +178,7 @@
 	return
 
 /atom/proc/emp_act(severity)
-	if(istype(wires))
+	if(istype(wires) && !HAS_SECONDARY_FLAG(src, NO_EMP_WIRES))
 		wires.emp_pulse()
 
 /atom/proc/bullet_act(obj/item/projectile/P, def_zone)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -541,6 +541,10 @@
 	subspace_switchable = 1
 	dog_fashion = null
 
+/obj/item/device/radio/borg/Initialize(mapload)
+	..()
+	SET_SECONDARY_FLAG(src, NO_EMP_WIRES)
+
 /obj/item/device/radio/borg/syndicate
 	syndie = 1
 	keyslot = new /obj/item/device/encryptionkey/syndicate

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -67,6 +67,7 @@
 #include "code\__HELPERS\bandetect.dm"
 #include "code\__HELPERS\cmp.dm"
 #include "code\__HELPERS\files.dm"
+#include "code\__HELPERS\flags.dm"
 #include "code\__HELPERS\game.dm"
 #include "code\__HELPERS\global_lists.dm"
 #include "code\__HELPERS\icon_smoothing.dm"


### PR DESCRIPTION
Fixes #24611.

:cl: coiax
fix: Cyborg radios can no longer have their inaccessible wires pulsed by
EMPs.
/:cl:

Adds a secondary flags system, for stuff that should be set as a flag,
but is too rare to clog up one of our coveted high speed flag slots.
Uses a null list to store the flags, when instanced, the list is in the
form flag_string->booleon, for the highest speed. I suggest we locate
other rare flags and move them to this system. (Like EARBANGPROTECT, I
mean come on).

@MrStonedOne @RemieRichards @Cyberboss for review.