### PR TITLE
[Box] Two map fixes

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -4153,6 +4153,11 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
@@ -56049,10 +56054,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/engine/engineering)


### PR DESCRIPTION
:cl: Penguaro
add: Brig - Added Air Alarm
del: Engineering - Removed Brig Shutter
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
While playing as a Malf AI for the first time, I had a delightful time terrorizing players and noticed some bugs with the map. In Engineering, one of the window panes has brig shutters installed. This PR removes them. In the Brig Hallway, there is no Air Alarm present nor do any of the other air alarms control the vents/scrubbers in that hallway. I added one.

![air](https://cloud.githubusercontent.com/assets/9791590/24306701/808ab7f0-108f-11e7-8c90-524da88bfbb2.jpg)
![shutter](https://cloud.githubusercontent.com/assets/9791590/24306705/8225aa34-108f-11e7-82fe-01a58b462552.jpg)