### PR TITLE
Changes the braindead message to be more intuitive

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -278,8 +278,7 @@
 			else if(!key)
 				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)
-				msg += "[t_He] [t_has] suddenly fallen asleep, suffering from Space Sleep Disorder.\n"
-				msg += "Find somewhere safe for [t_him], [t_He] may wake up soon.\n"
+				msg += "[t_He] have a blank, absent-minded stare and appear completly unresponsive to anything. [t_He] may snap out of it soon.\n"
 
 		if(digitalcamo)
 			msg += "[t_He] [t_is] moving [t_his] body in an unnatural and blatantly inhuman manner.\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -278,7 +278,7 @@
 			else if(!key)
 				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)
-				msg += "[t_He] have a blank, absent-minded stare and appear completly unresponsive to anything. [t_He] may snap out of it soon.\n"
+				msg += "[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon.\n"
 
 		if(digitalcamo)
 			msg += "[t_He] [t_is] moving [t_his] body in an unnatural and blatantly inhuman manner.\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -279,7 +279,7 @@
 				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)
 				msg += "[t_He] [t_has] suddenly fallen asleep, suffering from Space Sleep Disorder.\n"
-				msg += "Find somewhere safe for [t_him], [p_He] may wake up soon.\n"
+				msg += "Find somewhere safe for [t_him], [t_He] may wake up soon.\n"
 
 		if(digitalcamo)
 			msg += "[t_He] [t_is] moving [t_his] body in an unnatural and blatantly inhuman manner.\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -278,7 +278,8 @@
 			else if(!key)
 				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)
-				msg += "[t_He] [t_has] a vacant, braindead stare...\n"
+				msg += "[t_He] [t_has] suddenly fallen asleep, suffering from Space Sleep Disorder.\n"
+				msg += "Find somewhere safe for [t_him], [p_He] may wake up soon.\n"
 
 		if(digitalcamo)
 			msg += "[t_He] [t_is] moving [t_his] body in an unnatural and blatantly inhuman manner.\n"

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -905,7 +905,7 @@
 		to_chat(user, "<span class='warning'>There's nothing in [src] to transfer!</span>")
 		return
 	if(!occupier.mind || !occupier.client)
-		to_chat(user, "<span class='warning'>[occupier] is either inactive, destroyed, or braindead!</span>")
+		to_chat(user, "<span class='warning'>[occupier] is either inactive or destroyed!</span>")
 		return
 	if(!occupier.parent.stat)
 		to_chat(user, "<span class='warning'>[occupier] is refusing all attempts at transfer!</span>" )


### PR DESCRIPTION
:cl: Lzimann
tweak: Braindead has a more intuitive message
/:cl:

This changes the message when you examine someone without a client, from `They have a vacant, braindead stare...` to `They have a blank, absent-minded stare and appear completly unresponsive to anything. They may snap out of it soon.` 


The braindead line can be confusing for new players, since there is no indication whether or not the person can still come back to the game, and renaming this can help clear this confusion that happens with most(if not all) new players.

The pr also removes braindead from an APC message, having only "inactive or destroyed" is already enough.

