### PR TITLE
Removes Flame and Acid resistance from HoS Armor

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -95,7 +95,7 @@
 	name = "head of security cap"
 	desc = "The robust standard-issue cap of the Head of Security. For showing the officers who's in charge."
 	icon_state = "hoscap"
-	armor = list(melee = 40, bullet = 30, laser = 25, energy = 10, bomb = 25, bio = 10, rad = 0, fire = 50, acid = 60)
+	armor = list(melee = 40, bullet = 30, laser = 25, energy = 10, bomb = 25, bio = 10, rad = 0, fire = 10, acid = 10)
 	strip_delay = 80
 
 /obj/item/clothing/head/HoS/beret

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -35,7 +35,7 @@
 	icon_state = "hos"
 	item_state = "greatcoat"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	armor = list(melee = 30, bullet = 30, laser = 30, energy = 10, bomb = 25, bio = 0, rad = 0, fire = 70, acid = 90)
+	armor = list(melee = 30, bullet = 30, laser = 30, energy = 10, bomb = 25, bio = 0, rad = 0, fire = 20, acid = 30)
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	strip_delay = 80


### PR DESCRIPTION
🆑 NikNakFlak
tweak: The Head of Security armor has some nerfs.  It never made sense that a trenchcoat is fire resistance of fucking 70 and acid of fucking 90.  What the fuck is this suit made of?  These have been nerfed
/🆑

This is a non-meme PR.  If you're going to buff melee, bullet, and laser, it never made sense that this suit was only 20 less than an actual fucking firefighting hardsuit and more acid resistant than a hardsuit.