### PR TITLE
Remie's listtarget() optimisations

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -103,10 +103,9 @@
 //////////////HOSTILE MOB TARGETTING AND AGGRESSION////////////
 
 /mob/living/simple_animal/hostile/proc/ListTargets()//Step 1, find out what we can see
-	. = list()
 	if(!search_objects)
 		var/list/Mobs = hearers(vision_range, targets_from) - src //Remove self, so we don't suicide
-		. += Mobs
+		. = Mobs
 
 		var/static/hostile_machines = typecacheof(list(/obj/machinery/porta_turret, /obj/mecha, /obj/structure/destructible/clockwork/ocular_warden))
 
@@ -115,7 +114,7 @@
 				. += HM
 	else
 		var/list/Objects = oview(vision_range, targets_from)
-		. += Objects
+		. = Objects
 
 /mob/living/simple_animal/hostile/proc/FindTarget(var/list/possible_targets, var/HasTargetsList = 0)//Step 2, filter down possible targets to things we actually care about
 	. = list()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -104,8 +104,7 @@
 
 /mob/living/simple_animal/hostile/proc/ListTargets()//Step 1, find out what we can see
 	if(!search_objects)
-		var/list/Mobs = hearers(vision_range, targets_from) - src //Remove self, so we don't suicide
-		. = Mobs
+		. = hearers(vision_range, targets_from) - src //Remove self, so we don't suicide
 
 		var/static/hostile_machines = typecacheof(list(/obj/machinery/porta_turret, /obj/mecha, /obj/structure/destructible/clockwork/ocular_warden))
 
@@ -113,8 +112,7 @@
 			if(can_see(targets_from, HM, vision_range))
 				. += HM
 	else
-		var/list/Objects = oview(vision_range, targets_from)
-		. = Objects
+		. = oview(vision_range, targets_from)
 
 /mob/living/simple_animal/hostile/proc/FindTarget(var/list/possible_targets, var/HasTargetsList = 0)//Step 2, filter down possible targets to things we actually care about
 	. = list()


### PR DESCRIPTION
This is all Remie's suggestion.

Removes 2 list additions, 1 list assignment.
And a newline because webeditor.
Mobs still acquire, and reacquire targets.

Reason: Fixes #25007.

Test: Spawn 1000 orion syndicate hostile mobs, ~18000 listtarget calls.
BEFORE:
![](https://puu.sh/uFAXU/4416693884.png)
AFTER:
![](https://puu.sh/uFAmL/277023bbcf.png)