### PR TITLE
Wizards can now Summon Ghosts

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -493,6 +493,23 @@
 		dat += "<b>Already cast!</b><br>"
 	return dat
 
+/datum/spellbook_entry/summon/ghosts
+	name = "Summon Ghosts"
+	desc = "Spook the crew out by making them see dead people. Be warned, ghosts are capricious and occasionally vindicative, and some will use their incredibly minor abilties to frustrate you."
+	log_name = "SGH"
+
+/datum/spellbook_entry/summon/ghosts/IsAvailible()
+	if(!ticker.mode)
+		return FALSE
+
+/datum/spellbook_entry/summon/ghosts/Buy(mob/living/carbon/human/user, obj/item/weapon/spellbook/book)
+	feedback_add_details("wizard_spell_learned", log_name)
+	new /datum/round_event/wizard/ghost()
+	active = TRUE
+	user << "<span class='notice'>You have cast summon ghosts!</span>"
+	playsound(get_turf(user), 'sound/effects/ghost2.ogg', 50, 1)
+	return TRUE
+
 /datum/spellbook_entry/summon/guns
 	name = "Summon Guns"
 	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill you. Just be careful not to stand still too long!"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -501,6 +501,8 @@
 /datum/spellbook_entry/summon/ghosts/IsAvailible()
 	if(!ticker.mode)
 		return FALSE
+	else
+		return TRUE
 
 /datum/spellbook_entry/summon/ghosts/Buy(mob/living/carbon/human/user, obj/item/weapon/spellbook/book)
 	feedback_add_details("wizard_spell_learned", log_name)

--- a/code/modules/events/wizard/ghost.dm
+++ b/code/modules/events/wizard/ghost.dm
@@ -2,13 +2,12 @@
 	name = "G-G-G-Ghosts!"
 	weight = 3
 	typepath = /datum/round_event/wizard/ghost
-	max_occurrences = 5
+	max_occurrences = 1
 	earliest_start = 0
 
 /datum/round_event/wizard/ghost/start()
-	for(var/mob/dead/observer/G in player_list)
-		G.invisibility = 0
-		G << "You suddenly feel extremely obvious..."
+	var/msg = "<span class='warning'>You suddenly feel extremely obvious...</span>"
+	set_observer_default_invisibility(0, msg)
 
 
 //--//

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -490,7 +490,7 @@
 
 /obj/item/weapon/melee/ghost_sword/Destroy()
 	for(var/mob/dead/observer/G in spirits)
-		G.invisibility = initial(G.invisibility)
+		G.invisibility = observer_default_invisibility
 	spirits.Cut()
 	STOP_PROCESSING(SSobj, src)
 	poi_list -= src
@@ -537,7 +537,7 @@
 			current_spirits |= G
 
 	for(var/mob/dead/observer/G in spirits - current_spirits)
-		G.invisibility = initial(G.invisibility)
+		G.invisibility = observer_default_invisibility
 
 	spirits = current_spirits
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -2,6 +2,9 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 var/list/image/ghost_images_full = list() //this is a list of full images of the ghosts themselves
 var/list/image/ghost_images_default = list() //this is a list of the default (non-accessorized, non-dir) images of the ghosts themselves
 var/list/image/ghost_images_simple = list() //this is a list of all ghost images as the simple white ghost
+
+var/global/static/observer_default_invisibility = INVISIBILITY_OBSERVER
+
 /mob/dead/observer
 	name = "ghost"
 	desc = "It's a g-g-g-g-ghooooost!" //jinkies!
@@ -57,6 +60,8 @@ var/list/image/ghost_images_simple = list() //this is a list of all ghost images
 	var/deadchat_name
 
 /mob/dead/observer/New(mob/body)
+	invisibility = observer_default_invisibility
+
 	verbs += /mob/dead/observer/proc/dead_tele
 
 	if(global.cross_allowed)
@@ -801,3 +806,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(isobserver(user) && check_rights(R_SPAWN))
 		change_mob_type( /mob/living/carbon/human , null, null, TRUE) //always delmob, ghosts shouldn't be left lingering
 
+/proc/set_observer_default_invisibility(amount, message=null)
+	for(var/mob/dead/observer/G in player_list)
+		G.invisibility = amount
+		if(message)
+			G << message
+	observer_default_invisibility = amount


### PR DESCRIPTION
:cl: coiax
add: Wizards can now use their magic to make ghosts visible to haunt the crew, and possibly attempt to betray the wizard.
/:cl:

- Summon Ghosts, makes ghosts visible for the rest of the round.
- Modifies the Summon Events G-g-ghosts! event to also use the same mechanism of making all ghosts visible.
- New global var `observer_default_invisibility`, which all ghosts load their invisibility from when created. You need this because ghosts get destroyed and created every time you exit and reenter a body. Modified the spectral sword to use this, instead of initial().

- Pros for wizards to summon ghosts: It's spooky, and distracts the crew, they get to see the ghosts come out of the dead people they just murdered.
- Downsides of wizards to summon ghosts: They'll be always obvious when jaunting around, they can't really stealth, ghosts will do their best to upset the wizard's plans.
- If you were playing to WIN as a wizard, you probably wouldn't summon ghosts. But you wouldn't summon guns or magic either.