### PR TITLE
[Deltastation] Adds autolathe boards to tech storage and a full stack of metal to aux tool

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -44291,6 +44291,7 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/weapon/circuitboard/machine/autolathe,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bAQ" = (
@@ -51010,7 +51011,9 @@
 /area/storage/tools)
 "bMM" = (
 /obj/structure/table,
-/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
 /obj/item/stack/rods{
 	amount = 50
 	},
@@ -149196,7 +149199,7 @@ aic
 baW
 bcs
 aib
-eeC
+eeA
 aoQ
 aib
 aib
@@ -149450,13 +149453,13 @@ aUD
 aic
 aib
 aoQ
-eeB
+eeA
 aib
 aib
 bfy
 aic
 bjo
-eeD
+eeA
 aUG
 bou
 aaa


### PR DESCRIPTION
:cl: BeeSting12
add: Added 49 sheets of metal to deltastation's auxiliary tool storage.
add: Added an autolathe circuit board to deltastation's tech storage.
/:cl:

Why: All other maps have an autolathe board in tech storage. Only reason I could think of for not having it was the public autolathe but meta has autolathe boards and it also has a public autolathe. The one sheet of metal in auxiliary tool storage looked like an oversight to me so I made it a full stack.