### PR TITLE
Fixes lattice preventing space transitions

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -211,3 +211,13 @@
 			ChangeTurf(/turf/open/floor/plating)
 			return TRUE
 	return FALSE
+	
+/turf/open/space/ReplaceWithLattice()
+	var/dest_x = destination_x
+	var/dest_y = destination_y
+	var/dest_z = destination_z
+	..()
+	destination_x = dest_x
+	destination_y = dest_y
+	destination_z = dest_z
+	


### PR DESCRIPTION
:cl:
fix: Constructing lattice no longer prevents space transitions.
/:cl:

Not sure if we should fix this like this.
Should consider why the ```ChangeTurf()``` is even necessary.

Fixes #25999 