### PR TITLE
Holopads now require power.

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -65,7 +65,7 @@ var/list/holopads = list()
 	holopads -= src
 	return ..()
 
-/obj/machinery/holo_pad/power_change()
+/obj/machinery/holopad/power_change()
 	if (powered())
 		stat &= ~NOPOWER
 	else


### PR DESCRIPTION
The ability to work without power was caused by phil being unable to spell.
Opened separately for silicon players to call me hitler.
:cl: Francinum
fix: Holopads now require power.
/:cl:
