### PR TITLE
Syndicate Hardsuit colored lights + Light level decrease

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -231,6 +231,7 @@
 	visor_flags_inv = HIDEMASK|HIDEEYES|HIDEFACE|HIDEFACIALHAIR
 	visor_flags = STOPSPRESSUREDMAGE
 	light_color = LIGHT_COLOR_GREEN
+	brightness_on = 3
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/update_icon()
 	icon_state = "hardsuit[on]-[item_color]"
@@ -323,6 +324,7 @@
 	on = 0
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	light_color = LIGHT_COLOR_FIRE
+	brightness_on = 3
 
 
 /obj/item/clothing/suit/space/hardsuit/syndi/elite
@@ -686,6 +688,7 @@
 	item_color = "syndi"
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50, fire = 100, acid = 100)
 	light_color = LIGHT_COLOR_GREEN
+	brightness_on = 3
 
 ///SWAT version
 /obj/item/clothing/suit/space/hardsuit/shielded/swat

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -230,6 +230,7 @@
 	actions_types = list(/datum/action/item_action/toggle_helmet_mode)
 	visor_flags_inv = HIDEMASK|HIDEEYES|HIDEFACE|HIDEFACIALHAIR
 	visor_flags = STOPSPRESSUREDMAGE
+	light_color = LIGHT_COLOR_GREEN
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/update_icon()
 	icon_state = "hardsuit[on]-[item_color]"
@@ -321,6 +322,7 @@
 	visor_flags = 0
 	on = 0
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	light_color = LIGHT_COLOR_FIRE
 
 
 /obj/item/clothing/suit/space/hardsuit/syndi/elite
@@ -683,6 +685,7 @@
 	item_state = "syndie_helm"
 	item_color = "syndi"
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50, fire = 100, acid = 100)
+	light_color = LIGHT_COLOR_GREEN
 
 ///SWAT version
 /obj/item/clothing/suit/space/hardsuit/shielded/swat

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -323,8 +323,6 @@
 	visor_flags = 0
 	on = 0
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	light_color = LIGHT_COLOR_FIRE
-	brightness_on = 3
 
 
 /obj/item/clothing/suit/space/hardsuit/syndi/elite


### PR DESCRIPTION
:cl: Gun Hog
tweak: The Syndicate and Shielded Syndicate Hardsuits now have green visor
lights.
del: These two hardsuits now have weaker helmet lights.
/:cl:

I am not sure I am happy with these colors. Some recommendations (Please post a hex code if it is not defined) would be appreciated.
**LIGHT LEVEL OF 3 Changes to Elite Hardsuit reverted.**
![image](https://cloud.githubusercontent.com/assets/4955510/23657095/193386c6-0302-11e7-9163-1ab7f9b60c52.png)


**OLD LIGHT LEVEL OF 4**
![screenshot 2017-03-06 19 44 41](https://cloud.githubusercontent.com/assets/4955510/23638245/00863396-02a6-11e7-825c-db81e940eee8.png)
