### PR TITLE
Chasms properly smooth again

### DIFF
--- a/code/game/turfs/simulated/chasm.dm
+++ b/code/game/turfs/simulated/chasm.dm
@@ -8,7 +8,7 @@
 	smooth = SMOOTH_TRUE | SMOOTH_BORDER | SMOOTH_MORE
 	icon = 'icons/turf/floors/Chasms.dmi'
 	icon_state = "smooth"
-	canSmoothWith = list(turf/open/floor/fakepit, /turf/open/chasm)
+	canSmoothWith = list(/turf/open/floor/fakepit, /turf/open/chasm)
 	var/drop_x = 1
 	var/drop_y = 1
 	var/drop_z = 1

--- a/code/game/turfs/simulated/chasm.dm
+++ b/code/game/turfs/simulated/chasm.dm
@@ -8,7 +8,7 @@
 	smooth = SMOOTH_TRUE | SMOOTH_BORDER | SMOOTH_MORE
 	icon = 'icons/turf/floors/Chasms.dmi'
 	icon_state = "smooth"
-	canSmoothWith = list(/turf/open/floor/carpet, /turf/open/chasm)
+	canSmoothWith = list(turf/open/floor/fakepit, /turf/open/chasm)
 	var/drop_x = 1
 	var/drop_y = 1
 	var/drop_z = 1

--- a/code/game/turfs/simulated/chasm.dm
+++ b/code/game/turfs/simulated/chasm.dm
@@ -5,7 +5,7 @@
 	name = "chasm"
 	desc = "Watch your step."
 	baseturf = /turf/open/chasm
-	smooth = SMOOTH_TRUE | SMOOTH_BORDER
+	smooth = SMOOTH_TRUE | SMOOTH_BORDER | SMOOTH_MORE
 	icon = 'icons/turf/floors/Chasms.dmi'
 	icon_state = "smooth"
 	canSmoothWith = list(/turf/open/floor/carpet, /turf/open/chasm)

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -142,7 +142,7 @@
 turf/open/floor/fakepit
 	desc = "A clever illusion designed to look like a bottomless pit."
 	smooth = SMOOTH_TRUE | SMOOTH_BORDER | SMOOTH_MORE
-	canSmoothWith = list(turf/open/floor/fakepit, /turf/open/chasm)
+	canSmoothWith = list(/turf/open/floor/fakepit, /turf/open/chasm)
 	icon = 'icons/turf/floors/Chasms.dmi'
 	icon_state = "smooth"
 

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -141,7 +141,8 @@
 
 turf/open/floor/fakepit
 	desc = "A clever illusion designed to look like a bottomless pit."
-	smooth = SMOOTH_TRUE | SMOOTH_BORDER
+	smooth = SMOOTH_TRUE | SMOOTH_BORDER | SMOOTH_MORE
+	canSmoothWith = list(turf/open/floor/fakepit, /turf/open/chasm)
 	icon = 'icons/turf/floors/Chasms.dmi'
 	icon_state = "smooth"
 


### PR DESCRIPTION
:cl:
fix: Chasms now smooth properly.
/:cl:


Effectively every chasm that is actually mapped or created is a sub-type and smoothing recognizes them as different if you don't set the SMOOTH MORE flag. So because the types weren't in the list it didn't smooth.

Fixes #25140