### PR TITLE
Cleans up TK code a bit

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -131,11 +131,7 @@
 	if(isturf(A) || isturf(A.loc) || (A.loc && isturf(A.loc.loc)))
 		if(Adjacent(A) || (W && CheckReach(src, A, W.reach))) //Adjacent or reaching attacks
 			if(W)
-				if(W.pre_attackby(A,src,params))
-					// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
-					var/resolved = A.attackby(W,src,params)
-					if(!resolved && A && W)
-						W.afterattack(A,src,1,params) // 1: clicking something Adjacent
+				melee_item_attack_chain(src, W, A)
 			else
 				if(ismob(A))
 					changeNext_move(CLICK_CD_MELEE)
@@ -163,7 +159,7 @@
 				if(dummy.loc == there.loc)
 					qdel(dummy)
 					return 1
-				if(there.density && dummy in range(1, there)) //For windows and 
+				if(there.density && dummy in range(1, there)) //For windows and
 					qdel(dummy)
 					return 1
 				if(!dummy.Move(T)) //we're blocked!

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -114,10 +114,7 @@
 	if(A.ClickAccessible(src, depth=INVENTORY_DEPTH))
 		// No adjacency needed
 		if(W)
-			if(W.pre_attackby(A,src,params))
-				var/resolved = A.attackby(W,src)
-				if(!resolved && A && W)
-					W.afterattack(A,src,1,params) // 1 indicates adjacency
+			melee_item_attack_chain(src, W, A)
 		else
 			if(ismob(A))
 				changeNext_move(CLICK_CD_MELEE)
@@ -159,7 +156,7 @@
 				if(dummy.loc == there.loc)
 					qdel(dummy)
 					return 1
-				if(there.density && dummy in range(1, there)) //For windows and
+				if(there.density && dummy in range(1, there)) //For windows and suchlike
 					qdel(dummy)
 					return 1
 				if(!dummy.Move(T)) //we're blocked!

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -68,11 +68,7 @@
 
 	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc in contents)
 	if(A == loc || (A in loc) || (A in contents))
-		// No adjacency checks
-		if(W.pre_attackby(A,src,params))
-			var/resolved = A.attackby(W,src, params)
-			if(!resolved && A && W)
-				W.afterattack(A,src,1,params)
+		melee_item_attack_chain(src, W, A)
 		return
 
 	if(!isturf(loc))
@@ -81,10 +77,7 @@
 	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc && isturf(A.loc.loc))
 	if(isturf(A) || isturf(A.loc))
 		if(A.Adjacent(src)) // see adjacent.dm
-			if(W.pre_attackby(A,src,params))
-				var/resolved = A.attackby(W, src, params)
-				if(!resolved && A && W)
-					W.afterattack(A, src, 1, params)
+			melee_item_attack_chain(src, W, A)
 			return
 		else
 			W.afterattack(A, src, 0, params)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -1,4 +1,12 @@
 
+/proc/melee_item_attack_chain(mob/user, obj/item/I, atom/target, params)
+	if(I.pre_attackby(target, user, params))
+		// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
+		var/resolved = target.attackby(I,user,params)
+		if(!resolved && target && I)
+			I.afterattack(target, user, 1, params) // 1: clicking something Adjacent
+
+
 // Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.
 /obj/item/proc/attack_self(mob/user)
 	return

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -10,10 +10,28 @@ var/const/tk_maxrange = 15
 
 	By default, emulate the user's unarmed attack
 */
+
 /atom/proc/attack_tk(mob/user)
 	if(user.stat)
 		return
+	new /obj/effect/overlay/temp/telekinesis(loc)
 	user.UnarmedAttack(src,0) // attack_hand, attack_paw, etc
+	return
+
+/obj/attack_tk(mob/user)
+	if(user.stat)
+		return
+
+	var/obj/item/tk_grab/O = new(src)
+	O.tk_user = user
+	if(O.focus_object(src))
+		user.put_in_active_hand(O)
+	else
+		qdel(O)
+		..()
+	return
+
+/mob/attack_tk(mob/user)
 	return
 
 /*
@@ -23,37 +41,13 @@ var/const/tk_maxrange = 15
 	It is used for manipulating things at range, for example, opening and closing closets.
 	There are not a lot of defaults at this time, add more where appropriate.
 */
+
 /atom/proc/attack_self_tk(mob/user)
 	return
 
 /obj/item/attack_self_tk(mob/user)
 	attack_self(user)
 
-/obj/attack_tk(mob/user)
-	if(user.stat)
-		return
-	if(anchored)
-		..()
-		return
-
-	var/obj/item/tk_grab/O = new(src)
-	user.put_in_active_hand(O)
-	O.host = user
-	O.focus_object(src)
-	return
-
-/obj/item/attack_tk(mob/user)
-	if(user.stat)
-		return
-	var/obj/item/tk_grab/O = new(src)
-	user.put_in_active_hand(O)
-	O.host = user
-	O.focus_object(src)
-	return
-
-
-/mob/attack_tk(mob/user)
-	return // needs more thinking about
 
 /*
 	TK Grab Item (the workhorse of old TK)
@@ -74,9 +68,8 @@ var/const/tk_maxrange = 15
 	layer = ABOVE_HUD_LAYER
 	plane = ABOVE_HUD_PLANE
 
-	var/last_throw = 0
 	var/atom/movable/focus = null
-	var/mob/living/host = null
+	var/mob/living/carbon/tk_user = null
 
 
 /obj/item/tk_grab/dropped(mob/user)
@@ -107,26 +100,11 @@ var/const/tk_maxrange = 15
 /obj/item/tk_grab/afterattack(atom/target, mob/living/carbon/user, proximity, params)//TODO: go over this
 	if(!target || !user)
 		return
-	if(last_throw+3 > world.time)
-		return
-	if(!host || host != user)
-		qdel(src)
-		return
-	if(!(user.dna.check_mutation(TK)))
-		qdel(src)
-		return
-	if(isobj(target) && !isturf(target.loc))
-		return
-
-	if(!tkMaxRangeCheck(user, target, focus))
-		return
 
 	if(!focus)
-		focus_object(target, user)
+		focus_object(target)
 		return
-
-	if(focus.anchored || !isturf(focus.loc))
-		qdel(src)
+	else if(!check_if_focusable(focus))
 		return
 
 	if(target == focus)
@@ -135,83 +113,61 @@ var/const/tk_maxrange = 15
 
 
 	if(!isturf(target) && istype(focus,/obj/item) && target.Adjacent(focus))
+		apply_focus_overlay()
 		var/obj/item/I = focus
 		var/resolved = target.attackby(I, user, params)
 		if(!resolved && target && I)
 			I.afterattack(target,user,1) // for splashing with beakers
 			update_icon()
+		focus.do_attack_animation(target, null, focus)
 	else
 		apply_focus_overlay()
 		focus.throw_at(target, 10, 1,user)
-		last_throw = world.time
 		user.changeNext_move(CLICK_CD_MELEE)
 		update_icon()
 
-/proc/tkMaxRangeCheck(mob/user, atom/target, atom/focus)
+/proc/tkMaxRangeCheck(mob/user, atom/target)
 	var/d = get_dist(user, target)
-	if(focus)
-		d = max(d,get_dist(user,focus)) // whichever is further
 	if(d > tk_maxrange)
 		to_chat(user, "<span class ='warning'>Your mind won't reach that far.</span>")
-		return 0
-	return 1
+		return
+	return TRUE
 
 /obj/item/tk_grab/attack(mob/living/M, mob/living/user, def_zone)
 	return
 
-
-/obj/item/tk_grab/proc/focus_object(obj/target, mob/living/user)
-	if(!isobj(target))
-		return//Cant throw non objects atm might let it do mobs later
-	if(target.anchored || !isturf(target.loc))
-		qdel(src)
+/obj/item/tk_grab/proc/focus_object(obj/target)
+	if(!check_if_focusable(target))
 		return
 	focus = target
 	update_icon()
 	apply_focus_overlay()
-	return
+	return TRUE
 
+/obj/item/tk_grab/proc/check_if_focusable(obj/target)
+	if(!tk_user || !istype(tk_user) || !tk_user.dna.check_mutation(TK))
+		qdel(src)
+		return
+	if(!istype(target))
+		return
+	if(!tkMaxRangeCheck(tk_user, target))
+		return
+	if(target.anchored || !isturf(target.loc))
+		qdel(src)
+		return
+	return TRUE
 
 /obj/item/tk_grab/proc/apply_focus_overlay()
 	if(!focus)
 		return
 	new /obj/effect/overlay/temp/telekinesis(get_turf(focus))
 
-
 /obj/item/tk_grab/update_icon()
 	cut_overlays()
-	if(focus && focus.icon && focus.icon_state)
-		add_overlay(icon(focus.icon,focus.icon_state))
+	if(focus)
+		add_overlay(focus)
 	return
 
 /obj/item/tk_grab/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is using [user.p_their()] telekinesis to choke [user.p_them()]self! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (OXYLOSS)
-
-/*Not quite done likely needs to use something thats not get_step_to
-/obj/item/tk_grab/proc/check_path()
-	var/turf/ref = get_turf(src.loc)
-	var/turf/target = get_turf(focus.loc)
-	if(!ref || !target)
-		return 0
-	var/distance = get_dist(ref, target)
-	if(distance >= 10)
-		return 0
-	for(var/i = 1 to distance)
-		ref = get_step_to(ref, target, 0)
-	if(ref != target)
-		return 0
-	return 1
-*/
-
-//equip_to_slot_or_del(obj/item/W, slot, qdel_on_fail = 1)
-/*
-		if(istype(user, /mob/living/carbon))
-			if(user:mutations & TK && get_dist(source, user) <= 7)
-				if(user:get_active_hand())
-					return 0
-				var/X = source:x
-				var/Y = source:y
-				var/Z = source:z
-
-*/

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -109,22 +109,18 @@ var/const/tk_maxrange = 15
 
 	if(target == focus)
 		target.attack_self_tk(user)
-		return // todo: something like attack_self not laden with assumptions inherent to attack_self
+		return
 
 
 	if(!isturf(target) && istype(focus,/obj/item) && target.Adjacent(focus))
 		apply_focus_overlay()
-		var/obj/item/I = focus
-		var/resolved = target.attackby(I, user, params)
-		if(!resolved && target && I)
-			I.afterattack(target,user,1) // for splashing with beakers
-			update_icon()
+		melee_item_attack_chain(tk_user, focus, target) //isn't copying the attack chain fun. we should do it more often.
 		focus.do_attack_animation(target, null, focus)
 	else
 		apply_focus_overlay()
 		focus.throw_at(target, 10, 1,user)
 		user.changeNext_move(CLICK_CD_MELEE)
-		update_icon()
+	update_icon()
 
 /proc/tkMaxRangeCheck(mob/user, atom/target)
 	var/d = get_dist(user, target)
@@ -165,7 +161,13 @@ var/const/tk_maxrange = 15
 /obj/item/tk_grab/update_icon()
 	cut_overlays()
 	if(focus)
-		add_overlay(focus)
+		var/old_layer = focus.layer
+		var/old_plane = focus.plane
+		focus.layer = layer
+		focus.plane = FLOAT_PLANE
+		add_overlay(focus) //this is kind of ick, but it's better than using icon()
+		focus.layer = old_layer
+		focus.plane = old_plane
 	return
 
 /obj/item/tk_grab/suicide_act(mob/user)

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -29,7 +29,6 @@ var/const/tk_maxrange = 15
 	else
 		qdel(O)
 		..()
-	return
 
 /mob/attack_tk(mob/user)
 	return
@@ -177,7 +176,6 @@ var/const/tk_maxrange = 15
 		add_overlay(focus) //this is kind of ick, but it's better than using icon()
 		focus.layer = old_layer
 		focus.plane = old_plane
-	return
 
 /obj/item/tk_grab/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is using [user.p_their()] telekinesis to choke [user.p_them()]self! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -61,7 +61,7 @@
 		return ..()
 
 /obj/structure/chair/attack_tk(mob/user)
-	if(has_buckled_mobs())
+	if(!anchored || has_buckled_mobs())
 		..()
 	else
 		rotate()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -500,6 +500,7 @@
 
 	status = LIGHT_EMPTY
 	update()
+	return L
 
 /obj/machinery/light/attack_tk(mob/user)
 	if(status == LIGHT_EMPTY)
@@ -508,7 +509,8 @@
 
 	to_chat(user, "<span class='notice'>You telekinetically remove the light [fitting].</span>")
 	// create a light tube/bulb item and put it in the user's hand
-	drop_light_tube()
+	var/obj/item/weapon/light/L = drop_light_tube()
+	L.attack_tk(user)
 
 
 // break the light and make sparks if was on


### PR DESCRIPTION
Snip snip.
Also we had copied the melee item attack chain like five times and that's fucking awful I made it a proc instead.
Don't ask how I removed those accidental commits, exactly.

Main changes:
If somebody picks up or otherwise renders an item unsuitable for tk-grabbing, you IMMEDIATELY lose your focus on it, instead of retaining it until you try to do something.
Melee item attacks with TK will now also cause the item used to do an attack animation.