### PR TITLE
Adds 2% xeno egg spawners to all maps

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -530,7 +530,7 @@
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 32
-		},
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -557,14 +557,14 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 9;
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/mining_construction)
 "abj" = (
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1;
 	icon_state = "yellow";
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/mining_construction)
 "abk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -707,7 +707,7 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-		},
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -724,7 +724,7 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-		},
+	},
 /obj/machinery/door/airlock/external{
 	name = "External Solar Access";
 	req_access_txt = "10"
@@ -741,7 +741,7 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-		},
+	},
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -753,7 +753,7 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-		},
+	},
 /turf/open/space,
 /area/solar/auxstarboard)
 "abB" = (
@@ -911,7 +911,7 @@
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 0
-		},
+	},
 /turf/closed/wall/r_wall,
 /area/maintenance/auxsolarstarboard)
 "abM" = (
@@ -954,7 +954,7 @@
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 0
-		},
+	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
@@ -992,7 +992,7 @@
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK"
-		},
+	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry{
 	name = "Arrivals"
@@ -1305,7 +1305,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 9;
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/mining_construction)
 "acx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1316,7 +1316,7 @@
 	dir = 1;
 	icon_state = "yellow";
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/mining_construction)
 "acy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2277,7 +2277,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 10;
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/mining_construction)
 "aeB" = (
 /obj/structure/cable/white{
@@ -2557,7 +2557,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 5;
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/maintenance/starboard/fore_starboard_maintenance)
 "afc" = (
 /obj/structure/grille,
@@ -3721,7 +3721,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -3806,7 +3806,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -4743,7 +4743,7 @@
 	anchored = 1;
 	dir = 4;
 	icon_state = "reflector_box"
-		},
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -4776,7 +4776,7 @@
 	anchored = 1;
 	dir = 8;
 	icon_state = "reflector"
-		},
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -4976,7 +4976,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /turf/open/floor/plating,
 /area/bridge{
 	name = "Customs"
@@ -5058,7 +5058,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /turf/open/floor/plating,
 /area/security/checkpoint2)
 "akA" = (
@@ -5197,7 +5197,7 @@
 	anchored = 1;
 	dir = 1;
 	icon_state = "reflector_double"
-		},
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -5633,7 +5633,7 @@
 	anchored = 1;
 	dir = 4;
 	icon_state = "reflector_double"
-		},
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -6334,7 +6334,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 6;
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/maintenance/fpmaint2/fore_port_maintenance)
 "ano" = (
 /obj/structure/table/wood,
@@ -6740,7 +6740,7 @@
 	anchored = 1;
 	dir = 1;
 	icon_state = "reflector"
-		},
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -13478,7 +13478,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/cable/white,
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -14145,7 +14145,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -14792,7 +14792,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/light_switch{
 	pixel_x = 38
 	},
@@ -15075,7 +15075,7 @@
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 32
-		},
+	},
 /obj/machinery/camera{
 	c_tag = "Solar - Fore Port";
 	name = "solar camera"
@@ -15835,7 +15835,7 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-		},
+	},
 /obj/machinery/door/airlock/external{
 	name = "External Solar Access";
 	req_access_txt = "24";
@@ -15853,7 +15853,7 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-		},
+	},
 /obj/structure/fans/tiny,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -15870,7 +15870,7 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-		},
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16051,7 +16051,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
 	pixel_y = 24
@@ -16863,7 +16863,7 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-		},
+	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator{
@@ -18077,7 +18077,7 @@
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 32
-		},
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -19047,7 +19047,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -19231,7 +19231,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
@@ -20383,7 +20383,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -20426,7 +20426,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -21019,7 +21019,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Cargo Bay APC";
@@ -21755,7 +21755,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = -26
@@ -24154,7 +24154,7 @@
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 32
-		},
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -24561,7 +24561,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 4
@@ -25810,7 +25810,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
@@ -26354,7 +26354,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/chem_master/condimaster{
 	name = "BrewMaster 3000"
 	},
@@ -26692,7 +26692,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/cable/white,
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -27506,7 +27506,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -28875,7 +28875,7 @@
 	name = "WARNING: BLAST DOORS";
 	pixel_x = 0;
 	pixel_y = 0
-		},
+	},
 /turf/open/floor/plating,
 /area/security/brig)
 "bdl" = (
@@ -29531,7 +29531,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -30490,7 +30490,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
@@ -32212,7 +32212,7 @@
 	dir = 4;
 	icon_state = "direction_supply";
 	name = "supply department"
-		},
+	},
 /obj/structure/sign/directions/medical{
 	pixel_y = -8
 	},
@@ -39242,7 +39242,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/sign/electricshock{
@@ -39309,7 +39309,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -39675,7 +39675,7 @@
 	name = "WARNING: BLAST DOORS";
 	pixel_x = 0;
 	pixel_y = 32
-		},
+	},
 /turf/open/floor/plasteel/darkblue/side{
 	icon_state = "darkblue";
 	dir = 1
@@ -40149,7 +40149,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -40169,7 +40169,7 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-		},
+	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/gravity_generator)
 "byB" = (
@@ -41900,7 +41900,7 @@
 	icon_state = "pipe-j1s";
 	name = "HoP Junction";
 	sortType = 15
-		},
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -42469,7 +42469,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -42560,7 +42560,7 @@
 	dir = 1;
 	icon_state = "yellow";
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/engine/break_room)
 "bCn" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -42571,7 +42571,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/light_switch{
 	pixel_y = 26
 	},
@@ -43311,7 +43311,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/light_switch{
 	pixel_y = -26
 	},
@@ -43357,7 +43357,7 @@
 	desc = "A handy sign praising the engineering department.";
 	icon_state = "safety";
 	name = "engineering plaque"
-		},
+	},
 /turf/closed/wall,
 /area/engine/break_room)
 "bDO" = (
@@ -43716,7 +43716,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "bEx" = (
@@ -43953,7 +43953,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 5;
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/maintenance/starboard)
 "bEX" = (
 /obj/structure/closet/secure_closet/detective,
@@ -44713,7 +44713,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/machinery/power/apc{
 	cell_type = 10000;
 	dir = 1;
@@ -45330,7 +45330,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/button/door{
 	id = "transitlock";
 	name = "Transit Tube Lockdown Control";
@@ -45697,7 +45697,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -45852,7 +45852,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	icon_state = "intact";
 	dir = 5
@@ -46023,7 +46023,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -46817,7 +46817,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
@@ -48875,7 +48875,7 @@
 	icon_state = "direction_bridge";
 	name = "command department";
 	pixel_y = -8
-		},
+	},
 /turf/closed/wall,
 /area/storage/primary)
 "bOj" = (
@@ -49125,14 +49125,14 @@
 	icon_state = "direction_bridge";
 	name = "command department";
 	pixel_y = 0
-		},
+	},
 /obj/structure/sign/directions/engineering{
 	desc = "A direction sign, pointing out which way the Supply department is.";
 	dir = 1;
 	icon_state = "direction_supply";
 	name = "supply department";
 	pixel_y = 8
-		},
+	},
 /turf/closed/wall,
 /area/storage/tools)
 "bOG" = (
@@ -49403,7 +49403,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -50655,7 +50655,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -51836,7 +51836,7 @@
 	icon_state = "pipe-j1s";
 	name = "Security Junction";
 	sortType = 7
-		},
+	},
 /turf/open/floor/plasteel/red/corner,
 /area/hallway/primary/starboard)
 "bTh" = (
@@ -51940,7 +51940,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52154,7 +52154,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -53345,7 +53345,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -53893,7 +53893,7 @@
 	name = "WARNING: BLAST DOORS";
 	pixel_x = 0;
 	pixel_y = -32
-		},
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -54814,7 +54814,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /turf/open/floor/wood,
 /area/lawoffice)
 "bYN" = (
@@ -56117,7 +56117,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("Singularity")
-		},
+	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cbf" = (
@@ -57187,7 +57187,7 @@
 	dir = 1;
 	icon_state = "yellow";
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/engine/engineering)
 "ccX" = (
 /turf/open/floor/plasteel/yellow/side{
@@ -57224,7 +57224,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 9;
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/engine/engineering)
 "cdc" = (
 /obj/machinery/vending/engivend,
@@ -57505,7 +57505,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "cdK" = (
@@ -57907,7 +57907,7 @@
 	dir = 4;
 	icon_state = "camera";
 	network = list("Singularity")
-		},
+	},
 /turf/open/space,
 /area/space)
 "cey" = (
@@ -58615,7 +58615,7 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-		},
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -60186,7 +60186,7 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-		},
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -60355,7 +60355,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cjt" = (
@@ -61553,7 +61553,7 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-		},
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "clR" = (
@@ -62052,7 +62052,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -62139,7 +62139,7 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-		},
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -62421,7 +62421,7 @@
 	icon_state = "nboard00";
 	pixel_x = 32;
 	pixel_y = 0
-		},
+	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cnJ" = (
@@ -62537,7 +62537,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
@@ -63642,7 +63642,7 @@
 	name = "WARNING: PRESSURIZED DOORS";
 	pixel_x = 0;
 	pixel_y = 0
-		},
+	},
 /turf/closed/wall,
 /area/crew_quarters/courtroom)
 "cpO" = (
@@ -63825,7 +63825,7 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-		},
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -64045,7 +64045,7 @@
 	icon_state = "direction_bridge";
 	name = "command department";
 	pixel_y = 0
-		},
+	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
@@ -64231,7 +64231,7 @@
 	icon_state = "direction_bridge";
 	name = "command department";
 	pixel_y = 0
-		},
+	},
 /turf/closed/wall/r_wall,
 /area/gateway)
 "cqZ" = (
@@ -64811,7 +64811,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
@@ -64906,7 +64906,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
@@ -66207,7 +66207,7 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-		},
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -66237,7 +66237,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -66264,7 +66264,7 @@
 	dir = 1;
 	icon_state = "yellow";
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/engine/engineering{
 	name = "Engineering Storage"
 	})
@@ -66280,7 +66280,7 @@
 	dir = 1;
 	icon_state = "yellow";
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/engine/engineering{
 	name = "Engineering Storage"
 	})
@@ -66459,7 +66459,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
@@ -66872,7 +66872,7 @@
 	dir = 4;
 	icon_state = "camera";
 	network = list("Singularity")
-		},
+	},
 /turf/open/space,
 /area/space)
 "cvZ" = (
@@ -66881,7 +66881,7 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-		},
+	},
 /turf/open/space,
 /area/space)
 "cwa" = (
@@ -66890,7 +66890,7 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-		},
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -66961,7 +66961,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -68747,7 +68747,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("Singularity")
-		},
+	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "czm" = (
@@ -68809,7 +68809,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -70610,7 +70610,7 @@
 	dir = 1;
 	icon_state = "nboard00";
 	pixel_y = -32
-		},
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering{
@@ -70753,7 +70753,7 @@
 	name = "WARNING: PRESSURIZED DOORS";
 	pixel_x = 0;
 	pixel_y = 0
-		},
+	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva{
 	name = "E.V.A. Storage"
@@ -70892,7 +70892,7 @@
 	name = "WARNING: BLAST DOORS";
 	pixel_x = 0;
 	pixel_y = 0
-		},
+	},
 /turf/closed/wall/r_wall,
 /area/gateway)
 "cDe" = (
@@ -72413,7 +72413,7 @@
 	icon_state = "pipe-j1s";
 	name = "Medbay Junction";
 	sortType = 9
-		},
+	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "cFJ" = (
@@ -76113,7 +76113,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -76438,7 +76438,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/light_switch{
 	pixel_x = 38
 	},
@@ -76796,8 +76796,8 @@
 /turf/open/floor/plasteel,
 /area/maintenance/fpmaint2/port_maintenance)
 "cOr" = (
-/obj/effect/decal/remains/xeno,
 /obj/effect/decal/cleanable/xenoblood,
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/circuit/green,
 /area/toxins/xenobiology)
 "cOs" = (
@@ -76808,7 +76808,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -76939,7 +76939,7 @@
 	icon_state = "doors";
 	name = "WARNING: BIOHAZARD CELL";
 	pixel_x = 0
-		},
+	},
 /turf/closed/wall,
 /area/toxins/xenobiology)
 "cOG" = (
@@ -77117,7 +77117,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
@@ -77254,7 +77254,7 @@
 	icon_state = "pipe-j1s";
 	name = "Chemistry Junction";
 	sortType = 11
-		},
+	},
 /turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/aft)
 "cPj" = (
@@ -77937,7 +77937,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -79547,7 +79547,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -80622,7 +80622,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
@@ -81953,7 +81953,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
@@ -82089,7 +82089,7 @@
 /obj/structure/mirror{
 	icon_state = "mirror_broke";
 	pixel_y = 28
-		},
+	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
 	},
@@ -82139,7 +82139,7 @@
 /obj/structure/mirror{
 	icon_state = "mirror_broke";
 	pixel_y = 28
-		},
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
@@ -82539,7 +82539,7 @@
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 5;
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/toxins/lab)
 "cYV" = (
 /obj/machinery/computer/rdconsole/core,
@@ -83134,7 +83134,7 @@
 	departmentType = 0;
 	name = "Research RC";
 	pixel_x = 32;
-	pixel_y = 0
+	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /obj/machinery/camera{
@@ -83205,7 +83205,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -83921,7 +83921,7 @@
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 6;
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-		},
+	},
 /area/toxins/lab)
 "dbD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -85241,7 +85241,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/machinery/power/apc{
 	cell_type = 5000;
 	dir = 1;
@@ -86304,7 +86304,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -86348,7 +86348,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
@@ -86427,7 +86427,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -86743,7 +86743,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/toxins/explab)
@@ -86946,7 +86946,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -87901,7 +87901,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -87974,7 +87974,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -89566,7 +89566,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/camera{
 	c_tag = "Science - Research Director's Office";
 	dir = 8;
@@ -89741,7 +89741,7 @@
 	icon_state = "fire0";
 	pixel_x = 7;
 	pixel_y = -26
-		},
+	},
 /obj/machinery/light,
 /obj/machinery/light_switch{
 	pixel_x = 7;
@@ -90985,7 +90985,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = -26
-		},
+	},
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = -38
@@ -94117,7 +94117,7 @@
 	dir = 1;
 	icon_state = "nboard00";
 	pixel_y = -32
-		},
+	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	icon_state = "whitepurplecorner";
 	dir = 8
@@ -95528,7 +95528,7 @@
 	icon_state = "nboard00";
 	pixel_x = 32;
 	pixel_y = 0
-		},
+	},
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
 	layer = 4.1;
@@ -96928,7 +96928,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = -26
-		},
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -98800,7 +98800,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -99067,7 +99067,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/aft)
 "dEm" = (
@@ -101315,7 +101315,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /turf/open/floor/plasteel/blue/side{
 	dir = 5
 	},
@@ -101706,7 +101706,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -102122,7 +102122,7 @@
 /obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
-		},
+	},
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/sign/vacuum,
 /turf/open/floor/plating,
@@ -104143,7 +104143,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -104721,7 +104721,7 @@
 /turf/open/floor/plasteel/whiteblue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 4
-		},
+	},
 /area/shuttle/escape)
 "dPE" = (
 /obj/structure/table/glass,
@@ -105840,7 +105840,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/camera{
 	c_tag = "Chapel - Starboard";
 	dir = 8;
@@ -106407,7 +106407,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/light_switch{
 	pixel_x = 26;
@@ -107251,7 +107251,7 @@
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK"
-		},
+	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit{
 	name = "\improper Departure Lounge"
@@ -107371,7 +107371,7 @@
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 0
-		},
+	},
 /turf/closed/wall/r_wall,
 /area/maintenance/portsolar)
 "dUV" = (
@@ -107644,7 +107644,7 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-		},
+	},
 /turf/open/space,
 /area/solar/port)
 "dVx" = (
@@ -107653,7 +107653,7 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-		},
+	},
 /obj/machinery/door/airlock/external{
 	name = "External Solar Access";
 	req_access_txt = "10"
@@ -107670,7 +107670,7 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-		},
+	},
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -107686,7 +107686,7 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
-		},
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -108180,7 +108180,7 @@
 	icon_state = "nboard00";
 	name = "memorial board";
 	pixel_y = -32
-		},
+	},
 /obj/machinery/holopad,
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -109540,7 +109540,7 @@
 	icon_state = "fire0";
 	pixel_x = 24;
 	pixel_y = 0
-		},
+	},
 /obj/machinery/status_display{
 	pixel_x = 0;
 	pixel_y = 32
@@ -109609,7 +109609,7 @@
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 32
-		},
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
@@ -109676,7 +109676,7 @@
 /obj/structure/sign/poster{
 	icon_state = "poster22_legit";
 	pixel_y = -32
-		},
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
@@ -142232,7 +142232,7 @@ awX
 axa
 ame
 aib
-aJi
+axZ
 aAj
 azm
 aAj
@@ -143756,7 +143756,7 @@ ajY
 akW
 alZ
 anj
-aoh
+akV
 eeI
 aqa
 arq
@@ -146161,7 +146161,7 @@ cLH
 cLI
 cLH
 cLI
-cZW
+cIm
 dbq
 dcN
 dez
@@ -158497,7 +158497,7 @@ cUr
 cLM
 cLL
 cLM
-dau
+cIt
 dcd
 ddk
 dfg
@@ -163916,7 +163916,7 @@ dAL
 dCd
 dDz
 dAI
-dFv
+dCa
 dHf
 dHU
 aaa

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -41953,6 +41953,12 @@
 	temperature = 80
 	},
 /area/tcommsat/server)
+"buV" = (
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/toxins/xenobiology)
 
 (1,1,1) = {"
 aaa
@@ -70603,7 +70609,7 @@ aLH
 aMK
 aNU
 aOw
-buD
+buC
 aPG
 aRB
 aPG
@@ -71117,15 +71123,15 @@ aLJ
 aMM
 aNW
 aOx
-buE
+buC
 aPG
 aRB
 aPG
 buG
 buI
-buM
+buK
 aRB
-buT
+buR
 aMJ
 aad
 aad
@@ -71374,7 +71380,7 @@ aLK
 aMJ
 aNX
 aOy
-buF
+buC
 aPG
 aRE
 aSN
@@ -88358,7 +88364,7 @@ bfo
 bfP
 bgm
 bhi
-bgm
+buV
 bfP
 bje
 bjx

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -56147,6 +56147,10 @@
 /obj/machinery/light,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
+"cjQ" = (
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/engine,
+/area/toxins/xenobiology)
 
 (1,1,1) = {"
 aaa
@@ -98937,7 +98941,7 @@ bbO
 aAC
 aUf
 bed
-bfy
+cjQ
 bgu
 bfy
 bed

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -65190,6 +65190,10 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
+"cMC" = (
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/engine,
+/area/toxins/xenobiology)
 
 (1,1,1) = {"
 aaa
@@ -107486,7 +107490,7 @@ byf
 byf
 byf
 bDb
-bEm
+cMC
 bEm
 bEm
 bDb


### PR DESCRIPTION
:cl: coiax
add: All maps, not just Meta, have a 2% chance of receiving a xeno
egg in their Xenobiology areas. As with Meta, command receive a
classified update two minutes into the shift if an egg has been
delivered.
/:cl:

Why Metastation should be the only one with an egg spawner is beyond me.

- Most of the line chaff is with Delta, where the map merger REALLY wants to move some `{,` around.