### PR TITLE
Remove low priority from lighting

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -9,7 +9,6 @@ var/list/lighting_update_objects  = list() // List of lighting objects queued fo
 	name = "Lighting"
 	wait = 2
 	init_order = -20
-	priority = 35
 	flags = SS_TICKER
 
 	var/initialized = FALSE


### PR DESCRIPTION
Since we are only running it every two ticks now it should get equal parts priority as everything else
