### PR TITLE
Bluespace polycrystals and plastitanium are in the exports list now.

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -79,6 +79,12 @@
 	material_id = MAT_TITANIUM
 	message = "cm3 of titanium"
 
+// Plastitanium.
+/datum/export/material/plastitanium
+	cost = 750
+	material_id = MAT_TITANIUM // code can only check for one material_id; plastitanium is half plasma, half titanium, so ((250 x 250) + (250 x 500)) / 250
+	message = "cm3 of plastitanium"
+
 // Metal. Common building material.
 /datum/export/material/metal
 	message = "cm3 of metal"

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -79,6 +79,13 @@
 	message = "of reinforced glass"
 	export_types = list(/obj/item/stack/sheet/rglass)
 
+// Bluespace Polycrystals. About as common on the asteroid as
+
+/datum/export/stack/bscrystal
+	cost = 750
+	message = "of bluespace crystals"
+	export_types = list(/obj/item/stack/sheet/bluespace_crystal)
+
 // Wood. Quite expensive in the grim and dark 26 century.
 /datum/export/stack/wood
 	cost = 25


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/19503.

On numbers:

- Plastitanium contains both titanium and plasma; the code for materials only checks for one. The math I did to arrive at the number is in the comment.
- The math I did for bluespace crystals is pulled out of my ass.