### PR TITLE
Changes some names of bottles/patches and edits some amount of chems of mutadone/mannitol

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -72,7 +72,7 @@
 	list_reagents = list("chloralhydrate" = 15)
 
 /obj/item/weapon/reagent_containers/glass/bottle/charcoal
-	name = "antitoxin bottle"
+	name = "charcoal bottle"
 	desc = "A small bottle of charcoal."
 	icon_state = "bottle17"
 	list_reagents = list("charcoal" = 30)

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -19,13 +19,13 @@
 	return 1 // Masks were stopping people from "eating" patches. Thanks, inheritance.
 
 /obj/item/weapon/reagent_containers/pill/patch/styptic
-	name = "brute patch"
+	name = "Styptic Powder (20u)"
 	desc = "Helps with brute injuries."
 	list_reagents = list("styptic_powder" = 20)
 	icon_state = "bandaid_brute"
 
 /obj/item/weapon/reagent_containers/pill/patch/silver_sulf
-	name = "burn patch"
+	name = "Silver Sulfadiazine (20u)"
 	desc = "Helps with burn injuries."
 	list_reagents = list("silver_sulfadiazine" = 20)
 	icon_state = "bandaid_burn"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -64,80 +64,80 @@
 		qdel(src)
 
 /obj/item/weapon/reagent_containers/pill/tox
-	name = "toxins pill (50u)"
+	name = "toxins pill"
 	desc = "Highly toxic."
 	icon_state = "pill5"
 	list_reagents = list("toxin" = 50)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/cyanide
-	name = "cyanide pill (50u)"
+	name = "cyanide pill"
 	desc = "Don't swallow this."
 	icon_state = "pill5"
 	list_reagents = list("cyanide" = 50)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/adminordrazine
-	name = "adminordrazine pill (50u)"
+	name = "adminordrazine pill"
 	desc = "It's magic. We don't have to explain it."
 	icon_state = "pill16"
 	list_reagents = list("adminordrazine" = 50)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/morphine
-	name = "morphine pill (30u)"
+	name = "morphine pill"
 	desc = "Commonly used to treat insomnia."
 	icon_state = "pill8"
 	list_reagents = list("morphine" = 30)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/stimulant
-	name = "stimulant pill (50u)"
+	name = "stimulant pill"
 	desc = "Often taken by overworked employees, athletes, and the inebriated. You'll snap to attention immediately!"
 	icon_state = "pill19"
 	list_reagents = list("ephedrine" = 10, "antihol" = 10, "coffee" = 30)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/salbutamol
-	name = "salbutamol pill (30u)"
+	name = "salbutamol pill"
 	desc = "Used to treat oxygen deprivation."
 	icon_state = "pill16"
 	list_reagents = list("salbutamol" = 30)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/charcoal
-	name = "charcoal pill (10u)"
+	name = "charcoal pill"
 	desc = "Neutralizes many common toxins."
 	icon_state = "pill17"
 	list_reagents = list("charcoal" = 10)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/epinephrine
-	name = "epinephrine pill (15u)"
+	name = "epinephrine pill"
 	desc = "Used to stabilize patients."
 	icon_state = "pill5"
 	list_reagents = list("epinephrine" = 15)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/mannitol
-	name = "mannitol pill (15u)"
+	name = "mannitol pill"
 	desc = "Used to treat brain damage."
 	icon_state = "pill17"
 	list_reagents = list("mannitol" = 15)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/mutadone
-	name = "mutadone pill (10u)"
+	name = "mutadone pill"
 	desc = "Used to treat genetic damage."
 	icon_state = "pill20"
 	list_reagents = list("mutadone" = 10)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/salicyclic
-	name = "salicylic acid pill (24u)"
+	name = "salicylic acid pill"
 	desc = "Used to dull pain."
 	icon_state = "pill9"
 	list_reagents = list("sal_acid" = 24)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/oxandrolone
-	name = "oxandrolone pill (24u)"
+	name = "oxandrolone pill"
 	desc = "Used to stimulate burn healing."
 	icon_state = "pill11"
 	list_reagents = list("oxandrolone" = 24)
 	roundstart = 1
 
 /obj/item/weapon/reagent_containers/pill/insulin
-	name = "insulin pill (50u)"
+	name = "insulin pill"
 	desc = "Handles hyperglycaemic coma."
 	icon_state = "pill18"
 	list_reagents = list("insulin" = 50)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -64,80 +64,80 @@
 		qdel(src)
 
 /obj/item/weapon/reagent_containers/pill/tox
-	name = "toxins pill"
+	name = "toxins pill (50u)"
 	desc = "Highly toxic."
 	icon_state = "pill5"
 	list_reagents = list("toxin" = 50)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/cyanide
-	name = "cyanide pill"
+	name = "cyanide pill (50u)"
 	desc = "Don't swallow this."
 	icon_state = "pill5"
 	list_reagents = list("cyanide" = 50)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/adminordrazine
-	name = "adminordrazine pill"
+	name = "adminordrazine pill (50u)"
 	desc = "It's magic. We don't have to explain it."
 	icon_state = "pill16"
 	list_reagents = list("adminordrazine" = 50)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/morphine
-	name = "morphine pill"
+	name = "morphine pill (30u)"
 	desc = "Commonly used to treat insomnia."
 	icon_state = "pill8"
 	list_reagents = list("morphine" = 30)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/stimulant
-	name = "stimulant pill"
+	name = "stimulant pill (50u)"
 	desc = "Often taken by overworked employees, athletes, and the inebriated. You'll snap to attention immediately!"
 	icon_state = "pill19"
 	list_reagents = list("ephedrine" = 10, "antihol" = 10, "coffee" = 30)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/salbutamol
-	name = "salbutamol pill"
+	name = "salbutamol pill (30u)"
 	desc = "Used to treat oxygen deprivation."
 	icon_state = "pill16"
 	list_reagents = list("salbutamol" = 30)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/charcoal
-	name = "charcoal pill"
+	name = "charcoal pill (10u)"
 	desc = "Neutralizes many common toxins."
 	icon_state = "pill17"
 	list_reagents = list("charcoal" = 10)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/epinephrine
-	name = "epinephrine pill"
+	name = "epinephrine pill (15u)"
 	desc = "Used to stabilize patients."
 	icon_state = "pill5"
 	list_reagents = list("epinephrine" = 15)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/mannitol
-	name = "mannitol pill"
+	name = "mannitol pill (15u)"
 	desc = "Used to treat brain damage."
 	icon_state = "pill17"
-	list_reagents = list("mannitol" = 50)
+	list_reagents = list("mannitol" = 15)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/mutadone
-	name = "mutadone pill"
+	name = "mutadone pill (10u)"
 	desc = "Used to treat genetic damage."
 	icon_state = "pill20"
-	list_reagents = list("mutadone" = 50)
+	list_reagents = list("mutadone" = 10)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/salicyclic
-	name = "salicylic acid pill"
+	name = "salicylic acid pill (24u)"
 	desc = "Used to dull pain."
 	icon_state = "pill9"
 	list_reagents = list("sal_acid" = 24)
 	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/oxandrolone
-	name = "oxandrolone pill"
+	name = "oxandrolone pill (24u)"
 	desc = "Used to stimulate burn healing."
 	icon_state = "pill11"
 	list_reagents = list("oxandrolone" = 24)
 	roundstart = 1
 
 /obj/item/weapon/reagent_containers/pill/insulin
-	name = "insulin pill"
+	name = "insulin pill (50u)"
 	desc = "Handles hyperglycaemic coma."
 	icon_state = "pill18"
 	list_reagents = list("insulin" = 50)


### PR DESCRIPTION
Following changes were made.

[The amount of units were added to the patch names]
[Brute/burn patch name is changed to their chems]
[Mutadone units has been changed from 50 to 10]
[Mannitol units have changed from 50 to 15]

-for mannitol/Mutadone change:tbh who needs 50 UNITS Mutadone? plus it comes in a full pill bottle its to much to use 1 unit already clears all disabilities. Who needs 50 mannitol? the max you ever would need is 15 also the same thing as Mutadone comes in a full pillbottle again would put chemists out of jobs

-for the units change:so people dont overdose other people from using the stuff from medkits! like oxy pills



:cl: Hyena
tweak: Adds the amount of units to pills/patches,
tweak: Changes brute/burn patch name
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
