### PR TITLE
Adds missing access to the Aux Base Console

### DIFF
--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -19,7 +19,7 @@ interface with the mining shuttle at the landing site if a mobile beacon is also
 	var/launch_warning = TRUE
 	var/list/turrets = list() //List of connected turrets
 
-	req_one_access = list(access_cargo, access_construction, access_heads)
+	req_one_access = list(access_cargo, access_construction, access_heads, access_research)
 	var/possible_destinations
 	clockwork = TRUE
 	var/obj/item/device/gps/internal/base/locator


### PR DESCRIPTION
The research access was missing from the base management console. It
exists on the first airlock, meaning scientists could get into the base,
but not attempt to launch it.

:cl: Gun Hog
fix: The missing Science Department access has been added to the Auxiliary Base Management Console.
/:cl:
