### PR TITLE
Fix wire randomization

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -74,9 +74,11 @@
 	"white",
 	"yellow"
 	)
+	
+	my_possible_colors = possible_colors.Copy()
 
 	for(var/wire in shuffle(wires))
-		colors[pick_n_take(possible_colors.Copy())] = wire
+		colors[pick_n_take(my_possible_colors)] = wire
 
 /datum/wires/proc/shuffle_wires()
 	colors.Cut()

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -75,7 +75,7 @@
 	"yellow"
 	)
 	
-	my_possible_colors = possible_colors.Copy()
+	var/list/my_possible_colors = possible_colors.Copy()
 
 	for(var/wire in shuffle(wires))
 		colors[pick_n_take(my_possible_colors)] = wire


### PR DESCRIPTION
Fixes wires.dm following #25325 .

:cl: 
fix: Hackable wires should work as intended again.
/:cl:

Fixes #26017
Fixes #26015