### PR TITLE
Adds Colored Lights for Energy Swords

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -89,9 +89,9 @@
 	. = ..()
 
 /obj/item/weapon/melee/energy/sword/process()
+	if(hacked)
+		light_color = pick("#ff0000", "#00ff00", "#40ceff", "#9b51ff")
 	if(active)
-		if(hacked)
-			light_color = pick("#ff0000", "#00ff00", "#40ceff", "#9b51ff")
 		open_flame()
 	else
 		STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -16,7 +16,7 @@
 	resistance_flags = FIRE_PROOF
 	var/brightness_on = 3
 
-/obj/item/weapon/melee/energy/New()
+/obj/item/weapon/melee/energy/Initialize()
 	..()
 	if(random_color && possible_colors.len)
 		item_color = pick(possible_colors)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -4,6 +4,8 @@
 	var/throwforce_on = 20
 	var/icon_state_on = "axe1"
 	var/list/attack_verb_on = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	var/random_color = 0
+	var/list/possible_colors = list()
 	w_class = WEIGHT_CLASS_SMALL
 	sharpness = IS_SHARP
 	var/w_class_on = WEIGHT_CLASS_BULKY
@@ -12,6 +14,23 @@
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 30)
 	resistance_flags = FIRE_PROOF
+	var/brightness_on = 3
+
+/obj/item/weapon/melee/energy/New()
+	..()
+	if(random_color && possible_colors.len)
+		item_color = pick(possible_colors)
+		switch(item_color)//Only run this check if the color was picked randomly, so that colors can be manually set for non-random colored energy weapons.
+			if("red")
+				light_color = "#ff0000"
+			if("green")
+				light_color = "#00ff00"
+			if("blue")
+				light_color = "#40ceff"
+			if("purple")
+				light_color = "#9b51ff"
+	if(active)
+		set_light(brightness_on)
 
 /obj/item/weapon/melee/energy/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is [pick("slitting [user.p_their()] stomach open with", "falling on")] [src]! It looks like [user.p_theyre()] trying to commit seppuku!</span>")
@@ -61,11 +80,9 @@
 	armour_penetration = 35
 	origin_tech = "combat=3;magnets=4;syndicate=4"
 	block_chance = 50
+	random_color = 1
+	possible_colors = list("red", "blue", "green", "purple")
 	var/hacked = 0
-
-/obj/item/weapon/melee/energy/sword/New()
-	if(item_color == null)
-		item_color = pick("red", "blue", "green", "purple")
 
 /obj/item/weapon/melee/energy/sword/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -73,6 +90,8 @@
 
 /obj/item/weapon/melee/energy/sword/process()
 	if(active)
+		if(hacked)
+			light_color = pick("#ff0000", "#00ff00", "#40ceff", "#9b51ff")
 		open_flame()
 	else
 		STOP_PROCESSING(SSobj, src)
@@ -102,6 +121,7 @@
 		playsound(user, 'sound/weapons/saberon.ogg', 35, 1) //changed it from 50% volume to 35% because deafness
 		user << "<span class='notice'>[src] is now active.</span>"
 		START_PROCESSING(SSobj, src)
+		set_light(brightness_on)
 	else
 		force = initial(force)
 		throwforce = initial(throwforce)
@@ -114,6 +134,7 @@
 		playsound(user, 'sound/weapons/saberoff.ogg', 35, 1)  //changed it from 50% volume to 35% because deafness
 		user << "<span class='notice'>[src] can now be concealed.</span>"
 		STOP_PROCESSING(SSobj, src)
+		set_light(0)
 	add_fingerprint(user)
 
 /obj/item/weapon/melee/energy/is_hot()
@@ -160,6 +181,8 @@
 	item_color = null
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = IS_SHARP
+	light_color = "#40ceff"
+	random_color = 0
 
 /obj/item/weapon/melee/energy/sword/cyborg/saw/New()
 	..()
@@ -173,15 +196,24 @@
 
 /obj/item/weapon/melee/energy/sword/saber/blue
 	item_color = "blue"
+	random_color = 0
+	light_color = "#40ceff"
 
 /obj/item/weapon/melee/energy/sword/saber/purple
 	item_color = "purple"
+	random_color = 0
+	light_color = "#9b51ff"
 
 /obj/item/weapon/melee/energy/sword/saber/green
 	item_color = "green"
+	random_color = 0
+	light_color = "#00ff00"
 
 /obj/item/weapon/melee/energy/sword/saber/red
 	item_color = "red"
+	light_color = "#ff0000"
+	random_color = 0
+
 
 /obj/item/weapon/melee/energy/sword/saber/attackby(obj/item/weapon/W, mob/living/user, params)
 	if(istype(W, /obj/item/weapon/melee/energy/sword/saber))
@@ -215,6 +247,7 @@
 	desc = "Arrrr matey."
 	icon_state = "cutlass0"
 	icon_state_on = "cutlass1"
+	light_color = "#ff0000"
 
 /obj/item/weapon/melee/energy/sword/pirate/New()
 	return

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -4,8 +4,7 @@
 	var/throwforce_on = 20
 	var/icon_state_on = "axe1"
 	var/list/attack_verb_on = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	var/random_color = 0
-	var/list/possible_colors = list()
+	var/list/possible_colors
 	w_class = WEIGHT_CLASS_SMALL
 	sharpness = IS_SHARP
 	var/w_class_on = WEIGHT_CLASS_BULKY
@@ -18,7 +17,7 @@
 
 /obj/item/weapon/melee/energy/Initialize()
 	..()
-	if(random_color && possible_colors.len)
+	if(LAZYLEN(possible_colors))
 		item_color = pick(possible_colors)
 		switch(item_color)//Only run this check if the color was picked randomly, so that colors can be manually set for non-random colored energy weapons.
 			if("red")
@@ -44,7 +43,7 @@
 
 /obj/item/weapon/melee/energy/axe
 	name = "energy axe"
-	desc = "An energised battle axe."
+	desc = "An energized battle axe."
 	icon_state = "axe0"
 	force = 40
 	force_on = 150
@@ -60,6 +59,7 @@
 	origin_tech = "combat=4;magnets=3"
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	attack_verb_on = list()
+	light_color = "#40ceff"
 
 /obj/item/weapon/melee/energy/axe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] swings [src] towards [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -80,7 +80,6 @@
 	armour_penetration = 35
 	origin_tech = "combat=3;magnets=4;syndicate=4"
 	block_chance = 50
-	random_color = 1
 	possible_colors = list("red", "blue", "green", "purple")
 	var/hacked = 0
 
@@ -182,7 +181,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = IS_SHARP
 	light_color = "#40ceff"
-	random_color = 0
+	possible_colors = null
 
 /obj/item/weapon/melee/energy/sword/cyborg/saw/New()
 	..()
@@ -195,24 +194,16 @@
 /obj/item/weapon/melee/energy/sword/saber
 
 /obj/item/weapon/melee/energy/sword/saber/blue
-	item_color = "blue"
-	random_color = 0
-	light_color = "#40ceff"
+	possible_colors = list("blue")
 
 /obj/item/weapon/melee/energy/sword/saber/purple
-	item_color = "purple"
-	random_color = 0
-	light_color = "#9b51ff"
+	possible_colors = list("purple")
 
 /obj/item/weapon/melee/energy/sword/saber/green
-	item_color = "green"
-	random_color = 0
-	light_color = "#00ff00"
+	possible_colors = list("green")
 
 /obj/item/weapon/melee/energy/sword/saber/red
-	item_color = "red"
-	light_color = "#ff0000"
-	random_color = 0
+	possible_colors = list("red")
 
 
 /obj/item/weapon/melee/energy/sword/saber/attackby(obj/item/weapon/W, mob/living/user, params)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -266,7 +266,17 @@
 
 /obj/item/weapon/twohanded/dualsaber/Initialize()
 	..()
-	item_color = pick("red", "blue", "green", "purple")
+	if(random_color && possible_colors.len)
+		item_color = pick(possible_colors)
+		switch(item_color)//Only run this check if the color was picked randomly, so that colors can be manually set for non-random colored energy weapons.
+			if("red")
+				light_color = "#ff0000"
+			if("green")
+				light_color = "#00ff00"
+			if("blue")
+				light_color = "#40ceff"
+			if("purple")
+				light_color = "#9b51ff"
 
 /obj/item/weapon/twohanded/dualsaber/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -261,14 +261,13 @@
 	resistance_flags = FIRE_PROOF
 	var/hacked = 0
 	var/brightness_on = 6//TWICE AS BRIGHT AS A REGULAR ESWORD
-	var/random_color = 1
 	var/list/possible_colors = list("red", "blue", "green", "purple")
 
 /obj/item/weapon/twohanded/dualsaber/Initialize()
 	..()
-	if(random_color && possible_colors.len)
+	if(LAZYLEN(possible_colors))
 		item_color = pick(possible_colors)
-		switch(item_color)//Only run this check if the color was picked randomly, so that colors can be manually set for non-random colored energy weapons.
+		switch(item_color)
 			if("red")
 				light_color = "#ff0000"
 			if("green")
@@ -375,14 +374,16 @@
 	INVOKE_ASYNC(src, .proc/jedi_spin, user)
 
 /obj/item/weapon/twohanded/dualsaber/green
-	item_color = "green"
-	light_color = "#00ff00"
-	random_color = 0
+	possible_colors = list("green")
 
 /obj/item/weapon/twohanded/dualsaber/red
-	item_color = "red"
-	light_color = "#ff0000"
-	random_color = 0
+	possible_colors = list("red")
+
+/obj/item/weapon/twohanded/dualsaber/blue
+	possible_colors = list("blue")
+
+/obj/item/weapon/twohanded/dualsaber/purple
+	possible_colors = list("purple")
 
 /obj/item/weapon/twohanded/dualsaber/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/device/multitool))

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -252,6 +252,7 @@
 	armour_penetration = 35
 	origin_tech = "magnets=4;syndicate=5"
 	item_color = "green"
+	light_color = "#00ff00"//green
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 75
 	obj_integrity = 200
@@ -259,8 +260,11 @@
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
 	var/hacked = 0
+	var/brightness_on = 6//TWICE AS BRIGHT AS A REGULAR ESWORD
+	var/random_color = 1
+	var/list/possible_colors = list("red", "blue", "green", "purple")
 
-/obj/item/weapon/twohanded/dualsaber/New()
+/obj/item/weapon/twohanded/dualsaber/Initialize()
 	..()
 	item_color = pick("red", "blue", "green", "purple")
 
@@ -323,6 +327,7 @@
 		w_class = w_class_on
 		hitsound = 'sound/weapons/blade1.ogg'
 		START_PROCESSING(SSobj, src)
+		set_light(brightness_on)
 
 /obj/item/weapon/twohanded/dualsaber/unwield() //Specific unwield () to switch hitsounds.
 	sharpness = initial(sharpness)
@@ -330,9 +335,12 @@
 	..()
 	hitsound = "swing_hit"
 	STOP_PROCESSING(SSobj, src)
+	set_light(0)
 
 /obj/item/weapon/twohanded/dualsaber/process()
 	if(wielded)
+		if(hacked)
+			light_color = pick("#ff0000", "#00ff00", "#40ceff", "#9b51ff")
 		open_flame()
 	else
 		STOP_PROCESSING(SSobj, src)
@@ -356,11 +364,15 @@
 	// Light your candles while spinning around the room
 	INVOKE_ASYNC(src, .proc/jedi_spin, user)
 
-/obj/item/weapon/twohanded/dualsaber/green/New()
+/obj/item/weapon/twohanded/dualsaber/green
 	item_color = "green"
+	light_color = "#00ff00"
+	random_color = 0
 
-/obj/item/weapon/twohanded/dualsaber/red/New()
+/obj/item/weapon/twohanded/dualsaber/red
 	item_color = "red"
+	light_color = "#ff0000"
+	random_color = 0
 
 /obj/item/weapon/twohanded/dualsaber/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/device/multitool))


### PR DESCRIPTION
:cl: TalkingCactus
add: Energy swords (and other energy melee weapons) now have a colored light effect when active.
/:cl:

Also:

- Generalized color code for energy melee weapons to make it easier to add new colored weapons in the future.

- Fixed a typo in the energy axe's description.

Dark room:
![darkroom](http://image.prntscr.com/image/fc7d2ba89e5444bdbc53baae5ad0fbb6.png)
Bright room:
![brightroom](http://image.prntscr.com/image/ee6faac0362644e5a7b8d7d34bb675ab.png)