### PR TITLE
Fixes roundstart head announcements

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -24,7 +24,7 @@ Captain
 
 /datum/job/captain/announce(mob/living/carbon/human/H)
 	..()
-	minor_announce("Captain [H.real_name] on deck!")
+	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/minor_announce, "Captain [H.real_name] on deck!"))
 
 /datum/outfit/job/captain
 	name = "Captain"

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -90,10 +90,9 @@
 		. |= list(GLOB.access_maint_tunnels)
 
 /datum/job/proc/announce_head(var/mob/living/carbon/human/H, var/channels) //tells the given channel that the given mob is the new department head. See communications.dm for valid channels.
-	spawn(4) //to allow some initialization
-		if(H && GLOB.announcement_systems.len)
-			var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
-			announcer.announce("NEWHEAD", H.real_name, H.job, channels)
+	if(H && GLOB.announcement_systems.len)
+		//timer because these should come after the captain announcement
+		SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/addtimer, CALLBACK(pick(GLOB.announcement_systems), /obj/machinery/announcement_system/proc/announce, "NEWHEAD", H.real_name, H.job, channels), 1))
 
 //If the configuration option is set to require players to be logged as old enough to play certain jobs, then this proc checks that they are, otherwise it just returns 1
 /datum/job/proc/player_old_enough(client/C)


### PR DESCRIPTION
Fixes #25523

:cl: 
fix: Roundstart department head announcements have been fixed
/:cl:

The announcements were being made, but no one was in their body to hear them
