### PR TITLE
Fixes datacore icons for catpeople in command roles

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -944,15 +944,15 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	return 0
 
 //For creating consistent icons for human looking simple animals
-/proc/get_flat_human_icon(var/icon_id,var/outfit,var/datum/preferences/prefs)
+/proc/get_flat_human_icon(icon_id, datum/job/J, datum/preferences/prefs)
 	var/static/list/humanoid_icon_cache = list()
 	if(!icon_id || !humanoid_icon_cache[icon_id])
 		var/mob/living/carbon/human/dummy/body = new()
 
 		if(prefs)
 			prefs.copy_to(body)
-		if(outfit)
-			body.equipOutfit(outfit, TRUE)
+		if(J)
+			J.equip(body, TRUE, FALSE)
 
 		SSoverlays.Flush()
 

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -284,4 +284,4 @@
 		C = H.client
 	if(C)
 		P = C.prefs
-	return get_flat_human_icon(null,J.outfit,P)
+	return get_flat_human_icon(null, J, P)


### PR DESCRIPTION
Fixes #25973
This changes the `get_flat_human_icon` to call the job datum's equip, instead of just equiping the outfit.