### PR TITLE
[DNM - Requires testmerge/balancing]Adds gas miners to all maps + arrivals shuttles, lowers roundstart atmospherics pressure

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -24174,6 +24174,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/miner/carbon_dioxide/roundstart,
 /turf/open/floor/engine/co2,
 /area/atmos)
 "aUi" = (
@@ -26286,6 +26287,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/oxygen/roundstart,
 /turf/open/floor/engine/o2,
 /area/atmos)
 "aYd" = (
@@ -27613,6 +27615,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/miner/toxins/roundstart,
 /turf/open/floor/engine/plasma,
 /area/atmos)
 "baH" = (
@@ -29072,6 +29075,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/nitrogen/roundstart,
 /turf/open/floor/engine/n2,
 /area/atmos)
 "bdG" = (
@@ -30847,6 +30851,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/miner/n2o/roundstart,
 /turf/open/floor/engine/n2o,
 /area/atmos)
 "bgR" = (
@@ -112887,6 +112892,18 @@
 /area/engine/gravity_generator{
 	name = "Atmospherics Engine"
 	})
+"ehz" = (
+/obj/machinery/atmospherics/miner/nitrogen/aux{
+	name = "\improper Gas Vent"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/shuttle/arrival)
+"ehA" = (
+/obj/machinery/atmospherics/miner/oxygen/aux{
+	name = "\improper Gas Vent"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 aaa
@@ -151233,7 +151250,7 @@ acn
 acn
 acn
 acn
-acn
+ehz
 acn
 acn
 acn
@@ -152261,7 +152278,7 @@ acn
 acn
 acn
 acn
-acn
+ehA
 acn
 acn
 acn

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -50985,6 +50985,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/n2o/roundstart,
 /turf/open/floor/engine/n2o,
 /area/atmos)
 "bKK" = (
@@ -54592,6 +54593,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/toxins/roundstart,
 /turf/open/floor/engine/plasma,
 /area/atmos)
 "bRa" = (
@@ -57466,6 +57468,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/carbon_dioxide/roundstart,
 /turf/open/floor/engine/co2,
 /area/atmos)
 "bVQ" = (
@@ -66257,10 +66260,12 @@
 /area/maintenance/incinerator)
 "ckG" = (
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/nitrogen/roundstart,
 /turf/open/floor/engine/n2,
 /area/atmos)
 "ckH" = (
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/oxygen/roundstart,
 /turf/open/floor/engine/o2,
 /area/atmos)
 "ckI" = (
@@ -95609,6 +95614,18 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"dlJ" = (
+/obj/machinery/atmospherics/miner/nitrogen/aux{
+	name = "\improper Gas Vent"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/arrival)
+"dlK" = (
+/obj/machinery/atmospherics/miner/oxygen/aux{
+	name = "\improper Gas Vent"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 aaa
@@ -106521,9 +106538,9 @@ aWS
 aWS
 bcS
 beD
+dlJ
 beC
-beC
-beC
+dlK
 blO
 bcS
 aWS

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -41983,6 +41983,24 @@
 	},
 /turf/open/floor/circuit/green,
 /area/engine/engineering)
+"buW" = (
+/obj/machinery/atmospherics/miner/nitrogen/roundstart,
+/turf/open/floor/engine/n2,
+/area/atmos)
+"buX" = (
+/obj/machinery/atmospherics/miner/oxygen/roundstart,
+/turf/open/floor/engine/o2,
+/area/atmos)
+"buY" = (
+/obj/machinery/atmospherics/miner/nitrogen/aux,
+/turf/open/floor/plasteel/neutral,
+/area/shuttle/arrival)
+"buZ" = (
+/obj/machinery/atmospherics/miner/oxygen/aux{
+	name = "\improper Gas Vent"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 aaa
@@ -71124,11 +71142,11 @@ aad
 aad
 aad
 anx
-asv
+buW
 atw
 asv
 anx
-awA
+buX
 axh
 awA
 anx
@@ -83260,7 +83278,7 @@ bkd
 bko
 bko
 bko
-bko
+buY
 bko
 bko
 bko
@@ -84288,7 +84306,7 @@ bkd
 bko
 bko
 bko
-bko
+buZ
 bko
 bko
 bko

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -42351,6 +42351,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/n2o/roundstart,
 /turf/open/floor/engine/n2o,
 /area/atmos)
 "bFO" = (
@@ -43621,6 +43622,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/toxins/roundstart,
 /turf/open/floor/engine/plasma,
 /area/atmos)
 "bIx" = (
@@ -45006,6 +45008,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/carbon_dioxide/roundstart,
 /turf/open/floor/engine/co2,
 /area/atmos)
 "bLk" = (
@@ -46975,10 +46978,12 @@
 /area/engine/engineering)
 "bPe" = (
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/nitrogen/roundstart,
 /turf/open/floor/engine/n2,
 /area/atmos)
 "bPf" = (
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/oxygen/roundstart,
 /turf/open/floor/engine/o2,
 /area/atmos)
 "bPg" = (
@@ -56156,6 +56161,18 @@
 /obj/machinery/light,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
+"cjQ" = (
+/obj/machinery/atmospherics/miner/oxygen/aux{
+	name = "\improper Gas Vent"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/arrival)
+"cjR" = (
+/obj/machinery/atmospherics/miner/nitrogen/aux{
+	name = "\improper Gas Vent"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 aaa
@@ -75297,8 +75314,8 @@ aTr
 aTr
 aYW
 cjK
-aZS
-aZS
+cjQ
+cjR
 bXj
 aYW
 aTr

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -45402,6 +45402,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/n2o/roundstart,
 /turf/open/floor/engine/n2o,
 /area/atmos)
 "bUX" = (
@@ -47227,6 +47228,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/toxins/roundstart,
 /turf/open/floor/engine/plasma,
 /area/atmos)
 "bYX" = (
@@ -49081,6 +49083,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/carbon_dioxide/roundstart,
 /turf/open/floor/engine/co2,
 /area/atmos)
 "ccE" = (
@@ -53812,10 +53815,12 @@
 /area/shuttle/syndicate)
 "cmU" = (
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/nitrogen/roundstart,
 /turf/open/floor/engine/n2,
 /area/atmos)
 "cmV" = (
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/oxygen/roundstart,
 /turf/open/floor/engine/o2,
 /area/atmos)
 "cmW" = (
@@ -65270,6 +65275,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"cMP" = (
+/obj/machinery/atmospherics/miner/oxygen/aux{
+	name = "\improper Gas Vent"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/arrival)
+"cMQ" = (
+/obj/machinery/atmospherics/miner/nitrogen/aux,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 aaa
@@ -75147,9 +75162,9 @@ awW
 awW
 aCS
 aEq
+cMP
 aEr
-aEr
-aEr
+cMQ
 cLL
 aCS
 awW

--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -77,29 +77,27 @@
 
 /turf/open/floor/engine/n2o
 	name = "n2o floor"
-	initial_gas_mix = "n2o=6000;TEMP=293.15"
+	initial_gas_mix = "n2o=500;TEMP=293.15"
 
 /turf/open/floor/engine/co2
 	name = "co2 floor"
-	initial_gas_mix = "co2=50000;TEMP=293.15"
+	initial_gas_mix = "co2=500;TEMP=293.15"
 
 /turf/open/floor/engine/plasma
 	name = "plasma floor"
-	initial_gas_mix = "plasma=70000;TEMP=293.15"
+	initial_gas_mix = "plasma=700;TEMP=293.15"
 
 /turf/open/floor/engine/o2
 	name = "o2 floor"
-	initial_gas_mix = "o2=100000;TEMP=293.15"
+	initial_gas_mix = "o2=1000;TEMP=293.15"
 
 /turf/open/floor/engine/n2
 	name = "n2 floor"
-	initial_gas_mix = "n2=100000;TEMP=293.15"
+	initial_gas_mix = "n2=5000;TEMP=293.15"
 
 /turf/open/floor/engine/air
 	name = "air floor"
 	initial_gas_mix = "o2=2644;n2=10580;TEMP=293.15"
-
-
 
 /turf/open/floor/engine/cult
 	name = "engraved floor"

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -136,25 +136,65 @@
 	overlay_color = "#FFCCCC"
 	spawn_id = "n2o"
 
+/obj/machinery/atmospherics/miner/n2o/roundstart
+	spawn_mol = MOLES_CELLSTANDARD * 3
+	max_ext_kpa = 7500
+	power_draw = GASMINER_POWER_STATIC
+	power_draw_static = 150
+
 /obj/machinery/atmospherics/miner/nitrogen
 	name = "\improper N2 Gas Miner"
 	overlay_color = "#CCFFCC"
 	spawn_id = "n2"
+
+/obj/machinery/atmospherics/miner/nitrogen/aux
+	spawn_mol = MOLES_CELLSTANDARD * 2
+	max_ext_kpa = 130
+	power_draw_static = 100
+
+/obj/machinery/atmospherics/miner/nitrogen/roundstart
+	spawn_mol = MOLES_CELLSTANDARD * 12
+	max_ext_kpa = 20000
+	power_draw = GASMINER_POWER_STATIC
+	power_draw_static = 150
 
 /obj/machinery/atmospherics/miner/oxygen
 	name = "\improper O2 Gas Miner"
 	overlay_color = "#007FFF"
 	spawn_id = "o2"
 
+/obj/machinery/atmospherics/miner/oxygen/aux
+	spawn_mol = MOLES_CELLSTANDARD * 0.5
+	max_ext_kpa = 130
+	power_draw_static = 30
+
+/obj/machinery/atmospherics/miner/oxygen/roundstart
+	spawn_mol = MOLES_CELLSTANDARD * 3
+	max_ext_kpa = 20000
+	power_draw = GASMINER_POWER_STATIC
+	power_draw_static = 100
+
 /obj/machinery/atmospherics/miner/toxins
 	name = "\improper Plasma Gas Miner"
 	overlay_color = "#FF0000"
 	spawn_id = "plasma"
 
+/obj/machinery/atmospherics/miner/toxins/roundstart
+	spawn_mol = MOLES_CELLSTANDARD * 2
+	max_ext_kpa = 15000
+	power_draw = GASMINER_POWER_STATIC
+	power_draw_static = 300
+
 /obj/machinery/atmospherics/miner/carbon_dioxide
 	name = "\improper CO2 Gas Miner"
 	overlay_color = "#CDCDCD"
 	spawn_id = "co2"
+
+/obj/machinery/atmospherics/miner/carbon_dioxide/roundstart
+	spawn_mol = MOLES_CELLSTANDARD * 2
+	max_ext_kpa = 10000
+	power_draw = GASMINER_POWER_STATIC
+	power_draw_static = 50
 
 /obj/machinery/atmospherics/miner/bz
 	name = "\improper BZ Gas Miner"


### PR DESCRIPTION
What it says on the tin, instead of having super-high-pressure tanks be the only source of air, have gas miners that refill tanks to a high pressure but not obscene pressure, and consume power while doing so. The power values are probably too low but I didn't want atmospherics being a power sink near round start, I'll be recalculating values soon so it's perfectly filled at roundstart so it only starts taking power if you drain the tanks.

EDIT: Also adding them to all arrivals shuttles, so if it gets breached and is repaired it'll automatically refill to solve the problem of latejoiners dying from no pressure/air.

:cl: kevinz000
experimental: Atmospherics now have gas miners to supplement their shift-start allowance of air.
rscdel: Atmospherics' primary gas tanks now start at a lower pressure.
/:cl:

# AFTER THE VALUES ARE RECALCULATED, I SERIOUSLY WANT TO UP THE POWER DRAW, AS 150 WATTS ISNT ANYTHING. Should I just up it as-is and let it draw from atmospheric's APC, make it have a connection to the station power grid so it's directly drawing from that and NOT from the APC, or make it have a grid connection AS WELL AS a small SMES cell to store energy to last a few minutes?