### PR TITLE
Does some more theorycrafting with gulag minerals

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -206,9 +206,9 @@
 
 /turf/closed/mineral/random/labormineral
 	mineralSpawnChanceList = list(
-		/turf/closed/mineral/uranium = 2, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 3, /turf/closed/mineral/titanium = 4,
-		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 80,
-		/turf/closed/mineral/gibtonite = 3)
+		/turf/closed/mineral/uranium = 3, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 8, /turf/closed/mineral/titanium = 8,
+		/turf/closed/mineral/silver = 20, /turf/closed/mineral/plasma = 30, /turf/closed/mineral/iron = 95,
+		/turf/closed/mineral/gibtonite = 2)
 	icon_state = "rock_labor"
 
 
@@ -219,9 +219,9 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	defer_change = 1
 	mineralSpawnChanceList = list(
-		/turf/closed/mineral/uranium/volcanic = 2, /turf/closed/mineral/diamond/volcanic = 1, /turf/closed/mineral/gold/volcanic = 3, /turf/closed/mineral/titanium/volcanic = 4,
-		/turf/closed/mineral/silver/volcanic = 6, /turf/closed/mineral/plasma/volcanic = 15, /turf/closed/mineral/iron/volcanic = 80,
-		/turf/closed/mineral/gibtonite/volcanic = 3)
+		/turf/closed/mineral/uranium/volcanic = 3, /turf/closed/mineral/diamond/volcanic = 1, /turf/closed/mineral/gold/volcanic = 8, /turf/closed/mineral/titanium/volcanic = 8,
+		/turf/closed/mineral/silver/volcanic = 20, /turf/closed/mineral/plasma/volcanic = 30, /turf/closed/mineral/bscrystal/volcanic = 1, /turf/closed/mineral/gibtonite/volcanic = 2,
+		/turf/closed/mineral/iron/volcanic = 95)
 
 
 


### PR DESCRIPTION
:cl: Cobby
tweak: The gulag mineral ratio has been tweaked so there are PLENTY of iron ore, nice bits of silver/plasma, with the negative of having less really high valued ores. If you need minerals, it may be a good time to ask the warden now!
/:cl:

https://tgstation13.org/phpBB/viewtopic.php?f=10&t=10122&p=268704#p268704

I need people to go to jail to see if this is a bit more fair to people who are gulagged 😉 . You still have to get the points, it's just that iron is in abundance along with silver and plasma [aka making it viable for, you know, being used to get minerals].

Official Reasoning: It makes gulag [for the prisoner] less of a pain while still requiring the individual to work [since most of the time the ore will be iron]. Also makes gulag a more reliable source of minerals, make sure to check brig!
