### PR TITLE
The Space Bicycle Consortium has ended the price-gouging going on at your local station.

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1749,7 +1749,7 @@
 
 /datum/supply_pack/misc/bicycle
 	name = "Bicycle"
-	cost = 1000000
+	cost = 10000
 	contains = list(/obj/vehicle/bicycle)
 	crate_name = "Bicycle Crate"
 	crate_type = /obj/structure/closet/crate/large


### PR DESCRIPTION
# Rationale behind PR:
![chrome_2017-03-11_00-09-04](https://cloud.githubusercontent.com/assets/4081722/23821811/ab7f6598-05f2-11e7-80bc-bd614de2bc0b.png)

:cl: Space Bicycle Consortium
fix: Bicycles now only cost 10,000 yen, down from 1,000,000 yen.
/:cl: