### PR TITLE
Adds recharger to Cerestation's shuttle and Removes Centcomm's thunderdome doors

### DIFF
--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -63142,7 +63142,7 @@
 /area/shuttle/escape)
 "chy" = (
 /obj/structure/table,
-/obj/item/weapon/storage/firstaid/fire,
+/obj/machinery/recharger,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "chz" = (
@@ -63162,6 +63162,7 @@
 	pixel_y = 3
 	},
 /obj/item/weapon/crowbar,
+/obj/item/weapon/storage/firstaid/fire,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "chC" = (

--- a/_maps/map_files/generic/Centcomm.dmm
+++ b/_maps/map_files/generic/Centcomm.dmm
@@ -12090,17 +12090,10 @@
 /turf/closed/indestructible/riveted,
 /area/tdome/arena)
 "DF" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Gear Room";
-	opacity = 1;
-	req_access_txt = "101"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/turf/open/floor/plasteel{
-	tag = "icon-plasteel_warn_side (EAST)"
-	},
+/turf/closed/indestructible/riveted,
 /area/tdome/tdomeobserve)
 "DG" = (
 /obj/machinery/igniter,

--- a/_maps/map_files/generic/Centcomm.dmm
+++ b/_maps/map_files/generic/Centcomm.dmm
@@ -54926,7 +54926,7 @@ AG
 AM
 AG
 Bc
-DF
+zH
 DO
 Eh
 Eh
@@ -61608,7 +61608,7 @@ AL
 AF
 AL
 Bd
-DF
+zH
 Eb
 Eq
 Eq


### PR DESCRIPTION
:cl: BeeSting12
fix: Cerestation's shuttle now has a recharger.
del: Centcomm's thunderdome airlocks have been removed due to contestants breaking out.
/:cl:
Why: It's basically box's shuttle and box's shuttle has a recharger so logically Cere's would too
Why: Fixes #26050

I goofed and PRed the contents of #26082 with this one so I closed that one. Sorry.