### PR TITLE
Generates messages when xeno eggs are delivered

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -90644,10 +90644,7 @@
 /turf/open/floor/engine,
 /area/toxins/xenobiology)
 "daJ" = (
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/effect/decal/remains/xeno = 49, /obj/structure/alien/egg = 1);
-	name = "2% chance xeno egg spawner"
-	},
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
 /area/toxins/xenobiology)
 "daK" = (

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -13,7 +13,7 @@
 			intercepttext += " 2. If found, use any neccesary means to contain and destroy the organism.<BR>"
 			intercepttext += " 3. Avoid damage to the capital infrastructure of the station.<BR>"
 			intercepttext += "<BR>Note in the event of a quarantine breach or uncontrolled spread of the biohazard, <b>Biohazard Response Procedure 5-12</b> may be issued.<BR>"
-			print_command_report(intercepttext,"Level 5-6 Biohazard Response Procedures")
+			print_command_report(text=intercepttext,title="Level 5-6 Biohazard Response Procedures",announce=FALSE)
 			priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
 		if(2)
 			var/nukecode = random_nukecode()
@@ -29,8 +29,7 @@
 			intercepttext += "1. Secure the Nuclear Authentication Disk.<BR>"
 			intercepttext += "2. Detonate the Nuke located in the vault.<BR>"
 			intercepttext += "Nuclear Authentication Code: [nukecode] <BR>"
-			print_command_report(intercepttext,"Classified [command_name()] Update")
-			priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
+			print_command_report(text=intercepttext,announce=TRUE)
 
 			for(var/mob/living/silicon/ai/aiPlayer in player_list)
 				if (aiPlayer.client)
@@ -38,7 +37,6 @@
 					aiPlayer.set_zeroth_law(law)
 		else
 			..()
-	return
 
 
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -289,7 +289,7 @@
 			G.on_report()
 			intercepttext += G.get_report()
 
-	print_command_report(intercepttext, "Central Command Status Summary")
+	print_command_report(intercepttext, "Central Command Status Summary", announce=FALSE)
 	priority_announce("A summary has been copied and printed to all communications consoles.", "Enemy communication intercepted. Security level elevated.", 'sound/AI/intercept.ogg')
 	if(security_level < SEC_LEVEL_BLUE)
 		set_security_level(SEC_LEVEL_BLUE)

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer_event.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer_event.dm
@@ -18,10 +18,8 @@
 	new /obj/item/device/unactivated_swarmer(get_turf(the_gateway))
 	if(prob(25)) //25% chance to announce it to the crew
 		var/swarmer_report = "<font size=3><b>[command_name()] High-Priority Update</b></span>"
-		swarmer_report += "<br><br>Our long-range sensors have detected an odd signal emanating from your station's gateway. We recommend immediate investigation of your gateway, as something may have come \
-		through."
-		print_command_report(swarmer_report,"Classified [command_name()] Update")
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
+		swarmer_report += "<br><br>Our long-range sensors have detected an odd signal emanating from your station's gateway. We recommend immediate investigation of your gateway, as something may have come through."
+		print_command_report(swarmer_report, announce=TRUE)
 
 
 /datum/round_event/spawn_swarmer/proc/find_swarmer()

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -188,3 +188,9 @@
 		/obj/item/organ/body_egg/alien_embryo = 1,
 		/obj/item/organ/hivelord_core = 2)
 	lootcount = 3
+
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner
+	name = "2% chance xeno egg spawner"
+	loot = list(
+		/obj/effect/decal/remains/xeno = 49,
+		/obj/effect/spawner/xeno_egg_delivery = 1)

--- a/code/game/objects/effects/spawners/xeno_egg_delivery.dm
+++ b/code/game/objects/effects/spawners/xeno_egg_delivery.dm
@@ -1,0 +1,20 @@
+/obj/effect/spawner/xeno_egg_delivery
+	name = "xeno egg delivery"
+	icon = 'icons/mob/alien.dmi'
+	icon_state = "egg_growing"
+	var/announcement_time = 1200
+
+/obj/effect/spawner/xeno_egg_delivery/Initialize(mapload)
+	..()
+	var/turf/T = get_turf(src)
+	var/area/A = get_area(T)
+
+	new /obj/structure/alien/egg(T)
+	new /obj/effect/overlay/temp/gravpush(T)
+	playsound(T, 'sound/items/party_horn.ogg', 50, 1, -1)
+
+	message_admins("An alien egg has been delivered to [A] at [ADMIN_COORDJMP(T)].")
+	log_game("An alien egg has been delivered to [A] at [COORD(T)]")
+	var/message = "Attention [station_name()], we have entrusted you with a research specimen in [A]. Remember to follow all safety precautions when dealing with the specimen."
+	addtimer(CALLBACK(GLOBAL_PROC, /.proc/priority_announce, message), announcement_time)
+	qdel(src)

--- a/code/game/objects/effects/spawners/xeno_egg_delivery.dm
+++ b/code/game/objects/effects/spawners/xeno_egg_delivery.dm
@@ -16,5 +16,5 @@
 	message_admins("An alien egg has been delivered to [A] at [ADMIN_COORDJMP(T)].")
 	log_game("An alien egg has been delivered to [A] at [COORD(T)]")
 	var/message = "Attention [station_name()], we have entrusted you with a research specimen in [A]. Remember to follow all safety precautions when dealing with the specimen."
-	addtimer(CALLBACK(GLOBAL_PROC, /.proc/priority_announce, message), announcement_time)
+	addtimer(CALLBACK(GLOBAL_PROC, /.proc/print_command_report, message), announcement_time)
 	qdel(src)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -454,12 +454,12 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 
 	var/confirm = alert(src, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No")
+	var/announce_command_report = TRUE
 	if(confirm == "Yes")
 		priority_announce(input, null, 'sound/AI/commandreport.ogg')
-	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
+		announce_command_report = FALSE
 
-	print_command_report(input,"[confirm=="Yes" ? "" : "Classified "][command_name()] Update")
+	print_command_report(input,"[confirm=="Yes" ? "" : "Classified "][command_name()] Update",announce=announce_command_report)
 
 	log_admin("[key_name(src)] has created a command report: [input]")
 	message_admins("[key_name_admin(src)] has created a command report")

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -19,8 +19,7 @@
 
 	sentience_report += "<br><br>Based on [data], we believe that [one] of the station's [pets] has developed [strength] level intelligence, and the ability to communicate."
 
-	print_command_report(sentience_report, "Classified [command_name()] Update")
-	priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
+	print_command_report(text=sentience_report)
 	..()
 
 /datum/round_event/ghost_role/sentience/spawn_role()

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -13,7 +13,7 @@
 
 /datum/station_goal/proc/send_report()
 	priority_announce("Priority Nanotrasen directive received. Project \"[name]\" details inbound.", "Incoming Priority Message", 'sound/AI/commandreport.ogg')
-	print_command_report(get_report(),"Nanotrasen Directive [pick(phonetic_alphabet)] \Roman[rand(1,50)]")
+	print_command_report(get_report(),"Nanotrasen Directive [pick(phonetic_alphabet)] \Roman[rand(1,50)]", announce=FALSE)
 	on_report()
 
 /datum/station_goal/proc/on_report()

--- a/code/orphaned_procs/priority_announce.dm
+++ b/code/orphaned_procs/priority_announce.dm
@@ -30,11 +30,17 @@
 			if(M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
 				M << sound(sound)
 
-/proc/print_command_report(text = "", title = "Central Command Update")
-	for (var/obj/machinery/computer/communications/C in machines)
+/proc/print_command_report(text = "", title = null, announce=TRUE)
+	if(!title)
+		title = "Classified [command_name()] Update"
+
+	if(announce)
+		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
+
+	for(var/obj/machinery/computer/communications/C in machines)
 		if(!(C.stat & (BROKEN|NOPOWER)) && C.z == ZLEVEL_STATION)
-			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( C.loc )
-			P.name = "paper- '[title]'"
+			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(C.loc)
+			P.name = "paper - '[title]'"
 			P.info = text
 			C.messagetitle.Add("[title]")
 			C.messagetext.Add(text)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -672,6 +672,7 @@
 #include "code\game\objects\effects\spawners\lootdrop.dm"
 #include "code\game\objects\effects\spawners\structure.dm"
 #include "code\game\objects\effects\spawners\vaultspawner.dm"
+#include "code\game\objects\effects\spawners\xeno_egg_delivery.dm"
 #include "code\game\objects\items\apc_frame.dm"
 #include "code\game\objects\items\blueprints.dm"
 #include "code\game\objects\items\body_egg.dm"


### PR DESCRIPTION
:cl: coiax
add: The egg spawner on Metastation will generate a station message and
inform the admins if an egg is spawned. (It's only a two percent chance,
but live in hope.)
/:cl:

Metastation has a 2% egg spawner. If it picks the xeno egg, it does so
silently, telling no one. Now it ~~informs the station~~ prints a command report
and also admins and the game log.

- I've also refactored `print_command_report` so  you can just have the "COMMAND REPORT CREATED"
announcement built in

To reiterate, this behaviour is already in the map, I'm just generating
logging and messages. If admins want to simulate this, they can spawn a
`/obj/effect/spawner/xeno_egg_delivery` in any location they like.

Here is a screenshot from testing. Turns out that 2% is a very slim chance.
![image](https://cloud.githubusercontent.com/assets/609465/23723711/1a466af6-0442-11e7-8ad3-b00b1b188c29.png)
