### PR TITLE
SM speaks on engineering channel (now with 100% less conflicts)

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -114,6 +114,8 @@
 	var/config_hallucination_power = 0.1
 
 	var/obj/item/device/radio/radio
+	var/radio_key = /obj/item/device/encryptionkey/headset_eng
+	var/radio_channel = "Engineering"
 
 	//for logging
 	var/has_been_powered = 0
@@ -127,13 +129,15 @@
 /obj/machinery/power/supermatter_shard/make_frozen_visual()
 	return
 
-/obj/machinery/power/supermatter_shard/New()
+/obj/machinery/power/supermatter_shard/Initialize()
 	. = ..()
 	countdown = new(src)
 	countdown.start()
 	poi_list |= src
 	radio = new(src)
+	radio.keyslot = new radio_key
 	radio.listening = 0
+	radio.recalculateChannels()
 	investigate_log("has been created.", "supermatter")
 
 
@@ -338,26 +342,27 @@
 
 			if(damage > emergency_point)
 				SPEAK("[emergency_alert] Instability: [stability]%")
+				SPEAK("[emergency_alert] Instability: [stability]%", radio_channel)
 				lastwarning = REALTIMEOFDAY
 				if(!has_reached_emergency)
 					investigate_log("has reached the emergency point for the first time.", "supermatter")
 					message_admins("[src] has reached the emergency point <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>(JMP)</a>.")
 					has_reached_emergency = 1
 			else if(damage >= damage_archived) // The damage is still going up
-				SPEAK("[warning_alert] Instability: [stability]%")
+				SPEAK("[warning_alert] Instability: [stability]%", radio_channel)
 				lastwarning = REALTIMEOFDAY - (WARNING_DELAY * 5)
 
 			else                                                 // Phew, we're safe
-				SPEAK("[safe_alert] Instability: [stability]%")
+				SPEAK("[safe_alert] Instability: [stability]%", radio_channel)
 				lastwarning = REALTIMEOFDAY
 
 			if(power > POWER_PENALTY_THRESHOLD)
-				SPEAK("Warning: Hyperstructure has reached dangerous power level.")
+				SPEAK("Warning: Hyperstructure has reached dangerous power level.", radio_channel)
 				if(powerloss_inhibitor < 0.5)
-					SPEAK("DANGER: CHARGE INERTIA CHAIN REACTION IN PROGRESS.")
+					SPEAK("DANGER: CHARGE INERTIA CHAIN REACTION IN PROGRESS.", radio_channel)
 
 			if(combined_gas > MOLE_PENALTY_THRESHOLD)
-				SPEAK("Warning: Critical coolant mass reached.")
+				SPEAK("Warning: Critical coolant mass reached.", radio_channel)
 
 		if(damage > explosion_point)
 			for(var/mob in living_mob_list)


### PR DESCRIPTION
:cl: Qbopper
tweak: The supermatter crystal now sends its warning messages to the engineering channel. (if it's in critical condition the message will be sent to both common and engineering channels)
/:cl:

https://tgstation13.org/phpBB/viewtopic.php?f=10&t=10445#p275368

also changed New() to Initialize() as per cobby's request