### PR TITLE
Fixes sleeps in throw_impact causing issues with ssthrowing

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -272,6 +272,7 @@
 	return pass_flags&passflag
 
 /atom/movable/proc/throw_impact(atom/hit_atom, throwingdatum)
+	set waitfor = 0
 	return hit_atom.hitby(src)
 
 /atom/movable/hitby(atom/movable/AM, skipcatch, hitpush = 1, blocked)


### PR DESCRIPTION
This very likely caused the lance multi-hit bug since it sleeps in throw_impact and this would freeze ssthrowing while it slept causing shit to get confused.