### PR TITLE
Makes the preloader apply text macros: eval

### DIFF
--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -401,6 +401,8 @@ var/global/dmm_suite/preloader/_preloader = new
 		var/value = attributes[attribute]
 		if(islist(value))
 			value = deepCopyList(value)
+		if(istext(value))
+			value = eval("\"[value]\"")
 		what.vars[attribute] = value
 	use_preloader = FALSE
 


### PR DESCRIPTION
Fixes #24615
Closes #24614

:cl: Cyberboss
fix: You should no longer be seeing entities with `\improper` in front of their name
/:cl: