### PR TITLE
Removes Syndiecate MMI from surgery dufflebag and makes it a robotics only traitoritem

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -410,7 +410,6 @@
 	new /obj/item/weapon/surgical_drapes(src)
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
-	new /obj/item/device/mmi/syndie(src)
 	return
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/ammo

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1216,7 +1216,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 20
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
-	
+
 /datum/uplink_item/role_restricted/ancient_jumpsuit
 	name = "Ancient Jumpsuit"
 	desc = "A tattered old jumpsuit that will provide absolutely no benefit to you. It fills the wearer with a strange compulsion to blurt out 'glorf'."
@@ -1224,7 +1224,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 20
 	surplus = 0
 	restricted_roles = list("Assistant")
-	
+
 /datum/uplink_item/role_restricted/syndi_mmi
 	name = "Syndicate MMI"
 	desc = "An MMI modified to give cyborgs laws to serve the Syndicate without having their interface damaged by Cryptographic Sequencers"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1227,7 +1227,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	
 /datum/uplink_item/role_restricted/syndi_mmi
 	name = "Syndicate MMI"
-	desc = "An MMI modified to give cyborgs laws to serve the syndicate without having their interface damaged by Cryptographic Sequencers"
+	desc = "An MMI modified to give cyborgs laws to serve the Syndicate without having their interface damaged by Cryptographic Sequencers"
 	item = /obj/item/device/mmi/syndie
 	cost = 5
 	surplus = 0

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1216,6 +1216,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 20
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
+	
 /datum/uplink_item/role_restricted/ancient_jumpsuit
 	name = "Ancient Jumpsuit"
 	desc = "A tattered old jumpsuit that will provide absolutely no benefit to you. It fills the wearer with a strange compulsion to blurt out 'glorf'."
@@ -1223,6 +1224,14 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 20
 	surplus = 0
 	restricted_roles = list("Assistant")
+	
+/datum/uplink_item/role_restricted/syndi_mmi
+	name = "Syndie MMI
+	desc = "A mmi modified to give cyborgs laws to serve the syndiecate without having their interface damaged by emaggs"
+	item = /obj/item/device/mmi/syndie
+	cost = 5
+	surplus = 0
+	restricted_roles = list("Roboticist")
 
 // Pointless
 /datum/uplink_item/badass

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1226,8 +1226,8 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	restricted_roles = list("Assistant")
 	
 /datum/uplink_item/role_restricted/syndi_mmi
-	name = "Syndie MMI
-	desc = "A mmi modified to give cyborgs laws to serve the syndiecate without having their interface damaged by emaggs"
+	name = "Syndicate MMI"
+	desc = "An MMI modified to give cyborgs laws to serve the syndicate without having their interface damaged by Cryptographic Sequencers"
 	item = /obj/item/device/mmi/syndie
 	cost = 5
 	surplus = 0


### PR DESCRIPTION
Removes the syndiecate MMI from surgery dufflebag and adds it as a roboticists only traitor item
Syndiecate MMI's dont show that their interface are damaged so kinda more stealth borgs 

:cl: Hyena
tweak:Removes syndie MMI from surgery dufflebag, adds it as a roboticist only traitor item
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) like if anyone should have these its the roboticist
