### PR TITLE
Airlock repairs

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1126,19 +1126,32 @@ var/list/airlock_overlays = list()
 /obj/machinery/door/airlock/try_to_weld(obj/item/weapon/weldingtool/W, mob/user)
 	if(!operating && density)
 		if(W.remove_fuel(0,user))
-			user.visible_message("[user] is [welded ? "unwelding":"welding"] the airlock.", \
-							"<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>", \
-							"<span class='italics'>You hear welding.</span>")
-			playsound(loc, W.usesound, 40, 1)
-			if(do_after(user,40*W.toolspeed, 1, target = src))
-				if(density && !operating)//Door must be closed to weld.
-					if(!user || !W || !W.isOn() || !user.loc )
-						return
+			if(user.a_intent != INTENT_HELP)
+				user.visible_message("[user] is [welded ? "unwelding":"welding"] the airlock.", \
+								"<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>", \
+								"<span class='italics'>You hear welding.</span>")
+				playsound(loc, W.usesound, 40, 1)
+				if(do_after(user,40*W.toolspeed, 1, target = src, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
 					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 					welded = !welded
 					user.visible_message("[user.name] has [welded? "welded shut":"unwelded"] [src].", \
 										"<span class='notice'>You [welded ? "weld the airlock shut":"unweld the airlock"].</span>")
 					update_icon()
+			else if(obj_integrity < max_integrity)
+				user.visible_message("[user] is welding the airlock.", \
+								"<span class='notice'>You begin repairing the airlock...</span>", \
+								"<span class='italics'>You hear welding.</span>")
+				playsound(loc, W.usesound, 40, 1)
+				if(do_after(user,40*W.toolspeed, 1, target = src, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
+					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
+					obj_integrity = max_integrity
+					stat &= ~BROKEN
+					user.visible_message("[user.name] has repaired [src].", \
+										"<span class='notice'>You finish repairing the airlock.</span>")
+					update_icon()
+
+/obj/machinery/door/airlock/weld_checks(obj/item/weapon/weldingtool/W, mob/user)
+	return !operating && density && user && W && W.isOn() && user.loc
 
 /obj/machinery/door/airlock/try_to_crowbar(obj/item/I, mob/user)
 	var/beingcrowbarred = null

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1150,7 +1150,7 @@ var/list/airlock_overlays = list()
 										"<span class='notice'>You finish repairing the airlock.</span>")
 					update_icon()
 
-/obj/machinery/door/airlock/weld_checks(obj/item/weapon/weldingtool/W, mob/user)
+/obj/machinery/door/airlock/proc/weld_checks(obj/item/weapon/weldingtool/W, mob/user)
 	return !operating && density && user && W && W.isOn() && user.loc
 
 /obj/machinery/door/airlock/try_to_crowbar(obj/item/I, mob/user)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -154,17 +154,17 @@
 	return
 
 /obj/machinery/door/attackby(obj/item/I, mob/user, params)
-	if(user.a_intent != INTENT_HARM && (istype(I, /obj/item/weapon/crowbar) || istype(I, /obj/item/weapon/twohanded/fireaxe)))
-		try_to_crowbar(I, user)
-		return 1
-	else if(istype(I, /obj/item/weapon/weldingtool))
-		try_to_weld(I, user)
-		return 1
-	else if(!(I.flags & NOBLUDGEON) && user.a_intent != INTENT_HARM)
-		try_to_activate_door(user)
-		return 1
-	else
-		return ..()
+	if(user.a_intent != INTENT_HARM)
+		if((istype(I, /obj/item/weapon/crowbar) || istype(I, /obj/item/weapon/twohanded/fireaxe)))
+			try_to_crowbar(I, user)
+			return 1
+		else if(istype(I, /obj/item/weapon/weldingtool))
+			try_to_weld(I, user)
+			return 1
+		else if(!(I.flags & NOBLUDGEON))
+			try_to_activate_door(user)
+			return 1
+	return ..()
 
 /obj/machinery/door/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
 	if(damage_flag == "melee" && damage_amount < damage_deflection)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -154,16 +154,15 @@
 	return
 
 /obj/machinery/door/attackby(obj/item/I, mob/user, params)
-	if(user.a_intent != INTENT_HARM)
-		if((istype(I, /obj/item/weapon/crowbar) || istype(I, /obj/item/weapon/twohanded/fireaxe)))
-			try_to_crowbar(I, user)
-			return 1
-		else if(istype(I, /obj/item/weapon/weldingtool))
-			try_to_weld(I, user)
-			return 1
-		else if(!(I.flags & NOBLUDGEON))
-			try_to_activate_door(user)
-			return 1
+	if((istype(I, /obj/item/weapon/crowbar) || istype(I, /obj/item/weapon/twohanded/fireaxe)) && user.a_intent != INTENT_HARM)
+		try_to_crowbar(I, user)
+		return 1
+	else if(istype(I, /obj/item/weapon/weldingtool) && (user.a_intent != INTENT_HARM || iscyborg(user))
+		try_to_weld(I, user)
+		return 1
+	else if(!(I.flags & NOBLUDGEON) && user.a_intent != INTENT_HARM)
+		try_to_activate_door(user)
+		return 1
 	return ..()
 
 /obj/machinery/door/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -154,10 +154,10 @@
 	return
 
 /obj/machinery/door/attackby(obj/item/I, mob/user, params)
-	if((istype(I, /obj/item/weapon/crowbar) || istype(I, /obj/item/weapon/twohanded/fireaxe)) && user.a_intent != INTENT_HARM)
+	if(user.a_intent != INTENT_HARM && (istype(I, /obj/item/weapon/crowbar) || istype(I, /obj/item/weapon/twohanded/fireaxe)))
 		try_to_crowbar(I, user)
 		return 1
-	else if(istype(I, /obj/item/weapon/weldingtool) && (user.a_intent != INTENT_HARM || iscyborg(user))
+	else if(istype(I, /obj/item/weapon/weldingtool))
 		try_to_weld(I, user)
 		return 1
 	else if(!(I.flags & NOBLUDGEON) && user.a_intent != INTENT_HARM)


### PR DESCRIPTION
:cl: Cyberboss
tweak: You must now be on any intent EXCEPT help to weld an airlock shut
add: You can now repair airlocks with welding tools on help intent (broken airlocks still need their wires mended though)
/:cl:

Why: We don't have a way.

Why move welding to disarm? Because welding something shut isn't helpful.

I'm gonna be implementing this better in #24340, but I want to get the change approved separately
