### PR TITLE
Fixes being able to join as mutant human in command roles

### DIFF
--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -70,7 +70,7 @@
 	if(!visualsOnly && announce)
 		announce(H)
 
-	if(config.enforce_human_authority && src in command_positions)
+	if(config.enforce_human_authority && (title in command_positions))
 		H.dna.features["tail_human"] = "None"
 		H.dna.features["ears"] = "None"
 		H.regenerate_icons()


### PR DESCRIPTION
Command positions is a list of strings. Plus the `in` had bad precedent in the check.