### PR TITLE
AI Deployment Fixes

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -256,6 +256,8 @@ SUBSYSTEM_DEF(shuttle)
 	for(var/thing in GLOB.shuttle_caller_list)
 		if(isAI(thing))
 			var/mob/living/silicon/ai/AI = thing
+			if(AI.deployed_shell && !AI.deployed_shell.client)
+				continue
 			if(AI.stat || !AI.client)
 				continue
 		else if(istype(thing, /obj/machinery/computer/communications))

--- a/code/game/gamemodes/clock_cult/clock_helpers/scripture_checks.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/scripture_checks.dm
@@ -27,7 +27,9 @@
 /proc/get_unconverted_ais()
 	. = 0
 	for(var/ai in GLOB.ai_list)
-		var/mob/living/silicon/AI = ai
+		var/mob/living/silicon/ai/AI = ai
+		if(AI.deployed_shell && is_servant_of_ratvar(AI.deployed_shell))
+			continue
 		if(is_servant_of_ratvar(AI) || !isturf(AI.loc) || AI.z != ZLEVEL_STATION || AI.stat == DEAD)
 			continue
 		.++

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1063,7 +1063,7 @@
 
 /mob/living/silicon/robot/proc/undeploy()
 
-	if(!deployed || !mainframe)
+	if(!deployed || !mind || !mainframe)
 		return
 	mainframe.redeploy_action.Grant(mainframe)
 	mainframe.redeploy_action.last_used_shell = src


### PR DESCRIPTION
- Fixes https://github.com/tgstation/tgstation/issues/25645, deployed AIs not counting as active for auto shuttle calls.
- Fixes https://github.com/tgstation/tgstation/issues/25991, deployed clockwork AIs counting as unconverted.
- Fixes runtime when attempting undeploy a ghosted AI shell.

