### PR TITLE
Bank Machine now uses the radio rather than announcements

### DIFF
--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -51,7 +51,7 @@
 			SSshuttle.points -= 200
 			if(next_warning < world.time && prob(15))
 				var/area/A = get_area(loc)
-				var/message = "Unauthorized credit withdrawal underway in [A.map_name]!"
+				var/message = "Unauthorized credit withdrawal underway in [A.map_name]!!"
 				radio.talk_into(src, message, radio_channel, get_spans())
 				next_warning = world.time + minimum_time_between_warnings
 

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -4,7 +4,21 @@
 	icon = 'goon/icons/obj/goon_terminals.dmi'
 	idle_power_usage = 100
 	var/siphoning = FALSE
-	var/last_warning = 0
+	var/next_warning = 0
+	var/obj/item/device/radio/radio
+	var/radio_channel = "Common"
+	var/minimum_time_between_warnings = 400
+
+/obj/machinery/computer/bank_machine/Initialize(mapload)
+	..()
+	radio = new(src)
+	radio.subspace_transmission = TRUE
+	radio.canhear_range = 0
+	radio.recalculateChannels()
+
+/obj/machinery/computer/bank_machine/Destroy()
+	QDEL_NULL(radio)
+	. = ..()
 
 /obj/machinery/computer/bank_machine/attackby(obj/item/I, mob/user)
 	var/value = 0
@@ -32,18 +46,17 @@
 			say("Station funds depleted. Halting siphon.")
 			siphoning = FALSE
 		else
-			var/obj/item/stack/spacecash/c200/on_turf = locate() in src.loc
-			if(on_turf && on_turf.amount < on_turf.max_amount)
-				on_turf.amount++
-			else
-				new /obj/item/stack/spacecash/c200(get_turf(src))
+			new /obj/item/stack/spacecash/c200(get_turf(src)) // will autostack
 			playsound(src.loc, 'sound/items/poster_being_created.ogg', 100, 1)
 			SSshuttle.points -= 200
-			if(last_warning < world.time && prob(15))
+			if(next_warning < world.time && prob(15))
 				var/area/A = get_area(loc)
-				minor_announce("Unauthorized credit withdrawal underway in [A.map_name]." , "Network Breach", TRUE)
-				last_warning = world.time + 400
+				var/message = "Unauthorized credit withdrawal underway in [A.map_name]!"
+				radio.talk_into(src, message, radio_channel, get_spans())
+				next_warning = world.time + minimum_time_between_warnings
 
+/obj/machinery/computer/bank_machine/get_spans()
+	. = ..() | SPAN_ROBOT
 
 /obj/machinery/computer/bank_machine/attack_hand(mob/user)
 	if(..())
@@ -67,8 +80,8 @@
 	if(..())
 		return
 	if(href_list["siphon"])
-		say("<span class='warning'>Siphon of station credits has begun!</span>")
+		say("Siphon of station credits has begun!")
 		siphoning = TRUE
 	if(href_list["halt"])
-		say("<span class='warning'>Station credit withdrawal halted.</span>")
+		say("Station credit withdrawal halted.")
 		siphoning = FALSE


### PR DESCRIPTION
:cl: coiax
add: The Bank Machine in the vault now uses the radio to announce
unauthorized withdrawals, rather than an endless stream of
loud announcements.
/:cl:

- Look, the announcements are LOUD. People should want to stop people
siphoning the vault because they're taking the station's money, not
because the ANNOUNCMENTS ARE LOUD AND NEVER STOP.
- Also removes colour from the spoken messages by the machine (people
cannot talk red).
- Makes the time between announcements var editable.
- Just uses stack autostacking rather than doing it ourselves.


- _This is possibly covered under the freeze. Idk. Tell me if it is, I
will reopen it after._