### PR TITLE
Small fulton fixes

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -30,7 +30,7 @@ var/list/total_extraction_beacons = list()
 	else
 		var/A
 
-		A = input("Select a beacon to connect to", "Balloon Extraction Pack", A) in possible_beacons
+		A = input("Select a beacon to connect to", "Balloon Extraction Pack", A) as null|anything in possible_beacons
 
 		if(!A)
 			return

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -61,7 +61,7 @@ var/list/total_extraction_beacons = list()
 		to_chat(user, "<span class='notice'>You start attaching the pack to [A]...</span>")
 		if(do_after(user,50,target=A))
 			to_chat(user, "<span class='notice'>You attach the pack to [A] and activate it.</span>")
-			if(loc == user && user.back && istype(user.back, /obj/item/weapon/storage/backpack))
+			if(loc == user && istype(user.back, /obj/item/weapon/storage/backpack))
 				var/obj/item/weapon/storage/backpack/B = user.back
 				if(B.can_be_inserted(src,stop_messages = 1))
 					B.handle_item_insertion(src)

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -35,6 +35,7 @@ var/list/total_extraction_beacons = list()
 		if(!A)
 			return
 		beacon = A
+		to_chat(user, "You link the extraction pack to the beacon system.")
 
 /obj/item/weapon/extraction_pack/afterattack(atom/movable/A, mob/living/carbon/human/user, flag, params)
 	if(!beacon)
@@ -60,7 +61,7 @@ var/list/total_extraction_beacons = list()
 		to_chat(user, "<span class='notice'>You start attaching the pack to [A]...</span>")
 		if(do_after(user,50,target=A))
 			to_chat(user, "<span class='notice'>You attach the pack to [A] and activate it.</span>")
-			if(loc == user || istype(user.back, /obj/item/weapon/storage/backpack))
+			if(loc == user && user.back && istype(user.back, /obj/item/weapon/storage/backpack))
 				var/obj/item/weapon/storage/backpack/B = user.back
 				if(B.can_be_inserted(src,stop_messages = 1))
 					B.handle_item_insertion(src)
@@ -150,14 +151,14 @@ var/list/total_extraction_beacons = list()
 
 /obj/structure/extraction_point
 	name = "fulton recovery beacon"
-	desc = "A beacon for the fulton recovery system. Hit a beacon with a pack to link the pack to a beacon."
+	desc = "A beacon for the fulton recovery system. Activate a pack in your hand to link it to a beacon."
 	icon = 'icons/obj/fulton.dmi'
 	icon_state = "extraction_point"
 	anchored = 1
 	density = 0
 	var/beacon_network = "station"
 
-/obj/structure/extraction_point/New()
+/obj/structure/extraction_point/Initialize()
 	var/area/area_name = get_area(src)
 	name += " ([rand(100,999)]) ([area_name.name])"
 	total_extraction_beacons += src


### PR DESCRIPTION
I have been messing around with Fultons on a test server, and noticed a few unreported issues.

- Fixes lack of feedback on connecting to the beacon system. This only really was a problem when only one beacon existed in the world, but feedbacks are always nice. 
- Fixes runtimes caused by using the fulton system with no backpacks. This was caused by an OR in place of an AND. I have placed an extra null check just to be sure.
- Fixed the extraction point's description containing an outdated pack linking method
- Changed the New to an Initialize

What I couldn't fix is the check on line 57: sure, it prevents you from extracting something from your other hand, but you would still be able to extract something from your backpack, or from a box on the ground, which messes up the inventory icons, leaving behind phantom images of things. Perhaps change the check, to see if the target's location is directly on a turf?  
