### PR TITLE
Bulletproof(Tactical) Armour + Vest Defence Tweak

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -28,7 +28,7 @@
 	desc = "A bulletproof combat helmet that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
 	icon_state = "helmetalt"
 	item_state = "helmetalt"
-	armor = list(melee = 15, bullet = 40, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0, fire = 50, acid = 50)
+	armor = list(melee = 15, bullet = 60, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0, fire = 50, acid = 50)
 	can_flashlight = 1
 	dog_fashion = null
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -119,7 +119,7 @@
 	icon_state = "bulletproof"
 	item_state = "armor"
 	blood_overlay_type = "armor"
-	armor = list(melee = 15, bullet = 80, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0, fire = 50, acid = 50)
+	armor = list(melee = 15, bullet = 60, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0, fire = 50, acid = 50)
 	strip_delay = 70
 	put_on_delay = 50
 


### PR DESCRIPTION
One issue that has been bugging me for a while is the inconsistant bullet defence of the Bulletproof Vest and Helmet.

Currently the vest has 80 bullet defence, but the helmet has only 40 bullet defence.

In the interest of fairness  (since people will think I'm just buffing security), I've fixed this by buffing the helmet, and nerfing the vest, to have 60 bullet defence.

Thanks for reading.

🆑 Steelpoint
tweak: Bulletproof (Tactical) Armour has had its bullet defence tweaked to be consistent between both the helmet and vest variants. Defence is now at 60.
/🆑