### PR TITLE
Demotes HOLOGRAM to secondary flag

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -29,11 +29,11 @@
 #define BLOCK_GAS_SMOKE_EFFECT 8192	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY! (NOTE: flag shared with THICKMATERIAL)
 #define THICKMATERIAL 8192		//prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body. (NOTE: flag shared with BLOCK_GAS_SMOKE_EFFECT)
 #define DROPDEL			16384 // When dropped, it calls qdel on itself
-#define HOLOGRAM		32768	// HOlodeck shit should not be used in any fucking things
 
 /* Secondary atom flags, access using the SECONDARY_FLAG macros */
 
 #define NO_EMP_WIRES "no_emp_wires"
+#define HOLOGRAM "hologram"
 
 //turf-only flags
 #define NOJAUNT		1

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -91,7 +91,7 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 		return FALSE
 	if(!get_cost(O, contr, emag))
 		return FALSE
-	if(O.flags & HOLOGRAM)
+	if(HAS_SECONDARY_FLAG(O, HOLOGRAM))
 		return FALSE
 	return TRUE
 

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -70,14 +70,14 @@
 		if(T.Adjacent(user))
 			for(var/B in T)
 				var/atom/movable/AM = B
-				if(AM.flags & HOLOGRAM)
+				if(HAS_SECONDARY_FLAG(AM, HOLOGRAM))
 					continue
 				. += AM
 
 /datum/personal_crafting/proc/get_surroundings(mob/user)
 	. = list()
 	for(var/obj/item/I in get_environment(user))
-		if(I.flags & HOLOGRAM)
+		if(HAS_SECONDARY_FLAG(I, HOLOGRAM))
 			continue
 		if(istype(I, /obj/item/stack))
 			var/obj/item/stack/S = I

--- a/code/modules/holodeck/area_copy.dm
+++ b/code/modules/holodeck/area_copy.dm
@@ -33,9 +33,9 @@
 		if(istype(O,/obj/machinery))
 			var/obj/machinery/M = O
 			M.power_change()
-	
+
 	if(holoitem)
-		O.flags |= HOLOGRAM
+		SET_SECONDARY_FLAG(O, HOLOGRAM)
 	return O
 
 


### PR DESCRIPTION
No difference mechanically, but frees up a bitflag slot. Reminder that
if there are no secondary flags on an object, the check is the same as
checking a var is null.

There are only a handful of hologram items in place at any time, they
don't need a full slot in flags.