### PR TITLE
Riot Armour Helmet Consistency Change

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -45,7 +45,7 @@
 	alt_toggle_message = "You push the visor up on"
 	can_toggle = 1
 	flags = HEADBANGPROTECT
-	armor = list(melee = 45, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0, fire = 50, acid = 50)
+	armor = list(melee = 60, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0, fire = 50, acid = 50)
 	flags_inv = HIDEEARS|HIDEFACE
 	strip_delay = 80
 	actions_types = list(/datum/action/item_action/toggle)


### PR DESCRIPTION
This PR fixes a inconsistency with Riot Armour, the head slot has 45 melee protection, yet the chest has 60 (overall) melee protection.

As such this PR buffs the Riot Helmet to have 60 melee. I think this number is fair.

Thank you for reading.

-----

🆑 Steelpoint
tweak: The Riot Helmet has had its melee buffed from 45 to 60, to match the defence of the Riot Armour.
/🆑