### PR TITLE
Moves Metastation's Deepfryer

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -53809,6 +53809,7 @@
 	dir = 4
 	},
 /obj/item/stack/packageWrap,
+/obj/item/weapon/storage/box/donkpockets,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -55578,16 +55579,12 @@
 	},
 /area/hallway/primary/central)
 "bQA" = (
-/obj/structure/rack,
-/obj/item/weapon/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -129589,7 +129586,7 @@ bHb
 bMP
 bKg
 bLL
-ddD
+bNz
 bOT
 bQC
 bLK


### PR DESCRIPTION
The deepfryer in metastation's kitchen was moved to the place where a rack containing donkpockets previously was. Donkpockets were moved to the rack two tiles above it. Fixes #23806. 

Before:

![](https://i.gyazo.com/96847ffa87a6b1d2e29e8fd47849a1c5.png)

After:

![](https://i.gyazo.com/ef5837f1d09bd71459497a6ba08fc6eb.png)


:cl: BeeSting12
fix: Moved Metastation's deep fryer so that the chef can walk all the way around the table.
/:cl:

Why: Better freedom of movement through the kitchen.
