### PR TITLE
Syndicate lavaland base now has a single self-destruct bomb

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1463,6 +1463,79 @@
 	},
 /turf/open/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"du" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dv" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dw" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dx" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dy" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dz" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dA" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dB" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dC" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dD" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dE" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dF" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Self Destruct Control";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"dG" = (
+/turf/open/floor/circuit/red,
+/area/ruin/powered/syndicate_lava_base)
+"dH" = (
+/obj/item/weapon/bombcore/large,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered/syndicate_lava_base)
+"dI" = (
+/turf/open/floor/circuit/red,
+/area/ruin/powered/syndicate_lava_base)
+"dJ" = (
+/obj/machinery/syndicatebomb/self_destruct,
+/turf/open/floor/circuit/red,
+/area/ruin/powered/syndicate_lava_base)
+"dK" = (
+/turf/open/floor/circuit/red,
+/area/ruin/powered/syndicate_lava_base)
+"dL" = (
+/turf/open/floor/circuit/red,
+/area/ruin/powered/syndicate_lava_base)
 
 (1,1,1) = {"
 aa
@@ -1774,7 +1847,7 @@ ad
 ad
 ad
 ad
-ad
+dD
 ad
 ad
 ac
@@ -1799,14 +1872,14 @@ ad
 ad
 ad
 ad
+dw
 ad
 ad
 ad
 ad
 ad
 ad
-ad
-ad
+dA
 ad
 ad
 cI
@@ -2038,7 +2111,7 @@ ao
 ap
 ap
 ao
-bb
+ap
 ad
 bj
 bD
@@ -2047,7 +2120,7 @@ ao
 ap
 ch
 co
-cx
+cz
 ad
 cI
 cI
@@ -2096,7 +2169,7 @@ cF
 ad
 dl
 ad
-ad
+dH
 ad
 ad
 ab
@@ -2128,7 +2201,7 @@ bX
 ad
 co
 cz
-ad
+dB
 aR
 cN
 bG
@@ -2159,7 +2232,7 @@ ad
 ad
 aV
 ad
-ad
+dx
 bm
 bF
 ap
@@ -2285,7 +2358,7 @@ aY
 aY
 aY
 aY
-cj
+aY
 cp
 cA
 aY
@@ -2310,7 +2383,7 @@ ab
 ab
 ab
 ab
-ad
+du
 ad
 ar
 ar
@@ -2396,7 +2469,7 @@ ar
 ar
 aG
 ap
-aS
+ao
 ap
 bf
 ad
@@ -2408,13 +2481,13 @@ ca
 ck
 co
 cz
-ad
+dC
 aR
 ap
 cW
 db
 dj
-ad
+dE
 ac
 ac
 ac
@@ -2495,10 +2568,10 @@ cX
 dc
 ap
 ad
-ac
-ac
-ab
-ac
+ad
+ad
+ad
+ad
 ab
 ab
 ab
@@ -2523,7 +2596,7 @@ ad
 bt
 ap
 ao
-bb
+ap
 cc
 bv
 co
@@ -2535,10 +2608,10 @@ bI
 dd
 ap
 ad
-ac
-ab
-ab
-ac
+ap
+dI
+ap
+ad
 ab
 ab
 ab
@@ -2553,7 +2626,7 @@ ab
 ad
 ad
 ad
-ad
+dv
 ad
 ad
 ad
@@ -2569,16 +2642,16 @@ bv
 co
 cz
 ad
-bb
+ap
 cQ
 ap
 ap
 ap
+dF
+dG
+dJ
+dL
 ad
-ac
-ab
-ab
-ab
 ab
 ab
 ab
@@ -2599,13 +2672,13 @@ aN
 aT
 ap
 ap
-ad
+dy
 bv
 bv
 ao
 by
 by
-ad
+dz
 cr
 cC
 ad
@@ -2615,10 +2688,10 @@ aN
 aN
 bL
 ad
-ab
-ab
-ac
-ab
+ap
+dK
+ap
+ad
 ab
 ab
 ab
@@ -2656,9 +2729,9 @@ cH
 ad
 ad
 ad
-ab
-ab
-ab
+ad
+ad
+ad
 ab
 ab
 ab

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1448,47 +1448,47 @@
 /turf/open/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "du" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dv" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dw" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dx" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dy" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dz" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dA" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dB" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dC" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dD" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dE" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dF" = (
@@ -1504,7 +1504,7 @@
 /turf/open/floor/circuit/red,
 /area/ruin/powered/syndicate_lava_base)
 "dH" = (
-/obj/item/weapon/bombcore/large,
+/obj/item/weapon/bombcore/large/underwall,
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "dI" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -321,10 +321,6 @@
 	},
 /area/ruin/powered/syndicate_lava_base)
 "aS" = (
-/obj/machinery/syndicatebomb/badmin/varplosion{
-	can_unanchor = 0;
-	name = "self destruct device"
-	},
 /turf/open/floor/plasteel/black,
 /area/ruin/powered/syndicate_lava_base)
 "aT" = (
@@ -406,10 +402,6 @@
 	},
 /area/ruin/powered/syndicate_lava_base)
 "bb" = (
-/obj/machinery/syndicatebomb/badmin/varplosion{
-	can_unanchor = 0;
-	name = "self destruct device"
-	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -933,10 +925,6 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "cj" = (
-/obj/machinery/syndicatebomb/badmin/varplosion{
-	can_unanchor = 0;
-	name = "self destruct device"
-	},
 /turf/open/floor/plasteel/podhatch{
 	dir = 8
 	},
@@ -1054,10 +1042,6 @@
 	},
 /area/ruin/powered/syndicate_lava_base)
 "cx" = (
-/obj/machinery/syndicatebomb/badmin/varplosion{
-	can_unanchor = 0;
-	name = "self destruct device"
-	},
 /turf/open/floor/plasteel/podhatch,
 /area/ruin/powered/syndicate_lava_base)
 "cy" = (

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -249,9 +249,6 @@
 	payload = /obj/item/weapon/bombcore/badmin/summon/clown
 	beepsound = 'sound/items/bikehorn.ogg'
 
-/obj/machinery/syndicatebomb/badmin/varplosion
-	payload = /obj/item/weapon/bombcore/badmin/explosion
-
 /obj/machinery/syndicatebomb/empty
 	name = "bomb"
 	icon_state = "base-bomb"
@@ -263,6 +260,12 @@
 /obj/machinery/syndicatebomb/empty/New()
 	..()
 	wires.cut_all()
+
+/obj/machinery/syndicatebomb/self_destruct
+	name = "self destruct device"
+	desc = "Do not taunt. Warranty invalid if exposed to high temperature. Not suitable for agents under 3 years of age."
+	payload = /obj/item/weapon/bombcore/large
+	can_unanchor = FALSE
 
 ///Bomb Cores///
 
@@ -276,6 +279,10 @@
 	origin_tech = "syndicate=5;combat=6"
 	resistance_flags = FLAMMABLE //Burnable (but the casing isn't)
 	var/adminlog = null
+	var/range_heavy = 3
+	var/range_medium = 9
+	var/range_light = 17
+	var/range_flame = 17
 
 /obj/item/weapon/bombcore/ex_act(severity, target) // Little boom can chain a big boom.
 	detonate()
@@ -289,7 +296,7 @@
 	if(adminlog)
 		message_admins(adminlog)
 		log_game(adminlog)
-	explosion(get_turf(src), 3, 9, 17, flame_range = 17)
+	explosion(get_turf(src), range_heavy, range_medium, range_light, flame_range = range_flame)
 	if(loc && istype(loc,/obj/machinery/syndicatebomb/))
 		qdel(loc)
 	qdel(src)
@@ -367,26 +374,20 @@
 	playsound(src.loc, 'sound/misc/sadtrombone.ogg', 50)
 	..()
 
-/obj/item/weapon/bombcore/badmin/explosion
-	var/HeavyExplosion = 5
-	var/MediumExplosion = 10
-	var/LightExplosion = 20
-	var/Flames = 20
-
-/obj/item/weapon/bombcore/badmin/explosion/detonate()
-	explosion(get_turf(src), HeavyExplosion, MediumExplosion, LightExplosion, flame_range = Flames)
-	qdel(src)
+/obj/item/weapon/bombcore/large
+	name = "large bomb payload"
+	range_heavy = 5
+	range_medium = 10
+	range_light = 20
+	range_flame = 20
 
 /obj/item/weapon/bombcore/miniature
 	name = "small bomb core"
 	w_class = WEIGHT_CLASS_SMALL
-
-/obj/item/weapon/bombcore/miniature/detonate()
-	if(adminlog)
-		message_admins(adminlog)
-		log_game(adminlog)
-	explosion(src.loc, 1, 2, 4, flame_range = 2) //Identical to a minibomb
-	qdel(src)
+	range_heavy = 1
+	range_medium = 2
+	range_light = 4
+	range_flame = 2
 
 /obj/item/weapon/bombcore/chemical
 	name = "chemical payload"

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -381,6 +381,9 @@
 	range_light = 20
 	range_flame = 20
 
+/obj/item/weapon/bombcore/large/underwall
+	layer = ABOVE_OPEN_TURF_LAYER
+
 /obj/item/weapon/bombcore/miniature
 	name = "small bomb core"
 	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
:cl: coiax
tweak: The Syndicate lavaland base now has a single self destruct bomb
located next to the Communications Room. Guaranteed destruction of the
base is guaranteed by payloads embedded in the walls.
/:cl:

I saw WJohn do this for his syndicate space base, and thought it made a
lot better sense than just having a bunch of bombs lying around.

A very minor refactor of syndicate bomb code, mostly because the base
seemed to use a badmin bomb that had no other purpose other than being
slightly larger to explode?

![image](https://cloud.githubusercontent.com/assets/609465/23882761/9e48a6f4-085a-11e7-9f0e-e381955633f0.png)

(Syndicate balloon was already there, it's a special baseturf modification effect, not actually visible ingame)