### PR TITLE
Lattices now require wirecutters to deconstruct

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -39,11 +39,9 @@
 		new/obj/structure/lattice/clockwork/large(loc)
 
 /obj/structure/lattice/attackby(obj/item/C, mob/user, params)
-	if(istype(C, /obj/item/weapon/weldingtool))
-		var/obj/item/weapon/weldingtool/WT = C
-		if(WT.remove_fuel(0, user))
-			to_chat(user, "<span class='notice'>Slicing [name] joints ...</span>")
-			deconstruct()
+	if(istype(C, /obj/item/weapon/wirecutters))
+		to_chat(user, "<span class='notice'>Slicing [name] joints ...</span>")
+		deconstruct()
 	else
 		var/turf/T = get_turf(src)
 		return T.attackby(C, user) //hand this off to the turf instead (for building plating, catwalks, etc)


### PR DESCRIPTION
:cl:
tweak: Lattices now require wirecutters to deconstruct, rather than welding tools.
/:cl:

Suggested by OOC. Reasoning is that if they're so easy and cheap to place and since you never really have much of a reason to remove them in the first place, they may as well be cheap to remove. Easier to clean up misclicks like this to make your space base pretty!