### PR TITLE
Supermatter Area / Air Alarm Tweak Cont'd

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -9588,15 +9588,11 @@
 "atl" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall/r_wall,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "atm" = (
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "atn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -10244,9 +10240,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "auC" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -10256,9 +10250,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/circuit/green,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "auD" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -10267,9 +10259,7 @@
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
 /turf/open/floor/plating,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "auE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -10277,18 +10267,14 @@
 	scrub_Toxins = 0
 	},
 /turf/open/floor/engine,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "auF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	on = 1
 	},
 /turf/open/floor/engine,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "auG" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -10296,9 +10282,7 @@
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
 /turf/open/floor/plating,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "auH" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -10308,9 +10292,7 @@
 	d2 = 4
 	},
 /turf/open/floor/circuit/green,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "auI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10326,9 +10308,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "auJ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10878,15 +10858,11 @@
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
 /turf/open/floor/plating,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "avQ" = (
 /obj/machinery/power/supermatter_shard/crystal,
 /turf/open/floor/engine,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "avR" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -10895,9 +10871,7 @@
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
 /turf/open/floor/plating,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "avS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10914,9 +10888,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "avT" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -11410,9 +11382,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "awV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -11885,18 +11855,14 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "axQ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "axR" = (
 /obj/machinery/door/airlock/glass_atmos{
 	heat_proof = 1;
@@ -11905,9 +11871,7 @@
 	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/engine,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "axS" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	icon_state = "intact";
@@ -11915,17 +11879,13 @@
 	},
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "axT" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "axU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12556,9 +12516,7 @@
 	name = "Gas to Filter"
 	},
 /turf/open/floor/engine,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "azf" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -12566,9 +12524,7 @@
 	name = "Gas to Chamber"
 	},
 /turf/open/floor/engine,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "azg" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/structure/extinguisher_cabinet{
@@ -13108,9 +13064,7 @@
 "aAd" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "aAe" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/effect/turf_decal/bot,
@@ -13669,9 +13623,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "aBe" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/machinery/meter,
@@ -110595,9 +110547,7 @@
 	})
 "ebG" = (
 /turf/open/floor/engine,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "ebJ" = (
 /obj/machinery/door/window/brigdoor/northleft{
 	name = "Captain's Desk";
@@ -112888,9 +112838,7 @@
 	network = list("Engine")
 	},
 /turf/open/floor/circuit/green,
-/area/engine/gravity_generator{
-	name = "Atmospherics Engine"
-	})
+/area/engine/supermatter)
 "ehz" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -112900,6 +112848,49 @@
 	},
 /turf/open/floor/plasteel/neutral,
 /area/atmos)
+"ehA" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"ehB" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"ehC" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"ehD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/highpressure/fulltile,
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"ehE" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"ehF" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"ehG" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"ehH" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"ehI" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"ehJ" = (
+/obj/structure/sign/radiation,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"ehK" = (
+/obj/structure/sign/radiation,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"ehL" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"ehM" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 
 (1,1,1) = {"
 aaa
@@ -137907,11 +137898,11 @@ aoI
 apK
 ard
 asi
-aiW
+ehA
 auC
 auC
 auC
-aiW
+ehH
 azc
 aAc
 aAZ
@@ -138164,13 +138155,13 @@ aoJ
 apL
 are
 asj
-aiW
+ehB
 auD
 avP
 avP
 axP
-azd
-aiW
+ehJ
+ehL
 aAY
 ark
 aDH
@@ -138421,7 +138412,7 @@ aoK
 apM
 arf
 ask
-aiW
+ehC
 auE
 auE
 auE
@@ -138678,7 +138669,7 @@ aoK
 apN
 arg
 asl
-aoK
+ehD
 ebG
 avQ
 ebG
@@ -138935,7 +138926,7 @@ aoK
 apO
 arh
 asm
-aiW
+ehE
 auF
 auF
 auF
@@ -139192,13 +139183,13 @@ aoL
 apP
 ari
 asn
-aiW
+ehF
 auG
 avR
 avR
 axT
-azd
-aiW
+ehK
+ehM
 aBd
 ark
 aDL
@@ -139449,11 +139440,11 @@ aoI
 apK
 ebP
 aso
-aiW
+ehG
 ehy
 auH
 auH
-aiW
+ehI
 azg
 aAe
 aBe

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -20535,7 +20535,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aJB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -21087,21 +21087,21 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aKH" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "Gas to Chamber"
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aKI" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aKL" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	icon_state = "intact";
@@ -21823,10 +21823,10 @@
 	req_access_txt = "10"
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aMk" = (
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aMm" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/delivery,
@@ -22357,14 +22357,14 @@
 	name = "Gas to Filter"
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aNv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 2;
 	on = 1
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aNw" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -69317,7 +69317,7 @@
 	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "cpS" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -90891,7 +90891,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "daZ" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -90899,7 +90899,7 @@
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "dbb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -90908,7 +90908,7 @@
 	pressure_checks = 1
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "dbd" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -92768,7 +92768,7 @@
 "deD" = (
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "deI" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1;
@@ -92833,7 +92833,7 @@
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "deT" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1;
@@ -92862,7 +92862,7 @@
 "deV" = (
 /obj/structure/sign/fire,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "deW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -92897,7 +92897,7 @@
 "dfa" = (
 /obj/machinery/power/supermatter_shard/crystal,
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "dfb" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
@@ -92906,11 +92906,11 @@
 	},
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "dfc" = (
 /obj/structure/sign/electricshock,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "dfd" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1;
@@ -92969,13 +92969,13 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "dfk" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/structure/window/reinforced/highpressure/fulltile,
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "dfm" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -92983,7 +92983,7 @@
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "dfp" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -93004,7 +93004,7 @@
 	d2 = 2
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "dft" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1;
@@ -94749,7 +94749,7 @@
 	name = "Radiation Chamber Shutters"
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "dju" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -94768,7 +94768,7 @@
 	name = "Radiation Chamber Shutters"
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "djw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -94793,7 +94793,7 @@
 	name = "Radiation Chamber Shutters"
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "djy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -95606,7 +95606,42 @@
 	network = list("Engine")
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
+"dlJ" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"dlK" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"dlL" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"dlM" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"dlN" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"dlO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/highpressure/fulltile,
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"dlP" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"dlQ" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"dlR" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"dlS" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"dlT" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 
 (1,1,1) = {"
 aaa
@@ -137856,11 +137891,11 @@ aEr
 aFC
 aGZ
 aGZ
-axY
+dlL
 aKG
 aMj
 aKG
-axY
+dlP
 aQe
 aRv
 dfD
@@ -138113,11 +138148,11 @@ dej
 aFC
 deC
 deC
-axY
+dlM
 aKH
 aMk
 aNu
-axY
+dlQ
 dfp
 dfp
 dfE
@@ -138369,13 +138404,13 @@ aCY
 dek
 der
 deD
-axY
+dlJ
 aJv
 aKI
 aMj
 dfb
 dfj
-axY
+dlS
 deD
 dfF
 aTN
@@ -139397,13 +139432,13 @@ aCY
 dem
 aFD
 deD
-axY
-axY
+dlK
+dlN
 deV
-aCZ
+dlO
 dfc
-axY
-axY
+dlR
+dlT
 deD
 dfI
 dfS

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -22458,11 +22458,11 @@
 "aJt" = (
 /obj/structure/sign/radiation,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aJu" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aJv" = (
 /obj/machinery/door/airlock/glass_atmos{
 	name = "Supermatter Chamber";
@@ -22470,7 +22470,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aJw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -23178,12 +23178,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aKB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aKC" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2;
@@ -23192,11 +23192,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aKD" = (
 /obj/structure/sign/fire,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aKE" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -23883,45 +23883,45 @@
 "aLO" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aLP" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aLQ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aLR" = (
 /obj/machinery/door/airlock/glass_atmos{
 	name = "Supermatter Chamber";
 	req_access_txt = "24"
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aLS" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aLT" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aLU" = (
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aLV" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -24450,7 +24450,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aMR" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -24460,7 +24460,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/circuit/green,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aMS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -24468,7 +24468,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aMT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -24476,17 +24476,17 @@
 	scrub_Toxins = 0
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aMU" = (
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aMV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	on = 1
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aMW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -24495,7 +24495,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aMX" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -24505,7 +24505,7 @@
 	d2 = 4
 	},
 /turf/open/floor/circuit/green,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aMY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24522,7 +24522,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aMZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -25191,7 +25191,7 @@
 	name = "supermatter crystal"
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aOb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -25209,7 +25209,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aOc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -25502,7 +25502,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aOC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -25510,7 +25510,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aOD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -25518,7 +25518,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aOE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -25534,7 +25534,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aOF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -26390,7 +26390,7 @@
 "aPK" = (
 /obj/structure/sign/electricshock,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/supermatter)
 "aPL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -41984,7 +41984,7 @@
 	pixel_x = 23
 	},
 /turf/open/floor/circuit/green,
-/area/engine/engineering)
+/area/engine/supermatter)
 "buW" = (
 /obj/structure/cable/white{
 	tag = "icon-0-2";
@@ -41995,6 +41995,32 @@
 	dir = 5
 	},
 /area/bridge)
+"buX" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"buY" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"buZ" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"bva" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"bvb" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"bvc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"bvd" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"bve" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 
 (1,1,1) = {"
 aaa
@@ -72697,11 +72723,11 @@ aHl
 aIi
 aJs
 aKz
-aEt
+buY
 buV
 aMR
 aMR
-aEt
+bva
 aQL
 aRI
 aSS
@@ -72953,12 +72979,12 @@ aGj
 aHm
 aIj
 aJt
-aEt
+buX
 aLP
 aMS
 aMS
 aOC
-aEt
+bvb
 aQM
 aRJ
 aST
@@ -73472,7 +73498,7 @@ aLR
 aMU
 aOa
 aMU
-aPL
+bvc
 aQO
 aRL
 aSV
@@ -73986,7 +74012,7 @@ aLT
 aMW
 aMW
 aOD
-aEt
+bvd
 aQQ
 aRN
 aSX
@@ -74239,11 +74265,11 @@ aHr
 aIo
 aJw
 aKE
-aEt
+buZ
 aMX
 aMX
 aMX
-aEt
+bve
 aQR
 aRO
 aSY


### PR DESCRIPTION
:cl: Penguaro
tweak: Omega, Meta, & Delta Stations - The Vents and Scrubbers for the Supermatter Air Alarm are now isolated from the rest of the Air Alarms in Engineering.
/:cl:

The Air Alarms for Engineering include the specific scrubbers of the coolant loop for the Supermatter Engine. As such, it is easy to inadvertently disrupt the coolant when changing the operating mode on the air alarm in an emergency. Also as map edits go through, sometimes the scrubbers and vents are renumbered and if a player doesn't check each round, they may set up the wrong scrubbers for the coolant loop. Now there is a new area designated for the Supermatter Engine that forces the Air Alarm in the chamber to just recognize the three vents/scrubbers instead of the rest of the room. This continues my work from #25309.