### PR TITLE
Adds invisibility values to EVERRRRYTHING

### DIFF
--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -1,4 +1,6 @@
-
+#define TURF_INVIS_DEFAULT 2
+#define OBJ_INVIS_DEFAULT 3
+#define MOB_INVIS_DEFAULT 4
 #define SEE_INVISIBLE_MINIMUM 5
 
 #define SEE_INVISIBLE_NOLIGHTING 15 //to not see the lighting objects. Used for nightvision and observer with darkness toggled.

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,6 +1,7 @@
 /obj
 	languages_spoken = HUMAN
 	languages_understood = HUMAN
+	invisibility = OBJ_INVIS_DEFAULT
 	var/crit_fail = 0
 	animate_movement = 2
 	var/throwforce = 0

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -1,6 +1,7 @@
 /turf
 	icon = 'icons/turf/floors.dmi'
 	level = 1
+	invisibility = TURF_DEFAULT_INVIS
 
 	var/intact = 1
 	var/turf/baseturf = /turf/open/space

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -1,7 +1,7 @@
 /turf
 	icon = 'icons/turf/floors.dmi'
 	level = 1
-	invisibility = TURF_DEFAULT_INVIS
+	invisibility = TURF_INVIS_DEFAULT
 
 	var/intact = 1
 	var/turf/baseturf = /turf/open/space

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -1,7 +1,7 @@
 
 
 /mob/living/carbon/alien/larva/Life()
-	set invisibility = 0
+	set invisibility = MOB_INVIS_DEFAULT
 	set background = BACKGROUND_ENABLED
 
 	if (notransform)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -23,7 +23,7 @@
 #define BRAIN_DAMAGE_FILE "brain_damage_lines.json"
 
 /mob/living/carbon/human/Life()
-	set invisibility = 0
+	set invisibility = MOB_INVIS_DEFAULT
 	set background = BACKGROUND_ENABLED
 
 	if (notransform)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -4,7 +4,7 @@
 
 
 /mob/living/carbon/monkey/Life()
-	set invisibility = 0
+	set invisibility = MOB_INVIS_DEFAULT
 	set background = BACKGROUND_ENABLED
 
 	if (notransform)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -1,5 +1,5 @@
 /mob/living/Life()
-	set invisibility = 0
+	set invisibility = MOB_INVIS_DEFAULT
 	set background = BACKGROUND_ENABLED
 
 	if(digitalinvis)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -3,7 +3,6 @@
 	languages_spoken = HUMAN
 	languages_understood = HUMAN
 	sight = 0
-	invisibility = MOB_INVIS_DEFAULT
 	see_in_dark = 2
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ANTAG_HUD)
 	pressure_resistance = 10

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -3,6 +3,7 @@
 	languages_spoken = HUMAN
 	languages_understood = HUMAN
 	sight = 0
+	invisibility = MOB_INVIS_DEFAULT
 	see_in_dark = 2
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ANTAG_HUD)
 	pressure_resistance = 10

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/Life()
-	set invisibility = 0
+	set invisibility = MOB_INVIS_DEFAULT
 	set background = BACKGROUND_ENABLED
 
 	if (src.notransform)

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -8,7 +8,7 @@
 
 
 /mob/living/simple_animal/slime/Life()
-	set invisibility = 0
+	set invisibility = MOB_INVIS_DEFAULT
 	set background = BACKGROUND_ENABLED
 
 	if (notransform)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -499,6 +499,7 @@
 #include "code\game\machinery\dna_scanner.dm"
 #include "code\game\machinery\doppler_array.dm"
 #include "code\game\machinery\droneDispenser.dm"
+#include "code\game\machinery\engi_points_vendor.dm"
 #include "code\game\machinery\firealarm.dm"
 #include "code\game\machinery\flasher.dm"
 #include "code\game\machinery\gulag_item_reclaimer.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -499,7 +499,6 @@
 #include "code\game\machinery\dna_scanner.dm"
 #include "code\game\machinery\doppler_array.dm"
 #include "code\game\machinery\droneDispenser.dm"
-#include "code\game\machinery\engi_points_vendor.dm"
 #include "code\game\machinery\firealarm.dm"
 #include "code\game\machinery\flasher.dm"
 #include "code\game\machinery\gulag_item_reclaimer.dm"


### PR DESCRIPTION
Yea we have this great invisibility system that I can't use because almost everything is set to 0.

"Minimum" see_invisibility is at 5, so now mobs are 4, objs are 3, and turf is 2. 

Having it on a single sliding scale is still kinda lame, goggles that only let you see humans but make all turf/objs invisible would be fun... but I scaled it in the logical order. 

**This shouldn't affect anything in current gameplay** but now if, for example, you wanted a remote camera that you can't use to valid hunt but simply to check for damage as some part of, I dunno, engineering reward item, it is now far easier than trying to add overlays to all the mobs or some thing. 

I made this PR so the maintainers could yell at me for this being a horrible idea BEFORE I dumped hours into a system built around it. 