### PR TITLE
Fixes incorrectly named brig APC

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -4554,7 +4554,7 @@
 "ajy" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "Labor Shuttle Dock APC";
+	name = "Brig APC";
 	pixel_y = 24
 	},
 /obj/structure/cable{


### PR DESCRIPTION
Fixes #26058 

:cl:
fix: Fixed the incorrectly named Brig APC on Box Station=
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
