### PR TITLE
Increases Light Intensity Of PDA Light

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -28,7 +28,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	//Secondary variables
 	var/scanmode = 0 //1 is medical scanner, 2 is forensics, 3 is reagent scanner.
 	var/fon = 0 //Is the flashlight function on?
-	var/f_lum = 3 //Luminosity for the flashlight function
+	var/f_lum = 1 //Luminosity for the flashlight function
 	var/silent = 0 //To beep or not to beep, that is the question
 	var/toff = 0 //If 1, messenger disabled
 	var/tnote = null //Current Texts
@@ -56,8 +56,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/list/contained_item = list(/obj/item/weapon/pen, /obj/item/toy/crayon, /obj/item/weapon/lipstick, /obj/item/device/flashlight/pen, /obj/item/clothing/mask/cigarette)
 	var/obj/item/inserted_item //Used for pen, crayon, and lipstick insertion or removal. Same as above.
 	var/overlays_x_offset = 0	//x offset to use for certain overlays
-
-	light_power = 0.35
 
 /obj/item/device/pda/New()
 	..()


### PR DESCRIPTION
This PR slightly buffs the PDA light to provide reasonable light visability of the character, instead of being near pitch black. Comparison below.

Current PDA Light
![light1](https://cloud.githubusercontent.com/assets/6595389/23749675/5cc82712-0504-11e7-8184-8efc11cfd31f.png)

Proposed PDA Light
![light4](https://cloud.githubusercontent.com/assets/6595389/23749680/60f4d6e6-0504-11e7-8e23-68f10c2da181.png)

Thanks for reading.

🆑 Steelpoint
tweak: PDA Light's have had better light bulbs installed.
/🆑