### PR TITLE
Adding three units of *chemical im slapping in soon* to a plant will reduce the amount of reagents it spawns with (math inside, WIP)

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -477,6 +477,9 @@
 				user << "<span class='notice'>Nothing happens...</span>"
 
 	// 2 or 1 units is enough to change the yield and other stats.// Can change the yield and other stats, but requires more than mutagen
+	else if(S.has_reagent("mutagen", 3) || S.has_reagent("radium", 8) || S.has_Reagent("uranium", 5))
+		for(rate of myseed.reagents_add)
+			rate = rate - 0.05
 	else if(S.has_reagent("mutagen", 2) || S.has_reagent("radium", 5) || S.has_reagent("uranium", 5))
 		hardmutate()
 	else if(S.has_reagent("mutagen", 1) || S.has_reagent("radium", 2) || S.has_reagent("uranium", 2))


### PR DESCRIPTION
:cl: ma44
add: The Centcomm in your sector has reported that adding three units of *wip thingy* to a plant will reduce the amount of reagents it produces. 
/:cl:

**wip please don't kill me, bad code ahead**

[why]: # Some plants produce a lot of reagents that are unnecessary in scenarios like combining chemicals. This is a pr that is meant to address this issue 

## Maths

Each three untis of mutagen will decrease the amount of reagents by 5 at 100 potency, 2.5 at 50 and 1 at 20. 