### PR TITLE
Pseudolimbs refactor

### DIFF
--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -20,9 +20,6 @@
 	user.visible_message("[user] severs [L]'s [parse_zone(target_zone)]!", "<span class='notice'>You sever [L]'s [parse_zone(target_zone)].</span>")
 	if(surgery.operated_bodypart)
 		var/obj/item/bodypart/target_limb = surgery.operated_bodypart
-		var/obj/item/held_item = L.get_item_for_held_index(target_limb.held_index)
 		target_limb.drop_limb()
-		if(held_item && held_item.flags & NODROP)
-			qdel(target_limb) // arm is ruined
 
 	return 1

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -20,7 +20,7 @@
 	var/max_damage = 0
 	var/list/embedded_objects = list()
 	var/held_index = 0 //are we a hand? if so, which one!
-	var/is_psuedopart = 0 //For limbs that don't really exist, eg chainsaws
+	var/is_pseudopart = FALSE //For limbs that don't really exist, eg chainsaws
 
 	//Coloring and proper item icon update
 	var/skin_tone = ""
@@ -195,9 +195,6 @@
 		owner.update_body() //if our head becomes robotic, we remove the lizard horns and human hair.
 		owner.update_hair()
 		owner.update_damage_overlays()
-
-obj/item/bodypart/proc/set_fakeness(fakeness)
-	is_psuedopart = fakeness
 
 //we inform the bodypart of the changes that happened to the owner, or give it the informations from a source mob.
 /obj/item/bodypart/proc/update_limb(dropping_limb, mob/living/carbon/source)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -20,6 +20,7 @@
 	var/max_damage = 0
 	var/list/embedded_objects = list()
 	var/held_index = 0 //are we a hand? if so, which one!
+	var/is_psuedopart = 0 //For limbs that don't really exist, eg chainsaws
 
 	//Coloring and proper item icon update
 	var/skin_tone = ""
@@ -194,6 +195,9 @@
 		owner.update_body() //if our head becomes robotic, we remove the lizard horns and human hair.
 		owner.update_hair()
 		owner.update_damage_overlays()
+
+obj/item/bodypart/proc/set_fakeness(fakeness)
+	is_psuedopart = fakeness
 
 //we inform the bodypart of the changes that happened to the owner, or give it the informations from a source mob.
 /obj/item/bodypart/proc/update_limb(dropping_limb, mob/living/carbon/source)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -126,7 +126,7 @@
 	C.update_body()
 	C.update_hair()
 	C.update_canmove()
-	if(is_psuedopart)
+	if(is_pseudopart)
 		drop_organs(C)	//Psuedoparts shouldn't have organs, but just in case
 		qdel(src)
 

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -87,12 +87,9 @@
 	update_limb(1)
 	C.bodyparts -= src
 
-	var/psuedo_limb = FALSE //For things that takes the limb with it, attached chainsaws etc, but not things that don't really exist like zombie claws.
-	if(held_index) //ABSTRACT keeps things like the botany mister or defib paddles from counting
-		var/obj/item/held_item = owner.get_item_for_held_index(held_index)
-		C.dropItemToGround(held_item, 1)
+	if(held_index)
+		C.dropItemToGround(owner.get_item_for_held_index(held_index), 1)
 		C.hand_bodyparts[held_index] = null
-		psuedo_limb = held_item && held_item.flags & NODROP && held_item.flags & ABSTRACT && !(held_item.flags & DROPDEL)
 
 	owner = null
 
@@ -129,7 +126,8 @@
 	C.update_body()
 	C.update_hair()
 	C.update_canmove()
-	if(psuedo_limb)
+	if(is_psuedopart)
+		drop_organs(C)	//Psuedoparts shouldn't have organs, but just in case
 		qdel(src)
 
 

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -86,9 +86,13 @@
 	var/mob/living/carbon/C = owner
 	update_limb(1)
 	C.bodyparts -= src
-	if(held_index)
-		C.dropItemToGround(owner.get_item_for_held_index(held_index), 1)
+
+	var/psuedo_limb = FALSE //For things that takes the limb with it, attached chainsaws etc, but not things that don't really exist like zombie claws.
+	if(held_index) //ABSTRACT keeps things like the botany mister or defib paddles from counting
+		var/obj/item/held_item = owner.get_item_for_held_index(held_index)
+		C.dropItemToGround(held_item, 1)
 		C.hand_bodyparts[held_index] = null
+		psuedo_limb = held_item && held_item.flags & NODROP && held_item.flags & ABSTRACT && !(held_item.flags & DROPDEL)
 
 	owner = null
 
@@ -125,6 +129,8 @@
 	C.update_body()
 	C.update_hair()
 	C.update_canmove()
+	if(psuedo_limb)
+		qdel(src)
 
 
 //when a limb is dropped, the internal organs are removed from the mob and put into the limb

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -31,7 +31,7 @@
 					continue
 				if(S.requires_organic_bodypart && affecting.status == BODYPART_ROBOTIC)
 					continue
-				if(S.requires_real_bodypart && affecting.is_psuedopart)
+				if(S.requires_real_bodypart && affecting.is_pseudopart)
 					continue
 			else if(C && S.requires_bodypart) //mob with no limb in surgery zone when we need a limb
 				continue

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -31,6 +31,8 @@
 					continue
 				if(S.requires_organic_bodypart && affecting.status == BODYPART_ROBOTIC)
 					continue
+				if(S.requires_real_bodypart && affecting.is_psuedopart)
+					continue
 			else if(C && S.requires_bodypart) //mob with no limb in surgery zone when we need a limb
 				continue
 			if(!S.can_start(user, M))

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -43,6 +43,7 @@
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/replace, /datum/surgery_step/saw, /datum/surgery_step/add_limb)
 	species = list(/mob/living/carbon/human)
 	possible_locs = list("r_arm","l_arm","r_leg","l_leg","chest","head")
+	requires_real_bodypart = 1
 
 //SURGERY STEP SUCCESSES
 

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -43,7 +43,7 @@
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/replace, /datum/surgery_step/saw, /datum/surgery_step/add_limb)
 	species = list(/mob/living/carbon/human)
 	possible_locs = list("r_arm","l_arm","r_leg","l_leg","chest","head")
-	requires_real_bodypart = 1
+	requires_real_bodypart = TRUE
 
 //SURGERY STEP SUCCESSES
 

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -4,8 +4,8 @@
 	/datum/surgery_step/incise, /datum/surgery_step/manipulate_organs)
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list("chest", "head")
-	requires_organic_bodypart = 0
-	requires_real_bodypart = 1
+	requires_organic_bodypart = FALSE
+	requires_real_bodypart = TRUE
 
 /datum/surgery/organ_manipulation/soft
 	possible_locs = list("groin", "eyes", "mouth", "l_arm", "r_arm")

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -5,6 +5,7 @@
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list("chest", "head")
 	requires_organic_bodypart = 0
+	requires_real_bodypart = 1
 
 /datum/surgery/organ_manipulation/soft
 	possible_locs = list("groin", "eyes", "mouth", "l_arm", "r_arm")

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -60,7 +60,7 @@
 	else
 		target.regenerate_limb(target_zone)
 		var/obj/item/bodypart/L = target.get_bodypart(target_zone)
-		L.set_fakeness(1)
+		L.is_pseudopart = TRUE
 		user.visible_message("[user] finishes attaching [tool]!", "<span class='notice'>You attach [tool].</span>")
 		qdel(tool)
 		if(istype(tool, /obj/item/weapon/twohanded/required/chainsaw))

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -59,6 +59,8 @@
 		return 1
 	else
 		target.regenerate_limb(target_zone)
+		var/obj/item/bodypart/L = target.get_bodypart(target_zone)
+		L.set_fakeness(1)
 		user.visible_message("[user] finishes attaching [tool]!", "<span class='notice'>You attach [tool].</span>")
 		qdel(tool)
 		if(istype(tool, /obj/item/weapon/twohanded/required/chainsaw))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -13,7 +13,7 @@
 	var/obj/item/bodypart/operated_bodypart					//Operable body part
 	var/requires_bodypart = TRUE							//Surgery available only when a bodypart is present, or only when it is missing.
 	var/success_multiplier = 0								//Step success propability multiplier
-
+	var/requires_real_bodypart = 0							//Some surgeries don't work on limbs that don't really exist
 
 /datum/surgery/New(surgery_target, surgery_location, surgery_bodypart)
 	..()


### PR DESCRIPTION
:cl: QV
tweak: Refactored the way limbs that aren't limbs work
/:cl:

Adds a flag for limbs that don't really exist as in the case of attached chainsaws. Prevents doing organ manipulation or augmentation on chainsaws, and stops an arm from being dropped when a chainsaw is dismembered off someone. 