### PR TITLE
Wizard traps are damage proof, but can be erased with a null rod

### DIFF
--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -7,6 +7,8 @@
 	anchored = TRUE
 	alpha = 30 //initially quite hidden when not "recharging"
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | INDESTRUCTIBLE
+	var/divine_vulnerability = TRUE // can you destroy with null rod
+	var/disarm_with_examine = TRUE
 	var/last_trigger = 0
 	var/time_between_triggers = 600 //takes a minute to recharge
 
@@ -32,6 +34,8 @@
 
 /obj/structure/trap/examine(mob/user)
 	..()
+	if(!disarm_with_examine)
+		return
 	if(!isliving(user))
 		return
 	if(get_dist(user, src) <= 1)
@@ -59,6 +63,14 @@
 
 /obj/structure/trap/proc/trap_effect(mob/living/L)
 	return
+
+/obj/structure/trap/attackby(obj/I, mob/user, params)
+	if(istype(I, /obj/item/weapon/nullrod))
+		user.say("BEGONE FOUL MAGIKS!!")
+		to_chat(user, "<span class='danger'>You disrupt the magic of [src] with [I].</span>")
+		qdel(src)
+		return
+	. = ..()
 
 /obj/structure/trap/stun
 	name = "shock trap"

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -6,6 +6,7 @@
 	density = 0
 	anchored = TRUE
 	alpha = 30 //initially quite hidden when not "recharging"
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | INDESTRUCTIBLE
 	var/last_trigger = 0
 	var/time_between_triggers = 600 //takes a minute to recharge
 

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -524,14 +524,17 @@
 	name = "Spawn protection"
 	desc = "Stay outta the enemy spawn!"
 	icon_state = "trap"
-	resistance_flags = INDESTRUCTIBLE
+
+	// I don't know how you smuggled a null rod into CTF, but you can't
+	// use it to spawn camp.
+	divine_vulnerability = FALSE
+
+
 	var/team = WHITE_TEAM
 	time_between_triggers = 1
+	disarm_with_examine = FALSE
 	anchored = TRUE
 	alpha = 255
-
-/obj/structure/trap/examine(mob/user)
-	return
 
 /obj/structure/trap/ctf/trap_effect(mob/living/L)
 	if(!(src.team in L.faction))


### PR DESCRIPTION
:cl: coiax
fix: Wizard traps are now indestructible to normal damage, but can be erased with a holy weapon.
/:cl:

- CTF traps are still indestructible and null rod proof.

I forget that object damage is a thing.