### PR TITLE
Clock cults always have to summon Ratvar, but that always involves a proselytization burst

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -85,10 +85,8 @@ var/global/list/all_scripture = list() //a list containing scripture instances; 
 
 #define GATEWAY_RATVAR_ARRIVAL 300 //when progress is at or above this, game over ratvar's here everybody go home
 
-//Objective defines
-#define CLOCKCULT_GATEWAY "summon ratvar"
-
-#define CLOCKCULT_ESCAPE "proselytize the station"
+//Objective text define
+#define CLOCKCULT_OBJECTIVE "Construct the Ark of the Clockwork Justicar and free Ratvar."
 
 //misc clockcult stuff
 #define MARAUDER_EMERGE_THRESHOLD 65 //marauders cannot emerge unless host is at this% or less health

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -84,7 +84,6 @@ Credit where due:
 
 /datum/game_mode
 	var/list/servants_of_ratvar = list() //The Enlightened servants of Ratvar
-	var/clockwork_objective = CLOCKCULT_GATEWAY //The objective that the servants must fulfill
 	var/clockwork_explanation = "Construct a Gateway to the Celestial Derelict and free Ratvar." //The description of the current objective
 
 /datum/game_mode/clockwork_cult
@@ -126,7 +125,6 @@ Credit where due:
 	return 1
 
 /datum/game_mode/clockwork_cult/post_setup()
-	forge_clock_objectives()
 	for(var/S in servants_to_serve)
 		var/datum/mind/servant = S
 		log_game("[servant.key] was made an initial servant of Ratvar")
@@ -135,16 +133,6 @@ Credit where due:
 		equip_servant(L)
 		add_servant_of_ratvar(L, TRUE)
 	..()
-	return 1
-
-/datum/game_mode/clockwork_cult/proc/forge_clock_objectives() //Determine what objective that Ratvar's servants will fulfill
-	var/list/possible_objectives = list(CLOCKCULT_ESCAPE, CLOCKCULT_GATEWAY)
-	clockwork_objective = pick(possible_objectives)
-	switch(clockwork_objective)
-		if(CLOCKCULT_ESCAPE)
-			clockwork_explanation = "Construct a Gateway to the Celestial Derelict and proselytize the entire station."
-		if(CLOCKCULT_GATEWAY)
-			clockwork_explanation = "Construct a Gateway to the Celestial Derelict and free Ratvar."
 	return 1
 
 /datum/game_mode/clockwork_cult/proc/greet_servant(mob/M) //Description of their role
@@ -182,21 +170,18 @@ Credit where due:
 	if(!L || !istype(L) || !L.mind)
 		return 0
 	var/datum/mind/M = L.mind
-	to_chat(M.current, "<b>This is Ratvar's will:</b> [clockwork_explanation]")
-	M.memory += "<b>Ratvar's will:</b> [clockwork_explanation]<br>"
+	to_chat(M.current, "<b>This is Ratvar's will:</b> [CLOCKCULT_OBJECTIVE]")
+	M.memory += "<b>Ratvar's will:</b> [CLOCKCULT_OBJECTIVE]<br>"
 	return 1
 
 /datum/game_mode/clockwork_cult/proc/check_clockwork_victory()
-	switch(clockwork_objective)
-		if(CLOCKCULT_ESCAPE)
-			if(clockwork_gateway_activated)
-				ticker.news_report = CLOCK_PROSELYTIZATION
-				return TRUE
-		if(CLOCKCULT_GATEWAY)
-			if(ratvar_awakens)
-				ticker.news_report = CLOCK_SUMMON
-				return TRUE
-	ticker.news_report = CULT_FAILURE
+	if(clockwork_gateway_activated)
+		ticker.news_report = CLOCK_PROSELYTIZATION //failure, technically, but we have the station
+		if(ratvar_awakens)
+			ticker.news_report = CLOCK_SUMMON
+			return TRUE
+	else
+		ticker.news_report = CULT_FAILURE
 	return FALSE
 
 /datum/game_mode/clockwork_cult/declare_completion()
@@ -209,20 +194,20 @@ Credit where due:
 		var/datum/game_mode/clockwork_cult/C = ticker.mode
 		if(C.check_clockwork_victory())
 			text += "<span class='large_brass'><b>Ratvar's servants have succeeded in fulfilling His goals!</b></span>"
-			feedback_set_details("round_end_result", "win - servants completed their objective ([clockwork_objective])")
+			feedback_set_details("round_end_result", "win - servants completed their objective (summon ratvar)")
 		else
 			var/half_victory = FALSE
 			var/obj/structure/destructible/clockwork/massive/celestial_gateway/G = locate() in all_clockwork_objects
 			if(G)
 				half_victory = TRUE
 			if(half_victory)
-				text += "<span class='large_brass'><b>The crew escaped before [clockwork_objective == CLOCKCULT_GATEWAY ? "Ratvar could rise":"the station could be proselytized"], but the gateway \
+				text += "<span class='large_brass'><b>The crew escaped before Ratvar could rise, but the gateway \
 				was successfully constructed!</b></span>"
-				feedback_set_details("round_end_result", "halfwin - servants constructed the gateway but their objective was not completed ([clockwork_objective])")
+				feedback_set_details("round_end_result", "halfwin - servants constructed the gateway but their objective was not completed (summon ratvar)")
 			else
 				text += "<span class='userdanger'>Ratvar's servants have failed!</span>"
-				feedback_set_details("round_end_result", "loss - servants failed their objective ([clockwork_objective])")
-		text += "<br><b>The servants' objective was:</b> <br>[clockwork_explanation]"
+				feedback_set_details("round_end_result", "loss - servants failed their objective (summon ratvar)")
+		text += "<br><b>The servants' objective was:</b> <br>[CLOCKCULT_OBJECTIVE]"
 		text += "<br>Ratvar's servants had <b>[clockwork_caches]</b> Tinkerer's Caches."
 		text += "<br><b>Construction Value(CV)</b> was: <b>[clockwork_construction_value]</b>"
 		var/list/scripture_states = scripture_unlock_check()

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_judgement.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_judgement.dm
@@ -22,13 +22,6 @@
 	tier = SCRIPTURE_JUDGEMENT
 	sort_priority = 1
 
-/datum/clockwork_scripture/create_object/ark_of_the_clockwork_justiciar/New()
-	if(ticker && ticker.mode && ticker.mode.clockwork_objective != CLOCKCULT_GATEWAY)
-		invocations = list("ARMORER! FRIGHT! AMPERAGE! VANGUARD! I CALL UPON YOU!!", \
-		"THIS STATION WILL BE A BEACON OF HOPE IN THE DARKNESS OF SPACE!!", \
-		"HELP US MAKE THIS SHOW ENGINE'S GLORY!!")
-	..()
-
 /datum/clockwork_scripture/create_object/ark_of_the_clockwork_justiciar/check_special_requirements()
 	if(!slab.no_cost)
 		if(ratvar_awakens)
@@ -36,7 +29,7 @@
 			return FALSE
 		for(var/obj/structure/destructible/clockwork/massive/celestial_gateway/G in all_clockwork_objects)
 			var/area/gate_area = get_area(G)
-			to_chat(invoker, "<span class='userdanger'>There is already a gateway at [gate_area.map_name]!</span>")
+			to_chat(invoker, "<span class='userdanger'>There is already an Ark at [gate_area.map_name]!</span>")
 			return FALSE
 		var/area/A = get_area(invoker)
 		var/turf/T = get_turf(invoker)
@@ -44,9 +37,6 @@
 			to_chat(invoker, "<span class='warning'>You must be on the station to activate the Ark!</span>")
 			return FALSE
 		if(clockwork_gateway_activated)
-			if(ticker && ticker.mode && ticker.mode.clockwork_objective != CLOCKCULT_GATEWAY)
-				to_chat(invoker, "<span class='nezbere'>\"Look upon his works. Is it not glorious?\"</span>")
-			else
-				to_chat(invoker, "<span class='warning'>Ratvar's recent banishment renders him too weak to be wrung forth from Reebe!</span>")
+			to_chat(invoker, "<span class='warning'>Ratvar's recent banishment renders him too weak to be wrung forth from Reebe!</span>")
 			return FALSE
 	return ..()

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -1,6 +1,6 @@
 //The gateway to Reebe, from which Ratvar emerges.
 /obj/structure/destructible/clockwork/massive/celestial_gateway
-	name = "gateway to the Celestial Derelict"
+	name = "ark of the Clockwork Justicar"
 	desc = "A massive, thrumming rip in spacetime."
 	clockwork_desc = "A portal to the Celestial Derelict. Massive and intimidating, it is the only thing that can both transport Ratvar and withstand the massive amount of energy he emits."
 	obj_integrity = 500
@@ -30,33 +30,20 @@
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/spawn_animation()
 	var/turf/T = get_turf(src)
-	var/objective_is_gateway = (ticker && ticker.mode && ticker.mode.clockwork_objective == CLOCKCULT_GATEWAY)
 	new/obj/effect/clockwork/general_marker/inathneq(T)
-	if(objective_is_gateway)
-		hierophant_message("<span class='inathneq'>\"[text2ratvar("Engine, come forth and show your servants your mercy")]!\"</span>")
-	else
-		hierophant_message("<span class='inathneq'>\"[text2ratvar("We will show all the mercy of Engine")]!\"</span>")
+	hierophant_message("<span class='inathneq'>\"[text2ratvar("Engine, come forth and show your servants your mercy")]!\"</span>")
 	playsound(T, 'sound/magic/clockwork/invoke_general.ogg', 30, 0)
 	sleep(10)
 	new/obj/effect/clockwork/general_marker/sevtug(T)
-	if(objective_is_gateway)
-		hierophant_message("<span class='sevtug'>\"[text2ratvar("Engine, come forth and show this station your decorating skills")]!\"</span>")
-	else
-		hierophant_message("<span class='sevtug'>\"[text2ratvar("We will show all Engine's decorating skills")]!\"</span>")
+	hierophant_message("<span class='sevtug'>\"[text2ratvar("Engine, come forth and show this station your decorating skills")]!\"</span>")
 	playsound(T, 'sound/magic/clockwork/invoke_general.ogg', 45, 0)
 	sleep(10)
 	new/obj/effect/clockwork/general_marker/nezbere(T)
-	if(objective_is_gateway)
-		hierophant_message("<span class='nezbere'>\"[text2ratvar("Engine, come forth and shine your light across this realm")]!!\"</span>")
-	else
-		hierophant_message("<span class='nezbere'>\"[text2ratvar("We will show all Engine's light")]!!\"</span>")
+	hierophant_message("<span class='nezbere'>\"[text2ratvar("Engine, come forth and shine your light across this realm")]!!\"</span>")
 	playsound(T, 'sound/magic/clockwork/invoke_general.ogg', 60, 0)
 	sleep(10)
 	new/obj/effect/clockwork/general_marker/nzcrentr(T)
-	if(objective_is_gateway)
-		hierophant_message("<span class='nzcrentr'>\"[text2ratvar("Engine, come forth")].\"</span>")
-	else
-		hierophant_message("<span class='nzcrentr'>\"[text2ratvar("We will show all Engine's power")].\"</span>")
+	hierophant_message("<span class='nzcrentr'>\"[text2ratvar("Engine, come forth")].\"</span>")
 	playsound(T, 'sound/magic/clockwork/invoke_general.ogg', 75, 0)
 	sleep(10)
 	playsound(T, 'sound/magic/clockwork/invoke_general.ogg', 100, 0)
@@ -74,9 +61,7 @@
 	countdown = new(src)
 	countdown.start()
 	var/area/gate_area = get_area(src)
-	hierophant_message("<span class='large_brass'><b>A gateway to the Celestial Derelict has been created in [gate_area.map_name]!</b></span>", FALSE, src)
-	if(!objective_is_gateway)
-		ratvar_portal = FALSE
+	hierophant_message("<span class='large_brass'><b>An Ark of the Clockwork Justicar has been created in [gate_area.map_name]!</b></span>", FALSE, src)
 	SSshuttle.registerHostileEnvironment(src)
 	START_PROCESSING(SSprocessing, src)
 
@@ -84,7 +69,7 @@
 	STOP_PROCESSING(SSprocessing, src)
 	if(!purpose_fulfilled)
 		var/area/gate_area = get_area(src)
-		hierophant_message("<span class='large_brass'><b>A gateway to the Celestial Derelict has fallen at [gate_area.map_name]!</b></span>")
+		hierophant_message("<span class='large_brass'><b>An Ark of the Clockwork Justicar has fallen at [gate_area.map_name]!</b></span>")
 		send_to_playing_players(sound(null, 0, channel = 8))
 	var/was_stranded = SSshuttle.emergency.mode == SHUTTLE_STRANDED
 	SSshuttle.clearHostileEnvironment(src)
@@ -186,7 +171,7 @@
 				if(GATEWAY_REEBE_FOUND to GATEWAY_RATVAR_COMING)
 					to_chat(user, "<span class='heavy_brass'>It's reached the Celestial Derelict and is drawing power from it.</span>")
 				if(GATEWAY_RATVAR_COMING to INFINITY)
-					to_chat(user, "<span class='heavy_brass'>[ratvar_portal ? "Ratvar is coming through the gateway":"The gateway is glowing with massed power"]!</span>")
+					to_chat(user, "<span class='heavy_brass'>Ratvar is coming through the gateway!</span>")
 	else
 		switch(progress_in_seconds)
 			if(-INFINITY to GATEWAY_REEBE_FOUND)
@@ -194,7 +179,7 @@
 			if(GATEWAY_REEBE_FOUND to GATEWAY_RATVAR_COMING)
 				to_chat(user, "<span class='warning'>It seems to be leading somewhere.</span>")
 			if(GATEWAY_RATVAR_COMING to INFINITY)
-				to_chat(user, "<span class='boldwarning'>[ratvar_portal ? "Something is coming through":"It's glowing brightly"]!</span>")
+				to_chat(user, "<span class='boldwarning'>Something is coming through!</span>")
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/process()
 	if(!first_sound_played || prob(7))
@@ -276,39 +261,28 @@
 				animate(glow, transform = matrix() * 3, alpha = 0, time = 5)
 				var/turf/startpoint = get_turf(src)
 				QDEL_IN(src, 3)
-				if(ratvar_portal)
-					sleep(3)
-					clockwork_gateway_activated = TRUE
-					new/obj/structure/destructible/clockwork/massive/ratvar(startpoint)
-				else
-					INVOKE_ASYNC(SSshuttle.emergency, /obj/docking_port/mobile/emergency.proc/request, null, 0) //call the shuttle immediately
-					sleep(3)
-					clockwork_gateway_activated = TRUE
-					send_to_playing_players("<span class='ratvar'>\"[text2ratvar("Behold")]!\"</span>\n<span class='inathneq_large'>\"[text2ratvar("See Engine's mercy")]!\"</span>\n\
-					<span class='sevtug_large'>\"[text2ratvar("Observe Engine's design skills")]!\"</span>\n<span class='nezbere_large'>\"[text2ratvar("Behold Engine's light")]!!\"</span>\n\
-					<span class='nzcrentr_large'>\"[text2ratvar("Gaze upon Engine's power")]!\"</span>")
-					send_to_playing_players('sound/magic/clockwork/invoke_general.ogg')
-					var/x0 = startpoint.x
-					var/y0 = startpoint.y
-					for(var/I in spiral_range_turfs(255, startpoint))
-						var/turf/T = I
-						if(!T)
-							continue
-						var/dist = cheap_hypotenuse(T.x, T.y, x0, y0)
-						if(dist < 100)
-							dist = TRUE
-						else
-							dist = FALSE
-						T.ratvar_act(dist)
-						CHECK_TICK
-					for(var/mob/living/L in living_mob_list)
-						L.ratvar_act()
-					for(var/I in all_clockwork_mobs)
-						var/mob/M = I
-						if(M.stat == CONSCIOUS)
-							clockwork_say(M, text2ratvar(pick("Purge all untruths and honor Engine!", "All glory to Engine's light!", "Engine's power is unmatched!")))
+				sleep(3)
+				clockwork_gateway_activated = TRUE
+				new/obj/structure/destructible/clockwork/massive/ratvar(startpoint)
+				send_to_playing_players("<span class='inathneq_large'>\"[text2ratvar("See Engine's mercy")]!\"</span>\n\
+				<span class='sevtug_large'>\"[text2ratvar("Observe Engine's design skills")]!\"</span>\n<span class='nezbere_large'>\"[text2ratvar("Behold Engine's light")]!!\"</span>\n\
+				<span class='nzcrentr_large'>\"[text2ratvar("Gaze upon Engine's power")].\"</span>")
+				send_to_playing_players('sound/magic/clockwork/invoke_general.ogg')
+				var/x0 = startpoint.x
+				var/y0 = startpoint.y
+				for(var/I in spiral_range_turfs(255, startpoint))
+					var/turf/T = I
+					if(!T)
+						continue
+					var/dist = cheap_hypotenuse(T.x, T.y, x0, y0)
+					if(dist < 100)
+						dist = TRUE
+					else
+						dist = FALSE
+					T.ratvar_act(dist, TRUE)
+					CHECK_TICK
 
-//the actual appearance of the Gateway to the Celestial Derelict; an object so the edges of the gate can be clicked through.
+//the actual appearance of the Ark of the Clockwork Justicar; an object so the edges of the gate can be clicked through.
 /obj/effect/clockwork/overlay/gateway_glow
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "clockwork_gateway_charging"

--- a/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
@@ -27,7 +27,7 @@
 	var/image/alert_overlay = image('icons/effects/clockwork_effects.dmi', "ratvar_alert")
 	var/area/A = get_area(src)
 	notify_ghosts("The Justiciar's light calls to you! Reach out to Ratvar in [A.name] to be granted a shell to spread his glory!", null, source = src, alert_overlay = alert_overlay)
-	addtimer(CALLBACK(SSshuttle.emergency, /obj/docking_port/mobile/emergency..proc/request, null, 0.1), 50)
+	INVOKE_ASYNC(SSshuttle.emergency, /obj/docking_port/mobile/emergency..proc/request, null, 0)
 
 /obj/structure/destructible/clockwork/massive/ratvar/Destroy()
 	ratvar_awakens--
@@ -62,27 +62,30 @@
 		T.ratvar_act()
 	for(var/I in circleviewturfs(src, round(proselytize_range * 0.5)))
 		var/turf/T = I
-		T.ratvar_act(1)
+		T.ratvar_act(TRUE)
 	var/dir_to_step_in = pick(cardinal)
+	var/list/meals = list()
+	for(var/mob/living/L in living_mob_list) //we want to know who's alive so we don't lose and retarget a single person
+		if(L.z == z && !is_servant_of_ratvar(L) && L.mind)
+			meals += L
 	if(!prey)
 		for(var/obj/singularity/narsie/N in singularities)
 			if(N.z == z)
 				prey = N
 				break
-		if(!prey) //In case there's a Nar-Sie
-			var/list/meals = list()
-			for(var/mob/living/L in living_mob_list)
-				if(L.z == z && !is_servant_of_ratvar(L) && L.mind)
-					meals += L
-			if(meals.len)
-				prey = pick(meals)
-				to_chat(prey, "<span class='heavy_brass'><font size=5>\"You will do.\"</font></span>\n\
-				<span class='userdanger'>Something very large and very malevolent begins lumbering its way towards you...</span>")
-				prey << 'sound/effects/ratvar_reveal.ogg'
+		if(!prey && LAZYLEN(meals))
+			prey = pick(meals)
+			to_chat(prey, "<span class='heavy_brass'><font size=5>\"You will do, heretic.\"</font></span>\n\
+			<span class='userdanger'You feel something massive turn its crushing focus to you...</span>")
+			prey << 'sound/effects/ratvar_reveal.ogg'
 	else
-		if((!istype(prey, /obj/singularity/narsie) && prob(10)) || is_servant_of_ratvar(prey) || prey.z != z)
-			to_chat(prey, "<span class='heavy_brass'><font size=5>\"How dull. Leave me.\"</font></span>\n\
-			<span class='userdanger'>You feel tremendous relief as a set of horrible eyes loses sight of you...</span>")
+		if((!istype(prey, /obj/singularity/narsie) && prob(10) && LAZYLEN(meals) > 1) || prey.z != z || !(prey in meals))
+			if(is_servant_of_ratvar(prey))
+				to_chat(prey, "<span class='heavy_brass'><font size=5>\"Serve me well.\"</font></span>\n\
+				<span class='big_brass'>You feel great joy as your god turns His eye to another heretic...</span>")
+			else
+				to_chat(prey, "<span class='heavy_brass'><font size=5>\"No matter. I will find you later, heretic.\"</font></span>\n\
+				<span class='userdanger'>You feel tremendous relief as the crushing focus relents...</span>")
 			prey = null
 		else
 			dir_to_step_in = get_dir(src, prey) //Unlike Nar-Sie, Ratvar ruthlessly chases down his target


### PR DESCRIPTION
:cl: Joan
tweak: Clock cults always have to summon Ratvar, but that always involves a proselytization burst.
rscdel: The proselytization burst will no longer convert heretics, leaving Ratvar free to chase them down.
spellcheck: Places that referred to the Ark of the Clockwork Justicar as the "Gateway to the Celestial Derelict" have been corrected to always refer to the Ark.
/:cl:

The proselytization burst is so cool, but if you see it you can't do a ton of cool shit because Ratvar isn't up, and if Ratvar IS up, then you need to manually prosel a lot of shit.
So, best of both worlds.