### PR TITLE
Pagination for banning panel

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -181,8 +181,9 @@
 	else if(href_list["dbsearchckey"] || href_list["dbsearchadmin"])
 		var/adminckey = href_list["dbsearchadmin"]
 		var/playerckey = href_list["dbsearchckey"]
+		var/page = href_list["dbsearchpage"]
 
-		DB_ban_panel(playerckey, adminckey)
+		DB_ban_panel(playerckey, adminckey, page)
 		return
 
 	else if(href_list["dbbanedit"])


### PR DESCRIPTION
:cl: 
tweak: The Banning Panel now organises search results into pages of 15 each.
/:cl:

Fixes #17475
I tried to come up with a good index for this but the best case was three separate ones, one of which didn't get used, although that was possibly due to my small test table.

Rip Saegrimr's legacy.