### PR TITLE
Clockwork grilles no longer provide CV

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -230,16 +230,11 @@
 
 /obj/structure/grille/ratvar/New()
 	..()
-	change_construction_value(1)
 	if(broken)
 		new /obj/effect/overlay/temp/ratvar/grille/broken(get_turf(src))
 	else
 		new /obj/effect/overlay/temp/ratvar/grille(get_turf(src))
 		new /obj/effect/overlay/temp/ratvar/beam/grille(get_turf(src))
-
-/obj/structure/grille/ratvar/Destroy()
-	change_construction_value(-1)
-	return ..()
 
 /obj/structure/grille/ratvar/narsie_act()
 	take_damage(rand(1, 3), BRUTE)


### PR DESCRIPTION
:cl: Joan
tweak: Clockwork grilles no longer provide CV.
/:cl:

Rule number one: clockcult doesn't get something for nothing, and this was something for nothing. Very bad, not allowed, even if I added it.