### PR TITLE
Fixes cigarette branding and taste

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -104,24 +104,26 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "cigoff"
 	w_class = WEIGHT_CLASS_TINY
 	body_parts_covered = null
-	var/lit = 0
+	var/lit = FALSE
 	var/icon_on = "cigon"  //Note - these are in masks.dmi not in cigarette.dmi
 	var/icon_off = "cigoff"
 	var/type_butt = /obj/item/weapon/cigbutt
 	var/lastHolder = null
 	var/smoketime = 300
 	var/chem_volume = 30
+	var/list_reagents = list("nicotine" = 15)
 	heat = 1000
 
 /obj/item/clothing/mask/cigarette/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is huffing [src] as quickly as [user.p_they()] can! It looks like [user.p_theyre()] trying to give [user.p_them()]self cancer.</span>")
 	return (TOXLOSS|OXYLOSS)
 
-/obj/item/clothing/mask/cigarette/New()
+/obj/item/clothing/mask/cigarette/Initialize()
 	..()
 	create_reagents(chem_volume)
 	reagents.set_reacting(FALSE) // so it doesn't react until you light it
-	reagents.add_reagent("nicotine", 15)
+	if(list_reagents)
+		reagents.add_reagent_list(list_reagents)
 
 /obj/item/clothing/mask/cigarette/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -245,6 +247,38 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/is_hot()
 	return lit * heat
 
+// Cigarette brands.
+
+/obj/item/clothing/mask/cigarette/space_cigarette
+	desc = "A Space Cigarette brand cigarette."
+
+/obj/item/clothing/mask/cigarette/dromedary
+	desc = "A DromedaryCo brand cigarette."
+
+/obj/item/clothing/mask/cigarette/uplift
+	desc = "An Uplift Smooth brand cigarette."
+	list_reagents = list("nicotine" = 7.5, "menthol" = 7.5)
+
+/obj/item/clothing/mask/cigarette/robust
+	desc = "A Robust brand cigarette."
+
+/obj/item/clothing/mask/cigarette/robustgold
+	desc = "A Robust Gold brand cigarette."
+	list_reagents = list("nicotine" = 15, "gold" = 1)
+
+/obj/item/clothing/mask/cigarette/carp
+	desc = "A Carp Classic brand cigarette."
+
+/obj/item/clothing/mask/cigarette/syndicate
+	desc = "An unknown brand cigarette."
+	list_reagents = list("nicotine" = 15, "omnizine" = 15)
+
+/obj/item/clothing/mask/cigarette/shadyjims
+	desc = "A Shady Jim's Super Slims cigarette."
+	list_reagents = list("nicotine" = 15, "lipolicide" = 4, "ammonia" = 2, "plantbgone" = 1, "toxin" = 1.5)
+
+// Rollies.
+
 /obj/item/clothing/mask/cigarette/rollie
 	name = "rollie"
 	desc = "A roll of dried plant matter wrapped in thin paper."
@@ -262,9 +296,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	src.pixel_x = rand(-5, 5)
 	src.pixel_y = rand(-5, 5)
 
-/obj/item/clothing/mask/cigarette/rollie/trippy/New()
+/obj/item/clothing/mask/cigarette/rollie/trippy
+	list_reagents = list("nicotine" = 15, "mushroomhallucinogen" = 35)
+
+/obj/item/clothing/mask/cigarette/rollie/Initialize(mapload)
 	..()
-	reagents.add_reagent("mushroomhallucinogen", 50)
 	light()
 
 
@@ -338,9 +374,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "pipeoff"
 	smoketime = 0
 	chem_volume = 100
+	list_reagents = null
 	var/packeditem = 0
 
-/obj/item/clothing/mask/cigarette/pipe/New()
+/obj/item/clothing/mask/cigarette/pipe/Initialize()
 	..()
 	name = "empty [initial(name)]"
 

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -105,6 +105,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	w_class = WEIGHT_CLASS_TINY
 	body_parts_covered = null
 	var/lit = FALSE
+	var/starts_lit = FALSE
 	var/icon_on = "cigon"  //Note - these are in masks.dmi not in cigarette.dmi
 	var/icon_off = "cigoff"
 	var/type_butt = /obj/item/weapon/cigbutt
@@ -124,6 +125,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	reagents.set_reacting(FALSE) // so it doesn't react until you light it
 	if(list_reagents)
 		reagents.add_reagent_list(list_reagents)
+	if(starts_lit)
+		light()
 
 /obj/item/clothing/mask/cigarette/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -298,11 +301,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/rollie/trippy
 	list_reagents = list("nicotine" = 15, "mushroomhallucinogen" = 35)
-
-/obj/item/clothing/mask/cigarette/rollie/Initialize(mapload)
-	..()
-	light()
-
+	starts_lit = TRUE
 
 /obj/item/weapon/cigbutt/roach
 	name = "roach"

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -112,7 +112,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/lastHolder = null
 	var/smoketime = 300
 	var/chem_volume = 30
-	var/list_reagents = list("nicotine" = 15)
+	var/list/list_reagents = list("nicotine" = 15)
 	heat = 1000
 
 /obj/item/clothing/mask/cigarette/suicide_act(mob/user)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -110,8 +110,7 @@
 //CIG PACK//
 ////////////
 /obj/item/weapon/storage/fancy/cigarettes
-	name = "cigarettes packet"
-	var/brand = "Space Cigarettes"
+	name = "\improper Space Cigarettes packet"
 	desc = "The most popular brand of cigarettes, sponsors of the Space Olympics."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cig"
@@ -122,16 +121,7 @@
 	storage_slots = 6
 	can_hold = list(/obj/item/clothing/mask/cigarette, /obj/item/weapon/lighter)
 	icon_type = "cigarette"
-	spawn_type = /obj/item/clothing/mask/cigarette
-
-/obj/item/weapon/storage/fancy/cigarettes/PopulateContents()
-	..()
-	create_reagents(15 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
-	reagents.set_reacting(FALSE)
-	if(brand)
-		for(var/obj/item/clothing/mask/cigarette/cig in src)
-			cig.desc = "\An [brand] brand [cig.name]."
-		name = "\improper [brand] packet"
+	spawn_type = /obj/item/clothing/mask/cigarette/space_cigarette
 
 /obj/item/weapon/storage/fancy/cigarettes/AltClick(mob/user)
 	if(user.get_active_held_item())
@@ -161,13 +151,6 @@
 	else
 		cut_overlays()
 
-/obj/item/weapon/storage/fancy/cigarettes/remove_from_storage(obj/item/W, atom/new_location)
-	if(istype(W,/obj/item/clothing/mask/cigarette))
-		if(reagents)
-			reagents.trans_to(W,(reagents.total_volume/contents.len))
-	fancy_open = TRUE
-	..()
-
 /obj/item/weapon/storage/fancy/cigarettes/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M, /mob))
 		return
@@ -185,65 +168,52 @@
 		to_chat(user, "<span class='notice'>There are no [icon_type]s left in the pack.</span>")
 
 /obj/item/weapon/storage/fancy/cigarettes/dromedaryco
-	brand = "DromedaryCo"
+	name = "\improper DromedaryCo packet"
 	desc = "A packet of six imported DromedaryCo cancer sticks. A label on the packaging reads, \"Wouldn't a slow death make a change?\""
 	icon_state = "dromedary"
+	spawn_type = /obj/item/clothing/mask/cigarette/dromedary
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_uplift
-	brand = "Uplift Smooth"
+	name = "\improper Uplift Smooth packet"
 	desc = "Your favorite brand, now menthol flavored."
 	icon_state = "uplift"
+	spawn_type = /obj/item/clothing/mask/cigarette/uplift
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_robust
-	brand = "Robust"
+	name = "\improper Robust packet"
 	desc = "Smoked by the robust."
 	icon_state = "robust"
+	spawn_type = /obj/item/clothing/mask/cigarette/robust
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_robustgold
-	brand = "Robust Gold"
+	name = "\improper Robust Gold packet"
 	desc = "Smoked by the truly robust."
 	icon_state = "robustg"
-
-/obj/item/weapon/storage/fancy/cigarettes/cigpack_robustgold/PopulateContents()
-	..()
-	for(var/i = 1 to storage_slots)
-		reagents.add_reagent("gold",1)
+	spawn_type = /obj/item/clothing/mask/cigarette/robustgold
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_carp
-	brand = "Carp Classic"
+	name = "\improper Carp Classic packet"
 	desc = "Since 2313."
 	icon_state = "carp"
+	spawn_type = /obj/item/clothing/mask/cigarette/carp
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate
-	brand = "unknown"
+	name = "cigarette packet"
 	desc = "An obscure brand of cigarettes."
 	icon_state = "syndie"
-
-/obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate/PopulateContents()
-	..()
-	for(var/i = 1 to storage_slots)
-		reagents.add_reagent("omnizine",15)
-	name = "cigarette packet"
-
+	spawn_type = /obj/item/clothing/mask/cigarette/syndicate
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_midori
-	brand = "Midori Tabako"
+	name = "\improper Midori Tabako packet"
 	desc = "You can't understand the runes, but the packet smells funny."
 	icon_state = "midori"
 	spawn_type = /obj/item/clothing/mask/cigarette/rollie
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_shadyjims
-	brand = "Shady Jim's Super Slims"
+	name = "\improper Shady Jim's Super Slims packet"
 	desc = "Is your weight slowing you down? Having trouble running away from gravitational singularities? Can't stop stuffing your mouth? Smoke Shady Jim's Super Slims and watch all that fat burn away. Guaranteed results!"
 	icon_state = "shadyjim"
-
-/obj/item/weapon/storage/fancy/cigarettes/cigpack_shadyjims/PopulateContents()
-	..()
-	for(var/i = 1 to storage_slots)
-		reagents.add_reagent("lipolicide",4)
-		reagents.add_reagent("ammonia",2)
-		reagents.add_reagent("plantbgone",1)
-		reagents.add_reagent("toxin",1.5)
+	spawn_type = /obj/item/clothing/mask/cigarette/shadyjims
 
 /obj/item/weapon/storage/fancy/rollingpapers
 	name = "rolling paper pack"
@@ -267,7 +237,6 @@
 
 /obj/item/weapon/storage/fancy/cigarettes/cigars
 	name = "\improper premium cigar case"
-	brand = null
 	desc = "A case of premium cigars. Very expensive."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cigarcase"

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -49,6 +49,14 @@
 	..()
 	. = 1
 
+/datum/reagent/drug/menthol
+	name = "Menthol"
+	id = "menthol"
+	description = "Tastes naturally minty, and imparts a very mild numbing sensation."
+	taste_description = "mint"
+	reagent_state = LIQUID
+	color = "#80AF9C"
+
 /datum/reagent/drug/crank
 	name = "Crank"
 	id = "crank"


### PR DESCRIPTION
:cl: coiax
fix: Cigarette branding has been fixed.
add: Uplift Smooth brand cigarettes now taste minty as advertised.
del: You can no longer inject cigarette packets to inject all cigarettes
simultaneously.
/:cl:

- Makes subtypes of all the brands of cigarettes, and sets them to the
packets, removes the brand var and the special casing initializing that
had to be done for it.
- Adds "menthol", a do nothing drug chemical that tastes of mint to
Uplift Smooth (because they say they taste of mint, so we're fixing bugs
in the user's experience)
- Cigarettes now have a "list_reagents" var, for specifying their
initial reagents mix, like `reagent_container`