### PR TITLE
Remove active check from emitter ID controls locking

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -275,11 +275,8 @@
 			to_chat(user, "<span class='warning'>The lock seems to be broken!</span>")
 			return
 		if(allowed(user))
-			if(active)
-				locked = !locked
-				to_chat(user, "<span class='notice'>You [src.locked ? "lock" : "unlock"] the controls.</span>")
-			else
-				to_chat(user, "<span class='warning'>The controls can only be locked when \the [src] is online!</span>")
+			locked = !locked
+			to_chat(user, "<span class='notice'>You [src.locked ? "lock" : "unlock"] the controls.</span>")
 		else
 			to_chat(user, "<span class='danger'>Access denied.</span>")
 		return


### PR DESCRIPTION
:cl: ChemicalRascal
tweak: NT has seen fit to allow emitters to be locked "off", much as they could previously be locked "on", reflecting their recent importance in starting engines.
/:cl:

Balance change: Allows the CE to hopefully prevent idiocy relating to the SM shard being started too early, even if they're too lazy to actually just move the emitters.

Basically, I personally view the emitters being to the SM shard the same as what the PA is to singulo/tesla generators. It's currently way too easy for one chucklefuck engineer to run in, not paying attention, and start all the emitters because that's what you do right. Locking emitters off will at least allow engineers to be able to remind other engineers that, hey, wait, check your surroundings first, have a bloody think.

Emags still break the locks entirely, of course, and they still start unlocked.

And yes this is a salt-induced PR how could you tell