### PR TITLE
Prevents being added twice to the list of Sintouched

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1172,7 +1172,6 @@
 				log_admin("[key_name(usr)] has devil'ed [current]. The devil has been marked as ascendable.")
 			if("sintouched")
 				if(ishuman(current))
-					ticker.mode.sintouched += src
 					var/mob/living/carbon/human/H = current
 					H.influenceSin()
 					message_admins("[key_name_admin(usr)] has sintouch'ed [current].")

--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -191,7 +191,7 @@
 	for(var/mob/living/carbon/human/H in targets)
 		if(!H.mind)
 			continue
-		for(var/datum/objective/sintouched/A in H.mind.objectives)
+		if(locate(/datum/objective/sintouched) in H.mind.objectives)
 			continue
 		H.influenceSin()
 		H.Weaken(2)


### PR DESCRIPTION
The influenceSin() proc already adds the player to the list of people
who are sintouched. 

Fixed a check for already being sintouched in the influence sin spell , thanks @Cyberboss!

No known issue reports to close.
