### PR TITLE
Teleblocks some areas to prevent abuse, hopefully this works, DNM until i test it a bit

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -621,6 +621,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/security/armory
 	name = "Armory"
 	icon_state = "armory"
+	teleporter_blocked = 1
 
 /area/security/hos
 	name = "Head of Security's Office"

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -595,7 +595,105 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/medical/sleeper
 	name = "Medbay Treatment Center"
 	icon_state = "exam_room"
+480
 
+/area/assembly/assembly_line //Derelict Assembly Line
+
+481
+
+    name = "Assembly Line"
+
+482
+
+    icon_state = "ass_line"
+
+483
+
+    power_equip = 0
+
+484
+
+    power_light = 0
+
+485
+
+    power_environ = 0
+
+486
+
+​
+
+487
+
+//Teleporter
+
+488
+
+​
+
+489
+
+/area/teleporter
+
+490
+
+    name = "Teleporter Room"
+
+491
+
+    icon_state = "teleporter"
+
+492
+
+    music = "signal"
+
+493
+
+​
+
+494
+
+/area/gateway
+
+495
+
+    name = "Gateway"
+
+496
+
+    icon_state = "teleporter"
+
+497
+
+    music = "signal"
+
+498
+
+​
+
+499
+
+//MedBay
+
+500
+
+​
+
+501
+
+/area/medical/medbay
+
+502
+
+    name = "Medbay Central"
+
+503
+
+    icon_state = "medbay"
+
+504
+
+    music = 'sound/ambience/signal.ogg'
 //Security
 
 /area/security/main
@@ -621,7 +719,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/security/armory
 	name = "Armory"
 	icon_state = "armory"
-	teleporter_blocked = 1
+	teleporter_blocked = TRUE
 
 /area/security/hos
 	name = "Head of Security's Office"
@@ -649,12 +747,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/security/nuke_storage
 	name = "Vault"
 	icon_state = "nuke_storage"
-	teleporter_blocked = 1
+	teleporter_blocked = TRUE
 
-/area/ai_monitored/nuke_storage
+/area/ai_monitored/nuke_storage // Todo, purg
 	name = "Vault"
 	icon_state = "nuke_storage"
-	teleporter_blocked = 1
+	teleporter_blocked = TRUE
 
 /area/security/checkpoint
 	name = "Security Checkpoint"

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -649,10 +649,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/security/nuke_storage
 	name = "Vault"
 	icon_state = "nuke_storage"
+	teleporter_blocked = 1
 
 /area/ai_monitored/nuke_storage
 	name = "Vault"
 	icon_state = "nuke_storage"
+	teleporter_blocked = 1
 
 /area/security/checkpoint
 	name = "Security Checkpoint"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -9,7 +9,7 @@
 	layer = AREA_LAYER
 	mouse_opacity = 0
 	invisibility = INVISIBILITY_LIGHTING
-
+	teleporter_blocked = 0
 	var/map_name // Set in New(); preserves the name set by the map maker, even if renamed by the Blueprints.
 
 	var/valid_territory = 1 // If it's a valid territory for gangs to claim

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -9,7 +9,7 @@
 	layer = AREA_LAYER
 	mouse_opacity = 0
 	invisibility = INVISIBILITY_LIGHTING
-	teleporter_blocked = 0
+	var/teleporter_blocked = FALSE
 	var/map_name // Set in New(); preserves the name set by the map maker, even if renamed by the Blueprints.
 
 	var/valid_territory = 1 // If it's a valid territory for gangs to claim

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -51,10 +51,12 @@
 /area/shuttle/syndicate
 	name = "Syndicate Infiltrator"
 	blob_allowed = FALSE
+	teleporter_blocked = 1
 
 /area/shuttle/assault_pod
 	name = "Steel Rain"
 	blob_allowed = FALSE
+	teleporter_blocked = 1
 
 /area/shuttle/abandoned
 	name = "Abandoned Ship"

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -51,12 +51,12 @@
 /area/shuttle/syndicate
 	name = "Syndicate Infiltrator"
 	blob_allowed = FALSE
-	teleporter_blocked = 1
+	teleporter_blocked = TRUE
 
 /area/shuttle/assault_pod
 	name = "Steel Rain"
 	blob_allowed = FALSE
-	teleporter_blocked = 1
+	teleporter_blocked = TRUE
 
 /area/shuttle/abandoned
 	name = "Abandoned Ship"

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -213,7 +213,7 @@
 
 			var/sparks = get_turf(target)
 			var/datum/effect_system/spark_spread/y = new /datum/effect_system/spark_spread
-			y.set_up(5, 1, sparks)istype(
+			y.set_up(5, 1, sparks)
 			y.start()
 
 			var/turf/source = target

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -287,7 +287,7 @@
 		telefail()
 		temp_msg = "ERROR! Sector is outside known time and space!"
 		return
-	if(A.teleporter_blocked == 1)
+	if(A.teleporter_blocked)
 		telefail()
 		temp_msg = "ERROR! Sector is teleporter blocked!"
 		return

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -213,7 +213,7 @@
 
 			var/sparks = get_turf(target)
 			var/datum/effect_system/spark_spread/y = new /datum/effect_system/spark_spread
-			y.set_up(5, 1, sparks)
+			y.set_up(5, 1, sparks)istype(
 			y.start()
 
 			var/turf/source = target
@@ -286,6 +286,10 @@
 	if(z_co == ZLEVEL_CENTCOM || z_co < 1 || z_co > ZLEVEL_SPACEMAX)
 		telefail()
 		temp_msg = "ERROR! Sector is outside known time and space!"
+		return
+	if(A.teleporter_blocked == 1)
+		telefail()
+		temp_msg = "ERROR! Sector is teleporter blocked!"
 		return
 	if(teles_left > 0)
 		doteleport(user)


### PR DESCRIPTION

:cl:
add: Teleblocks areas such as the nuke shuttle, the vault, and the armory
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
There is no reason for science to teleport into areas such as the nuke shuttle, the armory, or the vault.
