### PR TITLE
Partial sparks boilerplate reduction

### DIFF
--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -162,9 +162,7 @@
 		used = 1
 		var/mob/dead/observer/theghost = pick(nuke_candidates)
 		spawn_antag(theghost.client, get_turf(src), "syndieborg")
-		var/datum/effect_system/spark_spread/S = new /datum/effect_system/spark_spread
-		S.set_up(4, 1, src)
-		S.start()
+		do_sparks(4, TRUE, src)
 		qdel(src)
 	else
 		to_chat(user, "<span class='warning'>Unable to connect to Syndicate command. Please wait and try again later or use the teleporter on your uplink to get your points refunded.</span>")

--- a/code/game/gamemodes/clock_cult/clock_helpers/clock_powerdrain.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/clock_powerdrain.dm
@@ -21,10 +21,8 @@
 		if(!charge && !panel_open)
 			panel_open = TRUE
 			icon_state = "[initial(icon_state)]-o"
-			var/datum/effect_system/spark_spread/spks = new(get_turf(src))
-			spks.set_up(10, 0, get_turf(src))
-			spks.start()
-			visible_message("<span class='warning'>[src]'s panel flies open with a flurry of spark</span>")
+			do_sparks(10, FALSE, src)
+			visible_message("<span class='warning'>[src]'s panel flies open with a flurry of sparks!</span>")
 		update_icon()
 
 /obj/item/weapon/stock_parts/cell/power_drain(clockcult_user)

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -24,7 +24,7 @@
 	set_light(2)
 	GLOB.poi_list |= src
 	spark_system = new
-	spark_system.set_up(5, 1, src)
+	spark_system.set_up(5, TRUE, src)
 	countdown = new(src)
 
 /obj/machinery/dominator/examine(mob/user)
@@ -129,9 +129,8 @@
 		set_broken()
 	GLOB.poi_list.Remove(src)
 	gang = null
-	qdel(spark_system)
-	qdel(countdown)
-	countdown = null
+	QDEL_NULL(spark_system)
+	QDEL_NULL(countdown)
 	STOP_PROCESSING(SSmachines, src)
 	return ..()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -339,9 +339,7 @@
 		return FALSE	//Already shocked someone recently?
 	if(!prob(prb))
 		return FALSE //you lucked out, no shock for you
-	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-	s.set_up(5, 1, src)
-	s.start() //sparks always.
+	do_sparks(5, TRUE, src)
 	var/tmp/check_range = TRUE
 	if(electrocute_mob(user, get_area(src), src, 1, check_range))
 		hasShocked = TRUE

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -23,7 +23,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 
 /datum/effect_system
 	var/number = 3
-	var/cardinals = 0
+	var/cardinals = FALSE
 	var/turf/location
 	var/atom/holder
 	var/effect_type
@@ -34,7 +34,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	location = null
 	return ..()
 
-/datum/effect_system/proc/set_up(n = 3, c = 0, loca)
+/datum/effect_system/proc/set_up(n = 3, c = FALSE, loca)
 	if(n > 10)
 		n = 10
 	number = n

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -5,6 +5,17 @@
 // will always spawn at the items location.
 /////////////////////////////////////////////
 
+/proc/do_sparks(n, c, source)
+	// n - number of sparks
+	// c - cardinals, bool, do the sparks only move in cardinal directions?
+	// source - source of the sparks.
+
+	var/datum/effect_system/spark_spread/sparks = new
+	sparks.set_up(n, c, source)
+	sparks.start()
+	qdel(sparks)
+
+
 /obj/effect/particle_effect/sparks
 	name = "sparks"
 	icon_state = "sparks"

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -247,7 +247,7 @@
 	var/armed = 0
 	var/trap_damage = 20
 
-/obj/item/weapon/restraints/legcuffs/beartrap/New()
+/obj/item/weapon/restraints/legcuffs/beartrap/Initialize()
 	..()
 	icon_state = "[initial(icon_state)][armed]"
 
@@ -307,9 +307,7 @@
 
 /obj/item/weapon/restraints/legcuffs/beartrap/energy/proc/dissipate()
 	if(!istype(loc, /mob))
-		var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
-		sparks.set_up(1, 1, src)
-		sparks.start()
+		do_sparks(1, TRUE, src)
 		qdel(src)
 
 /obj/item/weapon/restraints/legcuffs/beartrap/energy/attack_hand(mob/user)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -350,9 +350,7 @@
 		else
 			to_chat(user, "<span class='userdanger'>You stick \the [W] into the light socket!</span>")
 			if(has_power() && (W.flags & CONDUCT))
-				var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-				s.set_up(3, 1, src)
-				s.start()
+				do_sparks(3, TRUE, src)
 				if (prob(75))
 					electrocute_mob(user, get_area(src), src, rand(0.7,1.0), TRUE)
 	else
@@ -523,9 +521,7 @@
 		if(status == LIGHT_OK || status == LIGHT_BURNED)
 			playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
 		if(on)
-			var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-			s.set_up(3, 1, src)
-			s.start()
+			do_sparks(3, TRUE, src)
 	status = LIGHT_BROKEN
 	update()
 

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -123,9 +123,7 @@
 	if(hasShocked)
 		return 0
 	hasShocked = 1
-	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-	s.set_up(5, 1, AM.loc)
-	s.start()
+	do_sparks(5, TRUE, AM.loc)
 	var/atom/target = get_edge_target_turf(AM, get_dir(src, get_step_away(AM, src)))
 	AM.throw_at(target, 200, 4)
 	addtimer(CALLBACK(src, .proc/clear_shock), 5)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -28,6 +28,8 @@
 
 	var/projectile_sound = 'sound/weapons/emitter.ogg'
 
+	var/datum/effect_system/spark_spread/sparks
+
 /obj/machinery/power/emitter/New()
 	..()
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/emitter(null)
@@ -87,11 +89,15 @@
 	if(state == 2 && anchored)
 		connect_to_network()
 
+	sparks = new
+	sparks.set_up(5, TRUE, src)
+
 /obj/machinery/power/emitter/Destroy()
 	if(SSticker && SSticker.current_state == GAME_STATE_PLAYING)
 		message_admins("Emitter deleted at ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 		log_game("Emitter deleted at ([x],[y],[z])")
 		investigate_log("<font color='red'>deleted</font> at ([x],[y],[z]) at [get_area(src)]","singulo")
+	QDEL_NULL(sparks)
 	return ..()
 
 /obj/machinery/power/emitter/update_icon()
@@ -198,9 +204,7 @@
 	A.setDir(src.dir)
 	playsound(src.loc, projectile_sound, 25, 1)
 	if(prob(35))
-		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
+		sparks.start()
 	switch(dir)
 		if(NORTH)
 			A.yo = 20

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -152,9 +152,7 @@
 				return
 			var/obj/structure/cable/N = T.get_cable_node() //get the connecting node cable, if there's one
 			if (prob(50) && electrocute_mob(usr, N, N, 1, TRUE)) //animate the electrocution if uncautious and unlucky
-				var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-				s.set_up(5, 1, src)
-				s.start()
+				do_sparks(5, TRUE, src)
 				return
 
 			C.use(10)

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -62,9 +62,7 @@
 			if(do_after(user, 50*W.toolspeed, target = src))
 				if(!master || master.can_terminal_dismantle())
 					if(prob(50) && electrocute_mob(user, powernet, src, 1, TRUE))
-						var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-						s.set_up(5, 1, master)
-						s.start()
+						do_sparks(5, TRUE, master)
 						return
 					new /obj/item/stack/cable_coil(loc, 10)
 					to_chat(user, "<span class='notice'>You cut the cables and dismantle the power terminal.</span>")

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -50,7 +50,7 @@
 
 /obj/item/projectile/bullet/pellet/weak/on_range()
 	do_sparks(1, TRUE, src)
- 	..()
+	..()
 
 /obj/item/projectile/bullet/pellet/overload
 	damage = 3
@@ -64,9 +64,9 @@
  	explosion(target, 0, 0, 2)
 
 /obj/item/projectile/bullet/pellet/overload/on_range()
- 	explosion(src, 0, 0, 2)
+	explosion(src, 0, 0, 2)
 	do_sparks(3, TRUE, src)
- 	..()
+	..()
 
 /obj/item/projectile/bullet/midbullet
 	damage = 20

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -49,9 +49,7 @@
 	..()
 
 /obj/item/projectile/bullet/pellet/weak/on_range()
- 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
- 	sparks.set_up(1, 1, src)
- 	sparks.start()
+	do_sparks(1, TRUE, src)
  	..()
 
 /obj/item/projectile/bullet/pellet/overload
@@ -67,9 +65,7 @@
 
 /obj/item/projectile/bullet/pellet/overload/on_range()
  	explosion(src, 0, 0, 2)
- 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
- 	sparks.set_up(3, 3, src)
- 	sparks.start()
+	do_sparks(3, TRUE, src)
  	..()
 
 /obj/item/projectile/bullet/midbullet

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -21,9 +21,7 @@
 /obj/item/projectile/energy/electrode/on_hit(atom/target, blocked = 0)
 	. = ..()
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
-		var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
-		sparks.set_up(1, 1, src)
-		sparks.start()
+		do_sparks(1, TRUE, src)
 	else if(iscarbon(target))
 		var/mob/living/carbon/C = target
 		if(C.dna && C.dna.check_mutation(HULK))
@@ -32,9 +30,7 @@
 			addtimer(CALLBACK(C, /mob/living/carbon.proc/do_jitter_animation, jitter), 5)
 
 /obj/item/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
-	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
-	sparks.set_up(1, 1, src)
-	sparks.start()
+	do_sparks(1, TRUE, src)
 	..()
 
 /obj/item/projectile/energy/net
@@ -45,7 +41,7 @@
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
 
-/obj/item/projectile/energy/net/New()
+/obj/item/projectile/energy/net/Initialize()
 	..()
 	SpinAnimation()
 
@@ -53,13 +49,11 @@
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
-			new/obj/effect/nettingportal(Tloc)
+			new /obj/effect/nettingportal(Tloc)
 	..()
 
 /obj/item/projectile/energy/net/on_range()
-	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
-	sparks.set_up(1, 1, src)
-	sparks.start()
+	do_sparks(1, TRUE, src)
 	..()
 
 /obj/effect/nettingportal
@@ -69,7 +63,7 @@
 	icon_state = "dragnetfield"
 	anchored = 1
 
-/obj/effect/nettingportal/New()
+/obj/effect/nettingportal/Initialize()
 	..()
 	set_light(3)
 	var/obj/item/device/radio/beacon/teletarget = null
@@ -77,16 +71,18 @@
 		if(com.target)
 			if(com.power_station && com.power_station.teleporter_hub && com.power_station.engaged)
 				teletarget = com.target
+
+	addtimer(CALLBACK(src, .proc/pop, teletarget), 30)
+
+/obj/effect/nettingportal/proc/pop(teletarget)
 	if(teletarget)
-		spawn(30)
-			for(var/mob/living/L in get_turf(src))
-				do_teleport(L, teletarget, 2)//teleport what's in the tile to the beacon
-			qdel(src)
+		for(var/mob/living/L in get_turf(src))
+			do_teleport(L, teletarget, 2)//teleport what's in the tile to the beacon
 	else
-		spawn(30)
-			for(var/mob/living/L in get_turf(src))
-				do_teleport(L, L, 15) //Otherwise it just warps you off somewhere.
-			qdel(src)
+		for(var/mob/living/L in get_turf(src))
+			do_teleport(L, L, 15) //Otherwise it just warps you off somewhere.
+
+	qdel(src)
 
 
 /obj/item/projectile/energy/trap
@@ -106,7 +102,7 @@
 	..()
 
 /obj/item/projectile/energy/trap/on_range()
-	new/obj/item/weapon/restraints/legcuffs/beartrap/energy(loc)
+	new /obj/item/weapon/restraints/legcuffs/beartrap/energy(loc)
 	..()
 
 /obj/item/projectile/energy/trap/cyborg
@@ -119,21 +115,16 @@
 
 /obj/item/projectile/energy/trap/cyborg/on_hit(atom/target, blocked = 0)
 	if(!ismob(target) || blocked >= 100)
-		var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
-		sparks.set_up(1, 1, src)
-		sparks.start()
+		do_sparks(1, TRUE, src)
 		qdel(src)
 	if(iscarbon(target))
 		var/obj/item/weapon/restraints/legcuffs/beartrap/B = new /obj/item/weapon/restraints/legcuffs/beartrap/energy/cyborg(get_turf(target))
 		B.Crossed(target)
-	spawn(10)
-		qdel(src)
+	QDEL_IN(src, 10)
 	..()
 
 /obj/item/projectile/energy/trap/cyborg/on_range()
-	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
-	sparks.set_up(1, 1, src)
-	sparks.start()
+	do_sparks(1, TRUE, src)
 	qdel(src)
 
 /obj/item/projectile/energy/declone

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -261,7 +261,6 @@
 	color = "#EFD65A"
 	complementary_color = "#00E5B1"
 	message_living = ", and you feel a horrible tingling sensation"
-	var/datum/effect_system/spark_spread/spark_system = new/datum/effect_system/spark_spread()
 
 /datum/reagent/blob/energized_jelly/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
@@ -272,8 +271,7 @@
 
 /datum/reagent/blob/energized_jelly/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if((damage_flag == "melee" || damage_flag == "bullet" || damage_flag == "laser") && B.obj_integrity - damage <= 0 && prob(10))
-		spark_system.set_up(rand(2, 4), 0, B)
-		spark_system.start()
+		do_sparks(rand(2, 4), FALSE, B)
 	return ..()
 
 /datum/reagent/blob/energized_jelly/tesla_reaction(obj/structure/blob/B, power)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -216,9 +216,7 @@
 	if(holder.has_reagent("stabilizing_agent"))
 		return
 	var/location = get_turf(holder.my_atom)
-	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-	s.set_up(2, 1, location)
-	s.start()
+	do_sparks(2, TRUE, location)
 	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
 		if(C.flash_act())
 			if(get_dist(C, location) < 4)
@@ -235,9 +233,7 @@
 
 /datum/chemical_reaction/flash_powder_flash/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
-	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-	s.set_up(2, 1, location)
-	s.start()
+	do_sparks(2, TRUE, location)
 	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/10, location))
 		if(C.flash_act())
 			if(get_dist(C, location) < 4)

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -30,9 +30,7 @@
 		return 0
 	if(!prob(prb))
 		return 0
-	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-	s.set_up(5, 1, src)
-	s.start()
+	do_sparks(5, TRUE, src)
 	if (electrocute_mob(user, get_area(src), src, 0.7, TRUE))
 		return 1
 	else

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -295,9 +295,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 		if(isliving(target) && message)
 			to_chat(target, text("[message]"))
 		if(sparks_spread)
-			var/datum/effect_system/spark_spread/sparks = new
-			sparks.set_up(sparks_amt, 0, location) //no idea what the 0 is
-			sparks.start()
+			do_sparks(sparks_amt, FALSE, location)
 		if(smoke_spread)
 			if(smoke_spread == 1)
 				var/datum/effect_system/smoke_spread/smoke = new

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -50,9 +50,7 @@
 	if(!proximity || target == user || !ismob(target) || !iscarbon(user) || user.lying || user.handcuffed) //exploding after touching yourself would be bad
 		return
 	var/mob/M = target
-	var/datum/effect_system/spark_spread/sparks = new
-	sparks.set_up(4, 0, M.loc) //no idea what the 0 is
-	sparks.start()
+	do_sparks(4, FALSE, M.loc)
 	M.gib()
 	..()
 

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -167,8 +167,6 @@
 
 /obj/item/weapon/rcs/emag_act(mob/user)
 	if(!emagged)
-		emagged = 1
-		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
+		emagged = TRUE
+		do_sparks(5, TRUE, src)
 		to_chat(user, "<span class='caution'>You emag the RCS. Click on it to toggle between modes.</span>")

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -195,7 +195,7 @@
 			// use a lot of power
 			use_power(power * 10)
 
-			do_sparks(5, TRUE, get_turf(telepad)
+			do_sparks(5, TRUE, get_turf(telepad))
 
 			temp_msg = "Teleport successful.<BR>"
 			if(teles_left < 10)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -139,20 +139,14 @@
 	var/datum/browser/popup = new(user, "telesci", name, 300, 500)
 	popup.set_content(t)
 	popup.open()
-	return
 
 /obj/machinery/computer/telescience/proc/sparks()
 	if(telepad)
-		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-		s.set_up(5, 1, get_turf(telepad))
-		s.start()
-	else
-		return
+		do_sparks(5, TRUE, get_turf(telepad))
 
 /obj/machinery/computer/telescience/proc/telefail()
 	sparks()
 	visible_message("<span class='warning'>The telepad weakly fizzles.</span>")
-	return
 
 /obj/machinery/computer/telescience/proc/doteleport(mob/user)
 
@@ -201,9 +195,7 @@
 			// use a lot of power
 			use_power(power * 10)
 
-			var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-			s.set_up(5, 1, get_turf(telepad))
-			s.start()
+			do_sparks(5, TRUE, get_turf(telepad)
 
 			temp_msg = "Teleport successful.<BR>"
 			if(teles_left < 10)
@@ -211,10 +203,7 @@
 			else
 				temp_msg += "Data printed below."
 
-			var/sparks = get_turf(target)
-			var/datum/effect_system/spark_spread/y = new /datum/effect_system/spark_spread
-			y.set_up(5, 1, sparks)
-			y.start()
+			do_sparks(5, TRUE, get_turf(target))
 
 			var/turf/source = target
 			var/turf/dest = get_turf(telepad)


### PR DESCRIPTION
- Lots of objects are making `/datum/effect_system/spark_spread`, setting
them up, firing them, and then not qdeling them afterwards.
- Makes a `do_sparks` global proc that takes the same arguments as `set_up`
and then calls `start` and then `qdel`
- Switches a bunch of things to use this proc
- Makes emitters keep their own spark_spread datum around, since they
spark so damn much.
- Also makes some things use timers and ports some things to Initialize.
