### PR TITLE
Roundstart Events. Fixes xeno egg announcement timer

### DIFF
--- a/code/game/objects/effects/spawners/xeno_egg_delivery.dm
+++ b/code/game/objects/effects/spawners/xeno_egg_delivery.dm
@@ -16,5 +16,5 @@
 	message_admins("An alien egg has been delivered to [A] at [ADMIN_COORDJMP(T)].")
 	log_game("An alien egg has been delivered to [A] at [COORD(T)]")
 	var/message = "Attention [station_name()], we have entrusted you with a research specimen in [A]. Remember to follow all safety precautions when dealing with the specimen."
-	addtimer(CALLBACK(GLOBAL_PROC, /.proc/print_command_report, message), announcement_time)
+	ticker.OnRoundstart(CALLBACK(GLOBAL_PROC, /proc/addtimer, CALLBACK(GLOBAL_PROC, /.proc/print_command_report, message), announcement_time))
 	qdel(src)


### PR DESCRIPTION
:cl:
fix: The command report for random xeno eggs will now be delivered along with the rest of the roundstart reports
/:cl: