### PR TITLE
New bitflag CLEAN_ON_MOVE

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -19,10 +19,11 @@
 #define ON_BORDER		512		// item has priority to check when entering or leaving
 
 #define NOSLIP		1024 		//prevents from slipping on wet floors, in space etc
+#define CLEAN_ON_MOVE 2048
 
 // BLOCK_GAS_SMOKE_EFFECT only used in masks at the moment.
-#define BLOCK_GAS_SMOKE_EFFECT 8192	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY! (NOTE: flag shared with THICKMATERIAL)
-#define THICKMATERIAL 8192		//prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body. (NOTE: flag shared with BLOCK_GAS_SMOKE_EFFECT)
+#define BLOCK_GAS_SMOKE_EFFECT 4096	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY!
+#define THICKMATERIAL 8192		//prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body.
 #define DROPDEL			16384 // When dropped, it calls qdel on itself
 
 /* Secondary atom flags, access using the SECONDARY_FLAG macros */

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -103,7 +103,39 @@
 			O.Check()
 	if (orbiting)
 		orbiting.Check()
+
+	if(flags & CLEAN_ON_MOVE)
+		clean_on_move()
 	return 1
+
+/atom/movable/proc/clean_on_move()
+	var/turf/tile = loc
+	if(isturf(tile))
+		tile.clean_blood()
+		for(var/A in tile)
+			if(is_cleanable(A))
+				qdel(A)
+			else if(istype(A, /obj/item))
+				var/obj/item/cleaned_item = A
+				cleaned_item.clean_blood()
+			else if(ishuman(A))
+				var/mob/living/carbon/human/cleaned_human = A
+				if(cleaned_human.lying)
+					if(cleaned_human.head)
+						cleaned_human.head.clean_blood()
+						cleaned_human.update_inv_head()
+					if(cleaned_human.wear_suit)
+						cleaned_human.wear_suit.clean_blood()
+						cleaned_human.update_inv_wear_suit()
+					else if(cleaned_human.w_uniform)
+						cleaned_human.w_uniform.clean_blood()
+						cleaned_human.update_inv_w_uniform()
+					if(cleaned_human.shoes)
+						cleaned_human.shoes.clean_blood()
+						cleaned_human.update_inv_shoes()
+					cleaned_human.clean_blood()
+					cleaned_human.wash_cream()
+					to_chat(cleaned_human, "<span class='danger'>[src] cleans your face!</span>")
 
 /atom/movable/Destroy(force)
 	var/inform_admins = HAS_SECONDARY_FLAG(src, INFORM_ADMINS_ON_RELOCATE)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -606,36 +606,6 @@
 				updating = 1
 				addtimer(CALLBACK(src, .proc/do_camera_update, oldLoc), BORG_CAMERA_BUFFER)
 	if(module)
-		if(istype(module, /obj/item/weapon/robot_module/janitor))
-			var/turf/tile = loc
-			if(isturf(tile))
-				tile.clean_blood()
-				for(var/A in tile)
-					if(is_cleanable(A))
-						qdel(A)
-					else if(istype(A, /obj/item))
-						var/obj/item/cleaned_item = A
-						cleaned_item.clean_blood()
-					else if(ishuman(A))
-						var/mob/living/carbon/human/cleaned_human = A
-						if(cleaned_human.lying)
-							if(cleaned_human.head)
-								cleaned_human.head.clean_blood()
-								cleaned_human.update_inv_head()
-							if(cleaned_human.wear_suit)
-								cleaned_human.wear_suit.clean_blood()
-								cleaned_human.update_inv_wear_suit()
-							else if(cleaned_human.w_uniform)
-								cleaned_human.w_uniform.clean_blood()
-								cleaned_human.update_inv_w_uniform()
-							if(cleaned_human.shoes)
-								cleaned_human.shoes.clean_blood()
-								cleaned_human.update_inv_shoes()
-							cleaned_human.clean_blood()
-							cleaned_human.wash_cream()
-							to_chat(cleaned_human, "<span class='danger'>[src] cleans your face!</span>")
-			return
-
 		if(istype(module, /obj/item/weapon/robot_module/miner))
 			if(istype(loc, /turf/open/floor/plating/asteroid))
 				for(var/obj/item/I in held_items)
@@ -984,6 +954,11 @@
 		status_flags |= CANPUSH
 	else
 		status_flags &= ~CANPUSH
+
+	if(module.clean_on_move)
+		flags |= CLEAN_ON_MOVE
+	else
+		flags &= CLEAN_ON_MOVE
 
 	hat_offset = module.hat_offset
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -20,6 +20,7 @@
 
 	var/can_be_pushed = TRUE
 	var/magpulsing = FALSE
+	var/clean_on_move = FALSE
 
 	var/did_feedback = FALSE
 	var/feedback_key
@@ -391,6 +392,7 @@
 	moduleselect_icon = "janitor"
 	feedback_key = "cyborg_janitor"
 	hat_offset = -5
+	clean_on_move = TRUE
 
 /obj/item/weapon/reagent_containers/spray/cyborg_drying
 	name = "drying agent spray"

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -50,6 +50,9 @@
 		mybag = I
 		update_icon()
 	else if(istype(I, /obj/item/janiupgrade))
+		if(floorbuffer)
+			to_chat(user, "<span class='warning'>[src] already has a floor buffer!</span>")
+			return
 		floorbuffer = TRUE
 		qdel(I)
 		to_chat(user, "<span class='notice'>You upgrade [src] with the floor buffer.</span>")

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -7,6 +7,10 @@
 	var/obj/item/weapon/storage/bag/trash/mybag = null
 	var/floorbuffer = FALSE
 
+/obj/vehicle/janicart/Initialize(mapload)
+	..()
+	update_icon()
+
 /obj/vehicle/janicart/Destroy()
 	if(mybag)
 		qdel(mybag)

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -78,3 +78,6 @@
 		user.put_in_hands(mybag)
 		mybag = null
 		update_icon()
+
+/obj/vehicle/janicart/upgraded
+	floorbuffer = TRUE

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -5,13 +5,13 @@
 	icon_state = "pussywagon"
 
 	var/obj/item/weapon/storage/bag/trash/mybag = null
-	var/floorbuffer = 0
+	var/floorbuffer = FALSE
 
 /obj/vehicle/janicart/Destroy()
 	if(mybag)
 		qdel(mybag)
 		mybag = null
-	return ..()
+	. = ..()
 
 /obj/vehicle/janicart/buckle_mob(mob/living/buckled_mob, force = 0, check_loc = 0)
 	. = ..()
@@ -32,17 +32,6 @@
 	origin_tech = "materials=3;engineering=4"
 
 
-/obj/vehicle/janicart/Moved(atom/OldLoc, Dir)
-	if(floorbuffer)
-		var/turf/tile = loc
-		if(isturf(tile))
-			tile.clean_blood()
-			for(var/A in tile)
-				if(is_cleanable(A))
-					qdel(A)
-	. = ..()
-
-
 /obj/vehicle/janicart/examine(mob/user)
 	..()
 	if(floorbuffer)
@@ -56,14 +45,15 @@
 			return
 		if(!user.drop_item())
 			return
-		to_chat(user, "<span class='notice'>You hook the trashbag onto \the [name].</span>")
+		to_chat(user, "<span class='notice'>You hook the trashbag onto [src].</span>")
 		I.loc = src
 		mybag = I
 		update_icon()
 	else if(istype(I, /obj/item/janiupgrade))
-		floorbuffer = 1
+		floorbuffer = TRUE
 		qdel(I)
-		to_chat(user, "<span class='notice'>You upgrade \the [name] with the floor buffer.</span>")
+		to_chat(user, "<span class='notice'>You upgrade [src] with the floor buffer.</span>")
+		flags |= CLEAN_ON_MOVE
 		update_icon()
 	else
 		return ..()


### PR DESCRIPTION
Time to use those highspeed bitflag slots.

If an atom/movable has CLEAN_ON_MOVE set, it will behave like a janitor
cyborg when moving.

Current owners of the CLEAN_ON_MOVE flag are janitor cyborgs and the
janitor's pimping ride (when upgraded).

This has the side effect of slightly buffing janitor's pimping ride cleaning
to also clean people's faces and clothes.

- Also moves BLOCK_GAS_SMOKE_EFFECT and THICKMATERIAL to separate flags.
- You can no longer upgrade a pimping ride more than once.
- New typepath for an already upgraded pimping ride.