### PR TITLE
Golem Runes now show up on POI

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -484,6 +484,7 @@
 
 /obj/effect/golemrune/New()
 	..()
+	poi_list |= src
 	START_PROCESSING(SSobj, src)
 
 /obj/effect/golemrune/process()

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -482,9 +482,9 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = TURF_LAYER
 
-/obj/effect/golemrune/New()
+/obj/effect/golemrune/Initialize()
 	..()
-	poi_list |= src
+	poi_list += src
 	START_PROCESSING(SSobj, src)
 
 /obj/effect/golemrune/process()


### PR DESCRIPTION
:cl: Cobby
add: Golem runes are now viewable in orbit/observe/both
/:cl:

A cheeky fix for #11445 

If someone is spamming runes the ghost can just look them up in orbit or observe