### PR TITLE
[Centcomm Map] Fixes wrong DIR on light

### DIFF
--- a/_maps/map_files/generic/Centcomm.dmm
+++ b/_maps/map_files/generic/Centcomm.dmm
@@ -14446,7 +14446,7 @@
 /area/wizard_station)
 "KN" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
@@ -62947,7 +62947,7 @@ tH
 qk
 Ks
 ql
-Ma
+LY
 Mb
 yS
 Lc


### PR DESCRIPTION
:cl: Penguaro
fix: Wizard Ship - Bolts that floating light to the wall.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
There's a light with the wrong direction on the wizard ship. This fixes #25356.