### PR TITLE
Adds light colors for a few more computers

### DIFF
--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -3,6 +3,7 @@
 	desc = "It monitors power levels across the station."
 	icon_screen = "power"
 	icon_keyboard = "power_key"
+	light_color = LIGHT_COLOR_YELLOW
 	use_power = 2
 	idle_power_usage = 20
 	active_power_usage = 100

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -2,6 +2,7 @@
 	name = "Shuttle Console"
 	icon_screen = "shuttle"
 	icon_keyboard = "tech_key"
+	light_color = LIGHT_COLOR_CYAN
 	req_access = list( )
 	circuit = /obj/item/weapon/circuitboard/computer/shuttle
 	var/shuttleId

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -414,6 +414,7 @@
 	possible_destinations = "pod_asteroid"
 	icon = 'icons/obj/terminals.dmi'
 	icon_state = "dorm_available"
+	light_color = LIGHT_COLOR_BLUE
 	density = 0
 	clockwork = TRUE //it'd look weird
 

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -5,6 +5,7 @@
 	circuit = /obj/item/weapon/circuitboard/computer/syndicate_shuttle
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
+	light_color = LIGHT_COLOR_RED
 	req_access = list(access_syndicate)
 	shuttleId = "syndicate"
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s"
@@ -42,6 +43,7 @@
 	name = "syndicate assault pod control"
 	icon = 'icons/obj/terminals.dmi'
 	icon_state = "dorm_available"
+	light_color = LIGHT_COLOR_BLUE
 	req_access = list(access_syndicate)
 	shuttleId = "steel_rain"
 	possible_destinations = null


### PR DESCRIPTION
Shuttle consoles, which are cyan, syndicate shuttle consoles, which are red, pod launch computers, which are blue but you probably won't see them because no dynamic lights on shuttles yet, and power monitor consoles, which are yellow.