### PR TITLE
Merges HEADBANGPROTECT and EARBANGPROTECT into new secondary flag

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -19,11 +19,7 @@
 #define OVERLAY_QUEUED  256		//atom queued to SSoverlay
 #define ON_BORDER		512		// item has priority to check when entering or leaving
 
-#define EARBANGPROTECT		1024
-
-#define NOSLIP		1024 		//prevents from slipping on wet floors, in space etc (NOTE: flag shared with THICKMATERIAL for external suits and helmet)
-
-#define HEADBANGPROTECT		4096
+#define NOSLIP		1024 		//prevents from slipping on wet floors, in space etc
 
 // BLOCK_GAS_SMOKE_EFFECT only used in masks at the moment.
 #define BLOCK_GAS_SMOKE_EFFECT 8192	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY! (NOTE: flag shared with THICKMATERIAL)
@@ -37,6 +33,7 @@
 #define FROZEN "frozen"
 #define STATIONLOVING "stationloving"
 #define INFORM_ADMINS_ON_RELOCATE "inform_admins_on_relocate"
+#define BANG_PROTECT "bang_protect"
 
 //turf-only flags
 #define NOJAUNT		1

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -42,10 +42,13 @@
 /obj/item/device/radio/headset/syndicate/alt //undisguised bowman with flash protection
 	name = "syndicate headset"
 	desc = "A syndicate headset that can be used to hear all radio frequencies. Protects ears from flashbangs. \nTo access the syndicate channel, use ; before speaking."
-	flags = EARBANGPROTECT
 	origin_tech = "syndicate=3"
 	icon_state = "syndie_headset"
 	item_state = "syndie_headset"
+
+/obj/item/device/radio/headset/syndicate/alt/Initialize(mapload)
+	..()
+	SET_SECONDARY_FLAG(src, BANG_PROTECT)
 
 /obj/item/device/radio/headset/syndicate/alt/leader
 	name = "team leader headset"
@@ -72,9 +75,12 @@
 /obj/item/device/radio/headset/headset_sec/alt
 	name = "security bowman headset"
 	desc = "This is used by your elite security force. Protects ears from flashbangs. \nTo access the security channel, use :s."
-	flags = EARBANGPROTECT
 	icon_state = "sec_headset_alt"
 	item_state = "sec_headset_alt"
+
+/obj/item/device/radio/headset/headset_sec/alt/Initialize(mapload)
+	..()
+	SET_SECONDARY_FLAG(src, BANG_PROTECT)
 
 /obj/item/device/radio/headset/headset_eng
 	name = "engineering radio headset"
@@ -124,9 +130,12 @@
 /obj/item/device/radio/headset/heads/captain/alt
 	name = "\proper the captain's bowman headset"
 	desc = "The headset of the boss. Protects ears from flashbangs. \nChannels are as follows: :c - command, :s - security, :e - engineering, :u - supply, :v - service, :m - medical, :n - science."
-	flags = EARBANGPROTECT
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
+
+/obj/item/device/radio/headset/heads/captain/alt/Initialize(mapload)
+	..()
+	SET_SECONDARY_FLAG(src, BANG_PROTECT)
 
 /obj/item/device/radio/headset/heads/rd
 	name = "\proper the research director's headset"
@@ -143,9 +152,12 @@
 /obj/item/device/radio/headset/heads/hos/alt
 	name = "\proper the head of security's bowman headset"
 	desc = "The headset of the man in charge of keeping order and protecting the station. Protects ears from flashbangs. \nTo access the security channel, use :s. For command, use :c."
-	flags = EARBANGPROTECT
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
+
+/obj/item/device/radio/headset/heads/hos/alt/Initialize(mapload)
+	..()
+	SET_SECONDARY_FLAG(src, BANG_PROTECT)
 
 /obj/item/device/radio/headset/heads/ce
 	name = "\proper the chief engineer's headset"
@@ -196,10 +208,13 @@
 /obj/item/device/radio/headset/headset_cent/alt
 	name = "\improper Centcom bowman headset"
 	desc = "A headset especially for emergency response personnel. Protects ears from flashbangs. \nTo access the centcom channel, use :y."
-	flags = EARBANGPROTECT
 	icon_state = "cent_headset_alt"
 	item_state = "cent_headset_alt"
 	keyslot = null
+
+/obj/item/device/radio/headset/headset_cent/alt/Initialize(mapload)
+	..()
+	SET_SECONDARY_FLAG(src, BANG_PROTECT)
 
 /obj/item/device/radio/headset/ai
 	name = "\proper Integrated Subspace Transceiver "

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -171,10 +171,13 @@ var/list/damaged_clothes_icons = list()
 	desc = "Protects your hearing from loud noises, and quiet ones as well."
 	icon_state = "earmuffs"
 	item_state = "earmuffs"
-	flags = EARBANGPROTECT
 	strip_delay = 15
 	put_on_delay = 25
 	resistance_flags = FLAMMABLE
+
+/obj/item/clothing/ears/earmuffs/Initialize(mapload)
+	..()
+	SET_SECONDARY_FLAG(src, BANG_PROTECT)
 
 //Glasses
 /obj/item/clothing/glasses

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -2,7 +2,6 @@
 	name = "helmet"
 	desc = "Standard Security gear. Protects the head from impacts."
 	icon_state = "helmet"
-	flags = HEADBANGPROTECT
 	item_state = "helmet"
 	armor = list(melee = 35, bullet = 30, laser = 30,energy = 10, bomb = 25, bio = 0, rad = 0, fire = 50, acid = 50)
 	flags_inv = HIDEEARS
@@ -17,8 +16,9 @@
 	dog_fashion = /datum/dog_fashion/head/helmet
 
 
-/obj/item/clothing/head/helmet/New()
+/obj/item/clothing/head/helmet/Initialize()
 	..()
+	SET_SECONDARY_FLAG(src, BANG_PROTECT)
 
 /obj/item/clothing/head/helmet/sec
 	can_flashlight = 1
@@ -44,7 +44,6 @@
 	toggle_message = "You pull the visor down on"
 	alt_toggle_message = "You push the visor up on"
 	can_toggle = 1
-	flags = HEADBANGPROTECT
 	armor = list(melee = 45, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0, fire = 50, acid = 50)
 	flags_inv = HIDEEARS|HIDEFACE
 	strip_delay = 80
@@ -182,11 +181,15 @@
 	icon_state = "knight_green"
 	item_state = "knight_green"
 	armor = list(melee = 41, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0, fire = 0, acid = 50)
-	flags = null
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	strip_delay = 80
 	dog_fashion = null
+
+/obj/item/clothing/head/helmet/knight/Initialize(mapload)
+	..()
+	// old knight helmets do not offer protection against loud noises
+	CLEAR_SECONDARY_FLAG(src, BANG_PROTECT)
 
 /obj/item/clothing/head/helmet/knight/blue
 	icon_state = "knight_blue"
@@ -219,7 +222,6 @@
 //LightToggle
 
 /obj/item/clothing/head/helmet/update_icon()
-
 	var/state = "[initial(icon_state)]"
 	if(F)
 		if(F.on)
@@ -232,8 +234,6 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		H.update_inv_head()
-
-	return
 
 /obj/item/clothing/head/helmet/ui_action_click(mob/user, action)
 	if(istype(action, /datum/action/item_action/toggle_helmet_flashlight))
@@ -293,7 +293,6 @@
 
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 	update_helmlight(user)
-	return
 
 /obj/item/clothing/head/helmet/proc/update_helmlight(mob/user = null)
 	if(F)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -10,7 +10,7 @@
 	return number
 
 /mob/living/carbon/get_ear_protection()
-	if(head && (head.flags & HEADBANGPROTECT))
+	if(head && HAS_SECONDARY_FLAG(head, BANG_PROTECT))
 		return 1
 
 /mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -47,7 +47,7 @@
 	return number
 
 /mob/living/carbon/human/get_ear_protection()
-	if((ears && (ears.flags & EARBANGPROTECT)) || (head && (head.flags & HEADBANGPROTECT)))
+	if((ears && HAS_SECONDARY_FLAG(ears, BANG_PROTECT)) || (head && HAS_SECONDARY_FLAG(head, BANG_PROTECT)))
 		return 1
 
 /mob/living/carbon/human/on_hit(obj/item/projectile/P)


### PR DESCRIPTION
Unless we get a clothing item that can be worn on the head, and the
ears, and only protects from loud noises in one of the configurations,
this isn't going to be an issue.

Frees up another flag slot, all hail the secondary flags.