### PR TITLE
Lighting runs every two ticks.

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -11,9 +11,9 @@ var/list/lighting_update_overlays  = list() // List of lighting overlays queued 
 
 /datum/subsystem/lighting
 	name = "Lighting"
-	wait = 1
+	wait = 2
 	init_order = 1
-	priority = 25
+	priority = 35
 	flags = SS_TICKER
 
 	var/initialized = FALSE


### PR DESCRIPTION
This has the added benefit of making it more likely lighting moves when the person's tile glide has them at their new tile rather than before they get there.

@Incoming5643 