### PR TITLE
Dead AIs do not stop Clockcult Judgement tier

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_helpers/scripture_checks.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/scripture_checks.dm
@@ -28,7 +28,7 @@
 	. = 0
 	for(var/ai in ai_list)
 		var/mob/living/silicon/AI = ai
-		if(is_servant_of_ratvar(AI) || !isturf(AI.loc) || AI.z != ZLEVEL_STATION)
+		if(is_servant_of_ratvar(AI) || !isturf(AI.loc) || AI.z != ZLEVEL_STATION || AI.stat == DEAD)
 			continue
 		.++
 


### PR DESCRIPTION
:cl: coiax
fix: A dead AI no longer counts as an "unconverted AI" for clockcult.
/:cl:

Fucking wew.

Fixes #25353