### PR TITLE
Readds clonexadone, nerfs cyroxadone's cloneloss healing

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -132,7 +132,7 @@
 	switch(M.bodytemperature) // Low temperatures are required to take effect.
 		if(0 to 100) // At extreme temperatures (upgraded cryo) the effect is greatly increased.
 			M.status_flags &= ~DISFIGURED
-			M.adjustCloneLoss(-7, 0)
+			M.adjustCloneLoss(-1, 0)
 			M.adjustOxyLoss(-9, 0)
 			M.adjustBruteLoss(-5, 0)
 			M.adjustFireLoss(-5, 0)
@@ -140,7 +140,7 @@
 			. = 1
 		if(100 to 225) // At lower temperatures (cryo) the full effect is boosted
 			M.status_flags &= ~DISFIGURED
-			M.adjustCloneLoss(-2, 0)
+			M.adjustCloneLoss(-1, 0)
 			M.adjustOxyLoss(-7, 0)
 			M.adjustBruteLoss(-3, 0)
 			M.adjustFireLoss(-3, 0)
@@ -156,6 +156,28 @@
 			. = 1
 	..()
 
+/datum/reagent/medicine/clonexadone
+	name = "Clonexadone"
+	id = "clonexadone"
+	description = "A chemical that derives from Cryoxadone. It specializes in healing clone damage, but nothing else."
+	color = "#0000C8"
+	taste_description = "muscle"
+
+/datum/reagent/medicine/clonexadone/on_mob_life(mob/living/M)
+	switch(M.bodytemperature) // Low temperatures are required to take effect.
+		if(0 to 100) // At extreme temperatures (upgraded cryo) the effect is greatly increased.
+			M.status_flags &= ~DISFIGURED
+			M.adjustCloneLoss(-7, 0)
+			. = 1
+		if(100 to 225) // At lower temperatures (cryo) the full effect is boosted
+			M.status_flags &= ~DISFIGURED
+			M.adjustCloneLoss(-3, 0)
+			. = 1
+		if(225 to T0C)
+			M.status_flags &= ~DISFIGURED
+			M.adjustCloneLoss(-2, 0)
+			. = 1
+	..()
 
 /datum/reagent/medicine/rezadone
 	name = "Rezadone"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -159,9 +159,10 @@
 /datum/reagent/medicine/clonexadone
 	name = "Clonexadone"
 	id = "clonexadone"
-	description = "A chemical that derives from Cryoxadone. It specializes in healing clone damage, but nothing else."
+	description = "A chemical that derives from Cryoxadone. It specializes in healing clone damage, but nothing else. Requires very cold temperatures to properly metabolize, and metabolizes quicker than cryoxadone."
 	color = "#0000C8"
 	taste_description = "muscle"
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/clonexadone/on_mob_life(mob/living/M)
 	switch(M.bodytemperature) // Low temperatures are required to take effect.

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -184,6 +184,13 @@
 	results = list("cryoxadone" = 3)
 	required_reagents = list("stable_plasma" = 1, "acetone" = 1, "mutagen" = 1)
 
+/datum/chemical_reaction/clonexadone
+	name = "Clonexadone"
+	id = "clonexadone"
+	results = list("clonexadone" = 2)
+	required_reagents = list("cryoxadone" = 1, "sodium" = 1)
+	required_catalysts = list("plasma" = 5)
+
 /datum/chemical_reaction/haloperidol
 	name = "Haloperidol"
 	id = "haloperidol"


### PR DESCRIPTION
:cl:
tweak: Cryoxadone's ability to heal cloneloss has been greatly reduced.
add: Clonexadone has been readded. It functions exactly like cryoxadone, but only heals cloneloss, and at a decent rate. Brew it with 1 part cryoxadone, 1 part sodium, and 5 units of plasma for a catalyst.
/:cl:

*Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:*

Two reasons!
1. Interdepartmental cooperation when it comes to cloning. Cloning lots of people in a decent amount of time used to require frequent trips/deliveries from chemistry to get more clonexadone. Now that you get two beakers of cryoxadone roundstart, it requires basically no effort at all to just toss a guy into the tube until it dings.
2. Creative cryo mixes. Nowadays I only ever really see mannitol and occasionally iron or mutadone mixed into the cryo beakers (seriously, this is such a big thing that [mannitol has become the second most brewed chem](https://atlantaned.space/newSS13tools/stats/viewMonthlyStats.php?year=2017&month=02)). Chemists will be greatly encouraged to modify the contents of the cryo mix with the addition to clonexadone, possibly inspiring them to experiment with other robust mixes again.