### PR TITLE
Minor changes to some time procs

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -1,13 +1,15 @@
 //Returns the world time in english
 /proc/worldtime2text()
-	return gameTimestamp("hh:mm:ss")
+	return gameTimestamp("hh:mm:ss", wtime=world.time)
 
 /proc/time_stamp(format = "hh:mm:ss", show_ds)
 	var/time_string = time2text(world.timeofday, format)
 	return show_ds ? "[time_string]:[world.timeofday % 10]" : time_string
 
-/proc/gameTimestamp(format = "hh:mm:ss") // Get the game time in text
-	return time2text(world.time - timezoneOffset + 432000 - round_start_time, format)
+/proc/gameTimestamp(format = "hh:mm:ss", wtime=null)
+	if(!wtime)
+		wtime = world.time
+	return time2text(wtime - timezoneOffset + ticker.gametime_offset - round_start_time, format)
 
 /* Returns 1 if it is the selected month and day */
 /proc/isDay(month, day)

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -1,6 +1,6 @@
 //Returns the world time in english
 /proc/worldtime2text()
-	return gameTimestamp("hh:mm:ss", wtime=world.time)
+	return gameTimestamp("hh:mm:ss", world.time)
 
 /proc/time_stamp(format = "hh:mm:ss", show_ds)
 	var/time_string = time2text(world.timeofday, format)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -44,6 +44,8 @@ var/datum/controller/subsystem/ticker/ticker
 	var/timeLeft						//pregame timer
 	var/start_at
 
+	var/gametime_offset = 432000 // equal to 12 hours, making gametime at roundstart 12:00:00
+
 	var/totalPlayers = 0					//used for pregame stats on statpanel
 	var/totalPlayersReady = 0				//used for pregame stats on statpanel
 


### PR DESCRIPTION
- Lets you pass any value to gameTimestamp, allowing you to work out
what IC time it would be in (world.time + 3000).
- Puts the gametime_offset (currently 12 hours) in ticker, so it's not
just a fucking magic number in a function.

This would allow us, at a later date, to have the starting station time
randomised to be something other than 12:00. If we wanted to.