### PR TITLE
Prevents certain closet types from being anchored

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -33,6 +33,7 @@
 	var/material_drop = /obj/item/stack/sheet/metal
 	var/material_drop_amount = 2
 	var/delivery_icon = "deliverycloset" //which icon to use when packagewrapped. null to be unwrappable.
+	var/anchorable = TRUE
 
 
 /obj/structure/closet/Initialize(mapload)
@@ -240,7 +241,7 @@
 							"<span class='notice'>You [welded ? "weld" : "unwelded"] \the [src] with \the [WT].</span>",
 							"<span class='italics'>You hear welding.</span>")
 			update_icon()
-	else if(istype(W, /obj/item/weapon/wrench))
+	else if(istype(W, /obj/item/weapon/wrench) && anchorable)
 		if(isinspace() && !anchored)
 			return
 		anchored = !anchored

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -11,6 +11,7 @@
 	integrity_failure = 0
 	material_drop = /obj/item/stack/sheet/cloth
 	delivery_icon = null //unwrappable
+	anchorable = FALSE
 	var/foldedbag_path = /obj/item/bodybag
 	var/tagged = 0 // so closet code knows to put the tag overlay back
 

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -14,6 +14,7 @@
 	cutting_sound = 'sound/items/poster_ripped.ogg'
 	material_drop = /obj/item/stack/sheet/cardboard
 	delivery_icon = "deliverybox"
+	anchorable = FALSE
 	var/move_speed_multiplier = 1
 	var/move_delay = 0
 	var/egged = 0


### PR DESCRIPTION
Fixes #25877

:cl:
fix: Cardboard boxes and bodybags can no longer be anchored
/:cl: