### PR TITLE
Fixes ghosts being able to open the UI of non-haunted eightballs

### DIFF
--- a/code/game/objects/items/eightball.dm
+++ b/code/game/objects/items/eightball.dm
@@ -155,7 +155,7 @@
 
 	return most_popular_answer
 
-/obj/item/toy/eightball/ui_interact(mob/user, ui_key="main", datum/tgui/ui=null, force_open=0, datum/tgui/master_ui=null, datum/ui_state/state=observer_state)
+/obj/item/toy/eightball/haunted/ui_interact(mob/user, ui_key="main", datum/tgui/ui=null, force_open=0, datum/tgui/master_ui=null, datum/ui_state/state=observer_state)
 
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)


### PR DESCRIPTION
They would never be able to vote or anything, but they might think it's
haunted, when it is not.