### PR TITLE
Fixes #24788, cyborgs point hotkey

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -22,6 +22,9 @@
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return
+	if(modifiers["shift"] && modifiers["middle"])
+		ShiftMiddleClickOn(A)
+		return
 	if(modifiers["middle"])
 		MiddleClickOn(A)
 		return


### PR DESCRIPTION
Fixes #24788
:cl: MrSavage/PoopLicker/Davidj361
fix: Fixed the shift+middle-click pointing shortcut to work for cyborgs as the functionality wasn't even there
/:cl:

[why]: See https://github.com/tgstation/tgstation/issues/24788