### PR TITLE
Some Anomaly Changes

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -271,7 +271,18 @@
 
 	var/new_colour = pick("red", "orange")
 	var/mob/living/simple_animal/slime/S = new(T, new_colour)
-	S.rabid = 1
+	S.rabid = TRUE
+	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
+	S.Evolve()
+
+	spawn(0)
+		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [S.name]?", null, null, 0, 300, S, null)
+		var/mob/dead/observer/chosen = null
+
+		if(candidates.len)
+			chosen = pick(candidates)
+			message_admins("[key_name_admin(chosen)] was spawned as [S.name]")
+			S.key = chosen.key
 
 /////////////////////
 

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -265,9 +265,9 @@
 		T.atmos_spawn_air("o2=5;plasma=5;TEMP=1000")
 
 /obj/effect/anomaly/pyro/detonate()
-	INVOKE_ASYNC(src, .proc/makeslime)
+	INVOKE_ASYNC(src, .proc/makepyroslime)
 
-/obj/effect/anomaly/pyro/proc/makeslime()
+/obj/effect/anomaly/pyro/proc/makepyroslime()
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
 		T.atmos_spawn_air("o2=500;plasma=500;TEMP=1000") //Make it hot and burny for the new slime
@@ -276,14 +276,7 @@
 	S.rabid = TRUE
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
 	S.Evolve()
-
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [S.name]?", null, null, 0, 300, S, null)
-	var/mob/dead/observer/chosen = null
-
-	if(candidates.len)
-		chosen = pick(candidates)
-		message_admins("[key_name_admin(chosen)] was spawned as [S.name]")
-		S.key = chosen.key
+	offer_control(S)
 
 /////////////////////
 

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -265,24 +265,25 @@
 		T.atmos_spawn_air("o2=5;plasma=5;TEMP=1000")
 
 /obj/effect/anomaly/pyro/detonate()
+	INVOKE_ASYNC(src, .proc/makeslime)
+
+/obj/effect/anomaly/pyro/proc/makeslime()
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
 		T.atmos_spawn_air("o2=500;plasma=500;TEMP=1000") //Make it hot and burny for the new slime
-
 	var/new_colour = pick("red", "orange")
 	var/mob/living/simple_animal/slime/S = new(T, new_colour)
 	S.rabid = TRUE
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
 	S.Evolve()
 
-	spawn(0)
-		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [S.name]?", null, null, 0, 300, S, null)
-		var/mob/dead/observer/chosen = null
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [S.name]?", null, null, 0, 300, S, null)
+	var/mob/dead/observer/chosen = null
 
-		if(candidates.len)
-			chosen = pick(candidates)
-			message_admins("[key_name_admin(chosen)] was spawned as [S.name]")
-			S.key = chosen.key
+	if(candidates.len)
+		chosen = pick(candidates)
+		message_admins("[key_name_admin(chosen)] was spawned as [S.name]")
+		S.key = chosen.key
 
 /////////////////////
 

--- a/code/modules/events/anomaly_flux.dm
+++ b/code/modules/events/anomaly_flux.dm
@@ -7,8 +7,8 @@
 	weight = 20
 
 /datum/round_event/anomaly/anomaly_flux
-	startWhen = 3
-	announceWhen = 20
+	startWhen = 10
+	announceWhen = 3
 
 /datum/round_event/anomaly/anomaly_flux/announce()
 	priority_announce("Localized hyper-energetic flux wave detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")

--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -5,8 +5,8 @@
 	weight = 20
 
 /datum/round_event/anomaly/anomaly_pyro
-	startWhen = 10
-	announceWhen = 3
+	startWhen = 3
+	announceWhen = 10
 
 /datum/round_event/anomaly/anomaly_pyro/announce()
 	priority_announce("Pyroclastic anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")


### PR DESCRIPTION
:cl: Cheridan
tweak: The slime created by a pyroclastic anomaly detonating is now adult and player-controlled! Reminder that if you see an anomaly alert, you should grab an analyzer and head to the announced location to scan it, and then signal the given frequency on a signaller!
/:cl:

Pyroclastic anomalies make player-controlled adult slimes. I'd offer players control of these sometimes and it'd usually be pretty fun.
Tweaks announcement/spawn of anomalies some. Flux anomalies are super dangerous and are now announced ahead of time, and pyroclastic anomalies are somewhat less devastating so they're given some time before announcing, like gravitational ones.