### PR TITLE
Tasteful Botany Nerf

### DIFF
--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -158,27 +158,27 @@
 						if(gene.value > max_potency)
 							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_potency]</span> potency. "
 							dat += "Target gene will be degraded to <span class='highlight'>[max_potency]</span> potency on extraction."
-					if(istype(target, /datum/plant_gene/core/lifespan))
+					else if(istype(target, /datum/plant_gene/core/lifespan))
 						if(gene.value > max_endurance)
 							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_endurance]</span> lifespan. "
 							dat += "Target gene will be degraded to <span class='highlight'>[max_endurance]</span> Lifespan on extraction."
-					if(istype(target, /datum/plant_gene/core/endurance))
+					else if(istype(target, /datum/plant_gene/core/endurance))
 						if(gene.value > max_endurance)
 							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_endurance]</span> endurance. "
 							dat += "Target gene will be degraded to <span class='highlight'>[max_endurance]</span> endurance on extraction."
-					if(istype(target, /datum/plant_gene/core/yield))
+					else if(istype(target, /datum/plant_gene/core/yield))
 						if(gene.value > max_yield)
 							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_yield]</span> yield. "
 							dat += "Target gene will be degraded to <span class='highlight'>[max_yield]</span> yield on extraction."
-					if(istype(target, /datum/plant_gene/core/production))
+					else if(istype(target, /datum/plant_gene/core/production))
 						if(gene.value < min_production)
 							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[min_production]</span> production. "
 							dat += "Target gene will be degraded to <span class='highlight'>[min_production]</span> production on extraction."
-					if(istype(target, /datum/plant_gene/core/weed_rate))
+					else if(istype(target, /datum/plant_gene/core/weed_rate))
 						if(gene.value > max_wrate)
 							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_wrate]</span> weed rate. "
 							dat += "Target gene will be degraded to <span class='highlight'>[max_wrate]</span> weed rate on extraction."
-					if(istype(target, /datum/plant_gene/core/weed_chance))
+					else if(istype(target, /datum/plant_gene/core/weed_chance))
 						if(gene.value > max_wchance)
 							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_wchance]</span> weed chance. "
 							dat += "Target gene will be degraded to <span class='highlight'>[max_wchance]</span> weed chance on extraction."
@@ -341,17 +341,17 @@
 							var/datum/plant_gene/core/gene = G
 							if(istype(G, /datum/plant_gene/core/potency))
 								gene.value = min(gene.value, max_potency)
-							if(istype(G, /datum/plant_gene/core/lifespan))
+							else if(istype(G, /datum/plant_gene/core/lifespan))
 								gene.value = min(gene.value, max_endurance) //INTENDED
-							if(istype(G, /datum/plant_gene/core/endurance))
+							else if(istype(G, /datum/plant_gene/core/endurance))
 								gene.value = min(gene.value, max_endurance)
-							if(istype(G, /datum/plant_gene/core/production))
+							else if(istype(G, /datum/plant_gene/core/production))
 								gene.value = max(gene.value, min_production)
-							if(istype(G, /datum/plant_gene/core/yield))
+							else if(istype(G, /datum/plant_gene/core/yield))
 								gene.value = min(gene.value, max_yield)
-							if(istype(G, /datum/plant_gene/core/weed_rate))
+							else if(istype(G, /datum/plant_gene/core/weed_rate))
 								gene.value = min(gene.value, max_wrate)
-							if(istype(G, /datum/plant_gene/core/weed_chance))
+							else if(istype(G, /datum/plant_gene/core/weed_chance))
 								gene.value = min(gene.value, max_wchance)
 						disk.update_name()
 						qdel(seed)
@@ -450,7 +450,7 @@
 	materials = list(MAT_METAL=30, MAT_GLASS=10)
 	var/datum/plant_gene/gene
 	var/read_only = 0 //Well, it's still a floppy disk
-	unique_rename = 1 // >> writing unique renaming code for items when we have a perfectly good system, FOR SHAME
+	unique_rename = 1
 
 /obj/item/weapon/disk/plantgene/New()
 	..()
@@ -460,7 +460,7 @@
 
 /obj/item/weapon/disk/plantgene/proc/update_name()
 	if(gene)
-		name = "[gene.get_name()]"
+		name = "[gene.get_name()] (Plant Data Disk)"
 	else
 		name = "plant data disk"
 

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -55,6 +55,15 @@
 		var/wratemod = ML.rating*2.5
 		max_wrate = Floor(wratemod,1) // 2,5,7,10	Clamps at 10
 		max_wchance = ML.rating*16+3 // 19,35,51,67 	Clamps at 67
+	for(var/obj/item/weapon/circuitboard/machine/plantgenes/vaultcheck in component_parts)
+		if(istype(vaultcheck, /obj/item/weapon/circuitboard/machine/plantgenes/vault)) // DUMB BOTANY TUTS
+			max_potency = 100 // See 36 for how these work
+			max_yield = 10
+			min_production = 1
+			max_endurance = 100
+			max_wchance = 67
+			max_wrate = 10
+
 
 /obj/machinery/plantgenes/update_icon()
 	..()

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -15,11 +15,12 @@
 
 	var/datum/plant_gene/target
 	var/operation = ""
-	var/rating = 0
-	var/max_extract_pot = 50
-	// The cap on potency gene extraction.
-	// This number is for T1, each upgraded part adds 5% for a tech level above T1.
-	// At T4, it reaches 95%.
+	var/max_potency = 50 // See 36 for how these work
+	var/max_yield = 2
+	var/min_production = 12
+	var/max_endurance = 10 // IMPT: ALSO AFFECTS LIFESPAN
+	var/max_wchance = 0
+	var/max_wrate = 0
 
 /obj/machinery/plantgenes/New()
 	..()
@@ -36,15 +37,24 @@
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/weapon/stock_parts/scanning_module = 1)
 
-/obj/machinery/plantgenes/RefreshParts()
-	rating = 0
-	for(var/I in component_parts)
-		if(istype(I, /obj/item/weapon/stock_parts))
-			var/obj/item/weapon/stock_parts/S = I
-			rating += S.rating-1
-		else if(istype(I, /obj/item/weapon/circuitboard/machine/plantgenes/vault))
-			rating += 5 // Having original alien board is +25%
-	max_extract_pot = initial(max_extract_pot) + rating*5
+/obj/machinery/plantgenes/RefreshParts() // Comments represent the max you can set per tier, respectively. seeds.dm [219] clamps these for us but we don't want to mislead the viewer.
+	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
+		max_potency = initial(max_potency) + (M.rating**3) // 53,59,77,100 	 Clamps at 100
+
+		max_yield = initial(max_yield) + (M.rating*2) // 4,6,8,10 	Clamps at 10
+
+	for(var/obj/item/weapon/stock_parts/scanning_module/SM in component_parts)
+		if(SM.rating > 3) //If you create t5 parts I'm a step ahead mwahahaha!
+			min_production = 1
+		else
+			min_production = 12 - (SM.rating * 3) //9,6,3,1. Requires if to avoid going below clamp [1]
+
+		max_endurance = initial(max_endurance) + (SM.rating * 25) // 35,60,85,100	Clamps at 10min 100max
+
+	for(var/obj/item/weapon/stock_parts/micro_laser/ML in component_parts)
+		var/wratemod = ML.rating*2.5
+		max_wrate = Floor(wratemod,1) // 2,5,7,10	Clamps at 10
+		max_wchance = ML.rating*16+3 // 19,35,51,67 	Clamps at 67
 
 /obj/machinery/plantgenes/update_icon()
 	..()
@@ -130,11 +140,37 @@
 			if("extract")
 				dat += "<span class='highlight'>[target.get_name()]</span> gene from \the <span class='highlight'>[seed]</span>?<br>"
 				dat += "<span class='bad'>The sample will be destroyed in process!</span>"
-				if(istype(target, /datum/plant_gene/core/potency))
+				if(istype(target, /datum/plant_gene/core))
 					var/datum/plant_gene/core/gene = target
-					if(gene.value > max_extract_pot)
-						dat += "<br><br>This device's extraction capabilities are currently limited to [max_extract_pot] potency. "
-						dat += "Target gene will be degraded to [max_extract_pot] potency on extraction."
+					if(istype(target, /datum/plant_gene/core/potency))
+						if(gene.value > max_potency)
+							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_potency]</span> potency. "
+							dat += "Target gene will be degraded to <span class='highlight'>[max_potency]</span> potency on extraction."
+					if(istype(target, /datum/plant_gene/core/lifespan))
+						if(gene.value > max_endurance)
+							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_endurance]</span> lifespan. "
+							dat += "Target gene will be degraded to <span class='highlight'>[max_endurance]</span> Lifespan on extraction."
+					if(istype(target, /datum/plant_gene/core/endurance))
+						if(gene.value > max_endurance)
+							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_endurance]</span> endurance. "
+							dat += "Target gene will be degraded to <span class='highlight'>[max_endurance]</span> endurance on extraction."
+					if(istype(target, /datum/plant_gene/core/yield))
+						if(gene.value > max_yield)
+							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_yield]</span> yield. "
+							dat += "Target gene will be degraded to <span class='highlight'>[max_yield]</span> yield on extraction."
+					if(istype(target, /datum/plant_gene/core/production))
+						if(gene.value < min_production)
+							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[min_production]</span> production. "
+							dat += "Target gene will be degraded to <span class='highlight'>[min_production]</span> production on extraction."
+					if(istype(target, /datum/plant_gene/core/weed_rate))
+						if(gene.value > max_wrate)
+							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_wrate]</span> weed rate. "
+							dat += "Target gene will be degraded to <span class='highlight'>[max_wrate]</span> weed rate on extraction."
+					if(istype(target, /datum/plant_gene/core/weed_chance))
+						if(gene.value > max_wchance)
+							dat += "<br><br>This device's extraction capabilities are currently limited to <span class='highlight'>[max_wchance]</span> weed chance. "
+							dat += "Target gene will be degraded to <span class='highlight'>[max_wchance]</span> weed chance on extraction."
+
 			if("replace")
 				dat += "<span class='highlight'>[target.get_name()]</span> gene with <span class='highlight'>[disk.gene.get_name()]</span>?<br>"
 			if("insert")
@@ -289,9 +325,22 @@
 				if("extract")
 					if(disk && !disk.read_only)
 						disk.gene = G
-						if(istype(G, /datum/plant_gene/core/potency))
+						if(istype(G, /datum/plant_gene/core))
 							var/datum/plant_gene/core/gene = G
-							gene.value = min(gene.value, max_extract_pot)
+							if(istype(G, /datum/plant_gene/core/potency))
+								gene.value = min(gene.value, max_potency)
+							if(istype(G, /datum/plant_gene/core/lifespan))
+								gene.value = min(gene.value, max_endurance) //INTENDED
+							if(istype(G, /datum/plant_gene/core/endurance))
+								gene.value = min(gene.value, max_endurance)
+							if(istype(G, /datum/plant_gene/core/production))
+								gene.value = max(gene.value, min_production)
+							if(istype(G, /datum/plant_gene/core/yield))
+								gene.value = min(gene.value, max_yield)
+							if(istype(G, /datum/plant_gene/core/weed_rate))
+								gene.value = min(gene.value, max_wrate)
+							if(istype(G, /datum/plant_gene/core/weed_chance))
+								gene.value = min(gene.value, max_wchance)
 						disk.update_name()
 						qdel(seed)
 						seed = null
@@ -309,6 +358,7 @@
 						if(istype(disk.gene, /datum/plant_gene/reagent))
 							seed.reagents_from_genes()
 						repaint_seed()
+
 
 			update_genes()
 			operation = ""
@@ -347,6 +397,7 @@
 
 		for(var/datum/plant_gene/reagent/G in seed.genes)
 			reagent_genes += G
+
 		for(var/datum/plant_gene/trait/G in seed.genes)
 			trait_genes += G
 
@@ -387,6 +438,7 @@
 	materials = list(MAT_METAL=30, MAT_GLASS=10)
 	var/datum/plant_gene/gene
 	var/read_only = 0 //Well, it's still a floppy disk
+	unique_rename = 1 // >> writing unique renaming code for items when we have a perfectly good system, FOR SHAME
 
 /obj/item/weapon/disk/plantgene/New()
 	..()
@@ -394,22 +446,9 @@
 	src.pixel_x = rand(-5, 5)
 	src.pixel_y = rand(-5, 5)
 
-/obj/item/weapon/disk/plantgene/attackby(obj/item/weapon/W, mob/user, params)
-	..()
-	if(istype(W, /obj/item/weapon/pen))
-		var/t = stripped_input(user, "What would you like the label to be?", name, null)
-		if(user.get_active_held_item() != W)
-			return
-		if(!in_range(src, user) && loc != user)
-			return
-		if(t)
-			name = "plant data disk - '[t]'"
-		else
-			name = "plant data disk"
-
 /obj/item/weapon/disk/plantgene/proc/update_name()
 	if(gene)
-		name = "plant data disk - '[gene.get_name()]'"
+		name = "[gene.get_name()]"
 	else
 		name = "plant data disk"
 

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -15,7 +15,7 @@
 
 	var/datum/plant_gene/target
 	var/operation = ""
-	var/max_potency = 50 // See 36 for how these work
+	var/max_potency = 50 // See RefreshParts() for how these work
 	var/max_yield = 2
 	var/min_production = 12
 	var/max_endurance = 10 // IMPT: ALSO AFFECTS LIFESPAN
@@ -39,7 +39,10 @@
 
 /obj/machinery/plantgenes/RefreshParts() // Comments represent the max you can set per tier, respectively. seeds.dm [219] clamps these for us but we don't want to mislead the viewer.
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
-		max_potency = initial(max_potency) + (M.rating**3) // 53,59,77,100 	 Clamps at 100
+		if(M.rating > 3)
+			max_potency = 95
+		else
+			max_potency = initial(max_potency) + (M.rating**3) // 53,59,77,95 	 Clamps at 100
 
 		max_yield = initial(max_yield) + (M.rating*2) // 4,6,8,10 	Clamps at 10
 

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -60,7 +60,7 @@
 		max_wchance = ML.rating*16+3 // 19,35,51,67 	Clamps at 67
 	for(var/obj/item/weapon/circuitboard/machine/plantgenes/vaultcheck in component_parts)
 		if(istype(vaultcheck, /obj/item/weapon/circuitboard/machine/plantgenes/vault)) // DUMB BOTANY TUTS
-			max_potency = 100 // See 36 for how these work
+			max_potency = 100
 			max_yield = 10
 			min_production = 1
 			max_endurance = 100

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -1,4 +1,6 @@
-/*Power cells are in code\modules\power\cell.dm*/
+/*Power cells are in code\modules\power\cell.dm
+
+If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fit with the clamp to not confuse the user or cause possible exploits.*/
 /obj/item/weapon/storage/part_replacer
 	name = "rapid part exchange device"
 	desc = "Special mechanical module made to store, sort, and apply standard machine parts."

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -126,3 +126,4 @@ PJB3005 = Game Master
 Sweaterkittens = Game Master
 Feemjmeem = Game Master
 JStheguy = Game Master
+excessiveuseofcobby = Game Master


### PR DESCRIPTION
:cl:Cobby
experiment: All core traits [Hydroponics] scale with the parts in the gene machine. Time to beg Duke's Guide Read.... I mean RND!
tweak: Data disks with genes on them will have just the name of the gene instead of the prefix "plant data disk".
tweak: If you were unaware, you can rename these disks with a pen. Now, you can also change the description if you felt inclined to.
/:cl:

Gates giving the best stats to all of your plants the ever-so-elusive RND.

- Previous: Potency scaled with parts in the machine, Current: Potency, Lifespan, Endurance, Weed Chance, Weed Spread Rate, Production scale with parts in the machine
- Manipulator: Potency & Yield, Scanner: Production,Lifespan, and Endurance, Laser: Anything with 'weed' in the name

SLIGHT TWEAKS:

- Adds comment to fix clamps should anyone ever create T5 parts
- Removes "Plant data disk" from the name once the gene has been edited. Will now just have the gene as the name.
- Replaces whatever lame renaming system with Kor's unique_rename I have hijacked
- Makes me admin mwahahahaha I'M ROGUE
