### PR TITLE
Proselytizers converting clockwork floors to walls now always take 10 seconds

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
@@ -52,7 +52,10 @@
 	if(is_blocked_turf(src, TRUE))
 		to_chat(user, "<span class='warning'>Something is in the way, preventing you from proselytizing [src] into a clockwork wall.</span>")
 		return TRUE
-	return list("operation_time" = 100, "new_obj_type" = /turf/closed/wall/clockwork, "power_cost" = POWER_WALL_MINUS_FLOOR, "spawn_dir" = SOUTH)
+	var/operation_time = 100
+	if(proselytizer.speed_multiplier > 0)
+		operation_time /= proselytizer.speed_multiplier
+	return list("operation_time" = operation_time, "new_obj_type" = /turf/closed/wall/clockwork, "power_cost" = POWER_WALL_MINUS_FLOOR, "spawn_dir" = SOUTH)
 
 //False wall conversion
 /obj/structure/falsewall/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)


### PR DESCRIPTION
:cl: Joan
tweak: Proselytizers converting clockwork floors to walls now always take 10 seconds, regardless of how fast the proselytizer is.
/:cl:

Being able to turn a floor into a wall in 5 seconds makes cogscarabs actually pretty good at defense if they have the power, because they have a double-speed proselytizer.