### PR TITLE
Typo fix in Battlecruiser description

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -248,6 +248,6 @@
 /datum/map_template/shuttle/emergency/raven
 	suffix = "raven"
 	name = "Centcomm Raven Battlecruiser"
-	description = "The Centcomm Raven Battlecruiser is currently docked at the Centcomm ship bay awaiting a mission, this Battlecruiser has been reassigned as an emergency escape shuttle for currently unknown reasons. The Centcomm Raven Battlecutiser should comfortably fit a medium to large crew size crew and is complete with all required facitlities including a top of the range Centcomm Medical Bay."
+	description = "The Centcomm Raven Battlecruiser is currently docked at the Centcomm ship bay awaiting a mission, this Battlecruiser has been reassigned as an emergency escape shuttle for currently unknown reasons. The Centcomm Raven Battlecruiser should comfortably fit a medium to large crew size crew and is complete with all required facitlities including a top of the range Centcomm Medical Bay."
 	admin_notes = "The long way home"
 	credit_cost = 12500


### PR DESCRIPTION
Battlecutiser -> Battlecruiser

Also a newline because webeditor.