### PR TITLE
Fixes a potential runtime with iv drips, also adds mouse_drag_pointer for it

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/iv_drip.dmi'
 	icon_state = "iv_drip"
 	anchored = 0
+	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	var/mob/living/carbon/attached = null
 	var/mode = 1 // 1 is injecting, 0 is taking blood.
 	var/obj/item/weapon/reagent_containers/beaker = null
@@ -55,7 +56,7 @@
 			add_overlay(filling)
 
 /obj/machinery/iv_drip/MouseDrop(mob/living/target)
-	if(!ishuman(usr) || !usr.canUseTopic(src,BE_CLOSE))
+	if(!ishuman(usr) || !usr.canUseTopic(src,BE_CLOSE) || !isliving(target))
 		return
 
 	if(attached)


### PR DESCRIPTION
Runtimes like this: 
`[23:21:40] Runtime in iv_drip.dm, line 67: undefined proc or verb /obj/item/weapon/weldingtool/has dna(). `