### PR TITLE
Arrival ferry tweaks

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -10,7 +10,7 @@
 	if(var_name in banned_views)
 		return debug_variable(var_name, "SECRET", 0, src)
 	return ..()
-	
+
 /datum/configuration/vv_edit_var(var_name, var_value)
 	var/static/list/banned_edits = list("cross_address", "cross_allowed", "autoadmin", "autoadmin_rank")
 	if(var_name in banned_edits)
@@ -254,7 +254,7 @@
 	var/error_silence_time = 6000 // How long a unique error will be silenced for
 	var/error_msg_delay = 50 // How long to wait between messaging admins about occurrences of a unique error
 
-	var/arrivals_shuttle_dock_window = 55	//Time from when a player late joins on the arrivals shuttle to when the shuttle docks on the station
+	var/arrivals_shuttle_dock_window = 100	//Time from when a player late joins on the arrivals shuttle to when the shuttle docks on the station
 	var/arrivals_shuttle_require_safe_latejoin = FALSE	//Require the arrivals shuttle to be operational in order for latejoiners to join
 
 /datum/configuration/New()

--- a/code/modules/shuttle/arrivals.dm
+++ b/code/modules/shuttle/arrivals.dm
@@ -7,6 +7,7 @@
 	height = 15
 	dir = WEST
 	port_angle = 180
+	preferred_direction = WEST
 
 	callTime = INFINITY
 	ignitionTime = 50
@@ -62,7 +63,7 @@
 		if(!CheckTurfsPressure())
 			damaged = FALSE
 			if(console)
-				console.say("Repairs complete, launching soon.") 
+				console.say("Repairs complete, launching soon.")
 		return
 
 //If this proc is high on the profiler add a cooldown to the stuff after this line
@@ -76,7 +77,7 @@
 		if(mode != SHUTTLE_CALL)
 			sound_played = FALSE
 			mode = SHUTTLE_IDLE
-		else		
+		else
 			SendToStation()
 		return
 
@@ -158,7 +159,7 @@
 /obj/docking_port/mobile/arrivals/proc/RequireUndocked(mob/user)
 	if(mode == SHUTTLE_CALL || damaged)
 		return
-	
+
 	Launch(TRUE)
 
 	user << "<span class='notice'>Calling your shuttle. One moment...</span>"

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -316,7 +316,7 @@
 	if(!check_dock(S))
 		testing("check_dock failed on request for [src]")
 		return
-	
+
 	if(mode == SHUTTLE_IGNITING && destination == S)
 		return
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -475,12 +475,12 @@ BOMBCAP 20
 # of ruins.
 LAVALAND_BUDGET 60
 
-## Space Ruin Budged
+## Space Ruin Budget
 Space_Budget 16
 
 #Time in ds from when a player latejoins till the arrival shuttle docks at the station
-#Must be at least 30 to not break parallax I recommended at least 55 to be visually/aurally appropriate
-ARRIVALS_SHUTTLE_DOCK_WINDOW 55
+#Must be at least 30 to not break parallax I recommended at least 100 to be visually/aurally appropriate, and to let the hyperspace ripple animation play out.
+ARRIVALS_SHUTTLE_DOCK_WINDOW 100
 
 #Set this to 1 to prevent late join players from spawning if the arrivals shuttle is depressurized
 ARRIVALS_SHUTTLE_REQUIRE_SAFE_LATEJOIN 0


### PR DESCRIPTION
- The arrival ferry now takes 10 seconds to arrive, because you need 10
seconds for the hyperspace ripple animation to play.
- The direction of the shuttle's apparent travel is fixed (although I
have a sneaking suspicion that (non-parallax) space transit EAST/WEST
aren't distinguishable.