### PR TITLE
Caches produce components more often, but each linked cache slows down cache generation

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -43,7 +43,9 @@ var/global/list/all_scripture = list() //a list containing scripture instances; 
 
 #define SLAB_SLOWDOWN_MAXIMUM 2700 //maximum slowdown from additional servants; defaults to 4 minutes 30 seconds
 
-#define CACHE_PRODUCTION_TIME 900 //how long(deciseconds) caches require to produce a component; defaults to 1 minute 30 seconds
+#define CACHE_PRODUCTION_TIME 600 //how long(deciseconds) caches require to produce a component; defaults to 1 minute
+
+#define ACTIVE_CACHE_SLOWDOWN 100 //how many additional deciseconds caches take to produce a component for each linked cache; defaults to 10 seconds
 
 #define LOWER_PROB_PER_COMPONENT 10 //how much each component in the cache reduces the weight of getting another of that component type
 

--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -45,7 +45,7 @@ var/global/list/all_scripture = list() //a list containing scripture instances; 
 
 #define CACHE_PRODUCTION_TIME 600 //how long(deciseconds) caches require to produce a component; defaults to 1 minute
 
-#define ACTIVE_CACHE_SLOWDOWN 150 //how many additional deciseconds caches take to produce a component for each linked cache; defaults to 15 seconds
+#define ACTIVE_CACHE_SLOWDOWN 100 //how many additional deciseconds caches take to produce a component for each linked cache; defaults to 10 seconds
 
 #define LOWER_PROB_PER_COMPONENT 10 //how much each component in the cache reduces the weight of getting another of that component type
 

--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -45,7 +45,7 @@ var/global/list/all_scripture = list() //a list containing scripture instances; 
 
 #define CACHE_PRODUCTION_TIME 600 //how long(deciseconds) caches require to produce a component; defaults to 1 minute
 
-#define ACTIVE_CACHE_SLOWDOWN 100 //how many additional deciseconds caches take to produce a component for each linked cache; defaults to 10 seconds
+#define ACTIVE_CACHE_SLOWDOWN 150 //how many additional deciseconds caches take to produce a component for each linked cache; defaults to 15 seconds
 
 #define LOWER_PROB_PER_COMPONENT 10 //how much each component in the cache reduces the weight of getting another of that component type
 

--- a/code/game/gamemodes/clock_cult/clock_structures/tinkerers_cache.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/tinkerers_cache.dm
@@ -13,6 +13,7 @@
 	light_color = "#C2852F"
 	var/wall_generation_cooldown
 	var/turf/closed/wall/clockwork/linkedwall //if we've got a linked wall and are producing
+	var/static/linked_caches = 0 //how many caches are linked to walls; affects how fast components are produced
 
 /obj/structure/destructible/clockwork/cache/New()
 	..()
@@ -26,6 +27,7 @@
 	update_slab_info()
 	STOP_PROCESSING(SSobj, src)
 	if(linkedwall)
+		linked_caches--
 		linkedwall.linkedcache = null
 		linkedwall = null
 	return ..()
@@ -33,18 +35,20 @@
 /obj/structure/destructible/clockwork/cache/process()
 	if(!anchored)
 		if(linkedwall)
+			linked_caches--
 			linkedwall.linkedcache = null
 			linkedwall = null
 		return
 	for(var/turf/closed/wall/clockwork/C in range(4, src))
 		if(!C.linkedcache && !linkedwall)
+			linked_caches++
 			C.linkedcache = src
 			linkedwall = C
-			wall_generation_cooldown = world.time + (CACHE_PRODUCTION_TIME * get_efficiency_mod(TRUE))
+			wall_generation_cooldown = world.time + get_production_time()
 			visible_message("<span class='warning'>[src] starts to whirr in the presence of [C]...</span>")
 			break
 	if(linkedwall && wall_generation_cooldown <= world.time)
-		wall_generation_cooldown = world.time + (CACHE_PRODUCTION_TIME * get_efficiency_mod(TRUE))
+		wall_generation_cooldown = world.time + get_production_time()
 		var/component_id = generate_cache_component(null, src)
 		playsound(linkedwall, 'sound/magic/clockwork/fellowship_armory.ogg', rand(15, 20), 1, -3, 1, 1)
 		visible_message("<span class='[get_component_span(component_id)]'>Something</span><span class='warning'> cl[pick("ank", "ink", "unk", "ang")]s around inside of [src]...</span>")
@@ -102,9 +106,12 @@
 	..()
 	if(is_servant_of_ratvar(user) || isobserver(user))
 		if(linkedwall)
-			to_chat(user, "<span class='brass'>It is linked to a Clockwork Wall and will generate a component every <b>[round((CACHE_PRODUCTION_TIME * 0.1) * get_efficiency_mod(TRUE), 0.1)]</b> seconds!</span>")
+			to_chat(user, "<span class='brass'>It is linked to a Clockwork Wall and will generate a component every <b>[round(get_production_time() * 0.1, 0.1)]</b> seconds!</span>")
 		else
 			to_chat(user, "<span class='alloy'>It is unlinked! Construct a Clockwork Wall nearby to generate components!</span>")
 		to_chat(user, "<b>Stored components:</b>")
 		for(var/i in clockwork_component_cache)
 			to_chat(user, "<span class='[get_component_span(i)]_small'><i>[get_component_name(i)][i != REPLICANT_ALLOY ? "s":""]:</i> <b>[clockwork_component_cache[i]]</b></span>")
+
+/obj/structure/destructible/clockwork/cache/proc/get_production_time()
+	return (CACHE_PRODUCTION_TIME + (ACTIVE_CACHE_SLOWDOWN * linked_caches)) * get_efficiency_mod(TRUE)


### PR DESCRIPTION
:cl: Joan
experiment: Caches produce components every 70 seconds, from every 90, but each other linked, component-producing cache slows down cache generation by 10 seconds.
/:cl:

I see too many cache farms.
This changes the base component production time to 70 seconds, from 90, with an additional 10 seconds for each other linked cache; this means it's at the current production time at 3 linked caches.