### PR TITLE
Ports storage objects to Initialize

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -21,11 +21,6 @@
 	R.add_fingerprint(user)
 	qdel(src)
 
-/obj/item/weapon/storage/box/bodybags/New()
-	..()
-	for(var/i in 1 to 7)
-		new /obj/item/bodybag(src)
-
 
 // Bluespace bodybag
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -978,20 +978,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 	else
 		to_chat(user, "You do not have a PDA. You should make an issue report about this.")
 
-/obj/item/weapon/storage/box/PDAs/New()
-	..()
-	new /obj/item/device/pda(src)
-	new /obj/item/device/pda(src)
-	new /obj/item/device/pda(src)
-	new /obj/item/device/pda(src)
-	new /obj/item/weapon/cartridge/head(src)
-
-	var/newcart = pick(	/obj/item/weapon/cartridge/engineering,
-						/obj/item/weapon/cartridge/security,
-						/obj/item/weapon/cartridge/medical,
-						/obj/item/weapon/cartridge/signal/toxins,
-						/obj/item/weapon/cartridge/quartermaster)
-	new newcart(src)
 
 // Pass along the pulse to atoms in contents, largely added so pAIs are vulnerable to EMP
 /obj/item/device/pda/emp_act(severity)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -198,9 +198,8 @@
 	icon_state = "satchel"
 	resistance_flags = 0
 
-/obj/item/weapon/storage/backpack/satchel/leather/withwallet/New()
-	..()
-	new /obj/item/weapon/storage/wallet/random( src )
+/obj/item/weapon/storage/backpack/satchel/leather/withwallet/PopulateContents()
+	new /obj/item/weapon/storage/wallet/random(src)
 
 /obj/item/weapon/storage/backpack/satchel/eng
 	name = "industrial satchel"
@@ -284,11 +283,13 @@
 		anchored = 0
 		icon_state = initial(icon_state)
 
-/obj/item/weapon/storage/backpack/satchel/flat/New()
+/obj/item/weapon/storage/backpack/satchel/flat/Initialize(mapload)
 	..()
+	SSpersistence.new_secret_satchels += src
+
+/obj/item/weapon/storage/backpack/satchel/flat/PopulateContents()
 	new /obj/item/stack/tile/plasteel(src)
 	new /obj/item/weapon/crowbar(src)
-	SSpersistence.new_secret_satchels += src
 
 /obj/item/weapon/storage/backpack/satchel/flat/Destroy()
 	SSpersistence.new_secret_satchels -= src
@@ -299,7 +300,7 @@
 	var/list/reward_all_of_these = list() //use paths!
 	var/revealed = 0
 
-/obj/item/weapon/storage/backpack/satchel/flat/secret/New()
+/obj/item/weapon/storage/backpack/satchel/flat/secret/Initialize()
 	..()
 
 	if(isfloorturf(loc) && !istype(loc,/turf/open/floor/plating/))
@@ -356,9 +357,7 @@
 	item_state = "duffle-drone"
 	resistance_flags = FIRE_PROOF
 
-/obj/item/weapon/storage/backpack/dufflebag/drone/New()
-	..()
-
+/obj/item/weapon/storage/backpack/dufflebag/drone/PopulateContents()
 	new /obj/item/weapon/screwdriver(src)
 	new /obj/item/weapon/wrench(src)
 	new /obj/item/weapon/weldingtool(src)
@@ -373,8 +372,7 @@
 	icon_state = "duffle-clown"
 	item_state = "duffle-clown"
 
-/obj/item/weapon/storage/backpack/dufflebag/clown/cream_pie/New()
-	. = ..()
+/obj/item/weapon/storage/backpack/dufflebag/clown/cream_pie/PopulateContents()
 	for(var/i in 1 to 10)
 		new /obj/item/weapon/reagent_containers/food/snacks/pie/cream(src)
 
@@ -399,9 +397,7 @@
 	icon_state = "duffle-syndiemed"
 	item_state = "duffle-syndiemed"
 
-/obj/item/weapon/storage/backpack/dufflebag/syndie/surgery/New()
-	..()
-	contents = list()
+/obj/item/weapon/storage/backpack/dufflebag/syndie/surgery/PopulateContents()
 	new /obj/item/weapon/scalpel(src)
 	new /obj/item/weapon/hemostat(src)
 	new /obj/item/weapon/retractor(src)
@@ -412,7 +408,6 @@
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
 	new /obj/item/device/mmi/syndie(src)
-	return
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/ammo
 	name = "ammunition dufflebag"
@@ -423,80 +418,60 @@
 /obj/item/weapon/storage/backpack/dufflebag/syndie/ammo/shotgun
 	desc = "A large dufflebag, packed to the brim with Bulldog shotgun ammo."
 
-/obj/item/weapon/storage/backpack/dufflebag/syndie/ammo/shotgun/New()
-	..()
-	contents = list()
+/obj/item/weapon/storage/backpack/dufflebag/syndie/ammo/shotgun/PopulateContents()
 	for(var/i in 1 to 6)
 		new /obj/item/ammo_box/magazine/m12g(src)
 	new /obj/item/ammo_box/magazine/m12g/buckshot(src)
 	new /obj/item/ammo_box/magazine/m12g/slug(src)
 	new /obj/item/ammo_box/magazine/m12g/dragon(src)
-	return
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/ammo/smg
 	desc = "A large dufflebag, packed to the brim with C20r magazines."
 
-/obj/item/weapon/storage/backpack/dufflebag/syndie/ammo/smg/New()
-	..()
-	contents = list()
+/obj/item/weapon/storage/backpack/dufflebag/syndie/ammo/smg/PopulateContents()
 	for(var/i in 1 to 9)
 		new /obj/item/ammo_box/magazine/smgm45(src)
-	return
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/c20rbundle
 	desc = "A large dufflebag containing a C20r, some magazines, and a cheap looking suppressor."
 
-/obj/item/weapon/storage/backpack/dufflebag/syndie/c20rbundle/New()
-	..()
-	contents = list()
+/obj/item/weapon/storage/backpack/dufflebag/syndie/c20rbundle/PopulateContents()
 	new /obj/item/ammo_box/magazine/smgm45(src)
 	new /obj/item/ammo_box/magazine/smgm45(src)
 	new /obj/item/weapon/gun/ballistic/automatic/c20r(src)
 	new /obj/item/weapon/suppressor/specialoffer(src)
-	return
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/bulldogbundle
 	desc = "A large dufflebag containing a Bulldog, several drums, and a collapsed hardsuit."
 
-/obj/item/weapon/storage/backpack/dufflebag/syndie/bulldogbundle/New()
-	..()
-	contents = list()
+/obj/item/weapon/storage/backpack/dufflebag/syndie/bulldogbundle/PopulateContents()
 	new /obj/item/ammo_box/magazine/m12g(src)
 	new /obj/item/weapon/gun/ballistic/automatic/shotgun/bulldog(src)
 	new /obj/item/ammo_box/magazine/m12g/buckshot(src)
 	new /obj/item/clothing/glasses/thermal/syndi(src)
-	return
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/med/medicalbundle
 	desc = "A large dufflebag containing a medical equipment, a Donksoft machine gun, a big jumbo box of darts, and a knock-off pair of magboots."
 
-/obj/item/weapon/storage/backpack/dufflebag/syndie/med/medicalbundle/New()
-	..()
-	contents = list()
+/obj/item/weapon/storage/backpack/dufflebag/syndie/med/medicalbundle/PopulateContents()
 	new /obj/item/clothing/shoes/magboots/syndie(src)
 	new /obj/item/weapon/storage/firstaid/tactical(src)
 	new /obj/item/weapon/gun/ballistic/automatic/l6_saw/toy(src)
 	new /obj/item/ammo_box/foambox/riot(src)
-	return
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/med/medicalbundle
 	desc = "A large dufflebag containing a medical equipment, a Donksoft machine gun, a big jumbo box of darts, and a knock-off pair of magboots."
 
-/obj/item/weapon/storage/backpack/dufflebag/syndie/med/medicalbundle/New()
-	..()
-	contents = list()
+/obj/item/weapon/storage/backpack/dufflebag/syndie/med/medicalbundle/PopulateContents()
 	new /obj/item/clothing/shoes/magboots/syndie(src)
 	new /obj/item/weapon/storage/firstaid/tactical(src)
 	new /obj/item/weapon/gun/ballistic/automatic/l6_saw/toy(src)
 	new /obj/item/ammo_box/foambox/riot(src)
-	return
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/med/bioterrorbundle
 	desc = "A large dufflebag containing a deadly chemicals, a chemical spray, chemical grenade, a Donksoft assault rifle, riot grade darts, a minature syringe gun, and a box of syringes"
 
-/obj/item/weapon/storage/backpack/dufflebag/syndie/med/bioterrorbundle/New()
-	..()
-	contents = list()
+/obj/item/weapon/storage/backpack/dufflebag/syndie/med/bioterrorbundle/PopulateContents()
 	new /obj/item/weapon/reagent_containers/spray/chemsprayer/bioterror(src)
 	new /obj/item/weapon/storage/box/syndie_kit/chemical(src)
 	new /obj/item/weapon/gun/syringe/syndicate(src)
@@ -504,26 +479,19 @@
 	new /obj/item/weapon/storage/box/syringes(src)
 	new /obj/item/ammo_box/foambox/riot(src)
 	new /obj/item/weapon/grenade/chem_grenade/bioterrorfoam(src)
-	return
 
-/obj/item/weapon/storage/backpack/dufflebag/syndie/c4/New()
-	..()
-	contents = list()
+/obj/item/weapon/storage/backpack/dufflebag/syndie/c4/PopulateContents()
 	for(var/i in 1 to 10)
 		new /obj/item/weapon/grenade/plastic/c4(src)
-	return
 
-/obj/item/weapon/storage/backpack/dufflebag/syndie/x4/New()
-	..()
-	contents = list()
+/obj/item/weapon/storage/backpack/dufflebag/syndie/x4/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/weapon/grenade/plastic/x4(src)
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/firestarter
 	desc = "A large dufflebag containing New Russian pyro backpack sprayer, a pistol, a pipebomb, fireproof hardsuit, ammo, and other equipment."
 
-/obj/item/weapon/storage/backpack/dufflebag/syndie/firestarter/New()
-	..()
+/obj/item/weapon/storage/backpack/dufflebag/syndie/firestarter/PopulateContents()
 	new /obj/item/clothing/under/syndicate/soviet(src)
 	new /obj/item/weapon/watertank/operator(src)
 	new /obj/item/clothing/suit/space/hardsuit/syndi/elite(src)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -151,11 +151,6 @@
 
 	allow_quick_empty = 1 // this function is superceded
 
-/obj/item/weapon/storage/bag/sheetsnatcher/New()
-	..()
-	//verbs -= /obj/item/weapon/storage/verb/quick_empty
-	//verbs += /obj/item/weapon/storage/bag/sheetsnatcher/quick_empty
-
 /obj/item/weapon/storage/bag/sheetsnatcher/can_be_inserted(obj/item/W, stop_messages = 0)
 	if(!istype(W,/obj/item/stack/sheet) || istype(W,/obj/item/stack/sheet/mineral/sandstone) || istype(W,/obj/item/stack/sheet/mineral/wood))
 		if(!stop_messages)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -42,8 +42,7 @@
 	icon_state = "utilitybelt_ce"
 	item_state = "utility_ce"
 
-/obj/item/weapon/storage/belt/utility/chief/full/New()
-	..()
+/obj/item/weapon/storage/belt/utility/chief/full/PopulateContents()
 	new /obj/item/weapon/screwdriver/power(src)
 	new /obj/item/weapon/crowbar/power(src)
 	new /obj/item/weapon/weldingtool/experimental(src)//This can be changed if this is too much
@@ -54,8 +53,7 @@
 	//much roomier now that we've managed to remove two tools
 
 
-/obj/item/weapon/storage/belt/utility/full/New()
-	..()
+/obj/item/weapon/storage/belt/utility/full/PopulateContents()
 	new /obj/item/weapon/screwdriver(src)
 	new /obj/item/weapon/wrench(src)
 	new /obj/item/weapon/weldingtool(src)
@@ -65,8 +63,7 @@
 	new /obj/item/stack/cable_coil(src,30,pick("red","yellow","orange"))
 
 
-/obj/item/weapon/storage/belt/utility/atmostech/New()
-	..()
+/obj/item/weapon/storage/belt/utility/atmostech/PopulateContents()
 	new /obj/item/weapon/screwdriver(src)
 	new /obj/item/weapon/wrench(src)
 	new /obj/item/weapon/weldingtool(src)
@@ -153,8 +150,7 @@
 		/obj/item/weapon/restraints/legcuffs/bola
 		)
 
-/obj/item/weapon/storage/belt/security/full/New()
-	..()
+/obj/item/weapon/storage/belt/security/full/PopulateContents()
 	new /obj/item/weapon/reagent_containers/spray/pepper(src)
 	new /obj/item/weapon/restraints/handcuffs(src)
 	new /obj/item/weapon/grenade/flashbang(src)
@@ -235,8 +231,7 @@
 		/obj/item/device/soulstone
 		)
 
-/obj/item/weapon/storage/belt/soulstone/full/New()
-	..()
+/obj/item/weapon/storage/belt/soulstone/full/PopulateContents()
 	for(var/i in 1 to 6)
 		new /obj/item/device/soulstone(src)
 
@@ -265,8 +260,7 @@
 	icon_state = "belt"
 	item_state = "security"
 
-/obj/item/weapon/storage/belt/military/abductor/full/New()
-	..()
+/obj/item/weapon/storage/belt/military/abductor/full/PopulateContents()
 	new /obj/item/weapon/screwdriver/abductor(src)
 	new /obj/item/weapon/wrench/abductor(src)
 	new /obj/item/weapon/weldingtool/abductor(src)
@@ -304,8 +298,7 @@
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/molotov,
 		/obj/item/weapon/c4,
 		)
-/obj/item/weapon/storage/belt/grenade/full/New()
-	..()
+/obj/item/weapon/storage/belt/grenade/full/PopulateContents()
 	new /obj/item/weapon/grenade/flashbang(src)
 	new /obj/item/weapon/grenade/smokebomb(src)
 	new /obj/item/weapon/grenade/smokebomb(src)
@@ -345,8 +338,7 @@
 		/obj/item/weapon/gun/magic/wand
 		)
 
-/obj/item/weapon/storage/belt/wands/full/New()
-	..()
+/obj/item/weapon/storage/belt/wands/full/PopulateContents()
 	new /obj/item/weapon/gun/magic/wand/death(src)
 	new /obj/item/weapon/gun/magic/wand/resurrection(src)
 	new /obj/item/weapon/gun/magic/wand/polymorph(src)
@@ -400,8 +392,7 @@
 		)
 	alternate_worn_layer = UNDER_SUIT_LAYER
 
-/obj/item/weapon/storage/belt/holster/full/New()
-	..()
+/obj/item/weapon/storage/belt/holster/full/PopulateContents()
 	new /obj/item/weapon/gun/ballistic/revolver/detective(src)
 	new /obj/item/ammo_box/c38(src)
 	new /obj/item/ammo_box/c38(src)
@@ -505,7 +496,6 @@
 	..()
 
 
-/obj/item/weapon/storage/belt/sabre/New()
-	..()
+/obj/item/weapon/storage/belt/sabre/PopulateContents()
 	new /obj/item/weapon/melee/sabre(src)
 	update_icon()

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -154,6 +154,5 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 /obj/item/weapon/storage/book/bible/booze
 	desc = "To be applied to the head repeatedly."
 
-/obj/item/weapon/storage/book/bible/booze/New()
-	..()
+/obj/item/weapon/storage/book/bible/booze/PopulateContents()
 	new /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey(src)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -30,8 +30,8 @@
 	var/foldable = /obj/item/stack/sheet/cardboard
 	var/illustration = "writing"
 
-/obj/item/weapon/storage/box/Initialize()
-	. = ..()
+/obj/item/weapon/storage/box/Initialize(mapload)
+	..()
 	update_icon()
 
 /obj/item/weapon/storage/box/update_icon()
@@ -72,8 +72,7 @@
 	name = "diskette box"
 	illustration = "disk_kit"
 
-/obj/item/weapon/storage/box/disks/Initialize()
-	..()
+/obj/item/weapon/storage/box/disks/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/disk/data(src)
 
@@ -82,24 +81,21 @@
 	name = "plant data disks box"
 	illustration = "disk_kit"
 
-/obj/item/weapon/storage/box/disks_plantgene/Initialize()
-	..()
+/obj/item/weapon/storage/box/disks_plantgene/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/disk/plantgene(src)
 
 // Ordinary survival box
-/obj/item/weapon/storage/box/survival/New()
-	..()
+/obj/item/weapon/storage/box/survival/PopulateContents()
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 
-/obj/item/weapon/storage/box/survival/radio/New()
-	..()
+/obj/item/weapon/storage/box/survival/radio/PopulateContents()
+	..() // we want the survival stuff too.
 	new /obj/item/device/radio/off(src)
 
-/obj/item/weapon/storage/box/survival_mining/New()
-	..()
+/obj/item/weapon/storage/box/survival_mining/PopulateContents()
 	new /obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen/engi(src)
 	new /obj/item/weapon/crowbar/red(src)
@@ -107,31 +103,28 @@
 
 
 // Engineer survival box
-/obj/item/weapon/storage/box/engineer/New()
-	..()
+/obj/item/weapon/storage/box/engineer/PopulateContents()
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen/engi(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 
-/obj/item/weapon/storage/box/engineer/radio/New()
-	..()
+/obj/item/weapon/storage/box/engineer/radio/PopulateContents()
+	..() // we want the regular items too.
 	new /obj/item/device/radio/off(src)
 
 // Syndie survival box
-/obj/item/weapon/storage/box/syndie/New()
-	..()
+/obj/item/weapon/storage/box/syndie/PopulateContents()
 	new /obj/item/clothing/mask/gas/syndicate(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen/engi(src)
 
 // Security survival box
-/obj/item/weapon/storage/box/security/New()
-	..()
+/obj/item/weapon/storage/box/security/PopulateContents()
 	new /obj/item/clothing/mask/gas/sechailer(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 
-/obj/item/weapon/storage/box/security/radio/New()
-	..()
+/obj/item/weapon/storage/box/security/radio/PopulateContents()
+	..() // we want the regular stuff too
 	new /obj/item/device/radio/off(src)
 
 /obj/item/weapon/storage/box/gloves
@@ -139,8 +132,7 @@
 	desc = "Contains sterile latex gloves."
 	illustration = "latex"
 
-/obj/item/weapon/storage/box/gloves/New()
-	..()
+/obj/item/weapon/storage/box/gloves/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/clothing/gloves/color/latex(src)
 
@@ -149,8 +141,7 @@
 	desc = "This box contains sterile medical masks."
 	illustration = "sterile"
 
-/obj/item/weapon/storage/box/masks/New()
-	..()
+/obj/item/weapon/storage/box/masks/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/clothing/mask/surgical(src)
 
@@ -159,28 +150,26 @@
 	desc = "A box full of syringes."
 	illustration = "syringe"
 
-/obj/item/weapon/storage/box/syringes/New()
-	..()
+/obj/item/weapon/storage/box/syringes/PopulateContents()
 	for(var/i in 1 to 7)
-		new /obj/item/weapon/reagent_containers/syringe( src )
+		new /obj/item/weapon/reagent_containers/syringe(src)
 
 /obj/item/weapon/storage/box/medipens
 	name = "box of medipens"
 	desc = "A box full of epinephrine MediPens."
 	illustration = "syringe"
 
-/obj/item/weapon/storage/box/medipens/New()
-	..()
+/obj/item/weapon/storage/box/medipens/PopulateContents()
 	for(var/i in 1 to 7)
-		new /obj/item/weapon/reagent_containers/hypospray/medipen( src )
+		new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 
 /obj/item/weapon/storage/box/medipens/utility
 	name = "stimpack value kit"
 	desc = "A box with several stimpack medipens for the economical miner."
 	illustration = "syringe"
 
-/obj/item/weapon/storage/box/medipens/utility/New()
-	..()
+/obj/item/weapon/storage/box/medipens/utility/PopulateContents()
+	..() // includes regular medipens.
 	for(var/i in 1 to 5)
 		new /obj/item/weapon/reagent_containers/hypospray/medipen/stimpack(src)
 
@@ -188,8 +177,7 @@
 	name = "box of beakers"
 	illustration = "beaker"
 
-/obj/item/weapon/storage/box/beakers/New()
-	..()
+/obj/item/weapon/storage/box/beakers/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/reagent_containers/glass/beaker( src )
 
@@ -197,8 +185,7 @@
 	name = "box of DNA injectors"
 	desc = "This box contains injectors, it seems."
 
-/obj/item/weapon/storage/box/injectors/New()
-	..()
+/obj/item/weapon/storage/box/injectors/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/weapon/dnainjector/h2m(src)
 	for(var/i in 1 to 3)
@@ -210,8 +197,7 @@
 	icon_state = "secbox"
 	illustration = "flashbang"
 
-/obj/item/weapon/storage/box/flashbangs/New()
-	..()
+/obj/item/weapon/storage/box/flashbangs/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/grenade/flashbang(src)
 
@@ -221,8 +207,7 @@
 	icon_state = "secbox"
 	illustration = "flashbang"
 
-/obj/item/weapon/storage/box/flashes/New()
-	..()
+/obj/item/weapon/storage/box/flashes/PopulateContents()
 	for(var/i in 1 to 6)
 		new /obj/item/device/assembly/flash/handheld(src)
 
@@ -231,9 +216,9 @@
 	desc = "This box contains everything necessary to build a wall-mounted flash. <B>WARNING: Flashes can cause serious eye damage, protective eyewear is required.</B>"
 	illustration = "flashbang"
 
-/obj/item/weapon/storage/box/wall_flash/New()
-	..()
+/obj/item/weapon/storage/box/wall_flash/PopulateContents()
 	var/id = rand(1000, 9999)
+	// FIXME what if this conflicts with an existing one?
 
 	new /obj/item/wallframe/button(src)
 	new /obj/item/weapon/electronics/airlock(src)
@@ -250,8 +235,7 @@
 	desc = "<B>WARNING: These devices are extremely dangerous and can cause blindness and skin irritation.</B>"
 	illustration = "flashbang"
 
-/obj/item/weapon/storage/box/teargas/New()
-	..()
+/obj/item/weapon/storage/box/teargas/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
 
@@ -260,8 +244,7 @@
 	desc = "A box with 5 emp grenades."
 	illustration = "flashbang"
 
-/obj/item/weapon/storage/box/emps/New()
-	..()
+/obj/item/weapon/storage/box/emps/PopulateContents()
 	for(var/i in 1 to 5)
 		new /obj/item/weapon/grenade/empgrenade(src)
 
@@ -270,8 +253,7 @@
 	desc = "Box full of scum-bag tracking utensils."
 	illustration = "implant"
 
-/obj/item/weapon/storage/box/trackimp/New()
-	..()
+/obj/item/weapon/storage/box/trackimp/PopulateContents()
 	for(var/i in 1 to 4)
 		new /obj/item/weapon/implantcase/tracking(src)
 	new /obj/item/weapon/implanter(src)
@@ -283,8 +265,7 @@
 	desc = "For finding those who have died on the accursed lavaworld."
 	illustration = "implant"
 
-/obj/item/weapon/storage/box/minertracker/New()
-	..()
+/obj/item/weapon/storage/box/minertracker/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/weapon/implantcase/tracking(src)
 	new /obj/item/weapon/implanter(src)
@@ -296,8 +277,7 @@
 	desc = "Box of stuff used to implant chemicals."
 	illustration = "implant"
 
-/obj/item/weapon/storage/box/chemimp/New()
-	..()
+/obj/item/weapon/storage/box/chemimp/PopulateContents()
 	for(var/i in 1 to 5)
 		new /obj/item/weapon/implantcase/chem(src)
 	new /obj/item/weapon/implanter(src)
@@ -308,8 +288,7 @@
 	desc = "Box of exile implants. It has a picture of a clown being booted through the Gateway."
 	illustration = "implant"
 
-/obj/item/weapon/storage/box/exileimp/New()
-	..()
+/obj/item/weapon/storage/box/exileimp/PopulateContents()
 	for(var/i in 1 to 5)
 		new /obj/item/weapon/implantcase/exile(src)
 	new /obj/item/weapon/implanter(src)
@@ -319,13 +298,17 @@
 	desc = "The label indicates that it contains body bags."
 	illustration = "bodybags"
 
+/obj/item/weapon/storage/box/bodybags/PopulateContents()
+	..()
+	for(var/i in 1 to 7)
+		new /obj/item/bodybag(src)
+
 /obj/item/weapon/storage/box/rxglasses
 	name = "box of prescription glasses"
 	desc = "This box contains nerd glasses."
 	illustration = "glasses"
 
-/obj/item/weapon/storage/box/rxglasses/New()
-	..()
+/obj/item/weapon/storage/box/rxglasses/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/clothing/glasses/regular(src)
 
@@ -333,8 +316,7 @@
 	name = "box of drinking glasses"
 	desc = "It has a picture of drinking glasses on it."
 
-/obj/item/weapon/storage/box/drinkingglasses/New()
-	..()
+/obj/item/weapon/storage/box/drinkingglasses/PopulateContents()
 	for(var/i in 1 to 6)
 		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
 
@@ -342,8 +324,7 @@
 	name = "box of condiment bottles"
 	desc = "It has a large ketchup smear on it."
 
-/obj/item/weapon/storage/box/condimentbottles/New()
-	..()
+/obj/item/weapon/storage/box/condimentbottles/PopulateContents()
 	for(var/i in 1 to 6)
 		new /obj/item/weapon/reagent_containers/food/condiment(src)
 
@@ -351,8 +332,7 @@
 	name = "box of paper cups"
 	desc = "It has pictures of paper cups on the front."
 
-/obj/item/weapon/storage/box/cups/New()
-	..()
+/obj/item/weapon/storage/box/cups/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
 
@@ -361,8 +341,7 @@
 	desc = "<B>Instructions:</B> <I>Heat in microwave. Product will cool if not eaten within seven minutes.</I>"
 	illustration = "donk_kit"
 
-/obj/item/weapon/storage/box/donkpockets/New()
-	..()
+/obj/item/weapon/storage/box/donkpockets/PopulateContents()
 	for(var/i in 1 to 6)
 		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
 
@@ -374,9 +353,8 @@
 	can_hold = list(/obj/item/weapon/reagent_containers/food/snacks/monkeycube)
 	illustration = null
 
-/obj/item/weapon/storage/box/monkeycubes/New()
-	..()
-	for(var/i = 1; i <= 5; i++)
+/obj/item/weapon/storage/box/monkeycubes/PopulateContents()
+	for(var/i in 1 to 5)
 		new /obj/item/weapon/reagent_containers/food/snacks/monkeycube(src)
 
 /obj/item/weapon/storage/box/ids
@@ -384,8 +362,7 @@
 	desc = "Has so many empty IDs."
 	illustration = "id"
 
-/obj/item/weapon/storage/box/ids/New()
-	..()
+/obj/item/weapon/storage/box/ids/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/card/id(src)
 
@@ -395,13 +372,26 @@
 	desc = "A box of spare PDA microcomputers."
 	illustration = "pda"
 
+/obj/item/weapon/storage/box/PDAs/PopulateContents()
+	new /obj/item/device/pda(src)
+	new /obj/item/device/pda(src)
+	new /obj/item/device/pda(src)
+	new /obj/item/device/pda(src)
+	new /obj/item/weapon/cartridge/head(src)
+
+	var/newcart = pick(	/obj/item/weapon/cartridge/engineering,
+						/obj/item/weapon/cartridge/security,
+						/obj/item/weapon/cartridge/medical,
+						/obj/item/weapon/cartridge/signal/toxins,
+						/obj/item/weapon/cartridge/quartermaster)
+	new newcart(src)
+
 /obj/item/weapon/storage/box/silver_ids
 	name = "box of spare silver IDs"
 	desc = "Shiny IDs for important people."
 	illustration = "id"
 
-/obj/item/weapon/storage/box/silver_ids/New()
-	..()
+/obj/item/weapon/storage/box/silver_ids/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/card/id/silver(src)
 
@@ -410,7 +400,7 @@
 	desc = "Take away their last shred of dignity, their name."
 	illustration = "id"
 
-/obj/item/weapon/storage/box/prisoner/New()
+/obj/item/weapon/storage/box/prisoner/PopulateContents()
 	..()
 	new /obj/item/weapon/card/id/prisoner/one(src)
 	new /obj/item/weapon/card/id/prisoner/two(src)
@@ -425,8 +415,7 @@
 	desc = "A box full of PDA cartridges used by Security."
 	illustration = "pda"
 
-/obj/item/weapon/storage/box/seccarts/New()
-	..()
+/obj/item/weapon/storage/box/seccarts/PopulateContents()
 	new /obj/item/weapon/cartridge/detective(src)
 	for(var/i in 1 to 6)
 		new /obj/item/weapon/cartridge/security(src)
@@ -436,8 +425,7 @@
 	desc = "A box full of standard firing pins, to allow newly-developed firearms to operate."
 	illustration = "id"
 
-/obj/item/weapon/storage/box/firingpins/New()
-	..()
+/obj/item/weapon/storage/box/firingpins/PopulateContents()
 	for(var/i in 1 to 5)
 		new /obj/item/device/firing_pin(src)
 
@@ -446,8 +434,7 @@
 	desc = "A box full of laser tag firing pins, to allow newly-developed firearms to require wearing brightly coloured plastic armor before being able to be used."
 	illustration = "id"
 
-/obj/item/weapon/storage/box/lasertagpins/New()
-	..()
+/obj/item/weapon/storage/box/lasertagpins/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/device/firing_pin/tag/red(src)
 		new /obj/item/device/firing_pin/tag/blue(src)
@@ -458,8 +445,7 @@
 	icon_state = "secbox"
 	illustration = "handcuff"
 
-/obj/item/weapon/storage/box/handcuffs/New()
-	..()
+/obj/item/weapon/storage/box/handcuffs/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/restraints/handcuffs(src)
 
@@ -469,8 +455,7 @@
 	icon_state = "secbox"
 	illustration = "handcuff"
 
-/obj/item/weapon/storage/box/zipties/New()
-	..()
+/obj/item/weapon/storage/box/zipties/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/restraints/handcuffs/cable/zipties(src)
 
@@ -480,8 +465,7 @@
 	icon_state = "alienbox"
 	illustration = "handcuff"
 
-/obj/item/weapon/storage/box/alienhandcuffs/New()
-	..()
+/obj/item/weapon/storage/box/alienhandcuffs/PopulateContents()
 	for(var/i in 1 to 7)
 		new	/obj/item/weapon/restraints/handcuffs/alien(src)
 
@@ -490,8 +474,7 @@
 	desc = "A sleek, sturdy box used to hold replica spacesuits."
 	icon_state = "syndiebox"
 
-/obj/item/weapon/storage/box/fakesyndiesuit/New()
-	..()
+/obj/item/weapon/storage/box/fakesyndiesuit/PopulateContents()
 	new /obj/item/clothing/head/syndicatefake(src)
 	new /obj/item/clothing/suit/syndicatefake(src)
 
@@ -500,20 +483,18 @@
 	desc = "<span class='alert'>Keep out of reach of children.</span>"
 	illustration = "mousetraps"
 
-/obj/item/weapon/storage/box/mousetraps/New()
-	..()
+/obj/item/weapon/storage/box/mousetraps/PopulateContents()
 	for(var/i in 1 to 6)
-		new /obj/item/device/assembly/mousetrap( src )
+		new /obj/item/device/assembly/mousetrap(src)
 
 /obj/item/weapon/storage/box/pillbottles
 	name = "box of pill bottles"
 	desc = "It has pictures of pill bottles on its front."
 	illustration = "pillbox"
 
-/obj/item/weapon/storage/box/pillbottles/New()
-	..()
+/obj/item/weapon/storage/box/pillbottles/PopulateContents()
 	for(var/i in 1 to 7)
-		new /obj/item/weapon/storage/pill_bottle( src )
+		new /obj/item/weapon/storage/pill_bottle(src)
 
 /obj/item/weapon/storage/box/snappops
 	name = "snap pop box"
@@ -523,9 +504,8 @@
 	storage_slots = 8
 	can_hold = list(/obj/item/toy/snappop)
 
-/obj/item/weapon/storage/box/snappops/New()
-	..()
-	for(var/i=1; i <= storage_slots; i++)
+/obj/item/weapon/storage/box/snappops/PopulateContents()
+	for(var/i in 1 to storage_slots)
 		new /obj/item/toy/snappop(src)
 
 /obj/item/weapon/storage/box/matches
@@ -539,9 +519,8 @@
 	slot_flags = SLOT_BELT
 	can_hold = list(/obj/item/weapon/match)
 
-/obj/item/weapon/storage/box/matches/New()
-	..()
-	for(var/i=1; i <= storage_slots; i++)
+/obj/item/weapon/storage/box/matches/PopulateContents()
+	for(var/i in 1 to storage_slots)
 		new /obj/item/weapon/match(src)
 
 /obj/item/weapon/storage/box/matches/attackby(obj/item/weapon/match/W as obj, mob/user as mob, params)
@@ -560,29 +539,26 @@
 	max_combined_w_class = 21
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
 
-/obj/item/weapon/storage/box/lights/bulbs/New()
-	..()
-	for(var/i = 0; i < 21; i++)
+/obj/item/weapon/storage/box/lights/bulbs/PopulateContents()
+	for(var/i in 1 to 21)
 		new /obj/item/weapon/light/bulb(src)
 
 /obj/item/weapon/storage/box/lights/tubes
 	name = "box of replacement tubes"
 	illustration = "lighttube"
 
-/obj/item/weapon/storage/box/lights/tubes/New()
-	..()
-	for(var/i = 0; i < 21; i++)
+/obj/item/weapon/storage/box/lights/tubes/PopulateContents()
+	for(var/i in 1 to 21)
 		new /obj/item/weapon/light/tube(src)
 
 /obj/item/weapon/storage/box/lights/mixed
 	name = "box of replacement lights"
 	illustration = "lightmixed"
 
-/obj/item/weapon/storage/box/lights/mixed/New()
-	..()
-	for(var/i = 0; i < 14; i++)
+/obj/item/weapon/storage/box/lights/mixed/PopulateContents()
+	for(var/i in 1 to 14)
 		new /obj/item/weapon/light/tube(src)
-	for(var/i = 0; i < 7; i++)
+	for(var/i in 1 to 7)
 		new /obj/item/weapon/light/bulb(src)
 
 
@@ -590,8 +566,7 @@
 	name = "box of deputy armbands"
 	desc = "To be issued to those authorized to act as deputy of security."
 
-/obj/item/weapon/storage/box/deputy/New()
-	..()
+/obj/item/weapon/storage/box/deputy/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/clothing/tie/armband/deputy(src)
 
@@ -600,8 +575,7 @@
 	desc = "To be used to rapidly seal hull breaches."
 	illustration = "flashbang"
 
-/obj/item/weapon/storage/box/metalfoam/New()
-	..()
+/obj/item/weapon/storage/box/metalfoam/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/grenade/chem_grenade/metalfoam(src)
 
@@ -622,19 +596,15 @@
 	playsound(loc, "rustle", 50, 1, -5)
 	user.visible_message("<span class='notice'>[user] hugs \the [src].</span>","<span class='notice'>You hug \the [src].</span>")
 
-/obj/item/weapon/storage/box/hug/medical/New()
-	..()
+/obj/item/weapon/storage/box/hug/medical/PopulateContents()
 	new /obj/item/stack/medical/bruise_pack(src)
 	new /obj/item/stack/medical/ointment(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 
-/obj/item/weapon/storage/box/hug/survival/New()
-	..()
+/obj/item/weapon/storage/box/hug/survival/PopulateContents()
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
-
-/obj/item/ammo_casing/shotgun/rubbershot
 
 /obj/item/weapon/storage/box/rubbershot
 	name = "box of rubber shots"
@@ -642,8 +612,7 @@
 	icon_state = "rubbershot_box"
 	illustration = null
 
-/obj/item/weapon/storage/box/rubbershot/New()
-	..()
+/obj/item/weapon/storage/box/rubbershot/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/ammo_casing/shotgun/rubbershot(src)
 
@@ -653,15 +622,9 @@
 	icon_state = "lethalshot_box"
 	illustration = null
 
-/obj/item/weapon/storage/box/lethalshot/New()
-	..()
-	new /obj/item/ammo_casing/shotgun/buckshot(src)
-	new /obj/item/ammo_casing/shotgun/buckshot(src)
-	new /obj/item/ammo_casing/shotgun/buckshot(src)
-	new /obj/item/ammo_casing/shotgun/buckshot(src)
-	new /obj/item/ammo_casing/shotgun/buckshot(src)
-	new /obj/item/ammo_casing/shotgun/buckshot(src)
-	new /obj/item/ammo_casing/shotgun/buckshot(src)
+/obj/item/weapon/storage/box/lethalshot/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/ammo_casing/shotgun/buckshot(src)
 
 /obj/item/weapon/storage/box/beanbag
 	name = "box of beanbags"
@@ -669,23 +632,16 @@
 	icon_state = "rubbershot_box"
 	illustration = null
 
-/obj/item/weapon/storage/box/beanbag/New()
-	..()
-	new /obj/item/ammo_casing/shotgun/beanbag(src)
-	new /obj/item/ammo_casing/shotgun/beanbag(src)
-	new /obj/item/ammo_casing/shotgun/beanbag(src)
-	new /obj/item/ammo_casing/shotgun/beanbag(src)
-	new /obj/item/ammo_casing/shotgun/beanbag(src)
-	new /obj/item/ammo_casing/shotgun/beanbag(src)
-
+/obj/item/weapon/storage/box/beanbag/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/ammo_casing/shotgun/beanbag(src)
 
 /obj/item/weapon/storage/box/actionfigure
 	name = "box of action figures"
 	desc = "The latest set of collectable action figures."
 	icon_state = "box"
 
-/obj/item/weapon/storage/box/actionfigure/New()
-	..()
+/obj/item/weapon/storage/box/actionfigure/PopulateContents()
 	for(var/i in 1 to 4)
 		var/randomFigure = pick(subtypesof(/obj/item/toy/figure))
 		new randomFigure(src)
@@ -765,11 +721,16 @@
 	illustration = "donk_kit"
 	item_state = null
 
+/obj/item/weapon/storage/box/ingredients/Initialize()
+	..()
+	if(item_state)
+		name = "[name] ([item_state])"
+		desc = "A box containing supplementary ingredients for the aspiring chef. This box's theme is '[item_state]'."
+
 /obj/item/weapon/storage/box/ingredients/wildcard
 	item_state = "wildcard"
 
-/obj/item/weapon/storage/box/ingredients/wildcard/New()
-	..()
+/obj/item/weapon/storage/box/ingredients/wildcard/PopulateContents()
 	for(var/i in 1 to 7)
 		var/randomFood = pick(/obj/item/weapon/reagent_containers/food/snacks/grown/chili,
 							  /obj/item/weapon/reagent_containers/food/snacks/grown/tomato,
@@ -790,8 +751,7 @@
 /obj/item/weapon/storage/box/ingredients/fiesta
 	item_state = "fiesta"
 
-/obj/item/weapon/storage/box/ingredients/fiesta/New()
-	..()
+/obj/item/weapon/storage/box/ingredients/fiesta/PopulateContents()
 	new /obj/item/weapon/reagent_containers/food/snacks/tortilla(src)
 	for(var/i in 1 to 2)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/corn(src)
@@ -801,8 +761,7 @@
 /obj/item/weapon/storage/box/ingredients/italian
 	item_state = "italian"
 
-/obj/item/weapon/storage/box/ingredients/italian/New()
-	..()
+/obj/item/weapon/storage/box/ingredients/italian/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/tomato(src)
 		new /obj/item/weapon/reagent_containers/food/snacks/faggot(src)
@@ -811,8 +770,7 @@
 /obj/item/weapon/storage/box/ingredients/vegetarian
 	item_state = "vegetarian"
 
-/obj/item/weapon/storage/box/ingredients/vegetarian/New()
-	..()
+/obj/item/weapon/storage/box/ingredients/vegetarian/PopulateContents()
 	for(var/i in 1 to 2)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/carrot(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/grown/eggplant(src)
@@ -824,8 +782,7 @@
 /obj/item/weapon/storage/box/ingredients/american
 	item_state = "american"
 
-/obj/item/weapon/storage/box/ingredients/american/New()
-	..()
+/obj/item/weapon/storage/box/ingredients/american/PopulateContents()
 	for(var/i in 1 to 2)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/potato(src)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/tomato(src)
@@ -835,8 +792,7 @@
 /obj/item/weapon/storage/box/ingredients/fruity
 	item_state = "fruity"
 
-/obj/item/weapon/storage/box/ingredients/fruity/New()
-	..()
+/obj/item/weapon/storage/box/ingredients/fruity/PopulateContents()
 	for(var/i in 1 to 2)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/apple(src)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/citrus/orange(src)
@@ -847,8 +803,7 @@
 /obj/item/weapon/storage/box/ingredients/sweets
 	item_state = "sweets"
 
-/obj/item/weapon/storage/box/ingredients/sweets/New()
-	..()
+/obj/item/weapon/storage/box/ingredients/sweets/PopulateContents()
 	for(var/i in 1 to 2)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/cherries(src)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/banana(src)
@@ -859,8 +814,7 @@
 /obj/item/weapon/storage/box/ingredients/delights
 	item_state = "delights"
 
-/obj/item/weapon/storage/box/ingredients/delights/New()
-	..()
+/obj/item/weapon/storage/box/ingredients/delights/PopulateContents()
 	for(var/i in 1 to 2)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/potato/sweet(src)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/bluecherries(src)
@@ -871,8 +825,7 @@
 /obj/item/weapon/storage/box/ingredients/grains
 	item_state = "grains"
 
-/obj/item/weapon/storage/box/ingredients/grains/New()
-	..()
+/obj/item/weapon/storage/box/ingredients/grains/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/oat(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/grown/wheat(src)
@@ -883,8 +836,7 @@
 /obj/item/weapon/storage/box/ingredients/carnivore
 	item_state = "carnivore"
 
-/obj/item/weapon/storage/box/ingredients/carnivore/New()
-	..()
+/obj/item/weapon/storage/box/ingredients/carnivore/PopulateContents()
 	new /obj/item/weapon/reagent_containers/food/snacks/meat/slab/bear(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/meat/slab/spider(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/spidereggs(src)
@@ -896,40 +848,34 @@
 /obj/item/weapon/storage/box/ingredients/exotic
 	item_state = "exotic"
 
-/obj/item/weapon/storage/box/ingredients/exotic/New()
-	..()
+/obj/item/weapon/storage/box/ingredients/exotic/PopulateContents()
 	for(var/i in 1 to 2)
 		new /obj/item/weapon/reagent_containers/food/snacks/carpmeat(src)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/soybeans(src)
 		new /obj/item/weapon/reagent_containers/food/snacks/grown/cabbage(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/grown/chili(src)
 
-/obj/item/weapon/storage/box/ingredients/New()
-	..()
-	if(item_state)
-		name = "[name] ([item_state])"
-		desc = "A box containing supplementary ingredients for the aspiring chef. This box's theme is '[item_state]'."
-
 /obj/item/weapon/storage/box/emptysandbags
 	name = "box of empty sandbags"
 
-/obj/item/weapon/storage/box/emptysandbags/New()
-	..()
-	new /obj/item/weapon/emptysandbag(src)
-	new /obj/item/weapon/emptysandbag(src)
-	new /obj/item/weapon/emptysandbag(src)
-	new /obj/item/weapon/emptysandbag(src)
-	new /obj/item/weapon/emptysandbag(src)
-	new /obj/item/weapon/emptysandbag(src)
-	new /obj/item/weapon/emptysandbag(src)
+/obj/item/weapon/storage/box/emptysandbags/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/weapon/emptysandbag(src)
 
 /obj/item/weapon/storage/box/rndboards
 	name = "\proper the liberator's legacy"
 	desc = "A box containing a gift for worthy golems."
 
-/obj/item/weapon/storage/box/rndboards/New()
-	..()
+/obj/item/weapon/storage/box/rndboards/PopulateContents()
 	new /obj/item/weapon/circuitboard/machine/protolathe(src)
 	new /obj/item/weapon/circuitboard/machine/destructive_analyzer(src)
 	new /obj/item/weapon/circuitboard/machine/circuit_imprinter(src)
 	new /obj/item/weapon/circuitboard/computer/rdconsole(src)
+
+/obj/item/weapon/storage/box/silver_sulf
+	name = "box of silver sulfadiazine patches"
+	desc = "Contains patches used to treat burns."
+
+/obj/item/weapon/storage/box/silver_sulf/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -16,8 +16,7 @@
 	max_integrity = 150
 	var/folder_path = /obj/item/weapon/folder //this is the path of the folder that gets spawned in New()
 
-/obj/item/weapon/storage/briefcase/New()
-	..()
+/obj/item/weapon/storage/briefcase/PopulateContents()
 	new /obj/item/weapon/pen(src)
 	var/obj/item/weapon/folder/folder = new folder_path(src)
 	for(var/i in 1 to 6)
@@ -26,7 +25,7 @@
 /obj/item/weapon/storage/briefcase/lawyer
 	folder_path = /obj/item/weapon/folder/blue
 
-/obj/item/weapon/storage/briefcase/lawyer/New()
+/obj/item/weapon/storage/briefcase/lawyer/PopulateContents()
 	new /obj/item/weapon/stamp/law(src)
 	..()
 
@@ -47,8 +46,8 @@
 	obj_integrity = 150
 	max_integrity = 150
 
-/obj/item/weapon/storage/briefcase/sniperbundle/New()
-	..()
+/obj/item/weapon/storage/briefcase/sniperbundle/PopulateContents()
+	..() // in case you need any paperwork done after your rampage
 	new /obj/item/weapon/gun/ballistic/automatic/sniper_rifle/syndicate(src)
 	new /obj/item/clothing/neck/tie/red(src)
 	new /obj/item/clothing/under/syndicate/sniper(src)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -22,8 +22,7 @@
 	var/spawn_type = null
 	var/fancy_open = FALSE
 
-/obj/item/weapon/storage/fancy/New()
-	..()
+/obj/item/weapon/storage/fancy/PopulateContents()
 	for(var/i = 1 to storage_slots)
 		new spawn_type(src)
 
@@ -111,7 +110,8 @@
 //CIG PACK//
 ////////////
 /obj/item/weapon/storage/fancy/cigarettes
-	name = "Space Cigarettes"
+	name = "cigarettes packet"
+	var/brand = "Space Cigarettes"
 	desc = "The most popular brand of cigarettes, sponsors of the Space Olympics."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cig"
@@ -124,13 +124,14 @@
 	icon_type = "cigarette"
 	spawn_type = /obj/item/clothing/mask/cigarette
 
-/obj/item/weapon/storage/fancy/cigarettes/New()
+/obj/item/weapon/storage/fancy/cigarettes/PopulateContents()
 	..()
 	create_reagents(15 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
 	reagents.set_reacting(FALSE)
-	for(var/obj/item/clothing/mask/cigarette/cig in src)
-		cig.desc = "\An [name] brand [cig.name]."
-	name = "\improper [name] packet"
+	if(brand)
+		for(var/obj/item/clothing/mask/cigarette/cig in src)
+			cig.desc = "\An [brand] brand [cig.name]."
+		name = "\improper [brand] packet"
 
 /obj/item/weapon/storage/fancy/cigarettes/AltClick(mob/user)
 	if(user.get_active_held_item())
@@ -184,41 +185,41 @@
 		to_chat(user, "<span class='notice'>There are no [icon_type]s left in the pack.</span>")
 
 /obj/item/weapon/storage/fancy/cigarettes/dromedaryco
-	name = "DromedaryCo"
+	brand = "DromedaryCo"
 	desc = "A packet of six imported DromedaryCo cancer sticks. A label on the packaging reads, \"Wouldn't a slow death make a change?\""
 	icon_state = "dromedary"
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_uplift
-	name = "Uplift Smooth"
+	brand = "Uplift Smooth"
 	desc = "Your favorite brand, now menthol flavored."
 	icon_state = "uplift"
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_robust
-	name = "Robust"
+	brand = "Robust"
 	desc = "Smoked by the robust."
 	icon_state = "robust"
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_robustgold
-	name = "Robust Gold"
+	brand = "Robust Gold"
 	desc = "Smoked by the truly robust."
 	icon_state = "robustg"
 
-/obj/item/weapon/storage/fancy/cigarettes/cigpack_robustgold/New()
+/obj/item/weapon/storage/fancy/cigarettes/cigpack_robustgold/PopulateContents()
 	..()
 	for(var/i = 1 to storage_slots)
 		reagents.add_reagent("gold",1)
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_carp
-	name = "Carp Classic"
+	brand = "Carp Classic"
 	desc = "Since 2313."
 	icon_state = "carp"
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate
-	name = "unknown"
+	brand = "unknown"
 	desc = "An obscure brand of cigarettes."
 	icon_state = "syndie"
 
-/obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate/New()
+/obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate/PopulateContents()
 	..()
 	for(var/i = 1 to storage_slots)
 		reagents.add_reagent("omnizine",15)
@@ -226,17 +227,17 @@
 
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_midori
-	name = "Midori Tabako"
+	brand = "Midori Tabako"
 	desc = "You can't understand the runes, but the packet smells funny."
 	icon_state = "midori"
 	spawn_type = /obj/item/clothing/mask/cigarette/rollie
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_shadyjims
-	name ="Shady Jim's Super Slims"
+	brand = "Shady Jim's Super Slims"
 	desc = "Is your weight slowing you down? Having trouble running away from gravitational singularities? Can't stop stuffing your mouth? Smoke Shady Jim's Super Slims and watch all that fat burn away. Guaranteed results!"
 	icon_state = "shadyjim"
 
-/obj/item/weapon/storage/fancy/cigarettes/cigpack_shadyjims/New()
+/obj/item/weapon/storage/fancy/cigarettes/cigpack_shadyjims/PopulateContents()
 	..()
 	for(var/i = 1 to storage_slots)
 		reagents.add_reagent("lipolicide",4)
@@ -266,6 +267,7 @@
 
 /obj/item/weapon/storage/fancy/cigarettes/cigars
 	name = "\improper premium cigar case"
+	brand = null
 	desc = "A case of premium cigars. Very expensive."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cigarcase"

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -20,9 +20,9 @@
 	icon_state = "firstaid"
 	desc = "A first aid kit with the ability to heal common types of injuries."
 
-/obj/item/weapon/storage/firstaid/regular/New()
-	..()
-	if(empty) return
+/obj/item/weapon/storage/firstaid/regular/PopulateContents()
+	if(empty)
+		return
 	new /obj/item/stack/medical/gauze(src)
 	new /obj/item/stack/medical/bruise_pack(src)
 	new /obj/item/stack/medical/bruise_pack(src)
@@ -30,7 +30,6 @@
 	new /obj/item/stack/medical/ointment(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 	new /obj/item/device/healthanalyzer(src)
-	return
 
 /obj/item/weapon/storage/firstaid/fire
 	name = "burn treatment kit"
@@ -38,17 +37,19 @@
 	icon_state = "ointment"
 	item_state = "firstaid-ointment"
 
-/obj/item/weapon/storage/firstaid/fire/New()
+/obj/item/weapon/storage/firstaid/fire/Initialize(mapload)
 	..()
-	if(empty) return
 	icon_state = pick("ointment","firefirstaid")
+
+/obj/item/weapon/storage/firstaid/fire/PopulateContents()
+	if(empty)
+		return
 	for(var/i in 1 to 3)
 		new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
 	new /obj/item/weapon/reagent_containers/pill/oxandrolone(src)
 	new /obj/item/weapon/reagent_containers/pill/oxandrolone(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 	new /obj/item/device/healthanalyzer(src)
-	return
 
 /obj/item/weapon/storage/firstaid/toxin
 	name = "toxin treatment kit"
@@ -56,16 +57,18 @@
 	icon_state = "antitoxin"
 	item_state = "firstaid-toxin"
 
-/obj/item/weapon/storage/firstaid/toxin/New()
-	..()
-	if(empty) return
+/obj/item/weapon/storage/firstaid/toxin/Initialize(mapload)
+	. = ..()
 	icon_state = pick("antitoxin","antitoxfirstaid","antitoxfirstaid2","antitoxfirstaid3")
+
+/obj/item/weapon/storage/firstaid/toxin/PopulateContents()
+	if(empty)
+		return
 	for(var/i in 1 to 4)
 		new /obj/item/weapon/reagent_containers/syringe/charcoal(src)
 	for(var/i in 1 to 2)
 		new /obj/item/weapon/storage/pill_bottle/charcoal(src)
 	new /obj/item/device/healthanalyzer(src)
-	return
 
 /obj/item/weapon/storage/firstaid/o2
 	name = "oxygen deprivation treatment kit"
@@ -73,15 +76,14 @@
 	icon_state = "o2"
 	item_state = "firstaid-o2"
 
-/obj/item/weapon/storage/firstaid/o2/New()
-	..()
-	if(empty) return
+/obj/item/weapon/storage/firstaid/o2/PopulateContents()
+	if(empty)
+		return
 	for(var/i in 1 to 4)
 		new /obj/item/weapon/reagent_containers/pill/salbutamol(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 	new /obj/item/device/healthanalyzer(src)
-	return
 
 /obj/item/weapon/storage/firstaid/brute
 	name = "brute trauma treatment kit"
@@ -89,15 +91,14 @@
 	icon_state = "brute"
 	item_state = "firstaid-brute"
 
-/obj/item/weapon/storage/firstaid/brute/New()
-	..()
-	if(empty) return
+/obj/item/weapon/storage/firstaid/brute/PopulateContents()
+	if(empty)
+		return
 	for(var/i in 1 to 4)
 		new /obj/item/weapon/reagent_containers/pill/patch/styptic(src)
 	new /obj/item/stack/medical/gauze(src)
 	new /obj/item/stack/medical/gauze(src)
 	new /obj/item/device/healthanalyzer(src)
-	return
 
 /obj/item/weapon/storage/firstaid/tactical
 	name = "combat medical kit"
@@ -105,9 +106,9 @@
 	icon_state = "bezerk"
 	max_w_class = WEIGHT_CLASS_NORMAL
 
-/obj/item/weapon/storage/firstaid/tactical/New()
-	..()
-	if(empty) return
+/obj/item/weapon/storage/firstaid/tactical/PopulateContents()
+	if(empty)
+		return
 	new /obj/item/stack/medical/gauze(src)
 	new /obj/item/weapon/defibrillator/compact/combat/loaded(src)
 	new /obj/item/weapon/reagent_containers/hypospray/combat(src)
@@ -115,7 +116,6 @@
 	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
 	new /obj/item/weapon/reagent_containers/syringe/lethal/choral(src)
 	new /obj/item/clothing/glasses/hud/health/night(src)
-	return
 
 
 /*
@@ -147,21 +147,11 @@
 				usr.s_active.close(usr)
 			src.show_to(usr)
 
-/obj/item/weapon/storage/box/silver_sulf
-	name = "box of silver sulfadiazine patches"
-	desc = "Contains patches used to treat burns."
-
-/obj/item/weapon/storage/box/silver_sulf/New()
-	..()
-	for(var/i in 1 to 7)
-		new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
-
 /obj/item/weapon/storage/pill_bottle/charcoal
 	name = "bottle of charcoal pills"
 	desc = "Contains pills used to counter toxins."
 
-/obj/item/weapon/storage/pill_bottle/charcoal/New()
-	..()
+/obj/item/weapon/storage/pill_bottle/charcoal/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/reagent_containers/pill/charcoal(src)
 
@@ -169,8 +159,7 @@
 	name = "bottle of epinephrine pills"
 	desc = "Contains pills used to stabilize patients."
 
-/obj/item/weapon/storage/pill_bottle/epinephrine/New()
-	..()
+/obj/item/weapon/storage/pill_bottle/epinephrine/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/reagent_containers/pill/epinephrine(src)
 
@@ -178,8 +167,7 @@
 	name = "bottle of mutadone pills"
 	desc = "Contains pills used to treat genetic abnormalities."
 
-/obj/item/weapon/storage/pill_bottle/mutadone/New()
-	..()
+/obj/item/weapon/storage/pill_bottle/mutadone/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/reagent_containers/pill/mutadone(src)
 
@@ -187,8 +175,7 @@
 	name = "bottle of mannitol pills"
 	desc = "Contains pills used to treat brain damage."
 
-/obj/item/weapon/storage/pill_bottle/mannitol/New()
-	..()
+/obj/item/weapon/storage/pill_bottle/mannitol/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/reagent_containers/pill/mannitol(src)
 
@@ -196,17 +183,15 @@
 	name = "bottle of stimulant pills"
 	desc = "Guaranteed to give you that extra burst of energy during a long shift!"
 
-/obj/item/weapon/storage/pill_bottle/stimulant/New()
-	..()
+/obj/item/weapon/storage/pill_bottle/stimulant/PopulateContents()
 	for(var/i in 1 to 5)
 		new /obj/item/weapon/reagent_containers/pill/stimulant(src)
 
 /obj/item/weapon/storage/pill_bottle/mining
-	name = "box of patches"
+	name = "bottle of patches"
 	desc = "Contains patches used to treat brute and burn damage."
 
-/obj/item/weapon/storage/pill_bottle/mining/New()
-	..()
+/obj/item/weapon/storage/pill_bottle/mining/PopulateContents()
 	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
 	for(var/i in 1 to 3)
 		new /obj/item/weapon/reagent_containers/pill/patch/styptic(src)

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -70,6 +70,5 @@
 /obj/item/weapon/storage/internal/pocket/small/detective
 	priority = TRUE // so the detectives would discover pockets in their hats
 
-/obj/item/weapon/storage/internal/pocket/small/detective/New()
-	..()
+/obj/item/weapon/storage/internal/pocket/small/detective/PopulateContents()
 	new /obj/item/weapon/reagent_containers/food/drinks/flask/det(src)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -1,5 +1,3 @@
-
-
 /obj/item/weapon/storage/lockbox
 	name = "lockbox"
 	desc = "A locked box."
@@ -80,8 +78,7 @@
 	name = "lockbox of mindshield implants"
 	req_access = list(GLOB.access_security)
 
-/obj/item/weapon/storage/lockbox/loyalty/New()
-	..()
+/obj/item/weapon/storage/lockbox/loyalty/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/weapon/implantcase/mindshield(src)
 	new /obj/item/weapon/implanter/mindshield(src)
@@ -92,8 +89,7 @@
 	desc = "You have a bad feeling about opening this."
 	req_access = list(GLOB.access_security)
 
-/obj/item/weapon/storage/lockbox/clusterbang/New()
-	..()
+/obj/item/weapon/storage/lockbox/clusterbang/PopulateContents()
 	new /obj/item/weapon/grenade/clusterbuster(src)
 
 /obj/item/weapon/storage/lockbox/medal
@@ -109,8 +105,7 @@
 	icon_closed = "medalbox"
 	icon_broken = "medalbox+b"
 
-/obj/item/weapon/storage/lockbox/medal/New()
-	..()
+/obj/item/weapon/storage/lockbox/medal/PopulateContents()
 	new /obj/item/clothing/tie/medal/silver/valor(src)
 	new /obj/item/clothing/tie/medal/bronze_heart(src)
 	for(var/i in 1 to 3)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -145,10 +145,9 @@
 	max_combined_w_class = 21
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 
-/obj/item/weapon/storage/secure/briefcase/New()
+/obj/item/weapon/storage/secure/briefcase/PopulateContents()
 	new /obj/item/weapon/paper(src)
 	new /obj/item/weapon/pen(src)
-	return ..()
 
 /obj/item/weapon/storage/secure/briefcase/attack_hand(mob/user)
 	if ((src.loc == user) && (src.locked == 1))
@@ -161,10 +160,10 @@
 /obj/item/weapon/storage/secure/briefcase/syndie
 	force = 15
 
-/obj/item/weapon/storage/secure/briefcase/syndie/New()
+/obj/item/weapon/storage/secure/briefcase/syndie/PopulateContents()
+	..()
 	for(var/i = 0, i < storage_slots - 2, i++)
 		new /obj/item/stack/spacecash/c1000(src)
-	return ..()
 
 
 // -----------------------------
@@ -185,14 +184,9 @@
 	density = 0
 	cant_hold = list(/obj/item/weapon/storage/secure/briefcase)
 
-/obj/item/weapon/storage/secure/safe/New()
-	..()
+/obj/item/weapon/storage/secure/safe/PopulateContents()
 	new /obj/item/weapon/paper(src)
 	new /obj/item/weapon/pen(src)
 
 /obj/item/weapon/storage/secure/safe/attack_hand(mob/user)
 	return attack_self(user)
-
-/obj/item/weapon/storage/secure/safe/HoS/New()
-	..()
-	//new /obj/item/weapon/storage/lockbox/clusterbang(src) This item is currently broken... and probably shouldnt exist to begin with (even though it's cool)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -190,3 +190,6 @@
 
 /obj/item/weapon/storage/secure/safe/attack_hand(mob/user)
 	return attack_self(user)
+
+/obj/item/weapon/storage/secure/safe/HoS
+	name = "head of security's safe"

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -498,7 +498,7 @@
 		remove_from_storage(I, T)
 
 
-/obj/item/weapon/storage/New()
+/obj/item/weapon/storage/Initialize(mapload)
 	..()
 
 	can_hold = typecacheof(can_hold)
@@ -527,6 +527,8 @@
 	closer.layer = ABOVE_HUD_LAYER
 	closer.plane = ABOVE_HUD_PLANE
 	orient2hud()
+
+	PopulateContents()
 
 
 /obj/item/weapon/storage/Destroy()
@@ -561,3 +563,7 @@
 	for(var/atom/A in contents)
 		A.ex_act(severity, target)
 		CHECK_TICK
+
+//Cyberboss says: "USE THIS TO FILL IT, NOT INITIALIZE OR NEW"
+
+/obj/item/weapon/storage/proc/PopulateContents()

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -41,8 +41,7 @@
 	icon_state = "red"
 	item_state = "toolbox_red"
 
-/obj/item/weapon/storage/toolbox/emergency/New()
-	..()
+/obj/item/weapon/storage/toolbox/emergency/PopulateContents()
 	new /obj/item/weapon/crowbar/red(src)
 	new /obj/item/weapon/weldingtool/mini(src)
 	new /obj/item/weapon/extinguisher/mini(src)
@@ -65,8 +64,7 @@
 	icon_state = "blue"
 	item_state = "toolbox_blue"
 
-/obj/item/weapon/storage/toolbox/mechanical/New()
-	..()
+/obj/item/weapon/storage/toolbox/mechanical/PopulateContents()
 	new /obj/item/weapon/screwdriver(src)
 	new /obj/item/weapon/wrench(src)
 	new /obj/item/weapon/weldingtool(src)
@@ -84,8 +82,7 @@
 	icon_state = "yellow"
 	item_state = "toolbox_yellow"
 
-/obj/item/weapon/storage/toolbox/electrical/New()
-	..()
+/obj/item/weapon/storage/toolbox/electrical/PopulateContents()
 	var/pickedcolor = pick("red","yellow","green","blue","pink","orange","cyan","white")
 	new /obj/item/weapon/screwdriver(src)
 	new /obj/item/weapon/wirecutters(src)
@@ -107,8 +104,7 @@
 	force = 15
 	throwforce = 18
 
-/obj/item/weapon/storage/toolbox/syndicate/New()
-	..()
+/obj/item/weapon/storage/toolbox/syndicate/PopulateContents()
 	new /obj/item/weapon/screwdriver/nuke(src)
 	new /obj/item/weapon/wrench(src)
 	new /obj/item/weapon/weldingtool/largetank(src)
@@ -122,8 +118,7 @@
 	icon_state = "blue"
 	item_state = "toolbox_blue"
 
-/obj/item/weapon/storage/toolbox/drone/New()
-	..()
+/obj/item/weapon/storage/toolbox/drone/PopulateContents()
 	var/pickedcolor = pick("red","yellow","green","blue","pink","orange","cyan","white")
 	new /obj/item/weapon/screwdriver(src)
 	new /obj/item/weapon/wrench(src)
@@ -147,8 +142,7 @@
 	attack_verb = list("robusted", "crushed", "smashed")
 	var/proselytizer_type = /obj/item/clockwork/clockwork_proselytizer/scarab
 
-/obj/item/weapon/storage/toolbox/brass/prefilled/New()
-	..()
+/obj/item/weapon/storage/toolbox/brass/prefilled/PopulateContents()
 	new proselytizer_type(src)
 	new /obj/item/weapon/screwdriver/brass(src)
 	new /obj/item/weapon/wirecutters/brass(src)
@@ -159,7 +153,7 @@
 /obj/item/weapon/storage/toolbox/brass/prefilled/ratvar
 	var/slab_type = /obj/item/clockwork/slab/scarab
 
-/obj/item/weapon/storage/toolbox/brass/prefilled/ratvar/New()
+/obj/item/weapon/storage/toolbox/brass/prefilled/ratvar/PopulateContents()
 	..()
 	new slab_type(src)
 
@@ -177,8 +171,7 @@
 	storage_slots = 10
 	w_class = WEIGHT_CLASS_GIGANTIC //Holds more than a regular toolbox!
 
-/obj/item/weapon/storage/toolbox/artistic/New()
-	..()
+/obj/item/weapon/storage/toolbox/artistic/PopulateContents()
 	new/obj/item/weapon/storage/crayons(src)
 	new/obj/item/weapon/crowbar(src)
 	new/obj/item/stack/cable_coil/red(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -1,7 +1,6 @@
 /obj/item/weapon/storage/box/syndicate
 
-/obj/item/weapon/storage/box/syndicate/New()
-	..()
+/obj/item/weapon/storage/box/syndicate/PopulateContents()
 	switch (pickweight(list("bloodyspai" = 3, "stealth" = 2, "bond" = 2, "screwed" = 2, "sabotage" = 3, "guns" = 2, "murder" = 2, "implant" = 1, "hacker" = 3, "darklord" = 1, "sniper" = 1, "metaops" = 1, "ninja" = 1)))
 		if("bloodyspai") // 27 tc now this is more right
 			new /obj/item/clothing/under/chameleon(src) // 2 tc since it's not the full set
@@ -141,8 +140,7 @@
 /obj/item/weapon/storage/box/syndie_kit/imp_freedom
 	name = "boxed freedom implant (with injector)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_freedom/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/imp_freedom/PopulateContents()
 	var/obj/item/weapon/implanter/O = new(src)
 	O.imp = new /obj/item/weapon/implant/freedom(O)
 	O.update_icon()
@@ -150,25 +148,23 @@
 /obj/item/weapon/storage/box/syndie_kit/imp_microbomb
 	name = "Microbomb Implant (with injector)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_microbomb/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_microbomb/PopulateContents()
 	var/obj/item/weapon/implanter/O = new(src)
 	O.imp = new /obj/item/weapon/implant/explosive(O)
 	O.update_icon()
-	..()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_macrobomb
 	name = "Macrobomb Implant (with injector)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_macrobomb/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_macrobomb/PopulateContents()
 	var/obj/item/weapon/implanter/O = new(src)
 	O.imp = new /obj/item/weapon/implant/explosive/macro(O)
 	O.update_icon()
-	..()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_uplink
 	name = "boxed uplink implant (with injector)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_uplink/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_uplink/PopulateContents()
 	..()
 	var/obj/item/weapon/implanter/O = new(src)
 	O.imp = new /obj/item/weapon/implant/uplink(O)
@@ -177,16 +173,14 @@
 /obj/item/weapon/storage/box/syndie_kit/bioterror
 	name = "bioterror syringe box"
 
-/obj/item/weapon/storage/box/syndie_kit/bioterror/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/bioterror/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/reagent_containers/syringe/bioterror(src)
 
 /obj/item/weapon/storage/box/syndie_kit/imp_adrenal
 	name = "boxed adrenal implant (with injector)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_adrenal/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/imp_adrenal/PopulateContents()
 	var/obj/item/weapon/implanter/O = new(src)
 	O.imp = new /obj/item/weapon/implant/adrenalin(O)
 	O.update_icon()
@@ -194,8 +188,7 @@
 /obj/item/weapon/storage/box/syndie_kit/imp_storage
 	name = "boxed storage implant (with injector)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_storage/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/imp_storage/PopulateContents()
 	new /obj/item/weapon/implanter/storage(src)
 
 /obj/item/weapon/storage/box/syndie_kit/space
@@ -203,16 +196,14 @@
 	can_hold = list(/obj/item/clothing/suit/space/syndicate, /obj/item/clothing/head/helmet/space/syndicate)
 	max_w_class = WEIGHT_CLASS_NORMAL
 
-/obj/item/weapon/storage/box/syndie_kit/space/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/space/PopulateContents()
 	new /obj/item/clothing/suit/space/syndicate/black/red(src) // Black and red is so in right now
 	new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
 
 /obj/item/weapon/storage/box/syndie_kit/emp
 	name = "boxed EMP kit"
 
-/obj/item/weapon/storage/box/syndie_kit/emp/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/emp/PopulateContents()
 	new /obj/item/weapon/grenade/empgrenade(src)
 	new /obj/item/weapon/grenade/empgrenade(src)
 	new /obj/item/weapon/grenade/empgrenade(src)
@@ -224,8 +215,7 @@
 	name = "boxed chemical kit"
 	storage_slots = 14
 
-/obj/item/weapon/storage/box/syndie_kit/chemical/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/chemical/PopulateContents()
 	new /obj/item/weapon/reagent_containers/glass/bottle/polonium(src)
 	new /obj/item/weapon/reagent_containers/glass/bottle/venom(src)
 	new /obj/item/weapon/reagent_containers/glass/bottle/neurotoxin2(src)
@@ -243,8 +233,7 @@
 /obj/item/weapon/storage/box/syndie_kit/nuke
 	name = "box"
 
-/obj/item/weapon/storage/box/syndie_kit/nuke/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/nuke/PopulateContents()
 	new /obj/item/weapon/screwdriver/nuke(src)
 	new /obj/item/nuke_core_container(src)
 	new /obj/item/weapon/paper/nuke_instructions(src)
@@ -252,8 +241,7 @@
 /obj/item/weapon/storage/box/syndie_kit/tuberculosisgrenade
 	name = "boxed virus grenade kit"
 
-/obj/item/weapon/storage/box/syndie_kit/tuberculosisgrenade/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/tuberculosisgrenade/PopulateContents()
 	new /obj/item/weapon/grenade/chem_grenade/tuberculosis(src)
 	for(var/i in 1 to 5)
 		new /obj/item/weapon/reagent_containers/hypospray/medipen/tuberculosiscure(src)
@@ -263,8 +251,7 @@
 /obj/item/weapon/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"
 
-/obj/item/weapon/storage/box/syndie_kit/chameleon/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/chameleon/PopulateContents()
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/clothing/suit/chameleon(src)
 	new /obj/item/clothing/gloves/chameleon(src)
@@ -280,9 +267,7 @@
 
 //5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
 //Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)
-/obj/item/weapon/storage/box/syndie_kit/throwing_weapons/New()
-	..()
-	contents = list()
+/obj/item/weapon/storage/box/syndie_kit/throwing_weapons/PopulateContents()
 	new /obj/item/weapon/throwing_star(src)
 	new /obj/item/weapon/throwing_star(src)
 	new /obj/item/weapon/throwing_star(src)
@@ -291,28 +276,23 @@
 	new /obj/item/weapon/restraints/legcuffs/bola/tactical(src)
 	new /obj/item/weapon/restraints/legcuffs/bola/tactical(src)
 
-/obj/item/weapon/storage/box/syndie_kit/cutouts/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/cutouts/PopulateContents()
 	for(var/i in 1 to 3)
 		new/obj/item/cardboard_cutout/adaptive(src)
 	new/obj/item/toy/crayon/rainbow(src)
 
-/obj/item/weapon/storage/box/syndie_kit/romerol/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/romerol/PopulateContents()
 	new /obj/item/weapon/reagent_containers/glass/bottle/romerol(src)
 	new /obj/item/weapon/reagent_containers/syringe(src)
 	new /obj/item/weapon/reagent_containers/dropper(src)
 
-/obj/item/weapon/storage/box/syndie_kit/ez_clean/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/ez_clean/PopulateContents()
 	for(var/i in 1 to 3)
 		new/obj/item/weapon/grenade/chem_grenade/ez_clean(src)
 
-/obj/item/weapon/storage/box/hug/reverse_revolver/New()
-	..()
+/obj/item/weapon/storage/box/hug/reverse_revolver/PopulateContents()
 	new /obj/item/weapon/gun/ballistic/revolver/reverse(src)
 
-/obj/item/weapon/storage/box/syndie_kit/mimery/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/mimery/PopulateContents()
 	new /obj/item/weapon/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/weapon/spellbook/oneuse/mimery_guns(src)

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -72,8 +72,7 @@
 	else
 		return ..()
 
-/obj/item/weapon/storage/wallet/random/New()
-	..()
+/obj/item/weapon/storage/wallet/random/PopulateContents()
 	var/item1_type = pick( /obj/item/stack/spacecash/c10,/obj/item/stack/spacecash/c100,/obj/item/stack/spacecash/c1000,/obj/item/stack/spacecash/c20,/obj/item/stack/spacecash/c200,/obj/item/stack/spacecash/c50, /obj/item/stack/spacecash/c500)
 	var/item2_type
 	if(prob(50))


### PR DESCRIPTION
All storage objects now populate their initial contents with the
`PopulateContents` proc.

@Cyberboss tells me this is on the path to moving the holodeck to
templates.

- In addition, I refactored cigarettes slightly to have a "brand" var instead of having it rename itself, which caused cigar cases to have "packet" on the end.