### PR TITLE
Fixes Bubblegum self-deletion adding nulls to the GPS list

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -108,7 +108,7 @@ Difficulty: Hard
 	for(var/mob/living/simple_animal/hostile/megafauna/bubblegum/B in mob_list)
 		if(B != src)
 			qdel(src) //There can be only one
-			break
+			return
 	var/obj/effect/proc_holder/spell/bloodcrawl/bloodspell = new
 	AddSpell(bloodspell)
 	if(istype(loc, /obj/effect/dummy/slaughter))


### PR DESCRIPTION
The Initialize() proc would continue running after an additional spawned
Bubblegum tries to qdel itself, creating a new gps that does not get
quick-deleted properly as it happens AFTER Destroy() is called on the
Bubblegum.

Since the GPS is not removed from the list of GPS objects, it leaves a null entry which causes errors in things searching that list without a type check. This fix is to facilitate conversion of the GPS devices to TGUI after the freeze.