### PR TITLE
Quick fix for vg light memleak.

### DIFF
--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -108,13 +108,13 @@
 	else if (mx < LIGHTING_SOFT_THRESHOLD)
 		. = 0 // 0 means soft lighting.
 
-	cache_r  = lum_r * . || LIGHTING_SOFT_THRESHOLD
-	cache_g  = lum_g * . || LIGHTING_SOFT_THRESHOLD
-	cache_b  = lum_b * . || LIGHTING_SOFT_THRESHOLD
+	cache_r  = lum_r * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
+	cache_g  = lum_g * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
+	cache_b  = lum_b * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
 	#else
-	cache_r  = lum_r * .
-	cache_g  = lum_g * .
-	cache_b  = lum_b * .
+	cache_r  = lum_r * . + (rand(1,999)/100000)
+	cache_g  = lum_g * . + (rand(1,999)/100000)
+	cache_b  = lum_b * . + (rand(1,999)/100000)
 	#endif
 	cache_mx = mx
 


### PR DESCRIPTION
:cl:
fix: patched a hacky workaround for /vg/lights memory leaking crashing the server
/:cl:

We need to avoid color matrix cache hits because those are what leaks. This random bit of noise to the values does just that.

This increases client memory use somewhat, and increases network traffic some what, and the memory leak isn't fully gone, but its enough to last until 1377 comes out