### PR TITLE
Refactors T-Ray Scanners

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -28,9 +28,19 @@ MASS SPECTROMETER
 		START_PROCESSING(SSobj, src)
 
 /obj/item/device/t_scanner/proc/flick_sonar(obj/pipe)
-	var/image/I = image('icons/effects/effects.dmi', pipe, "blip", pipe.layer+1)
-	I.alpha = 128
-	flick_overlay_view(I, pipe, 8)
+	if(ismob(loc))
+		var/mob/M = loc
+		var/image/I = image(pipe.icon, get_turf(pipe), pipe.icon_state, pipe.layer+1, pipe.dir)
+		I.alpha = 128
+		I.color = pipe.color
+		if(M.client)
+			flick_overlay(I, list(M.client), 8)
+			for(var/C in pipe.overlays)
+				var/image/pipe_overlay = C
+				var/image/J = image(pipe_overlay.icon, get_turf(pipe), pipe_overlay.icon_state, pipe.layer+1, pipe_overlay.dir)
+				J.alpha = 128
+				J.color = pipe.color
+				flick_overlay(J, list(M.client), 8)
 
 /obj/item/device/t_scanner/process()
 	if(!on)
@@ -46,21 +56,8 @@ MASS SPECTROMETER
 			if(O.level != 1)
 				continue
 
-			var/mob/living/L = locate() in O
-
 			if(O.invisibility == INVISIBILITY_MAXIMUM)
-				O.invisibility = 0
-				if(L)
-					flick_sonar(O)
-				spawn(10)
-					if(O && O.loc)
-						var/turf/U = O.loc
-						if(U.intact)
-							O.invisibility = INVISIBILITY_MAXIMUM
-			else
-				if(L)
-					flick_sonar(O)
-
+				flick_sonar(O)
 
 /obj/item/device/healthanalyzer
 	name = "health analyzer"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -30,17 +30,12 @@ MASS SPECTROMETER
 /obj/item/device/t_scanner/proc/flick_sonar(obj/pipe)
 	if(ismob(loc))
 		var/mob/M = loc
-		var/image/I = image(pipe.icon, get_turf(pipe), pipe.icon_state, pipe.layer+1, pipe.dir)
-		I.alpha = 128
-		I.color = pipe.color
+		var/image/I = new(loc = get_turf(pipe))
+		var/mutable_appearance/MA = new(pipe)
+		MA.alpha = 128
+		I.appearance = MA
 		if(M.client)
 			flick_overlay(I, list(M.client), 8)
-			for(var/C in pipe.overlays)
-				var/image/pipe_overlay = C
-				var/image/J = image(pipe_overlay.icon, get_turf(pipe), pipe_overlay.icon_state, pipe.layer+1, pipe_overlay.dir)
-				J.alpha = 128
-				J.color = pipe.color
-				flick_overlay(J, list(M.client), 8)
 
 /obj/item/device/t_scanner/process()
 	if(!on)

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -61,17 +61,12 @@
 /obj/item/clothing/glasses/meson/engine/proc/flick_sonar(obj/pipe)
 	if(ismob(loc))
 		var/mob/M = loc
-		var/image/I = image(pipe.icon, get_turf(pipe), pipe.icon_state, pipe.layer+1, pipe.dir)
-		I.alpha = 128
-		I.color = pipe.color
+		var/image/I = new(loc = get_turf(pipe))
+		var/mutable_appearance/MA = new(pipe)
+		MA.alpha = 128
+		I.appearance = MA
 		if(M.client)
 			flick_overlay(I, list(M.client), 8)
-			for(var/C in pipe.overlays)
-				var/image/pipe_overlay = C
-				var/image/J = image(pipe_overlay.icon, get_turf(pipe), pipe_overlay.icon_state, pipe.layer+1, pipe_overlay.dir)
-				J.alpha = 128
-				J.color = pipe.color
-				flick_overlay(J, list(M.client), 8)
 
 /obj/item/clothing/glasses/meson/engine/proc/t_ray_on()
 	if(!ishuman(loc))

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -8,7 +8,6 @@
 	origin_tech = "materials=3;magnets=3;engineering=3;plasmatech=3"
 
 	var/mode = 0	//0 - regular mesons mode	1 - t-ray mode
-	var/invis_objects = list()
 	var/range = 1
 
 /obj/item/clothing/glasses/meson/engine/attack_self(mob/user)
@@ -26,7 +25,6 @@
 		darkness_view = 1
 		invis_view = SEE_INVISIBLE_MINIMUM
 		to_chat(loc, "<span class='notice'>You toggle the goggles' scanning mode to \[Meson].</span>")
-		invis_update()
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -43,39 +41,37 @@
 		return
 
 	if(!ishuman(loc))
-		invis_update()
 		return
 
 	var/mob/living/carbon/human/user = loc
 	if(user.glasses != src)
-		invis_update()
 		return
 
 	scan()
 
 /obj/item/clothing/glasses/meson/engine/proc/scan()
 	for(var/turf/T in range(range, loc))
-
-		if(!T.intact)
-			continue
-
 		for(var/obj/O in T.contents)
 			if(O.level != 1)
 				continue
 
 			if(O.invisibility == INVISIBILITY_MAXIMUM)
-				O.invisibility = 0
-				invis_objects += O
+				flick_sonar(O)
 
-	addtimer(CALLBACK(src, .proc/invis_update), 5)
-
-/obj/item/clothing/glasses/meson/engine/proc/invis_update()
-	for(var/obj/O in invis_objects)
-		if(!t_ray_on() || !(O in range(range, loc)))
-			invis_objects -= O
-			var/turf/T = O.loc
-			if(T && T.intact)
-				O.invisibility = INVISIBILITY_MAXIMUM
+/obj/item/clothing/glasses/meson/engine/proc/flick_sonar(obj/pipe)
+	if(ismob(loc))
+		var/mob/M = loc
+		var/image/I = image(pipe.icon, get_turf(pipe), pipe.icon_state, pipe.layer+1, pipe.dir)
+		I.alpha = 128
+		I.color = pipe.color
+		if(M.client)
+			flick_overlay(I, list(M.client), 8)
+			for(var/C in pipe.overlays)
+				var/image/pipe_overlay = C
+				var/image/J = image(pipe_overlay.icon, get_turf(pipe), pipe_overlay.icon_state, pipe.layer+1, pipe_overlay.dir)
+				J.alpha = 128
+				J.color = pipe.color
+				flick_overlay(J, list(M.client), 8)
 
 /obj/item/clothing/glasses/meson/engine/proc/t_ray_on()
 	if(!ishuman(loc))
@@ -125,7 +121,6 @@
 	else
 		STOP_PROCESSING(SSobj, src)
 		to_chat(user, "<span class='notice'>You turn the goggles off.</span>")
-		invis_update()
 
 	update_icon()
 	for(var/X in actions)


### PR DESCRIPTION
:cl: XDTM
fix: T-Ray scans are no longer visible to bystanders.
fix: T-Ray scans no longer allow viewers to interact with underfloor objects.
/:cl:

Pipes no longer get un-invisibilized by t-rays and instead show an overlay on top of the floor, only to the scanner holder/glasses wearer.

Fixes #22601
