### PR TITLE
Emergency shuttles forget early launch authorizations if stranded

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -118,7 +118,14 @@
 	// Launch check is in process in case auth_need changes for some reason
 	// probably external.
 	. = FALSE
-	if(!SSshuttle.emergency || ENGINES_STARTED || (!IS_DOCKED))
+	if(!SSshuttle.emergency)
+		return
+
+	if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
+		authorized.Cut()
+		emagged = FALSE
+
+	if(ENGINES_STARTED || (!IS_DOCKED))
 		return .
 
 	// Check to see if we've reached criteria for early launch


### PR DESCRIPTION
:cl: coiax
fix: Emergency shuttles will now forget early launch authorizations if
they cannot launch due to a hostile environment.
/:cl:

This isn't intended behaviour. And it's kind of punishing people for
leaving the shuttle to go deal with the hostile environment, and then
fucking off without them.