### PR TITLE
 Removes a ridiculous accidental buff to glowshroom spreading

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -122,6 +122,8 @@ var/list/blacklisted_glowshroom_turfs = typecacheof(list(
 			shrooms_planted++
 
 			CHECK_TICK
+		else
+			shrooms_planted++ //if we failed due to generation, don't try to plant one later
 	if(shrooms_planted < myseed.yield) //if we didn't get all possible shrooms planted, try again later
 		myseed.yield -= shrooms_planted
 		addtimer(CALLBACK(src, .proc/Spread), delay)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -124,8 +124,8 @@ var/list/blacklisted_glowshroom_turfs = typecacheof(list(
 			CHECK_TICK
 		else
 			shrooms_planted++ //if we failed due to generation, don't try to plant one later
+	myseed.yield -= shrooms_planted
 	if(shrooms_planted < myseed.yield) //if we didn't get all possible shrooms planted, try again later
-		myseed.yield -= shrooms_planted
 		addtimer(CALLBACK(src, .proc/Spread), delay)
 
 /obj/structure/glowshroom/proc/CalcDir(turf/location = loc)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -124,8 +124,8 @@ var/list/blacklisted_glowshroom_turfs = typecacheof(list(
 			CHECK_TICK
 		else
 			shrooms_planted++ //if we failed due to generation, don't try to plant one later
-	myseed.yield -= shrooms_planted
 	if(shrooms_planted < myseed.yield) //if we didn't get all possible shrooms planted, try again later
+		myseed.yield -= shrooms_planted
 		addtimer(CALLBACK(src, .proc/Spread), delay)
 
 /obj/structure/glowshroom/proc/CalcDir(turf/location = loc)


### PR DESCRIPTION
Failing to place a shroom due to generation didn't count as a planted shroom, meaning if it failed to plant a shroom due to high generation, it'd try again later instead of never trying again.