### PR TITLE
buffs TACTICAL medkits

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -111,8 +111,8 @@
 	new /obj/item/stack/medical/gauze(src)
 	new /obj/item/weapon/defibrillator/compact/combat/loaded(src)
 	new /obj/item/weapon/reagent_containers/hypospray/combat(src)
-	new /obj/item/reagent_containers/pill/patch/synth_flesh(src)
-	new /obj/item/reagent_containers/pill/patch/synth_flesh(src)
+	new /obj/item/weapon/reagent_containers/pill/patch/synth_flesh(src)
+	new /obj/item/weapon/reagent_containers/pill/patch/synth_flesh(src)
 	new /obj/item/weapon/reagent_containers/syringe/lethal/choral(src)
 	new /obj/item/clothing/glasses/hud/health/night(src)
 	return

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -111,8 +111,8 @@
 	new /obj/item/stack/medical/gauze(src)
 	new /obj/item/weapon/defibrillator/compact/combat/loaded(src)
 	new /obj/item/weapon/reagent_containers/hypospray/combat(src)
-	new /obj/item/weapon/reagent_containers/pill/patch/styptic(src)
-	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
+	new /obj/item/reagent_containers/pill/patch/synth_flesh(src)
+	new /obj/item/reagent_containers/pill/patch/synth_flesh(src)
 	new /obj/item/weapon/reagent_containers/syringe/lethal/choral(src)
 	new /obj/item/clothing/glasses/hud/health/night(src)
 	return

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -33,4 +33,4 @@
 /obj/item/weapon/reagent_containers/pill/patch/synth_flesh
 	name = "synthflesh patch"
 	desc = "Helps with burn and brute injuries."
-	list_reagents = list("synthflesh" = 20, "inacusiate" = 1,)
+	list_reagents = list("synthflesh" = 20, "inacusiate" = 1)

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -29,3 +29,8 @@
 	desc = "Helps with burn injuries."
 	list_reagents = list("silver_sulfadiazine" = 20)
 	icon_state = "bandaid_burn"
+	
+/obj/item/reagent_containers/pill/patch/synth_flesh
+	name = "synthflesh patch"
+	desc = "Helps with burn and brute injuries."
+	list_reagents = list("synthflesh" = 20, "inacusiate" = 1,)

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -30,7 +30,7 @@
 	list_reagents = list("silver_sulfadiazine" = 20)
 	icon_state = "bandaid_burn"
 	
-/obj/item/reagent_containers/pill/patch/synth_flesh
+/obj/item/weapon/reagent_containers/pill/patch/synth_flesh
 	name = "synthflesh patch"
 	desc = "Helps with burn and brute injuries."
 	list_reagents = list("synthflesh" = 20, "inacusiate" = 1,)


### PR DESCRIPTION
Tactical medkit burn/brute patches are switched out with synthflesh and 1 unit of inacusiate that will remove all ear damage (if you hit yourself with a bomb you dumb flukey!) only 2 per medkit as it replaced the burn/brute 


:cl: Hyena
tweak: Removes burn/brute patch from tactical medkits and replaces it with synthflesh
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) Tactical medkits should be tactical handling both damages at the same time or you get a tactical disadventage
