### PR TITLE
Aux base construction console fix

### DIFF
--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -273,14 +273,16 @@ obj/docking_port/stationary/public_mining_dock/onShuttleMove()
 	if(landing_spot.z != ZLEVEL_MINING)
 		user << "<span class='warning'>This device is only to be used in a mining zone.</span>"
 		return
-	var/obj/machinery/computer/auxillary_base/aux_base_console = locate(/obj/machinery/computer/auxillary_base) in machines
-	if(!aux_base_console || get_dist(landing_spot, aux_base_console) > console_range)
+	var/obj/machinery/computer/auxillary_base/aux_base_console
+	for(var/obj/machinery/computer/auxillary_base/ABC in machines)
+		if(get_dist(landing_spot, ABC) <= console_range)
+			aux_base_console = ABC
+			break
+	if(!aux_base_console) //Needs to be near the base to serve as its dock and configure it to control the mining shuttle.
 		user << "<span class='warning'>The auxillary base's console must be within [console_range] meters in order to interface.</span>"
-		return //Needs to be near the base to serve as its dock and configure it to control the mining shuttle.
+		return
 
 //Mining shuttles may not be created equal, so we find the map's shuttle dock and size accordingly.
-
-
 	for(var/S in SSshuttle.stationary)
 		var/obj/docking_port/stationary/SM = S //SM is declared outside so it can be checked for null
 		if(SM.id == "mining_home" || SM.id == "mining_away")

--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -68,11 +68,13 @@ mob/camera/aiEye/remote/base_construction/New(loc)
 /obj/machinery/computer/camera_advanced/base_construction/CreateEye()
 
 	var/spawn_spot
-	if(!found_aux_console)
-		found_aux_console = locate(/obj/machinery/computer/auxillary_base) in machines
+	for(var/obj/machinery/computer/auxillary_base/ABC in machines)
+		if(istype(get_area(ABC), /area/shuttle/auxillary_base))
+			found_aux_console = ABC
+			break
 
-		if(found_aux_console)
-			spawn_spot = found_aux_console
+	if(found_aux_console)
+		spawn_spot = found_aux_console
 	else
 		spawn_spot = src
 


### PR DESCRIPTION
- The camera computer will now locate the correct Aux Base computer, the
one inside of the Aux Base. If the Aux Base computer is missing, the eye will spawn at its source console.
- The mining shuttle beacon has also been fixed.

:cl: Gun Hog
fix: The Aux Base Construction Console now directs to the correct Base Management Console.
/:cl:

Fixes https://github.com/tgstation/tgstation/issues/24637