### PR TITLE
Admins have more tools for renaming the station

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -235,3 +235,10 @@ var/syndicate_code_response//Code response for traitors.
 			code_phrase += ", "
 
 	return code_phrase
+
+/proc/change_station_name(designation)
+	if(config && config.server_name)
+		world.name = "[config.server_name]: [designation]"
+	else
+		world.name = designation
+	station_name = designation

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -81,11 +81,7 @@
 	response_timer_id = null
 
 /obj/item/station_charter/proc/rename_station(designation, uname, ureal_name, ukey)
-	if(config && config.server_name)
-		world.name = "[config.server_name]: [designation]"
-	else
-		world.name = designation
-	station_name = designation
+	change_station_name(designation)
 	minor_announce("[ureal_name] has designated your station as [station_name()]", "Captain's Charter", 0)
 	log_game("[ukey] has renamed the station as [station_name()].")
 
@@ -95,5 +91,9 @@
 
 	if(!unlimited_uses)
 		used = TRUE
+
+/obj/item/station_charter/admin
+	unlimited_uses = TRUE
+	ignores_timeout = TRUE
 
 #undef STATION_RENAME_TIME_LIMIT

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -28,6 +28,7 @@
 			<A href='?src=\ref[src];secrets=fingerprints'>List Fingerprints</A><BR>
 			<A href='?src=\ref[src];secrets=ctfbutton'>Enable/Disable CTF</A><BR><BR>
 			<A href='?src=\ref[src];secrets=tdomereset'>Reset Thunderdome to default state</A><BR>
+			<A href='?src=\ref[src];secrets=set_name'>Rename Station Name</A><BR>
 			<A href='?src=\ref[src];secrets=reset_name'>Reset Station Name</A><BR>
 			<BR>
 			<B>Shuttles</B><BR>
@@ -148,14 +149,25 @@
 				message_admins("[key_name_admin(usr)] has cured all diseases.")
 				for(var/datum/disease/D in SSdisease.processing)
 					D.cure(D)
+		if("set_name")
+			if(!check_rights(R_ADMIN))
+				return
+			var/new_name = input(usr, "Please input a new name for the station.", "What?", "") as text|null
+			if(!new_name)
+				return
+			change_station_name(new_name)
+			log_admin("[key_name(usr)] renamed the station to \"[new_name]\".")
+			message_admins("<span class='adminnotice'>[key_name_admin(usr)] renamed the station to: [new_name].</span>")
+			priority_announce("[command_name()] has renamed the station to \"[new_name]\".")
 
 		if("reset_name")
 			if(!check_rights(R_ADMIN))
 				return
-			world.name = new_station_name()
-			station_name = world.name
+			var/new_name = new_station_name()
+			change_station_name(new_name)
 			log_admin("[key_name(usr)] reset the station name.")
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] reset the station name.</span>")
+			priority_announce("[command_name()] has renamed the station to \"[new_name]\".")
 
 		if("list_bombers")
 			if(!check_rights(R_ADMIN))


### PR DESCRIPTION
:cl: coiax
add: Admins have a "Rename Station Name" option, under Secrets.
add: A special admin station charter exists, that has unlimited uses and
can be used at any time.
/:cl:

I think station renaming has to include the special server config tag,
so I've made a global proc to handle that. I have other changes, but
these ones should be uncontroversial.