### PR TITLE
Glowshrooms now have colored light, tweaks glowshroom/glowberry lighting range

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -41,7 +41,7 @@ var/list/blacklisted_glowshroom_turfs = typecacheof(list(
 	addtimer(CALLBACK(src, .proc/setup), 0) //run this on the next tick so we can set vars first
 
 /obj/structure/glowshroom/proc/setup()
-	set_light(1.4 + potency*0.03, max(potency*0.05, 0.1))
+	set_light(1.4 + potency*0.03, max(potency*0.04, 0.1))
 	setDir(CalcDir())
 	var/base_icon_state = initial(icon_state)
 	if(!floor)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -12,6 +12,7 @@ var/list/blacklisted_glowshroom_turfs = typecacheof(list(
 	density = 0
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "glowshroom" //replaced in New
+	light_color = "#AAD84B"
 	layer = ABOVE_NORMAL_TURF_LAYER
 	obj_integrity = 30
 	max_integrity = 30
@@ -24,7 +25,9 @@ var/list/blacklisted_glowshroom_turfs = typecacheof(list(
 
 /obj/structure/glowshroom/glowcap
 	name = "glowcap"
+	desc = "Mycena Ruthenia, a species of mushroom that, while it does glow in the dark, is not actually bioluminescent."
 	icon_state = "glowcap"
+	light_color = LIGHT_COLOR_RED
 
 /obj/structure/glowshroom/single
 	yield = 0
@@ -35,7 +38,10 @@ var/list/blacklisted_glowshroom_turfs = typecacheof(list(
 
 /obj/structure/glowshroom/New()
 	..()
-	set_light(round(potency/10))
+	addtimer(CALLBACK(src, .proc/setup), 0) //run this on the next tick so we can set vars first
+
+/obj/structure/glowshroom/proc/setup()
+	set_light(max(round(potency*0.025), 1.4), max(round(potency*0.05), 0.1))
 	setDir(CalcDir())
 	var/base_icon_state = initial(icon_state)
 	if(!floor)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -41,7 +41,7 @@ var/list/blacklisted_glowshroom_turfs = typecacheof(list(
 	addtimer(CALLBACK(src, .proc/setup), 0) //run this on the next tick so we can set vars first
 
 /obj/structure/glowshroom/proc/setup()
-	set_light(max(round(potency*0.025), 1.4), max(round(potency*0.05), 0.1))
+	set_light(1.4 + potency*0.03, max(potency*0.05, 0.1))
 	setDir(CalcDir())
 	var/base_icon_state = initial(icon_state)
 	if(!floor)

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -228,14 +228,9 @@
 	name = "glowshroom cluster"
 	desc = "<I>Mycena Bregprox</I>: This species of mushroom glows in the dark."
 	icon_state = "glowshroom"
-	light_color = "#AAD84B"
 	filling_color = "#00FA9A"
 	var/effect_path = /obj/structure/glowshroom
 	origin_tech = "biotech=4;plasmatech=6"
-
-/obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/add_juice()
-	..()
-	set_light(max(seed.potency*0.025, 1.4), max(seed.potency*0.05, 0.1))
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/attack_self(mob/user)
 	if(isspaceturf(user.loc))
@@ -260,7 +255,7 @@
 	icon_dead = "glowshroom-dead"
 	plantname = "Glowcaps"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap
-	genes = list(/datum/plant_gene/trait/glow, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/plant_type/fungal_metabolism)
+	genes = list(/datum/plant_gene/trait/glow/red, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/plant_type/fungal_metabolism)
 	mutatelist = list()
 	reagents_add = list("teslium" = 0.1, "nutriment" = 0.04)
 	rarity = 30
@@ -270,7 +265,6 @@
 	name = "glowcap cluster"
 	desc = "<I>Mycena Ruthenia</I>: This species of mushroom glows in the dark, but isn't actually bioluminescent. They're warm to the touch..."
 	icon_state = "glowcap"
-	light_color = LIGHT_COLOR_RED
 	filling_color = "#00FA9A"
 	effect_path = /obj/structure/glowshroom/glowcap
 	origin_tech = "biotech=4;powerstorage=6;plasmatech=4"

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -228,9 +228,14 @@
 	name = "glowshroom cluster"
 	desc = "<I>Mycena Bregprox</I>: This species of mushroom glows in the dark."
 	icon_state = "glowshroom"
+	light_color = "#AAD84B"
 	filling_color = "#00FA9A"
 	var/effect_path = /obj/structure/glowshroom
 	origin_tech = "biotech=4;plasmatech=6"
+
+/obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/add_juice()
+	..()
+	set_light(max(seed.potency*0.025, 1.4), max(seed.potency*0.05, 0.1))
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/attack_self(mob/user)
 	if(isspaceturf(user.loc))
@@ -263,8 +268,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap
 	seed = /obj/item/seeds/glowshroom/glowcap
 	name = "glowcap cluster"
-	desc = "<I>Mycena Ruthenia</I>: This species of mushroom glows in the dark, but aren't bioluminescent. They're warm to the touch..."
+	desc = "<I>Mycena Ruthenia</I>: This species of mushroom glows in the dark, but isn't actually bioluminescent. They're warm to the touch..."
 	icon_state = "glowcap"
+	light_color = LIGHT_COLOR_RED
 	filling_color = "#00FA9A"
 	effect_path = /obj/structure/glowshroom/glowcap
 	origin_tech = "biotech=4;powerstorage=6;plasmatech=4"

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -271,7 +271,7 @@
 	if(!self_sustaining)
 		if(myseed && myseed.get_gene(/datum/plant_gene/trait/glow))
 			var/datum/plant_gene/trait/glow/G = myseed.get_gene(/datum/plant_gene/trait/glow)
-			set_light(G.get_lum(myseed))
+			set_light(G.glow_range(myseed), G.glow_power(myseed), G.glow_color)
 		else
 			set_light(0)
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -263,25 +263,30 @@
 
 /datum/plant_gene/trait/glow
 	// Makes plant glow. Makes plant in tray glow too.
-	// Adds potency*rate luminosity to products.
+	// Adds 1 + potency*rate light range and potency*(rate + 0.01) light_power to products.
 	name = "Bioluminescence"
-	rate = 0.1
+	rate = 0.03
 	examine_line = "<span class='info'>It emits a soft glow.</span>"
 	trait_id = "glow"
+	var/glow_color = "#AAD84B"
 
-/datum/plant_gene/trait/glow/proc/get_lum(obj/item/seeds/S)
-	return round(S.potency*rate)
+/datum/plant_gene/trait/glow/proc/glow_range(obj/item/seeds/S)
+	return 1.4 + S.potency*rate
+
+/datum/plant_gene/trait/glow/proc/glow_power(obj/item/seeds/S)
+	return max(S.potency*(rate + 0.01), 0.1)
 
 /datum/plant_gene/trait/glow/on_new(obj/item/weapon/reagent_containers/food/snacks/grown/G, newloc)
 	..()
-	if(ismob(newloc))
-		G.pickup(newloc)//adjusts the lighting on the mob
-	else
-		G.set_light(get_lum(G.seed))
+	G.set_light(glow_range(G.seed), glow_power(G.seed), glow_color)
+
+/datum/plant_gene/trait/glow/red
+	glow_color = LIGHT_COLOR_RED
 
 /datum/plant_gene/trait/glow/berry
 	name = "Strong Bioluminescence"
-	rate = 0.2
+	rate = 0.05
+	glow_color = null
 
 
 /datum/plant_gene/trait/teleport

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -281,6 +281,7 @@
 	G.set_light(glow_range(G.seed), glow_power(G.seed), glow_color)
 
 /datum/plant_gene/trait/glow/red
+	name = "Red Electrical Glow"
 	glow_color = LIGHT_COLOR_RED
 
 /datum/plant_gene/trait/glow/berry


### PR DESCRIPTION
:cl: Joan
rscadd: Glowshrooms now have colored light.
tweak: Tweaked the potency scaling for glowshroom/glowberry light; high-potency plantss no longer light up a huge area, but are slightly brighter.
/:cl:

Fixed a bug where the first glowshroom planted wouldn't have light properly based on potency.

Max potency shrooms
![](http://puu.sh/uwR0m/b13102b45b.png)
This is actually less wide-ranging than it used to be; light_range at 100 potency from 10 to 4, light_power from 1 to 4
