### PR TITLE
His Grace loves the station

### DIFF
--- a/code/game/objects/items/weapons/his_grace.dm
+++ b/code/game/objects/items/weapons/his_grace.dm
@@ -20,15 +20,20 @@
 	var/prev_bloodthirst = HIS_GRACE_SATIATED
 	var/force_bonus = 0
 
-/obj/item/weapon/his_grace/New()
+/obj/item/weapon/his_grace/Initialize(mapload)
 	..()
 	START_PROCESSING(SSprocessing, src)
+	set_stationloving(TRUE, inform_admins=TRUE)
+	poi_list += src
 
 /obj/item/weapon/his_grace/Destroy()
-	STOP_PROCESSING(SSprocessing, src)
+	// even if stationloving, his grace spits out corpses if "destroyed"
 	for(var/mob/living/L in src)
 		L.forceMove(get_turf(src))
-	return ..()
+	. = ..()
+	if(. != QDEL_HINT_LETMELIVE)
+		poi_list -= src
+		STOP_PROCESSING(SSprocessing, src)
 
 /obj/item/weapon/his_grace/attack_self(mob/living/user)
 	if(!awakened)


### PR DESCRIPTION
:cl: coiax
add: His Grace loves the station so much, he'll always come back to it,
even from death. Functions the same as the nuke disk "respawning",
except he will drop all corpses on the ground if destroyed, before
re-appearing somewhere else.
add: His Grace is now in the orbit list for ghosts.
/:cl:

- Why? Because it's an elderitch eeevil toolbox. Incinerating it or
shooting it lets you get the bodies back, but it'll still be there...
somewhere in the darkness, waiting to be found again.