### PR TITLE
Detective's revolver and ammo now starts in his holster

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -403,8 +403,8 @@
 /obj/item/weapon/storage/belt/holster/full/New()
 	..()
 	new /obj/item/weapon/gun/ballistic/revolver/detective(src)
-	new /obj/item/ammo_box/magazine/internal/cylinder/rev38(src)
-	new /obj/item/ammo_box/magazine/internal/cylinder/rev38(src)
+	new /obj/item/ammo_box/c38(src)
+	new /obj/item/ammo_box/c38(src)
 
 /obj/item/weapon/storage/belt/fannypack
 	name = "fannypack"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -399,6 +399,12 @@
 		/obj/item/ammo_box,
 		)
 	alternate_worn_layer = UNDER_SUIT_LAYER
+	
+/obj/item/weapon/storage/belt/holster/full/New()
+	..()
+	new /obj/item/weapon/gun/ballistic/revolver/detective(src)
+	new /obj/item/ammo_box/magazine/internal/cylinder/rev38(src)
+	new /obj/item/ammo_box/magazine/internal/cylinder/rev38(src)
 
 /obj/item/weapon/storage/belt/fannypack
 	name = "fannypack"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -181,10 +181,7 @@
 	new /obj/item/weapon/holosign_creator/security(src)
 	new /obj/item/weapon/reagent_containers/spray/pepper(src)
 	new /obj/item/clothing/suit/armor/vest/det_suit(src)
-	new /obj/item/ammo_box/c38(src)
-	new /obj/item/ammo_box/c38(src)
-	new /obj/item/weapon/storage/belt/holster(src)
-	new /obj/item/weapon/gun/ballistic/revolver/detective(src)
+	new /obj/item/weapon/storage/belt/holster/full(src)
 
 /obj/structure/closet/secure_closet/injection
 	name = "lethal injections"


### PR DESCRIPTION
if security can have this luxery why not the detective

:cl: Hyena
tweak: Detective revolver/ammo now starts in their shoulder holster
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)SECURITY GETS THIS LUXERY WHY NOT DETECTIV
