### PR TITLE
Fixes wood tiles interaction with quick tile replacement

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -140,17 +140,19 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 		pry_tile(C, user)
 		return 1
 	if(intact && istype(C, /obj/item/stack/tile))
-		var/obj/item/stack/tile/T = C
-		if(T.turf_type == type)
-			return
-		var/obj/item/weapon/crowbar/CB = user.is_holding_item_of_type(/obj/item/weapon/crowbar)
-		if(!CB)
-			return
-		var/turf/open/floor/plating/P = pry_tile(CB, user, TRUE)
-		if(!istype(P))
-			return
-		P.attackby(T, user, params)
+		try_replace_tile(C, user, params)
 	return 0
+
+/turf/open/floor/proc/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
+	if(T.turf_type == type)
+		return
+	var/obj/item/weapon/crowbar/CB = user.is_holding_item_of_type(/obj/item/weapon/crowbar)
+	if(!CB)
+		return
+	var/turf/open/floor/plating/P = pry_tile(CB, user, TRUE)
+	if(!istype(P))
+		return
+	P.attackby(T, user, params)
 
 /turf/open/floor/proc/pry_tile(obj/item/C, mob/user, silent = FALSE)
 	playsound(src, C.usesound, 80, 1)

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -18,6 +18,19 @@
 		pry_tile(C, user)
 		return
 
+/turf/open/floor/wood/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
+	if(T.turf_type == type)
+		return
+	var/obj/item/weapon/tool = user.is_holding_item_of_type(/obj/item/weapon/screwdriver)
+	if(!tool)
+		tool = user.is_holding_item_of_type(/obj/item/weapon/crowbar)
+	if(!tool)
+		return
+	var/turf/open/floor/plating/P = pry_tile(tool, user, TRUE)
+	if(!istype(P))
+		return
+	P.attackby(T, user, params)
+
 /turf/open/floor/wood/pry_tile(obj/item/C, mob/user, silent = FALSE)
 	var/is_screwdriver = istype(C, /obj/item/weapon/screwdriver)
 	playsound(src, C.usesound, 80, 1)


### PR DESCRIPTION
:cl: XDTM
fix: Wooden tiles can now be quick-replaced with a screwdriver instead of a crowbar, preserving the floor tile.
/:cl:

Fixes #25131
