### PR TITLE
[Box] Adjusts access for Science / Maintenace

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -31002,7 +31002,7 @@
 "bry" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Experimentation Lab Maintenance";
-	req_access_txt = "7"
+	req_access_txt = "47"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31070,7 +31070,8 @@
 /area/toxins/explab)
 "brE" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_access_txt = "0";
+	req_one_access_txt = "8;12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -31591,7 +31592,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
 	name = "Experimentation Lab";
-	req_access_txt = "7"
+	req_access_txt = "47"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -34013,7 +34014,8 @@
 	id = "telelab";
 	name = "Test Chamber Blast Doors";
 	pixel_x = 25;
-	pixel_y = 0
+	pixel_y = 0;
+	req_access_txt = "47"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -38037,7 +38039,8 @@
 /area/toxins/mixing)
 "bFY" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_access_txt = "0";
+	req_one_access_txt = "8;12"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -38310,7 +38313,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room Access";
-	req_access_txt = "8"
+	req_access_txt = "7"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -38660,7 +38663,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
 	name = "Toxins Lab";
-	req_access_txt = "8"
+	req_access_txt = "7"
 	},
 /turf/open/floor/plasteel/white,
 /area/toxins/mixing)
@@ -39553,7 +39556,7 @@
 "bIS" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room";
-	req_access_txt = "8"
+	req_access_txt = "7"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4


### PR DESCRIPTION
:cl: Penguaro
add: [Box] Adds access for Scientists to Starboard Maintenance Areas outside of Toxins.
tweak: [Box] Adjusted Science doors to more logical access codes.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Fixes #25759 Scientists cannot consistently access maintenance near their department. This adds access to the gas room (with freezer and heater up and right from tox) and adjusts some of the access numbers. I've also set door access to more logical settings. I've changed the Experimentor Lab from Tox Access to Research. This PR for the most part does not change any starting access areas for any Science staff for Skeleton or Normal Except:
-Toxins staff can access the afformentioned room and adjacent maintenance.
-Roboticists can now access Experimentor.