### PR TITLE
GODMODE prevents elder god effects

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -300,6 +300,9 @@
 	return(gain)
 
 /mob/living/narsie_act()
+	if(status_flags & GODMODE)
+		return
+
 	if(is_servant_of_ratvar(src) && !stat)
 		src << "<span class='userdanger'>You resist Nar-Sie's influence... but not all of it. <i>Run!</i></span>"
 		adjustBruteLoss(35)
@@ -324,6 +327,9 @@
 
 
 /mob/living/ratvar_act()
+	if(status_flags & GODMODE)
+		return
+
 	if(stat != DEAD && !is_servant_of_ratvar(src))
 		for(var/obj/item/weapon/implant/mindshield/M in implants)
 			qdel(M)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -141,6 +141,9 @@
 	dust()
 
 /mob/living/simple_animal/drone/ratvar_act()
+	if(status_flags & GODMODE)
+		return
+
 	if(internal_storage)
 		dropItemToGround(internal_storage)
 	if(head)


### PR DESCRIPTION
:cl: coiax
add: The Bardrone and Barmaid are neutral, even in the face of reality
altering elder gods.
/:cl:

- Bardrone isn't going to cogscarab in the face of Ratvar
- Bardrone and Barmaiden don't explode in the face of Narsie; they
instead have to awkwardly attempt to serve drinks to Harvesters.