### PR TITLE
Advanced Mimery tweak

### DIFF
--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -61,7 +61,7 @@
 		else
 			H << "<span class='notice'>You break your vow of silence.</span>"
 
-// These spells can only be gotten from the "Guide for Advanced Mimery series+" for Mime Traitors.
+// These spells can only be gotten from the "Guide for Advanced Mimery series" for Mime Traitors.
 
 /obj/effect/proc_holder/spell/targeted/forcewall/mime
 	name = "Invisible Blockade"
@@ -99,6 +99,7 @@
 	invocation_emote_self = "<span class='dangers'>You fire your finger gun!</span>"
 	range = 20
 	projectile_type = /obj/item/projectile/bullet/weakbullet2
+	projectile_amount = 3
 	sound = null
 	active_msg = "You draw your fingers!"
 	deactive_msg = "You put your fingers at ease. Another time."

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1222,7 +1222,6 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "A tattered old jumpsuit that will provide absolutely no benefit to you. It fills the wearer with a strange compulsion to blurt out 'glorf'."
 	item = /obj/item/clothing/under/color/grey/glorf
 	cost = 20
-	surplus = 0
 	restricted_roles = list("Assistant")
 
 /datum/uplink_item/role_restricted/haunted_magic_eightball

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1197,6 +1197,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 12
 	item = /obj/item/weapon/storage/box/syndie_kit/mimery
 	restricted_roles = list("Mime")
+	surplus = 0
 
 /datum/uplink_item/role_restricted/ez_clean_bundle
 	name = "EZ Clean Grenade Bundle"
@@ -1223,6 +1224,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/clothing/under/color/grey/glorf
 	cost = 20
 	restricted_roles = list("Assistant")
+	surplus = 0
 
 /datum/uplink_item/role_restricted/haunted_magic_eightball
 	name = "Haunted Magic Eightball"


### PR DESCRIPTION
:cl:
tweak: Traitor Mimes with the finger guns spell now fire 3 bullets at a time, as opposed to just 1.
/:cl:

Finger Guns beforehand, with it's long charge time, did not make up for it with one measly detective bullet. With this change, Mimes get more bang for their buck by shooting 3 bullets at a time.
