### PR TITLE
Admin sound channel tweaks

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -1,3 +1,3 @@
 //max channel is 1024. Only go lower from here, because byond tends to pick the first availiable channel to play sounds on
 #define CHANNEL_LOBBYMUSIC 1024
-#define SOUND_CHANNEL_ADMIN 1023
+#define CHANNEL_ADMIN 1023

--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -1,2 +1,3 @@
 //max channel is 1024. Only go lower from here, because byond tends to pick the first availiable channel to play sounds on
 #define CHANNEL_LOBBYMUSIC 1024
+#define SOUND_CHANNEL_ADMIN 1023

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -18,7 +18,7 @@ var/sound/admin_sound
 	var/sound/admin_sound = new()
 	admin_sound.file = S
 	admin_sound.priority = 250
-	admin_sound.channel = SOUND_CHANNEL_ADMIN
+	admin_sound.channel = CHANNEL_ADMIN
 	admin_sound.frequency = freq
 	admin_sound.wait = 1
 	admin_sound.repeat = 0
@@ -69,5 +69,3 @@ var/sound/admin_sound
 		if(M.client)
 			M << sound(null)
 	feedback_add_details("admin_verb","SS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-#undef SOUND_CHANNEL_ADMIN

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -1,4 +1,4 @@
-#define SOUND_CHANNEL_ADMIN 777
+
 var/sound/admin_sound
 
 /client/proc/play_sound(S as sound)


### PR DESCRIPTION
Moves admin sound channel to defines, moves it up too.
Likely fixes admin sounds getting interrupted by people spamming other sounds.