### PR TITLE
Adds Show/Hide functionality to plane masters

### DIFF
--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -3,6 +3,14 @@
 	icon_state = "blank"
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	blend_mode = BLEND_OVERLAY
+	var/show_alpha = 255
+	var/hide_alpha = 0
+	
+/obj/screen/plane_master/proc/show(override)
+	alpha = override || show_alpha
+	
+/obj/screen/plane_master/proc/hide(override)
+	alpha = override || hide_alpha
 
 //Why do plane masters need a backdrop sometimes? Read http://www.byond.com/forum/?post=2141928
 //Trust me, you need one. Period. If you don't think you do, you're doing something extremely wrong.

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -6,10 +6,10 @@
 	var/show_alpha = 255
 	var/hide_alpha = 0
 	
-/obj/screen/plane_master/proc/show(override)
+/obj/screen/plane_master/proc/Show(override)
 	alpha = override || show_alpha
 	
-/obj/screen/plane_master/proc/hide(override)
+/obj/screen/plane_master/proc/Hide(override)
 	alpha = override || hide_alpha
 
 //Why do plane masters need a backdrop sometimes? Read http://www.byond.com/forum/?post=2141928


### PR DESCRIPTION
If you don't want a plane master to appear by default, set its alpha to 0 in its definition.
Adds some helpers for hiding/showing plane masters.

Remake/Redo/Improvement of https://github.com/tgstation/tgstation/pull/25450