### PR TITLE
Fixes redundant messages about broken closets

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -96,7 +96,7 @@
 		if(resistance_flags & ON_FIRE)
 			to_chat(user, "<span class='warning'>It's on fire!</span>")
 		if(broken)
-			to_chat(user, "<span class='notice'>It looks broken.</span>")
+			to_chat(user, "<span class='notice'>It appears to be broken.</span>")
 		var/examine_status = examine_status(user)
 		if(examine_status)
 			to_chat(user, examine_status)
@@ -109,4 +109,5 @@
 		if(25 to 50)
 			return  "It appears heavily damaged."
 		if(0 to 25)
-			return  "<span class='warning'>It's falling apart!</span>"
+			if(!broken)
+				return  "<span class='warning'>It's falling apart!</span>"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -73,8 +73,6 @@
 	..()
 	if(anchored)
 		to_chat(user, "It is anchored to the ground.")
-	if(broken)
-		to_chat(user, "<span class='notice'>It appears to be broken.</span>")
 	else if(secure && !opened)
 		to_chat(user, "<span class='notice'>Alt-click to [locked ? "unlock" : "lock"].</span>")
 


### PR DESCRIPTION
:cl: Qbopper
fix: Secure lockers will no longer have multiple lines about being broken.
/:cl:

Fixes #25889 

New examine for emagged locker:

![emag](http://i.imgur.com/U3gUgnL.png)

New examine for shot locker:

![shot](http://i.imgur.com/kNVDXwc.png)

EDIT: also changes the line for all broken structures to "It appears to be broken" because that sounds better