### PR TITLE
Examining clothing with pockets will give information about the pockets

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -147,7 +147,7 @@
 			how_cool_are_your_threads += "Your [src]'s storage opens when clicked.\n"
 		else
 			how_cool_are_your_threads += "Your [src]'s storage opens when dragged to yourself.\n" 
-		how_cool_are_your_threads += "Your [src] can store [pockets.storage_slots] item[pockets.storage_slots > 1 ? "s" : ""]\n"
+		how_cool_are_your_threads += "Your [src] can store [pockets.storage_slots] item[pockets.storage_slots > 1 ? "s" : ""].\n"
 		if(pockets.quickdraw)
 			how_cool_are_your_threads += "You can quickly remove an item from your [src] using Alt-Click.\n"
 		if(pockets.silent)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -141,6 +141,19 @@
 	..()
 	if(damaged_clothes)
 		to_chat(user,  "<span class='warning'>It looks damaged!</span>")
+	if(pockets)
+		var/list/how_cool_are_your_threads = list("<span class='notice'>")
+		if(pockets.priority)
+			how_cool_are_your_threads += "Your [src]'s storage opens when clicked.\n"
+		else
+			how_cool_are_your_threads += "Your [src]'s storage opens when dragged to yourself.\n" 
+		how_cool_are_your_threads += "Your [src] can store [pockets.storage_slots] item[pockets.storage_slots > 1 ? "s" : ""]\n"
+		if(pockets.quickdraw)
+			how_cool_are_your_threads += "You can quickly remove an item from your [src] using Alt-Click.\n"
+		if(pockets.silent)
+			how_cool_are_your_threads += "Adding or Removing items from your [src] makes no noise.\n"
+		how_cool_are_your_threads += "</span>"
+		to_chat(user, how_cool_are_your_threads.Join())
 
 /obj/item/clothing/obj_break(damage_flag)
 	if(!damaged_clothes)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -148,6 +148,7 @@
 		else
 			how_cool_are_your_threads += "Your [src]'s storage opens when dragged to yourself.\n" 
 		how_cool_are_your_threads += "Your [src] can store [pockets.storage_slots] item[pockets.storage_slots > 1 ? "s" : ""].\n"
+		how_cool_are_your_threads += "Your [src] can store items that are [weightclass2text(pockets.max_w_class)] or smaller.\n"
 		if(pockets.quickdraw)
 			how_cool_are_your_threads += "You can quickly remove an item from your [src] using Alt-Click.\n"
 		if(pockets.silent)


### PR DESCRIPTION
* Type of interaction (eg: backpack style)
* Amount of slots
* If you can quickdraw
* If it's silent to use

I declared #25872 a feature, this just helps it seem more-so.


:cl:
add: Examining clothing with pockets will now give information about the pockets: number of slots, how it is interacted with (backpack, etc.), if it has quickdraw (Alt-Click) support and whether or not it is silent to interact with.
/:cl:

Eg:
Your mining boots's storage opens when dragged to yourself.
Your mining boots can store 2 items.
Your mining boots can store items that are small or smaller.
You can quickly remove an item from your mining boots using Alt-Click.
Adding or Removing items from your mining boots makes no noise.

granted, "small or smaller." looks dumb, but the rest of the descriptions (tiny, bulky, huge, normal-sized, gigantic) are all fine.
