### PR TITLE
Fixes medbot, and other weak simplemobs, smashing rwalls.

### DIFF
--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -38,6 +38,8 @@
 /turf/closed/wall/r_wall/attack_animal(mob/living/simple_animal/M)
 	M.changeNext_move(CLICK_CD_MELEE)
 	M.do_attack_animation(src)
+	if(!M.environment_smash)
+		return
 	if(M.environment_smash == 3)
 		dismantle_wall(1)
 		playsound(src, 'sound/effects/meteorimpact.ogg', 100, 1)


### PR DESCRIPTION
Fixes #25950 
They still get the animation, so you know you TRIED, but no noise.

And a newline because webeditor I guess.