### PR TITLE
Fixes anti toxin pill name

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -100,7 +100,7 @@
 	list_reagents = list("salbutamol" = 30)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/charcoal
-	name = "antitoxin pill"
+	name = "charcoal pill"
 	desc = "Neutralizes many common toxins."
 	icon_state = "pill17"
 	list_reagents = list("charcoal" = 10)


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/14280283/23767573/4ce794f4-0509-11e7-81a1-7a4fe0a59e8f.png)


:cl: Hyena
fix: fixes anti toxin pill naming
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) really... i saw a officer overdose on this because a chemist put real anti-toxin in the chem dispensers
