### PR TITLE
Raises the medical gauze's max stack size to 12

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -118,6 +118,7 @@
 	icon_state = "gauze"
 	stop_bleeding = 1800
 	self_delay = 20
+	max_amount = 12
 
 /obj/item/stack/medical/gauze/improvised
 	name = "improvised gauze"


### PR DESCRIPTION
:cl: XDTM
add: Medical Gauze now stacks up to 12
/:cl:

For golem purposes. It's not like we run out of gauze anyway.

Fixes #25363.
