### PR TITLE
Nerfs flashbang relic

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -638,7 +638,7 @@
 
 /obj/item/weapon/relic/proc/flash(mob/user)
 	playsound(src.loc, "sparks", rand(25,50), 1)
-	var/obj/item/weapon/grenade/flashbang/CB = new/obj/item/weapon/grenade/flashbang(get_turf(user))
+	var/obj/item/weapon/grenade/flashbang/CB = new/obj/item/weapon/grenade/flashbang(user.loc)
 	CB.prime()
 	warn_admins(user, "Flash")
 


### PR DESCRIPTION
Should fix #14112
Spawns the flashbang at the same place at the user, this should fix it as using a flashbang in a closet and dropping it (making it part of the closet's contents) normally stuns the user as well.