### PR TITLE
[Delta] Fixes Telecomms Temperature Air Mixing

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -55424,7 +55424,10 @@
 	req_access_txt = "61"
 	},
 /turf/open/floor/plasteel/vault{
-	dir = 8
+	dir = 5;
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "icon-vault (NORTHEAST)";
+	temperature = 80
 	},
 /area/tcommsat/server)
 "bUN" = (
@@ -61129,7 +61132,10 @@
 	req_access_txt = "61"
 	},
 /turf/open/floor/plasteel/vault{
-	dir = 8
+	dir = 5;
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "icon-vault (NORTHEAST)";
+	temperature = 80
 	},
 /area/tcommsat/server)
 "cfg" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -55426,7 +55426,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "icon-vault (NORTHEAST)";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -61134,7 +61133,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "icon-vault (NORTHEAST)";
 	temperature = 80
 	},
 /area/tcommsat/server)


### PR DESCRIPTION
## **Fixes Telecoms Temp Air Mixing On Deltastation**
Replaces tiles under Deltastations telecoms interior doors with the same type of tiles inside the telecoms room (The ones with a custom gas mix and temperature set). This is to prevent air mixing after the tiny fan and prematurely heating up/contaminating the telecommunications room.

## **Changelog**
:cl: Tofa01
Fix: [Delta] Fixes telecoms temperature and gas mixing / being contaminated.
/:cl:

## Fixes #25088