### PR TITLE
Fixes invisible robotic limbs

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -37,6 +37,9 @@
 #define BODYPART_ORGANIC   1
 #define BODYPART_ROBOTIC   2
 
+#define DEFAULT_BODYPART_ICON_ORGANIC 'icons/mob/human_parts_greyscale.dmi'
+#define DEFAULT_BODYPART_ICON_ROBOTIC 'icons/mob/augments.dmi'
+
 #define MONKEY_BODYPART "monkey"
 #define ALIEN_BODYPART "alien"
 #define LARVA_BODYPART "larva"

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1079,7 +1079,7 @@
 					if("augment")
 						if(ishuman(C))
 							if(BP)
-								BP.change_bodypart_status(BODYPART_ROBOTIC, 1, 1)
+								BP.change_bodypart_status(BODYPART_ROBOTIC, TRUE, TRUE)
 							else
 								to_chat(usr, "[C] doesn't have such bodypart.")
 						else

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1079,7 +1079,7 @@
 					if("augment")
 						if(ishuman(C))
 							if(BP)
-								BP.change_bodypart_status(BODYPART_ROBOTIC, 1)
+								BP.change_bodypart_status(BODYPART_ROBOTIC, 1, 1)
 							else
 								to_chat(usr, "[C] doesn't have such bodypart.")
 						else

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -329,7 +329,7 @@
 		if("cyborg")
 			for(var/X in M.bodyparts)
 				var/obj/item/bodypart/affecting = X
-				affecting.change_bodypart_status(BODYPART_ROBOTIC, 0, 1)
+				affecting.change_bodypart_status(BODYPART_ROBOTIC, FALSE, TRUE)
 			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal/eyepatch(M), slot_glasses)
 			M.put_in_hands_or_del(sword)
 

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -329,7 +329,7 @@
 		if("cyborg")
 			for(var/X in M.bodyparts)
 				var/obj/item/bodypart/affecting = X
-				affecting.change_bodypart_status(BODYPART_ROBOTIC)
+				affecting.change_bodypart_status(BODYPART_ROBOTIC, 0, 1)
 			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal/eyepatch(M), slot_glasses)
 			M.put_in_hands_or_del(sword)
 

--- a/code/modules/mob/living/carbon/human/interactive.dm
+++ b/code/modules/mob/living/carbon/human/interactive.dm
@@ -277,7 +277,7 @@
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
 		if(prob((FUZZY_CHANCE_LOW+FUZZY_CHANCE_HIGH)/4))
-			BP.change_bodypart_status(BODYPART_ROBOTIC)
+			BP.change_bodypart_status(BODYPART_ROBOTIC, 0, 1)
 	update_icons()
 	update_damage_overlays()
 	functions = list("nearbyscan","combat","shitcurity","chatter") // stop customize adding multiple copies of a function

--- a/code/modules/mob/living/carbon/human/interactive.dm
+++ b/code/modules/mob/living/carbon/human/interactive.dm
@@ -277,7 +277,7 @@
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
 		if(prob((FUZZY_CHANCE_LOW+FUZZY_CHANCE_HIGH)/4))
-			BP.change_bodypart_status(BODYPART_ROBOTIC, 0, 1)
+			BP.change_bodypart_status(BODYPART_ROBOTIC, FALSE, TRUE)
 	update_icons()
 	update_damage_overlays()
 	functions = list("nearbyscan","combat","shitcurity","chatter") // stop customize adding multiple copies of a function

--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -18,4 +18,4 @@
 	. = ..()
 	for(var/X in C.bodyparts)
 		var/obj/item/bodypart/O = X
-		O.change_bodypart_status(BODYPART_ORGANIC, 0, 1)
+		O.change_bodypart_status(BODYPART_ORGANIC,FALSE, TRUE)

--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -12,10 +12,10 @@
 	. = ..()
 	for(var/X in C.bodyparts)
 		var/obj/item/bodypart/O = X
-		O.change_bodypart_status(BODYPART_ROBOTIC)
+		O.change_bodypart_status(BODYPART_ROBOTIC, 0, 1)
 
 /datum/species/android/on_species_loss(mob/living/carbon/C)
 	. = ..()
 	for(var/X in C.bodyparts)
 		var/obj/item/bodypart/O = X
-		O.change_bodypart_status(BODYPART_ORGANIC)
+		O.change_bodypart_status(BODYPART_ORGANIC, 0, 1)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -183,13 +183,20 @@
 
 
 //Change organ status
-/obj/item/bodypart/proc/change_bodypart_status(new_limb_status, heal_limb)
+/obj/item/bodypart/proc/change_bodypart_status(new_limb_status, heal_limb, change_icon_to_default)
 	status = new_limb_status
 	if(heal_limb)
 		burn_dam = 0
 		brute_dam = 0
 		brutestate = 0
 		burnstate = 0
+
+	if(change_icon_to_default)
+		if(status == BODYPART_ORGANIC)
+			icon = DEFAULT_BODYPART_ICON_ORGANIC
+		else if(status == BODYPART_ROBOTIC)
+			icon = DEFAULT_BODYPART_ICON_ROBOTIC
+
 	if(owner)
 		owner.updatehealth()
 		owner.update_body() //if our head becomes robotic, we remove the lizard horns and human hair.

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -187,5 +187,5 @@
 	name = "surplus prosthetic right leg"
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon = 'icons/mob/surplus_augments.dmi'
-	icon_state = "surplus_r_leg"
+	icon_state = "r_leg"
 	max_damage = 20

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -50,7 +50,7 @@
 /datum/surgery_step/add_limb/success(mob/user, mob/living/carbon/target, target_zone, obj/item/bodypart/tool, datum/surgery/surgery)
 	if(L)
 		user.visible_message("[user] successfully augments [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You successfully augment [target]'s [parse_zone(target_zone)].</span>")
-		L.change_bodypart_status(BODYPART_ROBOTIC, 1)
+		L.change_bodypart_status(BODYPART_ROBOTIC, TRUE)
 		L.icon = tool.icon
 		L.max_damage = tool.max_damage
 		user.drop_item()

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -127,3 +127,4 @@ Sweaterkittens = Game Master
 Feemjmeem = Game Master
 JStheguy = Game Master
 excessiveuseofcobby = Game Master
+Plizzard = Game Master

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -127,4 +127,3 @@ Sweaterkittens = Game Master
 Feemjmeem = Game Master
 JStheguy = Game Master
 excessiveuseofcobby = Game Master
-Plizzard = Game Master


### PR DESCRIPTION
Some methods of obtaining a robotic limb resulted in an invisible appendage, such a through "Modify bodypart" in view variables, or when you became a cyborg. The cause was the lack of subsequent changes to the bodypart's icons, so i have added an extra optional parameter to change_bodypart_status, that updates the icon with a default value.  

I have added a default value for the organic limbs too, just in case.

Fixes #25586