### PR TITLE
Removes manifest rune

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -941,26 +941,3 @@ var/list/wall_runes = list()
 	user.Beam(T,icon_state="drainbeam",time=5)
 	user.visible_message("<span class='warning'>Blood flows from the rune into [user]!</span>", \
 	"<span class='cult'>Blood flows into you, healing your wounds and revitalizing your spirit.</span>")
-
-	visible_message("<span class='warning'>A cloud of red mist forms above [src], and from within steps... a man.</span>")
-	user << "<span class='cultitalic'>Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely...</span>"
-	var/turf/T = get_turf(src)
-	var/obj/structure/emergency_shield/invoker/N = new(T)
-
-	new_human.key = ghost_to_spawn.key
-	ticker.mode.add_cultist(new_human.mind, 0)
-	new_human << "<span class='cultitalic'><b>You are a servant of the Geometer. You have been made semi-corporeal by the cult of Nar-Sie, and you are to serve them at all costs.</b></span>"
-
-	while(user in T)
-		if(user.stat)
-			break
-		user.apply_damage(0.1, BRUTE)
-		sleep(3)
-
-	qdel(N)
-	if(new_human)
-		new_human.visible_message("<span class='warning'>[new_human] suddenly dissolves into bones and ashes.</span>", \
-								  "<span class='cultlarge'>Your link to the world fades. Your form breaks apart.</span>")
-		for(var/obj/I in new_human)
-			new_human.dropItemToGround(I)
-		new_human.dust()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -942,48 +942,6 @@ var/list/wall_runes = list()
 	user.visible_message("<span class='warning'>Blood flows from the rune into [user]!</span>", \
 	"<span class='cult'>Blood flows into you, healing your wounds and revitalizing your spirit.</span>")
 
-
-//Rite of Spectral Manifestation: Summons a ghost on top of the rune as a cultist human with no items. User must stand on the rune at all times, and takes damage for each summoned ghost.
-/obj/effect/rune/manifest
-	cultist_name = "Manifest Spirit"
-	cultist_desc = "manifests a spirit as a servant of the Geometer. The invoker must not move from atop the rune, and will take damage for each summoned spirit."
-	invocation = "Gal'h'rfikk harfrandid mud'gib!" //how the fuck do you pronounce this
-	icon_state = "6"
-	construct_invoke = 0
-	color = "#C80000"
-
-/obj/effect/rune/manifest/New(loc)
-	..()
-	notify_ghosts("Manifest rune created in [get_area(src)].", 'sound/effects/ghost2.ogg', source = src)
-
-/obj/effect/rune/manifest/can_invoke(mob/living/user)
-	if(!(user in get_turf(src)))
-		user << "<span class='cultitalic'>You must be standing on [src]!</span>"
-		fail_invoke()
-		log_game("Manifest rune failed - user not standing on rune")
-		return list()
-	var/list/ghosts_on_rune = list()
-	for(var/mob/dead/observer/O in get_turf(src))
-		if(O.client && !jobban_isbanned(O, ROLE_CULTIST))
-			ghosts_on_rune |= O
-	if(!ghosts_on_rune.len)
-		user << "<span class='cultitalic'>There are no spirits near [src]!</span>"
-		fail_invoke()
-		log_game("Manifest rune failed - no nearby ghosts")
-		return list()
-	return ..()
-
-/obj/effect/rune/manifest/invoke(var/list/invokers)
-	var/mob/living/user = invokers[1]
-	var/list/ghosts_on_rune = list()
-	for(var/mob/dead/observer/O in get_turf(src))
-		if(O.client && !jobban_isbanned(O, ROLE_CULTIST))
-			ghosts_on_rune |= O
-	var/mob/dead/observer/ghost_to_spawn = pick(ghosts_on_rune)
-	var/mob/living/carbon/human/new_human = new(get_turf(src))
-	new_human.real_name = ghost_to_spawn.real_name
-	new_human.alpha = 150 //Makes them translucent
-	..()
 	visible_message("<span class='warning'>A cloud of red mist forms above [src], and from within steps... a man.</span>")
 	user << "<span class='cultitalic'>Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely...</span>"
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
:cl:
del: The manifest run has been removed. Cults might actually have to TRY to have enough members to summon.
/:cl:

This rune is only ever used to summon 8 ghosts to get narnar. This trivializes the cults end game and no form of making it more dangerous or expensive can overpower the LOL WIN button it provides.
