### PR TITLE
Fixes #24998 (Statues spawned by wizards are invisible) - Correctly

### DIFF
--- a/code/controllers/subsystem/processing/overlays.dm
+++ b/code/controllers/subsystem/processing/overlays.dm
@@ -171,7 +171,7 @@ var/datum/controller/subsystem/processing/overlays/SSoverlays
 	
 	var/list/cached_other = other.our_overlays
 	if(cached_other)
-		if(cut_old)
+		if(cut_old || !LAZYLEN(our_overlays))
 			our_overlays = cached_other.Copy()
 		else
 			our_overlays |= cached_other

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -82,9 +82,7 @@
 	var/obj/structure/statue/petrified/S = new(loc, src, statue_timer)
 	S.name = "statue of [name]"
 	bleedsuppress = 1
-	S.icon = icon
-	S.icon_state = icon_state
-	S.copy_overlays(overlays)
+	S.copy_overlays(src)
 	var/newcolor = list(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
 	S.add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
 	return 1


### PR DESCRIPTION
Fixes #24998 
Closes #25633 
Also fixes code trying to add to ```our_overlays``` before ```our_overlays``` was created

Was a typo by @Cyberboss during his overlay compilation PR, easy mistake.