### PR TITLE
GoofEvents: Buffs some under-used events up

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -128,6 +128,9 @@
 /obj/effect/particle_effect/foam/metal/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return
 
+/obj/effect/particle_effect/foam/long_life
+	lifetime = 150
+
 
 ///////////////////////////////////////////////
 //FOAM EFFECT DATUM
@@ -141,6 +144,8 @@
 /datum/effect_system/foam_spread/metal
 	effect_type = /obj/effect/particle_effect/foam/metal
 
+/datum/effect_system/foam_spread/long
+	effect_type = /obj/effect/particle_effect/foam/long_life
 
 /datum/effect_system/foam_spread/New()
 	..()

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -7,8 +7,7 @@
 	alertadmins = 0
 
 /datum/round_event/electrical_storm
-	var/lightsoutAmount	= 20
-	var/lightsoutRange	= 25
+	var/lightsoutAmount	= 55
 	announceWhen	= 1
 
 /datum/round_event/electrical_storm/announce()
@@ -17,20 +16,20 @@
 
 /datum/round_event/electrical_storm/start()
 	var/list/epicentreList = list()
+	var/list/all_APCs = list()
 
-	for(var/i=1, i <= lightsoutAmount, i++)
-		var/list/possibleEpicentres = list()
-		for(var/obj/effect/landmark/newEpicentre in landmarks_list)
-			if(newEpicentre.name == "lightsout" && !(newEpicentre in epicentreList))
-				possibleEpicentres += newEpicentre
-		if(possibleEpicentres.len)
-			epicentreList += pick(possibleEpicentres)
-		else
+	for(var/obj/machinery/power/apc/apc in world)
+		all_APCs += apc
+		CHECK_TICK
+
+	shuffle(all_APCs)
+
+	for(var/obj/machinery/power/apc/apc2 in all_APCs)
+		epicentreList += apc2
+		lightsoutAmount--
+		if(lightsoutAmount == 0)
 			break
+		CHECK_TICK
 
-	if(!epicentreList.len)
-		return
-
-	for(var/obj/effect/landmark/epicentre in epicentreList)
-		for(var/obj/machinery/power/apc/apc in urange(lightsoutRange, epicentre))
-			apc.overload_lighting()
+	for(var/obj/machinery/power/apc/apc3 in epicentreList)
+		apc3.overload_lighting()

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -7,7 +7,7 @@
 	alertadmins = 0
 
 /datum/round_event/electrical_storm
-	var/lightsoutAmount	= 1
+	var/lightsoutAmount	= 20
 	var/lightsoutRange	= 25
 	announceWhen	= 1
 

--- a/code/modules/events/mice_migration.dm
+++ b/code/modules/events/mice_migration.dm
@@ -5,8 +5,8 @@
 
 /datum/round_event/mice_migration
 	announceWhen = 0
-	var/minimum_mice = 5
-	var/maximum_mice = 15
+	var/minimum_mice = 25
+	var/maximum_mice = 50
 
 /datum/round_event/mice_migration/announce()
 	var/cause = pick("space-winter", "budget-cuts", "Ragnarok",

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/vent_clog
 	name = "Clogged Vents"
 	typepath = /datum/round_event/vent_clog
-	weight = 35
+	weight = 55
 
 /datum/round_event/vent_clog
 	announceWhen	= 1
@@ -9,9 +9,6 @@
 	endWhen			= 35
 	var/interval 	= 2
 	var/list/vents  = list()
-	var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","mushroomhallucinogen","lube",
-								 "plantbgone","banana","charcoal","space_drugs","morphine","holywater","ethanol","hot_coco","sacid")
-
 /datum/round_event/vent_clog/announce()
 	priority_announce("The scrubbers network is experiencing a backpressure surge. Some ejection of contents may occur.", "Atmospherics alert")
 
@@ -33,15 +30,13 @@
 			vent = pick_n_take(vents)
 
 		if(vent && vent.loc)
-			var/datum/reagents/R = new/datum/reagents(50)
+			var/datum/reagents/R = new/datum/reagents(1000)
 			R.my_atom = vent
-			R.add_reagent(pick(gunk), 50)
+			R.add_reagent(pick(get_random_reagent_id()), 1000)
 
-			var/datum/effect_system/smoke_spread/chem/smoke = new
-			smoke.set_up(R, 1, vent, silent = 1)
-			playsound(vent.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
-			smoke.start()
-			qdel(R)
+			var/datum/effect_system/foam_spread/foam = new
+			foam.set_up(100, get_turf(vent), R)
+			foam.start()
 
 			var/cockroaches = prob(33) ? 3 : 0
 			while(cockroaches)

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -17,28 +17,23 @@
 	endWhen = rand(25, 100)
 	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/temp_vent in machines)
 		if(temp_vent.loc.z == ZLEVEL_STATION && !temp_vent.welded)
-			var/datum/pipeline/temp_vent_parent = temp_vent.PARENT1
-			if(temp_vent_parent.other_atmosmch.len > 20)
-				vents += temp_vent
+			vents += temp_vent
 	if(!vents.len)
 		return kill()
 
-/datum/round_event/vent_clog/tick()
-	if(activeFor % interval == 0)
-		var/obj/machinery/atmospherics/components/unary/vent = pick_n_take(vents)
-		while(vent && vent.welded)
-			vent = pick_n_take(vents)
-
+/datum/round_event/vent_clog/start()
+	for(var/obj/machinery/atmospherics/components/unary/vent in vents)
 		if(vent && vent.loc)
 			var/datum/reagents/R = new/datum/reagents(1000)
 			R.my_atom = vent
 			R.add_reagent(pick(get_random_reagent_id()), 1000)
 
-			var/datum/effect_system/foam_spread/foam = new
-			foam.set_up(100, get_turf(vent), R)
+			var/datum/effect_system/foam_spread/long/foam = new
+			foam.set_up(200, get_turf(vent), R)
 			foam.start()
 
 			var/cockroaches = prob(33) ? 3 : 0
 			while(cockroaches)
 				new /mob/living/simple_animal/cockroach(get_turf(vent))
 				cockroaches--
+		CHECK_TICK


### PR DESCRIPTION
# Lights Out
Makes it blow out a lot more lights than just one solitary room. Better grab a flashlight or a Janitor.

# Invasion Of The Mice
Hahahaha, this is so useless with only 5 mice usually. Buffs the amount spawned, Engineers better be on their guard.

# THEY'RE COMING OUT OF THE CLOGGED VENTS
![the-blob-14795036951](https://cloud.githubusercontent.com/assets/4081722/23839765/923512b0-075d-11e7-998f-7072a1e62811.jpg)

Be prepared.
