### PR TITLE
Fixes shield gen access

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -40178,7 +40178,7 @@
 	d2 = 2
 	},
 /obj/machinery/shieldwallgen{
-	req_access = list(55)
+	req_access_txt = "55"
 	},
 /turf/open/floor/plating,
 /area/toxins/xenobiology)


### PR DESCRIPTION
>Byond
>Lists
Whatever

:cl:
fix: The shield generators in Boxstation Xenobiology now have the correct access
/:cl:
