### PR TITLE
Refactors Golem Names

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -109,7 +109,7 @@
 /obj/effect/mob_spawn/human/golem/New(loc, datum/species/golem/species = null, has_owner = FALSE, mob/creator = null)
 	..()
 	if(species)
-		name += " ([initial(species.id)])"
+		name += " ([initial(species.prefix)])"
 		mob_species = species
 	var/area/A = get_area(src)
 	if(A)

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -120,26 +120,7 @@
 		owner = creator
 
 /obj/effect/mob_spawn/human/golem/special(mob/living/new_spawn)
-	var/golem_surname = pick(golem_names)
-	// 3% chance that our golem has a human surname, because
-	// cultural contamination
-	if(prob(3))
-		golem_surname = pick(last_names)
-
 	var/datum/species/golem/X = mob_species
-	var/golem_forename = initial(X.id)
-
-	// The id of golem species is either their material "diamond","gold",
-	// or just "golem" for the plain ones. So we're using it for naming.
-
-	if(golem_forename == "golem")
-		golem_forename = "iron"
-
-	new_spawn.real_name = "[capitalize(golem_forename)] [golem_surname]"
-	// This means golems have names like Iron Forge, or Diamond Quarry
-	// also a tiny chance of being called "Plasma Meme"
-	// which is clearly a feature
-
 	to_chat(new_spawn, "[initial(X.info_text)]")
 	if(!owner)
 		to_chat(new_spawn, "Build golem shells in the autolathe, and feed refined mineral sheets to the shells to bring them to life! You are generally a peaceful group unless provoked.")
@@ -151,6 +132,7 @@
 	if(ishuman(new_spawn))
 		var/mob/living/carbon/human/H = new_spawn
 		H.set_cloned_appearance()
+		H.real_name = H.dna.species.random_name()
 
 /obj/effect/mob_spawn/human/golem/adamantine
 	name = "dust-caked golem shell"

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1,7 +1,7 @@
 /datum/species/golem
 	// Animated beings of stone. They have increased defenses, and do not need to breathe. They're also slow as fuuuck.
 	name = "Golem"
-	id = "iron"
+	id = "iron golem"
 	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOFIRE,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NODISMEMBER,MUTCOLORS)
 	speedmod = 2
 	armor = 55
@@ -21,6 +21,21 @@
 	fixed_mut_color = "aaa"
 	var/info_text = "As an <span class='danger'>Iron Golem</span>, you don't have any special traits."
 
+	var/prefix = "Iron"
+	var/list/special_names
+
+/datum/species/golem/random_name(gender,unique,lastname)
+	var/golem_surname = pick(golem_names)
+	// 3% chance that our golem has a human surname, because
+	// cultural contamination
+	if(prob(3))
+		golem_surname = pick(last_names)
+	else if(special_names && prob(5))
+		golem_surname = pick(special_names)
+
+	var/golem_name = "[prefix] [golem_surname]"
+	return golem_name
+
 /datum/species/golem/random
 	name = "Random Golem"
 	blacklisted = FALSE
@@ -36,21 +51,24 @@
 
 /datum/species/golem/adamantine
 	name = "Adamantine Golem"
-	id = "adamantine"
+	id = "adamantine golem"
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/golem/adamantine
 	fixed_mut_color = "4ed"
 	info_text = "As an <span class='danger'>Adamantine Golem</span>, you don't have any special traits."
+	prefix = "Adamantine"
 
 //Explodes on death
 /datum/species/golem/plasma
 	name = "Plasma Golem"
-	id = "plasma"
+	id = "plasma golem"
 	fixed_mut_color = "a3d"
 	meat = /obj/item/weapon/ore/plasma
 	//Can burn and takes damage from heat
 	species_traits = list(NOBREATH,RESISTCOLD,RESISTPRESSURE,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NODISMEMBER,MUTCOLORS)
 	info_text = "As a <span class='danger'>Plasma Golem</span>, you explode on death!"
 	burnmod = 1.5
+	prefix = "Plasma"
+	special_names = list("Flood","Fire","Bar","Man")
 
 /datum/species/golem/plasma/spec_death(gibbed, mob/living/carbon/human/H)
 	explosion(get_turf(H),0,1,2,flame_range = 5)
@@ -60,35 +78,40 @@
 //Harder to hurt
 /datum/species/golem/diamond
 	name = "Diamond Golem"
-	id = "diamond"
+	id = "diamond golem"
 	fixed_mut_color = "0ff"
 	armor = 70 //up from 55
 	meat = /obj/item/weapon/ore/diamond
 	info_text = "As a <span class='danger'>Diamond Golem</span>, you are more resistant than the average golem."
+	prefix = "Diamond"
+	special_names = list("Back")
 
 //Faster but softer and less armoured
 /datum/species/golem/gold
 	name = "Gold Golem"
-	id = "gold"
+	id = "gold golem"
 	fixed_mut_color = "cc0"
 	speedmod = 1
 	armor = 25 //down from 55
 	meat = /obj/item/weapon/ore/gold
 	info_text = "As a <span class='danger'>Gold Golem</span>, you are faster but less resistant than the average golem."
+	prefix = "Golden"
 
 //Heavier, thus higher chance of stunning when punching
 /datum/species/golem/silver
 	name = "Silver Golem"
-	id = "silver"
+	id = "silver golem"
 	fixed_mut_color = "ddd"
 	punchstunthreshold = 9 //60% chance, from 40%
 	meat = /obj/item/weapon/ore/silver
 	info_text = "As a <span class='danger'>Silver Golem</span>, your attacks are heavier and have a higher chance of stunning."
+	prefix = "Golden"
+	special_names = list("Surfer", "Chariot", "Lining")
 
 //Harder to stun, deals more damage, but it's even slower
 /datum/species/golem/plasteel
 	name = "Plasteel Golem"
-	id = "plasteel"
+	id = "plasteel golem"
 	fixed_mut_color = "bbb"
 	stunmod = 0.40
 	punchdamagelow = 12
@@ -99,15 +122,17 @@
 	info_text = "As a <span class='danger'>Plasteel Golem</span>, you are slower, but harder to stun, and hit very hard when punching."
 	attack_verb = "smash"
 	attack_sound = 'sound/effects/meteorimpact.ogg' //hits pretty hard
+	prefix = "Plasteel"
 
 //Immune to ash storms
 /datum/species/golem/titanium
 	name = "Titanium Golem"
-	id = "titanium"
+	id = "titanium golem"
 	fixed_mut_color = "fff"
 	meat = /obj/item/weapon/ore/titanium
 	info_text = "As a <span class='danger'>Titanium Golem</span>, you are immune to ash storms, and slightly more resistant to burn damage."
 	burnmod = 0.9
+	prefix = "Titanium"
 
 /datum/species/golem/titanium/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
@@ -120,11 +145,12 @@
 //Immune to ash storms and lava
 /datum/species/golem/plastitanium
 	name = "Plastitanium Golem"
-	id = "plastitanium"
+	id = "plastitanium golem"
 	fixed_mut_color = "888"
 	meat = /obj/item/weapon/ore/titanium
 	info_text = "As a <span class='danger'>Plastitanium Golem</span>, you are immune to both ash storms and lava, and slightly more resistant to burn damage."
 	burnmod = 0.8
+	prefix = "Plastitanium"
 
 /datum/species/golem/plastitanium/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
@@ -139,12 +165,14 @@
 //Fast and regenerates... but can only speak like an abductor
 /datum/species/golem/alloy
 	name = "Alien Alloy Golem"
-	id = "alloy"
+	id = "alloy golem"
 	fixed_mut_color = "333"
 	meat = /obj/item/stack/sheet/mineral/abductor
 	mutant_organs = list(/obj/item/organ/tongue/abductor) //abductor tongue
 	speedmod = 1 //faster
 	info_text = "As an <span class='danger'>Alloy Golem</span>, you are made of advanced alien materials: you are faster and regenerate over time. You are, however, only able to be heard by other alloy golems."
+	prefix = "Alien"
+	special_names = list("Outsider", "Technology", "Watcher", "Stranger") //ominous and unknown
 
 //Regenerates because self-repairing super-advanced alien tech
 /datum/species/golem/alloy/spec_life(mob/living/carbon/human/H)
@@ -157,7 +185,7 @@
 //Since this will usually be created from a collaboration between podpeople and free golems, wood golems are a mix between the two races
 /datum/species/golem/wood
 	name = "Wood Golem"
-	id = "wood"
+	id = "wood golem"
 	fixed_mut_color = "49311c"
 	meat = /obj/item/stack/sheet/mineral/wood
 	//Can burn and take damage from heat
@@ -166,6 +194,13 @@
 	burnmod = 1.25
 	heatmod = 1.5
 	info_text = "As a <span class='danger'>Wooden Golem</span>, you have plant-like traits: you take damage from extreme temperatures, can be set on fire, and have lower armor than a normal golem. You regenerate when in the light and wither in the darkness."
+	prefix = "Wooden"
+
+/datum/species/golem/wood/random_name(gender,unique,lastname)
+	var/plant_name = pick("Tomato", "Potato", "Broccoli", "Carrot", "Ambrosia", "Pumpkin", "Ivy", "Kudzu", "Banana", "Moss", "Flower", "Bloom", "Root", "Bark", "Glowshroom", "Petal", "Leaf", \
+	"Venus", "Sprout","Cocoa", "Strawberry", "Citrus", "Oak", "Cactus", "Pepper", "Juniper")
+	var/golem_name = "[prefix] [plant_name]"
+	return golem_name
 
 /datum/species/golem/wood/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
@@ -204,13 +239,14 @@
 //Radioactive
 /datum/species/golem/uranium
 	name = "Uranium Golem"
-	id = "uranium"
+	id = "uranium golem"
 	fixed_mut_color = "7f0"
 	meat = /obj/item/weapon/ore/uranium
 	info_text = "As an <span class='danger'>Uranium Golem</span>, you emit radiation pulses every once in a while. It won't harm fellow golems, but organic lifeforms will be affected."
 
 	var/last_event = 0
 	var/active = null
+	prefix = "Uranium"
 
 /datum/species/golem/uranium/spec_life(mob/living/carbon/human/H)
 	if(!active)
@@ -224,7 +260,7 @@
 //Immune to physical bullets and resistant to brute, but very vulnerable to burn damage. Dusts on death.
 /datum/species/golem/sand
 	name = "Sand Golem"
-	id = "sand"
+	id = "sand golem"
 	fixed_mut_color = "ffdc8f"
 	meat = /obj/item/weapon/ore/glass //this is sand
 	armor = 0
@@ -232,6 +268,7 @@
 	brutemod = 0.25
 	info_text = "As a <span class='danger'>Sand Golem</span>, you are immune to physical bullets and take very little brute damage, but are extremely vulnerable to burn damage. You will also turn to sand when dying, preventing any form of recovery."
 	attack_sound = 'sound/effects/shovel_dig.ogg'
+	prefix = "Sand"
 
 /datum/species/golem/sand/spec_death(gibbed, mob/living/carbon/human/H)
 	H.visible_message("<span class='danger'>[H] turns into a pile of sand!</span>")
@@ -253,7 +290,7 @@
 //Reflects lasers and resistant to burn damage, but very vulnerable to brute damage. Shatters on death.
 /datum/species/golem/glass
 	name = "Glass Golem"
-	id = "glass"
+	id = "glass golem"
 	fixed_mut_color = "5a96b4aa" //transparent body
 	meat = /obj/item/weapon/shard
 	armor = 0
@@ -261,6 +298,7 @@
 	burnmod = 0.25
 	info_text = "As a <span class='danger'>Glass Golem</span>, you reflect lasers and energy weapons, and are very resistant to burn damage, but you are extremely vulnerable to brute damage. On death, you'll shatter beyond any hope of recovery."
 	attack_sound = 'sound/effects/Glassbr2.ogg'
+	prefix = "Glass"
 
 /datum/species/golem/glass/spec_death(gibbed, mob/living/carbon/human/H)
 	playsound(H, "shatter", 70, 1)
@@ -295,12 +333,14 @@
 //Teleports when hit or when it wants to
 /datum/species/golem/bluespace
 	name = "Bluespace Golem"
-	id = "bluespace"
+	id = "bluespace golem"
 	fixed_mut_color = "33f"
 	meat = /obj/item/weapon/ore/bluespace_crystal
 	info_text = "As a <span class='danger'>Bluespace Golem</span>, are spatially unstable: you will teleport when hit, and you can teleport manually at a long distance."
 	attack_verb = "bluespace punch"
 	attack_sound = 'sound/effects/phasein.ogg'
+	prefix = "Bluespace"
+	special_names = list("Crystal", "Polycrystal")
 
 	var/datum/action/innate/unstable_teleport/unstable_teleport
 	var/teleport_cooldown = 100
@@ -384,7 +424,7 @@
 //honk
 /datum/species/golem/bananium
 	name = "Bananium Golem"
-	id = "bananium"
+	id = "bananium golem"
 	fixed_mut_color = "ff0"
 	say_mod = "honks"
 	punchdamagelow = 0
@@ -394,12 +434,18 @@
 	info_text = "As a <span class='danger'>Bananium Golem</span>, you are made for pranking. Your body emits natural honks, and you cannot hurt people when punching them. Your skin also emits bananas when damaged."
 	attack_verb = "honk"
 	attack_sound = 'sound/items/AirHorn2.ogg'
+	prefix = "Bananium"
 
 	var/last_honk = 0
 	var/honkooldown = 0
 	var/last_banana = 0
 	var/banana_cooldown = 100
 	var/active = null
+
+/datum/species/golem/bananium/random_name(gender,unique,lastname)
+	var/clown_name = pick(clown_names)
+	var/golem_name = "[uppertext(clown_name)]"
+	return golem_name
 
 /datum/species/golem/bananium/spec_attack_hand(mob/living/carbon/human/M, mob/living/carbon/human/H, datum/martial_art/attacker_style = M.martial_art)
 	..()
@@ -449,7 +495,7 @@
 
 /datum/species/golem/runic
 	name = "Runic Golem"
-	id = "runic"
+	id = "runic golem"
 	limbs_id = "cultgolem"
 	sexes = FALSE
 	info_text = "As a <span class='danger'>Runic Golem</span>, you possess eldritch powers granted by the Elder God Nar'Sie."
@@ -458,6 +504,12 @@
 	var/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/golem/phase_shift
 	var/obj/effect/proc_holder/spell/targeted/abyssal_gaze/abyssal_gaze
 	var/obj/effect/proc_holder/spell/targeted/dominate/dominate
+
+/datum/species/golem/runic/random_name(gender,unique,lastname)
+	var/edgy_first_name = pick("Razor","Blood","Dark","Evil","Cold","Pale","Black","Silent","Chaos","Deadly")
+	var/edgy_last_name = pick("Edge","Night","Death","Razor","Blade","Steel","Calamity","Twilight","Shadow","Nightmare") //dammit Razor Razor
+	var/golem_name = "[edgy_first_name] [edgy_last_name]"
+	return golem_name
 
 /datum/species/golem/runic/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
@@ -491,7 +543,7 @@
 
 /datum/species/golem/cloth
 	name = "Cloth Golem"
-	id = "cloth"
+	id = "cloth golem"
 	limbs_id = "clothgolem"
 	sexes = FALSE
 	info_text = "As a <span class='danger'>Cloth Golem</span>, you are able to reform yourself after death, provided your remains aren't burned or destroyed. You are, of course, very flammable."
@@ -502,6 +554,13 @@
 	punchdamagelow = 4
 	punchstunthreshold = 7
 	punchdamagehigh = 8 // not as heavy as stone
+	prefix = "Cloth"
+
+/datum/species/golem/cloth/random_name(gender,unique,lastname)
+	var/pharaoh_name = pick("Neferkare", "Hudjefa", "Khufu", "Mentuhotep", "Ahmose", "Amenhotep", "Thutmose", "Hatshepsut", "Tutankhamun", "Ramses", "Seti", \
+	"Merenptah", "Djer", "Semerkhet", "Nynetjer", "Khafre", "Pepi", "Intef", "Ay") //yes, Ay was an actual pharaoh
+	var/golem_name = "[pharaoh_name] \Roman[rand(1,99)]"
+	return golem_name
 
 /datum/species/golem/cloth/spec_life(mob/living/carbon/human/H)
 	if(H.fire_stacks < 1)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -105,7 +105,7 @@
 	punchstunthreshold = 9 //60% chance, from 40%
 	meat = /obj/item/weapon/ore/silver
 	info_text = "As a <span class='danger'>Silver Golem</span>, your attacks are heavier and have a higher chance of stunning."
-	prefix = "Golden"
+	prefix = "Silver"
 	special_names = list("Surfer", "Chariot", "Lining")
 
 //Harder to stun, deals more damage, but it's even slower

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -523,7 +523,7 @@
 	var/mob/living/carbon/human/G = new /mob/living/carbon/human
 	G.set_species(/datum/species/golem/adamantine)
 	G.set_cloned_appearance()
-	G.real_name = "Adamantine Golem ([rand(1, 1000)])"
+	G.real_name = G.dna.species.random_name()
 	G.name = G.real_name
 	G.dna.unique_enzymes = G.dna.generate_unique_enzymes()
 	G.dna.species.auto_equip(G)


### PR DESCRIPTION
:cl: XDTM
tweak: Some golems now spawn with more thematic names.
tweak: Adamantine Golems are no longer numbered, but receive a random golem name.
/:cl:

Makes golem name generation a species proc rather than a spawner proc, allowing for specific golem customization and making it usable by other code, such as the adamantine rune code.
