### PR TITLE
kinda fixes immortality spam

### DIFF
--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -122,7 +122,7 @@
 		return
 	C << "<span class='notice'>Death is not your end!</span>"
 
-	spawn(rand(80,120))
+	if(do_after(C, rand(80,120), target = C))
 		C.revive(full_heal = 1, admin_revive = 1)
 		C << "<span class='notice'>You have regenerated.</span>"
 		C.visible_message("<span class='warning'>[usr] appears to wake from the dead, having healed all wounds.</span>")


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/24682

If you stand still it will still spam it but if you move at all after the first revive it should cancel
Would fix properly with a var but procs don't take vars that way and I'm not adding a var to all carbons for this, I might be stupid and not be seeing a simple fix though