### PR TITLE
Debug admin verb: Pump Random Event

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -153,7 +153,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/jump_to_ruin,
 	/client/proc/clear_dynamic_transit,
 	/client/proc/toggle_medal_disable,
-	/client/proc/view_runtimes
+	/client/proc/view_runtimes,
+	/client/proc/pump_random_event
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -776,7 +776,7 @@ var/list/TYPES_SHORTCUTS = list(
 /client/proc/pump_random_event()
 	set category = "Debug"
 	set name = "Pump Random Event"
-	set desc = "Scheudules the event subsystem to fire a new random event immediately."
+	set desc = "Schedules the event subsystem to fire a new random event immediately. Some events may fire without notification."
 	if(!holder)
 		return
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -772,3 +772,16 @@ var/list/TYPES_SHORTCUTS = list(
 		return
 
 	error_cache.show_to(src)
+
+/client/proc/pump_random_event()
+	set category = "Debug"
+	set name = "Pump Random Event"
+	set desc = "Scheudules the event subsystem to fire a new random event immediately."
+	if(!holder)
+		return
+
+	SSevent.scheduled = world.time
+
+	message_admins("<span class='adminnotice'>[key_name_admin(src)] pumped a random event.</span>")
+	feedback_add_details("admin_verb","PRE")
+	log_admin("[key_name(src)] pumped a random event.")


### PR DESCRIPTION
Forces the event subsystem to make a new random event when it next
fires. (Most of the time this will be space dust.)

Used for testing the random event systems.