### PR TITLE
New uplink item: Unholy Water

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -196,6 +196,12 @@
 	desc = "A flask of holy water...it's been sitting in the Necropolis a while though."
 	list_reagents = list("hell_water" = 100)
 
+/obj/item/weapon/reagent_containers/food/drinks/bottle/holywater/unholy
+	name = "dark flask"
+	desc = "An inscription on the side of the flask reads: QUIA VISUS ADESSE BIBENDUM."
+	list_reagents = list("unholy_water" = 100)
+	color = "#7D1919"
+
 /obj/item/weapon/reagent_containers/food/drinks/bottle/vermouth
 	name = "Goldeneye Vermouth"
 	desc = "Sweet, sweet dryness~"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -879,4 +879,4 @@
 	taste_description = "horror"
 
 /datum/reagent/toxin/unholy_water/on_mob_life(mob/living/M)
-	 M.cultslurring = min(M.cultslurring, 3)
+	 M.cultslurring = min(M.cultslurring + 3, 3)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -868,3 +868,15 @@
 	color = "#F0F8FF" // rgb: 240, 248, 255
 	toxpwr = 0
 	taste_description = "stillness"
+
+
+/datum/reagent/toxin/unholy_water
+	name = "Unholy Water"
+	id = "unholy_water"
+	description = "Overwhelms the victim's speech centres with images of dark gods and impending doom."
+	color = "#660000"
+	toxpwr = 0
+	taste_description = "horror"
+
+/datum/reagent/toxin/unholy_water/on_mob_life(mob/living/M)
+	 M.cultslurring = min(M.cultslurring, 3)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -656,6 +656,13 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cant_discount = TRUE
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 
+/datum/uplink_item/stealthy_weapons/unholy_water
+	name = "Unholy Water"
+	desc = "A bottle full of cursed water that overwhelms the victim's speech centres with images of dark gods and impending doom. Otherwise harmless."
+	item = /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater/unholy
+	cost = 2
+	surplus = 25
+
 /datum/uplink_item/stealthy_weapons/dart_pistol
 	name = "Dart Pistol"
 	desc = "A miniaturized version of a normal syringe gun. It is very quiet when fired and can fit into any \


### PR DESCRIPTION
:cl: coiax
add: Syndicate agents have obtained a new toxin that overwhelms the
victim's speech centres with visions of dark gods and impending doom.
add: Adds Unholy Water flask to uplink for 2 TC. All the fun of mute
toxin while spooking everyone else!
/:cl:

Metabreaker traitor item, you know, if you feel like it. Can be used as
a mute in a pinch, although they'll still cry for help.