### PR TITLE
Fixes that poster in Metastation Vacant Office

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -93982,7 +93982,7 @@
 /obj/item/weapon/clipboard,
 /obj/item/weapon/paper,
 /obj/structure/sign/poster/official/random{
-	pixel_y = -32
+	pixel_y = 32
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/609465/23680799/7465fb32-0384-11e7-83a0-4bc0d9b6e029.png)

Previously the poster appeared to be on that chair, it is now on the wall, like it should be.