### PR TITLE
Reduces the armor creep whilst also creating consistency, and not violating the freeze

### DIFF
--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -1044,8 +1044,8 @@
 /obj/item/clothing/suit/armor/vest,
 /obj/item/clothing/suit/armor/vest,
 /obj/structure/table,
-/obj/item/clothing/head/helmet/swat/nanotrasen,
-/obj/item/clothing/head/helmet/swat/nanotrasen,
+/obj/item/clothing/head/helmet,
+/obj/item/clothing/head/helmet,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "bQ" = (
@@ -2121,7 +2121,7 @@ ax
 aL
 bO
 ax
-dg
+df
 ac
 bx
 dj
@@ -2151,7 +2151,7 @@ ay
 aP
 ba
 ac
-de
+dd
 bx
 bQ
 bz

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -410,7 +410,7 @@
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
-	helmet = /obj/item/clothing/head/helmet/swat/nanotrasen
+	helmet = /obj/item/clothing/head/helmet
 	back = /obj/item/weapon/storage/backpack/security
 	has_id = 1
 	id_job = "Private Security Force"

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -112,7 +112,7 @@
 	gloves = /obj/item/clothing/gloves/combat
 	radio = /obj/item/device/radio/headset
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
-	helmet = /obj/item/clothing/head/helmet/swat/nanotrasen
+	helmet = /obj/item/clothing/head/helmet
 	back = /obj/item/weapon/storage/backpack/security
 	has_id = 1
 	id_job = "Private Security Force"


### PR DESCRIPTION
This removes the SWAT helm from the simple mobs corpses and meta whiteship

Removals are permitted during the freeze:
[17:07:03] < coleslaw > a feature freeze does not prevent removals
[17:07:05] < coleslaw > or reverts
