### PR TITLE
Makes Paralyse() respect stunmods

### DIFF
--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -6,7 +6,11 @@
 /mob/living/carbon/human/Weaken(amount, updating = 1, ignore_canstun = 0)
 	amount = dna.species.spec_stun(src,amount)
 	return ..()
-
+	
+/mob/living/carbon/human/Paralyse(amount, updating = 1, ignore_canstun = 0)
+	amount = dna.species.spec_stun(src,amount)
+	return ..()
+	
 /mob/living/carbon/human/cure_husk()
 	. = ..()
 	if(.)


### PR DESCRIPTION
Not sure if this is intentional or a bug..?
if it's intentional this is a tweak/rebalance.