### PR TITLE
Implements LIGHTING_ROUND_VALUE in lighting

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -4,7 +4,7 @@
 #define LIGHTING_FALLOFF        1 // type of falloff to use for lighting; 1 for circular, 2 for square
 #define LIGHTING_LAMBERTIAN     0 // use lambertian shading for light sources
 #define LIGHTING_HEIGHT         1 // height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone
-#define LIGHTING_ROUND_VALUE    1 / 128 //Value used to round lumcounts, values smaller than 1/255 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
+#define LIGHTING_ROUND_VALUE    1 / 64 //Value used to round lumcounts, values smaller than 1/129 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
 
 #define LIGHTING_ICON 'icons/effects/lighting_object.dmi' // icon used for lighting shading effects
 

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -114,15 +114,15 @@
 	else if (mx < LIGHTING_SOFT_THRESHOLD)
 		. = 0 // 0 means soft lighting.
 
-	cache_r  = lum_r * . || LIGHTING_SOFT_THRESHOLD
-	cache_g  = lum_g * . || LIGHTING_SOFT_THRESHOLD
-	cache_b  = lum_b * . || LIGHTING_SOFT_THRESHOLD
+	cache_r  = round(lum_r * ., LIGHTING_ROUND_VALUE) || LIGHTING_SOFT_THRESHOLD
+	cache_g  = round(lum_g * ., LIGHTING_ROUND_VALUE) || LIGHTING_SOFT_THRESHOLD
+	cache_b  = round(lum_b * ., LIGHTING_ROUND_VALUE) || LIGHTING_SOFT_THRESHOLD
 	#else
-	cache_r  = lum_r * .
-	cache_g  = lum_g * .
-	cache_b  = lum_b * .
+	cache_r  = round(lum_r * ., LIGHTING_ROUND_VALUE)
+	cache_g  = round(lum_g * ., LIGHTING_ROUND_VALUE)
+	cache_b  = round(lum_b * ., LIGHTING_ROUND_VALUE)
 	#endif
-	cache_mx = mx
+	cache_mx = round(mx, LIGHTING_ROUND_VALUE)
 
 	for (var/TT in masters)
 		var/turf/T = TT


### PR DESCRIPTION
Implements LIGHTING_ROUND_VALUE, which was defined as 1 / 128 but never used anywhere. It's since been moved up to 1 / 64 as a result of discussion in this pull.

#25778 worked off the assumption that values for lighting would actually reach 1 or 0 when the tile was full bright/full dark. For whatever reason once a lighting object had been interacted with it would sometimes lead to values of just not quite 0 and not quite 1 moving forward. That pull worked on the assumption that LIGHTING_ROUND_VALUE was a thing that actually existed, but it didn't. So now it does.

Theoretically this DOES change the visuals, but the chunking of values is so fine I could not tell the difference.