### PR TITLE
[DNM]Fix for not dropping twohands required items, you get one last swing then it drops.

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -190,6 +190,14 @@
 	..(user, FALSE)
 	user.dropItemToGround(src)
 
+/obj/item/weapon/twohanded/required/attack(mob/living/M, mob/living/user)
+	var/datum/O = user.is_holding_item_of_type(/obj/item/weapon/twohanded/offhand)
+	if(src.flags & NODROP || O)					//If we're a NODROP, or if there is an offhand item in the other hand, attack.
+		..()
+		return
+	..()										//One last desperate swing.
+	user.dropItemToGround(src)
+
 /*
  * Fireaxe
  */

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -525,6 +525,7 @@
 /obj/item/weapon/twohanded/required/chainsaw/doomslayer
 	name = "THE GREAT COMMUNICATOR"
 	desc = "<span class='warning'>VRRRRRRR!!!</span>"
+	flags = NODROP
 	armour_penetration = 100
 	force_on = 30
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -119,7 +119,7 @@
 	name = "offhand"
 	icon_state = "offhand"
 	w_class = WEIGHT_CLASS_HUGE
-	flags = ABSTRACT | NODROP
+	flags = ABSTRACT | NODROP | DROPDEL
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/item/weapon/twohanded/offhand/unwield()
@@ -139,6 +139,12 @@
 	if (QDELETED(src))
 		return
 	qdel(src)																//If it's another offhand, or literally anything else, qdel. If I knew how to add logging messages I'd put one here.
+
+/obj/item/weapon/twohanded/offhand/dropped()
+		var/O = user.get_inactive_held_item()
+		if(istype(O, /obj/item/weapon/twohanded/offhand/required))
+			user.dropItemToGround(O, FALSE)									//Not forced to let the NODROPs stay.
+		..()
 
 ///////////Two hand required objects///////////////
 //This is for objects that require two hands to even pick up
@@ -188,14 +194,6 @@
 	if(show_message)
 		to_chat(user, "<span class='notice'>You drop [src].</span>")
 	..(user, FALSE)
-	user.dropItemToGround(src)
-
-/obj/item/weapon/twohanded/required/attack(mob/living/M, mob/living/user)
-	var/O = user.is_holding_item_of_type(/obj/item/weapon/twohanded/offhand)
-	if(src.flags & NODROP || O)					//If we're a NODROP, or if there is an offhand item in the other hand, attack.
-		..()
-		return
-	..()										//One last desperate swing.
 	user.dropItemToGround(src)
 
 /*

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -169,7 +169,7 @@
 	..()
 	var/slotbit = slotdefine2slotbit(slot)
 	if(slot_flags & slotbit)
-		var/datum/O = user.is_holding_item_of_type(/obj/item/weapon/twohanded/offhand)
+		var/O = user.is_holding_item_of_type(/obj/item/weapon/twohanded/offhand)
 		if(!O || QDELETED(O))
 			return
 		qdel(O)
@@ -191,7 +191,7 @@
 	user.dropItemToGround(src)
 
 /obj/item/weapon/twohanded/required/attack(mob/living/M, mob/living/user)
-	var/datum/O = user.is_holding_item_of_type(/obj/item/weapon/twohanded/offhand)
+	var/O = user.is_holding_item_of_type(/obj/item/weapon/twohanded/offhand)
 	if(src.flags & NODROP || O)					//If we're a NODROP, or if there is an offhand item in the other hand, attack.
 		..()
 		return


### PR DESCRIPTION
Fixes #25904 
Couldn't hook into offhand's dropped or destroy so this is the solution. You have to be stunimmune or buckled anyway, so you get one last desperate swing before losing your weapon, regardeless if it hits.

Makes the doomslayer NODROP to prevent snowflake.

Working on a thing.