### PR TITLE
EMP'd cloners merely eject early, not gib the clone

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -374,7 +374,9 @@
 
 /obj/machinery/clonepod/emp_act(severity)
 	if(prob(100/(severity*efficiency)))
-		malfunction()
+		connected_message(Gibberish("EMP-caused Accidental Ejection", 0))
+		SPEAK(Gibberish("Exposure to electromagnetic fields has caused the ejection of [occupant.real_name] prematurely." ,0))
+		go_out()
 	..()
 
 /obj/machinery/clonepod/ex_act(severity, target)


### PR DESCRIPTION
:cl: coiax
del: A cloner that is EMP'd will merely eject the clone early, rather
than gibbing it. Emagging the cloner will still gib the clone.
/:cl:

Early ejectees don't tend to survive, but it's more of a chance than
just gibbing them.