### PR TITLE
[Delta] Fixes Some Doubled Up Turfs

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -18602,9 +18602,6 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "aIx" = (
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
 /obj/structure/table,
 /obj/item/weapon/storage/crayons,
 /obj/item/weapon/storage/crayons,
@@ -19305,13 +19302,10 @@
 	},
 /area/security/prison)
 "aJQ" = (
-/turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
+/turf/open/floor/plating,
 /area/security/prison)
 "aJR" = (
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
## **[Delta] Fixes Some Doubled Up Turfs On Deltastation**
Fixes some doubled up turfs specifically in the perma-brig wing allowing a player to pick up a table when only clicking on a box of crayons. I am unsure about how these got there but they do seem to cause some problems so if anyone else spots them please post where it was found here and i will fix it ASAP.

## **Changelog**
:cl: Tofa01
Fix: [Delta] Fixes some doubled up turfs causing items and objects to get stuck to stuff
/:cl:

## **Fixes #25124**
