### PR TITLE
Fixes surplus leg name

### DIFF
--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -177,14 +177,14 @@
 	max_damage = 20
 
 /obj/item/bodypart/l_leg/robot/surplus
-	name = "surplus prosthetic leg"
+	name = "surplus prosthetic left leg"
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon = 'icons/mob/augments.dmi'
 	icon_state = "surplus_l_leg"
 	max_damage = 20
 
 /obj/item/bodypart/r_leg/robot/surplus
-	name = "surplus prosthetic leg"
+	name = "surplus prosthetic right leg"
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon = 'icons/mob/augments.dmi'
 	icon_state = "surplus_r_leg"


### PR DESCRIPTION
left leg or right leg?
this fixes surplus legs not having a name which leg they are


:cl: Hyena
fix: Surplus leg r/l name fixed
/:cl:

