### PR TITLE
Adds rechargers to the boxstation shuttle

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -58748,6 +58748,7 @@
 	pixel_y = 3
 	},
 /obj/item/weapon/crowbar,
+/obj/item/weapon/storage/firstaid/fire,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "cwH" = (

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -56235,7 +56235,7 @@
 /area/engine/engineering)
 "crN" = (
 /obj/structure/table,
-/obj/item/weapon/storage/firstaid/fire,
+/obj/machinery/recharger,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "crO" = (

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -22,7 +22,7 @@
 /area/shuttle/escape)
 "af" = (
 /obj/structure/table,
-/obj/item/weapon/storage/firstaid/fire,
+/obj/machinery/recharger,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "ag" = (

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -42,6 +42,7 @@
 	pixel_y = 3
 	},
 /obj/item/weapon/crowbar,
+/obj/item/weapon/storage/firstaid/fire,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aj" = (


### PR DESCRIPTION
See title. It's on the left table in the shuttle cockpit. Tested it earlier and it worked. Nevermind, the burnkit is back. First PR, lemme know if I messed up. 
:cl: BeeSting12
add: Nanotrasen has decided to better equip the box-class emergency shuttles with a recharger on a table in the cockpit.
/:cl:

Why: To recharge weapons obviously.

I'll fix any issues tomorrow afternoon, if any. Knowing me, there will be. 