### PR TITLE
Fixes Pressure Plate recipe

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -450,5 +450,5 @@
 	name = "Pressure Plate"
 	result = /obj/item/device/pressure_plate
 	time = 5
-	reqs = list(/obj/item/stack/sheet/plasteel = 1, /obj/item/stack/tile = 1, /obj/item/stack/cable_coil = 2)
+	reqs = list(/obj/item/stack/sheet/plasteel = 1, /obj/item/stack/tile/plasteel = 1, /obj/item/stack/cable_coil = 2)
 	category = CAT_MISC


### PR DESCRIPTION
:cl: XDTM
fix: Pressure plates are now craftable.
/:cl:

Fixes #25144

As an aside: why the fuck are metal floor tiles typed as plasteel