### PR TITLE
Plane masters can now decide if they should be in user's screens by default

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -64,7 +64,10 @@
 	hand_slots = list()
 
 	for(var/mytype in subtypesof(/obj/screen/plane_master))
-		var/obj/screen/plane_master/instance = new mytype()
+		var/obj/screen/plane_master/instance = mytype
+		if(!initial(instance.auto_add_to_players))
+			continue
+		instance = new mytype()
 		plane_masters["[instance.plane]"] = instance
 		instance.backdrop(mymob)
 

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -3,6 +3,7 @@
 	icon_state = "blank"
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	blend_mode = BLEND_OVERLAY
+	var/auto_add_to_players = TRUE
 
 //Why do plane masters need a backdrop sometimes? Read http://www.byond.com/forum/?post=2141928
 //Trust me, you need one. Period. If you don't think you do, you're doing something extremely wrong.


### PR DESCRIPTION
```/obj/screen/plane_master``` can now decide whether it should be automatically added to user's screens.
for @Robustin 

(branch nonsense because github sucks)