### PR TITLE
SM transmits to Engineering channel when destabilizing

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -106,6 +106,8 @@
 	var/config_hallucination_power = 0.1
 
 	var/obj/item/device/radio/radio
+	var/radio_key = /obj/item/device/encryptionkey/headset_eng
+	var/radio_channel = "Engineering"
 
 	//for logging
 	var/has_been_powered = 0
@@ -119,13 +121,15 @@
 /obj/machinery/power/supermatter_shard/make_frozen_visual()
 	return
 
-/obj/machinery/power/supermatter_shard/New()
+/obj/machinery/power/supermatter_shard/Initialize()
 	. = ..()
 	countdown = new(src)
 	countdown.start()
 	poi_list |= src
 	radio = new(src)
+	radio.keyslot = new radio_key
 	radio.listening = 0
+	radio.recalculateChannels()
 	investigate_log("has been created.", "supermatter")
 
 
@@ -333,29 +337,27 @@
 			var/stability = num2text(round((damage / explosion_point) * 100))
 
 			if(damage > emergency_point)
-
 				radio.talk_into(src, "[emergency_alert] Instability: [stability]%")
+				radio.talk_into(src, "[emergency_alert] Instability: [stability]%", radio_channel)
 				lastwarning = REALTIMEOFDAY
 				if(!has_reached_emergency)
 					investigate_log("has reached the emergency point for the first time.", "supermatter")
 					message_admins("[src] has reached the emergency point <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>(JMP)</a>.")
 					has_reached_emergency = 1
 			else if(damage >= damage_archived) // The damage is still going up
-				radio.talk_into(src, "[warning_alert] Instability: [stability]%")
+				radio.talk_into(src, "[warning_alert] Instability: [stability]%", radio_channel)
 				lastwarning = REALTIMEOFDAY - (WARNING_DELAY * 5)
 
 			else                                                 // Phew, we're safe
-				radio.talk_into(src, "[safe_alert] Instability: [stability]%")
+				radio.talk_into(src, "[safe_alert] Instability: [stability]%", radio_channel)
 				lastwarning = REALTIMEOFDAY
 
 			if(power > POWER_PENALTY_THRESHOLD)
-				radio.talk_into(src, "Warning: Hyperstructure has reached dangerous power level.")
+				radio.talk_into(src, "Warning: Hyperstructure has reached dangerous power level.", radio_channel)
 				if(powerloss_inhibitor < 0.5)
-					radio.talk_into(src, "DANGER: CHARGE INERTIA CHAIN REACTION IN PROGRESS.")
-
+					radio.talk_into(src, "DANGER: CHARGE INERTIA CHAIN REACTION IN PROGRESS.", radio_channel)
 			if(combined_gas > MOLE_PENALTY_THRESHOLD)
-				radio.talk_into(src, "Warning: Critical coolant mass reached.")
-
+				radio.talk_into(src, "Warning: Critical coolant mass reached.", radio_channel)
 		if(damage > explosion_point)
 			for(var/mob in living_mob_list)
 				var/mob/living/L = mob


### PR DESCRIPTION
:cl: Qbopper
tweak: The supermatter crystal now sends its warning messages to the engineering channel. (if it's in critical condition the message will be sent to both common and engineering channels)
/:cl:

https://tgstation13.org/phpBB/viewtopic.php?f=10&t=10445#p275368

also changed New() to Initialize() as per cobby's request