### PR TITLE
[wip] Simple admin tool for getting signups

### DIFF
--- a/code/controllers/subsystem/voting.dm
+++ b/code/controllers/subsystem/voting.dm
@@ -138,8 +138,6 @@ var/datum/controller/subsystem/vote/SSvote
 			to_chat(world, "<span style='boldannounce'>Notice:Restart vote will not restart the server automatically because there are active admins on.</span>")
 			message_admins("A restart vote has passed, but there are active admins on with +server, so it has been canceled. If you wish, you may restart the server.")
 
-	return .
-
 /datum/controller/subsystem/vote/proc/submit_vote(vote)
 	if(mode)
 		if(config.vote_no_dead && usr.stat == DEAD && !usr.client.holder)

--- a/code/modules/admin/pray_for_fun.dm
+++ b/code/modules/admin/pray_for_fun.dm
@@ -1,0 +1,48 @@
+/proc/press_gang(num_required)
+	var/delay = 300
+	message_admin("[key_name(usr)] is running a press gang! Results in [delay / 10] seconds...")
+
+	var/list/generated_actions = list()
+
+	var/list/signups = list()
+
+	for(var/c in clients)
+		var/client/C = c
+		var/datum/action/pray_for_fun/V = new(signups)
+		V.Grant(C.mob)
+		generated_actions += V
+
+	sleep(delay)
+
+	for(var/v in generated_actions)
+		var/datum/action/pray_for_fun/V = v
+		if(!QDELETED(V))
+			V.Remove(V.owner)
+
+	var/total_signups = signups.len
+
+	var/list/selected = list()
+	var/list/lookups = list()
+	while(signups.len || (selected.len < num_required))
+		var/mob/M = pick_n_take(signups)
+		if(!QDELETED(M))
+			selected += M
+			lookups += ADMIN_LOOKUP(M)
+
+
+	message_admins("Press gang complete! [total_signups] signed up, [selected.len] have been chosen: [english_list(lookups)]")
+	log_game("A press gang had [total_signups], [selected.len] were chosen: [english_list(selected)]")
+
+
+/datum/action/pray_for_fun
+	name = "Pray for Fun!"
+
+/datum/action/pray_for_fun/IsAvailable()
+	return TRUE
+
+/datum/action/pray_for_fun/Trigger()
+	if(!..())
+		return
+	target += owner
+	to_chat(owner, "<span class='warning'>You have prayed for fun! Hopefully RNG is on your side...</span>")
+	Remove(owner)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -961,6 +961,7 @@
 #include "code\modules\admin\IsBanned.dm"
 #include "code\modules\admin\NewBan.dm"
 #include "code\modules\admin\player_panel.dm"
+#include "code\modules\admin\pray_for_fun.dm"
 #include "code\modules\admin\secrets.dm"
 #include "code\modules\admin\sql_message_system.dm"
 #include "code\modules\admin\stickyban.dm"


### PR DESCRIPTION
Admins trigger a "pray for fun request", everyone gets an action button
they can trigger if they want to opt in to the fun lottery.

After a delay to signup, X number of people are selected, and the admins
are messaged with their mobs so they can PM or whisper them as
appropriate.

No action is taken on being selected other than the admins being
messaged, so the admins can feel free to request 3 people, but only pick
~~their metabuddy~~ the most suitable candidate.

Will probably make the action button a clown.

Reasons: Well, it means that everyone gets a chance for fun, rather than
the first person who can come up with the lowest common denominator of
12 and 18.