### PR TITLE
THIS STUPID PEN PR FINALLY IS FINISHED GAH

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -11,10 +11,7 @@
 	return
 
 /obj/attackby(obj/item/I, mob/living/user, params)
-	if(unique_rename && istype(I, /obj/item/weapon/pen))
-		rewrite(user)
-	else
-		return I.attack_obj(src, user)
+	return I.attack_obj(src, user)
 
 /mob/living/attackby(obj/item/I, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -292,35 +292,32 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 // I have cleaned it up a little, but it could probably use more.  -Sayu
 // The lack of ..() is intentional, do not add one
 /obj/item/attackby(obj/item/weapon/W, mob/user, params)
-	if(unique_rename && istype(W, /obj/item/weapon/pen))
-		rewrite(user)
-	else
-		if(istype(W,/obj/item/weapon/storage))
-			var/obj/item/weapon/storage/S = W
-			if(S.use_to_pickup)
-				if(S.collection_mode) //Mode is set to collect multiple items on a tile and we clicked on a valid one.
-					if(isturf(loc))
-						var/list/rejections = list()
+	if(istype(W,/obj/item/weapon/storage))
+		var/obj/item/weapon/storage/S = W
+		if(S.use_to_pickup)
+			if(S.collection_mode) //Mode is set to collect multiple items on a tile and we clicked on a valid one.
+				if(isturf(loc))
+					var/list/rejections = list()
 
-						var/list/things = loc.contents.Copy()
-						if (S.collection_mode == 2)
-							things = typecache_filter_list(things, typecacheof(type))
+					var/list/things = loc.contents.Copy()
+					if (S.collection_mode == 2)
+						things = typecache_filter_list(things, typecacheof(type))
 
-						var/len = things.len
-						if(!len)
-							to_chat(user, "<span class='notice'>You failed to pick up anything with [S].</span>")
-							return
-						var/datum/progressbar/progress = new(user, len, loc)
+					var/len = things.len
+					if(!len)
+						to_chat(user, "<span class='notice'>You failed to pick up anything with [S].</span>")
+						return
+					var/datum/progressbar/progress = new(user, len, loc)
 
-						while (do_after(user, 10, TRUE, S, FALSE, CALLBACK(src, .proc/handle_mass_pickup, S, things, loc, rejections, progress)))
-							sleep(1)
+					while (do_after(user, 10, TRUE, S, FALSE, CALLBACK(src, .proc/handle_mass_pickup, S, things, loc, rejections, progress)))
+						sleep(1)
 
-						qdel(progress)
+					qdel(progress)
 
-						to_chat(user, "<span class='notice'>You put everything you could [S.preposition] [S].</span>")
+					to_chat(user, "<span class='notice'>You put everything you could [S.preposition] [S].</span>")
 
-				else if(S.can_be_inserted(src))
-					S.handle_item_insertion(src)
+			else if(S.can_be_inserted(src))
+				S.handle_item_insertion(src)
 
 /obj/item/proc/handle_mass_pickup(obj/item/weapon/storage/S, list/things, atom/thing_loc, list/rejections, datum/progressbar/progress)
 	for(var/obj/item/I in things)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -68,14 +68,6 @@
 	else
 		return null
 
-/obj/proc/rewrite(mob/user)
-	var/penchoice = alert("What would you like to edit?", "Rename or change description?", "Rename", "Change description", "Cancel")
-	if(!QDELETED(src) && user.canUseTopic(src, BE_CLOSE))
-		if(penchoice == "Rename")
-			rename_obj(user)
-		if(penchoice == "Change description")
-			redesc_obj(user)
-
 /obj/proc/handle_internal_lifeform(mob/lifeform_inside_me, breath_request)
 	//Return: (NONSTANDARD)
 	//		null if object handles breathing logic for lifeform
@@ -200,28 +192,3 @@
 	..()
 	if(unique_rename)
 		to_chat(user, "<span class='notice'>Use a pen on it to rename it or change its description.</span>")
-
-/obj/proc/rename_obj(mob/M)
-	var/input = stripped_input(M,"What do you want to name \the [name]?", ,"", MAX_NAME_LEN)
-	var/oldname = name
-
-	if(!QDELETED(src) && M.canUseTopic(src, BE_CLOSE) && input != "")
-		if(oldname == input)
-			to_chat(M, "You changed \the [name] to... well... \the [name].")
-			return
-		else
-			name = input
-			to_chat(M, "\The [oldname] has been successfully been renamed to \the [input].")
-			return
-	else
-		return
-
-/obj/proc/redesc_obj(mob/M)
-	var/input = stripped_input(M,"Describe \the [name] here", ,"", 100)
-
-	if(!QDELETED(src) && M.canUseTopic(src, BE_CLOSE) && input != "")
-		desc = input
-		to_chat(M, "You have successfully changed \the [name]'s description.")
-		return
-	else
-		return

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -99,6 +99,41 @@
 	else
 		. = ..()
 
+/obj/item/weapon/pen/afterattack(obj/O, mob/living/user, proximity)
+	//Changing Name/Description of items. Only works if they have the 'unique_rename' var set
+	if(isobj(O) && proximity)
+		if(O.unique_rename)
+			var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
+			if(!QDELETED(O) && user.canUseTopic(O, be_close = TRUE))
+
+				if(penchoice == "Rename")
+					var/input = stripped_input(user,"What do you want to name \the [O.name]?", ,"", MAX_NAME_LEN)
+					var/oldname = O.name
+					if(!QDELETED(O) && user.canUseTopic(O, be_close = TRUE))
+						if(oldname == input)
+							to_chat(user, "You changed \the [O.name] to... well... \the [O.name].")
+							return
+						else
+							O.name = input
+							to_chat(user, "\The [oldname] has been successfully been renamed to \the [input].")
+							return
+					else
+						to_chat(user, "You are too far away!")
+
+				if(penchoice == "Change description")
+					var/input = stripped_input(user,"Describe \the [O.name] here", ,"", 100)
+					if(!QDELETED(O) && user.canUseTopic(O, be_close = TRUE))
+						O.desc = input
+						to_chat(user, "You have successfully changed \the [O.name]'s description.")
+						return
+					else
+						to_chat(user, "You are too far away!")
+			else
+				to_chat(user, "You are too far away!")
+				return
+	else
+		return
+
 /*
  * Sleepypens
  */


### PR DESCRIPTION
Reason: Making the proc based on attackby for objects was a dumb oversight on my end and required every object that wanted to be renamed check inheritance, which could create problems.

This makes it SO much simpler by making it oriented on the pen. Thanks @AnturK for telling me to do it on afterattack.

Should fix any and all issues revolving renaming not being able to work.