### PR TITLE
Fixes Interdiction Lenses having light when not anchored

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures/interdiction_lens.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/interdiction_lens.dm
@@ -19,9 +19,9 @@
 	var/interdiction_range = 14 //how large an area it drains and disables in
 	var/static/list/rage_messages = list("...", "Disgusting.", "Die.", "Foul.", "Worthless.", "Mortal.", "Unfit.", "Weak.", "Fragile.", "Useless.", "Leave my sight!")
 
-/obj/structure/destructible/clockwork/powered/interdiction_lens/New()
+/obj/structure/destructible/clockwork/powered/interdiction_lens/Initialize()
 	..()
-	set_light(1.4, 0.8, "#F42B9D")
+	update_current_glow()
 
 /obj/structure/destructible/clockwork/powered/interdiction_lens/examine(mob/user)
 	..()
@@ -30,12 +30,25 @@
 	if(is_servant_of_ratvar(user) || isobserver(user))
 		to_chat(user, "<span class='neovgre_small'>If it fails to drain any electronics or has nothing to return power to, it will disable itself for <b>[round(recharge_time/600, 1)]</b> minutes.</span>")
 
+/obj/structure/destructible/clockwork/powered/interdiction_lens/update_anchored(mob/user, do_damage)
+	..()
+	update_current_glow()
+
 /obj/structure/destructible/clockwork/powered/interdiction_lens/toggle(fast_process, mob/living/user)
 	. = ..()
+	update_current_glow()
+
+/obj/structure/destructible/clockwork/powered/interdiction_lens/proc/update_current_glow()
 	if(active)
-		set_light(2, 1.6, "#EE54EE")
+		if(disabled)
+			set_light(2, 1.6, "#151200")
+		else
+			set_light(2, 1.6, "#EE54EE")
 	else
-		set_light(1.4, 0.8, "#F42B9D")
+		if(anchored)
+			set_light(1.4, 0.8, "#F42B9D")
+		else
+			set_light(0)
 
 /obj/structure/destructible/clockwork/powered/interdiction_lens/attack_hand(mob/living/user)
 	if(user.canUseTopic(src, !issilicon(user), NO_DEXTERY))
@@ -53,8 +66,8 @@
 	recharging = world.time + recharge_time
 	flick("interdiction_lens_discharged", src)
 	icon_state = "interdiction_lens_inactive"
-	set_light(2, 1.6, "#151200")
 	disabled = TRUE
+	update_current_glow()
 	return TRUE
 
 /obj/structure/destructible/clockwork/powered/interdiction_lens/process()

--- a/code/game/gamemodes/clock_cult/clock_structures/interdiction_lens.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/interdiction_lens.dm
@@ -58,7 +58,7 @@
 		toggle(0, user)
 
 /obj/structure/destructible/clockwork/powered/interdiction_lens/forced_disable(bad_effects)
-	if(disabled)
+	if(disabled || !anchored)
 		return FALSE
 	if(!active)
 		toggle(0)


### PR DESCRIPTION
Also fixes emping an unanchored lens disabling it, as it shouldn't simultaneously be 'active' and unanchored.