### PR TITLE
Fixes slimes not being able to latch onto humans + faction tweak

### DIFF
--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -264,9 +264,9 @@
 	gun = tentacle_gun
 	..()
 
-/obj/item/ammo_casing/magic/tentacle/Destroy(obj/item/weapon/gun/magic/tentacle/tentacle_gun)
+/obj/item/ammo_casing/magic/tentacle/Destroy()
 	gun = null
-	..()
+	return ..()
 
 /obj/item/projectile/tentacle
 	name = "tentacle"

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -264,9 +264,9 @@
 	gun = tentacle_gun
 	..()
 
-/obj/item/ammo_casing/magic/tentacle/Destroy()
+/obj/item/ammo_casing/magic/tentacle/Destroy(obj/item/weapon/gun/magic/tentacle/tentacle_gun)
 	gun = null
-	return ..()
+	..()
 
 /obj/item/projectile/tentacle
 	name = "tentacle"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -898,14 +898,14 @@
 	.["Toggle Purrbation"] = "?_src_=vars;purrbation=\ref[src]"
 
 /mob/living/carbon/human/MouseDrop_T(mob/living/target, mob/living/user)
-	if((target != pulling) || (grab_state < GRAB_AGGRESSIVE) || (user != target) || !isliving(target) || !isliving(user))	//Get consent first :^)
+	if((target != pulling) || (grab_state < GRAB_AGGRESSIVE) || (user != target) || target.stat || user.stat)	//Get consent first :^)
 		. = ..()
 		return
-	buckle_mob(target, FALSE, TRUE, TRUE)
+	buckle_mob(target, TRUE, TRUE)
 	. = ..()
 
-/mob/living/carbon/human/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE, yes = FALSE)
-	if(!yes)
+/mob/living/carbon/human/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
+	if(!force)//humans are only meant to be ridden through piggybacking and special cases
 		return
 	if(!is_type_in_typecache(M, can_ride_typecache))
 		M.visible_message("<span class='warning'>[M] really can't seem to mount [src]...</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -925,9 +925,9 @@
 	. = ..(M, force, check_loc)
 	stop_pulling()
 
-/mob/living/carbon/human/unbuckle_mob(mob/living/M)
+/mob/living/carbon/human/unbuckle_mob(mob/living/M, force=FALSE)
 	if(iscarbon(M))
 		if(riding_datum)
 			riding_datum.unequip_buckle_inhands(M)
 			riding_datum.restore_position(M)
-	. = ..(M)
+	. = ..(M, force)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -898,7 +898,7 @@
 	.["Toggle Purrbation"] = "?_src_=vars;purrbation=\ref[src]"
 
 /mob/living/carbon/human/MouseDrop_T(mob/living/target, mob/living/user)
-	if((target != pulling) || (grab_state < GRAB_AGGRESSIVE) || (user != target) || !iscarbon(user) || stat || user.stat)//Get consent first :^)
+	if((target != pulling) || (grab_state < GRAB_AGGRESSIVE) || (user != target) || !isliving(user) || stat || user.stat)//Get consent first :^)
 		. = ..()
 		return
 	buckle_mob(target, TRUE, TRUE)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -898,7 +898,7 @@
 	.["Toggle Purrbation"] = "?_src_=vars;purrbation=\ref[src]"
 
 /mob/living/carbon/human/MouseDrop_T(mob/living/target, mob/living/user)
-	if((target != pulling) || (grab_state < GRAB_AGGRESSIVE) || (user != target) || stat || user.stat)	//Get consent first :^)
+	if((target != pulling) || (grab_state < GRAB_AGGRESSIVE) || (user != target) || !iscarbon(user) || stat || user.stat)//Get consent first :^)
 		. = ..()
 		return
 	buckle_mob(target, TRUE, TRUE)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -898,7 +898,7 @@
 	.["Toggle Purrbation"] = "?_src_=vars;purrbation=\ref[src]"
 
 /mob/living/carbon/human/MouseDrop_T(mob/living/target, mob/living/user)
-	if((target != pulling) || (grab_state < GRAB_AGGRESSIVE) || (user != target) || target.stat || user.stat)	//Get consent first :^)
+	if((target != pulling) || (grab_state < GRAB_AGGRESSIVE) || (user != target) || stat || user.stat)	//Get consent first :^)
 		. = ..()
 		return
 	buckle_mob(target, TRUE, TRUE)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -50,4 +50,4 @@ var/global/default_martial_art = new/datum/martial_art
 	var/datum/personal_crafting/handcrafting
 	can_buckle = TRUE
 	buckle_lying = FALSE
-	can_ride_typecache = list(/mob/living/carbon/human)
+	can_ride_typecache = list(/mob/living/carbon/human, /mob/living/simple_animal/slime)

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -78,7 +78,7 @@
 
 /mob/living/simple_animal/slime/proc/Feedon(mob/living/M)
 	M.unbuckle_all_mobs(force=1) //Slimes rip other mobs (eg: shoulder parrots) off (Slimes Vs Slimes is already handled in CanFeedon())
-	if(M.buckle_mob(src, force=TRUE, yes=TRUE))
+	if(M.buckle_mob(src, force=TRUE))
 		layer = M.layer+0.01 //appear above the target mob
 		M.visible_message("<span class='danger'>[name] has latched onto [M]!</span>", \
 						"<span class='userdanger'>[name] has latched onto [M]!</span>")

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -78,12 +78,12 @@
 
 /mob/living/simple_animal/slime/proc/Feedon(mob/living/M)
 	M.unbuckle_all_mobs(force=1) //Slimes rip other mobs (eg: shoulder parrots) off (Slimes Vs Slimes is already handled in CanFeedon())
-	if(M.buckle_mob(src, force=1))
+	if(M.buckle_mob(src, force=TRUE, yes=TRUE))
 		layer = M.layer+0.01 //appear above the target mob
 		M.visible_message("<span class='danger'>[name] has latched onto [M]!</span>", \
 						"<span class='userdanger'>[name] has latched onto [M]!</span>")
 	else
-		src << "<span class='warning'><i>I have failed to latch onto the subject</i></span>"
+		src << "<span class='warning'><i>I have failed to latch onto the subject!</i></span>"
 
 /mob/living/simple_animal/slime/proc/Feedstop(silent=0, living=1)
 	if(buckled)
@@ -96,7 +96,7 @@
 			visible_message("<span class='warning'>[src] has let go of [buckled]!</span>", \
 							"<span class='notice'><i>I stopped feeding.</i></span>")
 		layer = initial(layer)
-		buckled.unbuckle_mob(src,force=1)
+		buckled.unbuckle_mob(src,force=TRUE)
 
 /mob/living/simple_animal/slime/verb/Evolve()
 	set category = "Slime"

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -15,7 +15,7 @@ var/list/slime_colours = list("rainbow", "grey", "purple", "metal", "orange",
 	var/docile = 0
 	languages_spoken = SLIME | HUMAN
 	languages_understood = SLIME | HUMAN
-	faction = list("slime")
+	faction = list("slime","neutral")
 
 	harm_intent_damage = 5
 	icon_living = "grey baby slime"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -116,7 +116,7 @@ var/next_mob_id = 0
 					msg = blind_message
 				else
 					continue
-			
+
 			else if(T.lighting_overlay)
 				if(T.lighting_overlay.invisibility <= M.see_invisible && T.is_softly_lit()) //the light object is dark and not invisible to us
 					if(blind_message)
@@ -767,7 +767,7 @@ var/next_mob_id = 0
 	setDir(angle2dir(rotation+dir2angle(dir)))
 
 //You can buckle on mobs if you're next to them since most are dense
-/mob/buckle_mob(mob/living/M, force = 0)
+/mob/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE, yes = FALSE)
 	if(M.buckled)
 		return 0
 	var/turf/T = get_turf(src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -767,7 +767,7 @@ var/next_mob_id = 0
 	setDir(angle2dir(rotation+dir2angle(dir)))
 
 //You can buckle on mobs if you're next to them since most are dense
-/mob/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE, yes = FALSE)
+/mob/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
 	if(M.buckled)
 		return 0
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
:cl: XDTM
fix: Slimes can now properly latch onto humans.
fix: Slimes won't aggro neutral mobs anymore. This includes blood-spawned gold slime mobs.
/:cl:

Fixes #24746.
Fixes #24412.

The faction won't affect slime aggro rules, i checked. Which is sorta bad, anyway.

Whoever made piggyback riding also made buckling mobs to humans SO MUCH MORE COMPLICATED I SPENT AN HOUR AND A HALF DEBUGGING THIS AND WHY DID YOU USE YES AS AN ARGUMENT NAME