### PR TITLE
Fixes the IV drip limits to more sane reagent_containers.

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -7,11 +7,14 @@
 	var/mob/living/carbon/attached = null
 	var/mode = 1 // 1 is injecting, 0 is taking blood.
 	var/obj/item/weapon/reagent_containers/beaker = null
+	var/list/drip_containers = list(/obj/item/weapon/reagent_containers/blood,
+											/obj/item/weapon/reagent_containers/food/drinks,
+											/obj/item/weapon/reagent_containers/glass)
 
-
-/obj/machinery/iv_drip/New()
+/obj/machinery/iv_drip/Initialize()
 	..()
 	update_icon()
+	drip_containers = typecacheof(drip_containers)
 
 /obj/machinery/iv_drip/update_icon()
 	if(attached)
@@ -80,7 +83,7 @@
 
 
 /obj/machinery/iv_drip/attackby(obj/item/weapon/W, mob/user, params)
-	if (istype(W, /obj/item/weapon/reagent_containers/blood) || istype(W, /obj/item/weapon/reagent_containers/food/drinks) || istype(W, /obj/item/weapon/reagent_containers/glass) )
+	if (is_type_in_typecache(W, drip_containers))
 		if(!isnull(beaker))
 			to_chat(user, "<span class='warning'>There is already a reagent container loaded!</span>")
 			return

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -8,7 +8,7 @@
 	var/mode = 1 // 1 is injecting, 0 is taking blood.
 	var/obj/item/weapon/reagent_containers/beaker = null
 	var/list/drip_containers = list(/obj/item/weapon/reagent_containers/blood,
-											/obj/item/weapon/reagent_containers/food/drinks,
+											/obj/item/weapon/reagent_containers/food,
 											/obj/item/weapon/reagent_containers/glass)
 
 /obj/machinery/iv_drip/Initialize()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -80,7 +80,7 @@
 
 
 /obj/machinery/iv_drip/attackby(obj/item/weapon/W, mob/user, params)
-	if (istype(W, /obj/item/weapon/reagent_containers))
+	if (istype(W, /obj/item/weapon/reagent_containers/blood) || istype(W, /obj/item/weapon/reagent_containers/food/drinks) || istype(W, /obj/item/weapon/reagent_containers/glass) )
 		if(!isnull(beaker))
 			to_chat(user, "<span class='warning'>There is already a reagent container loaded!</span>")
 			return


### PR DESCRIPTION
Fixes #25892
Bloodpacks /obj/item/weapon/reagent_containers/blood
Any type of drink container /obj/item/weapon/reagent_containers/food
Any type of glass container /obj/item/weapon/reagent_containers/glass (chem beakers and chem bottles)

I didnt remove the drinks and other stuff because that then maybe decided as a balance change
Edit: Ignore the above all foods are now counted because people want pizza IV drips apparently....