### PR TITLE
[BoxStation] Delivery Office Tweak

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -25271,10 +25271,18 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/structure/filingcabinet/filingcabinet,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/wrapping_paper{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/stack/packageWrap{
+	pixel_x = -1;
+	pixel_y = -1
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 1
@@ -25613,12 +25621,15 @@
 /area/quartermaster/office)
 "bfR" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/item/weapon/hand_labeler{
+	pixel_y = 8
 	},
-/obj/item/weapon/pen,
+/obj/item/weapon/hand_labeler{
+	pixel_y = 8
+	},
+/obj/item/weapon/storage/box,
+/obj/item/weapon/storage/box,
+/obj/item/weapon/storage/box,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bfS" = (
@@ -30577,6 +30588,9 @@
 	dir = 1;
 	layer = 2.9
 	},
+/obj/structure/table/reinforced,
+/obj/item/device/destTagger,
+/obj/item/device/destTagger,
 /turf/open/floor/plasteel/brown{
 	dir = 1
 	},
@@ -40619,14 +40633,14 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint)
 "bKF" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/box,
-/obj/item/weapon/storage/box,
-/obj/item/weapon/storage/box,
-/obj/item/weapon/hand_labeler,
-/obj/item/weapon/hand_labeler,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Cargo Technician"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -40764,6 +40778,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bKQ" = (
@@ -41161,10 +41176,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bLF" = (
-/obj/structure/table/reinforced,
-/obj/item/device/destTagger,
-/obj/item/device/destTagger,
-/obj/machinery/computer/stockexchange,
+/obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bLG" = (
@@ -42049,17 +42061,18 @@
 /area/toxins/test_area)
 "bNH" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/wrapping_paper{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/stack/packageWrap{
-	pixel_x = -1;
-	pixel_y = -1
-	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -26
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3
+	},
+/obj/item/weapon/pen{
+	pixel_x = -3
+	},
+/obj/item/weapon/folder/yellow{
+	pixel_x = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -87397,7 +87410,7 @@ apd
 beA
 bqp
 bbR
-aqU
+boU
 bLF
 aZK
 bnJ


### PR DESCRIPTION
Made some playability alterations for the Delivery Office on the TGStation AKA BoxStation Map.

![pr image](https://cloud.githubusercontent.com/assets/9791590/23770789/10f5bd7e-04da-11e7-95e7-02f558b9ca44.jpg)

:cl: Penguaro
tweak: Adjusted table locations
tweak: Moved chair and Cargo Tech start location
tweak: Moved filing cabinet
del: Removed Stock Computer
/:cl:

[why]: # The win-door was essentially useless as a player inside the office cannot open it across the table and a player outside the office could only open it if they had cargo access. I rearranged the tables to accommodate usage of the win-door. I also wanted to move the destination taggers as they were obscured by the stock computer and a newer player may not be aware of their location. I removed the stock computer entirely as there are three others in cargo, two of which are accessible by Cargo Technician and Shaft Miner. I shuffled some of the objects on the tables around to create a logical work flow.