### PR TITLE
Messing around with MapMerger [Disk Fridge in Hydro, Mirror in Genetics (BOX CHANGES)]

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -16941,9 +16941,6 @@
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aKL" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics Storage"
 	},
@@ -17003,6 +17000,15 @@
 "aKU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
+	},
+/obj/machinery/smartfridge/disks{
+	pixel_x = -32;
+	pixel_y = 32;
+	step_x = 0;
+	step_y = 0
+	},
+/obj/machinery/airalarm{
+	pixel_y = 55
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
@@ -65190,6 +65196,15 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
+"cMC" = (
+/turf/open/floor/plasteel/hydrofloor,
+/area/hydroponics)
+"cMD" = (
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 
 (1,1,1) = {"
 aaa
@@ -104141,7 +104156,7 @@ bua
 bvn
 bwL
 bxX
-bsL
+cMD
 bua
 bBJ
 bhh
@@ -106165,7 +106180,7 @@ aCA
 anf
 aFp
 aGW
-anf
+aIp
 aIp
 aKI
 aMA
@@ -106423,7 +106438,7 @@ alP
 aFo
 aGV
 aIp
-aIp
+cMC
 aKL
 aMz
 aNQ


### PR DESCRIPTION
:cl: Cobby
add: [BOX]There is now a "disk fridge" in botany. Use it to sort those sweet genes!
add: [BOX]There is now a mirror in genetics. Bedhead should be a crime!
/:cl:

This is just me messing around with the map merger and getting comfortable with it. I made them minor since they're 2 different things [which would typically require atomization]. If they're honestly that big of a deal I'll atomize them since this was actually really easy and now I feel dumb. 

Reason for changes:

1. The Disk fridge is a QoL with no mechanical benefits unless you consider organization of the disks a balance mechanic for the gene machine, which is silly.
2. The Mirror in genetics idea was stolen from Meta. If someone want to crush snowflakes then just break the mirror. Otherwise this is a cosmetic feature. If you are reaching, there is /some/ balance to be had about people prone to liking their cosmetics now lose a window of opportunity, but I mean your fault for letting them get cloned in the first place.


![img](http://i.imgur.com/curqLtl.png) ![img](http://i.imgur.com/1jSnTyK.png)