### PR TITLE
Spider bites and carp stamina attacks respect shields [DNM] [DON'T FUCKING CLOSE ORANGES] [HALP]

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -316,7 +316,6 @@
 		apply_damage(damage, M.melee_damage_type, affecting, armor)
 		damage_clothes(damage, M.melee_damage_type, "melee", affecting.body_zone)
 
-
 /mob/living/carbon/human/attack_slime(mob/living/simple_animal/slime/M)
 	if(..()) //successful slime attack
 		var/damage = rand(5, 25)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -39,12 +39,10 @@
 	return 1	//No drifting in space for space carp!	//original comments do not steal
 
 /mob/living/simple_animal/hostile/carp/AttackingTarget()
-	..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if(H.check_shields(0, "the full force of [name]'s blow", src, attack_type = MELEE_ATTACK))
-			return 0
-		H.adjustStaminaLoss(8)
+	if(..())
+		if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			H.adjustStaminaLoss(8)
 
 /mob/living/simple_animal/hostile/carp/holocarp
 	icon_state = "holocarp"

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -42,6 +42,8 @@
 	..()
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
+		if(H.check_shields(0, "the full force of [name]'s blow", src, attack_type = MELEE_ATTACK))
+			return 0
 		H.adjustStaminaLoss(8)
 
 /mob/living/simple_animal/hostile/carp/holocarp

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -9,17 +9,11 @@
 	var/poison_type = "toxin"
 
 /mob/living/simple_animal/hostile/poison/AttackingTarget()
-	..()
-	if(isliving(target))
-		var/mob/living/L = target
-		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
-			if (H.check_shields(0, "the [name]'s poison tendrils", src, attack_type = MELEE_ATTACK))
-				return 0
-		if(L.reagents)
-			L.reagents.add_reagent(poison_type, poison_per_bite)
-
-
+	if(..())
+		if(isliving(target))
+			var/mob/living/L = target
+			if(L.reagents)
+				L.reagents.add_reagent(poison_type, poison_per_bite)
 
 //basic spider mob, these generally guard nests
 /mob/living/simple_animal/hostile/poison/giant_spider

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -12,6 +12,10 @@
 	..()
 	if(isliving(target))
 		var/mob/living/L = target
+		if(ishuman(L))
+			var/mob/living/carbon/human/H = L
+			if (H.check_shields(0, "the [name]'s poison tendrils", src, attack_type = MELEE_ATTACK))
+				return 0
 		if(L.reagents)
 			L.reagents.add_reagent(poison_type, poison_per_bite)
 


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/14299. Kind of. 

But what appears to be happening in this fix is that even if the attack makes it past the shield, the poison is not applied. I have no idea why. Sticking a return 1 at the end of the human_defense proc [not in this PR, but I tried it] didn't do shit.