### PR TITLE
Deconstructing display cases and coffins drop the correct amount of wood

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -131,6 +131,8 @@
 	max_integrity = 70
 	horizontal = TRUE
 	delivery_icon = "deliverycrate"
+	material_drop = /obj/item/stack/sheet/mineral/wood
+	material_drop_amount = 5
 
 /obj/structure/closet/wardrobe/red
 	name = "security wardrobe"

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -207,7 +207,7 @@
 		playsound(src.loc, I.usesound, 50, 1)
 		if(do_after(user, 30*I.toolspeed, target = src))
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-			new /obj/item/stack/sheet/mineral/wood(get_turf(src))
+			new /obj/item/stack/sheet/mineral/wood(get_turf(src), 5)
 			qdel(src)
 
 	else if(istype(I, /obj/item/weapon/electronics/airlock))


### PR DESCRIPTION
:cl:
fix: Deconstructing display cases and coffins now drop the correct amount of wood.
/:cl:

Fixes #24547
Fixes #25420
