### PR TITLE
Additional deadchat fixes

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -34,5 +34,5 @@
 
 // A link given to ghost alice to follow bob
 #define FOLLOW_LINK(alice, bob) "<a href=?src=\ref[alice];follow=\ref[bob]>(F)</a>"
-#define TURF_LINK(alice, turfy) "<a href=?src=\ref[alice];jump_to_turf=\ref[turfy]>(T)</a>"
-#define FOLLOW_OR_TURF_LINK(alice, bob, turfy) "<a href=?src=\ref[alice];follow=\ref[bob];jump_to_turf=\ref[turfy]>(F)</a>"
+#define TURF_LINK(alice, turfy) "<a href=?src=\ref[alice];x=[turfy.x];y=[turfy.y];z=[turfy.z]>(T)</a>"
+#define FOLLOW_OR_TURF_LINK(alice, bob, turfy) "<a href=?src=\ref[alice];follow=\ref[bob];x=[turfy.x];y=[turfy.y];z=[turfy.z]>(F)</a>"

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -408,3 +408,5 @@ Proc for attack log creation, because really why not
 				var/turf_link = TURF_LINK(M, turf_target)
 				rendered_message = "[turf_link] [message]"
 				to_chat(M, rendered_message)
+		else
+			to_chat(M, message)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -671,12 +671,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			var/atom/movable/target = locate(href_list["follow"])
 			if(istype(target) && (target != src))
 				ManualFollow(target)
-		if(href_list["jump_to_turf"])
-			var/turf/target = locate(href_list["jump_to_turf"])
+				return
+		if(href_list["x"] && href_list["y"] && href_list["z"])
+			var/tx = href_list["x"]
+			var/ty = href_list["y"]
+			var/tz = href_list["z"]
+			var/turf/target = locate(tx, ty, tz)
 			if(istype(target))
 				forceMove(target)
+				return
 		if(href_list["reenter"])
 			reenter_corpse()
+			return
 
 //We don't want to update the current var
 //But we will still carry a mind.

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -673,9 +673,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 				ManualFollow(target)
 				return
 		if(href_list["x"] && href_list["y"] && href_list["z"])
-			var/tx = href_list["x"]
-			var/ty = href_list["y"]
-			var/tz = href_list["z"]
+			var/tx = text2num(href_list["x"])
+			var/ty = text2num(href_list["y"])
+			var/tz = text2num(href_list["z"])
 			var/turf/target = locate(tx, ty, tz)
 			if(istype(target))
 				forceMove(target)


### PR DESCRIPTION
Fixes #25008.

- People who are dead but not observers can hear deadchat.
- Follow links will try to follow first, then attempt a turf jump,
rather than always doing the turf jump.
- By using coordinates rather than /ref it'll stop the malformed (F)
links to jump to the turfs.