### PR TITLE
Fixes map rotation message showing same map

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -181,7 +181,7 @@ var/datum/subsystem/mapping/SSmapping
 	var/datum/map_config/VM = global.config.maplist[pickedmap]
 	message_admins("Randomly rotating map to [VM.map_name]")
 	. = changemap(VM)
-	if (.)
+	if (. && VM.map_name != config.map_name)
 		world << "<span class='boldannounce'>Map rotation has chosen [VM.map_name] for next round!</span>"
 
 /datum/subsystem/mapping/proc/changemap(var/datum/map_config/VM)	


### PR DESCRIPTION
:cl: Cyberboss
tweak: The map rotation message will only show if the map is actually changing
/:cl: