### PR TITLE
Adds an id card to the free golem ship vendor

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -209,6 +209,7 @@
 	..()
 	desc += "\nIt seems a few selections have been added."
 	prize_list += list(
+		new /datum/data/mining_equipment("Extra Id",       			/obj/item/weapon/card/id/mining, 				                   	250),
 		new /datum/data/mining_equipment("Science Goggles",       	/obj/item/clothing/glasses/science, 				                   	250),
 		new /datum/data/mining_equipment("Monkey Cube",				/obj/item/weapon/reagent_containers/food/snacks/monkeycube,        		300),
 		new /datum/data/mining_equipment("Toolbelt",				/obj/item/weapon/storage/belt/utility,	    							350),


### PR DESCRIPTION
:cl:
add: Free golems can now buy new ids for 250 points.
/:cl:

So you can keep a spare or give new golems one.
