### PR TITLE
Nerfs CNS rebooters with a bugfix

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -117,6 +117,7 @@
 		return
 	crit_fail = TRUE
 	addtimer(CALLBACK(src, .proc/reboot), 90 / severity)
+	..()
 
 /obj/item/organ/cyberimp/brain/anti_stun/proc/reboot()
 	crit_fail = FALSE


### PR DESCRIPTION
nothing personal science players i want to farm bugfixes no bully
makes them stun you again like they're intended to when they get emped
:cl: powergaming research director
bugfix: woops i dropped the emp protection module when i made your cns rebooters today, guess they're vulnerable again!
/:cl: