### PR TITLE
Fixes grammar on objects landing and bouncing off rims

### DIFF
--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -124,10 +124,10 @@
 		if(istype(I, /obj/item/projectile))
 			return
 		if(prob(50))
-			I.loc = src.loc
-			visible_message("<span class='warning'> Swish! \the [I] lands in \the [src].</span>")
+			I.forceMove(get_turf(src))
+			visible_message("<span class='warning'>Swish! [I] lands in [src].</span>")
 		else
-			visible_message("<span class='danger'> \the [I] bounces off of \the [src]'s rim!</span>")
+			visible_message("<span class='danger'>[I] bounces off of [src]'s rim!</span>")
 		return 0
 	else
 		return ..()

--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -340,11 +340,11 @@
 		if(istype(I, /obj/item/projectile))
 			return
 		if(prob(75))
-			I.loc = src
-			visible_message("<span class='notice'>\the [I] lands in \the [src].</span>")
+			I.forceMove(src)
+			visible_message("<span class='notice'>[I] lands in [src].</span>")
 			update_icon()
 		else
-			visible_message("<span class='notice'>\the [I] bounces off of \the [src]'s rim!</span>")
+			visible_message("<span class='notice'>[I] bounces off of [src]'s rim!</span>")
 		return 0
 	else
 		return ..(mover, target, height)


### PR DESCRIPTION
Similar messages for basket ball hoops, and things landing in disposal
bins. Huh.

- Also makes things use forceMove, instead of setting loc