### PR TITLE
Hand labelers cannot be used on any mobs.

### DIFF
--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -49,11 +49,8 @@
 	if(length(A.name) + length(label) > 64)
 		to_chat(user, "<span class='warning'>Label too big!</span>")
 		return
-	if(ishuman(A))
-		to_chat(user, "<span class='warning'>You can't label humans!</span>")
-		return
-	if(issilicon(A))
-		to_chat(user, "<span class='warning'>You can't label cyborgs!</span>")
+	if(ismob(A))
+		to_chat(user, "<span class='warning'>You can't label creatures!</span>") // use a collar
 		return
 
 	user.visible_message("[user] labels [A] as [label].", \


### PR DESCRIPTION
Closes https://github.com/tgstation/tgstation/issues/17743. If you want to rename a mob this is what pet collars are for, plus there are just too many checks

also feel free to suggest a less shitty word than "creatures"