### PR TITLE
Changes plant default glow color (mostly glowshroom) to be less overpoweringly green.

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -268,7 +268,7 @@
 	rate = 0.03
 	examine_line = "<span class='info'>It emits a soft glow.</span>"
 	trait_id = "glow"
-	var/glow_color = "#AAD84B"
+	var/glow_color = "#9ADF8B"
 
 /datum/plant_gene/trait/glow/proc/glow_range(obj/item/seeds/S)
 	return 1.4 + S.potency*rate


### PR DESCRIPTION
**TESTED AT A LIGHT POWER OF 4 AND RANGE OF 4, WHICH IS AROUND HIGH POTENCY.**

## **BEFORE**
![BEFORE](https://i.gyazo.com/7775dac5c866600be40124b7211f2437.png)
## **AFTER**
![AFTER](https://i.gyazo.com/c8a2edef3b8db13d4358b74fc6f41f8e.png)