### PR TITLE
Fix for bug #25899 (spray guns)

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -94,6 +94,9 @@
 		return 0
 
 /obj/item/weapon/extinguisher/afterattack(atom/target, mob/user , flag)
+	// Make it so the extinguisher doesn't spray yourself when you click your inventory items
+	if (target.loc == usr)
+		return
 	//TODO; Add support for reagents in water.
 	if(refilling)
 		refilling = FALSE

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -95,7 +95,7 @@
 
 /obj/item/weapon/extinguisher/afterattack(atom/target, mob/user , flag)
 	// Make it so the extinguisher doesn't spray yourself when you click your inventory items
-	if (target.loc == usr)
+	if (target.loc == user)
 		return
 	//TODO; Add support for reagents in water.
 	if(refilling)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -94,6 +94,9 @@
 		return 0
 
 /obj/item/weapon/extinguisher/afterattack(atom/target, mob/user , flag)
+	// Make it so the bioterror spray doesn't spray yourself when you click your belt item
+	if (target.loc == usr)
+		return
 	//TODO; Add support for reagents in water.
 	if(refilling)
 		refilling = FALSE

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -22,6 +22,10 @@
 
 
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user)
+	// Make it so the bioterror spray doesn't spray yourself when you click your inventory items
+	if (istype(src, /obj/item/weapon/reagent_containers/spray/chemsprayer) && A.loc == usr)
+		return
+
 	if(istype(A, /obj/structure/sink) || istype(A, /obj/structure/janitorialcart) || istype(A, /obj/machinery/hydroponics))
 		return
 
@@ -61,7 +65,7 @@
 
 
 /obj/item/weapon/reagent_containers/spray/proc/spray(atom/A)
-	var/range = max(min(spray_range, get_dist(src, A)), 1)
+	var/range = max(min(current_range, get_dist(src, A)), 1)
 	var/obj/effect/decal/chempuff/D = new /obj/effect/decal/chempuff(get_turf(src))
 	D.create_reagents(amount_per_transfer_from_this)
 	var/puff_reagent_left = range //how many turf, mob or dense objet we can react with before we consider the chem puff consumed

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -22,6 +22,10 @@
 
 
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user)
+	// Make it so the bioterror spray doesn't spray yourself when you click your belt item
+	if (istype(src, /obj/item/weapon/reagent_containers/spray/chemsprayer) && A.loc == usr)
+		return
+
 	if(istype(A, /obj/structure/sink) || istype(A, /obj/structure/janitorialcart) || istype(A, /obj/machinery/hydroponics))
 		return
 
@@ -61,7 +65,7 @@
 
 
 /obj/item/weapon/reagent_containers/spray/proc/spray(atom/A)
-	var/range = max(min(spray_range, get_dist(src, A)), 1)
+	var/range = max(min(current_range, get_dist(src, A)), 1)
 	var/obj/effect/decal/chempuff/D = new /obj/effect/decal/chempuff(get_turf(src))
 	D.create_reagents(amount_per_transfer_from_this)
 	var/puff_reagent_left = range //how many turf, mob or dense objet we can react with before we consider the chem puff consumed

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -22,10 +22,6 @@
 
 
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user)
-	// Make it so the bioterror spray doesn't spray yourself when you click your inventory items
-	if (istype(src, /obj/item/weapon/reagent_containers/spray/chemsprayer) && A.loc == usr)
-		return
-
 	if(istype(A, /obj/structure/sink) || istype(A, /obj/structure/janitorialcart) || istype(A, /obj/machinery/hydroponics))
 		return
 
@@ -173,6 +169,12 @@
 	amount_per_transfer_from_this = 5
 	list_reagents = list("condensedcapsaicin" = 40)
 
+// Fix pepperspraying yourself
+/obj/item/weapon/reagent_containers/spray/pepper/afterattack(atom/A as mob|obj, mob/user)
+	if (A.loc == user)
+		return
+	..()
+
 //water flower
 /obj/item/weapon/reagent_containers/spray/waterflower
 	name = "water flower"
@@ -204,6 +206,11 @@
 	volume = 600
 	origin_tech = "combat=3;materials=3;engineering=3"
 
+/obj/item/weapon/reagent_containers/spray/chemsprayer/afterattack(atom/A as mob|obj, mob/user)
+	// Make it so the bioterror spray doesn't spray yourself when you click your inventory items
+	if (A.loc == user)
+		return
+	..()
 
 /obj/item/weapon/reagent_containers/spray/chemsprayer/spray(atom/A)
 	var/direction = get_dir(src, A)


### PR DESCRIPTION
Fixes #25899
:cl: Davidj361
fix: Made it so chemsprayers, peppersprays, extinguishers don't spray when you click your inventory items
fix: Spray guns now actually have their range change when changing modes between spray and stream
/:cl:

[why]: See https://github.com/tgstation/tgstation/issues/25899 also the stream & spray feature wasn't working as intended.