### PR TITLE
Deathrattles follow links jump to turf if no mob is found

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -34,3 +34,4 @@
 
 // A link given to ghost alice to follow bob
 #define FOLLOW_LINK(alice, bob) "<a href=?src=\ref[alice];follow=\ref[bob]>(F)</a>"
+#define TURF_LINK(alice, turfy) "<a href=?src=\ref[alice];jump_to_turf=\ref[turfy]>(T)</a>"

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -35,3 +35,4 @@
 // A link given to ghost alice to follow bob
 #define FOLLOW_LINK(alice, bob) "<a href=?src=\ref[alice];follow=\ref[bob]>(F)</a>"
 #define TURF_LINK(alice, turfy) "<a href=?src=\ref[alice];jump_to_turf=\ref[turfy]>(T)</a>"
+#define FOLLOW_OR_TURF_LINK(alice, bob, turfy) "<a href=?src=\ref[alice];follow=\ref[bob];jump_to_turf=\ref[turfy]>(F)</a>"

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -396,9 +396,13 @@ Proc for attack log creation, because really why not
 
 		if(isobserver(M))
 			if(follow_target)
-				var/link = FOLLOW_LINK(M, follow_target)
-				message = "[link] [message]"
-			if(turf_target)
+				var/F
+				if(turf_target)
+					F = FOLLOW_OR_TURF_LINK(M, follow_target, turf_target)
+				else
+					F = FOLLOW_LINK(M, follow_target)
+				message = "[F] [message]"
+			else if(turf_target)
 				var/turf_link = TURF_LINK(M, turf_target)
 				message = "[turf_link] [message]"
 		M << "[message]"

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -368,7 +368,7 @@ Proc for attack log creation, because really why not
 			for(var/i in 1 to step_count)
 				step(X, pick(NORTH, SOUTH, EAST, WEST))
 
-/proc/deadchat_broadcast(message, mob/follow_target=null, speaker_key=null, message_type=DEADCHAT_REGULAR)
+/proc/deadchat_broadcast(message, mob/follow_target=null, turf/turf_target=null, speaker_key=null, message_type=DEADCHAT_REGULAR)
 	for(var/mob/M in player_list)
 		var/datum/preferences/prefs
 		if(M.client && M.client.prefs)
@@ -394,8 +394,11 @@ Proc for attack log creation, because really why not
 				if(prefs.toggles & DISABLE_ARRIVALRATTLE)
 					continue
 
-		if(isobserver(M) && follow_target)
-			var/link = FOLLOW_LINK(M, follow_target)
-			M << "[link] [message]"
-		else
-			M << "[message]"
+		if(isobserver(M))
+			if(follow_target)
+				var/link = FOLLOW_LINK(M, follow_target)
+				message = "[link] [message]"
+			if(turf_target)
+				var/turf_link = TURF_LINK(M, turf_target)
+				message = "[turf_link] [message]"
+		M << "[message]"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -657,6 +657,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			var/atom/movable/target = locate(href_list["follow"])
 			if(istype(target) && (target != src))
 				ManualFollow(target)
+		if(href_list["jump_to_turf"])
+			var/turf/target = locate(href_list["jump_to_turf"])
+			if(istype(target))
+				forceMove(target)
 		if(href_list["reenter"])
 			reenter_corpse()
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -52,7 +52,7 @@
 	if(mind && mind.name && mind.active && (!(T.flags & NO_DEATHRATTLE)))
 		var/area/A = get_area(T)
 		var/rendered = "<span class='deadsay'><b>[mind.name]</b> has died at <b>[A.name]</b>.</span>"
-		deadchat_broadcast(rendered, follow_target = src, message_type=DEADCHAT_DEATHRATTLE)
+		deadchat_broadcast(rendered, follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
 	if(mind)
 		mind.store_memory("Time of death: [tod]", 0)
 	living_mob_list -= src


### PR DESCRIPTION
:cl: coiax
add: When someone dies, if their body is no longer present, the (F) link will instead jump to the turf they previously occupied.
/:cl:

Supermatter disintegrations, singularity eatings, other stuff that
doesn't leave a body means that the (F) link doesn't work. But now it will.