### PR TITLE
Syndicate Cyborgs now have red headlamps

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -814,6 +814,7 @@
 	lawupdate = FALSE
 	scrambledcodes = TRUE // These are rogue borgs.
 	ionpulse = TRUE
+	light_color = LIGHT_COLOR_RED
 	var/playstyle_string = "<span class='userdanger'>You are a Syndicate assault cyborg!</span><br>\
 							<b>You are armed with powerful offensive tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
 							Your cyborg LMG will slowly produce ammunition from your power supply, and your operative pinpointer will find and locate fellow nuclear operatives. \


### PR DESCRIPTION
Syndicate Cyborg (Assault and Medical) headlamps are now red.


:cl: Gun Hog
tweak: Syndicate Cyborg headlamps now emit red light.
/:cl:

Syndieborgs clearly have red headlamps, so now the actual light reflects this!

![image](https://cloud.githubusercontent.com/assets/4955510/23637610/48aa0af2-02a2-11e7-9a44-f40d3bb319e5.png)

