### PR TITLE
Fixes a runtime with building combat mechs

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -5,8 +5,8 @@
 
 /obj/mecha/combat/CheckParts(atom/holder)
 	..()
-	var/obj/item/weapon/stock_parts/capacitor/C = locate() in holder
-	var/obj/item/weapon/stock_parts/scanning_module/SM = locate() in holder
+	var/obj/item/weapon/stock_parts/capacitor/C = locate() in holder.contents
+	var/obj/item/weapon/stock_parts/scanning_module/SM = locate() in holder.contents
 	step_energy_drain = 20 - (5 * SM.rating) //10 is normal, so on lowest part its worse, on second its ok and on higher its real good up to 0 on best
 	armor["energy"] += (C.rating * 10) //Each level of capacitor protects the mech against emp by 10%
 	qdel(C)

--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -3,10 +3,10 @@
 	internal_damage_threshold = 50
 	armor = list(melee = 30, bullet = 30, laser = 15, energy = 20, bomb = 20, bio = 0, rad = 0, fire = 100, acid = 100)
 
-/obj/mecha/combat/CheckParts(atom/holder)
+/obj/mecha/combat/CheckParts(list/parts_list)
 	..()
-	var/obj/item/weapon/stock_parts/capacitor/C = locate() in holder.contents
-	var/obj/item/weapon/stock_parts/scanning_module/SM = locate() in holder.contents
+	var/obj/item/weapon/stock_parts/capacitor/C = locate() in contents
+	var/obj/item/weapon/stock_parts/scanning_module/SM = locate() in contents
 	step_energy_drain = 20 - (5 * SM.rating) //10 is normal, so on lowest part its worse, on second its ok and on higher its real good up to 0 on best
 	armor["energy"] += (C.rating * 10) //Each level of capacitor protects the mech against emp by 10%
 	qdel(C)

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -562,7 +562,7 @@
 
 /datum/construction/reversible/mecha/gygax/spawn_result()
 	var/obj/mecha/combat/gygax/M = new result(get_turf(holder))
-	M.CheckParts(holder)
+	M.CheckParts(holder.contents)
 	qdel(holder)
 	feedback_inc("mecha_gygax_created",1)
 	return
@@ -1147,7 +1147,7 @@
 
 /datum/construction/reversible/mecha/durand/spawn_result()
 	var/obj/mecha/combat/gygax/M = new result(get_turf(holder))
-	M.CheckParts(holder)
+	M.CheckParts(holder.contents)
 	qdel(holder)
 	feedback_inc("mecha_durand_created",1)
 	return
@@ -1479,7 +1479,7 @@
 
 /datum/construction/reversible/mecha/phazon/spawn_result()
 	var/obj/mecha/combat/gygax/M = new result(get_turf(holder))
-	M.CheckParts(holder)
+	M.CheckParts(holder.contents)
 	qdel(holder)
 	feedback_inc("mecha_phazon_created",1)
 	return


### PR DESCRIPTION
CheckParts for mechs was trying to use an atom, when the parent, and all other versions, use a list