### PR TITLE
Fixes structures being unable to go through spatial gateways

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_effects/spatial_gateway.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/spatial_gateway.dm
@@ -112,7 +112,7 @@
 
 /obj/effect/clockwork/spatial_gateway/Bumped(atom/A)
 	..()
-	if(isliving(A) || istype(A, /obj/item))
+	if(A && !QDELETED(A))
 		pass_through_gateway(A)
 
 /obj/effect/clockwork/spatial_gateway/proc/pass_through_gateway(atom/movable/A, no_cost)


### PR DESCRIPTION
:cl: Joan
bugfix: Fixes structures being unable to go through spatial gateways.
/:cl:

Mechs, structures, etc. Gotta have that robotics mecha gateway synergy.