### PR TITLE
[Meta] Changes Chapel doors to lower security

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -82338,29 +82338,28 @@
 /turf/closed/wall,
 /area/chapel/office)
 "cLb" = (
-/obj/machinery/door/airlock/centcom{
-	layer = 2.7;
-	name = "Crematorium Maintenance";
-	opacity = 1;
-	req_access_txt = "27"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/maintenance{
+	name = "Crematorium Maintenance";
+	req_access_txt = "12;27";
+	req_one_access_txt = "0"
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft{
 	name = "Aft Maintenance"
 	})
 "cLc" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Chapel Office Maintenance";
-	opacity = 1;
-	req_access_txt = "27"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Office Maintenance";
+	req_access_txt = "12;22";
+	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft{
@@ -83029,9 +83028,9 @@
 /area/chapel/office)
 "cMb" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Chapel Maintenance Access ";
-	req_access_txt = "0";
-	req_one_access_txt = "12;27"
+	name = "Chapel Maintenance";
+	req_access_txt = "12";
+	req_one_access_txt = "0"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -83953,15 +83952,14 @@
 /area/chapel/main)
 "cNH" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "Chapel";
-	opacity = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Chapel"
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
@@ -84192,14 +84190,13 @@
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
 "cOc" = (
-/obj/machinery/door/airlock/centcom{
-	layer = 2.7;
-	name = "Crematorium";
-	opacity = 1;
-	req_access_txt = "27"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Crematorium";
+	req_access_txt = "22;27";
+	req_one_access_txt = "0"
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
@@ -84304,12 +84301,11 @@
 /area/chapel/main)
 "cOn" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "Chapel";
-	opacity = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Chapel"
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
@@ -84837,12 +84833,11 @@
 /turf/closed/wall,
 /area/chapel/office)
 "cPl" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Chapel Office";
-	opacity = 1;
-	req_access_txt = "27"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/glass{
+	name = "Chapel Office";
+	req_access_txt = "22"
+	},
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
 "cPm" = (
@@ -85305,9 +85300,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/centcom{
-	name = "Funeral Parlour";
-	opacity = 1
+/obj/machinery/door/airlock/glass{
+	name = "Funeral Parlour"
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
@@ -137891,11 +137885,11 @@ aEr
 aFC
 aGZ
 aGZ
-dlL
+dlJ
 aKG
 aMj
 aKG
-dlP
+dlJ
 aQe
 aRv
 dfD
@@ -138148,11 +138142,11 @@ dej
 aFC
 deC
 deC
-dlM
+dlJ
 aKH
 aMk
 aNu
-dlQ
+dlJ
 dfp
 dfp
 dfE
@@ -138410,7 +138404,7 @@ aKI
 aMj
 dfb
 dfj
-dlS
+dlJ
 deD
 dfF
 aTN
@@ -139432,13 +139426,13 @@ aCY
 dem
 aFD
 deD
-dlK
-dlN
+dlJ
+dlJ
 deV
 dlO
 dfc
-dlR
-dlT
+dlJ
+dlJ
 deD
 dfI
 dfS


### PR DESCRIPTION
:cl: Penguaro
tweak: [Meta] The Chapel Security Hatches were very intimidating. They have been changed to more inviting glass doors.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Really why does Chapel ever need one of the most secure doors available? The Event Horizon called to say they want their gothic decor back...

This fixes #25612