### PR TITLE
Fixes suffocation damage ratio for low ox

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -130,7 +130,7 @@
 		if(prob(20))
 			emote("gasp")
 		if(O2_partialpressure > 0)
-			var/ratio = safe_oxy_min/O2_partialpressure
+			var/ratio = 1 - O2_partialpressure/safe_oxy_min
 			adjustOxyLoss(min(5*ratio, 3))
 			failed_last_breath = 1
 			oxygen_used = breath_gases["o2"][MOLES]*ratio


### PR DESCRIPTION
:cl: QV
fix: Fixed taking max suffocation damage whenever oxygen was slightly low
/:cl:

With this, you don't take max oxloss if there's 1kpa less oxygen in the atmosphere than you need. It scales linearly from 0 per tick at full ox to 3 per tick at 60% ox or less, which as far as I can tell from existing code was the intention.