### PR TITLE
Adds negative damage scaling to Buckshot.

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -38,6 +38,8 @@
 /obj/item/projectile/bullet/pellet/Range()
 	..()
 	damage += -0.75
+	if(damage < 0)
+		qdel(src)
 
 /obj/item/projectile/bullet/pellet/weak
 	damage = 6

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -35,6 +35,10 @@
 	name = "pellet"
 	damage = 12.5
 
+/obj/item/projectile/bullet/pellet/Range()
+	..()
+	damage += -0.75
+
 /obj/item/projectile/bullet/pellet/weak
 	damage = 6
 


### PR DESCRIPTION
:cl: 
add: Adds scaling damage to buckshot.
/:cl:

[]: # 
Buckshot now deals 0.75 damage less per tile travelled.
This weakens buckshot which was previously had it's pellets buffed.

This is subject to change.