### PR TITLE
Fixes the back turfs on the lighthouse shuttle

### DIFF
--- a/_maps/shuttles/ferry_lighthouse.dmm
+++ b/_maps/shuttles/ferry_lighthouse.dmm
@@ -83,7 +83,7 @@
 /area/shuttle/transport)
 "as" = (
 /obj/structure/emergency_shield,
-/turf/open/space,
+/turf/open/floor/mineral/titanium/blue/airless,
 /area/shuttle/transport)
 "at" = (
 /obj/machinery/door/airlock,
@@ -376,8 +376,8 @@ aa
 (4,1,1) = {"
 ac
 af
-ah
-ah
+bh
+bh
 an
 aq
 as
@@ -385,9 +385,9 @@ aB
 as
 as
 aX
-ah
-ah
-ah
+bh
+bh
+bh
 bi
 bj
 "}


### PR DESCRIPTION
The emergency forcefields and foam on the back of the shuttle were on space turfs meaning they didn't load in with the template.
