### PR TITLE
Supermatter crystals can no longer be frozen.

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -69,6 +69,9 @@
 	var/produces_gas = 1
 	var/obj/effect/countdown/supermatter/countdown
 
+/obj/machinery/power/supermatter_shard/make_frozen_visual()
+	return
+
 /obj/machinery/power/supermatter_shard/New()
 	. = ..()
 	countdown = new(src)


### PR DESCRIPTION
Why does a block of crystal containing so much energy it can vaporize anything that touches it and emit lethal radiation whenever it's energized get frozen by griefgas?