### PR TITLE
Readds secborgs (as a traitor item)

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -393,8 +393,7 @@
 /obj/item/borg/upgrade/traitorsec/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return 0
-    
-	R.wiresexposed = TRUE
-	R.emag_act(user)
-	R.wiresexposed = FALSE
+		
 	R.module.transform_to(/obj/item/weapon/robot_module/security)
+	R.emag_act(user)
+	

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -384,7 +384,7 @@
 	
 /obj/item/borg/upgrade/traitorsec
 	name = "Bloodhound upgrade module"
-	desc = "Ilegal upgrade board that unlocks banned security module"
+	desc = "Ilegal upgrade board that unlocks the banned security module."
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
 	origin_tech = "data=4;combat=4;syndicate=3"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -15,7 +15,7 @@
 	// if module is reset
 	var/one_use = FALSE
 
-/obj/item/borg/upgrade/proc/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/proc/action(mob/living/silicon/robot/R,mob/living/user)
 	if(R.stat == DEAD)
 		usr << "<span class='notice'>[src] will not function on a deceased cyborg.</span>"
 		return 1
@@ -54,7 +54,7 @@
 	icon_state = "cyborg_upgrade1"
 	one_use = TRUE
 
-/obj/item/borg/upgrade/restart/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/restart/action(mob/living/silicon/robot/R,mob/living/user)
 	if(R.health < 0)
 		usr << "<span class='warning'>You have to repair the cyborg before using this module!</span>"
 		return 0
@@ -74,7 +74,7 @@
 	require_module = 1
 	origin_tech = "engineering=4;materials=5;programming=4"
 
-/obj/item/borg/upgrade/vtec/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/vtec/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 	if(R.speed < 0)
@@ -94,7 +94,7 @@
 	module_type = /obj/item/weapon/robot_module/security
 	origin_tech = "engineering=4;powerstorage=4;combat=4"
 
-/obj/item/borg/upgrade/disablercooler/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/disablercooler/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -117,7 +117,7 @@
 	icon_state = "cyborg_upgrade3"
 	origin_tech = "engineering=4;powerstorage=4"
 
-/obj/item/borg/upgrade/thrusters/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/thrusters/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -136,7 +136,7 @@
 	module_type = /obj/item/weapon/robot_module/miner
 	origin_tech = "engineering=4;materials=5"
 
-/obj/item/borg/upgrade/ddrill/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/ddrill/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -158,7 +158,7 @@
 	module_type = /obj/item/weapon/robot_module/miner
 	origin_tech = "engineering=4;materials=4;bluespace=4"
 
-/obj/item/borg/upgrade/soh/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/soh/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -177,7 +177,7 @@
 	require_module = 1
 	origin_tech = "combat=4;syndicate=1"
 
-/obj/item/borg/upgrade/syndicate/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/syndicate/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -197,7 +197,7 @@
 	module_type = /obj/item/weapon/robot_module/miner
 	origin_tech = "engineering=4;materials=4;plasmatech=4"
 
-/obj/item/borg/upgrade/lavaproof/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/lavaproof/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 	R.weather_immunities += "lava"
@@ -216,7 +216,7 @@
 	var/mob/living/silicon/robot/cyborg
 	var/datum/action/toggle_action
 
-/obj/item/borg/upgrade/selfrepair/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/selfrepair/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -316,7 +316,7 @@
 	origin_tech = null
 	var/list/additional_reagents = list()
 
-/obj/item/borg/upgrade/hypospray/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/hypospray/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 	for(var/obj/item/weapon/reagent_containers/borghypo/H in R.module)
@@ -349,7 +349,7 @@
 	origin_tech = "materials=5;engineering=7;combat=3"
 	icon_state = "cyborg_upgrade3"
 
-/obj/item/borg/upgrade/piercing_hypospray/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/piercing_hypospray/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -372,7 +372,7 @@
 	module_type = /obj/item/weapon/robot_module/medical
 	origin_tech = "programming=4;engineering=6;materials=5;powerstorage=5;biotech=5"
 
-/obj/item/borg/upgrade/defib/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/defib/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -383,20 +383,18 @@
 	return 1
 	
 /obj/item/borg/upgrade/traitorsec
-	name = "Bloodhound upgrade module"
-	desc = "Ilegal upgrade board that unlocks the banned security module"
-	icon_state = "cyborg_upgrade3"
-	require_module = 1
-	origin_tech = "data=4;combat=4;syndicate=3"
-	
-/obj/item/borg/upgrade/traitorsec/attack()
-	return
+        name = "Bloodhound upgrade module"
+        desc = "Ilegal upgrade board that unlocks the banned security module"
+        icon_state = "cyborg_upgrade3"
+        require_module = 1
+        origin_tech = "data=4;combat=4;syndicate=3"
 
-/obj/item/borg/upgrade/afterattack(atom/target, mob/user, proximity)
-	var/atom/A = target
-	if(!proximity && prox_check)
-		return
-	if(!isrobot(target))
-		return
-	A.emag_act(user)
-	A.transform_to(/obj/item/weapon/robot_module/security)
+
+/obj/item/borg/upgrade/traitorsec/action(mob/living/silicon/robot/R,/mob/living/user)
+        if(..())
+            return 0
+       
+       wiresexposed = TRUE
+        A.emag_act(user)
+        wiresexposed = FALSE
+        A.transform_to(/obj/item/weapon/robot_module/security)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -384,7 +384,7 @@
 	
 /obj/item/borg/upgrade/traitorsec
 	name = "Bloodhound upgrade module"
-	desc = "Ilegal upgrade board that unlocks the banned security module"
+	desc = "Ilegal upgrade board that unlocks banned security module"
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
 	origin_tech = "data=4;combat=4;syndicate=3"
@@ -394,7 +394,6 @@
 	if(..())
 		return 0
 		
-	R.module.transform_to(/obj/item/weapon/robot_module/security)
+	R.module.transform_to(/obj/item/weapon/robot_module/security/traitorsec)
 	R.emag_act(user)
-	
 	return 1

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -391,8 +391,8 @@
 
 
 /obj/item/borg/upgrade/traitorsec/action(mob/living/silicon/robot/R,/mob/living/user)
-        if(..())
-            return 0
+	if(..())
+		return 0
        
        wiresexposed = TRUE
         A.emag_act(user)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -383,18 +383,18 @@
 	return 1
 	
 /obj/item/borg/upgrade/traitorsec
-        name = "Bloodhound upgrade module"
-        desc = "Ilegal upgrade board that unlocks the banned security module"
-        icon_state = "cyborg_upgrade3"
-        require_module = 1
-        origin_tech = "data=4;combat=4;syndicate=3"
+	name = "Bloodhound upgrade module"
+	desc = "Ilegal upgrade board that unlocks the banned security module"
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	origin_tech = "data=4;combat=4;syndicate=3"
 
 
 /obj/item/borg/upgrade/traitorsec/action(mob/living/silicon/robot/R,/mob/living/user)
 	if(..())
 		return 0
-       
-       wiresexposed = TRUE
-        A.emag_act(user)
-        wiresexposed = FALSE
-        A.transform_to(/obj/item/weapon/robot_module/security)
+    
+	wiresexposed = TRUE
+	R.emag_act(user)
+	wiresexposed = FALSE
+	A.transform_to(/obj/item/weapon/robot_module/security)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -383,7 +383,7 @@
 	return 1
 	
 /obj/item/borg/upgrade/traitorsec
-	name = "Despot upgrade module"
+	name = "O.V.E.R.S.E.E.R. upgrade module"
 	desc = "Ilegal upgrade board that unlocks the banned security module"
 	icon_state = "cyborg_upgrade3"
 	require_module = 1

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -397,3 +397,4 @@
 	R.module.transform_to(/obj/item/weapon/robot_module/security)
 	R.emag_act(user)
 	
+	return 1

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -394,7 +394,7 @@
 	if(..())
 		return 0
     
-	wiresexposed = TRUE
+	R.wiresexposed = TRUE
 	R.emag_act(user)
-	wiresexposed = FALSE
-	A.transform_to(/obj/item/weapon/robot_module/security)
+	R.wiresexposed = FALSE
+	R.transform_to(/obj/item/weapon/robot_module/security)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -390,11 +390,11 @@
 	origin_tech = "data=4;combat=4;syndicate=3"
 
 
-/obj/item/borg/upgrade/traitorsec/action(mob/living/silicon/robot/R,/mob/living/user)
+/obj/item/borg/upgrade/traitorsec/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return 0
     
 	R.wiresexposed = TRUE
 	R.emag_act(user)
 	R.wiresexposed = FALSE
-	R.transform_to(/obj/item/weapon/robot_module/security)
+	R.module.transform_to(/obj/item/weapon/robot_module/security)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -381,3 +381,22 @@
 	R.module.add_module(S, FALSE, TRUE)
 
 	return 1
+	
+/obj/item/borg/upgrade/traitorsec
+	name = "Despot upgrade module"
+	desc = "Ilegal upgrade board that unlocks the banned security module"
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	origin_tech = "data=4;combat=4;syndicate=3"
+	
+/obj/item/borg/upgrade/traitorsec/attack()
+	return
+
+/obj/item/borg/upgrade/afterattack(atom/target, mob/user, proximity)
+	var/atom/A = target
+	if(!proximity && prox_check)
+		return
+	if(!isrobot(target))
+		return
+	A.emag_act(user)
+	A.transform to(/obj/item/weapon/robot_module/security)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -383,7 +383,7 @@
 	return 1
 	
 /obj/item/borg/upgrade/traitorsec
-	name = "O.V.E.R.S.E.E.R. upgrade module"
+	name = "Bloodhound upgrade module"
 	desc = "Ilegal upgrade board that unlocks the banned security module"
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
@@ -399,4 +399,4 @@
 	if(!isrobot(target))
 		return
 	A.emag_act(user)
-	A.transform to(/obj/item/weapon/robot_module/security)
+	A.transform_to(/obj/item/weapon/robot_module/security)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -317,7 +317,7 @@
 	new /obj/item/weapon/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/weapon/spellbook/oneuse/mimery_guns(src)
 	
-	/obj/item/weapon/storage/box/syndie_kit/traitorsec_boards/New()
+/obj/item/weapon/storage/box/syndie_kit/traitorsec_boards/New()
 	..()
 	contents = list()
 	new /obj/item/borg/upgrade/traitorsec(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -316,3 +316,10 @@
 	..()
 	new /obj/item/weapon/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/weapon/spellbook/oneuse/mimery_guns(src)
+	
+	/obj/item/weapon/storage/box/syndie_kit/traitorsec_boards/New()
+	..()
+	contents = list()
+	new /obj/item/borg/upgrade/traitorsec(src)
+	new /obj/item/borg/upgrade/traitorsec(src)
+	new /obj/item/borg/upgrade/traitorsec(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -498,7 +498,7 @@
 		else
 			if(!user.drop_item())
 				return
-			if(U.action(src))
+			if(U.action(src,user))
 				user << "<span class='notice'>You apply the upgrade to [src].</span>"
 				if(U.one_use)
 					qdel(U)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -332,6 +332,14 @@
 	can_be_pushed = FALSE
 	hat_offset = 3
 
+/obj/item/weapon/robot_module/security/traitorsec
+	name = "Bloodhound"
+	cyborg_base_icon = "synd_sec"
+	moduleselect_icon = "malf"
+	feedback_key = "cyborg_traitorsec"
+	can_be_pushed = FALSE
+	hat_offset = 3
+	
 /obj/item/weapon/robot_module/security/do_transform_animation()
 	..()
 	loc << "<span class='userdanger'>While you have picked the security module, you still have to follow your laws, NOT Space Law. \

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1228,7 +1228,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	name = "Bloodhound upgrade modules"
 	desc = "A box containing three illegal cyborg upgrade modules that both hack the cyborg and activate its hidden security module."
 	item = /obj/item/weapon/storage/box/syndie_kit/traitorsec_boards
-	cost = 14
+	cost = 16
 	restricted_roles = list("Roboticist")
 	surplus = 5
 

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1223,6 +1223,14 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 20
 	surplus = 0
 	restricted_roles = list("Assistant")
+	
+/datum/uplink_item/role_restricted/traitorsec
+	name = "D.E.S.P.O.T. upgrade module"
+	desc = "An illegal cyborg upgrade module that both hacks the cyborg and activates it's hidden security module."
+	item = /obj/item/borg/upgrade/traitorsec
+	cost = 12
+	restricted_roles = list("Roboticist")
+	surplus = 5
 
 // Pointless
 /datum/uplink_item/badass

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1225,7 +1225,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	restricted_roles = list("Assistant")
 	
 /datum/uplink_item/role_restricted/traitorsec
-	name = "D.E.S.P.O.T. upgrade module"
+	name = "O.V.E.R.S.E.E.R. upgrade module"
 	desc = "An illegal cyborg upgrade module that both hacks the cyborg and activates it's hidden security module."
 	item = /obj/item/borg/upgrade/traitorsec
 	cost = 12

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1225,9 +1225,9 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	restricted_roles = list("Assistant")
 	
 /datum/uplink_item/role_restricted/traitorsec
-	name = "Bloodhound upgrade module"
-	desc = "An illegal cyborg upgrade module that both hacks the cyborg and activates its hidden security module."
-	item = /obj/item/borg/upgrade/traitorsec
+	name = "Bloodhound upgrade modules"
+	desc = "A box containing three illegal cyborg upgrade modules that both hack the cyborg and activate its hidden security module."
+	item = /obj/item/weapon/storage/box/syndie_kit/traitorsec_boards
 	cost = 12
 	restricted_roles = list("Roboticist")
 	surplus = 5

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1228,7 +1228,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	name = "Bloodhound upgrade modules"
 	desc = "A box containing three illegal cyborg upgrade modules that both hack the cyborg and activate its hidden security module."
 	item = /obj/item/weapon/storage/box/syndie_kit/traitorsec_boards
-	cost = 12
+	cost = 14
 	restricted_roles = list("Roboticist")
 	surplus = 5
 

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1225,8 +1225,8 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	restricted_roles = list("Assistant")
 	
 /datum/uplink_item/role_restricted/traitorsec
-	name = "O.V.E.R.S.E.E.R. upgrade module"
-	desc = "An illegal cyborg upgrade module that both hacks the cyborg and activates it's hidden security module."
+	name = "Bloodhound upgrade module"
+	desc = "An illegal cyborg upgrade module that both hacks the cyborg and activates its hidden security module."
 	item = /obj/item/borg/upgrade/traitorsec
 	cost = 12
 	restricted_roles = list("Roboticist")


### PR DESCRIPTION
:cl: 
add: Added a roboticist-specific traitor item - a box of Bloodhound upgrade boards.
/:cl:

Adds a board that can hack cyborgs and turn them into secborgs. Babby's first code that likely doesn't even work. 
