### PR TITLE
Autoimplanters renamed to autosurgeons; nuke op autosurgeon fix

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -69,7 +69,7 @@
 	new /obj/item/weapon/storage/belt/medical(src)
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/weapon/reagent_containers/hypospray/CMO(src)
-	new /obj/item/device/autoimplanter/cmo(src)
+	new /obj/item/device/autosurgeon/cmo(src)
 	new /obj/item/weapon/door_remote/chief_medical_officer(src)
 
 /obj/structure/closet/secure_closet/animal

--- a/code/modules/admin/verbs/manipulate_organs.dm
+++ b/code/modules/admin/verbs/manipulate_organs.dm
@@ -47,7 +47,7 @@
 				I = organ
 				I.removed(C)
 
-			organ.loc = get_turf(C)
+			organ.forceMove(get_turf(C))
 
 			if(operation == "remove organ/implant")
 				qdel(organ)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -144,28 +144,19 @@
 //BOX O' IMPLANTS
 
 /obj/item/weapon/storage/box/cyber_implants
-	name = "boxed cybernetic implant"
+	name = "boxed cybernetic implants"
 	desc = "A sleek, sturdy box."
 	icon_state = "cyber_implants"
-
-/obj/item/weapon/storage/box/cyber_implants/New(loc, implant)
-	..()
-	new /obj/item/device/autoimplanter(src)
-	if(ispath(implant))
-		new implant(src)
-
-/obj/item/weapon/storage/box/cyber_implants/bundle
-	name = "boxed cybernetic implants"
 	var/list/boxed = list(
-		/obj/item/organ/eyes/robotic/xray,
-		/obj/item/organ/eyes/robotic/thermals,
-		/obj/item/organ/cyberimp/brain/anti_stun,
-		/obj/item/organ/cyberimp/chest/reviver)
+		/obj/item/device/autosurgeon/thermal_eyes,
+		/obj/item/device/autosurgeon/xray_eyes,
+		/obj/item/device/autosurgeon/anti_stun,
+		/obj/item/device/autosurgeon/reviver)
 	var/amount = 5
 
 /obj/item/weapon/storage/box/cyber_implants/bundle/New()
 	..()
 	var/implant
-	while(contents.len <= amount + 1) // +1 for the autoimplanter.
+	while(contents.len <= amount)
 		implant = pick(boxed)
 		new implant(src)

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -3,7 +3,7 @@
 /obj/item/device/autosurgeon
 	name = "autosurgeon"
 	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. It has a slot to insert implants/organs and a screwdriver slot for removing accidentally added items."
-	icon_state = "autosurgeon"
+	icon_state = "autoimplanter"
 	item_state = "walkietalkie"//left as this so as to intentionally not have inhands
 	w_class = WEIGHT_CLASS_SMALL
 	var/obj/item/organ/storedorgan
@@ -14,7 +14,7 @@
 /obj/item/device/autosurgeon/Initialize(mapload)
 	..()
 	if(starting_organ)
-		storedorgan = new starting_organ(src)
+		insert_organ(new starting_organ(src))
 
 /obj/item/device/autosurgeon/proc/insert_organ(var/obj/item/I)
 	storedorgan = I

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -1,21 +1,27 @@
 #define INFINITE -1
 
-/obj/item/device/autoimplanter
-	name = "autoimplanter"
-	desc = "A device that automatically injects a cyber-implant into the user without the hassle of extensive surgery. It has a slot to insert implants and a screwdriver slot for removing accidentally added implants."
-	icon_state = "autoimplanter"
+/obj/item/device/autosurgeon
+	name = "autosurgeon"
+	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. It has a slot to insert implants/organs and a screwdriver slot for removing accidentally added items."
+	icon_state = "autosurgeon"
 	item_state = "walkietalkie"//left as this so as to intentionally not have inhands
 	w_class = WEIGHT_CLASS_SMALL
 	var/obj/item/organ/storedorgan
-	var/organ_type = /obj/item/organ/cyberimp
+	var/organ_type = /obj/item/organ
 	var/uses = INFINITE
+	var/starting_organ
 
-/obj/item/device/autoimplanter/New()
+/obj/item/device/autosurgeon/Initialize(mapload)
 	..()
-	if(storedorgan)
-		storedorgan.loc = src
+	if(starting_organ)
+		storedorgan = new starting_organ(src)
 
-/obj/item/device/autoimplanter/attack_self(mob/user)//when the object it used...
+/obj/item/device/autosurgeon/proc/insert_organ(var/obj/item/I)
+	storedorgan = I
+	I.forceMove(src)
+	name = "[initial(name)] ([storedorgan.name])"
+
+/obj/item/device/autosurgeon/attack_self(mob/user)//when the object it used...
 	if(!uses)
 		to_chat(user, "<span class='warning'>[src] has already been used. The tools are dull and won't reactivate.</span>")
 		return
@@ -26,12 +32,13 @@
 	user.visible_message("<span class='notice'>[user] presses a button on [src], and you hear a short mechanical noise.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
 	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
 	storedorgan = null
+	name = initial(name)
 	if(uses != INFINITE)
 		uses--
 	if(!uses)
 		desc = "[initial(desc)] Looks like it's been used up."
 
-/obj/item/device/autoimplanter/attackby(obj/item/I, mob/user, params)
+/obj/item/device/autosurgeon/attackby(obj/item/I, mob/user, params)
 	if(istype(I, organ_type))
 		if(storedorgan)
 			to_chat(user, "<span class='notice'>[src] already has an implant stored.</span>")
@@ -41,7 +48,7 @@
 			return
 		if(!user.drop_item())
 			return
-		I.loc = src
+		I.forceMove(src)
 		storedorgan = I
 		to_chat(user, "<span class='notice'>You insert the [I] into [src].</span>")
 	else if(istype(I, /obj/item/weapon/screwdriver))
@@ -58,8 +65,20 @@
 			if(!uses)
 				desc = "[initial(desc)] Looks like it's been used up."
 
-/obj/item/device/autoimplanter/cmo
-	name = "medical HUD autoimplanter"
-	desc = "A single use autoimplanter that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
-	storedorgan = new/obj/item/organ/cyberimp/eyes/hud/medical()
+/obj/item/device/autosurgeon/cmo
+	desc = "A single use autosurgeon that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
 	uses = 1
+	starting_organ = /obj/item/organ/cyberimp/eyes/hud/medical
+
+
+/obj/item/device/autosurgeon/thermal_eyes
+	starting_organ = /obj/item/organ/eyes/robotic/thermals
+
+/obj/item/device/autosurgeon/xray_eyes
+	starting_organ = /obj/item/organ/eyes/robotic/xray
+
+/obj/item/device/autosurgeon/anti_stun
+	starting_organ = /obj/item/organ/cyberimp/brain/anti_stun
+
+/obj/item/device/autosurgeon/reviver
+	starting_organ = /obj/item/organ/cyberimp/chest/reviver

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -12,13 +12,17 @@
 	var/vital = 0
 
 
-/obj/item/organ/proc/Insert(mob/living/carbon/M, special = 0)
+/obj/item/organ/proc/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
 	if(!iscarbon(M) || owner == M)
 		return
 
 	var/obj/item/organ/replaced = M.getorganslot(slot)
 	if(replaced)
 		replaced.Remove(M, special = 1)
+		if(drop_if_replaced)
+			replaced.forceMove(get_turf(src))
+		else
+			qdel(replaced)
 
 	owner = M
 	M.internal_organs |= src

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1146,40 +1146,40 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 
 /datum/uplink_item/cyber_implants/spawn_item(turf/loc, obj/item/device/uplink/U)
 	if(item)
-		if(istype(item, /obj/item/organ/cyberimp))
+		if(istype(item, /obj/item/organ))
 			return new /obj/item/weapon/storage/box/cyber_implants(loc, item)
 		else
 			return ..()
 
 
 /datum/uplink_item/cyber_implants/thermals
-	name = "Thermal eyes"
-	desc = "These cybernetic eyes will give you thermal vision. Comes with a free autoimplanter."
-	item = /obj/item/organ/eyes/robotic/thermals
+	name = "Thermal Eyes"
+	desc = "These cybernetic eyes will give you thermal vision. Comes with a free autosurgeon."
+	item = /obj/item/device/autosurgeon/thermal_eyes
 	cost = 8
 
 /datum/uplink_item/cyber_implants/xray
 	name = "X-Ray Vision Implant"
-	desc = "These cybernetic eyes will give you X-ray vision. Comes with an autoimplanter."
-	item = /obj/item/organ/eyes/robotic/xray
+	desc = "These cybernetic eyes will give you X-ray vision. Comes with an autosurgeon."
+	item = /obj/item/device/autosurgeon/xray_eyes
 	cost = 10
 
 /datum/uplink_item/cyber_implants/antistun
 	name = "CNS Rebooter Implant"
-	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autoimplanter."
-	item = /obj/item/organ/cyberimp/brain/anti_stun
+	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
+	item = /obj/item/device/autosurgeon/anti_stun
 	cost = 12
 
 /datum/uplink_item/cyber_implants/reviver
 	name = "Reviver Implant"
-	desc = "This implant will attempt to revive you if you lose consciousness. Comes with an autoimplanter."
-	item = /obj/item/organ/cyberimp/chest/reviver
+	desc = "This implant will attempt to revive you if you lose consciousness. Comes with an autosurgeon."
+	item = /obj/item/device/autosurgeon/reviver
 	cost = 8
 
 /datum/uplink_item/cyber_implants/bundle
 	name = "Cybernetic Implants Bundle"
-	desc = "A random selection of cybernetic implants. Guaranteed 5 high quality implants. Comes with an autoimplanter."
-	item = /obj/item/weapon/storage/box/cyber_implants/bundle
+	desc = "A random selection of cybernetic implants. Guaranteed 5 high quality implants. Comes with an autosurgeon."
+	item = /obj/item/weapon/storage/box/cyber_implants
 	cost = 40
 	cant_discount = TRUE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2021,7 +2021,7 @@
 #include "code\modules\surgery\organs\augments_chest.dm"
 #include "code\modules\surgery\organs\augments_eyes.dm"
 #include "code\modules\surgery\organs\augments_internal.dm"
-#include "code\modules\surgery\organs\autoimplanter.dm"
+#include "code\modules\surgery\organs\autosurgeon.dm"
 #include "code\modules\surgery\organs\helpers.dm"
 #include "code\modules\surgery\organs\organ_internal.dm"
 #include "code\modules\surgery\organs\vocal_cords.dm"


### PR DESCRIPTION
Fixes #24443.

:cl: coiax
add: Autoimplanters have been renamed to autosurgeons. Currently only
the CMO and nuclear operatives have access to autosurgeons. What is the
CMO hiding?
fix: All upgraded organs for purchase by nuclear operatives now actually
come in an autosurgeon, for speed of surgery.
/:cl:

- Autosurgeons now insert any type of organ put in
- Replaced organs are dropped on the floor by default, and if told not
to, will GC, rather than just disappearing through lack of references
- Makes autosurgeons have a `starting_organ` type, where it'll make an
internal organ to be dispensed.
- Autosurgeons now change their name depending on their internal organ
- Nuke ops now just buy the autoimplanter with the organ already inside
it.