### PR TITLE
CTF is now Synth Battles [Fix to #25939]

### DIFF
--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -247,6 +247,7 @@
 /obj/machinery/capture_the_flag/proc/spawn_team_member(client/new_team_member)
 	var/mob/living/carbon/human/M = new/mob/living/carbon/human(get_turf(src))
 	new_team_member.prefs.copy_to(M)
+	M.set_species(/datum/species/human)
 	M.key = new_team_member.key
 	M.faction += team
 	M.equipOutfit(ctf_gear)

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -247,7 +247,7 @@
 /obj/machinery/capture_the_flag/proc/spawn_team_member(client/new_team_member)
 	var/mob/living/carbon/human/M = new/mob/living/carbon/human(get_turf(src))
 	new_team_member.prefs.copy_to(M)
-	M.set_species(/datum/species/human)
+	M.set_species(/datum/species/synth)
 	M.key = new_team_member.key
 	M.faction += team
 	M.equipOutfit(ctf_gear)


### PR DESCRIPTION
See Title.

I would rather it be this than adding some sort of blacklist check to it in the case we add future roundstart species.

Fixes #25939