### PR TITLE
Nuke ops can purchase syndrones for 75 TC each

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -16,7 +16,7 @@
 	icon_living = "drone_synd"
 	picked = TRUE //the appearence of syndrones is static, you don't get to change it.
 	health = 30
-	maxHealth = 120 //If you murder other drones and cannibalize them you can get much stronger
+	maxHealth = 30
 	faction = list("syndicate")
 	speak_emote = list("hisses")
 	bubble_icon = "syndibot"
@@ -25,29 +25,32 @@
 	"1. Interfere.\n"+\
 	"2. Kill.\n"+\
 	"3. Destroy."
-	default_storage = /obj/item/device/radio/uplink
+	default_storage = /obj/item/device/radio/uplink/nuclear
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 	seeStatic = 0 //Our programming is superior.
 	hacked = TRUE
+	var/starting_tc = 10
 
 /mob/living/simple_animal/drone/syndrone/Initialize()
 	..()
-	internal_storage.hidden_uplink.telecrystals = 10
-
-/mob/living/simple_animal/drone/syndrone/Login()
-	..()
-	to_chat(src, "<span class='notice'>You can kill and eat other drones to increase your health!</span>" )
+	internal_storage.hidden_uplink.telecrystals = starting_tc
+	head.flags |= NODROP
+	var/obj/item/weapon/implant/weapons_auth/W = new/obj/item/weapon/implant/weapons_auth(src)
+	W.implant(src)
 
 /mob/living/simple_animal/drone/syndrone/badass
 	name = "Badass Syndrone"
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite
 	default_storage = /obj/item/device/radio/uplink/nuclear
+	starting_tc = 30
 
-/mob/living/simple_animal/drone/syndrone/badass/Initialize()
+/mob/living/simple_animal/drone/syndrone/nuke_op/Initialize()
 	..()
-	internal_storage.hidden_uplink.telecrystals = 30
-	var/obj/item/weapon/implant/weapons_auth/W = new/obj/item/weapon/implant/weapons_auth(src)
-	W.implant(src)
+	var/datum/ai_laws/syndicate_override/L = new
+	laws = L.inherent.Join("\n")
+	qdel(L)
+
+	qdel(internal_storage)
 
 /mob/living/simple_animal/drone/snowflake
 	default_hatmask = /obj/item/clothing/head/chameleon/drone
@@ -65,6 +68,9 @@
 /obj/item/drone_shell/syndrone/badass
 	name = "badass syndrone shell"
 	drone_type = /mob/living/simple_animal/drone/syndrone/badass
+
+/obj/item/drone_shell/syndrone/nuke_op
+	drone_type = /mob/living/simple_animal/drone/syndrone/nuke_op
 
 /obj/item/drone_shell/snowflake
 	name = "snowflake drone shell"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -558,6 +558,13 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	refundable = TRUE
 	cost = 35
 
+/datum/uplink_item/support/reinforcement/syndrone
+	name = "Syndrone Shell"
+	desc = "A highly experimental weaponised drone, with hacked laws, but no additional equipment. Hard to hit, can crawl through vents, open all doors, but is extremely fragile, and vulnerable to flashbangs and EMPs."
+	cost = 75 // no builtin TC, better give the litte guy a gun or sword
+	refundable = TRUE
+	item = /obj/item/drone_shell/syndrone/nuke_op
+
 /datum/uplink_item/support/gygax
 	name = "Gygax Exosuit"
 	desc = "A lightweight exosuit, painted in a dark scheme. Its speed and equipment selection make it excellent \


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/609465/24172941/063369c0-0e82-11e7-9e61-7ea88b35315f.png)

:cl: coiax
add: Nuclear operatives with more money than sense can buy a syndrone
shell for 75TC. A syndrone is fragile, but has all access and
ventcrawling. A nuke op syndrone does not spawn with any additional TC
or equipment.
del: Syndrones now have 30hp, just like regular drones, they cannot
repair themselves to gain 120hp.
add: All syndicate drones have weapons authentication implants.
add: Syndicate drones cannot remove their helmets.
/:cl:

- I am the Steelpoint of drones. Apparently. I think you're mean to
Steelpoint, but that's another thing.
- A nuke op drone has standard syndiborg laws.
- The shells are refundable if no one's in the mood to play a tiny bundle of death.

Jusifications for Price

- 75 TC will buy you another human operative and 50 TC of equipment.
- 70 TC will buy you TWO medical syndiborgs, both with emags and all
acces.
- 80 TC will buy you a Dark Gygax.
- 66 TC will buy you six syndicate bombs.
- 65 TC will buy you a syndicate assault borg, which also has all access and an emag, comes
with a (practically) unlimited gun and grenade launcher.

Yes, it is strong, it's hard to hit, it has all access, but it is skill
limited by the player, and needs at least some equipment to do anything.