### PR TITLE
Fixes Chemistry being way too fucking easy to break into

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -25408,7 +25408,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/captain)
 "bfF" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/medical/chemistry)
 "bfG" = (
 /obj/structure/grille,
@@ -27251,7 +27251,7 @@
 /area/assembly/chargebay)
 "bjQ" = (
 /obj/machinery/smartfridge/chemistry,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/medical/chemistry)
 "bjR" = (
 /obj/structure/table/glass,
@@ -30155,6 +30155,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "bpN" = (
@@ -30672,6 +30676,11 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 1
 	},


### PR DESCRIPTION
:cl: Iamgoofball
fix: Chemistry, the room capable of producing dev20 explosion grenades, infinite hellfire, and an excessive supply of methamphetamines, has been given extra protection.
/:cl:

Botanists can't roundstart weld past the r-walls. Maybe people won't decide "chemist hasnt made meth within first 3 minutes time 2 weld down walls/steal vendor wrench table then steal both dispensers" anymore.

This is a bugfix for a player problem.