### PR TITLE
Revert "Hand labelers cannot be used on any mobs."

### DIFF
--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -49,8 +49,11 @@
 	if(length(A.name) + length(label) > 64)
 		to_chat(user, "<span class='warning'>Label too big!</span>")
 		return
-	if(ismob(A))
-		to_chat(user, "<span class='warning'>You can't label creatures!</span>") // use a collar
+	if(ishuman(A))
+		to_chat(user, "<span class='warning'>You can't label humans!</span>")
+		return
+	if(issilicon(A))
+		to_chat(user, "<span class='warning'>You can't label cyborgs!</span>")
 		return
 
 	user.visible_message("[user] labels [A] as [label].", \


### PR DESCRIPTION
Reverts tgstation/tgstation#25583

Reopens https://github.com/tgstation/tgstation/issues/17743

Fix it properly instead of butchering the feature