### PR TITLE
Adds missing access check to brigdoors

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -214,7 +214,7 @@
 	. = TRUE
 	
 	if(!allowed(usr))
-		say("Access denied.")
+		to_chat(usr, "<span class='warning'>Access denied.</span>")
 		return FALSE
 
 	switch(action)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -212,6 +212,11 @@
 	if(..())
 		return
 	. = TRUE
+	
+	if(!allowed(usr))
+		say("Access denied.")
+		return FALSE
+
 	switch(action)
 		if("time")
 			var/value = text2num(params["adjust"])


### PR DESCRIPTION
Fixes #24270
:cl:
fix: Brig cell doors now properly require the correct access
/:cl:
