### PR TITLE
CTF teams have their own radio channels + fixes

### DIFF
--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -134,7 +134,9 @@ var/list/radiochannels = list(
 	"Syndicate" = 1213,
 	"Supply" = 1347,
 	"Service" = 1349,
-	"AI Private" = 1447
+	"AI Private" = 1447,
+	"Red Team" = 1215,
+	"Blue Team" = 1217
 )
 
 var/list/radiochannelsreverse = list(
@@ -148,7 +150,9 @@ var/list/radiochannelsreverse = list(
 	"1213" = "Syndicate",
 	"1347" = "Supply",
 	"1349" = "Service",
-	"1447" = "AI Private"
+	"1447" = "AI Private",
+	"1215" = "Red Team",
+	"1217" = "Blue Team"
 )
 
 //depenging helpers
@@ -162,6 +166,8 @@ var/const/ENG_FREQ = 1357 //engineering, coloured orange in chat window
 var/const/SEC_FREQ = 1359 //security, coloured red in chat window
 var/const/CENTCOM_FREQ = 1337 //centcom frequency, coloured grey in chat window
 var/const/AIPRIV_FREQ = 1447 //AI private, colored magenta in chat window
+var/const/REDTEAM_FREQ = 1215 // red team (CTF) frequency, coloured red
+var/const/BLUETEAM_FREQ = 1217 // blue team (CTF) frequency, coloured blue
 
 #define TRANSMISSION_WIRE	0
 #define TRANSMISSION_RADIO	1

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -107,7 +107,7 @@
 	else if(data == 5)
 
 		for(var/obj/item/device/radio/R in all_radios["[freq]"])
-			if(!R.centcom)
+			if(!R.independent)
 				continue
 
 			if(R.receive_range(freq, level) > -1)
@@ -222,8 +222,8 @@
 	else if(data == 5)
 
 		for(var/obj/item/device/radio/R in all_radios["[RADIO_CHAT]"])
-			if(R.centcom)
-				receive |= R.send_hear(CENTCOM_FREQ)
+			if(R.independent)
+				receive |= R.send_hear(display_freq)
 
 	// --- Broadcast to ALL radio devices ---
 

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -1,4 +1,3 @@
-
 /obj/item/device/encryptionkey
 	name = "standard encryption key"
 	desc = "An encryption key for a radio headset.  Has no special codes in it.  WHY DOES IT EXIST?  ASK NANOTRASEN."
@@ -8,7 +7,7 @@
 	origin_tech = "engineering=2;bluespace=1"
 	var/translate_binary = 0
 	var/syndie = 0
-	var/centcom = 0
+	var/independent = FALSE
 	var/list/channels = list()
 
 /obj/item/device/encryptionkey/syndicate
@@ -126,7 +125,7 @@
 	name = "centcom radio encryption key"
 	desc = "An encryption key for a radio headset.  To access the centcom channel, use :y."
 	icon_state = "cent_cypherkey"
-	centcom = 1
+	independent = TRUE
 	channels = list("Centcom" = 1)
 
 /obj/item/device/encryptionkey/ai //ported from NT, this goes 'inside' the AI.

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -291,8 +291,8 @@
 		if(keyslot2.syndie)
 			src.syndie = 1
 
-		if (keyslot2.centcom)
-			centcom = 1
+		if (keyslot2.independent)
+			independent = TRUE
 
 
 	for(var/ch_name in channels)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -23,7 +23,7 @@
 	var/subspace_switchable = 0
 	var/subspace_transmission = 0
 	var/syndie = 0//Holder to see if it's a syndicate encrpyed radio
-	var/centcom = 0//Bleh, more dirty booleans
+	var/independent = FALSE // If true, bypasses any tcomms machinery.
 	var/freqlock = 0 //Frequency lock to stop the user from untuning specialist radios.
 	var/emped = 0	//Highjacked to track the number of consecutive EMPs on the radio, allowing consecutive EMP's to stack properly.
 //			"Example" = FREQ_LISTENING|FREQ_BROADCASTING
@@ -58,7 +58,7 @@
 	channels = list()
 	translate_binary = 0
 	syndie = 0
-	centcom = 0
+	independent = FALSE
 
 	if(keyslot)
 		for(var/ch_name in keyslot.channels)
@@ -73,8 +73,8 @@
 		if(keyslot.syndie)
 			syndie = 1
 
-		if(keyslot.centcom)
-			centcom = 1
+		if(keyslot.independent)
+			independent = TRUE
 
 	for(var/ch_name in channels)
 		secure_radio_connections[ch_name] = add_radio(src, radiochannels[ch_name])
@@ -299,9 +299,9 @@
 	else
 		jobname = "Unknown"
 
-	/* ###### Centcom channel bypasses all comms relays. ###### */
+	/* ###### `independent` radios bypass all comms relays. ###### */
 
-	if (freqnum == CENTCOM_FREQ && centcom)
+	if(independent)
 		var/datum/signal/signal = new
 		signal.transmission_method = 2
 		signal.data = list(
@@ -478,7 +478,7 @@
 		if(!(src.syndie)) //Checks to see if it's allowed on that frequency, based on the encryption keys
 			return -1
 	if(freq == CENTCOM_FREQ)
-		if (!(src.centcom))
+		if(!independent)
 			return -1
 	if (!on)
 		return -1

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -13,7 +13,9 @@ var/list/freqtospan = list(
 	"1353" = "comradio",
 	"1447" = "aiprivradio",
 	"1213" = "syndradio",
-	"1337" = "centcomradio"
+	"1337" = "centcomradio",
+	"1215" = "redteamradio",
+	"1217" = "blueteamradio"
 	)
 
 /atom/movable/proc/say(message)

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -39,6 +39,8 @@ em						{font-style: normal;	font-weight: bold;}
 .syndradio				{color: #6d3f40;}
 .centcomradio			{color: #686868;}
 .aiprivradio			{color: #ff00ff;}
+.redteamradio           {color: #ff0000;}
+.blueteamradio          {color: #0000ff;}
 
 .yell					{					font-weight: bold;}
 


### PR DESCRIPTION
:cl: coiax
fix: Teams playing CTF have their own radio channels, rather than using
the Centcom and Syndicate channels.
fix: Actually actually makes CTF barricades repair between rounds.
fix: Blue CTF lasers have little blue effects when they hit things, rather
than red effects.
/:cl:

- Multiple admins have asked me to fix CTF using real radio channels, so
I modified the radio code a tiny bit, and boom, Red Team and Blue Team
radios.