### PR TITLE
Removes the gold material cost from Cryo syringes

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -81,7 +81,7 @@
 	id = "noreactsyringe"
 	req_tech = list("materials" = 3, "engineering" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_GLASS = 2000, MAT_GOLD = 1000)
+	materials = list(MAT_GLASS = 2000)
 	build_path = /obj/item/weapon/reagent_containers/syringe/noreact
 	category = list("Medical Designs")
 


### PR DESCRIPTION
:cl: Centcomm
tweak: Gold is no longer required to construct cryo syringes
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 

Expensive, uses up a small (that adds up) chuck of gold for a syringe. Syringes are not reliable for chemical storage, as the cryo beaker is meant for that, and using it in syringe guns makes it pretty expensive ammo (metal + gold for 20 units of chems and syringe goes poof) 