### PR TITLE
Makes shuttle docking ignore subtypes of the baseturf

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -488,7 +488,7 @@
 		var/turf/T1 = L1[i]
 		if(!T1)
 			continue
-		if(T0.type != T0.baseturf) //So if there is a hole in the shuttle we don't drag along the space/asteroid/etc to wherever we are going next
+		if(!istype(T0.type, T0.baseturf)) //So if there is a hole in the shuttle we don't drag along the space/asteroid/etc to wherever we are going next
 			T0.copyTurf(T1)
 			T1.baseturf = destination_turf_type
 			var/area/old = T1.loc

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -422,7 +422,7 @@
 		var/turf/T1 = L1[i]
 		if(!T1)
 			continue
-		if(T0.type != T0.baseturf)
+		if(!istype(T0, T0.baseturf))
 			ripple_turfs += T1
 
 	return ripple_turfs
@@ -488,7 +488,7 @@
 		var/turf/T1 = L1[i]
 		if(!T1)
 			continue
-		if(!istype(T0.type, T0.baseturf)) //So if there is a hole in the shuttle we don't drag along the space/asteroid/etc to wherever we are going next
+		if(!istype(T0, T0.baseturf)) //So if there is a hole in the shuttle we don't drag along the space/asteroid/etc to wherever we are going next
 			T0.copyTurf(T1)
 			T1.baseturf = destination_turf_type
 			var/area/old = T1.loc


### PR DESCRIPTION
I'm assuming this was happening because /turf/open/space != /turf/open/space/transit