### PR TITLE
Fixes problem with fulltile windows being incorrectly made in buildmode

### DIFF
--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -284,7 +284,7 @@
 						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
 						WIN.setDir(WEST)
 					if(NORTHWEST)
-						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
+						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced/fulltile(get_turf(object))
 						WIN.setDir(NORTHWEST)
 				log_admin("Build Mode: [key_name(user)] built a window at ([object.x],[object.y],[object.z])")
 		if(ADV_BUILDMODE)


### PR DESCRIPTION
Full tile windows built from Buildmode Basic were pointed at an old path. Changes this to match the new path.
:cl: 
fix: Fixed buildmodes full tile window to be correct path
/:cl: