### PR TITLE
Refactors xeno eggs, and makes glowing resin glow

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_xeno_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_xeno_nest.dmm
@@ -51,12 +51,7 @@
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
 	},
-/obj/structure/alien/weeds{
-	desc = "A large mottled egg.";
-	obj_integrity = 100;
-	icon_state = "egg_hatched";
-	name = "egg"
-	},
+/obj/structure/alien/egg/burst,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaycontent/a5{
 	always_unpowered = 1;
@@ -139,12 +134,7 @@
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
 	},
-/obj/structure/alien/weeds{
-	desc = "A large mottled egg.";
-	obj_integrity = 100;
-	icon_state = "egg_hatched";
-	name = "egg"
-	},
+/obj/structure/alien/egg/burst,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaycontent/a5{
 	always_unpowered = 1;
@@ -334,12 +324,7 @@
 	})
 "x" = (
 /obj/structure/alien/weeds,
-/obj/structure/alien/weeds{
-	desc = "A large mottled egg.";
-	obj_integrity = 100;
-	icon_state = "egg_hatched";
-	name = "egg"
-	},
+/obj/structure/alien/egg/burst,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaycontent/a5{
 	always_unpowered = 1;
@@ -405,12 +390,7 @@
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
 	},
-/obj/structure/alien/weeds{
-	desc = "A large mottled egg.";
-	obj_integrity = 100;
-	icon_state = "egg_hatched";
-	name = "egg"
-	},
+/obj/structure/alien/egg/burst,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaycontent/a5{
@@ -424,12 +404,7 @@
 	})
 "C" = (
 /obj/structure/alien/weeds,
-/obj/structure/alien/weeds{
-	desc = "A large mottled egg.";
-	obj_integrity = 100;
-	icon_state = "egg_hatched";
-	name = "egg"
-	},
+/obj/structure/alien/egg/burst,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaycontent/a5{

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -127,15 +127,20 @@
 	var/last_expand = 0 //last world.time this weed expanded
 	var/growth_cooldown_low = 150
 	var/growth_cooldown_high = 200
-	var/static/list/blacklisted_turfs = typecacheof(list(
-	/turf/open/space,
-	/turf/open/chasm,
-	/turf/open/floor/plating/lava))
+	var/static/list/blacklisted_turfs
 
-/obj/structure/alien/weeds/New()
+/obj/structure/alien/weeds/Initialize()
 	pixel_x = -4
 	pixel_y = -4 //so the sprites line up right in the map editor
 	..()
+
+	if(!blacklisted_turfs)
+		blacklisted_turfs = typecacheof(list(
+			/turf/open/space,
+			/turf/open/chasm,
+			/turf/open/floor/plating/lava))
+
+
 	last_expand = world.time + rand(growth_cooldown_low, growth_cooldown_high)
 	if(icon == initial(icon))
 		switch(rand(1,3))
@@ -171,12 +176,14 @@
 	name = "glowing resin"
 	desc = "Blue bioluminescence shines from beneath the surface."
 	icon_state = "weednode"
-	light_range = 1
+	light_color = LIGHT_COLOR_BLUE
+	var/lon_range = 3
 	var/node_range = NODERANGE
 
-/obj/structure/alien/weeds/node/New()
+/obj/structure/alien/weeds/node/Initialize()
 	icon = 'icons/obj/smooth_structures/alien/weednode.dmi'
 	..()
+	set_light(lon_range)
 	var/obj/structure/alien/weeds/W = locate(/obj/structure/alien/weeds) in loc
 	if(W && W != src)
 		qdel(W)
@@ -200,10 +207,9 @@
  */
 
 //for the status var
-#define BURST 0
-#define BURSTING 1
-#define GROWING 2
-#define GROWN 3
+#define BURST "burst"
+#define GROWING "growing"
+#define GROWN "grown"
 #define MIN_GROWTH_TIME 900	//time it takes to grow a hugger
 #define MAX_GROWTH_TIME 1500
 
@@ -211,28 +217,43 @@
 	name = "egg"
 	desc = "A large mottled egg."
 	icon_state = "egg_growing"
-	density = 0
-	anchored = 1
+	density = FALSE
+	anchored = TRUE
 	obj_integrity = 100
 	max_integrity = 100
 	var/status = GROWING	//can be GROWING, GROWN or BURST; all mutually exclusive
 	layer = MOB_LAYER
+	var/obj/item/clothing/mask/facehugger/child
 
 
-/obj/structure/alien/egg/New()
-	new /obj/item/clothing/mask/facehugger(src)
+/obj/structure/alien/egg/Initialize(mapload)
 	..()
-	addtimer(CALLBACK(src, .proc/Grow), rand(MIN_GROWTH_TIME, MAX_GROWTH_TIME))
+	update_icon()
+	if(status == GROWING || status == GROWN)
+		child = new(src)
+	if(status == GROWING)
+		addtimer(CALLBACK(src, .proc/Grow), rand(MIN_GROWTH_TIME, MAX_GROWTH_TIME))
+	if(status == GROWN)
+		add_to_proximity_list(src, 1)
 
 /obj/structure/alien/egg/Destroy()
 	remove_from_proximity_list(src, 1)
-	return ..()
+	. = ..()
+
+/obj/structure/alien/egg/update_icon()
+	..()
+	if(status == GROWING)
+		icon_state = "[initial(icon_state)]_growing"
+	if(status == GROWN)
+		icon_state = initial(icon_state)
+	if(status == BURST)
+		icon_state = "[initial(icon_state)]_hatched"
 
 /obj/structure/alien/egg/attack_paw(mob/living/user)
-	return attack_hand(user)
+	. = attack_hand(user)
 
 /obj/structure/alien/egg/attack_alien(mob/living/carbon/alien/user)
-	return attack_hand(user)
+	. = attack_hand(user)
 
 /obj/structure/alien/egg/attack_hand(mob/living/user)
 	if(user.getorgan(/obj/item/organ/alien/plasmavessel))
@@ -247,39 +268,39 @@
 				return
 			if(GROWN)
 				to_chat(user, "<span class='notice'>You retrieve the child.</span>")
-				Burst(0)
+				Burst(kill=FALSE)
 				return
 	else
 		to_chat(user, "<span class='notice'>It feels slimy.</span>")
 		user.changeNext_move(CLICK_CD_MELEE)
 
 
-/obj/structure/alien/egg/proc/GetFacehugger()
-	return locate(/obj/item/clothing/mask/facehugger) in contents
-
 /obj/structure/alien/egg/proc/Grow()
-	icon_state = "egg"
 	status = GROWN
+	update_icon()
 	add_to_proximity_list(src, 1)
 
-/obj/structure/alien/egg/proc/Burst(kill = 1)	//drops and kills the hugger if any is remaining
+//drops and kills the hugger if any is remaining
+/obj/structure/alien/egg/proc/Burst(kill = TRUE)
 	if(status == GROWN || status == GROWING)
 		remove_from_proximity_list(src, 1)
-		icon_state = "egg_hatched"
+		status = BURST
+		update_icon()
 		flick("egg_opening", src)
-		status = BURSTING
-		spawn(15)
-			status = BURST
-			var/obj/item/clothing/mask/facehugger/child = GetFacehugger()
-			if(child)
-				child.loc = get_turf(src)
-				if(kill && istype(child))
-					child.Die()
-				else
-					for(var/mob/M in range(1,src))
-						if(CanHug(M))
-							child.Attach(M)
-							break
+		addtimer(CALLBACK(src, .proc/finish_bursting, kill), 15)
+
+/obj/structure/alien/egg/proc/finish_bursting(kill = TRUE)
+	if(child)
+		child.forceMove(get_turf(src))
+		// TECHNICALLY you could put non-facehuggers in the child var
+		if(istype(child))
+			if(kill)
+				child.Die()
+			else
+				for(var/mob/M in range(1,src))
+					if(CanHug(M))
+						child.Attach(M)
+						break
 
 /obj/structure/alien/egg/Moved(oldloc)
 	remove_from_proximity_list(oldloc, 1)
@@ -289,7 +310,7 @@
 
 /obj/structure/alien/egg/deconstruct()
 	if(!(flags & NODECONSTRUCT))
-		if(status != BURST && status != BURSTING)
+		if(status != BURST)
 			Burst()
 		else if(status == BURST)
 			qdel(src)	//Remove the egg after it has been hit after bursting.
@@ -310,7 +331,15 @@
 		if(C.stat == CONSCIOUS && C.getorgan(/obj/item/organ/body_egg/alien_embryo))
 			return
 
-		Burst(0)
+		Burst(kill=FALSE)
+
+/obj/structure/alien/egg/grown
+	status = GROWN
+	icon_state = "egg"
+
+/obj/structure/alien/egg/burst
+	status = BURST
+	icon_state = "egg_hatched"
 
 #undef BURST
 #undef BURSTING

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -222,6 +222,7 @@
 	anchored = TRUE
 	obj_integrity = 100
 	max_integrity = 100
+	integrity_failure = 5
 	var/status = GROWING	//can be GROWING, GROWN or BURST; all mutually exclusive
 	layer = MOB_LAYER
 	var/obj/item/clothing/mask/facehugger/child
@@ -236,6 +237,8 @@
 		addtimer(CALLBACK(src, .proc/Grow), rand(MIN_GROWTH_TIME, MAX_GROWTH_TIME))
 	if(status == GROWN)
 		add_to_proximity_list(src, 1)
+	if(status == BURST)
+		obj_integrity = integrity_failure
 
 /obj/structure/alien/egg/Destroy()
 	remove_from_proximity_list(src, 1)
@@ -310,14 +313,10 @@
 		add_to_proximity_list(src, 1)
 	return ..()
 
-/obj/structure/alien/egg/deconstruct()
+/obj/structure/alien/egg/obj_break(damage_flag)
 	if(!(flags & NODECONSTRUCT))
 		if(status != BURST)
-			Burst()
-		else if(status == BURST)
-			qdel(src)	//Remove the egg after it has been hit after bursting.
-	else
-		qdel(src)
+			Burst(kill=TRUE)
 
 /obj/structure/alien/egg/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > 500)

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -69,7 +69,6 @@
 /obj/structure/alien/resin/New(location)
 	..()
 	air_update_turf(1)
-	return
 
 /obj/structure/alien/resin/Move()
 	var/turf/T = loc
@@ -217,6 +216,7 @@
 /obj/structure/alien/egg
 	name = "egg"
 	desc = "A large mottled egg."
+	var/base_icon = "egg"
 	icon_state = "egg_growing"
 	density = FALSE
 	anchored = TRUE
@@ -243,12 +243,13 @@
 
 /obj/structure/alien/egg/update_icon()
 	..()
-	if(status == GROWING)
-		icon_state = "[initial(icon_state)]_growing"
-	if(status == GROWN)
-		icon_state = initial(icon_state)
-	if(status == BURST)
-		icon_state = "[initial(icon_state)]_hatched"
+	switch(status)
+		if(GROWING)
+			icon_state = "[base_icon]_growing"
+		if(GROWN)
+			icon_state = "[base_icon]"
+		if(BURST)
+			icon_state = "[base_icon]_hatched"
 
 /obj/structure/alien/egg/attack_paw(mob/living/user)
 	. = attack_hand(user)
@@ -343,7 +344,6 @@
 	icon_state = "egg_hatched"
 
 #undef BURST
-#undef BURSTING
 #undef GROWING
 #undef GROWN
 #undef MIN_GROWTH_TIME

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -177,7 +177,8 @@
 	desc = "Blue bioluminescence shines from beneath the surface."
 	icon_state = "weednode"
 	light_color = LIGHT_COLOR_BLUE
-	var/lon_range = 3
+	light_power = 0.5
+	var/lon_range = 4
 	var/node_range = NODERANGE
 
 /obj/structure/alien/weeds/node/Initialize()


### PR DESCRIPTION
:cl: coiax
add: Alien glowing resin now glows.
/:cl:

Christ, all I wanted was to make glowing resin glow blue, like it says
it's supposed to.

Instead, I stumble onto the horrors of alien egg code.
First fix the spawn, then fix the icon states, then fix var edited burst
eggs, then make fully grown eggs spawned, then fix some weird use of
locate, rather than a var, then make the typecache spawn on Initialize.

Should be no behaviour differences. Apart from the glowing resin.