### PR TITLE
Misc runtime fixes

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -287,12 +287,10 @@
 			if(label && !..())
 				var/newtype = label2types[label]
 				if(newtype)
-					var/obj/machinery/portable_atmospherics/canister/replacement = new newtype(loc, air_contents)
-					if(connected_port)
-						replacement.connected_port = connected_port
-						replacement.connected_port.connected_device = replacement
-					replacement.interact(usr)
-					qdel(src)
+					var/obj/machinery/portable_atmospherics/canister/replacement = newtype
+					name = initial(replacement.name)
+					desc = initial(replacement.name)
+					icon_state = initial(replacement.icon_state)
 		if("pressure")
 			var/pressure = params["pressure"]
 			if(pressure == "reset")

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -440,6 +440,7 @@
 	chameleon_gun_vars = list()
 	ammo_copy_vars = list("firing_effect_type")
 	chameleon_ammo_vars = list()
+	recharge_newshot()
 	get_chameleon_projectile(/obj/item/weapon/gun/energy/laser)
 
 /obj/item/weapon/gun/energy/laser/chameleon/emp_act(severity)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -232,7 +232,7 @@ var/const/INJECT = 5 //injection
 	var/need_mob_update = 0
 	for(var/reagent in cached_reagents)
 		var/datum/reagent/R = reagent
-		if(!R.holder)
+		if(QDELETED(R.holder))
 			continue
 		if(!C)
 			C = R.holder.my_atom


### PR DESCRIPTION
- Fixes chameleon gun runtime.
- Fixes canister relabel runtime. Also changes how it works. Seriously who thought this was good idea.
- Fixes reagents processing on qdeleted mobs.