### PR TITLE
Changes lizard heat and cold damage

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -7,6 +7,8 @@
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS)
 	mutant_bodyparts = list("tail_lizard", "snout", "spines", "horns", "frills", "body_markings", "legs")
 	mutant_organs = list(/obj/item/organ/tongue/lizard)
+	coldmod = 1.5
+	heatmod = 0.75
 	default_features = list("mcolor" = "0F0", "tail" = "Smooth", "snout" = "Round", "horns" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None", "legs" = "Normal Legs")
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -8,7 +8,7 @@
 	mutant_bodyparts = list("tail_lizard", "snout", "spines", "horns", "frills", "body_markings", "legs")
 	mutant_organs = list(/obj/item/organ/tongue/lizard)
 	coldmod = 1.5
-	heatmod = 0.75
+	heatmod = 0.67
 	default_features = list("mcolor" = "0F0", "tail" = "Smooth", "snout" = "Round", "horns" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None", "legs" = "Normal Legs")
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'


### PR DESCRIPTION
:cl: rock
tweak: lizards are hurt slightly more by cold but less by heat. this does not mean they are more resistant to being lasered, fortunately.
/:cl:
shitty testing showed the dude with the advantage lasted like 2 seconds longer under temperatures so this is pretty minor tbh fam 
examples of how this effects stuff(tested before the lizard buff from resistance of 0.75 to 0.67
THINGS THIS EFFECTS MAJORLY:
lizards being set on fire (roughly 4 seconds)
being frozen to death by a cold shower (like 10 seconds)
being frozen by a temperature gun (does 6.75 damage on one hit instead of 4.5)
THINGS THIS EFFECTS MINORLY
being attacked by a basilisk/watcher (I didn't even have to test this with humans, on a straight hallway I was able to run out of its range and escape with 38.5 burn damage despite it shooting me at least a half dozen times)
unloading a tempgun as fast as possible on somebody on cold (does roughly 30 damage instead of 20)
being burned by a tempgun (does 2 damage on hit to humans, 1.5 to lizards)
being unloaded with a burning tempgun (does 15 dmg instead of 18)
a few missed spurts with a flamethrower (like 1 second)
being spaced with no internals (less than a second)
boiling to death in a hot shower (almost exactly 1 second)