### PR TITLE
Increase Sync Range of Exosuit Fabricator

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -244,7 +244,7 @@
 	updateUsrDialog()
 	sleep(30) //only sleep if called by user
 
-	for(var/obj/machinery/computer/rdconsole/RDC in oview(5,src))
+	for(var/obj/machinery/computer/rdconsole/RDC in oview(7,src))
 		if(!RDC.sync)
 			continue
 		for(var/v in RDC.files.known_tech)


### PR DESCRIPTION
:cl: Penguaro
tweak: Increased Synchronization Range on Exosuit Fabricator
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Currently the Exosuit Fabricators will only look 5 tiles away when synching to an RD Console. I increased the range to 7 to allow the lower Exosuit Fabricator on the BoxStation map to sync. Fixes #24912