### PR TITLE
Fixes stamps not appearing on photocopied papers

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -89,6 +89,10 @@
 							c.fields = copy.fields
 							c.update_icon()
 							c.updateinfolinks()
+							c.stamps = copy.stamps
+							if(copy.stamped)
+								c.stamped = copy.stamped.Copy()
+							c.copy_overlays(copy, TRUE)
 							toner--
 					busy = 1
 					sleep(15)


### PR DESCRIPTION
Fixes #26108

:cl:
fix: Photocopied papers will now retain their stamps
/:cl: