### PR TITLE
Light fitting and light bulb/tubes refactor

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -203,6 +203,11 @@
 			target.status = L2.status
 			target.switchcount = L2.switchcount
 			target.rigged = emagged
+
+			target.l_range = L2.l_range
+			target.light_power = L2.l_power
+			target.light_color = L2.l_color
+
 			target.on = target.has_power()
 			target.update()
 			qdel(L2)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -203,7 +203,6 @@
 			target.status = L2.status
 			target.switchcount = L2.switchcount
 			target.rigged = emagged
-			target.brightness = L2.brightness
 			target.on = target.has_power()
 			target.update()
 			qdel(L2)


### PR DESCRIPTION
No user visible changes.

- Removed lightbulbs inherit the color, strength and range of their
fittings.
- Light fittings only break on mapload
- Light fittings now use Initialize() instead of spawns in new

- This'll allow for colored bulbs a lot easier, but doesn't introduce
any or change anything.