### PR TITLE
Alt-clicking a command headset toggles HIGH VOLUME mode.

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -299,3 +299,8 @@
 		secure_radio_connections[ch_name] = add_radio(src, radiochannels[ch_name])
 
 	return
+
+/obj/item/device/radio/headset/AltClick(mob/user)
+	if (command)
+		use_command = !use_command
+		to_chat(user, "<span class='notice'>You toggle high-volume mode.</span>")


### PR DESCRIPTION
:cl: bgobandit
tweak: Alt-clicking a command headset toggles HIGH VOLUME mode.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
You can alt-click headsets while wearing them. What this adds to the game: QoL, making me want to stab myself a little bit less