### PR TITLE
Sepia slime timestop nerf

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -684,7 +684,7 @@
 /datum/chemical_reaction/slime/slimestop/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
 	var/mob/mob = get_mob_by_key(holder.my_atom.fingerprintslast)
-	var/obj/effect/timestop/T = new /obj/effect/timestop
+	var/obj/effect/timestop/T = new /obj/effect/timestop/sepia
 	T.loc = get_turf(holder.my_atom)
 	T.immune += mob
 	T.timestop()

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -614,6 +614,8 @@
 /obj/effect/timestop/wizard
 	duration = 100
 
+/obj/effect/timestop/sepia
+	duration = 70
 
 /obj/item/stack/tile/bluespace
 	name = "bluespace floor tile"


### PR DESCRIPTION
Cedar is too lazy.
Yeah technically ready.

Specifics: Uses a new timestop subtype with half the default duration of 140. Now 30% shorter than a wizard timestop.