### PR TITLE
Nar'sie's summoning makes ghosts visible

### DIFF
--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -31,6 +31,9 @@
 	send_to_playing_players("<span class='narsie'>NAR-SIE HAS RISEN</span>")
 	send_to_playing_players(pick('sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg'))
 
+	// THE VEIL IS TORN
+	new /datum/round_event/wizard/ghost()
+
 	var/area/A = get_area(src)
 	if(A)
 		var/image/alert_overlay = image('icons/effects/effects.dmi', "ghostalertsie")


### PR DESCRIPTION
:cl: coiax
add: In the unlikely event that blood cultists summon a dark elder god,
it would damage the veil between worlds sufficently that ghosts would be
visible to living people.
/:cl:

The veil is torn, Narsie pours through along with any ghosts who just
want to watch people be murdered, rather than become harvesters
themselves.