### PR TITLE
Adds cyan glowsticks

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -369,6 +369,10 @@
 	name = "blue glowstick"
 	color = LIGHT_COLOR_BLUE
 
+/obj/item/device/flashlight/glowstick/cyan
+	name = "cyan glowstick"
+	color = LIGHT_COLOR_CYAN
+
 /obj/item/device/flashlight/glowstick/orange
 	name = "orange glowstick"
 	color = LIGHT_COLOR_ORANGE

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1010,6 +1010,7 @@
 					/obj/item/device/flashlight/glowstick,
 					/obj/item/device/flashlight/glowstick/red,
 					/obj/item/device/flashlight/glowstick/blue,
+					/obj/item/device/flashlight/glowstick/cyan,
 					/obj/item/device/flashlight/glowstick/orange,
 					/obj/item/device/flashlight/glowstick/yellow,
 					/obj/item/device/flashlight/glowstick/pink)


### PR DESCRIPTION
:cl: coiax
add: Glowsticks can now be found in "Swarmer Cyan" colors.
/:cl:

because apparently adding the colour cyan to swarmers was too potential
to cause meta or some shit idk