### PR TITLE
Fixes: Ninjas can steal tech again

### DIFF
--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -131,7 +131,8 @@ They *could* go in their appropriate files, but this is supposed to be modular
 		for(var/datum/tech/current_data in S.stored_research)
 			to_chat(H, "<span class='notice'>Checking \the [current_data.name] database.</span>")
 			if(do_after(H, S.s_delay, target = src) && G.candrain && src)
-				for(var/datum/tech/analyzing_data in files.known_tech)
+				for(var/id in files.known_tech)
+					var/datum/tech/analyzing_data = files.known_tech[id]
 					if(current_data.id == analyzing_data.id)
 						if(analyzing_data.level > current_data.level)
 							to_chat(H, "<span class='notice'>Database:</span> <b>UPDATED</b>.")
@@ -162,7 +163,8 @@ They *could* go in their appropriate files, but this is supposed to be modular
 		for(var/datum/tech/current_data in S.stored_research)
 			to_chat(H, "<span class='notice'>Checking \the [current_data.name] database.</span>")
 			if(do_after(H, S.s_delay, target = src) && G.candrain && src)
-				for(var/datum/tech/analyzing_data in files.known_tech)
+				for(var/id in files.known_tech)
+					var/datum/tech/analyzing_data = files.known_tech[id]
 					if(current_data.id == analyzing_data.id)
 						if(analyzing_data.level > current_data.level)
 							to_chat(H, "<span class='notice'>Database:</span> <b>UPDATED</b>.")


### PR DESCRIPTION
:cl: ktccd
fix: Ninja suits have received a new software update, making them able to **actually steal tech levels** from R&D consoles and servers, thus avoid being forced to honourably kill themselves for failing their objective.
/:cl:

[why]: # 
Ninjas can steal tech levels from the servers and R&D consoles again. Code is still terrible copy-paste, but hey, it works and this is a bugfix not a remake PR. Big props to LeoZ and Jalleo for helping me understand more oldcode stuff and installing a healthy dose of fear for it.