### PR TITLE
Fixes being unable to add materials to autolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -135,7 +135,7 @@
 		busy = 0
 		return 1
 
-	if(O.flags & HOLOGRAM)
+	if(HAS_SECONDARY_FLAG(O, HOLOGRAM))
 		return 1
 
 	var/material_amount = materials.get_item_material_amount(O)


### PR DESCRIPTION
Fixes #24811. Looks like I missed an old style hologram flag. Should
have really used a different name to highlight this, but oh well.