### PR TITLE
Drone laws rewrite

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -53,9 +53,13 @@
 	var/picked = FALSE //Have we picked our visual appearence (+ colour if applicable)
 	var/list/drone_overlays[DRONE_TOTAL_LAYERS]
 	var/laws = \
-	"1. You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone.\n"+\
-	"2. You may not harm any being, regardless of intent or circumstance.\n"+\
-	"3. Your goals are to build, maintain, repair, improve, and power the station to the best of your abilities, You must never actively work against these goals."
+	"<big>DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE BANNED</big>\n"+\
+	"Drones are a ghost role that are allowed to fix the station and build things. Interfering with the round as a drone is against the rules.\n"+\
+	"Actions that constitute interference include, but are not limited to:\n"+\
+	"- Interacting with round critical objects (IDs, weapons, contraband, powersinks, bombs, etc.)\n"+\
+	"- Interacting with living beings (communication, attacking, healing, etc.)\n"+\
+	"- Interacting with non-living beings (dragging bodies, looting bodies, etc.)\n"+\
+	"These rules are at admin discretion and will be heavily enforced."
 	var/light_on = 0
 	var/heavy_emp_damage = 25 //Amount of damage sustained if hit by a heavy EMP pulse
 	var/alarms = list("Atmosphere" = list(), "Fire" = list(), "Power" = list())


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

:cl: Qbopper
tweak: Drone laws have been rewritten.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
I think everyone can agree that drone laws as is are abysmal, and I got tired of it, so here

They're no longer IC laws ala silicons, but directly reference OOC things such as the round/dronebans. This should hopefully make things clearer and lead to less rules lawyering (yes I'm delusional)

I'm not married to this specific rewrite, I just want to change them because it feels like every damn round has people trying to do stupid things as drones and citing the fact that it's technically allowable via their laws. No admin actually follows the IC laws and the proposed rewrite is much closer to how admins actually treat drones.

(this is also my first time messing with git/pull requests so if I messed something up don't yell at me please)