### PR TITLE
Makes the preloader apply text macros: Re-engineering

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -554,3 +554,59 @@ var/list/binary = list("0","1")
 	var/list/tosend = list()
 	tosend["data"] = finalized
 	log << json_encode(tosend)
+
+//Used for applying byonds text macros to strings that are loaded at runtime
+/proc/apply_text_macros(string)
+	var/next_backslash = findtextEx(string, "\\")
+	if(!next_backslash)
+		return string
+	
+	var/leng = length(string)
+
+	var/next_space = findtextEx(string, " ", next_backslash + 1)
+	if(!next_space)
+		next_space = leng - next_backslash
+
+	if(!next_space)	//trailing bs
+		return string
+
+	var/base = next_backslash == 1 ? "" : copytext(string, 1, next_backslash)
+	var/macro = lowertext(copytext(string, next_backslash + 1, next_space))
+	var/rest = next_backslash > leng ? "" : copytext(string, next_space)
+
+
+	//See http://www.byond.com/docs/ref/info.html#/DM/text/macros
+	switch(macro)
+		//prefixes/agnostic
+		if("the")
+			rest = text("\the []", rest)
+		if("a")
+			rest = text("\a []", rest)
+		if("an")
+			rest = text("\an []", rest)
+		if("proper")
+			rest = text("\proper []", rest)
+		if("improper")
+			rest = text("\improper []", rest)
+		if("roman")
+			rest = text("\roman []", rest)
+		//postfixes
+		if("th")
+			base = text("[]\th", rest)
+		if("s")
+			base = text("[]\s", rest)
+		if("he")
+			base = text("[]\he", rest)
+		if("she")
+			base = text("[]\she", rest)
+		if("his")
+			base = text("[]\his", rest)
+		if("himself")
+			base = text("[]\himself", rest)
+		if("herself")
+			base = text("[]\herself", rest)
+		if("hers")
+			base = text("[]\hers", rest)
+	
+	testing("Substituted macro(\\[macro]) in string([string]). Result: [base + rest]")
+	. = base + .(rest)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -557,13 +557,13 @@ var/list/binary = list("0","1")
 
 //Used for applying byonds text macros to strings that are loaded at runtime
 /proc/apply_text_macros(string)
-	var/next_backslash = findtextEx(string, "\\")
+	var/next_backslash = findtext(string, "\\")
 	if(!next_backslash)
 		return string
 	
 	var/leng = length(string)
 
-	var/next_space = findtextEx(string, " ", next_backslash + 1)
+	var/next_space = findtext(string, " ", next_backslash + 1)
 	if(!next_space)
 		next_space = leng - next_backslash
 
@@ -572,8 +572,7 @@ var/list/binary = list("0","1")
 
 	var/base = next_backslash == 1 ? "" : copytext(string, 1, next_backslash)
 	var/macro = lowertext(copytext(string, next_backslash + 1, next_space))
-	var/rest = next_backslash > leng ? "" : copytext(string, next_space)
-
+	var/rest = next_backslash > leng ? "" : copytext(string, next_space + 1)
 
 	//See http://www.byond.com/docs/ref/info.html#/DM/text/macros
 	switch(macro)
@@ -608,5 +607,7 @@ var/list/binary = list("0","1")
 		if("hers")
 			base = text("[]\hers", rest)
 	
-	testing("Substituted macro(\\[macro]) in string([string]). Result: [base + rest]")
-	. = base + .(rest)
+	testing("Substituted macro(\\[macro]) in string([string]). Result: \"[base + rest]\"")
+	. = base
+	if(rest)
+		. += .(rest)

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -401,6 +401,8 @@ var/global/dmm_suite/preloader/_preloader = new
 		var/value = attributes[attribute]
 		if(islist(value))
 			value = deepCopyList(value)
+		if(istext(value))
+			value = apply_text_macros(value)
 		what.vars[attribute] = value
 	use_preloader = FALSE
 


### PR DESCRIPTION
Fixes #24615
Closes #24619

@RemieRichards 

:cl: Cyberboss
fix: You should no longer be seeing entities with `\improper` in front of their name
/:cl: