### PR TITLE
Removes autoaccept charter rename, refactors charters

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -235,3 +235,10 @@ var/syndicate_code_response//Code response for traitors.
 			code_phrase += ", "
 
 	return code_phrase
+
+/proc/change_station_name(designation)
+	if(config && config.server_name)
+		world.name = "[config.server_name]: [designation]"
+	else
+		world.name = designation
+	station_name = designation

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -4,14 +4,17 @@
 	name = "station charter"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll2"
-	desc = "An official document entrusting the governance of the station \
-		and surrounding space to the Captain. "
+	desc = "An official document entrusting the governance of the station and surrounding space to the Captain. "
 	var/used = FALSE
 
 	var/unlimited_uses = FALSE
 	var/ignores_timeout = FALSE
-	var/response_timer_id = null
-	var/approval_time = 600
+
+	var/cooldown_time = 600
+	var/last_used
+
+	var/mob/living/proposer
+	var/proposed_name
 
 	var/static/regex/standard_station_regex
 
@@ -26,22 +29,20 @@
 		standard_station_regex = new(regexstr)
 
 /obj/item/station_charter/Destroy()
-	if(response_timer_id)
-		deltimer(response_timer_id)
-	response_timer_id = null
+	proposer = null
 	. = ..()
 
 /obj/item/station_charter/attack_self(mob/living/user)
 	if(used)
 		user << "This charter has already been used to name the station."
 		return
+	if(last_used && last_used + cooldown_time > world.time)
+		user << "Your proposed rename is being evaluated by [command_name()], try again later."
+		return
+
 	if(!ignores_timeout && (world.time-round_start_time > STATION_RENAME_TIME_LIMIT)) //5 minutes
 		user << "The crew has already settled into the shift. \
 			It probably wouldn't be good to rename the station right now."
-		return
-	if(response_timer_id)
-		user << "You're still waiting for approval from your employers about \
-			your proposed name change, it'd be best to wait for now."
 		return
 
 	var/new_name = stripped_input(user, message="What do you want to name \
@@ -51,49 +52,48 @@
 
 	if(!new_name)
 		return
-	log_game("[key_name(user)] has proposed to name the station as \
-		[new_name]")
+	log_game("[key_name(user)] has proposed to name the station as [new_name]")
+
+
+	proposer = user
+	proposed_name = new_name
+	last_used = world.time
 
 	if(standard_station_regex.Find(new_name))
 		user << "Your name has been automatically approved."
-		rename_station(new_name, user)
+		message_admins("[ADMIN_LOOKUP(user)] renamed the station to \"[new_name]\", automatically accepted because of the use of standard format.")
+		log_admin("[key_name(proposer)] renamed the station via charter to the standard format name: [proposed_name]")
+		accept()
 		return
+	user << "Your station name has been sent to your employers for approval."
 
-	user << "Your name has been sent to your employers for approval."
-	// Autoapproves after a certain time
-	response_timer_id = addtimer(CALLBACK(src, .proc/rename_station, new_name, user.name, user.real_name, key_name(user)), approval_time, TIMER_STOPPABLE)
-	admins << "<span class='adminnotice'><b><font color=orange>CUSTOM STATION RENAME:</font></b>[key_name_admin(user)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) proposes to rename the station to [new_name] (will autoapprove in [approval_time / 10] seconds). (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[user]'>BSA</A>) (<A HREF='?_src_=holder;reject_custom_name=\ref[src]'>REJECT</A>) (<a href='?_src_=holder;CentcommReply=\ref[user]'>RPLY</a>)</span>"
+	message_admins("<b><font color=orange>CUSTOM STATION RENAME: </font></b>[ADMIN_LOOKUP(user)] proposes to rename the station to \"[new_name]\". [ADMIN_BSA(user)] (<A HREF='?_src_=holder;station_charter=\ref[src];action=reject'>REJECT</A>) (<A HREF='?_src_=holder;station_charter=\ref[src];action=accept'>ACCEPT</A>) (<A HREF='?_src_=holder;station_charter=\ref[src];action=dust'>DUST CHARTER</A>)")
+	log_admin("[key_name(proposer)] proposed to rename the station via charter to: [proposed_name]")
 
-/obj/item/station_charter/proc/reject_proposed(user)
-	if(!user)
-		return
-	if(!response_timer_id)
-		return
+/obj/item/station_charter/proc/reject()
 	var/turf/T = get_turf(src)
-	T.visible_message("<span class='warning'>The proposed changes disappear \
-		from [src]; it looks like they've been rejected.</span>")
-	var/m = "[key_name(user)] has rejected the proposed station name."
+	T.visible_message("<span class='warning'>The proposed changes disappear from [src]; it looks like they've been rejected.</span>")
+	last_used = 0
 
-	message_admins(m)
-	log_admin(m)
+/obj/item/station_charter/proc/accept()
+	if(!proposed_name)
+		return
 
-	deltimer(response_timer_id)
-	response_timer_id = null
-
-/obj/item/station_charter/proc/rename_station(designation, uname, ureal_name, ukey)
-	if(config && config.server_name)
-		world.name = "[config.server_name]: [designation]"
-	else
-		world.name = designation
-	station_name = designation
-	minor_announce("[ureal_name] has designated your station as [station_name()]", "Captain's Charter", 0)
-	log_game("[ukey] has renamed the station as [station_name()].")
-
+	change_station_name(proposed_name)
 	name = "station charter for [station_name()]"
-	desc = "An official document entrusting the governance of \
-		[station_name()] and surrounding space to Captain [uname]."
+
+	if(proposer)
+		minor_announce("[proposer.real_name] has designated your station as [station_name()]", "Captain's Charter", 0)
+		log_game("[key_name(proposer)] has renamed the station as [station_name()].")
+		desc = "An official document entrusting the governance of [station_name()] and surrounding space to Captain [proposer.real_name]."
 
 	if(!unlimited_uses)
 		used = TRUE
+
+/obj/item/station_charter/burn()
+	if(!QDELETED(src))
+		var/turf/T = get_turf(src)
+		T.visible_message("<span class='warning'>[src] turns to ashes!</span>")
+		..()
 
 #undef STATION_RENAME_TIME_LIMIT

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1777,12 +1777,28 @@
 		message_admins("[src.owner] replied to [key_name(H)]'s Syndicate message with: \"[input]\"")
 		H << "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from your benefactor.  Message as follows, agent. [input].  Message ends.\""
 
-	else if(href_list["reject_custom_name"])
+	else if(href_list["station_charter"])
 		if(!check_rights(R_ADMIN))
 			return
-		var/obj/item/station_charter/charter = locate(href_list["reject_custom_name"])
-		if(istype(charter))
-			charter.reject_proposed(usr)
+		var/obj/item/station_charter/charter = locate(href_list["station_charter"])
+		if(!istype(charter))
+			return
+
+		var/action = href_list["action"]
+		var/msg
+		if(action == "reject")
+			msg = "[src.owner] rejected [key_name(charter.proposer)]'s rename of \"[charter.proposed_name]\""
+			charter.reject()
+		else if(action == "accept")
+			msg = "[src.owner] accepted [key_name(charter.proposer)]'s rename of \"[charter.proposed_name]\""
+			charter.accept()
+		else if(action == "dust")
+			msg = "[src.owner] turned the station charter to dust after [key_name(charter.proposer)] proposed the rename of \"[charter.proposed_name]\""
+			charter.burn()
+		if(msg)
+			log_admin(msg)
+			message_admins(msg)
+
 	else if(href_list["jumpto"])
 		if(!isobserver(usr) && !check_rights(R_ADMIN))
 			return


### PR DESCRIPTION
:cl: coiax
del: A station charter requires admin approval to change the station name, instead of just not being vetoed.
experiment: Reminder, proposed station names that follow the standard format are always instantly accepted. Lots of room for creativity in there.
add: All admin actions regarding station charters are logged.
/:cl:

I have seen too many blatantly unacceptable and offensive names go by, even with admins being online who would be vetoing them. Often in the rush of new round messages, the rename proposal is lost.

Instead, all messages have to be accepted or rejected. Rejecting a message clears the cooldown between rename requests (at 60 seconds currently). Admins also have a button to instantly turn the charter to ashes, to be used as seen fit. All of these actions are logged.