### PR TITLE
Fixes temperature not causing turfs to activate

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -546,8 +546,7 @@ var/list/gaslist_cache = null
 				sample_temp = sample.temperature_archived
 
 		var/temperature_delta = abs(temp - sample_temp)
-		if((temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND) && \
-			temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND * temp)
+		if(temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
 			return "temp"
 
 	return ""


### PR DESCRIPTION
@MrStonedOne 

For the life of me I can't figure out why this check was here, so I removed it and, lo and behold. Space heaters work

Fixes #17255 

:cl:
fix: Temperature changes will now properly cause atmospherics simulation to activate
/:cl: