### PR TITLE
Cerestation Tweaks MKIII

### DIFF
--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -37973,6 +37973,12 @@
 	},
 /area/medical/cmo)
 "boW" = (
+/obj/machinery/camera{
+	c_tag = "Chief Medical Officer's Office";
+	dir = 1;
+	icon_state = "camera";
+	network = list("SS13")
+	},
 /mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/plasteel/barber{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -56919,6 +56925,12 @@
 /area/engine/engine_smes)
 "bUS" = (
 /obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Engineering Power Storage 2";
+	dir = 1;
+	icon_state = "camera";
+	network = list("SS13","CE")
+	},
 /turf/open/floor/plasteel/yellow/side{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -77761,6 +77773,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/hor)
 "cFl" = (
@@ -90406,6 +90419,14 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "dfN" = (
+/obj/structure/window/reinforced,
+/obj/machinery/camera{
+	c_tag = "Medbay-Engineering Bridge 2";
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/space)
+"dfO" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/astplate{
@@ -90414,7 +90435,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dfO" = (
+"dfP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -90424,14 +90445,14 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/medbay)
-"dfP" = (
+"dfQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/medbay)
-"dfQ" = (
+"dfR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -90441,7 +90462,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dfR" = (
+"dfS" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90449,7 +90470,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dfS" = (
+"dfT" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -90462,7 +90483,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dfT" = (
+"dfU" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90470,14 +90491,14 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dfU" = (
+"dfV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/medbay)
-"dfV" = (
+"dfW" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
 	req_access_txt = "0";
@@ -90490,7 +90511,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/morgue)
-"dfW" = (
+"dfX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
 	on = 1;
@@ -90500,7 +90521,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/morgue)
-"dfX" = (
+"dfY" = (
 /obj/structure/table,
 /obj/item/weapon/folder,
 /obj/machinery/camera{
@@ -90513,7 +90534,7 @@
 	dir = 5
 	},
 /area/medical/morgue)
-"dfY" = (
+"dfZ" = (
 /obj/structure/cable/orange{
 	d2 = 2;
 	icon_state = "0-2"
@@ -90531,14 +90552,14 @@
 	dir = 5
 	},
 /area/medical/morgue)
-"dfZ" = (
+"dga" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"dga" = (
+"dgb" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90546,7 +90567,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dgb" = (
+"dgc" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -90559,14 +90580,14 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dgc" = (
+"dgd" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/central)
-"dgd" = (
+"dge" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90574,14 +90595,14 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dge" = (
+"dgf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/medbay)
-"dgf" = (
+"dgg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -90589,7 +90610,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/genetics_cloning)
-"dgg" = (
+"dgh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -90597,14 +90618,6 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/genetics_cloning)
-"dgh" = (
-/obj/structure/bodycontainer/morgue,
-/obj/effect/landmark/revenantspawn,
-/turf/open/floor/plasteel/vault{
-	baseturf = /turf/open/floor/plating/asteroid/airless;
-	dir = 5
-	},
-/area/medical/morgue)
 "dgi" = (
 /obj/structure/bodycontainer/morgue,
 /obj/effect/landmark/revenantspawn,
@@ -90614,6 +90627,14 @@
 	},
 /area/medical/morgue)
 "dgj" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/landmark/revenantspawn,
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dgk" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -90630,7 +90651,7 @@
 	dir = 5
 	},
 /area/medical/morgue)
-"dgk" = (
+"dgl" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90638,7 +90659,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dgl" = (
+"dgm" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -90651,7 +90672,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dgm" = (
+"dgn" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -90661,13 +90682,13 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dgn" = (
+"dgo" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/morgue)
-"dgo" = (
+"dgp" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -90682,7 +90703,7 @@
 	dir = 5
 	},
 /area/medical/morgue)
-"dgp" = (
+"dgq" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90690,7 +90711,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dgq" = (
+"dgr" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -90703,7 +90724,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dgr" = (
+"dgs" = (
 /obj/structure/bodycontainer/morgue,
 /obj/effect/landmark/revenantspawn,
 /turf/open/floor/plasteel/vault{
@@ -90711,7 +90732,7 @@
 	dir = 5
 	},
 /area/medical/morgue)
-"dgs" = (
+"dgt" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -90721,16 +90742,6 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/morgue)
-"dgt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
 "dgu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -90783,6 +90794,16 @@
 	})
 "dgz" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgA" = (
+/obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
@@ -90792,7 +90813,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dgA" = (
+"dgB" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -90805,14 +90826,14 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dgB" = (
+"dgC" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dgC" = (
+"dgD" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90820,7 +90841,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dgD" = (
+"dgE" = (
 /obj/structure/closet,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90828,7 +90849,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dgE" = (
+"dgF" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -90846,19 +90867,11 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/genetics_cloning)
-"dgF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/medical/morgue)
 "dgG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/black{
+/turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/morgue)
@@ -90871,6 +90884,14 @@
 	},
 /area/medical/morgue)
 "dgI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dgJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	layer = 2.4;
@@ -90880,7 +90901,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/morgue)
-"dgJ" = (
+"dgK" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -90890,21 +90911,6 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/morgue)
-"dgK" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
 "dgL" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -90951,6 +90957,21 @@
 	name = "Port Asteroid Maintenance"
 	})
 "dgO" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgP" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90958,7 +90979,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dgP" = (
+"dgQ" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating{
@@ -90967,7 +90988,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dgQ" = (
+"dgR" = (
 /obj/structure/bodycontainer/morgue,
 /obj/machinery/camera{
 	c_tag = "Morgue South";
@@ -90981,7 +91002,7 @@
 	dir = 5
 	},
 /area/medical/morgue)
-"dgR" = (
+"dgS" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -90989,14 +91010,6 @@
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/medical/morgue)
-"dgS" = (
-/obj/structure/bodycontainer/morgue,
-/obj/effect/landmark/revenantspawn,
-/turf/open/floor/plasteel/vault{
-	baseturf = /turf/open/floor/plating/asteroid/airless;
-	dir = 5
 	},
 /area/medical/morgue)
 "dgT" = (
@@ -91008,6 +91021,14 @@
 	},
 /area/medical/morgue)
 "dgU" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/landmark/revenantspawn,
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dgV" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -91017,13 +91038,13 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/morgue)
-"dgV" = (
+"dgW" = (
 /obj/structure/closet,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"dgW" = (
+"dgX" = (
 /obj/structure/girder,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91031,7 +91052,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dgX" = (
+"dgY" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -91040,7 +91061,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dgY" = (
+"dgZ" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91048,7 +91069,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dgZ" = (
+"dha" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Morgue";
 	req_access_txt = "5"
@@ -91062,7 +91083,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/morgue)
-"dha" = (
+"dhb" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -91071,13 +91092,13 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
-"dhb" = (
+"dhc" = (
 /obj/structure/rack,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dhc" = (
+"dhd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -91086,7 +91107,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
-"dhd" = (
+"dhe" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -91100,14 +91121,14 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
-"dhe" = (
+"dhf" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"dhf" = (
+"dhg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -91118,7 +91139,7 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"dhg" = (
+"dhh" = (
 /obj/structure/girder,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91126,7 +91147,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dhh" = (
+"dhi" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -91140,7 +91161,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dhi" = (
+"dhj" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91148,7 +91169,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dhj" = (
+"dhk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -91160,7 +91181,7 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"dhk" = (
+"dhl" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -91173,7 +91194,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dhl" = (
+"dhm" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91181,13 +91202,6 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dhm" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/engine/engineering)
 "dhn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -91196,6 +91210,13 @@
 	},
 /area/engine/engineering)
 "dho" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dhp" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -91204,14 +91225,14 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
-"dhp" = (
+"dhq" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"dhq" = (
+"dhr" = (
 /obj/structure/grille,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91219,7 +91240,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dhr" = (
+"dhs" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -91229,7 +91250,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dhs" = (
+"dht" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -91239,7 +91260,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dht" = (
+"dhu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -91249,7 +91270,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
-"dhu" = (
+"dhv" = (
 /obj/structure/sign/enginesafety{
 	pixel_y = -32
 	},
@@ -91261,7 +91282,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
-"dhv" = (
+"dhw" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -91282,7 +91303,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
-"dhw" = (
+"dhx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -91291,18 +91312,10 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
-"dhx" = (
+"dhy" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/maintenance/starboard{
-	name = "Starboard Asteroid Maintenance"
-	})
-"dhy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
@@ -91315,6 +91328,14 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "dhA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhB" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -91327,7 +91348,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dhB" = (
+"dhC" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91335,16 +91356,16 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dhC" = (
+"dhD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"dhD" = (
+"dhE" = (
 /turf/closed/wall,
 /area/crew_quarters/chief)
-"dhE" = (
+"dhF" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -91365,10 +91386,10 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"dhF" = (
+"dhG" = (
 /turf/closed/wall,
 /area/crew_quarters/chief)
-"dhG" = (
+"dhH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -91377,14 +91398,14 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
-"dhH" = (
+"dhI" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dhI" = (
+"dhJ" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -91392,7 +91413,7 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"dhJ" = (
+"dhK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -91400,7 +91421,7 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"dhK" = (
+"dhL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -91413,7 +91434,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dhL" = (
+"dhM" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91421,7 +91442,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dhM" = (
+"dhN" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -91431,7 +91452,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dhN" = (
+"dhO" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating{
@@ -91440,14 +91461,9 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dhO" = (
+"dhP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/chief)
-"dhP" = (
-/turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
@@ -91457,6 +91473,11 @@
 	},
 /area/crew_quarters/chief)
 "dhR" = (
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dhS" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/weapon/paper/monitorkey,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -91465,7 +91486,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"dhS" = (
+"dhT" = (
 /obj/item/weapon/cartridge/engineering{
 	pixel_x = 4;
 	pixel_y = 5
@@ -91487,17 +91508,17 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"dhT" = (
+"dhU" = (
 /turf/closed/wall,
 /area/crew_quarters/chief)
-"dhU" = (
+"dhV" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dhV" = (
+"dhW" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -91506,7 +91527,7 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"dhW" = (
+"dhX" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -91517,7 +91538,7 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"dhX" = (
+"dhY" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -91531,7 +91552,7 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"dhY" = (
+"dhZ" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91539,19 +91560,19 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dhZ" = (
+"dia" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"dia" = (
+"dib" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"dib" = (
+"dic" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
@@ -91559,7 +91580,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"dic" = (
+"did" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/clipboard,
 /obj/item/clothing/glasses/meson{
@@ -91569,7 +91590,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"did" = (
+"die" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -91583,7 +91604,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"die" = (
+"dif" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	on = 1
@@ -91592,7 +91613,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"dif" = (
+"dig" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -91601,16 +91622,9 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"dig" = (
+"dih" = (
 /turf/closed/wall,
 /area/crew_quarters/chief)
-"dih" = (
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/starboard{
-	name = "Starboard Asteroid Maintenance"
-	})
 "dii" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91619,7 +91633,6 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "dij" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -91627,6 +91640,7 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "dik" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -91634,7 +91648,6 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "dil" = (
-/obj/structure/girder,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -91642,6 +91655,7 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "dim" = (
+/obj/structure/girder,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -91663,6 +91677,13 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "dip" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -91673,7 +91694,7 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"diq" = (
+"dir" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/astplate{
@@ -91682,7 +91703,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"dir" = (
+"dis" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91690,7 +91711,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dis" = (
+"dit" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91698,13 +91719,13 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dit" = (
+"diu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"diu" = (
+"div" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
@@ -91717,7 +91738,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"div" = (
+"diw" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -91732,10 +91753,10 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/chief)
-"diw" = (
+"dix" = (
 /turf/closed/wall,
 /area/crew_quarters/chief)
-"dix" = (
+"diy" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -91743,21 +91764,6 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
-	})
-"diy" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/starboard{
-	name = "Starboard Asteroid Maintenance"
 	})
 "diz" = (
 /obj/structure/cable/orange{
@@ -91895,6 +91901,21 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "diI" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -91907,7 +91928,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"diJ" = (
+"diK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -91918,14 +91939,14 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"diK" = (
+"diL" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"diL" = (
+"diM" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating{
@@ -91934,15 +91955,8 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"diM" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/starboard{
-	name = "Starboard Asteroid Maintenance"
-	})
 "diN" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -91957,6 +91971,13 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "diP" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diQ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91964,7 +91985,7 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"diQ" = (
+"diR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -91977,7 +91998,7 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"diR" = (
+"diS" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91985,7 +92006,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"diS" = (
+"diT" = (
 /obj/structure/girder,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91993,7 +92014,7 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"diT" = (
+"diU" = (
 /obj/structure/grille,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92001,7 +92022,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"diU" = (
+"diV" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92009,7 +92030,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"diV" = (
+"diW" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -92018,7 +92039,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"diW" = (
+"diX" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -92027,7 +92048,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"diX" = (
+"diY" = (
 /obj/structure/girder,
 /obj/item/stack/rods,
 /turf/open/floor/plating{
@@ -92036,13 +92057,13 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"diY" = (
+"diZ" = (
 /obj/structure/rack,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
-"diZ" = (
+"dja" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/astplate{
@@ -92051,7 +92072,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dja" = (
+"djb" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
 /turf/open/floor/plating{
@@ -92060,16 +92081,8 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djb" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/maintcentral{
-	name = "Central Asteroid Maintenance"
-	})
 "djc" = (
-/obj/structure/grille,
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -92077,17 +92090,17 @@
 	name = "Central Asteroid Maintenance"
 	})
 "djd" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/astplate{
+/obj/structure/grille,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
 "dje" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating{
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/maintcentral{
@@ -92098,11 +92111,11 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
 	})
 "djg" = (
-/obj/machinery/light/small,
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -92110,6 +92123,14 @@
 	name = "Port Asteroid Maintenance"
 	})
 "djh" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dji" = (
 /obj/machinery/door/airlock/glass_external{
 	cyclelinkeddir = 8
 	},
@@ -92119,17 +92140,9 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"dji" = (
-/obj/structure/girder,
-/obj/item/stack/sheet/metal,
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/maintcentral{
-	name = "Central Asteroid Maintenance"
-	})
 "djj" = (
 /obj/structure/girder,
+/obj/item/stack/sheet/metal,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -92138,13 +92151,21 @@
 	})
 "djk" = (
 /obj/structure/girder,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
 "djl" = (
+/obj/structure/girder,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djm" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92152,7 +92173,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djm" = (
+"djn" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92160,7 +92181,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djn" = (
+"djo" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92168,14 +92189,14 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djo" = (
+"djp" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djp" = (
+"djq" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/astplate{
@@ -92184,7 +92205,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djq" = (
+"djr" = (
 /obj/structure/girder,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92192,17 +92213,9 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"djr" = (
+"djs" = (
 /obj/structure/girder,
 /obj/structure/grille,
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/maintcentral{
-	name = "Central Asteroid Maintenance"
-	})
-"djs" = (
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -92218,6 +92231,14 @@
 	name = "Central Asteroid Maintenance"
 	})
 "dju" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92225,7 +92246,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djv" = (
+"djw" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/astplate{
@@ -92234,7 +92255,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djw" = (
+"djx" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92242,18 +92263,10 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djx" = (
+"djy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/maintcentral{
-	name = "Central Asteroid Maintenance"
-	})
-"djy" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -92261,6 +92274,14 @@
 	name = "Central Asteroid Maintenance"
 	})
 "djz" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -92270,7 +92291,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djA" = (
+"djB" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92278,7 +92299,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djB" = (
+"djC" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92286,7 +92307,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djC" = (
+"djD" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
 /turf/open/floor/plating{
@@ -92295,7 +92316,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djD" = (
+"djE" = (
 /obj/structure/girder,
 /obj/structure/grille,
 /turf/open/floor/plating{
@@ -92304,7 +92325,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djE" = (
+"djF" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92312,7 +92333,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djF" = (
+"djG" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92320,7 +92341,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djG" = (
+"djH" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92328,7 +92349,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djH" = (
+"djI" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92336,7 +92357,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djI" = (
+"djJ" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92344,7 +92365,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djJ" = (
+"djK" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating{
@@ -92353,7 +92374,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djK" = (
+"djL" = (
 /obj/structure/grille,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92361,7 +92382,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djL" = (
+"djM" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92369,7 +92390,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djM" = (
+"djN" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92377,7 +92398,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djN" = (
+"djO" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/syringe/charcoal,
 /turf/open/floor/plating{
@@ -92386,7 +92407,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djO" = (
+"djP" = (
 /obj/structure/table,
 /obj/item/clothing/mask/muzzle,
 /obj/item/clothing/glasses/sunglasses/blindfold,
@@ -92396,7 +92417,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djP" = (
+"djQ" = (
 /obj/structure/closet,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92404,7 +92425,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djQ" = (
+"djR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -92414,7 +92435,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djR" = (
+"djS" = (
 /obj/structure/girder,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92422,7 +92443,7 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djS" = (
+"djT" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92430,15 +92451,19 @@
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
-"djT" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/asteroid,
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
 "djU" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/machinery/camera{
+	c_tag = "Docking-Medbay Bridge 2";
+	dir = 8;
+	network = list("SS13")
+	},
+/turf/open/floor/engine,
+/area/space)
+"djV" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -92446,20 +92471,28 @@
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
-"djV" = (
+"djW" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"djX" = (
 /turf/closed/wall/rust{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/theatre{
 	name = "Top Secret Clown HQ"
 	})
-"djW" = (
+"djY" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
 /area/space)
-"djX" = (
+"djZ" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -92471,12 +92504,12 @@
 	dir = 2
 	},
 /area/space)
-"djY" = (
+"dka" = (
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
 /area/space)
-"djZ" = (
+"dkb" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -92488,7 +92521,7 @@
 	dir = 2
 	},
 /area/space)
-"dka" = (
+"dkc" = (
 /obj/machinery/power/apc{
 	cell_type = 5000;
 	dir = 4;
@@ -92516,21 +92549,21 @@
 	dir = 2
 	},
 /area/space)
-"dkb" = (
-/turf/closed/wall/rust{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/theatre{
-	name = "Top Secret Clown HQ"
-	})
-"dkc" = (
-/turf/closed/wall/rust{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/theatre{
-	name = "Top Secret Clown HQ"
-	})
 "dkd" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dke" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkf" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Chief Engineer's Desk";
@@ -92544,12 +92577,12 @@
 	dir = 2
 	},
 /area/space)
-"dke" = (
+"dkg" = (
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
 /area/space)
-"dkf" = (
+"dkh" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/lighter,
@@ -92562,7 +92595,7 @@
 	dir = 2
 	},
 /area/space)
-"dkg" = (
+"dki" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -92579,7 +92612,7 @@
 	dir = 2
 	},
 /area/space)
-"dkh" = (
+"dkj" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -92594,21 +92627,21 @@
 	dir = 2
 	},
 /area/space)
-"dki" = (
-/turf/closed/wall/rust{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/theatre{
-	name = "Top Secret Clown HQ"
-	})
-"dkj" = (
-/turf/closed/wall/rust{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/theatre{
-	name = "Top Secret Clown HQ"
-	})
 "dkk" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkl" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkm" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/button/door{
 	desc = "A remote control-switch for the engineering security doors.";
@@ -92637,7 +92670,7 @@
 	dir = 2
 	},
 /area/space)
-"dkl" = (
+"dkn" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
@@ -92646,7 +92679,7 @@
 	dir = 2
 	},
 /area/space)
-"dkm" = (
+"dko" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/yellow,
 /obj/item/weapon/paper/monitorkey,
@@ -92655,7 +92688,7 @@
 	dir = 2
 	},
 /area/space)
-"dkn" = (
+"dkp" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -92672,7 +92705,7 @@
 	dir = 2
 	},
 /area/space)
-"dko" = (
+"dkq" = (
 /obj/structure/closet/secure_closet/engineering_chief{
 	req_access_txt = "0"
 	},
@@ -92680,14 +92713,14 @@
 	dir = 2
 	},
 /area/space)
-"dkp" = (
+"dkr" = (
 /turf/closed/wall/rust{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/theatre{
 	name = "Top Secret Clown HQ"
 	})
-"dkq" = (
+"dks" = (
 /obj/machinery/camera{
 	c_tag = "Chief Engineer's Office";
 	dir = 4;
@@ -92703,12 +92736,12 @@
 	dir = 2
 	},
 /area/space)
-"dkr" = (
+"dkt" = (
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
 /area/space)
-"dks" = (
+"dku" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
@@ -92720,7 +92753,7 @@
 	dir = 2
 	},
 /area/space)
-"dkt" = (
+"dkv" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -92731,7 +92764,7 @@
 	dir = 2
 	},
 /area/space)
-"dku" = (
+"dkw" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
@@ -92743,21 +92776,21 @@
 	dir = 2
 	},
 /area/space)
-"dkv" = (
-/turf/closed/wall/rust{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/theatre{
-	name = "Top Secret Clown HQ"
-	})
-"dkw" = (
-/turf/closed/wall/rust{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/theatre{
-	name = "Top Secret Clown HQ"
-	})
 "dkx" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dky" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkz" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -92766,23 +92799,23 @@
 	dir = 2
 	},
 /area/space)
-"dky" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral{
-	dir = 2
-	},
-/area/space)
-"dkz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral{
-	dir = 2
-	},
-/area/space)
 "dkA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkC" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -92796,7 +92829,7 @@
 	dir = 2
 	},
 /area/space)
-"dkB" = (
+"dkD" = (
 /obj/item/weapon/cartridge/engineering{
 	pixel_x = 4;
 	pixel_y = 5
@@ -92817,21 +92850,21 @@
 	dir = 2
 	},
 /area/space)
-"dkC" = (
-/turf/closed/wall/rust{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/theatre{
-	name = "Top Secret Clown HQ"
-	})
-"dkD" = (
-/turf/closed/wall/rust{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/theatre{
-	name = "Top Secret Clown HQ"
-	})
 "dkE" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkF" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkG" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92839,7 +92872,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dkF" = (
+"dkH" = (
 /obj/structure/cable/orange{
 	d1 = 2;
 	d2 = 8;
@@ -92851,7 +92884,18 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dkG" = (
+"dkI" = (
+/obj/machinery/camera{
+	c_tag = "Aux Base Construction North";
+	dir = 1;
+	icon_state = "camera";
+	network = list("SS13")
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/shuttle/auxillary_base)
+"dkJ" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -92863,7 +92907,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dkH" = (
+"dkK" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -92876,36 +92920,10 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dkI" = (
+"dkL" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dkJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/floorgrime{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dkK" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dkL" = (
-/obj/structure/closet/firecloset/full,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -92916,13 +92934,39 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
 "dkN" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkO" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkP" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkQ" = (
 /obj/structure/grille,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92930,7 +92974,17 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dkO" = (
+"dkR" = (
+/obj/machinery/camera{
+	c_tag = "Aux Base Construction South";
+	dir = 6;
+	icon_state = "camera"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/shuttle/auxillary_base)
+"dkS" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 4;
@@ -92942,7 +92996,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dkP" = (
+"dkT" = (
 /obj/structure/cable/orange{
 	d1 = 2;
 	d2 = 8;
@@ -92954,7 +93008,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dkQ" = (
+"dkU" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -92967,7 +93021,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dkR" = (
+"dkV" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -92980,54 +93034,13 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dkS" = (
+"dkW" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dkT" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dkU" = (
-/obj/structure/closet,
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dkV" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dkW" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -93047,10 +93060,10 @@
 	name = "Aft Asteroid Maintenance"
 	})
 "dkY" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/asteroid,
+/obj/structure/closet,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
@@ -93067,8 +93080,7 @@
 	name = "Aft Asteroid Maintenance"
 	})
 "dla" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -93077,56 +93089,6 @@
 	name = "Aft Asteroid Maintenance"
 	})
 "dlb" = (
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dlc" = (
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dld" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dle" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/open/floor/plating{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dlf" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -93138,15 +93100,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlg" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating/astplate{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/maintenance/aft{
-	name = "Aft Asteroid Maintenance"
-	})
-"dlh" = (
+"dlc" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -93154,7 +93108,107 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
+"dld" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dle" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlf" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlg" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
 "dli" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlj" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlk" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dll" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlm" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 4;
@@ -93167,7 +93221,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlj" = (
+"dln" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -93181,7 +93235,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlk" = (
+"dlo" = (
 /obj/structure/cable/orange{
 	d1 = 2;
 	d2 = 8;
@@ -93193,7 +93247,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dll" = (
+"dlp" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -93205,7 +93259,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlm" = (
+"dlq" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -93221,7 +93275,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dln" = (
+"dlr" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -93234,14 +93288,14 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlo" = (
+"dls" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlp" = (
+"dlt" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -93254,7 +93308,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlq" = (
+"dlu" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 8;
@@ -93267,7 +93321,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlr" = (
+"dlv" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -93275,7 +93329,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dls" = (
+"dlw" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -93287,7 +93341,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlt" = (
+"dlx" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -93295,7 +93349,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlu" = (
+"dly" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -93303,14 +93357,40 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlv" = (
+"dlz" = (
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Research-Docking Bridge 5";
+	dir = 1;
+	icon_state = "camera";
+	network = list("SS13")
+	},
+/turf/open/floor/engine,
+/area/space)
+"dlA" = (
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Research-Docking Bridge 4";
+	dir = 1;
+	icon_state = "camera";
+	network = list("SS13")
+	},
+/turf/open/floor/engine,
+/area/space)
+"dlB" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlw" = (
+"dlC" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -93318,7 +93398,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlx" = (
+"dlD" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -93331,13 +93411,13 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dly" = (
+"dlE" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlz" = (
+"dlF" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -93346,7 +93426,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlA" = (
+"dlG" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating{
@@ -93355,7 +93435,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlB" = (
+"dlH" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -93365,7 +93445,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/aft)
-"dlC" = (
+"dlI" = (
 /obj/structure/grille,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -93373,7 +93453,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlD" = (
+"dlJ" = (
 /obj/structure/grille,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -93381,7 +93461,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlE" = (
+"dlK" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 4;
@@ -93393,7 +93473,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlF" = (
+"dlL" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -93403,7 +93483,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlG" = (
+"dlM" = (
 /obj/structure/cable/orange{
 	d1 = 2;
 	d2 = 8;
@@ -93413,21 +93493,21 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlH" = (
+"dlN" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlI" = (
+"dlO" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlJ" = (
+"dlP" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/power/apc{
@@ -93444,14 +93524,14 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlK" = (
+"dlQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlL" = (
+"dlR" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 4;
@@ -93463,7 +93543,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dlM" = (
+"dlS" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/light{
@@ -93474,14 +93554,14 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlN" = (
+"dlT" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlO" = (
+"dlU" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/cable/orange{
@@ -93493,14 +93573,14 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlP" = (
+"dlV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlQ" = (
+"dlW" = (
 /obj/machinery/airalarm{
 	dir = 4;
 	icon_state = "alarm0";
@@ -93510,7 +93590,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlR" = (
+"dlX" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -93520,7 +93600,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlS" = (
+"dlY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
 	on = 1;
@@ -93538,7 +93618,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlT" = (
+"dlZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -93546,7 +93626,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlU" = (
+"dma" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -93554,7 +93634,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/mixing)
-"dlV" = (
+"dmb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -93562,7 +93642,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/mixing)
-"dlW" = (
+"dmc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -93570,7 +93650,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlX" = (
+"dmd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -93583,7 +93663,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlY" = (
+"dme" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -93596,7 +93676,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dlZ" = (
+"dmf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -93609,7 +93689,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dma" = (
+"dmg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -93626,73 +93706,73 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/storage)
-"dmb" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/toxins/storage)
-"dmc" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/toxins/storage)
-"dmd" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/toxins/storage)
-"dme" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/toxins/storage)
-"dmf" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/toxins/storage)
-"dmg" = (
-/turf/closed/wall/r_wall{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/hor)
 "dmh" = (
-/turf/closed/wall/r_wall{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/hor)
+/area/toxins/storage)
 "dmi" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dmj" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dmk" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dml" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dmm" = (
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmj" = (
+"dmn" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmo" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmp" = (
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmk" = (
+"dmq" = (
 /obj/structure/displaycase/labcage,
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dml" = (
+"dmr" = (
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmm" = (
+"dms" = (
 /obj/machinery/button/door{
 	id = "researchlockdown";
 	name = "Research Emergency Lockdown";
@@ -93708,7 +93788,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmn" = (
+"dmt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -93716,13 +93796,13 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmo" = (
+"dmu" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmp" = (
+"dmv" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 4;
@@ -93736,7 +93816,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmq" = (
+"dmw" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/astplate{
@@ -93745,7 +93825,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmr" = (
+"dmx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -93759,18 +93839,18 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dms" = (
+"dmy" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmt" = (
+"dmz" = (
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmu" = (
+"dmA" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
 	pixel_x = 1;
@@ -93786,19 +93866,19 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmv" = (
+"dmB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/hor)
-"dmw" = (
+"dmC" = (
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmx" = (
+"dmD" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Research Director's Desk";
@@ -93811,7 +93891,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmy" = (
+"dmE" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
@@ -93819,13 +93899,13 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmz" = (
+"dmF" = (
 /obj/machinery/computer/mecha,
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmA" = (
+"dmG" = (
 /obj/structure/rack,
 /obj/item/device/paicard{
 	pixel_x = 4
@@ -93838,7 +93918,7 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/hor)
-"dmB" = (
+"dmH" = (
 /obj/structure/cable/orange{
 	d1 = 2;
 	d2 = 4;
@@ -93850,7 +93930,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmC" = (
+"dmI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -93865,7 +93945,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmD" = (
+"dmJ" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -93881,7 +93961,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmE" = (
+"dmK" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -93896,7 +93976,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmF" = (
+"dmL" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -93912,12 +93992,12 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmG" = (
+"dmM" = (
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmH" = (
+"dmN" = (
 /obj/effect/landmark/xmastree/rdrod,
 /obj/machinery/airalarm{
 	dir = 4;
@@ -93928,7 +94008,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmI" = (
+"dmO" = (
 /obj/structure/rack,
 /obj/item/device/aicard,
 /obj/effect/turf_decal/stripes/line{
@@ -93936,12 +94016,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/hor)
-"dmJ" = (
+"dmP" = (
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
-"dmK" = (
+"dmQ" = (
 /obj/structure/grille,
 /turf/closed/wall/rust{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -93949,42 +94029,42 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmL" = (
-/turf/closed/wall/r_wall{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/hor)
-"dmM" = (
-/turf/closed/wall/r_wall{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/hor)
-"dmN" = (
-/turf/closed/wall/r_wall{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/hor)
-"dmO" = (
-/turf/closed/wall/r_wall{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/hor)
-"dmP" = (
-/turf/closed/wall/r_wall{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/hor)
-"dmQ" = (
-/turf/closed/wall/r_wall{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/crew_quarters/hor)
 "dmR" = (
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
 "dmS" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmT" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmU" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmV" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmW" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmX" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -93994,7 +94074,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmT" = (
+"dmZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -94002,7 +94082,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmU" = (
+"dna" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -94017,7 +94097,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmV" = (
+"dnb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/grille,
 /turf/open/floor/plating{
@@ -94026,7 +94106,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmW" = (
+"dnc" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 4;
@@ -94043,7 +94123,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmX" = (
+"dnd" = (
 /obj/structure/cable/orange{
 	d1 = 2;
 	d2 = 8;
@@ -94059,14 +94139,14 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmY" = (
+"dne" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dmZ" = (
+"dnf" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -94079,7 +94159,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dna" = (
+"dng" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -94092,7 +94172,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnb" = (
+"dnh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -94105,7 +94185,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnc" = (
+"dni" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -94118,7 +94198,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnd" = (
+"dnj" = (
 /obj/structure/grille,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -94126,7 +94206,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dne" = (
+"dnk" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -94140,7 +94220,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnf" = (
+"dnl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -94153,7 +94233,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dng" = (
+"dnm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -94163,7 +94243,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnh" = (
+"dnn" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
 /turf/open/floor/plating{
@@ -94172,7 +94252,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dni" = (
+"dno" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -94185,7 +94265,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnj" = (
+"dnp" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -94193,7 +94273,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnk" = (
+"dnq" = (
 /obj/machinery/light/small,
 /obj/structure/chair{
 	dir = 4
@@ -94204,7 +94284,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnl" = (
+"dnr" = (
 /obj/structure/table,
 /obj/item/weapon/wrench,
 /turf/open/floor/plating{
@@ -94213,7 +94293,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnm" = (
+"dns" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 4;
@@ -94229,7 +94309,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnn" = (
+"dnt" = (
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
@@ -94245,7 +94325,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dno" = (
+"dnu" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -94256,7 +94336,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnp" = (
+"dnv" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/astplate{
@@ -94265,7 +94345,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnq" = (
+"dnw" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -94273,7 +94353,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dnr" = (
+"dnx" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating{
@@ -94282,7 +94362,7 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
-"dns" = (
+"dny" = (
 /obj/structure/girder,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -101395,7 +101475,7 @@ cdn
 aZA
 aZy
 ceq
-djT
+djV
 aZo
 aZn
 aYT
@@ -101652,7 +101732,7 @@ cdo
 aZA
 cdY
 bCF
-djU
+djW
 aZo
 aZo
 aYT
@@ -101900,7 +101980,7 @@ aYT
 aYT
 aYT
 aZo
-djq
+djr
 aZm
 aYX
 aZn
@@ -102669,7 +102749,7 @@ bXp
 aZn
 aYX
 aZm
-djf
+djg
 beC
 bCF
 blT
@@ -102939,11 +103019,11 @@ aZA
 bec
 aZm
 aZn
-dkb
-dki
+dkd
+dkk
 cea
 cea
-dkC
+dkE
 aZn
 cgm
 aZA
@@ -103166,7 +103246,7 @@ aZn
 aZm
 aZn
 aYX
-dhg
+dhh
 aZm
 aZm
 aZn
@@ -103714,7 +103794,7 @@ cfv
 cfF
 cfE
 cfE
-dkD
+dkF
 aZn
 aZn
 cgj
@@ -103932,21 +104012,21 @@ bsd
 bsc
 bsc
 bsc
-dgt
+dgu
 bEd
 bnT
 bnT
 bnT
-dhh
-dhk
+dhi
+dhl
 bnT
 bnT
 bOv
-dhK
+dhL
 bQY
 bPW
-diI
-diQ
+diJ
+diR
 bVl
 aYX
 aZA
@@ -103966,7 +104046,7 @@ aZo
 aZo
 aZn
 aZn
-djV
+djX
 cea
 cfE
 cfE
@@ -104004,11 +104084,11 @@ aaa
 aaa
 cgS
 cBU
-dlH
-dlM
-dlQ
+dlN
+dlS
+dlW
 cCO
-dmb
+dmh
 cBU
 cgS
 cgS
@@ -104189,19 +104269,19 @@ bty
 bzs
 bty
 bsd
-dgu
-dgK
+dgv
+dgL
 aYX
 aZm
 aYX
-dhi
+dhj
 aZm
 cfg
 beC
-dhA
+dhB
 aZn
 aZm
-diq
+dir
 aYX
 aZm
 aZm
@@ -104224,7 +104304,7 @@ aZn
 cdZ
 cdZ
 cdZ
-dkc
+dke
 cfG
 cfE
 cfZ
@@ -104261,11 +104341,11 @@ aaa
 aaa
 aaa
 cBU
-dlI
-dlN
+dlO
+dlT
 cDE
-dlW
 dmc
+dmi
 cBU
 cgS
 cgS
@@ -104446,17 +104526,17 @@ byg
 bzt
 bAy
 bsd
-dgv
-dgL
+dgw
+dgM
 aYX
 bGn
 bHz
 beC
 aZm
 aZm
-dhq
+dhr
 bfr
-dhL
+dhM
 aYX
 aZn
 aZo
@@ -104484,7 +104564,7 @@ cev
 cfw
 cev
 cev
-dkv
+dkx
 cea
 aZn
 cgo
@@ -104518,11 +104598,11 @@ aaa
 aaa
 aaa
 cBU
-dlJ
-dlO
-dlR
+dlP
+dlU
 dlX
 dmd
+dmj
 cBU
 cgS
 cgS
@@ -104703,15 +104783,15 @@ byh
 bzu
 bAz
 bsd
-dgw
-dgM
+dgx
+dgN
 aYX
 aYX
 aZm
 aZn
 aZn
 aZn
-dhr
+dhs
 bfr
 beC
 aYX
@@ -104739,9 +104819,9 @@ cet
 ceu
 cdZ
 cea
-dkj
-dkp
-dkw
+dkl
+dkr
+dky
 aYP
 aZn
 aZn
@@ -104775,11 +104855,11 @@ cuQ
 cuQ
 cuQ
 ctW
-dlK
-dlP
+dlQ
+dlV
 cDE
-dlY
 dme
+dmk
 cBU
 cgS
 cgS
@@ -104960,9 +105040,9 @@ byi
 bzv
 bAA
 bsc
-dgx
-dgN
-dgW
+dgy
+dgO
+dgX
 aZn
 aZn
 aZn
@@ -104970,7 +105050,7 @@ aZn
 aZn
 aZn
 bOw
-dhM
+dhN
 aZn
 aZn
 bHA
@@ -105034,9 +105114,9 @@ cvR
 ctW
 cCQ
 cCQ
-dlS
-dlZ
+dlY
 dmf
+dml
 cBU
 cCB
 cjU
@@ -105291,8 +105371,8 @@ cwO
 ctW
 cBU
 cBU
-dlT
-dma
+dlZ
+dmg
 ctW
 ctW
 cCC
@@ -105727,11 +105807,11 @@ aZm
 aZn
 bvg
 bwD
-dfQ
+dfR
 bzx
 aZn
 aZn
-dgy
+dgz
 blW
 aYX
 aZm
@@ -105811,7 +105891,7 @@ cAU
 cYc
 cCD
 cDv
-dmr
+dmx
 cEQ
 cFb
 cmA
@@ -105984,13 +106064,13 @@ dfL
 bbf
 bbf
 bbf
-dfR
-dga
-dgk
-dgp
-dgz
+dfS
+dgb
+dgl
+dgq
+dgA
 blW
-dgX
+dgY
 aYX
 bHA
 bHA
@@ -106071,7 +106151,7 @@ cgL
 cgL
 cxT
 cFc
-dmK
+dmQ
 cjU
 cjV
 cgR
@@ -106241,11 +106321,11 @@ bse
 bnT
 bvh
 bwE
-dfS
-dgb
-dgl
-dgq
-dgA
+dfT
+dgc
+dgm
+dgr
+dgB
 bEe
 aZz
 bec
@@ -106327,7 +106407,7 @@ ckH
 ckz
 cjV
 cgu
-dmC
+dmI
 cjU
 cFH
 cjU
@@ -106496,7 +106576,7 @@ aZX
 bqE
 aZm
 aZm
-dfN
+dfO
 aZm
 bmO
 bmO
@@ -106576,7 +106656,7 @@ cXW
 cvW
 cvW
 cvW
-dlU
+dma
 cAc
 cAX
 ctW
@@ -106584,9 +106664,9 @@ cBR
 cBR
 cBR
 cBR
-dmD
+dmJ
 coJ
-dmS
+dmY
 cjV
 cgR
 cgR
@@ -106833,7 +106913,7 @@ cwR
 cxv
 cyc
 cvW
-dlV
+dmb
 cAd
 cAY
 ctW
@@ -106841,9 +106921,9 @@ cCF
 cDw
 cEf
 cBR
-dmE
+dmK
 cjU
-dmT
+dmZ
 cjU
 cgu
 cgu
@@ -107355,10 +107435,10 @@ cCH
 cDx
 cCH
 cBR
-dmF
+dmL
 cFu
 cFI
-dmV
+dnb
 cFu
 cFu
 cGU
@@ -107614,12 +107694,12 @@ cEg
 cBR
 cFf
 cDv
-dmU
+dna
 cDv
 cDv
-dnb
-dnf
-dni
+dnh
+dnl
+dno
 cDv
 cHK
 cHZ
@@ -109406,13 +109486,13 @@ cyS
 czr
 cAk
 cBf
-dmg
-dmi
-dml
-dms
-dmw
-dmG
-dmL
+dmm
+dmo
+dmr
+dmy
+dmC
+dmM
+dmR
 cFd
 cxT
 cjV
@@ -109665,11 +109745,11 @@ cAj
 cBg
 cBV
 cCM
-dmm
-dmt
-dmx
-dmH
-dmM
+dms
+dmz
+dmD
+dmN
+dmS
 cFd
 cCC
 cjU
@@ -109922,13 +110002,13 @@ cAl
 cBh
 cBW
 cCN
-dmn
-dmu
-dmy
+dmt
+dmA
+dmE
 cFi
-dmN
+dmT
 cFJ
-dmW
+dnc
 coJ
 clV
 cjV
@@ -110178,12 +110258,12 @@ czt
 cAm
 cBi
 cBX
-dmj
-dmo
+dmp
+dmu
 cEj
-dmz
+dmF
 cFj
-dmO
+dmU
 chc
 cFe
 cjU
@@ -110437,10 +110517,10 @@ cBj
 cBY
 cCP
 cCP
-dmv
+dmB
 cES
 cFk
-dmP
+dmV
 chc
 cFd
 cll
@@ -110448,7 +110528,7 @@ cll
 cll
 cll
 cll
-dno
+dnu
 chc
 cgN
 cgN
@@ -110691,20 +110771,20 @@ cta
 czv
 cAj
 cBk
-dmh
-dmk
+dmn
+dmq
 cDF
 cEk
-dmA
-dmI
-dmQ
+dmG
+dmO
+dmW
 chc
-dmX
-dmZ
-dnc
+dnd
+dnf
+dni
 cGv
 cHi
-dnm
+dns
 cHM
 cjV
 cgN
@@ -110953,8 +111033,8 @@ cWn
 cWn
 cWn
 cWq
-dmJ
-dmR
+dmP
+dmX
 chc
 chc
 chc
@@ -111220,7 +111300,7 @@ cET
 cET
 cFe
 cll
-dnq
+dnw
 chc
 cgN
 aaa
@@ -111991,7 +112071,7 @@ cFl
 cET
 cFd
 cll
-dnr
+dnx
 chc
 cgN
 aaa
@@ -112246,7 +112326,7 @@ cFl
 cGG
 cFl
 cET
-dnn
+dnt
 cIc
 cgu
 chc
@@ -112720,12 +112800,12 @@ cgS
 cgS
 cgS
 chM
-cih
+cig
 ciH
 ciH
-ciH
+dkI
 ckq
-ciH
+dkR
 ciH
 ciH
 cmQ
@@ -114047,7 +114127,7 @@ cGY
 cCc
 cHt
 cll
-dns
+dny
 cgR
 cgN
 aaa
@@ -114796,7 +114876,7 @@ cte
 cUn
 cvv
 cwq
-dlB
+dlH
 cxO
 cyD
 cue
@@ -115005,7 +115085,7 @@ aZo
 aZo
 aZo
 aZm
-djg
+djh
 aZm
 aYP
 cbO
@@ -115070,11 +115150,11 @@ cCc
 cFO
 cLN
 cxT
-dnd
+dnj
 cln
 cxT
 cxT
-dnp
+dnv
 chc
 cgN
 cgN
@@ -115327,7 +115407,7 @@ cxo
 cxo
 cjU
 cnL
-dne
+dnk
 coD
 cgL
 chc
@@ -116097,10 +116177,10 @@ cyH
 cFD
 cxo
 cjU
-dna
-coJ
 dng
-dnj
+coJ
+dnm
+dnp
 cjU
 cgR
 cgN
@@ -116337,7 +116417,7 @@ cjG
 cte
 cUn
 ckB
-dlx
+dlD
 cxo
 cxo
 cxo
@@ -116357,7 +116437,7 @@ chc
 cln
 cjU
 cll
-dnk
+dnq
 cjU
 cgR
 cgN
@@ -116613,8 +116693,8 @@ cxo
 chb
 cln
 cjU
-dnh
-dnl
+dnn
+dnr
 cjU
 cgN
 cgN
@@ -117364,7 +117444,7 @@ crD
 cjG
 cte
 cUn
-dlv
+dlB
 cln
 cxo
 cxo
@@ -117621,7 +117701,7 @@ crC
 cjG
 cte
 cUn
-dlw
+dlC
 clo
 cxo
 cxQ
@@ -117638,7 +117718,7 @@ cxQ
 cyF
 cyY
 cxo
-dmY
+dne
 cln
 cgL
 cjU
@@ -119935,7 +120015,7 @@ csu
 ctw
 cUn
 cjX
-dly
+dlE
 cln
 cll
 cxT
@@ -120194,7 +120274,7 @@ cUn
 chc
 cxT
 cjt
-dlE
+dlK
 cyK
 chc
 czT
@@ -120392,7 +120472,7 @@ byS
 cMH
 byS
 bxu
-dir
+dis
 bAe
 bAd
 cMH
@@ -120450,8 +120530,8 @@ ctv
 cUn
 cjU
 ckB
-dlC
-dlF
+dlI
+dlL
 chc
 cjU
 czT
@@ -120641,25 +120721,25 @@ bAd
 byS
 bFo
 byQ
-dhb
+dhc
 byS
 cMH
 cMH
 cbr
-dhB
-dhN
-dhY
+dhC
+dhO
+dhZ
 cbr
 cbr
 cbr
-diT
-diW
+diU
+diX
 bWU
 byS
 bAd
 byS
 byS
-djh
+dji
 cMH
 aZH
 aZt
@@ -120707,9 +120787,9 @@ ctx
 cUn
 cjU
 cll
-dlD
-dlG
-dlL
+dlJ
+dlM
+dlR
 cjU
 cjU
 chc
@@ -120900,22 +120980,22 @@ byP
 byP
 byP
 byO
-dhl
+dhm
 bvU
-dhs
+dht
 cbr
 cbr
 cbr
-dis
+dit
 cbr
 cbr
-diU
+diV
 cbr
 cbr
 cbr
 cbr
-djb
-dje
+djc
+djf
 caf
 bBN
 bBN
@@ -120963,7 +121043,7 @@ cjG
 ctv
 cUn
 cjU
-dlz
+dlF
 chc
 chb
 cjt
@@ -120973,9 +121053,9 @@ cjT
 cBH
 cCt
 cjT
-dmp
+dmv
 cEK
-dmB
+dmH
 cjT
 coD
 cgL
@@ -121165,13 +121245,13 @@ bAd
 cMH
 byS
 bAd
-diR
-diV
-diX
+diS
+diW
+diY
 cbr
 cbr
-dja
-djc
+djb
+djd
 cbr
 cbr
 cbr
@@ -121220,7 +121300,7 @@ cjG
 ctv
 cUn
 cgN
-dlA
+dlG
 cjU
 ckz
 cgL
@@ -121430,8 +121510,8 @@ bOM
 bOM
 bOM
 bOM
-dji
-djl
+djj
+djm
 byS
 bAd
 bBN
@@ -121744,7 +121824,7 @@ cjU
 cjU
 cjU
 chc
-dmq
+dmw
 cjU
 cjU
 cjU
@@ -121945,12 +122025,12 @@ bYq
 bXG
 bOM
 byS
-djm
+djn
 cbr
 cbr
 byS
 cbr
-djG
+djH
 cdB
 bLA
 cdB
@@ -122202,11 +122282,11 @@ bYr
 bZb
 bOM
 bAd
-djn
-djr
+djo
 djs
+djt
 bvU
-djx
+djy
 cbr
 cMH
 cMH
@@ -122245,7 +122325,7 @@ arw
 cqC
 aQS
 arz
-cUy
+dlz
 cuk
 cgN
 cgN
@@ -122463,7 +122543,7 @@ cMH
 cMH
 byS
 cMH
-djy
+djz
 cbr
 byS
 byS
@@ -122722,7 +122802,7 @@ cbr
 byS
 cbr
 cbr
-djL
+djM
 bAd
 aZt
 aZt
@@ -122951,7 +123031,7 @@ aZt
 bAd
 cMH
 byQ
-dgO
+dgP
 bFp
 bGF
 bHM
@@ -122975,11 +123055,11 @@ bXJ
 bGE
 cMP
 cbr
-djt
+dju
 cNc
-djz
+djA
 cbr
-djM
+djN
 byS
 aZH
 aZt
@@ -123207,7 +123287,7 @@ bal
 aZt
 bAd
 bAd
-dgB
+dgC
 byP
 bFq
 bGG
@@ -123236,8 +123316,8 @@ cbr
 cMH
 bAd
 cbr
-djN
-djR
+djO
+djS
 aZH
 aZt
 aaa
@@ -123493,7 +123573,7 @@ bOM
 bOM
 byS
 cbr
-djO
+djP
 cMH
 aZH
 aZt
@@ -123748,7 +123828,7 @@ caA
 cbi
 cbi
 bOM
-djA
+djB
 cbr
 bAe
 byS
@@ -124005,7 +124085,7 @@ caB
 cbj
 cbP
 bOM
-djB
+djC
 cbr
 bBN
 bBN
@@ -124489,7 +124569,7 @@ bua
 bvx
 bxc
 bcp
-dgc
+dgd
 bco
 bal
 bDf
@@ -124519,7 +124599,7 @@ bOM
 bOM
 bOM
 bOM
-djC
+djD
 cbr
 cMH
 aZH
@@ -124777,7 +124857,7 @@ cbk
 cbk
 bOM
 cbr
-djH
+djI
 cMH
 aZt
 aZt
@@ -125291,7 +125371,7 @@ cbk
 cbk
 bOM
 cbr
-djI
+djJ
 bAd
 aZH
 aZH
@@ -125804,9 +125884,9 @@ caG
 cbm
 cbm
 bOM
-djD
+djE
 cbr
-djP
+djQ
 byS
 aZH
 aZt
@@ -126043,10 +126123,10 @@ bJH
 bpS
 bGJ
 bNF
-dhC
-dhO
-dhZ
-dit
+dhD
+dhP
+dia
+diu
 bTL
 bUI
 bVJ
@@ -126061,9 +126141,9 @@ caH
 cbn
 cbR
 bOM
-djE
+djF
 cbr
-djQ
+djR
 cMH
 aZH
 aZt
@@ -126294,13 +126374,13 @@ abC
 abC
 abC
 bFx
-dha
-dhc
+dhb
+dhd
 bJI
 bLk
 bME
 bOW
-dhD
+dhE
 bQx
 bnk
 bSJ
@@ -126319,7 +126399,7 @@ cbm
 cbm
 bOM
 bAd
-djJ
+djK
 bvU
 bBN
 aZH
@@ -126552,14 +126632,14 @@ cWJ
 cWJ
 cXQ
 bGP
-dhd
+dhe
 bJJ
-dhm
 dhn
-dht
+dho
+dhu
 bOX
 bQy
-dia
+dib
 bSK
 bTM
 bUK
@@ -126576,7 +126656,7 @@ bOM
 bOM
 bOM
 cbr
-djK
+djL
 caf
 byS
 aZH
@@ -126815,8 +126895,8 @@ bLm
 bMF
 bPa
 bOY
-dhP
-dib
+dhQ
+dic
 bSL
 bTM
 bUL
@@ -126832,7 +126912,7 @@ caJ
 cbo
 cbo
 bOM
-djF
+djG
 bAd
 cbr
 bBN
@@ -127072,9 +127152,9 @@ bLn
 bMG
 bNG
 bOZ
-dhQ
-dic
-diu
+dhR
+did
+div
 bTM
 bUM
 bVM
@@ -127328,10 +127408,10 @@ cMz
 bLo
 bMH
 bPa
-dhE
+dhF
 bQz
-did
-div
+die
+diw
 bTM
 bUN
 bJx
@@ -127583,11 +127663,11 @@ cXQ
 bIe
 bJK
 bLo
-dho
+dhp
 bNH
 bPb
-dhR
-die
+dhS
+dif
 bSM
 bTM
 bUO
@@ -127841,10 +127921,10 @@ bIf
 bJK
 bMI
 bNI
-dhu
+dhv
 bPc
-dhS
-dif
+dhT
+dig
 bSN
 bTN
 bUP
@@ -128099,10 +128179,10 @@ bJK
 bLo
 bNJ
 bPd
-dhF
-dhT
-dig
-diw
+dhG
+dhU
+dih
+dix
 bTO
 bUQ
 bVP
@@ -128115,12 +128195,12 @@ bGE
 bGE
 byS
 bAd
-dju
+djv
 byS
 bPt
 byP
 cbr
-djS
+djT
 aZH
 aZt
 aaa
@@ -128355,7 +128435,7 @@ bIa
 bJN
 bLp
 bMJ
-dhv
+dhw
 bPe
 bQA
 bRB
@@ -128373,7 +128453,7 @@ cMV
 cbr
 cbr
 cbr
-djv
+djw
 byP
 byP
 cbr
@@ -128381,11 +128461,11 @@ cMH
 aZH
 aZt
 aaa
-djW
-dkd
-dkk
-dkq
-dkx
+djY
+dkf
+dkm
+dks
+dkz
 aaa
 aaa
 aaa
@@ -128612,8 +128692,8 @@ bIg
 bJK
 bLo
 bLo
-dhw
-dhG
+dhx
+dhH
 bQB
 bRC
 bSP
@@ -128626,7 +128706,7 @@ bQH
 bQH
 byS
 bAe
-djj
+djk
 cbr
 byP
 byP
@@ -128638,11 +128718,11 @@ byS
 aZH
 aaa
 aaa
-djX
-dke
-dkl
-dkr
-dky
+djZ
+dkg
+dkn
+dkt
+dkA
 aaa
 aaa
 aaa
@@ -128895,11 +128975,11 @@ bAd
 aZt
 aaa
 aaa
-djY
-dkf
-dkm
-dks
-dkz
+dka
+dkh
+dko
+dku
+dkB
 aaa
 aaa
 aaa
@@ -129152,11 +129232,11 @@ byS
 aZt
 aaa
 aaa
-djZ
-dkg
-dkn
-dkt
-dkA
+dkb
+dki
+dkp
+dkv
+dkC
 aaa
 aaa
 aaa
@@ -129409,11 +129489,11 @@ bAd
 aZt
 aaa
 aaa
-dka
-dkh
-dko
-dku
-dkB
+dkc
+dkj
+dkq
+dkw
+dkD
 aaa
 aaa
 aaa
@@ -129658,7 +129738,7 @@ bAd
 byS
 byQ
 byP
-djw
+djx
 cMH
 aZt
 aZt
@@ -130426,7 +130506,7 @@ bQH
 bAd
 bAd
 cMH
-djo
+djp
 byP
 byS
 bBN
@@ -130668,7 +130748,7 @@ bIn
 bJU
 bpS
 biO
-bNL
+biO
 biO
 bQH
 bRK
@@ -131197,7 +131277,7 @@ byS
 bDc
 byQ
 byP
-djp
+djq
 byS
 bBN
 aZH
@@ -131453,7 +131533,7 @@ bAd
 cMH
 byQ
 byP
-djk
+djl
 bZS
 cMH
 cMH
@@ -132198,7 +132278,7 @@ cSv
 buq
 bvT
 bxv
-dfT
+dfU
 bAd
 cTr
 bCe
@@ -132736,7 +132816,7 @@ bAd
 bVA
 byQ
 byP
-djd
+dje
 cMH
 cal
 caP
@@ -133039,7 +133119,7 @@ arw
 cqC
 aQS
 arz
-cUy
+dlA
 cuk
 aaa
 aXR
@@ -133484,7 +133564,7 @@ bhP
 bal
 bxA
 cMH
-dgd
+dge
 cbr
 bBN
 bBN
@@ -133742,11 +133822,11 @@ bal
 bxz
 byS
 bAd
-dgm
+dgn
 cbr
 cbr
-dgP
-dgY
+dgQ
+dgZ
 byP
 bDa
 byQ
@@ -134001,7 +134081,7 @@ aZt
 bAd
 byS
 cbr
-dgC
+dgD
 bvU
 bDd
 byP
@@ -134010,10 +134090,10 @@ byP
 byP
 byO
 byQ
-dhH
+dhI
 byS
 bAd
-dix
+diy
 bUa
 byS
 byQ
@@ -134258,7 +134338,7 @@ aZt
 aZt
 bAd
 byS
-dgD
+dgE
 byS
 byQ
 bBg
@@ -134268,14 +134348,14 @@ byQ
 byP
 byP
 byQ
-dhU
+dhV
 byQ
 byQ
 byQ
 bDa
 byQ
 byP
-diZ
+dja
 cMH
 aZH
 aZH
@@ -135022,7 +135102,7 @@ arw
 bpW
 aQS
 cSC
-aSQ
+buu
 bvW
 arw
 aaa
@@ -135338,10 +135418,10 @@ chF
 chV
 cir
 chq
-dkF
-dkG
 dkH
-dkO
+dkJ
+dkK
+dkS
 cHM
 cjV
 cmZ
@@ -135597,9 +135677,9 @@ chr
 chr
 cjU
 cgu
-dkI
-dkP
+dkL
 dkT
+dkX
 cms
 cnb
 cmA
@@ -135856,9 +135936,9 @@ cgu
 cgu
 cjV
 cjU
-dkU
+dkY
 cmt
-dkZ
+dld
 cjT
 coC
 cBH
@@ -135952,7 +136032,7 @@ aax
 aax
 aax
 aaw
-aaw
+acL
 cJi
 aal
 aal
@@ -136050,7 +136130,7 @@ arw
 bpW
 aQS
 cSC
-buu
+aSQ
 bvW
 arw
 aaa
@@ -136116,7 +136196,7 @@ cgu
 cjU
 cjV
 cjV
-dlb
+dlf
 coD
 cgL
 cpZ
@@ -136375,7 +136455,7 @@ cfJ
 chc
 cnM
 cgL
-dlo
+dls
 cjU
 cqD
 crY
@@ -136888,7 +136968,7 @@ clQ
 cmu
 ckG
 cln
-dlh
+dll
 chc
 chc
 cqD
@@ -137078,7 +137158,7 @@ arw
 bpW
 aQS
 cSC
-aSQ
+dfN
 bvW
 arw
 aaa
@@ -137396,7 +137476,7 @@ cgi
 cgi
 cfJ
 cjV
-dkJ
+dkM
 clj
 clS
 cmw
@@ -137915,8 +137995,8 @@ cll
 clU
 cmy
 cnc
-dlc
-dli
+dlg
+dlm
 cpm
 cqc
 cqL
@@ -138173,7 +138253,7 @@ cll
 cjU
 cnd
 cnO
-dlj
+dln
 cpm
 cqd
 cqM
@@ -139457,7 +139537,7 @@ cgi
 cfJ
 cfJ
 chc
-dld
+dlh
 clj
 cqf
 cqf
@@ -139714,8 +139794,8 @@ cgi
 cfJ
 cfJ
 cjV
-dle
-dlk
+dli
+dlo
 cUh
 cqf
 cqQ
@@ -139972,7 +140052,7 @@ baS
 cgi
 cjV
 cnQ
-dll
+dlp
 clj
 cqf
 cqR
@@ -140230,7 +140310,7 @@ cgi
 cjU
 cjV
 coF
-dlp
+dlt
 cqf
 cqS
 cse
@@ -140486,7 +140566,7 @@ baS
 cgi
 cgu
 cIa
-dlm
+dlq
 cpo
 cqf
 cqT
@@ -141478,15 +141558,15 @@ arA
 arA
 arA
 arA
-arA
-arA
-arA
-arA
 cdj
 arA
 arA
 arA
 arA
+arA
+arA
+arA
+djU
 arA
 arA
 arA
@@ -142025,7 +142105,7 @@ cjU
 cjU
 cll
 cJf
-dkW
+dla
 cll
 cHM
 coK
@@ -142279,14 +142359,14 @@ cgi
 cgi
 cgu
 cjV
-dkK
+dkN
 clm
-dkV
-dkX
+dkZ
+dlb
 cng
-dlf
+dlj
 coL
-dlq
+dlu
 cjU
 chc
 chc
@@ -142536,7 +142616,7 @@ cgi
 cgi
 cgu
 cjU
-dkL
+dkO
 clj
 clW
 clW
@@ -142794,7 +142874,7 @@ cgi
 cgu
 cjV
 cll
-dkQ
+dkU
 clW
 cmB
 cnh
@@ -143308,7 +143388,7 @@ cgi
 cgu
 chc
 cll
-dkR
+dkV
 clW
 cmD
 cnj
@@ -143775,7 +143855,7 @@ bIz
 bKd
 bLJ
 bEK
-dhx
+dhy
 bPG
 bQN
 bRT
@@ -144034,9 +144114,9 @@ bLK
 bEK
 bNY
 bNZ
-dhV
-dih
-diy
+dhW
+dii
+diz
 bgr
 bbq
 bbo
@@ -144292,8 +144372,8 @@ bEK
 cKY
 bNZ
 bNZ
-dii
-diz
+dij
+diA
 bgp
 bbq
 bbq
@@ -144336,7 +144416,7 @@ ciS
 cjw
 cjw
 cxT
-dkS
+dkW
 clW
 cmE
 cnl
@@ -144532,10 +144612,10 @@ bqf
 brF
 bsV
 buJ
-dfO
 dfP
-dfU
-dge
+dfQ
+dfV
+dgf
 bBq
 bCt
 bDO
@@ -144549,8 +144629,8 @@ bMS
 bLP
 bPH
 bNZ
-dij
-diA
+dik
+diB
 bgp
 bbq
 bbq
@@ -144592,7 +144672,7 @@ cxT
 ciS
 cjw
 cjV
-dkM
+dkP
 clj
 clW
 clW
@@ -144806,7 +144886,7 @@ bMT
 bOb
 bPI
 bNZ
-dik
+dil
 bTc
 bgr
 bbo
@@ -144839,7 +144919,7 @@ cgi
 cgu
 cgu
 cgM
-dkE
+dkG
 cgL
 cgL
 cxT
@@ -144849,7 +144929,7 @@ cit
 chc
 chc
 cjU
-dkN
+dkQ
 clj
 cjU
 cjV
@@ -145063,8 +145143,8 @@ bMU
 bOc
 bPJ
 bNZ
-dil
-diB
+dim
+diC
 bgp
 bbq
 bbq
@@ -145110,10 +145190,10 @@ cjU
 clq
 cll
 cjU
-dla
-dlg
+dle
+dlk
 cjU
-dlr
+dlv
 cjU
 cjV
 cjV
@@ -145369,9 +145449,9 @@ cjT
 cjT
 cnm
 cjT
-dln
+dlr
 cjT
-dls
+dlw
 cng
 csm
 csV
@@ -145577,8 +145657,8 @@ cMD
 bOd
 bPL
 bNZ
-dim
-diC
+din
+diD
 bgp
 bgp
 bbq
@@ -145628,10 +145708,10 @@ cln
 chb
 cgL
 cxT
-dlt
+dlx
 cIc
 cHM
-dlu
+dly
 coJ
 cuF
 csC
@@ -145834,7 +145914,7 @@ bLP
 bOc
 bPM
 bNZ
-din
+dio
 bTe
 bMb
 bgs
@@ -145880,7 +145960,7 @@ cgu
 cgu
 chc
 cjU
-dkY
+dlc
 cnn
 ckz
 chc
@@ -146864,7 +146944,7 @@ bLP
 bNZ
 bgq
 bTi
-diJ
+diK
 bgq
 bbo
 bbq
@@ -147120,8 +147200,8 @@ bIE
 bNZ
 bNZ
 bgq
-diD
-diK
+diE
+diL
 bgq
 bbo
 bbq
@@ -147635,7 +147715,7 @@ bGk
 bgq
 bRW
 bTe
-diL
+diM
 bgs
 bbo
 bbq
@@ -147890,9 +147970,9 @@ bNb
 bOj
 bGk
 bQQ
-dio
-diE
-diM
+dip
+diF
+diN
 bgs
 bbo
 bbo
@@ -148133,7 +148213,7 @@ buN
 bwm
 bya
 bzm
-dgf
+dgg
 bAt
 bCB
 bDY
@@ -148149,7 +148229,7 @@ bPP
 bQR
 bRX
 bTj
-diN
+diO
 bgr
 bbo
 bbo
@@ -148390,10 +148470,10 @@ buO
 bwn
 bya
 bzn
-dgg
+dgh
 bBw
 bAu
-dgE
+dgF
 bEX
 bGk
 bHt
@@ -148403,9 +148483,9 @@ bLV
 bII
 bOl
 cKZ
-dhW
+dhX
 bIO
-diF
+diG
 bMb
 bgs
 bbo
@@ -148661,9 +148741,9 @@ bIJ
 cWD
 bGk
 bgq
-dip
+diq
 bTd
-diO
+diP
 bgq
 bbo
 bbq
@@ -148903,11 +148983,11 @@ bjY
 buQ
 bwp
 byb
-dfV
+dfW
 bkC
 bkB
 bkB
-dgF
+dgG
 bkB
 bGk
 bHv
@@ -148919,7 +148999,7 @@ bHv
 bGk
 bgq
 bIO
-diG
+diH
 bUg
 bgr
 bbo
@@ -149161,11 +149241,11 @@ buR
 bwq
 bjY
 boU
-dgh
+dgi
 bmz
 bCD
-dgG
-dgQ
+dgH
+dgR
 bGk
 cWy
 bHv
@@ -149178,7 +149258,7 @@ bgq
 bIO
 bTb
 bhb
-diS
+diT
 bbo
 bbq
 bbq
@@ -149421,8 +149501,8 @@ boU
 bmz
 bmz
 bmz
-dgH
-dgR
+dgI
+dgS
 bGk
 cWz
 bHv
@@ -149434,7 +149514,7 @@ bGk
 bgp
 bOn
 bTb
-diP
+diQ
 bgr
 bbo
 bbo
@@ -149675,11 +149755,11 @@ bqp
 bpr
 bjY
 boU
-dgi
-dgn
-dgr
-dgI
-dgS
+dgj
+dgo
+dgs
+dgJ
+dgT
 bGk
 bGk
 bHv
@@ -149690,7 +149770,7 @@ bGk
 bGk
 bjg
 bPS
-diH
+diI
 bhd
 bgr
 bgq
@@ -149931,7 +150011,7 @@ btk
 buS
 bwr
 bjY
-dfW
+dfX
 bmz
 bmz
 bmz
@@ -149944,7 +150024,7 @@ bGk
 bGk
 bGk
 bGk
-dhI
+dhJ
 bhd
 bOn
 bTb
@@ -150188,18 +150268,18 @@ bjY
 buQ
 bws
 bjY
-dfX
+dfY
 bmz
 bmz
 bmz
 bmz
-dgT
+dgU
 bkB
 bhg
 bhd
 bKu
 bhc
-dhp
+dhq
 bhd
 bPQ
 bQT
@@ -150445,13 +150525,13 @@ bnM
 buT
 bwt
 bjY
-dfY
-dgj
-dgo
-dgs
-dgJ
-dgU
-dgZ
+dfZ
+dgk
+dgp
+dgt
+dgK
+dgV
+dha
 bHw
 bjZ
 bjZ
@@ -150459,7 +150539,7 @@ bjZ
 bjZ
 bOm
 bPR
-dhX
+dhY
 bQU
 bTl
 bjZ
@@ -150710,7 +150790,7 @@ bkB
 bkB
 bkB
 blR
-dhe
+dhf
 bgr
 bgs
 bhd
@@ -150971,7 +151051,7 @@ bgs
 bgr
 bgr
 bgs
-dhy
+dhz
 bOn
 bgq
 bgs
@@ -150979,7 +151059,7 @@ bgq
 bgq
 bgr
 bhd
-diY
+diZ
 bgr
 bgs
 bgs
@@ -151485,8 +151565,8 @@ bgs
 bgq
 bgq
 bgs
-dhz
-dhJ
+dhA
+dhK
 bgp
 bbq
 bbq
@@ -152253,7 +152333,7 @@ bhd
 bip
 bgs
 bIL
-dhj
+dhk
 bLY
 bNd
 bOr
@@ -153023,7 +153103,7 @@ bgr
 bhd
 bip
 bgr
-dhf
+dhg
 bKx
 bMb
 bgr
@@ -153272,7 +153352,7 @@ bjY
 bgq
 bjg
 bye
-dfZ
+dga
 bgs
 bgr
 bgs
@@ -153791,7 +153871,7 @@ bjZ
 bjZ
 bjZ
 bEb
-dgV
+dgW
 bgs
 bgs
 bIR

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -2587,7 +2587,9 @@
 	})
 "afp" = (
 /obj/machinery/light/small,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
 	})
@@ -3627,6 +3629,7 @@
 	icon_state = "camera";
 	network = list("SS13")
 	},
+/obj/item/device/radio/beacon,
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -4550,7 +4553,9 @@
 /area/security/transfer)
 "aiS" = (
 /obj/structure/girder,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
 	})
@@ -4762,7 +4767,7 @@
 	})
 "ajp" = (
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -4774,7 +4779,7 @@
 	},
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -4792,7 +4797,7 @@
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -5254,7 +5259,7 @@
 /area/space)
 "ako" = (
 /obj/item/trash/can,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -5963,7 +5968,7 @@
 /area/security/transfer)
 "alO" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -6079,7 +6084,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -6505,7 +6510,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -6916,7 +6921,7 @@
 	name = "disposal pipe - Custodials";
 	sortType = 22
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -6997,6 +7002,11 @@
 /obj/structure/cable/orange{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (WEST)";
+	icon_state = "ast_warn_end";
+	dir = 8
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -7091,6 +7101,7 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
+/obj/effect/turf_decal/stripes/asteroid/end,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -7398,7 +7409,7 @@
 /area/security/prison)
 "aoq" = (
 /obj/structure/closet/firecloset/full,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -7411,7 +7422,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -7717,6 +7728,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (WEST)";
+	icon_state = "ast_warn_end";
+	dir = 8
+	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -7973,7 +7989,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -8244,7 +8260,12 @@
 	pixel_y = 2
 	},
 /obj/structure/cable/orange,
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (WEST)";
+	icon_state = "warn_end";
+	dir = 8
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/security/prison)
@@ -8417,7 +8438,12 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (NORTH)";
+	icon_state = "warn_end";
+	dir = 1
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/locker)
@@ -8477,6 +8503,9 @@
 	c_tag = "Bridge Maintenance Eastl";
 	dir = 8
 	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
@@ -8870,7 +8899,7 @@
 	dir = 5;
 	icon_state = "camera"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -8880,7 +8909,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -8962,7 +8991,8 @@
 "arv" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/pickaxe/mini,
-/turf/open/floor/plating/astplate{
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -9776,7 +9806,7 @@
 "asX" = (
 /obj/structure/table,
 /obj/item/device/flashlight/lamp,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -9889,7 +9919,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -9935,7 +9965,6 @@
 "ato" = (
 /obj/structure/table/wood,
 /obj/item/weapon/paper_bin,
-/obj/item/weapon/stamp/cmo,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -9994,7 +10023,6 @@
 "atw" = (
 /obj/structure/table/wood,
 /obj/item/weapon/paper_bin,
-/obj/item/weapon/stamp/ce,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -10048,6 +10076,11 @@
 /obj/structure/cable/orange{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (EAST)";
+	icon_state = "ast_warn_end";
+	dir = 4
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -10342,7 +10375,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -10459,7 +10492,12 @@
 	pixel_x = -25;
 	pixel_y = 1
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (EAST)";
+	icon_state = "warn_end";
+	dir = 4
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/sleep_female)
@@ -10476,7 +10514,7 @@
 	},
 /obj/item/device/assembly/mousetrap/armed,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -10787,16 +10825,18 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
 	})
 "auZ" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plating/asteroid,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
 	})
@@ -10900,7 +10940,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -11243,6 +11283,11 @@
 /obj/structure/cable/orange{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (WEST)";
+	icon_state = "ast_warn_end";
+	dir = 8
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -11633,7 +11678,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -11694,7 +11739,12 @@
 	name = "Male Sleeping Quarters APC";
 	pixel_y = -24
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (EAST)";
+	icon_state = "warn_end";
+	dir = 4
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/sleep_male)
@@ -11713,7 +11763,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -11734,7 +11784,12 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (WEST)";
+	icon_state = "warn_end";
+	dir = 8
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/cmo{
@@ -12190,17 +12245,19 @@
 	dir = 1
 	},
 /obj/structure/closet/crate,
-/turf/open/floor/plating/asteroid,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
 	})
 "axE" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -12710,7 +12767,12 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (NORTH)";
+	icon_state = "warn_end";
+	dir = 1
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/courtroom)
@@ -12739,7 +12801,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -12754,11 +12816,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -12802,7 +12863,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -13044,7 +13105,6 @@
 "azh" = (
 /obj/structure/table/wood,
 /obj/item/weapon/paper_bin,
-/obj/item/weapon/stamp/rd,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -13109,6 +13169,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -13135,7 +13196,12 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (EAST)";
+	icon_state = "warn_end";
+	dir = 4
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -13152,6 +13218,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -13510,7 +13577,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -13522,12 +13589,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/item/device/assembly/mousetrap/armed,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/item/device/assembly/mousetrap/armed,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -13559,7 +13625,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -13583,6 +13649,11 @@
 /obj/structure/cable/orange{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (WEST)";
+	icon_state = "warn_end";
+	dir = 8
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -13874,6 +13945,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (EAST)";
+	icon_state = "ast_warn_end";
+	dir = 4
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -14168,6 +14244,7 @@
 /area/security/prison)
 "aBi" = (
 /obj/machinery/light,
+/obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -14342,7 +14419,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -14391,7 +14468,7 @@
 	dir = 6;
 	icon_state = "camera"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -14604,7 +14681,9 @@
 /obj/structure/closet/crate,
 /obj/item/weapon/coin/silver,
 /obj/item/weapon/coin/silver,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
 	})
@@ -14807,7 +14886,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -14821,7 +14900,7 @@
 	pixel_y = 0
 	},
 /obj/structure/rack,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -15070,7 +15149,6 @@
 	})
 "aCS" = (
 /obj/structure/closet/secure_closet/RD,
-/obj/item/clothing/mask/facehugger/lamarr,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -15215,6 +15293,11 @@
 /obj/structure/cable/orange{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (WEST)";
+	icon_state = "ast_warn_end";
+	dir = 8
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -15572,7 +15655,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -15807,7 +15890,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/astplate{
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -15827,8 +15911,8 @@
 	name = "Fore Asteroid Maintenance"
 	})
 "aEl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -15873,7 +15957,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/brown{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/quartermaster/office)
 "aEq" = (
@@ -15884,7 +15968,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/quartermaster/office)
 "aEr" = (
@@ -16417,7 +16501,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/grille/broken,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -16430,7 +16514,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/table,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -16451,6 +16535,11 @@
 	name = "Dorm Toilets APC";
 	pixel_y = -24
 	},
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (NORTH)";
+	icon_state = "warn_end";
+	dir = 1
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -16468,7 +16557,7 @@
 /obj/structure/sign/electricshock{
 	pixel_y = -32
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -16556,6 +16645,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -16579,6 +16669,11 @@
 /obj/structure/cable/orange{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (WEST)";
+	icon_state = "warn_end";
+	dir = 8
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -16790,7 +16885,6 @@
 "aFE" = (
 /obj/structure/table/wood,
 /obj/item/weapon/paper_bin,
-/obj/item/weapon/stamp/qm,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -17359,6 +17453,7 @@
 "aGG" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light,
+/obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -17677,7 +17772,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (EAST)";
+	icon_state = "warn_end";
+	dir = 4
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/quartermaster/qm{
@@ -17834,11 +17934,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -18365,6 +18464,7 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
+/obj/effect/turf_decal/stripes/asteroid/end,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -18384,7 +18484,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -18979,7 +19079,18 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (EAST)";
+	icon_state = "warn_end";
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Cargo Security Checkpoint APC";
+	pixel_x = -23;
+	pixel_y = 2
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/security/checkpoint/supply)
@@ -19011,7 +19122,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -19043,6 +19154,11 @@
 	name = "Detective's Office APC";
 	pixel_x = 23;
 	pixel_y = 2
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (WEST)";
+	icon_state = "ast_warn_end";
+	dir = 8
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -19231,7 +19347,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/device/assembly/mousetrap/armed,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -19423,7 +19539,12 @@
 	pixel_x = -23;
 	pixel_y = 2
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (EAST)";
+	icon_state = "warn_end";
+	dir = 4
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -19603,6 +19724,7 @@
 /obj/structure/closet/crate,
 /obj/item/weapon/coin/silver,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
@@ -19616,6 +19738,7 @@
 "aKG" = (
 /obj/machinery/light/small,
 /obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
@@ -20453,7 +20576,7 @@
 	dir = 6;
 	icon_state = "camera"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -20461,7 +20584,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -20476,6 +20599,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -20494,7 +20618,7 @@
 /obj/structure/sign/electricshock{
 	pixel_y = 32
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -20732,6 +20856,11 @@
 	pixel_x = -25;
 	pixel_y = 1
 	},
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (EAST)";
+	icon_state = "warn_end";
+	dir = 4
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -20754,6 +20883,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -20770,7 +20900,7 @@
 	icon_state = "camera"
 	},
 /obj/structure/chair/stool,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -21082,7 +21212,7 @@
 "aNj" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -21103,7 +21233,7 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -21119,7 +21249,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -21132,7 +21262,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -21244,7 +21374,9 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/space/fragile,
 /obj/item/clothing/head/helmet/space/fragile,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
 	})
@@ -21259,7 +21391,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -21275,6 +21407,11 @@
 /obj/structure/cable/orange{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (WEST)";
+	icon_state = "ast_warn_end";
+	dir = 8
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -21310,11 +21447,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -21350,7 +21486,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -21365,7 +21501,7 @@
 	pixel_y = 1;
 	d2 = 2
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -21546,7 +21682,7 @@
 "aNX" = (
 /obj/machinery/light/small,
 /obj/structure/closet/emcloset,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -21704,7 +21840,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -21745,7 +21881,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/computer/station_alert,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -21969,7 +22105,7 @@
 "aOE" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -22004,11 +22140,10 @@
 	})
 "aOI" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -22034,7 +22169,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -22050,7 +22185,7 @@
 /obj/structure/sign/electricshock{
 	pixel_x = 32
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -22611,7 +22746,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -22626,7 +22761,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -23854,6 +23989,11 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/brown/corner{
 	tag = "icon-browncorner (EAST)";
 	icon_state = "browncorner";
@@ -23917,7 +24057,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -23930,7 +24070,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -24367,15 +24507,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -24418,7 +24557,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/weapon/stock_parts/cell/high,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -24908,6 +25047,10 @@
 /area/hallway/primary/fore)
 "aSX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/neutral/corner{
 	icon_state = "neutralcorner";
 	dir = 8;
@@ -25372,7 +25515,9 @@
 "aTL" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
 	})
@@ -26046,11 +26191,10 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -26331,7 +26475,9 @@
 "aVo" = (
 /obj/machinery/light/small,
 /obj/item/device/assembly/mousetrap/armed,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/fore{
 	name = "Fore Asteroid Maintenance"
 	})
@@ -26861,7 +27007,7 @@
 	name = "Cargo SMES Access";
 	req_access_txt = "10;11;12"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -26878,7 +27024,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -26888,7 +27034,7 @@
 	dir = 6;
 	icon_state = "camera"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -27080,6 +27226,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (WEST)";
+	icon_state = "warn_end";
+	dir = 8
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -27253,7 +27404,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
@@ -29834,6 +29985,7 @@
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -29954,6 +30106,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/turf_decal/stripes/asteroid/end,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -30121,8 +30274,8 @@
 "bbW" = (
 /obj/structure/cable/orange{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -31178,25 +31331,16 @@
 	name = "Port Asteroid Maintenance"
 	})
 "bdP" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Port Asteroid Maintence APC";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/orange{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/power/terminal{
+	tag = "icon-term (EAST)";
+	icon_state = "term";
 	dir = 4
 	},
-/turf/open/floor/plating{
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -31488,7 +31632,7 @@
 "bes" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/starboard)
@@ -31499,7 +31643,7 @@
 	icon_state = "camera"
 	},
 /obj/structure/chair/stool,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/starboard)
@@ -31563,17 +31707,26 @@
 	},
 /area/hallway/primary/starboard)
 "beA" = (
-/obj/structure/girder,
-/obj/structure/grille/broken,
-/turf/open/floor/plating/asteroid,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/device/assembly/mousetrap/armed,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
 "beB" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -31949,7 +32102,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/starboard)
@@ -31964,7 +32117,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/starboard)
@@ -31983,6 +32136,11 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (WEST)";
+	icon_state = "warn_end";
+	dir = 8
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -32035,17 +32193,10 @@
 	},
 /area/hallway/primary/starboard)
 "bfp" = (
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating{
+/turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
+/area/crew_quarters/theatre)
 "bfq" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -32541,7 +32692,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/starboard)
@@ -32557,7 +32708,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/starboard)
@@ -32640,21 +32791,10 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "bgt" = (
-/obj/machinery/power/terminal{
-	tag = "icon-term (EAST)";
-	icon_state = "term";
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/turf/open/floor/plating{
+/turf/open/floor/wood{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
+/area/crew_quarters/theatre)
 "bgu" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable/orange,
@@ -32995,7 +33135,7 @@
 	name = "Medbay SMES Access";
 	req_access_txt = "10;11;12"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/starboard)
@@ -33034,13 +33174,10 @@
 	},
 /area/hallway/primary/starboard)
 "bha" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
@@ -33089,31 +33226,26 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "bhi" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
+/area/crew_quarters/theatre)
 "bhj" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/window{
+	tag = "icon-window (EAST)";
+	icon_state = "window";
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stage_left{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
+/area/crew_quarters/theatre)
 "bhk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -33129,34 +33261,17 @@
 	name = "Port Asteroid Maintenance"
 	})
 "bhl" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal{
-	tag = "icon-term (EAST)";
-	icon_state = "term";
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/sign/electricshock{
-	pixel_y = -32
-	},
-/turf/open/floor/plating{
+/turf/open/floor/wood{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
+/area/crew_quarters/theatre)
 "bhm" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner{
 	icon_state = "neutralcorner";
 	dir = 8;
@@ -33915,13 +34030,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
@@ -33986,37 +34098,20 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "biu" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Serivce SMES Access";
-	req_access_txt = "10;11;12"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
+/area/crew_quarters/theatre)
 "biv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window{
+	tag = "icon-window (EAST)";
+	icon_state = "window";
+	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Serivce SMES Access";
-	req_access_txt = "10;11;12"
-	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/stage_left{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
+/area/crew_quarters/theatre)
 "biw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -34426,17 +34521,14 @@
 	dir = 8
 	},
 /obj/structure/closet/crate,
-/turf/open/floor/plating/astplate{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
 "bjf" = (
 /obj/structure/closet/firecloset/full,
-/turf/open/floor/plating/astplate{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
@@ -34453,12 +34545,18 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (NORTH)";
+	icon_state = "ast_warn_end";
+	dir = 1
+	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/surgery)
 "bji" = (
 /obj/machinery/light/small,
+/obj/structure/closet,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -34472,44 +34570,37 @@
 	icon_state = "1-4"
 	},
 /obj/structure/grille/broken,
-/turf/open/floor/plating/astplate{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
 "bjk" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/rack,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
-	dir = 1
-	},
-/turf/open/floor/plating/astplate{
+/obj/effect/spawner/lootdrop/costume,
+/obj/effect/spawner/lootdrop/costume,
+/turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
+/area/crew_quarters/theatre)
 "bjl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window{
+	tag = "icon-window (EAST)";
+	icon_state = "window";
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
-	dir = 1
+/obj/structure/rack,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/spawner/lootdrop/costume,
+/obj/effect/spawner/lootdrop/costume,
+/turf/open/floor/plasteel/stage_left{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/maintenance/port{
-	name = "Port Asteroid Maintenance"
-	})
+/area/crew_quarters/theatre)
 "bjm" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -35272,23 +35363,20 @@
 	},
 /area/medical/virology)
 "bkO" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 2;
-	on = 1
-	},
-/turf/open/floor/plasteel/white{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/medical/virology)
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "bkP" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/turf/open/floor/plasteel/white{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/medical/virology)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "bkQ" = (
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -35320,34 +35408,32 @@
 	name = "Starboard Asteroid Maintenance"
 	})
 "bkT" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
 "bkU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -35363,7 +35449,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -35382,7 +35468,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -35398,11 +35484,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -35699,62 +35784,59 @@
 	},
 /area/hallway/primary/starboard)
 "bly" = (
-/obj/structure/bodycontainer/morgue,
-/obj/effect/landmark/revenantspawn,
-/turf/open/floor/plasteel/black{
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/hallway/primary/starboard)
 "blz" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black{
+/turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/medical/cmo)
 "blA" = (
-/obj/machinery/airalarm{
-	frequency = 1439;
-	locked = 0;
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/black{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/medical/morgue)
-"blB" = (
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 2;
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
 	on = 1
 	},
-/turf/open/floor/plasteel/black{
+/turf/open/floor/plasteel/barber{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/medical/cmo)
+"blB" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
 "blC" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Morgue APC";
-	pixel_x = 0;
-	pixel_y = 24
-	},
 /obj/structure/table,
-/obj/item/weapon/storage/box/bodybags,
-/obj/item/weapon/pen,
-/obj/structure/cable/orange{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/item/weapon/cartridge/medical{
+	pixel_x = -2;
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel/black{
+/obj/item/weapon/cartridge/medical{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/weapon/cartridge/medical,
+/obj/item/weapon/cartridge/chemistry{
+	pixel_y = 2
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/barber{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/medical/cmo)
 "blD" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet,
@@ -35862,12 +35944,14 @@
 	},
 /area/medical/virology)
 "blQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel/white{
-	baseturf = /turf/open/floor/plating/asteroid/airless
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/area/medical/virology)
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "blR" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -35901,21 +35985,21 @@
 	name = "Port Asteroid Maintenance"
 	})
 "blU" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -35931,7 +36015,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -35961,11 +36045,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -36317,23 +36400,20 @@
 	},
 /area/medical/morgue)
 "bmA" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 2;
+	on = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black{
+/turf/open/floor/plasteel/barber{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/medical/cmo)
 "bmB" = (
-/obj/structure/table,
-/obj/item/weapon/paper/morguereminder,
-/turf/open/floor/plasteel/black{
+/turf/open/floor/plasteel/barber{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/medical/cmo)
 "bmC" = (
 /obj/structure/table,
 /obj/item/weapon/folder/red{
@@ -36427,7 +36507,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -36707,10 +36787,19 @@
 	},
 /area/engine/supermatter)
 "bnk" = (
-/turf/open/floor/plating{
+/obj/machinery/computer/station_alert,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer RC";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/engineering)
+/area/crew_quarters/chief)
 "bnl" = (
 /obj/machinery/light,
 /turf/open/floor/plating{
@@ -37023,13 +37112,20 @@
 	},
 /area/hallway/primary/starboard)
 "bnC" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/black{
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Chief Medical Officer's Office APC";
+	pixel_x = 23;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/barber{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/medical/cmo)
 "bnD" = (
 /obj/machinery/button/door{
 	id = "medp1";
@@ -37105,7 +37201,7 @@
 	density = 0;
 	layer = 4
 	},
-/turf/closed/wall{
+/turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/surgery)
@@ -37849,14 +37945,10 @@
 	},
 /area/hallway/primary/starboard)
 "boS" = (
-/obj/machinery/door/airlock/medical{
-	name = "Morgue";
-	req_access_txt = "6;5"
-	},
-/turf/open/floor/plasteel/black{
+/turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/hallway/primary/starboard)
 "boT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
@@ -37875,41 +37967,23 @@
 	},
 /area/medical/morgue)
 "boV" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black{
+/obj/machinery/light,
+/turf/open/floor/plasteel/barber{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/medical/cmo)
 "boW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Morgue";
-	dir = 10;
-	icon_state = "camera";
-	network = list("SS13","CMO");
-	tag = "icon-camera (SOUTHWEST)"
-	},
-/turf/open/floor/plasteel/black{
+/mob/living/simple_animal/pet/cat/Runtime,
+/turf/open/floor/plasteel/barber{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/medical/cmo)
 "boX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/black{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/barber{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/medical/cmo)
 "boY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -38055,10 +38129,6 @@
 	dir = 4;
 	on = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -38079,9 +38149,6 @@
 	},
 /area/medical/virology)
 "bpn" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -38155,7 +38222,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/closed/wall{
+/turf/closed/wall/rust{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -38582,26 +38649,31 @@
 	},
 /area/security/checkpoint/medical)
 "bqc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/medical/cmo)
 "bqd" = (
-/obj/machinery/door/airlock/medical{
-	name = "Morgue";
-	req_access_txt = "6"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = null;
+	name = "Chief Medical Officer's Office";
+	req_access_txt = "40"
 	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black{
+/turf/open/floor/plasteel/barber{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/medical/cmo)
 "bqe" = (
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -38860,7 +38932,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/closed/wall,
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
@@ -39551,7 +39625,10 @@
 /area/security/checkpoint/medical)
 "brC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/white{
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1;
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/medbay)
@@ -39565,7 +39642,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white{
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1;
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/medbay)
@@ -39746,7 +39827,7 @@
 	dir = 5;
 	icon_state = "camera";
 	network = list("SS13","CMO");
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -40403,6 +40484,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -41428,6 +41510,10 @@
 /area/medical/medbay)
 "buI" = (
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -42539,7 +42625,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -43044,7 +43130,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/maintcentral{
@@ -43063,11 +43149,10 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/maintcentral{
@@ -43086,11 +43171,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/maintcentral{
@@ -43113,7 +43197,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/maintcentral{
@@ -43126,7 +43210,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/maintcentral{
@@ -43408,9 +43492,9 @@
 /area/medical/medbay)
 "bxY" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell{
-	tag = "icon-cell-off (WEST)";
+	dir = 8;
 	icon_state = "cell-off";
-	dir = 8
+	tag = ""
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -43456,6 +43540,11 @@
 /obj/structure/cable/orange{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (EAST)";
+	icon_state = "ast_warn_end";
+	dir = 4
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -43713,6 +43802,10 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "engineeringlockdown";
+	name = "Emergency Lockdown Blastdoor"
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -43731,6 +43824,10 @@
 	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "engineeringlockdown";
+	name = "Emergency Lockdown Blastdoor"
+	},
 /turf/open/floor/plasteel/yellow{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -43739,6 +43836,10 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "engineeringlockdown";
+	name = "Emergency Lockdown Blastdoor"
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -43842,6 +43943,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id = "engineeringlockdown";
+	name = "Emergency Lockdown Blastdoor"
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -43860,6 +43965,10 @@
 	name = "Engineering Foyer";
 	req_access_txt = "0";
 	req_one_access_txt = "10;24"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "engineeringlockdown";
+	name = "Emergency Lockdown Blastdoor"
 	},
 /turf/open/floor/plasteel/yellow{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -43894,7 +44003,9 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
@@ -44155,6 +44266,13 @@
 	},
 /area/medical/genetics_cloning)
 "bzo" = (
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
 	icon_state = "whiteblue";
@@ -44246,7 +44364,7 @@
 /area/awaymission/research/interior/gateway)
 "bzx" = (
 /obj/item/clothing/head/cone,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -44363,6 +44481,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/sign/poster/contraband/have_a_puff{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/hydrofloor{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -44398,7 +44519,7 @@
 	icon_state = "ast_warn";
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -44645,7 +44766,7 @@
 "bAe" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/maintcentral{
@@ -44782,7 +44903,9 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -44799,6 +44922,14 @@
 /area/medical/genetics_cloning)
 "bAv" = (
 /obj/machinery/dna_scannernew,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
 	icon_state = "whiteblue";
@@ -45254,6 +45385,7 @@
 	pixel_x = -28;
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -45304,7 +45436,7 @@
 	dir = 5;
 	icon_state = "camera";
 	network = list("SS13");
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -45339,6 +45471,11 @@
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
@@ -45876,8 +46013,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j1"
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -45958,6 +46096,11 @@
 	icon_state = "tube1";
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
 	icon_state = "whiteblue";
@@ -45966,20 +46109,17 @@
 	},
 /area/medical/genetics_cloning)
 "bCD" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Cloning APC";
-	pixel_x = -25;
-	pixel_y = 1
+/obj/structure/bodycontainer/morgue,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/obj/structure/cable/orange{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/effect/landmark/revenantspawn,
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
 	},
-/turf/open/floor/plating/astplate{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/medical/genetics_cloning)
+/area/medical/morgue)
 "bCE" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -45988,7 +46128,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -46009,7 +46149,7 @@
 	dir = 4
 	},
 /obj/item/device/assembly/mousetrap/armed,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -46022,7 +46162,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -46164,6 +46304,11 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (EAST)";
+	icon_state = "ast_warn_end";
+	dir = 4
+	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -46217,6 +46362,7 @@
 	dir = 8
 	},
 /obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/maintcentral{
@@ -46903,14 +47049,17 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -46923,6 +47072,14 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -46970,7 +47127,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -47506,6 +47663,11 @@
 	network = list("SS13","CMO");
 	tag = "icon-camera (SOUTHWEST)"
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -47518,6 +47680,16 @@
 	},
 /obj/item/weapon/storage/box/bodybags,
 /obj/item/weapon/pen,
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Cloning Lab APC";
+	pixel_x = 23;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -47720,6 +47892,7 @@
 	})
 "bFr" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/rack,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -48212,7 +48385,9 @@
 "bGn" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
@@ -48358,6 +48533,11 @@
 /obj/structure/cable/orange{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (EAST)";
+	icon_state = "ast_warn_end";
+	dir = 4
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -48854,7 +49034,9 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/weapon/electronics/airlock,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
@@ -49144,6 +49326,8 @@
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-20";
+	light_color = "#E1E17D";
+	light_range = 5;
 	luminosity = 2;
 	tag = "icon-plant-20"
 	},
@@ -49184,7 +49368,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -49613,6 +49796,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/rack,
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -50159,6 +50343,7 @@
 	icon_state = "1-4";
 	tag = ""
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -50186,6 +50371,11 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -51122,6 +51312,12 @@
 /area/engine/engineering)
 "bLn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -51138,6 +51334,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -51530,6 +51727,7 @@
 "bMc" = (
 /obj/structure/table,
 /obj/item/weapon/storage/fancy/cigarettes,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
@@ -51793,6 +51991,7 @@
 	icon_state = "camera";
 	network = list("SS13","CE")
 	},
+/obj/machinery/vending/tool,
 /turf/open/floor/plasteel/yellow/side{
 	tag = "icon-yellow (WEST)";
 	icon_state = "yellow";
@@ -51808,12 +52007,20 @@
 	},
 /area/engine/engineering)
 "bMG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/electrical{
 	pixel_x = -4;
 	pixel_x = 1;
 	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -51822,6 +52029,10 @@
 "bMH" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/engineering_construction,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -52056,6 +52267,7 @@
 /obj/structure/rack,
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/weapon/weldingtool/hugetank,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -52368,18 +52580,25 @@
 	},
 /area/atmos)
 "bNG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/yellow/side{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
 "bNH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/yellow/side{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
@@ -52516,11 +52735,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -52537,7 +52755,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/chemistry)
@@ -52728,9 +52947,7 @@
 	dir = 4
 	},
 /obj/structure/grille/broken,
-/turf/open/floor/plating/astplate{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
@@ -52738,13 +52955,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
@@ -52822,7 +53036,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/port{
@@ -52839,7 +53053,12 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (WEST)";
+	icon_state = "warn_end";
+	dir = 8
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/fitness)
@@ -53098,33 +53317,59 @@
 	},
 /area/engine/engineering)
 "bOX" = (
-/obj/machinery/vending/tool,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/engineering)
+/area/crew_quarters/chief)
 "bOY" = (
-/obj/structure/closet/secure_closet/engineering_welding,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/engineering)
+/area/crew_quarters/chief)
 "bOZ" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/engineering)
+/area/crew_quarters/chief)
 "bPa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53134,25 +53379,22 @@
 	},
 /area/engine/engineering)
 "bPb" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/engineering)
+/area/crew_quarters/chief)
 "bPc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/enginesafety{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/yellow/side{
-	baseturf = /turf/open/floor/plating/asteroid/airless
-	},
-/area/engine/engineering)
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/crew_quarters/chief)
 "bPd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -53176,20 +53418,18 @@
 	},
 /area/engine/engineering)
 "bPe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/side{
+	tag = "icon-yellow (SOUTHWEST)";
+	icon_state = "yellow";
+	dir = 10;
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/engineering)
@@ -53572,11 +53812,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -53591,7 +53830,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -53607,7 +53846,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -53960,6 +54199,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/orange,
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (EAST)";
+	icon_state = "ast_warn_end";
+	dir = 4
+	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -54067,24 +54311,43 @@
 	},
 /area/atmos)
 "bQx" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4
+/obj/machinery/computer/card/minor/ce,
+/obj/machinery/button/door{
+	id = "engiestoragesmes";
+	name = "Engineering SMES Blast Door Control";
+	pixel_x = -24;
+	pixel_y = 0;
+	req_access_txt = "10;11"
 	},
-/turf/closed/wall,
-/area/engine/engineering)
-"bQy" = (
-/turf/closed/wall,
-/area/engine/engineering)
-"bQz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Engineering Miscellaneous Storage";
-	req_access_txt = "10"
+/obj/machinery/button/door{
+	id = "engineeringlockdown";
+	name = "Engineering SMES Blast Door Control";
+	pixel_x = -24;
+	pixel_y = 8;
+	req_access_txt = "10;11"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/engineering)
+/area/crew_quarters/chief)
+"bQy" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"bQz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
 "bQA" = (
 /obj/machinery/door/airlock/engineering{
 	cyclelinkeddir = null;
@@ -54236,7 +54499,9 @@
 /area/hallway/primary/starboard)
 "bQM" = (
 /obj/structure/closet/firecloset/full,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
@@ -54248,7 +54513,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/device/assembly/mousetrap/armed,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -54288,7 +54553,8 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/genetics)
@@ -54304,11 +54570,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -54979,7 +55244,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -54996,17 +55261,17 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/medbay2)
 "bRV" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -55014,7 +55279,9 @@
 	})
 "bRW" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
@@ -55028,7 +55295,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -55395,55 +55662,59 @@
 	},
 /area/atmos)
 "bSJ" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating{
+/obj/machinery/computer/apc_control,
+/turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/engineering)
+/area/crew_quarters/chief)
 "bSK" = (
-/obj/machinery/light/small,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating{
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/engineering)
+/area/crew_quarters/chief)
 "bSL" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plating{
+/obj/machinery/suit_storage_unit/ce,
+/turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/engineering)
+/area/crew_quarters/chief)
 "bSM" = (
-/obj/structure/closet/crate{
-	name = "solar pack crate"
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
 	},
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/weapon/circuitboard/computer/solar_control,
-/obj/item/weapon/electronics/tracker,
-/obj/item/weapon/paper/solar,
-/obj/machinery/light/small,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/engineering)
+/area/crew_quarters/chief)
 "bSN" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plating{
+/obj/item/weapon/twohanded/required/kirbyplants{
+	tag = "icon-plant-21";
+	icon_state = "plant-21"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Chief Engineer's Office APC";
+	pixel_x = 23;
+	pixel_y = 2
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/engineering)
+/area/crew_quarters/chief)
 "bSO" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/engineering_particle_accelerator,
@@ -55582,7 +55853,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -55613,7 +55884,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -55629,7 +55900,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -55644,7 +55915,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -55665,7 +55936,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -55681,7 +55952,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -55699,7 +55970,7 @@
 	name = "disposal pipe - Atmospherics";
 	sortType = 6
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -55717,7 +55988,7 @@
 	name = "disposal pipe - Engineering";
 	sortType = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -55737,7 +56008,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -56037,7 +56308,7 @@
 	dir = 5
 	},
 /turf/closed/wall,
-/area/atmos)
+/area/crew_quarters/chief)
 "bTM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56045,7 +56316,7 @@
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/atmos)
+/area/crew_quarters/chief)
 "bTN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -56053,7 +56324,7 @@
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/atmos)
+/area/crew_quarters/chief)
 "bTO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -56061,7 +56332,7 @@
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/atmos)
+/area/crew_quarters/chief)
 "bTP" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/engineering_construction,
@@ -56190,6 +56461,8 @@
 /area/engine/engine_smes)
 "bUa" = (
 /obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
@@ -56238,7 +56511,10 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -56249,7 +56525,7 @@
 	icon_state = "pipe-j1";
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/starboard{
@@ -56257,7 +56533,9 @@
 	})
 "bUg" = (
 /obj/machinery/light/small,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
@@ -57514,14 +57792,13 @@
 	},
 /area/atmos)
 "bWD" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
-	dir = 1
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/maintcentral{
@@ -57671,7 +57948,9 @@
 "bWU" = (
 /obj/machinery/light/small,
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
@@ -57824,6 +58103,7 @@
 "bXk" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/pickaxe/emergency,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
@@ -58755,6 +59035,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (WEST)";
+	icon_state = "ast_warn_end";
+	dir = 8
+	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -59397,11 +59682,10 @@
 	name = "Central Asteroid Maintenance"
 	})
 "caf" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/maintcentral{
@@ -59606,6 +59890,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/orange,
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (EAST)";
+	icon_state = "ast_warn_end";
+	dir = 4
+	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -60083,7 +60372,9 @@
 /obj/structure/rack,
 /obj/item/weapon/pickaxe/emergency,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
@@ -60294,6 +60585,7 @@
 /area/atmos)
 "cbT" = (
 /obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -60351,7 +60643,10 @@
 /obj/structure/rack,
 /obj/item/weapon/pickaxe/emergency,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/asteroid,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/port{
 	name = "Port Asteroid Maintenance"
 	})
@@ -60933,7 +61228,10 @@
 	icon_state = "crateopen";
 	opened = 1
 	},
-/turf/open/floor/plating/asteroid,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/maintcentral{
 	name = "Central Asteroid Maintenance"
 	})
@@ -60985,6 +61283,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb,
+/obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -62174,7 +62473,6 @@
 "cfu" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/clown,
-/obj/effect/landmark/start/clown,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -62273,6 +62571,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/pie/cream,
 /obj/item/weapon/storage/box/mousetraps,
 /obj/item/weapon/storage/crayons,
+/obj/item/clothing/mask/joy,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -62785,7 +63084,9 @@
 /area/hallway/primary/starboard)
 "cgC" = (
 /obj/structure/ore_box,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
@@ -62793,7 +63094,9 @@
 /obj/item/weapon/ore/iron,
 /obj/item/weapon/ore/iron,
 /obj/item/weapon/ore/iron,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
@@ -62854,7 +63157,10 @@
 /area/hallway/primary/starboard)
 "cgK" = (
 /obj/item/weapon/storage/bag/ore,
-/turf/open/floor/plating/asteroid,
+/obj/item/weapon/pickaxe/mini,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
@@ -63741,6 +64047,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (WEST)";
+	icon_state = "warn_end";
+	dir = 8
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -64057,7 +64368,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/portsolar{
@@ -64275,11 +64586,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -64516,7 +64826,9 @@
 /obj/structure/rack,
 /obj/item/weapon/pickaxe,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
@@ -64812,6 +65124,11 @@
 /obj/structure/cable/orange{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (EAST)";
+	icon_state = "warn_end";
+	dir = 4
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -65163,7 +65480,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -65187,7 +65504,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -65207,7 +65524,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -65252,6 +65569,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (NORTH)";
+	icon_state = "ast_warn_end";
+	dir = 1
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -65531,7 +65853,7 @@
 "clR" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable/orange,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -65564,7 +65886,7 @@
 	pixel_x = 0;
 	tag = ""
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -65578,7 +65900,7 @@
 	tag = ""
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -65586,7 +65908,12 @@
 	})
 "clV" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating/asteroid,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
@@ -65825,7 +66152,8 @@
 	icon_state = "1-4"
 	},
 /obj/structure/grille/broken,
-/turf/open/floor/plating/astplate{
+/obj/item/stack/rods,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -66168,7 +66496,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
@@ -66239,7 +66569,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/device/assembly/mousetrap/armed,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -66312,6 +66642,11 @@
 /obj/structure/cable/orange{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (WEST)";
+	icon_state = "ast_warn_end";
+	dir = 8
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -66720,7 +67055,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating/astplate{
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -67264,6 +67601,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (NORTH)";
+	icon_state = "ast_warn_end";
+	dir = 1
+	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -67278,7 +67620,7 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -67344,11 +67686,10 @@
 	name = "Aft Asteroid Maintenance"
 	})
 "coK" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -67363,7 +67704,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -67701,11 +68042,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -67763,11 +68103,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -69559,7 +69898,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -69863,7 +70202,12 @@
 	name = "Arrivals APC";
 	pixel_y = -24
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (NORTH)";
+	icon_state = "warn_end";
+	dir = 1
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -69875,8 +70219,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -70497,6 +70841,10 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "RoboticsShutters"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "researchlockdown";
+	name = "Research Emergency Lockdown"
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -70510,6 +70858,10 @@
 /obj/machinery/door/window/northright{
 	name = "Robotics Desk";
 	req_access_txt = "29"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "researchlockdown";
+	name = "Research Emergency Lockdown"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -70532,6 +70884,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "researchlockdown";
+	name = "Research Emergency Lockdown"
 	},
 /turf/open/floor/plasteel/whitepurple{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -70561,6 +70917,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "researchlockdown";
+	name = "Research Emergency Lockdown"
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -70577,6 +70937,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "researchlockdown";
+	name = "Research Emergency Lockdown"
 	},
 /turf/open/floor/plasteel/purple{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -70595,6 +70959,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "researchlockdown";
+	name = "Research Emergency Lockdown"
+	},
 /turf/open/floor/plasteel/purple{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -70612,7 +70980,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/aft)
@@ -71373,7 +71741,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/aft)
@@ -71393,7 +71761,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/aft)
@@ -71407,6 +71775,11 @@
 /obj/structure/cable/orange{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (EAST)";
+	icon_state = "ast_warn_end";
+	dir = 4
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -71851,7 +72224,7 @@
 /area/toxins/lab)
 "cwp" = (
 /obj/structure/closet/toolcloset,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/aft)
@@ -71874,7 +72247,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/aft)
@@ -72467,6 +72840,11 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (WEST)";
+	icon_state = "warn_end";
+	dir = 8
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -72757,7 +73135,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/chair/stool,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/aft)
@@ -73188,6 +73566,11 @@
 	pixel_x = -25
 	},
 /obj/structure/cable/orange,
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (NORTH)";
+	icon_state = "warn_end";
+	dir = 1
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -73200,14 +73583,14 @@
 /obj/structure/sign/electricshock{
 	pixel_y = -32
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/aft)
 "cyE" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable/orange,
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/aft)
@@ -73418,20 +73801,24 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/whitepurple/side{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/mixing)
 "czi" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/whitepurple/side{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/mixing)
 "czj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/whitepurple/corner{
 	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
@@ -73454,6 +73841,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/closet/wardrobe/science_white,
 /turf/open/floor/plasteel/whitepurple/side{
 	tag = "icon-whitepurple (NORTHEAST)";
 	icon_state = "whitepurple";
@@ -73981,13 +74369,17 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -74802,6 +75194,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	on = 1
+	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -75099,6 +75495,11 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -75359,31 +75760,40 @@
 	},
 /area/toxins/storage)
 "cBV" = (
-/turf/closed/wall{
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cBW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cBX" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
-	req_access_txt = "8"
+/obj/machinery/door/airlock/glass_research{
+	name = "Research Director's Office";
+	req_access_txt = "30"
 	},
 /turf/open/floor/plasteel/whitepurple{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cBY" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cBZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -75674,6 +76084,11 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (EAST)";
+	icon_state = "ast_warn_end";
+	dir = 4
+	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -75788,6 +76203,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/turf_decal/stripes/asteroid/end,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -75850,18 +76266,27 @@
 	name = "Research Division"
 	})
 "cCM" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
+/obj/structure/table,
+/obj/item/weapon/cartridge/signal/toxins,
+/obj/item/weapon/cartridge/signal/toxins{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/weapon/cartridge/signal/toxins{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cCN" = (
+/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
+/turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cCO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -75872,14 +76297,11 @@
 	},
 /area/toxins/storage)
 "cCP" = (
-/obj/machinery/portable_atmospherics/scrubber/huge/movable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cCQ" = (
 /obj/machinery/portable_atmospherics/scrubber/huge/movable,
 /turf/open/floor/plasteel{
@@ -76316,12 +76738,11 @@
 	},
 /area/toxins/storage)
 "cDF" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
+/obj/machinery/suit_storage_unit/rd,
+/turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cDG" = (
 /obj/structure/table,
 /obj/machinery/newscaster/security_unit{
@@ -76673,25 +77094,22 @@
 	},
 /area/toxins/server)
 "cEj" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel{
+/obj/machinery/modular_computer/console/preset/research,
+/turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cEk" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/camera{
-	c_tag = "Toxins Storage";
-	dir = 9;
-	icon_state = "camera";
-	network = list("SS13","RD");
-	tag = "icon-camera (NORTHWEST)"
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/aicore{
+	pixel_x = -2;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	baseturf = /turf/open/floor/plating/asteroid/airless
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/area/toxins/storage)
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/hor)
 "cEl" = (
 /obj/machinery/computer/secure_data,
 /obj/item/device/radio/intercom{
@@ -77044,7 +77462,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/closed/mineral,
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
@@ -77092,6 +77512,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/device/assembly/mousetrap/armed,
+/obj/item/stack/sheet/metal,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -77107,12 +77528,15 @@
 	name = "Aft Asteroid Maintenance"
 	})
 "cES" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	baseturf = /turf/open/floor/plating/asteroid/airless
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/area/toxins/storage)
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/hor)
 "cET" = (
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -77241,10 +77665,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -77265,6 +77688,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -77290,6 +77714,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/turf_decal/stripes/asteroid/end,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -77312,34 +77737,32 @@
 	name = "Aft Asteroid Maintenance"
 	})
 "cFi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 1;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
+/obj/machinery/light_switch{
+	pixel_y = -23
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel{
+/obj/item/weapon/twohanded/required/kirbyplants/dead,
+/turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cFj" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel{
+/obj/machinery/computer/card/minor/rd,
+/obj/machinery/camera{
+	c_tag = "Research Director's Office";
+	dir = 1;
+	icon_state = "camera";
+	network = list("SS13")
+	},
+/turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cFk" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel{
-	baseturf = /turf/open/floor/plating/asteroid/airless
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/area/toxins/storage)
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/hor)
 "cFl" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -77442,11 +77865,8 @@
 	name = "Aft Asteroid Maintenance"
 	})
 "cFu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plating/astplate{
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -77478,6 +77898,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -77587,7 +78008,9 @@
 "cFH" = (
 /obj/machinery/light/small,
 /obj/structure/closet/firecloset/full,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
@@ -77606,7 +78029,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	name = "Toxins Storage APC";
+	name = "Research Director's Office APC";
 	pixel_x = 0;
 	pixel_y = 25
 	},
@@ -77619,10 +78042,11 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/effect/turf_decal/stripes/asteroid/end,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cFK" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -77698,7 +78122,7 @@
 	dir = 2;
 	on = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -77709,7 +78133,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -77816,6 +78240,7 @@
 	icon_state = "tube1";
 	dir = 8
 	},
+/obj/item/device/radio/beacon,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -77899,6 +78324,7 @@
 /area/toxins/misc_lab)
 "cGg" = (
 /obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
@@ -78140,6 +78566,7 @@
 	},
 /area/hallway/secondary/entry)
 "cGE" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating/asteroid,
 /area/hallway/secondary/entry)
 "cGF" = (
@@ -78278,7 +78705,7 @@
 "cGU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/grille,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -78410,7 +78837,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/device/assembly/mousetrap/armed,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -78490,7 +78917,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -78534,7 +78961,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/misc_lab)
@@ -78548,7 +78976,7 @@
 	dir = 4
 	},
 /obj/item/device/assembly/mousetrap/armed,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -79629,7 +80057,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -79662,7 +80090,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -79766,6 +80194,7 @@
 	pixel_x = 32;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -80388,6 +80817,11 @@
 /obj/structure/cable/orange{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end{
+	tag = "icon-ast_warn_end (EAST)";
+	icon_state = "ast_warn_end";
+	dir = 4
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -81871,7 +82305,7 @@
 "cOf" = (
 /obj/structure/grille/broken,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -82021,7 +82455,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -82187,15 +82621,14 @@
 	},
 /area/quartermaster/office)
 "cOD" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	icon_state = "ast_warn";
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/fore{
@@ -84477,7 +84910,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/astplate{
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (NORTH)";
+	icon_state = "warn_end";
+	dir = 1
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -84496,7 +84934,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/astplate{
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/maintenance/aft{
@@ -85355,10 +85793,10 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/closed/wall{
+/turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cWm" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -85376,7 +85814,7 @@
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cWo" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall{
@@ -85397,7 +85835,7 @@
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/toxins/storage)
+/area/crew_quarters/hor)
 "cWr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85813,6 +86251,13 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/whitepurple/side{
 	tag = "icon-whitepurple (SOUTHWEST)";
 	icon_state = "whitepurple";
@@ -85821,6 +86266,9 @@
 	},
 /area/toxins/mixing)
 "cXZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	tag = "icon-whitepurplecorner (WEST)";
 	icon_state = "whitepurplecorner";
@@ -85829,10 +86277,13 @@
 	},
 /area/toxins/mixing)
 "cYa" = (
-/obj/structure/closet/wardrobe/science_white,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -85862,6 +86313,1580 @@
 	},
 /area/toxins/mixing)
 "cYd" = (
+/obj/item/clothing/head/sombrero/shamebrero,
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"cYe" = (
+/obj/structure/sign/poster/contraband/borg_fancy_1{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/ai_monitored/turret_protected/AIsatextFP{
+	name = "AI Satellite Service"
+	})
+"cYf" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYg" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYj" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYk" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYl" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYm" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYn" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYo" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYp" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYq" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYs" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYt" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYu" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYv" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYw" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYx" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYy" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYz" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYA" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYB" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYC" = (
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYD" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/office)
+"cYE" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYF" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYG" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYH" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYI" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYJ" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYK" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYL" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYM" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYN" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYO" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYP" = (
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYQ" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYR" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYS" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYT" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYU" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYV" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYX" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYY" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cYZ" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZa" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZb" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZc" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZd" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/office)
+"cZf" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZg" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZi" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZj" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZk" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZl" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZm" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZn" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZo" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZp" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZq" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZr" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/security/prison)
+"cZs" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/security/prison)
+"cZt" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZu" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZv" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/closet,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZw" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZx" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZy" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZz" = (
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZA" = (
+/obj/effect/landmark/start/cargo_technician,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/office)
+"cZB" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZC" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZD" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/glass_command{
+	cyclelinkeddir = null;
+	name = "Bridge";
+	req_access_txt = "19";
+	req_one_access = null;
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/bridge)
+"cZF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/glass_command{
+	cyclelinkeddir = null;
+	name = "Bridge";
+	req_access_txt = "19";
+	req_one_access = null;
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/bridge)
+"cZG" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZH" = (
+/obj/structure/closet/firecloset/full,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/machinery/camera{
+	c_tag = "Cargo Hall West";
+	dir = 1;
+	icon_state = "camera";
+	network = list("SS13","QM")
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/office)
+"cZJ" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZK" = (
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZL" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZM" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"cZN" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"cZO" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"cZP" = (
+/obj/machinery/door/airlock/glass_mining{
+	name = "Quartermaster's Office";
+	req_access_txt = "41";
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"cZQ" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"cZR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"cZS" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"cZT" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/spawner/lootdrop/costume,
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/locker)
+"cZU" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"cZV" = (
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 0;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/brown{
+	tag = "icon-brown (NORTHWEST)";
+	icon_state = "brown";
+	dir = 9;
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/quartermaster/qm)
+"cZW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/brown{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1
+	},
+/area/quartermaster/qm)
+"cZX" = (
+/turf/open/floor/plasteel/brown{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1
+	},
+/area/quartermaster/qm)
+"cZY" = (
+/turf/open/floor/plasteel/brown{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1
+	},
+/area/quartermaster/qm)
+"cZZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/brown{
+	tag = "icon-brown (NORTHEAST)";
+	icon_state = "brown";
+	dir = 5;
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/quartermaster/qm)
+"daa" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dab" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dac" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dad" = (
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Quartermaster's Office APC";
+	pixel_x = 23;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/stripes/end{
+	tag = "icon-warn_end (WEST)";
+	icon_state = "warn_end";
+	dir = 8
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"dae" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daf" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/brown{
+	tag = "icon-brown (WEST)";
+	icon_state = "brown";
+	dir = 8;
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/quartermaster/qm)
+"dag" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/weapon/folder,
+/obj/item/weapon/clipboard,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"dah" = (
+/obj/structure/table,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen/fourcolor,
+/obj/item/weapon/stamp/qm,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"dai" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel/brown{
+	tag = "icon-brown (EAST)";
+	icon_state = "brown";
+	dir = 4;
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/quartermaster/qm)
+"dak" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dal" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dam" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dan" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dao" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"dap" = (
+/obj/structure/closet/secure_closet/quartermaster,
+/turf/open/floor/plasteel/brown{
+	tag = "icon-brown (WEST)";
+	icon_state = "brown";
+	dir = 8;
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/quartermaster/qm)
+"daq" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"dar" = (
+/obj/machinery/computer/cargo,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"das" = (
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"dat" = (
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	name = "Quartermaster RC";
+	pixel_x = 30;
+	pixel_y = 0
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel/brown{
+	tag = "icon-brown (EAST)";
+	icon_state = "brown";
+	dir = 4;
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/quartermaster/qm)
+"dau" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dav" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daw" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dax" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"day" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daz" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daA" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel/brown{
+	tag = "icon-brown (SOUTHWEST)";
+	icon_state = "brown";
+	dir = 10;
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	on = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Quartermaster's Office";
+	dir = 1;
+	icon_state = "camera";
+	network = list("SS13","QM")
+	},
+/turf/open/floor/plasteel/brown{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daC" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/brown{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daD" = (
+/turf/open/floor/plasteel/brown{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daE" = (
+/obj/item/weapon/twohanded/required/kirbyplants{
+	tag = "icon-plant-21";
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/brown{
+	tag = "icon-brown (SOUTHEAST)";
+	icon_state = "brown";
+	dir = 6;
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/office)
+"daG" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daH" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daI" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daJ" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daK" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daL" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daM" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/qm)
+"daN" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daO" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/device/assembly/mousetrap/armed,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daP" = (
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daQ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daR" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daS" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daT" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daU" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daV" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daW" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"daX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"daY" = (
 /obj/structure/sign/biohazard{
 	desc = "A sign stating that there are better, more efficient methods of suicide that don't cause extra work for security and the janitor. Volunteer to be miner bait, be voluntary specimen for Research, or just find your nearest external airlock! ";
 	name = "SUICIDE HOPLINE ISN'T THE WAY!";
@@ -85874,7 +87899,175 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/heads)
-"cYe" = (
+"daZ" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"dba" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbb" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbc" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"dbd" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbe" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbf" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"dbg" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbh" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbi" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbj" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbk" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbl" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"dbm" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbn" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"dbo" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"dbp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -85887,7 +88080,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYf" = (
+"dbq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -85900,7 +88093,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYg" = (
+"dbr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -85913,7 +88106,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYh" = (
+"dbs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -85926,7 +88119,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYi" = (
+"dbt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -85940,7 +88133,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYj" = (
+"dbu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -85953,7 +88146,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYk" = (
+"dbv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -85966,7 +88159,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYl" = (
+"dbw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -85979,7 +88172,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYm" = (
+"dbx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -85992,7 +88185,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYn" = (
+"dby" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -86005,7 +88198,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYo" = (
+"dbz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -86016,7 +88209,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYp" = (
+"dbA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -86029,7 +88222,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYq" = (
+"dbB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -86043,7 +88236,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYr" = (
+"dbC" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -86057,7 +88250,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYs" = (
+"dbD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -86070,7 +88263,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYt" = (
+"dbE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -86083,7 +88276,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYu" = (
+"dbF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -86096,7 +88289,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYv" = (
+"dbG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -86107,7 +88300,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYw" = (
+"dbH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -86121,7 +88314,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYx" = (
+"dbI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -86134,7 +88327,7 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hallway/primary/fore)
-"cYy" = (
+"dbJ" = (
 /obj/structure/window/reinforced,
 /obj/machinery/camera{
 	c_tag = "Core-Command-Cargo Bridge Ceneter";
@@ -86142,6 +88335,5961 @@
 	},
 /turf/open/floor/engine,
 /area/space)
+"dbK" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbM" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbN" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/fore{
+	name = "Fore Asteroid Maintenance"
+	})
+"dbO" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"dbP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	tag = "icon-neutralcorner (NORTH)";
+	icon_state = "neutralcorner";
+	dir = 1;
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"dbQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"dbR" = (
+/obj/structure/table,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dbS" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dbT" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dbU" = (
+/obj/structure/girder,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dbV" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dbW" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dbX" = (
+/obj/machinery/camera{
+	c_tag = "Service SMES";
+	dir = 6;
+	icon_state = "camera";
+	network = list("SS13","QM")
+	},
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dbY" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Port Asteroid Maintence APC";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dbZ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dca" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcb" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcc" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	icon_state = "ast_warn";
+	dir = 4
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcd" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dce" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcf" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/device/assembly/mousetrap/armed,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcg" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dch" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/computer/station_alert,
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dci" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcj" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dck" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcm" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcn" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dco" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/starboard)
+"dcp" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcs" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dct" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcv" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	tag = "icon-term (EAST)";
+	icon_state = "term";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/sign/electricshock{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcw" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcx" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcy" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcz" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/starboard)
+"dcA" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcC" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcD" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcE" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcF" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcG" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcH" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcI" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcJ" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcK" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dcM" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/snacks/baguette,
+/obj/structure/sign/poster/official/the_owl{
+	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Theatre Backstage";
+	dir = 4;
+	icon_state = "camera"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcN" = (
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 0;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcO" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcP" = (
+/obj/structure/table/wood,
+/obj/item/device/instrument/guitar,
+/obj/item/device/instrument/violin,
+/obj/machinery/camera{
+	c_tag = "Theatre Stage";
+	dir = 4;
+	icon_state = "camera"
+	},
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcQ" = (
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	on = 1
+	},
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcR" = (
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcS" = (
+/obj/machinery/door/window/eastright{
+	name = "Theatre Stage"
+	},
+/turf/open/floor/plasteel/stage_left{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcT" = (
+/turf/open/floor/plasteel/stairs{
+	tag = "icon-stairs (WEST)";
+	icon_state = "stairs";
+	dir = 8;
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcU" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	on = 1
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcW" = (
+/obj/structure/chair/wood,
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dcX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	icon_state = "neutralcorner";
+	dir = 8;
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/port)
+"dcY" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/rack,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dcZ" = (
+/obj/structure/grille/broken,
+/obj/item/stack/rods,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dda" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"ddb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"ddc" = (
+/obj/structure/table,
+/obj/item/weapon/lipstick/random,
+/obj/item/weapon/lipstick/random,
+/obj/item/weapon/lipstick/random,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddd" = (
+/obj/effect/landmark/start/mime,
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dde" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plasteel/redyellow{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddg" = (
+/obj/structure/table/wood,
+/obj/structure/sign/poster/random{
+	name = "random contraband poster";
+	pixel_x = -32;
+	pixel_y = 0;
+	random_basetype = /obj/structure/sign/poster/contraband
+	},
+/obj/item/clothing/head/sombrero,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddh" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddi" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddj" = (
+/obj/structure/table/wood,
+/obj/item/candle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddk" = (
+/obj/structure/chair/wood{
+	tag = "icon-wooden_chair (WEST)";
+	icon_state = "wooden_chair";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddl" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddm" = (
+/obj/structure/chair/wood{
+	tag = "icon-wooden_chair (WEST)";
+	icon_state = "wooden_chair";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 0;
+	pixel_y = 23
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddn" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddo" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddp" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddq" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddr" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dds" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddt" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"ddu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"ddv" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance";
+	req_access_txt = "46"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 2;
+	on = 1
+	},
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddx" = (
+/obj/effect/landmark/start/clown,
+/turf/open/floor/plasteel/redyellow{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddy" = (
+/turf/open/floor/plasteel/redyellow{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddz" = (
+/obj/machinery/door/airlock{
+	name = "Theatre Backstage";
+	req_access_txt = "46"
+	},
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddA" = (
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 2;
+	on = 1
+	},
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddC" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddD" = (
+/obj/structure/chair/wood,
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 2;
+	on = 1
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddF" = (
+/obj/structure/chair/wood,
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddG" = (
+/obj/machinery/door/airlock/glass{
+	name = "The Chuckle Den"
+	},
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddH" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddI" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddJ" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddK" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddL" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddM" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddN" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddO" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddP" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddQ" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddR" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddS" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddT" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"ddU" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/girder,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"ddV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"ddW" = (
+/obj/structure/closet/secure_closet/freezer/cream_pie,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/item/weapon/reagent_containers/food/snacks/pie/cream,
+/obj/item/weapon/reagent_containers/food/snacks/pie/cream,
+/obj/item/weapon/reagent_containers/food/snacks/pie/cream,
+/obj/item/weapon/reagent_containers/food/snacks/pie/cream,
+/obj/item/weapon/reagent_containers/food/snacks/pie/cream,
+/turf/open/floor/plasteel/redyellow{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddX" = (
+/obj/structure/table,
+/obj/item/clothing/mask/facehugger/toy,
+/obj/item/clothing/mask/fakemoustache,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/redyellow{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddY" = (
+/obj/structure/table,
+/obj/item/clothing/mask/pig,
+/obj/item/clothing/mask/cowmask,
+/obj/item/clothing/mask/cigarette/cigar/cohiba,
+/obj/structure/sign/poster/contraband/the_griffin{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/redyellow{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ddZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dea" = (
+/obj/structure/piano,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"deb" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dec" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"ded" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dee" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"def" = (
+/obj/structure/chair/wood{
+	tag = "icon-wooden_chair (WEST)";
+	icon_state = "wooden_chair";
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Theatre";
+	dir = 1;
+	icon_state = "camera";
+	network = list("SS13")
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"deg" = (
+/obj/structure/table/wood,
+/obj/item/candle,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"deh" = (
+/obj/structure/chair/wood{
+	tag = "icon-wooden_chair (WEST)";
+	icon_state = "wooden_chair";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dei" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dej" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"dek" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/port)
+"del" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dem" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"den" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deo" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dep" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"deq" = (
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"der" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"des" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"det" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"deu" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dev" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dew" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/patients_rooms)
+"dex" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dey" = (
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dez" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Theatre APC";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/asteroid/end,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre)
+"deF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 2
+	},
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/starboard)
+"deI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/starboard)
+"deJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/map/left/ceres{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/starboard)
+"deK" = (
+/obj/machinery/suit_storage_unit/cmo,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"deL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"deM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 0;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"deN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"deO" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"deP" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deQ" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deR" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deT" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deU" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deV" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"deW" = (
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/starboard)
+"deX" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"deY" = (
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"deZ" = (
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfa" = (
+/obj/structure/table/glass,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/weapon/folder,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfc" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/surgery)
+"dfd" = (
+/obj/structure/girder,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dfe" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dff" = (
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/starboard)
+"dfg" = (
+/obj/machinery/computer/card/minor/cmo,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfh" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfi" = (
+/obj/machinery/computer/med_data/laptop,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfj" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfm" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfn" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfq" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfr" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfs" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dft" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dfu" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/central)
+"dfv" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfw" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/stamp/cmo,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfy" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/surgery)
+"dfz" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfA" = (
+/obj/structure/closet,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dfB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/mine/unexplored{
+	name = "Medical Asteroid"
+	})
+"dfC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dfD" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/surgery)
+"dfE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfF" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfH" = (
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/virology)
+"dfI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dfJ" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dfK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteblue/side{
+	tag = "icon-whiteblue (NORTH)";
+	icon_state = "whiteblue";
+	dir = 1;
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/medbay)
+"dfL" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dfM" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	icon_state = "ast_warn";
+	dir = 4
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dfN" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dfO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/medbay)
+"dfP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/medbay)
+"dfQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dfR" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dfS" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dfT" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dfU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/medbay)
+"dfV" = (
+/obj/machinery/door/airlock/medical{
+	name = "Morgue";
+	req_access_txt = "0";
+	req_one_access_txt = "5;9"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dfW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dfX" = (
+/obj/structure/table,
+/obj/item/weapon/folder,
+/obj/machinery/camera{
+	c_tag = "Morgue North";
+	dir = 6;
+	icon_state = "camera"
+	},
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dfY" = (
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Morgue APC";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/table,
+/obj/item/weapon/storage/box/bodybags,
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dfZ" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dga" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgb" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgc" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/central)
+"dgd" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dge" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/medbay)
+"dgf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/genetics_cloning)
+"dgg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/genetics_cloning)
+"dgh" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/landmark/revenantspawn,
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dgi" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/landmark/revenantspawn,
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dgj" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/table,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dgk" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgl" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgm" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dgn" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dgo" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dgp" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgq" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgr" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/landmark/revenantspawn,
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dgs" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dgt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgA" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgB" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dgC" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dgD" = (
+/obj/structure/closet,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dgE" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/genetics_cloning)
+"dgF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dgG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dgH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dgI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	layer = 2.4;
+	on = 1
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dgJ" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dgK" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgL" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgM" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgN" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgO" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dgP" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dgQ" = (
+/obj/structure/bodycontainer/morgue,
+/obj/machinery/camera{
+	c_tag = "Morgue South";
+	dir = 1;
+	icon_state = "camera";
+	network = list("SS13")
+	},
+/obj/effect/landmark/revenantspawn,
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dgR" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dgS" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/landmark/revenantspawn,
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dgT" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/landmark/revenantspawn,
+/turf/open/floor/plasteel/vault{
+	baseturf = /turf/open/floor/plating/asteroid/airless;
+	dir = 5
+	},
+/area/medical/morgue)
+"dgU" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dgV" = (
+/obj/structure/closet,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dgW" = (
+/obj/structure/girder,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgX" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dgY" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dgZ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue";
+	req_access_txt = "5"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/morgue)
+"dha" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dhb" = (
+/obj/structure/rack,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dhc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dhd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dhe" = (
+/obj/structure/grille/broken,
+/obj/item/stack/rods,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/rack,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhg" = (
+/obj/structure/girder,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dhh" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dhi" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dhj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhk" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dhl" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dhm" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dhn" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dho" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dhp" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhq" = (
+/obj/structure/grille,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dhr" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dhs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dht" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/yellow/side{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dhu" = (
+/obj/structure/sign/enginesafety{
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dhv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/yellow/corner{
+	tag = "icon-yellowcorner (WEST)";
+	icon_state = "yellowcorner";
+	dir = 8;
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dhw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dhx" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhA" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dhB" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dhC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dhD" = (
+/turf/closed/wall,
+/area/crew_quarters/chief)
+"dhE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Chief Engineer's Office";
+	req_access_txt = "56"
+	},
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dhF" = (
+/turf/closed/wall,
+/area/crew_quarters/chief)
+"dhG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel/yellow/side{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/engine/engineering)
+"dhH" = (
+/obj/structure/grille/broken,
+/obj/item/stack/rods,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dhI" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhK" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dhL" = (
+/obj/structure/closet/wardrobe/mixed,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dhM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dhN" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dhO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dhP" = (
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dhQ" = (
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dhR" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/weapon/paper/monitorkey,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/mob/living/simple_animal/parrot/Poly,
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dhS" = (
+/obj/item/weapon/cartridge/engineering{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/weapon/cartridge/engineering{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/weapon/cartridge/engineering{
+	pixel_x = 3
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light_switch{
+	pixel_x = 27
+	},
+/obj/item/weapon/cartridge/atmos,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dhT" = (
+/turf/closed/wall,
+/area/crew_quarters/chief)
+"dhU" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dhV" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhW" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhX" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dhY" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dhZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dia" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dib" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dic" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/clipboard,
+/obj/item/clothing/glasses/meson{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"did" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"die" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dif" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"dig" = (
+/turf/closed/wall,
+/area/crew_quarters/chief)
+"dih" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dii" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dij" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dik" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dil" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dim" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"din" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dio" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dip" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diq" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"dir" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dis" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dit" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"diu" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/stamp/ce,
+/obj/item/weapon/pen,
+/obj/machinery/light,
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"div" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/chief)
+"diw" = (
+/turf/closed/wall,
+/area/crew_quarters/chief)
+"dix" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/crate,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"diy" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diz" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diA" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diB" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diC" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diD" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diE" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diF" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diG" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diH" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"diJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diK" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diL" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diM" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diN" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diO" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diP" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"diR" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"diS" = (
+/obj/structure/girder,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diT" = (
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"diU" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"diV" = (
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"diW" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"diX" = (
+/obj/structure/girder,
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"diY" = (
+/obj/structure/rack,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"diZ" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dja" = (
+/obj/structure/grille/broken,
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djb" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djc" = (
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djd" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dje" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djf" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"djg" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"djh" = (
+/obj/machinery/door/airlock/glass_external{
+	cyclelinkeddir = 8
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dji" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djj" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djk" = (
+/obj/structure/girder,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djl" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djm" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djn" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djo" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djp" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djq" = (
+/obj/structure/girder,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"djr" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djs" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djt" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dju" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djv" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djw" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djy" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djA" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djB" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djC" = (
+/obj/structure/grille/broken,
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djD" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djE" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djF" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djG" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djH" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djI" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djJ" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djK" = (
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djL" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djM" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djN" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/syringe/charcoal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djO" = (
+/obj/structure/table,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djP" = (
+/obj/structure/closet,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djR" = (
+/obj/structure/girder,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djS" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"djT" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"djU" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/port{
+	name = "Port Asteroid Maintenance"
+	})
+"djV" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"djW" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"djX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"djY" = (
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"djZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dka" = (
+/obj/machinery/power/apc{
+	cell_type = 5000;
+	dir = 4;
+	name = "CE Office APC";
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkb" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkc" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkd" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer RC";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/computer/apc_control,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dke" = (
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkf" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/clipboard,
+/obj/item/weapon/lighter,
+/obj/item/clothing/glasses/meson{
+	pixel_y = 4
+	},
+/obj/item/weapon/stamp/ce,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dki" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkj" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkk" = (
+/obj/machinery/computer/station_alert,
+/obj/machinery/button/door{
+	desc = "A remote control-switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_x = -24;
+	pixel_y = -10;
+	req_access_txt = "10"
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for secure storage.";
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	pixel_x = -24;
+	pixel_y = 0;
+	req_access_txt = "11"
+	},
+/obj/machinery/button/door{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_x = -24;
+	pixel_y = 10;
+	req_access_txt = "24"
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkl" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/chief_engineer,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkm" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/paper/monitorkey,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	external_pressure_bound = 101.325;
+	on = 1;
+	pressure_checks = 1
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dko" = (
+/obj/structure/closet/secure_closet/engineering_chief{
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkp" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkq" = (
+/obj/machinery/camera{
+	c_tag = "Chief Engineer's Office";
+	dir = 4;
+	network = list("SS13")
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/computer/card/minor/ce,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkr" = (
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dks" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/storage/fancy/cigarettes,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkt" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dku" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 27
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/mob/living/simple_animal/parrot/Poly,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkv" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkw" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkx" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dky" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkB" = (
+/obj/item/weapon/cartridge/engineering{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/weapon/cartridge/engineering{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/weapon/cartridge/engineering{
+	pixel_x = 3
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light_switch{
+	pixel_x = 27
+	},
+/obj/item/weapon/cartridge/atmos,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/space)
+"dkC" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkD" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/theatre{
+	name = "Top Secret Clown HQ"
+	})
+"dkE" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkF" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkG" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkH" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkI" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkJ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkK" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkL" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkM" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkN" = (
+/obj/structure/grille,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkO" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkP" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkQ" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkR" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkS" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkT" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkU" = (
+/obj/structure/closet,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkV" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkW" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkX" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkY" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dkZ" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dla" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlb" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlc" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dld" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dle" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlf" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlg" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlh" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dli" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlj" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlk" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dll" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlm" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dln" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/stack/rods,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlo" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlp" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/device/assembly/mousetrap/armed,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlq" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlr" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dls" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlt" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlu" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlv" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlw" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlx" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dly" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlz" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlA" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/aft)
+"dlC" = (
+/obj/structure/grille,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlD" = (
+/obj/structure/grille,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlE" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlF" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid,
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlG" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/asteroid,
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlH" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlI" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlJ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Toxins Storage APC";
+	pixel_x = 0;
+	pixel_y = 25
+	},
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlK" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlL" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dlM" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlN" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlO" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlP" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlQ" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlR" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/obj/machinery/camera{
+	c_tag = "Toxins Storage";
+	dir = 9;
+	icon_state = "camera";
+	network = list("SS13","RD");
+	tag = "icon-camera (NORTHWEST)"
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/mixing)
+"dlV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/mixing)
+"dlW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dlZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dma" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_research{
+	name = "Toxins Storage";
+	req_access_txt = "8"
+	},
+/turf/open/floor/plasteel/neutral{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dmb" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dmc" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dmd" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dme" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dmf" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/toxins/storage)
+"dmg" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmh" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmi" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmj" = (
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmk" = (
+/obj/structure/displaycase/labcage,
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dml" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmm" = (
+/obj/machinery/button/door{
+	id = "researchlockdown";
+	name = "Research Emergency Lockdown";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmo" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmp" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmq" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmr" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dms" = (
+/obj/machinery/ai_status_display,
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmt" = (
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmu" = (
+/obj/structure/table,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/weapon/pen,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/stamp/rd{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/hor)
+"dmw" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmx" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Research Director's Desk";
+	departmentType = 5;
+	name = "Research Director RC";
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmy" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmz" = (
+/obj/machinery/computer/mecha,
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmA" = (
+/obj/structure/rack,
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
+/obj/item/device/taperecorder{
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/hor)
+"dmB" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmD" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmE" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmF" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmG" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmH" = (
+/obj/effect/landmark/xmastree/rdrod,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmI" = (
+/obj/structure/rack,
+/obj/item/device/aicard,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/hor)
+"dmJ" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmK" = (
+/obj/structure/grille,
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmL" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmM" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmN" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmO" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmP" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmQ" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmR" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
+"dmS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmT" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille/broken,
+/obj/item/stack/rods,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmV" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmW" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmX" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmY" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/asteroid,
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dmZ" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dna" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnb" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnc" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnd" = (
+/obj/structure/grille,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dne" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille/broken,
+/obj/item/stack/rods,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnf" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dng" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnh" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dni" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnj" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnk" = (
+/obj/machinery/light/small,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnl" = (
+/obj/structure/table,
+/obj/item/weapon/wrench,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnm" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnn" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dno" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnp" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnq" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dnr" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
+"dns" = (
+/obj/structure/girder,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/aft{
+	name = "Aft Asteroid Maintenance"
+	})
 
 (1,1,1) = {"
 aaa
@@ -92252,14 +100400,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -92509,14 +100657,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -92766,14 +100914,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -93023,14 +101171,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -93247,7 +101395,7 @@ cdn
 aZA
 aZy
 ceq
-bqE
+djT
 aZo
 aZn
 aYT
@@ -93280,14 +101428,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -93481,9 +101629,9 @@ aaa
 aaa
 aaa
 aYT
-aYT
-aYT
-aYT
+bjB
+bjB
+bjB
 aZm
 bUh
 bVh
@@ -93504,7 +101652,7 @@ cdo
 aZA
 cdY
 bCF
-bqE
+djU
 aZo
 aZo
 aYT
@@ -93537,20 +101685,20 @@ aaa
 aaa
 aaa
 aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cgN
-cgS
 cgS
 cgS
 cgS
@@ -93717,18 +101865,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aYP
-aYP
-aYP
-aYP
-aYP
-aYP
-aYP
-aYP
-aYP
-aaa
-aaa
+bjB
+bjB
+bjB
+bjB
+bjB
+bjB
+bjB
+bjB
+bjB
+bjB
 aaa
 aaa
 aaa
@@ -93737,10 +101883,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aYP
-aYP
-aYT
-aYT
+bjB
+bjB
+bjB
 aYX
 bUi
 bVi
@@ -93752,9 +101900,9 @@ aYT
 aYT
 aYT
 aZo
-aZo
-aZo
-aZo
+djq
+aZm
+aYX
 aZn
 aZm
 cdp
@@ -93794,19 +101942,19 @@ aaa
 aaa
 aaa
 aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-cgS
-cgS
-cgS
-cgS
-cgS
 cgS
 cgS
 cgS
@@ -93974,25 +102122,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aYP
-aYP
-aYP
+bjB
+bjB
+bjB
+bjB
 aYP
 aYP
 aYT
-aYT
-aYT
-aYT
-aYT
-aYP
-aaa
-aaa
+bjB
+bjB
+bjB
+bjB
+bjB
 aaa
 aaa
-aYP
-aYP
-aYT
+aaa
+aaa
+bjB
+bjB
+bjB
 aYP
 aYP
 aYP
@@ -94008,8 +102156,8 @@ aZm
 aYT
 aZo
 aZo
-aZn
-aZA
+aZm
+ccr
 aZA
 bbg
 aZA
@@ -94058,10 +102206,10 @@ aaa
 aaa
 aaa
 aaa
-cgS
-cgS
-cgS
-cgN
+aaa
+aaa
+aaa
+aaa
 cgR
 cgR
 cgR
@@ -94223,15 +102371,15 @@ aaa
 aaa
 aaa
 aaa
+bjB
+bjB
+bjB
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aYP
-aYP
+bjB
+bjB
+bjB
+bjB
+bjB
 aYP
 aYP
 aYP
@@ -94263,8 +102411,8 @@ aYX
 bXo
 aYX
 aZo
-aZo
-aZo
+aZm
+aYX
 bWp
 blT
 bbf
@@ -94315,10 +102463,10 @@ aaa
 aaa
 aaa
 aaa
-cgS
-cgR
-cgR
-cgR
+aaa
+aaa
+aaa
+aaa
 cgR
 cgR
 cgR
@@ -94479,14 +102627,14 @@ aaa
 aaa
 aaa
 aaa
+bjB
+bjB
+aYP
+aYP
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aYP
+aYP
+aYP
 aYP
 aYP
 aYP
@@ -94520,9 +102668,9 @@ bWN
 bXp
 aZn
 aYX
-aZn
-bec
-aZA
+aZm
+djf
+beC
 bCF
 blT
 bbf
@@ -94572,11 +102720,11 @@ aaa
 aaa
 aaa
 cgS
+aaa
+aaa
 cgS
-cgR
-cgR
-cgR
-cgR
+cgS
+cgS
 cgR
 cgR
 cgR
@@ -94732,16 +102880,16 @@ abC
 aaa
 aaa
 aaa
+aYP
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aYP
+aYP
+aYP
+aYP
+aYP
+aYP
 aYP
 aYP
 aYP
@@ -94777,9 +102925,9 @@ aZn
 aZz
 aZA
 bHy
-aZA
-aZA
-aZA
+aZm
+beC
+aZz
 bCF
 bCF
 aZA
@@ -94789,13 +102937,13 @@ aZA
 aZA
 aZA
 bec
+aZm
 aZn
-aZn
+dkb
+dki
 cea
 cea
-cea
-cea
-cea
+dkC
 aZn
 cgm
 aZA
@@ -94830,10 +102978,10 @@ aaa
 aaa
 cgS
 cgS
-cgN
-cgR
-cgR
-cgR
+aaa
+cgS
+cgS
+cgS
 cgR
 cgR
 cgR
@@ -94988,15 +103136,15 @@ aaa
 abC
 aaa
 aaa
+aYP
+aYP
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aYP
+aYP
+aYP
+aYT
+aYP
+aYP
 aYP
 aYP
 aYP
@@ -95015,18 +103163,18 @@ aYT
 aYT
 aYP
 aZn
-aZn
+aZm
 aZn
 aYX
-aZo
-aZo
+dhg
+aZm
+aZm
 aZn
 aZn
-aZn
 aZo
-aZo
-aZo
-aZn
+aYX
+aYX
+aZm
 aZn
 bVj
 bau
@@ -95042,9 +103190,9 @@ bCF
 aZA
 aZA
 bbg
-aZn
-aZn
-aZn
+aZm
+aYX
+aZm
 aZn
 aZn
 cea
@@ -95084,14 +103232,14 @@ aaa
 aaa
 aaa
 aaa
+aaa
 cgS
 cgS
+cgR
+cgR
+cgR
 cgS
-cgN
-cgR
-cgR
-cgR
-cgR
+cgS
 cgR
 cgR
 cgR
@@ -95245,20 +103393,20 @@ aaa
 abC
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aYP
 aYP
-aYP
+aZo
+aZo
+aZo
 aYT
 aYT
 aYT
+aYT
+aYT
+aZo
+aZo
+aZo
+aZo
 bnS
 aYT
 aYT
@@ -95271,9 +103419,9 @@ aYT
 aYP
 aZn
 aZm
-aZn
+aZm
 bFa
-aZA
+bec
 bHy
 bec
 aZA
@@ -95281,7 +103429,7 @@ aZn
 bNg
 bNg
 aZA
-aZn
+aZm
 aZA
 aZA
 blT
@@ -95296,10 +103444,10 @@ bbf
 bbf
 bbf
 bmN
-bGo
+cad
 aYX
-aZn
-aZn
+aYX
+aYX
 aZn
 aZn
 aZn
@@ -95339,16 +103487,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 cgS
-cgS
-cgS
-cgS
-cgN
-cgN
-cgN
-cgN
 cgR
 cgR
+cgR
+cgR
+cgR
+cgS
+cgS
 cgR
 cgR
 cgR
@@ -95502,20 +103650,20 @@ aYN
 aYN
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aYP
 aYP
-aYP
-aYP
-aYT
-aYT
-aYT
+aZo
+dci
+aZo
+aYX
+aYX
+dda
+aZm
+aZm
+aZo
+bec
+bad
+aZm
 aYT
 aYT
 aYT
@@ -95554,7 +103702,7 @@ aZA
 bWp
 cbw
 cbZ
-aZn
+aZm
 aZn
 aZo
 aZo
@@ -95566,7 +103714,7 @@ cfv
 cfF
 cfE
 cfE
-cea
+dkD
 aZn
 aZn
 cgj
@@ -95598,15 +103746,15 @@ aaa
 aaa
 aaa
 cgS
+cBU
+cBU
+cBU
+cBU
+cBU
+cBU
+cBU
 cgS
 cgS
-cgS
-cgN
-cgN
-cgN
-cgN
-cgN
-cgN
 cgR
 cgR
 cgR
@@ -95759,20 +103907,20 @@ aZW
 aZJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aYP
-aYP
-aYP
-aYP
-aYP
-aYP
-aYT
-aYT
-aYT
-aYT
+aZm
+aZm
+bFm
+beD
+dcA
+dcK
+beD
+ddt
+ddU
+bkb
+bkb
+bSs
+aZo
 aYT
 aYT
 aYT
@@ -95784,21 +103932,21 @@ bsd
 bsc
 bsc
 bsc
-bCF
+dgt
 bEd
 bnT
 bnT
 bnT
-bvh
-bnT
+dhh
+dhk
 bnT
 bnT
 bOv
-bPW
+dhK
 bQY
 bPW
-bPW
-bPW
+diI
+diQ
 bVl
 aYX
 aZA
@@ -95808,17 +103956,17 @@ bCW
 aZA
 bbi
 bdL
+aZm
+aZn
+aZo
+aZo
+aZo
+aZo
+aZo
+aZo
 aZn
 aZn
-aZo
-aZo
-aZo
-aZo
-aZo
-aZo
-aZn
-aZn
-cea
+djV
 cea
 cfE
 cfE
@@ -95855,15 +104003,15 @@ aaa
 aaa
 aaa
 cgS
+cBU
+dlH
+dlM
+dlQ
+cCO
+dmb
+cBU
 cgS
 cgS
-cgS
-cgS
-cgS
-cgS
-cgN
-cgN
-cgN
 cgR
 cgR
 cgR
@@ -96016,20 +104164,20 @@ aYN
 aYN
 aYP
 aYP
-aYP
-aYP
-aYP
-aYP
-aYP
-aYP
-aYP
-aYP
-aYP
-aYP
-aYT
-aYT
-aYT
-aYT
+aZn
+aZm
+aZA
+bCW
+dcp
+dcB
+dcL
+ddb
+ddu
+ddV
+den
+dez
+deP
+aZm
 aYT
 aYT
 aYT
@@ -96041,31 +104189,31 @@ bty
 bzs
 bty
 bsd
-bCF
-blW
-aZA
-aZA
-aZA
-aZA
+dgu
+dgK
+aYX
+aZm
+aYX
+dhi
+aZm
+cfg
+beC
+dhA
 aZn
-bFn
-aZA
-bCW
-aZn
+aZm
+diq
+aYX
+aZm
 aZm
 aZn
 aZn
 aZn
-aZn
-aZn
-aZn
-aZn
 aZA
 bCW
 aZn
 aZm
-aZn
-aZo
+aZm
+aZm
 aZo
 aZo
 aZo
@@ -96076,7 +104224,7 @@ aZn
 cdZ
 cdZ
 cdZ
-cea
+dkc
 cfG
 cfE
 cfZ
@@ -96111,16 +104259,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+cBU
+dlI
+dlN
+cDE
+dlW
+dmc
+cBU
 cgS
 cgS
-cgS
-cgS
-cgS
-cgS
-cgS
-cgS
-cgS
-cgN
 cgN
 cgN
 cgR
@@ -96273,20 +104421,20 @@ aZn
 aYT
 aYT
 aYT
-aYT
-aYT
-aYT
-aYT
-aYT
-aYT
-aYT
-aYT
-aYT
-aYP
-aYT
-aYT
-aYP
-aYT
+aZo
+bau
+aZA
+bCW
+dcq
+dcC
+bfp
+bfp
+ddv
+bfp
+bfp
+deA
+bCW
+dfd
 aYT
 aYT
 aYP
@@ -96298,18 +104446,18 @@ byg
 bzt
 bAy
 bsd
-bCF
-blW
-aZA
+dgv
+dgL
+aYX
 bGn
 bHz
-aZA
-aZn
-aZn
-aZA
-bCW
-aZA
-aZn
+beC
+aZm
+aZm
+dhq
+bfr
+dhL
+aYX
 aZn
 aZo
 aZo
@@ -96336,7 +104484,7 @@ cev
 cfw
 cev
 cev
-cea
+dkv
 cea
 aZn
 cgo
@@ -96369,13 +104517,13 @@ cgS
 aaa
 aaa
 aaa
-cgS
-cgN
-cgS
-cgS
-cgS
-cgS
-cgS
+cBU
+dlJ
+dlO
+dlR
+dlX
+dmd
+cBU
 cgS
 cgS
 cgN
@@ -96530,20 +104678,20 @@ aZn
 aYT
 aYT
 aYT
-aYT
 aZo
 aZo
+aZm
+dcj
+dcr
+dcD
+dcM
+ddc
+ddw
+ddW
+bfp
+deB
+deQ
 aZo
-aZo
-aZo
-aYT
-aYT
-aYT
-aYP
-aYT
-aYT
-aYP
-aYT
 aYT
 aYT
 aYP
@@ -96555,18 +104703,18 @@ byh
 bzu
 bAz
 bsd
-bCF
-blW
+dgw
+dgM
+aYX
+aYX
+aZm
 aZn
 aZn
 aZn
-aZn
-aZn
-aZn
-aZA
-bCW
-aZA
-aZn
+dhr
+bfr
+beC
+aYX
 aZn
 bHA
 bHA
@@ -96591,9 +104739,9 @@ cet
 ceu
 cdZ
 cea
-cea
-cea
-cea
+dkj
+dkp
+dkw
 aYP
 aZn
 aZn
@@ -96627,12 +104775,12 @@ cuQ
 cuQ
 cuQ
 ctW
-cgN
-cgN
-cgN
-cgN
-cgN
-cgS
+dlK
+dlP
+cDE
+dlY
+dme
+cBU
 cgS
 cgS
 cgS
@@ -96786,21 +104934,21 @@ aZK
 aZn
 aZo
 aZo
-aZo
-aZo
+aYX
+aYX
 aZm
-aZL
-bdL
+dcb
+bCW
 beA
-aZo
-aZo
-aZo
-aZo
-aZn
-aZn
-aYT
-aYT
-aYT
+dcE
+dcN
+ddd
+ddx
+ddX
+bfp
+deC
+deR
+aYX
 aYT
 aYT
 aYP
@@ -96812,9 +104960,9 @@ byi
 bzv
 bAA
 bsc
-bCF
-blW
-aZn
+dgx
+dgN
+dgW
 aZn
 aZn
 aZn
@@ -96822,7 +104970,7 @@ aZn
 aZn
 aZn
 bOw
-bbi
+dhM
 aZn
 aZn
 bHA
@@ -96884,12 +105032,12 @@ cuR
 cvR
 cvR
 ctW
-cgR
-cgR
-cgR
-cgR
-cgN
-cjU
+cCQ
+cCQ
+dlS
+dlZ
+dmf
+cBU
 cCB
 cjU
 cgN
@@ -97004,10 +105152,10 @@ axm
 aFS
 atR
 aez
-aez
-aez
-aez
-aez
+aqG
+afS
+afV
+afS
 afV
 afV
 aPF
@@ -97037,27 +105185,27 @@ aaa
 aaa
 aaa
 aYP
-aZn
+aYX
 aZz
 aZz
 aZz
-aZn
-aZn
+aZm
+aZm
 bbg
-bbV
+dbW
 aZA
-aZz
-aZz
-aZz
-aZz
-aZz
-aZz
-aZz
-aZz
-aZn
-aZo
-aYT
-aYT
+bFm
+bCY
+dcs
+dcF
+dcO
+dde
+ddy
+ddY
+bfp
+deD
+bfq
+aZm
 aYT
 aYT
 aYT
@@ -97071,7 +105219,7 @@ bty
 bsc
 bCG
 blW
-aZn
+aYX
 aZn
 aZn
 bHA
@@ -97141,17 +105289,17 @@ cuS
 cvR
 cwO
 ctW
-ctW
-ctW
-ctW
-ctW
+cBU
+cBU
+dlT
+dma
 ctW
 ctW
 cCC
 cjU
 chc
-chc
-cgu
+cjU
+cjV
 cgu
 cgu
 cgR
@@ -97271,8 +105419,8 @@ aPG
 aPG
 afq
 aTk
-adZ
-aez
+afV
+afV
 acH
 acH
 abE
@@ -97303,20 +105451,20 @@ aZz
 aZz
 aZz
 aZz
-aZz
-aZn
-aZn
-aZn
+bCW
+dck
+dct
+dcG
+bfp
+ddf
+ddz
+ddZ
+bfp
+deE
+bfr
 aZm
-aZL
-aZA
-aZz
-aZz
-aZo
-aZo
-aZo
-aZo
-aZo
+aYX
+aYX
 aZo
 bsd
 bsd
@@ -97328,7 +105476,7 @@ bsd
 bsc
 bCH
 blW
-aZn
+aYX
 aZn
 aZn
 bHA
@@ -97406,11 +105554,11 @@ cYb
 ctW
 cCB
 cjU
-cgu
+cjV
+cjX
 cgL
-cgL
-cgu
-cgu
+cjV
+cjU
 cgR
 cgR
 cgR
@@ -97503,8 +105651,8 @@ acH
 acH
 aez
 aez
-aez
-aez
+afV
+afV
 atR
 atR
 atR
@@ -97528,8 +105676,8 @@ aot
 aeV
 afq
 afq
-aiS
-aez
+aUW
+afV
 aez
 acH
 abE
@@ -97555,38 +105703,38 @@ aYP
 aZn
 aZn
 aZX
-aZA
-aZA
+aZz
+aZz
 bbu
 aZn
 aZn
+dcc
+dcl
 aZn
-aZn
-aZn
-aZn
-aZn
-aZn
-aZn
-aZA
-aZz
-aZo
-aZo
-aZo
-aZo
-aZo
-aZo
-aZn
+dcH
+dcP
+ddg
+ddA
+dea
+bfp
+deF
+bfr
+beC
+beC
+aZm
+aYX
+aZm
 aZn
 bvg
 bwD
-aZy
+dfQ
 bzx
 aZn
 aZn
-bCF
+dgy
 blW
-aZn
-aZn
+aYX
+aZm
 aZn
 bHA
 bKA
@@ -97663,11 +105811,11 @@ cAU
 cYc
 cCD
 cDv
-cDv
+dmr
 cEQ
 cFb
 cmA
-cgu
+cjV
 cgu
 cgR
 cgR
@@ -97758,11 +105906,11 @@ acH
 acH
 acH
 aez
-aez
-afq
-aqH
-afq
-amJ
+afS
+akp
+cYL
+akp
+cYU
 auY
 awi
 axp
@@ -97774,19 +105922,19 @@ aDn
 aEy
 aFV
 aHr
-anz
+dak
 aJy
 afo
 aju
 afo
 aNB
 aOI
-afo
+aSe
 aRm
 aus
 akq
 akq
-ajt
+aqm
 aez
 acH
 abW
@@ -97810,40 +105958,40 @@ aYT
 aYT
 aYT
 aYT
-aZo
-aZo
-bau
-aZn
-aZn
-aZn
-aZn
-aZm
-aZm
-aZm
-aZm
-aZm
-aZm
-aZm
-aZn
-bka
 aYX
-blT
+aYX
+dbT
+dbU
+aZm
+aZm
+aZm
+dcd
+dcm
+aZm
+dcI
+dcQ
+ddh
+ddB
+deb
+bfp
+deG
+deS
+dfe
+dfs
+bbf
+dfJ
+dfL
 bbf
 bbf
 bbf
-bbf
-bbf
-bbf
-bbf
-bbf
-bbf
-bbf
-bbf
-bbf
-bmN
+dfR
+dga
+dgk
+dgp
+dgz
 blW
-aZA
-aZn
+dgX
+aYX
 bHA
 bHA
 cMA
@@ -97921,11 +106069,11 @@ ctW
 cCE
 cgL
 cgL
-cgL
+cxT
 cFc
-ckH
-cgu
-cgu
+dmK
+cjU
+cjV
 cgR
 cgR
 cgN
@@ -98013,13 +106161,13 @@ ala
 afV
 abW
 aez
-aez
-adZ
+afV
+cYs
 afS
-amJ
-aqk
-aox
-anz
+cYI
+cYM
+cYR
+cYV
 auZ
 awj
 axq
@@ -98030,8 +106178,8 @@ aCd
 aDo
 aEz
 aFW
-akE
-afo
+daa
+aSe
 aJz
 afq
 aLm
@@ -98042,9 +106190,9 @@ aLm
 aLn
 aLn
 aLn
-akq
-ajt
-aez
+akp
+alo
+afS
 aez
 abW
 abW
@@ -98065,39 +106213,39 @@ aYT
 aYT
 aYT
 aYT
-aZo
-aZo
-aZn
-aZA
-aZA
-aZn
-aZn
-aZn
-aZn
+aZm
+aZm
+aYX
+beC
+aZz
+dbV
 aZm
 bdM
+dbZ
+dce
+dcn
 beB
 bfp
-beD
+dcR
 bhi
 biu
 bjk
-bkb
+bfp
 bkT
 blU
 bmM
-bnT
+dft
 bnT
 bnT
 bse
 bnT
 bvh
 bwE
-bnT
-bnT
-bnT
-bnT
-bnT
+dfS
+dgb
+dgl
+dgq
+dgA
 bEe
 aZz
 bec
@@ -98177,10 +106325,10 @@ cAW
 ctW
 ckH
 ckz
-chc
+cjV
 cgu
-cFc
-cgL
+dmC
+cjU
 cFH
 cjU
 cgR
@@ -98270,8 +106418,8 @@ akq
 afS
 acH
 aez
-aoR
-ahr
+cYn
+aCr
 cJx
 cJA
 arS
@@ -98288,9 +106436,9 @@ arS
 aEA
 aFX
 arS
-adZ
+aqG
 anC
-aiS
+aUW
 aLm
 aMD
 aND
@@ -98299,8 +106447,8 @@ aPH
 aRn
 aSh
 aLm
-akq
-afq
+akp
+afV
 aVo
 afV
 abW
@@ -98322,24 +106470,24 @@ aYP
 aYP
 aYP
 aYP
-aZn
-aZA
-aZA
-aZA
-aZn
-aZo
-aZo
-aZo
-aZn
+aZm
+dbR
+ceG
+beC
+aZm
+aZm
 aZm
 bdN
 beC
-bfq
-beC
+dcf
+bVi
+dcu
+bfp
+dcS
 bhj
 biv
 bjl
-bkc
+bfp
 bkU
 blV
 bmN
@@ -98347,9 +106495,9 @@ bau
 aZX
 bqE
 aZm
-aZn
-aZA
-aZn
+aZm
+dfN
+aZm
 bmO
 bmO
 bmO
@@ -98428,7 +106576,7 @@ cXW
 cvW
 cvW
 cvW
-cvW
+dlU
 cAc
 cAX
 ctW
@@ -98436,10 +106584,10 @@ cBR
 cBR
 cBR
 cBR
-cFd
-cgL
-cgL
-cgu
+dmD
+coJ
+dmS
+cjV
 cgR
 cgR
 cgR
@@ -98522,12 +106670,12 @@ acH
 acH
 afV
 ajs
-akq
+aym
 alb
 afS
 aez
-adZ
-anC
+afV
+cYo
 arS
 cJy
 cJB
@@ -98545,20 +106693,20 @@ aDp
 aEB
 aFY
 arS
-adZ
+afV
 anC
 aKF
 aLn
 aME
-aNp
-aNp
-aOl
-aNp
-aNp
+daW
+dbc
+dbf
+dbl
+dbn
 aLn
-akq
-akq
-aqH
+akp
+akp
+dbN
 aez
 acH
 abW
@@ -98579,24 +106727,24 @@ abC
 abD
 aYP
 aYP
-aZn
-aZB
-aZn
-aZo
-aZo
-aZo
-aZo
-aZo
-aZn
 aZm
-bdO
+dbS
 beC
+aYX
+aZm
+aZo
+aZm
+dbX
+bVi
 bfr
-beC
+bVi
 bhk
-aZm
-aZB
-aZA
+bfp
+dcT
+ddi
+ddC
+dec
+bfp
 bkV
 blW
 aZB
@@ -98685,7 +106833,7 @@ cwR
 cxv
 cyc
 cvW
-cvW
+dlV
 cAd
 cAY
 ctW
@@ -98693,10 +106841,10 @@ cCF
 cDw
 cEf
 cBR
-cFd
-cgL
-cnX
-cgu
+dmE
+cjU
+dmT
+cjU
 cgu
 cgu
 cgu
@@ -98783,8 +106931,8 @@ afS
 alc
 afS
 aez
-afq
-anC
+akp
+cYp
 arS
 cJz
 cJC
@@ -98802,7 +106950,7 @@ aDq
 aEC
 aFZ
 arS
-adZ
+afS
 anC
 aKG
 aLn
@@ -98811,9 +106959,9 @@ aNE
 aOL
 aPI
 aRo
-aNp
+dbo
 aLm
-alb
+dbL
 aUQ
 afS
 aez
@@ -98836,24 +106984,24 @@ aaa
 aaa
 aYP
 aYP
-aZn
-aZn
-aZn
-aZo
-aZo
-aZo
-aZo
-aZo
-aZn
 aZm
+aYX
+aYX
+aYX
+aZo
+aZo
+aZm
+dbY
+dca
+dcg
 bdP
-beD
-bfs
+dcv
+bfp
 bgt
 bhl
-aZm
-aZn
-aZA
+bgt
+ded
+bfp
 bkV
 blW
 bmO
@@ -98951,14 +107099,14 @@ cCJ
 cCG
 cBR
 cFe
-cFt
-chc
+cjV
+cjU
+cjV
+cjV
 cgu
-cgu
-cgu
-cgu
-chc
-chc
+cjV
+cjV
+cjU
 chb
 cjV
 cIr
@@ -99033,15 +107181,15 @@ acH
 acH
 acH
 acH
-aez
+afS
 cJq
 aqm
 akq
 ald
 akq
 akq
-akq
-anC
+akp
+cYq
 arS
 arS
 arS
@@ -99061,7 +107209,7 @@ aGa
 arS
 adZ
 aJA
-adZ
+afV
 aLm
 aMG
 aNF
@@ -99098,19 +107246,19 @@ aYP
 aYT
 aYT
 aYT
-aZY
-aZY
-aZY
 aZm
 aZm
 bdQ
 aZm
-bft
+dch
 bgu
 bgu
-aZm
-aZn
-aZn
+bfp
+dcU
+ddj
+ddD
+dee
+bfp
 bkV
 blW
 bmO
@@ -99128,7 +107276,7 @@ bBz
 bBz
 bmO
 aZz
-aZA
+aZm
 bHA
 bIZ
 bKF
@@ -99207,14 +107355,14 @@ cCH
 cDx
 cCH
 cBR
-cln
+dmF
 cFu
 cFI
-cFI
-cFI
-cFI
+dmV
+cFu
+cFu
 cGU
-cFI
+cFu
 cFI
 cHJ
 cHY
@@ -99290,18 +107438,18 @@ acH
 acH
 acH
 acH
-aez
+avi
 akq
 afq
 afq
 afq
-afq
-afq
-afq
-amI
-ahr
+akq
+akq
+akq
+aBC
+aCr
 apX
-anN
+aoq
 arS
 asP
 atV
@@ -99358,18 +107506,18 @@ aYP
 aZY
 bbv
 bbW
-bcy
-bde
-bdR
-aZm
-aZm
-aZm
-aZm
-aZm
-aZn
-aZm
+aZY
+aZY
+aZY
+dcw
+bfp
+dcV
+ddk
+ddE
+def
+bfp
 bkW
-blW
+deT
 bmO
 bnV
 bpz
@@ -99466,12 +107614,12 @@ cEg
 cBR
 cFf
 cDv
+dmU
 cDv
 cDv
-cDv
-cDv
-cDv
-cDv
+dnb
+dnf
+dni
 cDv
 cHK
 cHZ
@@ -99618,15 +107766,15 @@ bbX
 bbX
 bbX
 bbX
-aZY
-aZo
-aZo
-aZo
-aZn
-aZn
-aZn
+dcx
+dcJ
+dcW
+ddl
+ddF
+deg
+bfp
 bkV
-blW
+deU
 bmO
 bnV
 bpA
@@ -99722,12 +107870,12 @@ cDz
 cEh
 cBR
 cFg
-cgL
-cgL
+cxT
+ckH
 chb
 cGu
 cjV
-chc
+cjU
 chc
 chb
 cgL
@@ -99875,15 +108023,15 @@ bbX
 bbX
 bdf
 bdS
-aZY
-aZY
-aZY
-aZo
-aZo
-aZo
-aZo
+dcy
+bfp
+bfp
+ddm
+bgt
+deh
+bfp
 bkV
-blW
+deV
 bmO
 bnW
 bpB
@@ -99980,14 +108128,14 @@ cEi
 cBR
 cFd
 cgL
+cjU
+cjV
 chc
 chc
 chc
 chc
-chc
-chc
-chc
-chc
+cjV
+cjV
 cjV
 cIu
 cIG
@@ -100134,11 +108282,11 @@ bcz
 bcz
 bcz
 bfu
-aZY
-aZo
-aZo
-aZo
-aZo
+bfp
+bhl
+bgt
+dei
+bfp
 bkX
 blX
 bmO
@@ -100237,8 +108385,8 @@ cBR
 cBR
 cFd
 cgL
-cgL
-cgu
+clr
+cjU
 cgu
 chc
 chc
@@ -100391,11 +108539,11 @@ aZY
 aZY
 aZY
 bfv
-aZY
-aZY
-aZY
-aZY
-aZY
+bfp
+ddn
+ddG
+dej
+bfp
 bkY
 blY
 bmO
@@ -100493,10 +108641,10 @@ cDB
 czG
 chb
 cFd
-cgL
-cgL
-cgu
-cgu
+cxT
+ckH
+cjU
+cjV
 cgu
 cgu
 chc
@@ -100648,10 +108796,10 @@ bcB
 bdT
 bcB
 bfw
-bcB
+dcX
 bhm
 bcB
-bcB
+bKJ
 bkd
 bkZ
 blZ
@@ -100753,7 +108901,7 @@ cFh
 cFv
 cgL
 cgL
-cgu
+cjU
 cgu
 cgu
 chc
@@ -100908,7 +109056,7 @@ bfx
 bbz
 bbz
 biw
-bbz
+dek
 bbz
 bla
 bma
@@ -101165,7 +109313,7 @@ bfy
 bbA
 bbA
 bix
-bbA
+bix
 bbA
 blb
 bmb
@@ -101258,16 +109406,16 @@ cyS
 czr
 cAk
 cBf
-cBU
-cBU
-cBU
-cBU
-cBU
-cBU
-cBU
+dmg
+dmi
+dml
+dms
+dmw
+dmG
+dmL
 cFd
-cgL
-chc
+cxT
+cjV
 chc
 cgu
 cgu
@@ -101517,16 +109665,16 @@ cAj
 cBg
 cBV
 cCM
-cCM
-cCM
-cCM
-cCM
-cBU
+dmm
+dmt
+dmx
+dmH
+dmM
 cFd
-cgL
+cCC
 cjU
-chc
-cgu
+cjU
+cjV
 cgu
 cgu
 chc
@@ -101535,11 +109683,11 @@ cgS
 cgS
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -101774,16 +109922,16 @@ cAl
 cBh
 cBW
 cCN
-cCN
-cCN
-cCN
+dmn
+dmu
+dmy
 cFi
-cBU
+dmN
 cFJ
-cFv
-cnb
+dmW
+coJ
 clV
-chc
+cjV
 chc
 chc
 chc
@@ -101792,11 +109940,11 @@ cgN
 cgS
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -101879,7 +110027,7 @@ aog
 cJv
 axw
 ayt
-aof
+cZr
 aBi
 afr
 aDu
@@ -102030,18 +110178,18 @@ czt
 cAm
 cBi
 cBX
-cCO
-cDE
+dmj
+dmo
 cEj
-cDE
+dmz
 cFj
-cBU
+dmO
 chc
-cFd
-cgL
-cgL
-chc
-chc
+cFe
+cjU
+cjV
+cjV
+cjU
 chc
 cjV
 chc
@@ -102049,11 +110197,11 @@ cgN
 cgN
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -102288,29 +110436,29 @@ cAn
 cBj
 cBY
 cCP
-cDF
-cDF
+cCP
+dmv
 cES
 cFk
-cBU
+dmP
 chc
 cFd
-cgL
-cgL
-cgL
-cgL
-cgL
-cnb
+cll
+cll
+cll
+cll
+cll
+dno
 chc
 cgN
 cgN
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -102543,31 +110691,31 @@ cta
 czv
 cAj
 cBk
-cBV
-cCQ
+dmh
+dmk
 cDF
 cEk
-cES
-cFk
-cBU
+dmA
+dmI
+dmQ
 chc
-cFw
-cGv
-cGv
+dmX
+dmZ
+dnc
 cGv
 cHi
-cFv
-chb
-chc
+dnm
+cHM
+cjV
 cgN
 cgN
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aab
@@ -102805,26 +110953,26 @@ cWn
 cWn
 cWn
 cWq
-cBV
-cBU
+dmJ
+dmR
 chc
 chc
 chc
 cjX
-cgL
-cgL
-cFd
-ckH
-chc
+cjV
+cjV
+cFe
+cIc
+cjV
 chc
 cgN
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aad
 aad
@@ -103070,9 +111218,9 @@ cET
 cET
 cET
 cET
-cFd
-cgL
-cyK
+cFe
+cll
+dnq
 chc
 cgN
 aaa
@@ -103164,7 +111312,7 @@ aog
 cJu
 axw
 ayt
-aof
+cZs
 aBi
 afr
 aDv
@@ -103327,9 +111475,9 @@ cFl
 cFl
 cGV
 cET
-cFd
-cgL
-chb
+cFe
+cll
+cHM
 chc
 cgN
 aaa
@@ -103584,9 +111732,9 @@ cFl
 cFl
 cFl
 cET
-cFd
-cGu
-cjU
+cFe
+cCC
+cjV
 chc
 cgN
 aaa
@@ -103842,8 +111990,8 @@ cGF
 cFl
 cET
 cFd
-cgL
-chc
+cll
+dnr
 chc
 cgN
 aaa
@@ -104098,8 +112246,8 @@ cFl
 cGG
 cFl
 cET
-cFd
-ckH
+dnn
+cIc
 cgu
 chc
 cgN
@@ -104355,9 +112503,9 @@ cFl
 cGH
 cET
 cET
-cFd
-clV
-cgu
+cFe
+cJf
+cjV
 chc
 cgN
 aaa
@@ -104612,8 +112760,8 @@ cGw
 cGI
 cGW
 cET
-cFd
-cgL
+cFe
+cll
 cgu
 chc
 cgN
@@ -104870,7 +113018,7 @@ cGJ
 cFn
 cCc
 cHr
-cGu
+cCC
 cjU
 chc
 cgN
@@ -105127,8 +113275,8 @@ cGK
 cEt
 cCc
 cHr
-cgL
-chc
+cxT
+cjU
 chc
 cgN
 aaa
@@ -105383,9 +113531,9 @@ cNu
 cGL
 cGX
 cCc
-cFd
-cgL
-cgu
+cFe
+cxT
+cjV
 cgu
 cgN
 aaa
@@ -105641,7 +113789,7 @@ cEt
 cEt
 cHj
 cHs
-cgL
+cll
 cgu
 cgR
 cgN
@@ -105898,8 +114046,8 @@ cGM
 cGY
 cCc
 cHt
-cgL
-cgu
+cll
+dns
 cgR
 cgN
 aaa
@@ -106154,9 +114302,9 @@ cGz
 cGN
 cGZ
 cCc
-cFd
-cgL
-chc
+cFe
+cll
+cjV
 cgR
 cgN
 aaa
@@ -106247,7 +114395,7 @@ aue
 avg
 afS
 axD
-adZ
+afS
 azY
 aBs
 aCi
@@ -106412,8 +114560,8 @@ cCc
 cHa
 cCc
 cHu
-cgL
-chc
+cll
+cjV
 cgR
 cgN
 aaa
@@ -106499,12 +114647,12 @@ amG
 akC
 agz
 afV
-akp
+aym
 auf
-akp
+aym
 afS
-afq
-akq
+akp
+aOF
 cJJ
 aBt
 aCj
@@ -106648,7 +114796,7 @@ cte
 cUn
 cvv
 cwq
-cwq
+dlB
 cxO
 cyD
 cue
@@ -106658,8 +114806,8 @@ cwg
 cCe
 cDb
 cyU
-cEv
 cue
+chc
 chc
 cCc
 cLM
@@ -106669,7 +114817,7 @@ cFI
 cHb
 cGv
 cHv
-cGu
+cCC
 cjU
 cgR
 cgN
@@ -106757,9 +114905,9 @@ afR
 afR
 afV
 asY
-akp
-avh
-awu
+aym
+cYZ
+akH
 axE
 ayA
 azY
@@ -106833,8 +114981,8 @@ bvm
 bwV
 byz
 bzM
-bkb
-bkb
+beD
+beD
 bCY
 bbi
 bFn
@@ -106857,7 +115005,7 @@ aZo
 aZo
 aZo
 aZm
-cad
+djg
 aZm
 aYP
 cbO
@@ -106916,17 +115064,17 @@ cCf
 cyU
 cDQ
 cue
-cue
+chc
 chc
 cCc
 cFO
 cLN
 cxT
-ckH
+dnd
 cln
-cgL
-cgL
-cmA
+cxT
+cxT
+dnp
 chc
 cgN
 cgN
@@ -107017,8 +115165,8 @@ afV
 afV
 afV
 afV
-afq
-anC
+akp
+cZl
 cJK
 aBt
 aCl
@@ -107179,7 +115327,7 @@ cxo
 cxo
 cjU
 cnL
-cjT
+dne
 coD
 cgL
 chc
@@ -107274,8 +115422,8 @@ aez
 aez
 adZ
 afS
-afq
-ayB
+akp
+cZm
 cJK
 aBs
 aCm
@@ -107292,7 +115440,7 @@ aNV
 aOV
 aPZ
 aRB
-cYe
+dbp
 cOS
 aTY
 afq
@@ -107514,12 +115662,12 @@ abW
 adZ
 adZ
 adZ
+afV
 adZ
 adZ
 adZ
 adZ
 adZ
-adZ
 aez
 aez
 aez
@@ -107527,12 +115675,12 @@ aez
 aez
 aez
 aez
-aez
-aez
-aez
-adZ
-afq
-anC
+afV
+afS
+afV
+afV
+cZj
+cZn
 azY
 aBv
 aCn
@@ -107549,7 +115697,7 @@ aNW
 aLm
 aQa
 aRt
-cYf
+dbq
 cOF
 anC
 aez
@@ -107674,7 +115822,7 @@ crz
 cjG
 cts
 cUn
-cgL
+cll
 cln
 cxo
 cxR
@@ -107691,12 +115839,12 @@ cxQ
 cyF
 cFC
 cxo
-chc
+cjU
 cln
-cgL
-cgL
-chc
-chc
+cjU
+cjU
+cjU
+cjU
 cgR
 cgN
 cgN
@@ -107772,14 +115920,14 @@ afS
 afw
 afq
 afq
-aiS
+aUW
 adZ
-adZ
-adZ
+afS
+afV
 alO
 afS
-aez
-aez
+afV
+afV
 aez
 aez
 aez
@@ -107787,9 +115935,9 @@ aez
 adZ
 aug
 aqG
-afq
-afq
-anC
+cZf
+akp
+cZo
 azY
 aBw
 aCo
@@ -107806,7 +115954,7 @@ azY
 aLm
 aQb
 aRt
-cYg
+dbr
 cOF
 aTZ
 aez
@@ -107931,8 +116079,8 @@ crA
 cjG
 cte
 cUn
-cgL
-cln
+cll
+clj
 cxo
 cxS
 cyH
@@ -107948,12 +116096,12 @@ cEY
 cyH
 cFD
 cxo
-chc
-cln
-cgL
-chb
-chc
-cgN
+cjU
+dna
+coJ
+dng
+dnj
+cjU
 cgR
 cgN
 cgN
@@ -108032,21 +116180,21 @@ aih
 aiT
 ahr
 ahr
-ahr
-ahr
+cYf
+aCr
 amH
-afq
+cYm
 aoq
-adZ
-adZ
+afV
+aqG
 afV
 alR
 afq
 akq
-avi
-afq
-afq
-anC
+cZa
+akp
+akp
+cZp
 azY
 azY
 azY
@@ -108055,15 +116203,15 @@ azY
 azY
 azY
 azY
-aqm
-aug
-aEi
-aMV
+dau
+daG
+aOH
+aRj
 aNX
 aLm
 aQc
 aRt
-cYh
+dbs
 cOV
 aTr
 cPs
@@ -108188,8 +116336,8 @@ crB
 cjG
 cte
 cUn
-ckG
-clq
+ckB
+dlx
 cxo
 cxo
 cxo
@@ -108207,10 +116355,10 @@ cxo
 cxo
 chc
 cln
-cgL
-cGu
 cjU
-cgN
+cll
+dnk
+cjU
 cgR
 cgN
 cgS
@@ -108288,21 +116436,21 @@ afS
 afS
 adZ
 ajL
-akq
-akq
-afq
-amI
-ahr
-ahr
-ahr
+akp
+akp
+akp
+aBC
+aCr
+aCr
+aCr
 aqj
 ahr
 asc
 asZ
-asZ
-asZ
+cYW
+cZb
 awv
-aox
+cZk
 ayC
 azZ
 aBx
@@ -108316,11 +116464,11 @@ aJT
 aBx
 aBx
 aCp
-aBx
+daX
 aOW
 aQd
 aRC
-cYi
+dbt
 aTr
 aUa
 cPt
@@ -108445,7 +116593,7 @@ crC
 cjG
 cte
 cUn
-cgL
+cll
 cln
 cxo
 cxQ
@@ -108464,10 +116612,10 @@ cyY
 cxo
 chb
 cln
-cgL
-cgL
-chc
-cgN
+cjU
+dnh
+dnl
+cjU
 cgN
 cgN
 cgN
@@ -108544,40 +116692,40 @@ agC
 ahs
 afV
 adZ
+afV
+afV
+cYg
+cYj
 aez
-aez
-alo
-afq
-aez
-aez
+afV
 adZ
-afq
-aeU
-afo
+akp
+aii
+aSe
 aot
 amJ
-apw
+cYX
 avj
-apu
+cZg
 afS
 ayD
 aAa
-afq
-afq
-afq
-apx
-afK
-afq
-aqH
-aoy
-afq
-afq
-afq
-akq
+akp
+akp
+cZC
+cZK
+cZS
+dab
+dal
+dav
+daH
+akp
+akp
+auZ
 akH
 aQa
 aRD
-cYj
+dbu
 aTq
 aUb
 cOV
@@ -108721,10 +116869,10 @@ cFC
 cxo
 cgL
 cln
-cgL
-cgu
-cgu
-cgR
+cjU
+cjU
+cjU
+cjU
 cgR
 cgN
 cgN
@@ -108804,18 +116952,18 @@ adZ
 adZ
 aez
 aez
+afV
 aez
 aez
-aez
-aeU
-afo
-aot
-amJ
-aox
-anz
-adZ
-aeV
-akq
+aii
+aSe
+aiX
+cYJ
+cYN
+cYS
+afV
+aht
+akp
 afS
 ayE
 aAb
@@ -108834,7 +116982,7 @@ aGE
 aGE
 aQe
 aRD
-cYk
+dbv
 aTq
 aUc
 aUX
@@ -108978,8 +117126,8 @@ cFD
 cxo
 cgL
 cln
-cgL
-cgu
+cmF
+cjU
 cgR
 cgR
 cgR
@@ -109064,15 +117212,15 @@ adZ
 aez
 aez
 adZ
-aeV
-amJ
-aqk
-anz
+aht
+cYt
+cYE
+cYK
+afV
+afS
 adZ
-adZ
-adZ
-aeV
-akq
+aht
+akp
 afS
 ayF
 aAc
@@ -109091,7 +117239,7 @@ aNY
 aGE
 aQa
 aRD
-cYl
+dbw
 aTq
 aUd
 aUc
@@ -109216,7 +117364,7 @@ crD
 cjG
 cte
 cUn
-cjX
+dlv
 cln
 cxo
 cxo
@@ -109233,10 +117381,10 @@ cxo
 cxo
 cxo
 cxo
-cgL
+clr
 cln
 cjX
-cjU
+cjV
 cjU
 cjU
 cjV
@@ -109320,22 +117468,22 @@ adZ
 adZ
 aez
 aez
-afV
+afS
 aor
-amK
+cYu
 adZ
 adZ
 adZ
 adZ
 adZ
-aeV
-akq
+aPE
+cZh
 afV
 ayG
 aAd
-aBA
-akp
-akp
+cZu
+aym
+aym
 aFc
 aGE
 aGE
@@ -109348,7 +117496,7 @@ aNZ
 aGE
 aQa
 aRD
-cYm
+dbx
 aTq
 aUe
 aUc
@@ -109473,7 +117621,7 @@ crC
 cjG
 cte
 cUn
-cgL
+dlw
 clo
 cxo
 cxQ
@@ -109490,7 +117638,7 @@ cxQ
 cyF
 cyY
 cxo
-cjX
+dmY
 cln
 cgL
 cjU
@@ -109577,10 +117725,10 @@ adZ
 adZ
 aez
 aez
-aez
-aeV
-amK
-adZ
+afS
+cYr
+cYv
+afV
 are
 are
 are
@@ -109592,7 +117740,7 @@ afV
 afV
 aBB
 akp
-akp
+aym
 aFd
 aGE
 aHP
@@ -109605,7 +117753,7 @@ aHP
 aGE
 aQa
 aRD
-cYn
+dby
 aTq
 aUf
 aUc
@@ -109833,10 +117981,10 @@ adZ
 adZ
 adZ
 adZ
-aez
-aez
-aos
-amK
+afV
+afV
+ahv
+cYw
 aez
 are
 asd
@@ -109847,9 +117995,9 @@ aww
 axF
 ayH
 are
-aBC
-aCr
-aCr
+cZv
+cZy
+cZD
 aFe
 aGE
 aHP
@@ -109862,7 +118010,7 @@ aOa
 aGE
 aQa
 aRE
-cYo
+dbz
 aTq
 aUg
 aUc
@@ -110088,12 +118236,12 @@ afV
 afV
 afV
 adZ
+afV
 adZ
-adZ
-adZ
-aeU
-aot
-amK
+afV
+aii
+aiX
+cYx
 adZ
 arf
 ase
@@ -110119,7 +118267,7 @@ aGE
 aGE
 aQa
 aRD
-cYp
+dbA
 aTq
 aUh
 aUc
@@ -110346,12 +118494,12 @@ aiU
 ajM
 akE
 afo
-afo
-afo
+aSe
+aSe
 any
-aou
-amK
-akq
+ahs
+cYy
+aOF
 are
 cJE
 atc
@@ -110376,7 +118524,7 @@ aOb
 are
 aQf
 aRF
-cYq
+dbB
 aTs
 aUi
 aUY
@@ -110778,7 +118926,7 @@ cxo
 cgL
 cln
 cnX
-cgu
+cjU
 cjV
 cjV
 cjV
@@ -110858,14 +119006,14 @@ ahA
 ahw
 aiW
 afV
-adZ
-adZ
+afV
+afV
 adZ
 afS
 alR
 aeV
-anC
-aqm
+cYz
+cYF
 are
 asf
 atb
@@ -110890,7 +119038,7 @@ aOc
 are
 aQh
 aRD
-cYr
+dbC
 cOW
 aTr
 aTr
@@ -111034,8 +119182,8 @@ cFD
 cxo
 ckF
 cln
-cgL
-cgu
+cmF
+cjU
 cgR
 cgR
 cgN
@@ -111117,11 +119265,11 @@ aiX
 afS
 adZ
 adZ
-adZ
+afV
 afq
 amJ
 aow
-apu
+cYA
 adZ
 are
 asg
@@ -111136,7 +119284,7 @@ aBD
 aCt
 aDR
 aFf
-aGF
+cZT
 are
 aIR
 aJX
@@ -111147,7 +119295,7 @@ aOd
 are
 aQh
 aRD
-cYs
+dbD
 cOF
 acH
 acH
@@ -111374,10 +119522,10 @@ afS
 afS
 adZ
 adZ
-adZ
+afV
 afq
 amK
-adZ
+afS
 adZ
 adZ
 are
@@ -111404,7 +119552,7 @@ are
 are
 aQi
 aRD
-cYt
+dbE
 cOF
 acH
 acH
@@ -111661,7 +119809,7 @@ aFg
 aOX
 aQj
 aRH
-cYu
+dbF
 cOF
 acH
 acH
@@ -111786,10 +119934,10 @@ crJ
 csu
 ctw
 cUn
-cgL
-cgL
+cjX
+dly
 cln
-cxT
+cll
 cxT
 cpX
 czU
@@ -111888,10 +120036,10 @@ afV
 adZ
 adZ
 adZ
-adZ
+afS
 afq
 amK
-adZ
+afV
 apv
 aqn
 arg
@@ -111918,7 +120066,7 @@ awy
 aOY
 aQk
 aRI
-cYv
+dbG
 aTu
 aUk
 aUk
@@ -111986,9 +120134,9 @@ bBN
 bBN
 bAd
 bAd
-bAd
-bBN
-bBN
+byS
+cMH
+byS
 bBN
 aZH
 aZH
@@ -112044,9 +120192,9 @@ cjG
 ctv
 cUn
 chc
-cgL
+cxT
 cjt
-clg
+dlE
 cyK
 chc
 czT
@@ -112063,7 +120211,7 @@ cnL
 coD
 cgL
 cgL
-cgu
+cjU
 cgR
 cgR
 cgN
@@ -112148,7 +120296,7 @@ adZ
 alP
 akq
 amK
-adZ
+afV
 apv
 aqo
 arh
@@ -112175,7 +120323,7 @@ atf
 aOZ
 aQl
 aRF
-cYw
+dbH
 aTv
 aUl
 aVa
@@ -112233,22 +120381,22 @@ aaa
 aaa
 aZt
 bAd
-bAd
+byS
 byS
 bDa
-bBN
-bBN
-bBN
-bBN
-bAd
-bAd
+cMH
 byS
-bDc
-byQ
-bTz
+bBN
+byS
+byS
+cMH
+byS
+bxu
+dir
+bAe
 bAd
-bAd
-bAd
+cMH
+byS
 bAd
 bBN
 aZH
@@ -112301,11 +120449,11 @@ cjG
 ctv
 cUn
 cjU
-ckG
-ckH
-cln
+ckB
+dlC
+dlF
 chc
-chc
+cjU
 czT
 czT
 czT
@@ -112319,8 +120467,8 @@ czT
 cln
 cgL
 cgL
-cmF
-cgu
+cmA
+cjU
 cgR
 cgR
 cgN
@@ -112432,7 +120580,7 @@ cJZ
 are
 aQm
 aRJ
-cYx
+dbI
 aTw
 aUm
 aVb
@@ -112490,28 +120638,28 @@ aaa
 aZf
 aZt
 bAd
-bAd
+byS
 bFo
 byQ
-byQ
-bBN
-bBN
-bBN
-byQ
-byQ
-byQ
-byQ
-byQ
-byQ
-byQ
-bEi
-byQ
+dhb
+byS
+cMH
+cMH
+cbr
+dhB
+dhN
+dhY
+cbr
+cbr
+cbr
+diT
+diW
 bWU
 byS
 bAd
-bAd
 byS
-cae
+byS
+djh
 cMH
 aZH
 aZt
@@ -112557,27 +120705,27 @@ crM
 cjG
 ctx
 cUn
-chc
-cgL
-ckH
-cjt
-clg
-chc
-chc
+cjU
+cll
+dlD
+dlG
+dlL
+cjU
+cjU
 chc
 chc
 cCs
 chc
 chc
+cjU
 chc
-chc
-chc
+cjU
 cnL
 coD
 chb
-chc
-chc
-cgu
+cjU
+cjU
+cjU
 cgR
 cgR
 cgN
@@ -112659,7 +120807,7 @@ adZ
 adZ
 adZ
 adZ
-afq
+cYk
 amK
 aez
 aez
@@ -112751,23 +120899,23 @@ byQ
 byP
 byP
 byP
-byP
-byP
-byP
-byP
-byP
-byP
-byP
 byO
-byP
-byP
-byP
-byP
-byP
-byP
-byP
-byP
-byO
+dhl
+bvU
+dhs
+cbr
+cbr
+cbr
+dis
+cbr
+cbr
+diU
+cbr
+cbr
+cbr
+cbr
+djb
+dje
 caf
 bBN
 bBN
@@ -112814,8 +120962,8 @@ cjF
 cjG
 ctv
 cUn
-chc
-chc
+cjU
+dlz
 chc
 chb
 cjt
@@ -112825,9 +120973,9 @@ cjT
 cBH
 cCt
 cjT
-clg
+dmp
 cEK
-cnL
+dmB
 cjT
 coD
 cgL
@@ -112918,7 +121066,7 @@ adZ
 afS
 alR
 amL
-aez
+afS
 aez
 apv
 aqp
@@ -113003,7 +121151,7 @@ aaa
 aaa
 aZt
 bBN
-bBN
+cMH
 bDb
 byP
 bGE
@@ -113014,19 +121162,19 @@ bGE
 bGE
 bGE
 bAd
+cMH
+byS
 bAd
-bAd
-bAd
-bPt
-bVA
-bDa
-byQ
-byQ
-byQ
-byQ
-byQ
-byP
-byP
+diR
+diV
+diX
+cbr
+cbr
+dja
+djc
+cbr
+cbr
+cbr
 bAd
 aZt
 aZt
@@ -113072,8 +121220,8 @@ cjG
 ctv
 cUn
 cgN
-chc
-chc
+dlA
+cjU
 ckz
 cgL
 cgL
@@ -113088,7 +121236,7 @@ coD
 cgL
 cgL
 ckz
-cgu
+cjU
 cgR
 cgR
 cgR
@@ -113175,7 +121323,7 @@ adZ
 aez
 alS
 amM
-aez
+afV
 aez
 apv
 apv
@@ -113260,7 +121408,7 @@ aaa
 aZt
 aZt
 bBN
-bBN
+byS
 byQ
 byP
 bGE
@@ -113282,13 +121430,13 @@ bOM
 bOM
 bOM
 bOM
-byQ
-bYK
+dji
+djl
 byS
 bAd
 bBN
-bBN
-bAd
+cMH
+byS
 bAd
 aZt
 aaa
@@ -113330,22 +121478,22 @@ cty
 cWe
 cgN
 cgN
-chc
+cjU
 cjV
-chc
+cjU
 cjX
 cgL
 ckH
 cgL
 cjU
 cgL
-cgL
-cgL
+cxT
+cxT
 cgL
 cjX
-chc
 cjU
-cgu
+cjU
+cjU
 cgR
 cgR
 cgR
@@ -113429,7 +121577,7 @@ afS
 adZ
 adZ
 adZ
-aez
+afV
 alT
 amN
 anA
@@ -113539,12 +121687,12 @@ bXG
 bYp
 bXG
 bOM
-byQ
-byP
-byP
-bAd
-bBN
-byQ
+cbr
+cbr
+cbr
+cMH
+byS
+cbr
 cdi
 byS
 byS
@@ -113589,18 +121737,18 @@ cgN
 cgN
 chc
 cgR
+cjU
 cgu
 cgu
-cgu
-cgu
+cjU
+cjU
+cjU
 chc
-chc
-chc
-chc
-cgu
-cgu
-cgu
-cgu
+dmq
+cjU
+cjU
+cjU
+cjU
 cgR
 cgR
 cgR
@@ -113686,7 +121834,7 @@ abW
 abW
 adZ
 adZ
-aez
+afV
 aez
 afq
 amK
@@ -113796,13 +121944,13 @@ bXG
 bYq
 bXG
 bOM
-bAd
-byQ
-byP
-byP
-bAd
-byQ
-bFq
+byS
+djm
+cbr
+cbr
+byS
+cbr
+djG
 cdB
 bLA
 cdB
@@ -113944,10 +122092,10 @@ abW
 abW
 adZ
 aez
-aez
+afV
 afq
 amK
-adZ
+afV
 apv
 apv
 apv
@@ -114031,7 +122179,7 @@ aZf
 aZt
 aZH
 bAd
-byS
+cMH
 byQ
 byP
 bGE
@@ -114054,12 +122202,12 @@ bYr
 bZb
 bOM
 bAd
-bPt
-caM
-byP
-byP
-byP
-byP
+djn
+djr
+djs
+bvU
+djx
+cbr
 cMH
 cMH
 byS
@@ -114201,15 +122349,15 @@ abW
 acH
 acH
 aez
-aez
-afq
+afS
+awZ
 amK
+afS
 adZ
-adZ
-alo
+cYG
 arl
-akq
-aqG
+cYO
+aiS
 auq
 aoq
 awD
@@ -114315,10 +122463,10 @@ cMH
 cMH
 byS
 cMH
-byP
-byP
-bBN
-bBN
+djy
+cbr
+byS
+byS
 aZt
 aZt
 aaa
@@ -114458,8 +122606,8 @@ abW
 acH
 acH
 acH
-aez
-afq
+afV
+afS
 anB
 aox
 apw
@@ -114468,7 +122616,7 @@ aox
 aox
 atk
 aur
-aox
+cZc
 awE
 afV
 axI
@@ -114544,7 +122692,7 @@ bwY
 aZf
 aZt
 bAd
-bBN
+byS
 bAf
 byP
 bAd
@@ -114572,9 +122720,9 @@ cbr
 cMV
 cbr
 byS
-byQ
-byP
-byP
+cbr
+cbr
+djL
 bAd
 aZt
 aZt
@@ -114715,8 +122863,8 @@ acH
 acH
 acH
 acH
-aez
-aez
+afV
+afV
 anC
 afq
 afq
@@ -114725,13 +122873,13 @@ alS
 afq
 aqG
 aus
-akq
+akp
 awF
-afo
-afo
-afo
-afo
-afo
+aSe
+aSe
+aSe
+aSe
+aSe
 aEb
 aFk
 aGM
@@ -114801,9 +122949,9 @@ bwZ
 bal
 aZt
 bAd
-bBN
+cMH
 byQ
-byP
+dgO
 bFp
 bGF
 bHM
@@ -114827,12 +122975,12 @@ bXJ
 bGE
 cMP
 cbr
-cbr
+djt
 cNc
-byP
-byP
-byP
-bBN
+djz
+cbr
+djM
+byS
 aZH
 aZt
 aaa
@@ -115059,7 +123207,7 @@ bal
 aZt
 bAd
 bAd
-bDa
+dgB
 byP
 bFq
 bGG
@@ -115087,9 +123235,9 @@ cMW
 cbr
 cMH
 bAd
-byQ
-byP
-bBN
+cbr
+djN
+djR
 aZH
 aZt
 aaa
@@ -115343,10 +123491,10 @@ bOM
 bOM
 bOM
 bOM
-bAd
-byQ
-byP
-bBN
+byS
+cbr
+djO
+cMH
 aZH
 aZt
 aaa
@@ -115492,7 +123640,7 @@ anE
 amR
 apy
 akF
-akq
+akp
 aso
 atm
 auu
@@ -115512,7 +123660,7 @@ aKg
 aLi
 aLU
 aHS
-cYd
+daY
 aPe
 aQr
 aRD
@@ -115600,10 +123748,10 @@ caA
 cbi
 cbi
 bOM
-bAf
-byP
-byP
-bBN
+djA
+cbr
+bAe
+byS
 aZH
 aZt
 aZt
@@ -115749,7 +123897,7 @@ anF
 aoz
 apz
 aqt
-akq
+akp
 aso
 atn
 auv
@@ -115832,7 +123980,7 @@ bAP
 bBO
 bDd
 bEk
-bAd
+byS
 bGI
 bHQ
 bJx
@@ -115857,8 +124005,8 @@ caB
 cbj
 cbP
 bOM
-byQ
-byP
+djB
+cbr
 bBN
 bBN
 aZH
@@ -116006,7 +124154,7 @@ amQ
 aoA
 apA
 aqu
-akq
+akp
 aso
 ato
 auw
@@ -116089,7 +124237,7 @@ bAP
 bBO
 bDe
 bEl
-bAd
+cMH
 bGI
 bHR
 bJx
@@ -116114,8 +124262,8 @@ caC
 cbi
 cbi
 bOM
-byQ
-byP
+cbr
+cbr
 bBN
 aZH
 aZH
@@ -116341,7 +124489,7 @@ bua
 bvx
 bxc
 bcp
-bco
+dgc
 bco
 bal
 bDf
@@ -116371,9 +124519,9 @@ bOM
 bOM
 bOM
 bOM
-bPt
-byP
-bBN
+djC
+cbr
+cMH
 aZH
 aZH
 aZt
@@ -116590,7 +124738,7 @@ bal
 ben
 bmr
 bnc
-bco
+dfu
 cQW
 brb
 bsq
@@ -116628,9 +124776,9 @@ caD
 cbk
 cbk
 bOM
-byQ
-bYK
-byS
+cbr
+djH
+cMH
 aZt
 aZt
 aZt
@@ -116885,8 +125033,8 @@ caE
 cbl
 cbQ
 bOM
-byQ
-byP
+cbr
+cbr
 bAd
 aZH
 aZt
@@ -117142,8 +125290,8 @@ caF
 cbk
 cbk
 bOM
-byQ
-byO
+cbr
+djI
 bAd
 aZH
 aZH
@@ -117399,9 +125547,9 @@ bOM
 bOM
 bOM
 bOM
-byQ
-byP
-bAd
+cbr
+cbr
+byS
 bBN
 aZH
 aZt
@@ -117656,10 +125804,10 @@ caG
 cbm
 cbm
 bOM
-caM
-byP
-byP
-bBN
+djD
+cbr
+djP
+byS
 aZH
 aZt
 aZt
@@ -117816,7 +125964,7 @@ aza
 aAw
 aBP
 aCJ
-aEf
+cZE
 aFv
 aGV
 aCJ
@@ -117895,10 +126043,10 @@ bJH
 bpS
 bGJ
 bNF
-bNF
-bNF
-bNF
-bNF
+dhC
+dhO
+dhZ
+dit
 bTL
 bUI
 bVJ
@@ -117913,10 +126061,10 @@ caH
 cbn
 cbR
 bOM
-byQ
-byQ
-byP
-bBN
+djE
+cbr
+djQ
+cMH
 aZH
 aZt
 aZt
@@ -118146,13 +126294,13 @@ abC
 abC
 abC
 bFx
-bGO
-bHZ
+dha
+dhc
 bJI
 bLk
 bME
-bLk
 bOW
+dhD
 bQx
 bnk
 bSJ
@@ -118171,8 +126319,8 @@ cbm
 cbm
 bOM
 bAd
-byQ
-byP
+djJ
+bvU
 bBN
 aZH
 aZt
@@ -118330,7 +126478,7 @@ azc
 aAy
 aBR
 awL
-aEh
+cZF
 aFx
 aGX
 aHX
@@ -118404,14 +126552,14 @@ cWJ
 cWJ
 cXQ
 bGP
-bIa
+dhd
 bJJ
-bLl
-bLl
-bLl
+dhm
+dhn
+dht
 bOX
 bQy
-bnk
+dia
 bSK
 bTM
 bUK
@@ -118427,10 +126575,10 @@ bOM
 bOM
 bOM
 bOM
-byQ
-byQ
-byP
-bBN
+cbr
+djK
+caf
+byS
 aZH
 aZt
 aZt
@@ -118665,10 +126813,10 @@ bIb
 bJK
 bLm
 bMF
-bLo
+bPa
 bOY
-bQy
-bnk
+dhP
+dib
 bSL
 bTM
 bUL
@@ -118684,9 +126832,9 @@ caJ
 cbo
 cbo
 bOM
-bVA
+djF
 bAd
-byP
+cbr
 bBN
 aZH
 aZt
@@ -118924,9 +127072,9 @@ bLn
 bMG
 bNG
 bOZ
-bQy
-bnk
-bnk
+dhQ
+dic
+diu
 bTM
 bUM
 bVM
@@ -118942,9 +127090,9 @@ cbo
 cbS
 bOM
 bAd
-bAd
-byP
-bBN
+byS
+cbr
+byS
 aZH
 aZH
 aZH
@@ -119179,11 +127327,11 @@ bId
 cMz
 bLo
 bMH
-bNH
 bPa
+dhE
 bQz
-bnk
-bnk
+did
+div
 bTM
 bUN
 bJx
@@ -119199,9 +127347,9 @@ cbo
 cbo
 bOM
 bAd
-bAd
-byP
-bBN
+cMH
+cbr
+byS
 aZH
 aZH
 aZH
@@ -119435,11 +127583,11 @@ cXQ
 bIe
 bJK
 bLo
-cMC
+dho
 bNH
 bPb
-bQy
-bnk
+dhR
+die
 bSM
 bTM
 bUO
@@ -119457,7 +127605,7 @@ bOM
 bOM
 bAd
 bAd
-byP
+cbr
 bBN
 aZH
 aZH
@@ -119465,9 +127613,9 @@ aZH
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -119691,12 +127839,12 @@ bFC
 cKV
 bIf
 bJK
-bLo
 bMI
 bNI
+dhu
 bPc
-bQy
-bnk
+dhS
+dif
 bSN
 bTN
 bUP
@@ -119710,11 +127858,11 @@ bZR
 bGE
 bAd
 bAd
+byS
 bAd
-bAd
-bAd
-byQ
-byP
+byS
+cbr
+cbr
 bBN
 aZH
 aZH
@@ -119722,9 +127870,9 @@ aZH
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -119949,12 +128097,12 @@ bGS
 bHZ
 bJK
 bLo
-bLo
 bNJ
 bPd
-bQy
-bQy
-bQy
+dhF
+dhT
+dig
+diw
 bTO
 bUQ
 bVP
@@ -119965,14 +128113,14 @@ bGE
 bGE
 bGE
 bGE
+byS
 bAd
-bAd
-bYa
-bAd
+dju
+byS
 bPt
-byQ
 byP
-bBN
+cbr
+djS
 aZH
 aZt
 aaa
@@ -120207,7 +128355,7 @@ bIa
 bJN
 bLp
 bMJ
-bLp
+dhv
 bPe
 bQA
 bRB
@@ -120216,28 +128364,28 @@ bTP
 bUR
 bVQ
 bWD
+cbr
+cbr
+cbr
+cbr
+cbr
+cMV
+cbr
+cbr
+cbr
+djv
 byP
 byP
-byP
-byP
-byP
-cai
-byP
-byQ
-byQ
-bDa
-byQ
-byQ
-byP
-bBN
+cbr
+cMH
 aZH
 aZt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+djW
+dkd
+dkk
+dkq
+dkx
 aaa
 aaa
 aaa
@@ -120368,7 +128516,7 @@ aim
 aiY
 ajN
 afS
-adZ
+afS
 adZ
 akG
 abW
@@ -120464,8 +128612,8 @@ bIg
 bJK
 bLo
 bLo
-bLo
-bPa
+dhw
+dhG
 bQB
 bRC
 bSP
@@ -120476,25 +128624,25 @@ bQH
 bQH
 bQH
 bQH
-bAd
-bTz
-byQ
+byS
+bAe
+djj
+cbr
 byP
 byP
 byP
 byP
 byP
 byP
-byP
-bBN
+byS
 aZH
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+djX
+dke
+dkl
+dkr
+dky
 aaa
 aaa
 aaa
@@ -120625,9 +128773,9 @@ ain
 aiZ
 ajO
 akH
-alr
+cYh
 afV
-adZ
+afS
 adZ
 aez
 aez
@@ -120735,23 +128883,23 @@ bXU
 bQH
 bAd
 bAd
-bAd
-bAd
-bAd
+byS
+cMH
+byS
+bDb
 byQ
 byQ
-byQ
-byP
+byO
 byP
 bAd
 aZt
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+djY
+dkf
+dkm
+dks
+dkz
 aaa
 aaa
 aaa
@@ -120882,13 +129030,13 @@ aio
 aio
 ajP
 akH
-alr
+cYi
 amb
-alS
-afq
-aez
+cYl
+akp
+afV
 afS
-aqG
+cYH
 arv
 asw
 atz
@@ -121000,15 +129148,15 @@ byP
 byP
 bYK
 byS
-bAd
+byS
 aZt
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+djZ
+dkg
+dkn
+dkt
+dkA
 aaa
 aaa
 aaa
@@ -121139,14 +129287,14 @@ ahI
 aja
 ajQ
 afS
-adZ
+afS
 aiS
+akp
+alS
 akq
-akq
-akq
-aoQ
-afq
-afq
+amb
+akp
+akp
 asw
 asw
 asw
@@ -121166,7 +129314,7 @@ adZ
 aLm
 aMj
 aNl
-aOl
+daZ
 aLm
 aQG
 aRN
@@ -121250,22 +129398,22 @@ bQH
 bAd
 bAd
 bAd
-bAd
+byS
 cbp
 byQ
 byP
-bAd
+byS
 bAd
 bAd
 bAd
 aZt
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dka
+dkh
+dko
+dku
+dkB
 aaa
 aaa
 aaa
@@ -121398,26 +129546,26 @@ afS
 afS
 adZ
 adZ
-adZ
+afV
 afq
 akq
 akq
 akq
-akq
-alQ
+akp
+cYP
 atA
 auE
 ahr
 aqj
-ahr
-ahr
+aCr
+aCr
 aAF
 aBU
-ahr
-aqj
-ahr
+aCr
+cZG
+aCr
 aHe
-aEj
+aBA
 adZ
 adZ
 aLm
@@ -121507,11 +129655,11 @@ bQH
 bAd
 bAd
 bAd
-bAd
+byS
 byQ
 byP
-byP
-bAd
+djw
+cMH
 aZt
 aZt
 aZt
@@ -121656,26 +129804,26 @@ afV
 abC
 akG
 adZ
-aez
-afq
-afq
+afV
+aUV
+cYB
 aqH
-afq
-afq
-afq
-apx
-afq
-afq
-afq
-afq
-afq
-afq
-afq
-afq
-afq
-afq
+akq
+akq
+akq
+alQ
+akq
+akq
+akq
+akp
+akq
+akq
+akq
+akq
+akq
+akq
 anC
-ajt
+dam
 afS
 aLn
 aMl
@@ -121915,24 +130063,24 @@ abW
 abW
 aez
 aez
+afS
 aez
-aez
-aez
-afq
-aoy
+afV
+cYQ
+cYT
 apx
 afq
 afq
 alQ
-aez
+afV
 aoy
 apx
 aqH
-afq
+akq
 afq
 afq
 anC
-afq
+akq
 aKn
 aLn
 aLn
@@ -122020,10 +130168,10 @@ bWI
 bQH
 bAd
 bAd
-bAd
+byS
 caM
 byP
-bAd
+byS
 bAd
 aZt
 aZH
@@ -122174,8 +130322,8 @@ abW
 acH
 acH
 aez
-aez
-aez
+afV
+afS
 afV
 adZ
 adZ
@@ -122185,16 +130333,16 @@ adZ
 afS
 aez
 aez
-anN
+cZH
 afq
 aoy
 aIe
-ahr
-azq
-ahr
-auE
-ahr
-aOo
+aCr
+daw
+daI
+daO
+daR
+dba
 aPi
 aQJ
 aRD
@@ -122277,10 +130425,10 @@ bXZ
 bQH
 bAd
 bAd
-bAd
-byQ
+cMH
+djo
 byP
-bBN
+byS
 bBN
 aZH
 aZH
@@ -122443,15 +130591,15 @@ acH
 acH
 aez
 aEi
-aez
+afS
 afV
 aez
-aez
-afq
-afq
-apx
-aus
-avh
+afV
+dax
+akp
+daP
+daS
+auZ
 aPj
 aQa
 aRD
@@ -122532,12 +130680,12 @@ bWJ
 bXi
 bXZ
 bQH
-bAd
+byS
 bAd
 byQ
 byP
 byP
-bBN
+cMH
 aZH
 aZH
 aZH
@@ -122697,16 +130845,16 @@ acH
 acH
 acH
 aez
-aez
-adZ
-afq
+afS
+afS
+akp
 aez
 acH
 acH
 aez
 aez
-aez
-adZ
+afS
+afV
 aLm
 aLm
 aLm
@@ -122954,9 +131102,9 @@ abW
 abW
 abW
 adZ
-afq
-afq
-afq
+akp
+akp
+akp
 aez
 acH
 acH
@@ -123049,8 +131197,8 @@ byS
 bDc
 byQ
 byP
-byP
-bAd
+djp
+byS
 bBN
 aZH
 aZH
@@ -123212,7 +131360,7 @@ afS
 afS
 afS
 afS
-alQ
+cZz
 afV
 adZ
 abW
@@ -123302,10 +131450,10 @@ bQH
 bAd
 bAd
 bAd
-bAd
+cMH
 byQ
 byP
-byP
+djk
 bZS
 cMH
 cMH
@@ -123468,8 +131616,8 @@ abW
 afS
 azm
 akp
-akq
-akq
+cZw
+akp
 afS
 adZ
 abW
@@ -123556,10 +131704,10 @@ bQH
 bTY
 bQH
 bQH
+cMH
 byS
-bAd
-bAd
-bAd
+byS
+cMH
 byQ
 byP
 bZS
@@ -123812,10 +131960,10 @@ bJZ
 bQH
 cLc
 cLe
-byP
-cai
-bAd
-bAd
+cbr
+cMV
+cMH
+cMH
 byQ
 byP
 byP
@@ -124050,7 +132198,7 @@ cSv
 buq
 bvT
 bxv
-byO
+dfT
 bAd
 cTr
 bCe
@@ -124070,8 +132218,8 @@ bQH
 bTZ
 bQH
 bAd
-byP
-byP
+cbr
+cbr
 byP
 byP
 byO
@@ -124307,7 +132455,7 @@ cSv
 bhP
 bvU
 bxw
-byP
+cbr
 bAe
 cTr
 bCf
@@ -124327,10 +132475,10 @@ cLa
 cLa
 cLa
 bAd
-bAd
-byQ
-byQ
-byQ
+cMH
+byP
+byP
+byP
 byP
 cMH
 cak
@@ -124564,8 +132712,8 @@ cSv
 bur
 bal
 bxx
-byQ
-byP
+cbr
+cbr
 cTr
 bCg
 bDD
@@ -124588,7 +132736,7 @@ bAd
 bVA
 byQ
 byP
-byP
+djd
 cMH
 cal
 caP
@@ -124822,7 +132970,7 @@ bus
 bal
 bxy
 byR
-byP
+cbr
 cTu
 cTq
 cTz
@@ -124841,7 +132989,7 @@ bAd
 bAd
 bAd
 bAd
-bAd
+byS
 bYa
 byQ
 byP
@@ -125079,8 +133227,8 @@ bhP
 bal
 bxz
 byS
-byP
-byP
+cbr
+cbr
 cTu
 cTA
 bBf
@@ -125098,7 +133246,7 @@ bAd
 bAd
 bAd
 bAd
-bAd
+byS
 byQ
 byP
 bYK
@@ -125335,14 +133483,14 @@ cSv
 bhP
 bal
 bxA
-byS
-bAf
-byP
+cMH
+dgd
+cbr
 bBN
 bBN
-bBN
-bBN
-bBN
+cMH
+cMH
+cMH
 caM
 bJZ
 bJZ
@@ -125354,11 +133502,11 @@ bJZ
 bAd
 bAd
 bAd
-bAd
+byS
 byQ
+byO
 byP
-byP
-bBN
+byS
 bBN
 aZt
 aZt
@@ -125594,27 +133742,27 @@ bal
 bxz
 byS
 bAd
-bLA
+dgm
+cbr
+cbr
+dgP
+dgY
 byP
-byQ
-byQ
-byQ
-byQ
 bDa
 byQ
 byQ
 byQ
 bNS
-bAd
+byS
 bAd
 bAd
 byS
 bAd
 bAd
-bAd
+cMH
 byQ
 byP
-bAd
+byS
 bBN
 aZH
 aZt
@@ -125852,26 +134000,26 @@ bxB
 aZt
 bAd
 byS
+cbr
+dgC
+bvU
+bDd
 byP
 byP
 byP
 byP
-byP
-byP
-byP
-byP
-byP
+byO
 byQ
-bPt
+dhH
+byS
 bAd
-bAd
-bFo
+dix
 bUa
-bAd
+byS
 byQ
 byQ
 byP
-bBN
+cMH
 aZH
 aZH
 aZt
@@ -126109,26 +134257,26 @@ arw
 aZt
 aZt
 bAd
-bBN
-byQ
-byQ
+byS
+dgD
+byS
 byQ
 bBg
-byQ
+bDb
 byQ
 byQ
 byP
 byP
 byQ
-byQ
+dhU
 byQ
 byQ
 byQ
 bDa
 byQ
 byP
-byP
-bBN
+diZ
+cMH
 aZH
 aZH
 aZt
@@ -126368,13 +134516,13 @@ aZt
 aZt
 bBN
 bBN
-bBN
-bBN
+byS
+cMH
 byS
 bBN
-bBN
-bBN
-bAd
+cMH
+cMH
+byS
 byP
 byP
 byP
@@ -126384,8 +134532,8 @@ byP
 byP
 byP
 byP
-bAd
-bBN
+cMH
+byS
 aZH
 aZt
 aZt
@@ -126631,17 +134779,17 @@ aZH
 aZt
 aZt
 aZt
-bAd
-bAd
+byS
+byS
 bBN
 bBN
+cMH
 bBN
 bBN
-bBN
-bBN
-bBN
-bBN
-bBN
+byS
+cMH
+cMH
+byS
 aZH
 aZH
 aZt
@@ -126676,8 +134824,8 @@ chD
 chT
 cip
 chr
-chc
-chc
+cjV
+cjU
 chc
 cgu
 cgu
@@ -126935,9 +135083,9 @@ ciq
 ciR
 cjs
 cjS
-cgL
-chc
-chc
+cll
+cjV
+cjU
 chc
 cna
 cnK
@@ -127190,12 +135338,12 @@ chF
 chV
 cir
 chq
-cjt
-cjT
-cjT
-clg
-chb
-chc
+dkF
+dkG
+dkH
+dkO
+cHM
+cjV
 cmZ
 cmZ
 cmZ
@@ -127447,14 +135595,14 @@ chq
 chr
 chr
 chr
+cjU
 cgu
-cgu
-ckz
-cjt
-cjT
+dkI
+dkP
+dkT
 cms
 cnb
-cmF
+cmA
 coB
 cgL
 cpX
@@ -127707,13 +135855,13 @@ cgi
 cgu
 cgu
 cjV
-cgu
-cgL
+cjU
+dkU
 cmt
-cjT
+dkZ
 cjT
 coC
-cjT
+cBH
 cpY
 cqI
 crW
@@ -127965,10 +136113,10 @@ cgi
 cgu
 cgu
 cgu
-cgu
-chc
-chc
-cnL
+cjU
+cjV
+cjV
+dlb
 coD
 cgL
 cpZ
@@ -128227,8 +136375,8 @@ cfJ
 chc
 cnM
 cgL
-cgL
-chc
+dlo
+cjU
 cqD
 crY
 cLu
@@ -128484,7 +136632,7 @@ chc
 chc
 cln
 chb
-chc
+cjV
 chc
 cqD
 crZ
@@ -128740,7 +136888,7 @@ clQ
 cmu
 ckG
 cln
-cmA
+dlh
 chc
 chc
 cqD
@@ -128996,7 +137144,7 @@ cli
 clR
 cmv
 ckH
-cln
+clq
 chc
 cpm
 cpm
@@ -129248,13 +137396,13 @@ cgi
 cgi
 cfJ
 cjV
-ckB
+dkJ
 clj
 clS
 cmw
 cgL
 cln
-chc
+cjU
 cpm
 cqa
 cqJ
@@ -129394,7 +137542,7 @@ arz
 arz
 arz
 arz
-cYy
+dbJ
 aTD
 arw
 aaa
@@ -129767,8 +137915,8 @@ cll
 clU
 cmy
 cnc
-cjt
-cms
+dlc
+dli
 cpm
 cqc
 cqL
@@ -130020,12 +138168,12 @@ cfJ
 cfJ
 cjU
 ckE
-cll
+cIC
 cll
 cjU
 cnd
 cnO
-cln
+dlj
 cpm
 cqd
 cqM
@@ -130279,7 +138427,7 @@ cjU
 cjU
 cjV
 cjU
-cjU
+cjV
 chb
 cnP
 cln
@@ -130386,7 +138534,7 @@ adh
 aal
 agj
 ahi
-ahS
+cYe
 aiB
 agk
 ajX
@@ -130536,7 +138684,7 @@ cfJ
 cfJ
 cfJ
 cfJ
-chc
+cjV
 ckF
 cnP
 coE
@@ -131051,9 +139199,9 @@ cgi
 cgi
 cfJ
 chc
-chc
+cjU
 cnP
-cln
+clj
 cqf
 cUl
 cqO
@@ -131309,8 +139457,8 @@ cgi
 cfJ
 cfJ
 chc
-cnP
-cln
+dld
+clj
 cqf
 cqf
 cqP
@@ -131565,9 +139713,9 @@ cgi
 cgi
 cfJ
 cfJ
-chc
-cnP
-cjt
+cjV
+dle
+dlk
 cUh
 cqf
 cqQ
@@ -131822,10 +139970,10 @@ baS
 baS
 baS
 cgi
-cgu
+cjV
 cnQ
-cnO
-cln
+dll
+clj
 cqf
 cqR
 cse
@@ -132079,10 +140227,10 @@ bNT
 bey
 baS
 cgi
-cgu
+cjU
 cjV
 coF
-cnM
+dlp
 cqf
 cqS
 cse
@@ -132259,11 +140407,11 @@ bbo
 bbo
 bbq
 bbq
-baS
-baS
-baS
-baS
-baS
+bbq
+bbq
+bbq
+bbq
+bbq
 bbq
 baS
 bnx
@@ -132337,8 +140485,8 @@ cLm
 baS
 cgi
 cgu
-cjX
-cnP
+cIa
+dlm
 cpo
 cqf
 cqT
@@ -132517,9 +140665,9 @@ bbq
 bbq
 bbq
 baS
-bia
-biW
-bjN
+baS
+baS
+baS
 baS
 baS
 baS
@@ -132777,11 +140925,11 @@ baS
 bib
 biX
 biX
-biX
 blv
 bmy
+bmy
 bnz
-boQ
+bmy
 bpY
 bru
 bsL
@@ -133034,8 +141182,8 @@ baS
 bic
 cKy
 biY
-biY
 blw
+deH
 biY
 bnA
 bHe
@@ -133285,15 +141433,15 @@ bbo
 bbo
 baS
 ber
-ber
+dcz
 bgg
 baS
 bid
 bbs
 bjO
-bkA
 blx
-cKC
+deI
+bkA
 bnB
 boR
 bqa
@@ -133548,10 +141696,10 @@ bgW
 bie
 biZ
 bjP
-bkB
-bkB
-bkB
-bkB
+baS
+deJ
+deW
+dff
 boS
 bqb
 cSt
@@ -133739,9 +141887,9 @@ alx
 alx
 and
 and
-adZ
-aez
-aez
+afV
+afV
+afS
 aez
 afV
 adZ
@@ -133805,11 +141953,11 @@ bgX
 bif
 bja
 bjQ
-bkB
+baS
 bly
-bly
-bly
-bmz
+bia
+biW
+bjN
 bqb
 brw
 bsO
@@ -133873,16 +142021,16 @@ cfJ
 cgi
 cgi
 cgu
-cgu
-chc
-chc
-clV
-cmA
-cgL
-cgL
+cjU
+cjU
+cll
+cJf
+dkW
+cll
+cHM
 coK
 cps
-chc
+cjV
 chc
 chc
 chc
@@ -134000,15 +142148,15 @@ afV
 aqH
 afq
 apx
-aoQ
-afK
+cZd
+cZi
 aiS
 azp
-aoQ
+amb
 aBV
 adZ
 afV
-aez
+afV
 aez
 alx
 alx
@@ -134062,11 +142210,11 @@ baS
 big
 bja
 bjP
-bkC
+deo
 blz
-bmz
-bmz
-boT
+blz
+blz
+blz
 bqb
 brx
 bsP
@@ -134130,16 +142278,16 @@ cfJ
 cgi
 cgi
 cgu
-cgu
-ckF
+cjV
+dkK
 clm
-cjT
-cjT
+dkV
+dkX
 cng
-cjT
+dlf
 coL
-coD
-chc
+dlq
+cjU
 chc
 chc
 chc
@@ -134251,21 +142399,21 @@ alx
 and
 and
 aez
-aez
-afq
+afS
+afV
 aoQ
 afq
-afq
-apx
-afq
-afq
-afq
-anC
-afq
-aqH
-afq
-aoQ
-afq
+akq
+alQ
+akq
+akq
+akp
+cZq
+akp
+cZx
+akp
+amb
+cZL
 aez
 and
 and
@@ -134312,18 +142460,18 @@ bbq
 bbq
 bbq
 baS
-bev
+dco
 bfk
 bgk
 baS
 big
 bjb
 bjR
-bkB
-bly
-bly
-bly
-boU
+dep
+deK
+deX
+dfg
+dfv
 bqb
 bry
 bsP
@@ -134387,9 +142535,9 @@ cgi
 cgi
 cgi
 cgu
-cgu
-ckF
-cln
+cjU
+dkL
+clj
 clW
 clW
 clW
@@ -134513,17 +142661,17 @@ aoR
 ahr
 ahr
 ahr
-ahr
+cYY
 avL
 ahr
 ahr
 azq
-ahr
+cZt
 ahr
 ahr
 aEj
-adZ
-aez
+afS
+afV
 aez
 aez
 aKo
@@ -134576,10 +142724,10 @@ baS
 big
 bja
 bjP
-bkB
+deq
 blA
-bmz
-bmz
+deY
+bmB
 boV
 bqb
 brz
@@ -134644,9 +142792,9 @@ cgi
 cgi
 cgi
 cgu
-cgu
-cgL
-cln
+cjV
+cll
+dkQ
 clW
 cmB
 cnh
@@ -134763,7 +142911,7 @@ ajn
 alx
 alx
 aez
-aez
+afS
 afV
 afq
 anC
@@ -134779,7 +142927,7 @@ arC
 arC
 afq
 anC
-afV
+afS
 adZ
 aIf
 adZ
@@ -134797,8 +142945,8 @@ aUH
 aVk
 aVE
 aLm
-adZ
-aez
+afV
+afV
 aXa
 aXt
 aXL
@@ -134833,10 +142981,10 @@ baS
 big
 bja
 bjP
-bkB
-bly
-bly
-bly
+der
+deL
+deZ
+dfh
 boW
 bqb
 brA
@@ -134901,9 +143049,9 @@ cgi
 cgi
 cgi
 cgu
-cjU
-ckG
-cln
+cjV
+ckB
+clj
 clW
 cmC
 cni
@@ -135020,7 +143168,7 @@ ajn
 ajn
 ajn
 ajn
-aiS
+aUW
 aoQ
 aoR
 aqN
@@ -135036,10 +143184,10 @@ asx
 arC
 aqH
 aEk
-aoQ
-afq
-apO
-adZ
+amb
+akp
+dac
+afS
 aKp
 aLr
 aMs
@@ -135055,7 +143203,7 @@ aVl
 aVF
 aLm
 ajt
-afq
+aqH
 aXb
 aXu
 aXM
@@ -135090,11 +143238,11 @@ baS
 big
 bja
 bjP
-bkB
-blz
-bmz
-bmz
-boU
+des
+deM
+dfa
+dfi
+dfw
 bqb
 brB
 bsS
@@ -135115,7 +143263,7 @@ bLH
 bEK
 bNW
 bPE
-bgp
+bgs
 bgp
 bbq
 bbq
@@ -135159,8 +143307,8 @@ cgi
 cgi
 cgu
 chc
-cgL
-clo
+cll
+dkR
 clW
 cmD
 cnj
@@ -135280,7 +143428,7 @@ ane
 alr
 aoR
 apP
-adZ
+afV
 arC
 asy
 atC
@@ -135291,12 +143439,12 @@ atC
 atC
 aAH
 arC
-adZ
+afS
 amI
-ahr
-ahr
-ahr
-aEj
+aCr
+aCr
+aCr
+aBA
 aKo
 aKo
 aKo
@@ -135347,10 +143495,10 @@ baS
 big
 bja
 bjP
-bkB
-bly
-bly
-bly
+det
+deN
+dfb
+dfj
 boX
 bqc
 brC
@@ -135416,8 +143564,8 @@ cgi
 cgi
 cgu
 chc
-cgL
-cln
+cxT
+clj
 clW
 cmC
 cmC
@@ -135536,7 +143684,7 @@ amg
 ajn
 anM
 aoS
-apx
+cYC
 adZ
 arC
 asz
@@ -135549,16 +143697,16 @@ atC
 aAI
 arC
 adZ
-adZ
-adZ
+afS
+afV
 aiS
-akq
-amI
-aEj
-aqH
-adZ
-adZ
-adZ
+dad
+dan
+day
+aCr
+aBA
+daT
+dbb
 aLm
 aRa
 aRK
@@ -135568,7 +143716,7 @@ aUK
 aVf
 aVH
 aLm
-afq
+aqH
 anC
 aXb
 aXb
@@ -135604,15 +143752,15 @@ cKp
 big
 bja
 bjP
-bkB
+deu
 blB
 bmA
-bmA
-bmA
+dfk
+dfx
 bqd
 brD
 bsU
-buH
+bza
 buI
 bqe
 bxT
@@ -135627,12 +143775,12 @@ bIz
 bKd
 bLJ
 bEK
-bhd
+dhx
 bPG
 bQN
 bRT
 bTa
-bgp
+bgs
 bbq
 bbo
 baW
@@ -135673,7 +143821,7 @@ cfJ
 cfJ
 chc
 cjW
-cgL
+cxT
 clp
 clW
 cmC
@@ -135807,15 +143955,15 @@ aAI
 arC
 adZ
 adZ
-adZ
-adZ
-adZ
-afq
-amI
-ahr
-aEj
-adZ
-adZ
+cZM
+cZU
+dae
+dao
+daz
+daJ
+anC
+daU
+afS
 aPl
 aRb
 aRR
@@ -135827,7 +143975,7 @@ aLm
 aLm
 aoR
 apu
-adZ
+afS
 alx
 alx
 alx
@@ -135861,18 +144009,18 @@ baS
 big
 bja
 bjS
-bkB
+dev
 blC
 bmB
 bnC
-bmz
-bkB
-brE
+bmB
+dfC
+dfK
 cMq
 buH
-buH
+bHn
 bqe
-cTo
+buH
 bAn
 bBp
 bCr
@@ -135886,10 +144034,10 @@ bLK
 bEK
 bNY
 bNZ
-bit
-bhd
-bTb
-bgp
+dhV
+dih
+diy
+bgr
 bbq
 bbo
 baW
@@ -135917,8 +144065,8 @@ cfJ
 cfJ
 cgi
 cgi
-cgu
-cgu
+cjV
+cjV
 cgu
 cgu
 cfJ
@@ -135927,10 +144075,10 @@ cgi
 cgi
 cfJ
 chc
-chc
-chc
+cjU
+cjU
 cjX
-cgL
+cxT
 cln
 clW
 cmC
@@ -136064,12 +144212,12 @@ aAJ
 arC
 anV
 anV
-anV
-adZ
-adZ
-afq
-aqH
-afq
+cZN
+cZV
+daf
+dap
+daA
+daK
 amI
 ahr
 aOo
@@ -136118,7 +144266,7 @@ baS
 big
 bja
 bjP
-bkD
+dew
 bkD
 bkD
 bkD
@@ -136127,7 +144275,7 @@ bqe
 brE
 bsT
 buH
-buH
+bHn
 cWw
 bzd
 bqe
@@ -136144,8 +144292,8 @@ bEK
 cKY
 bNZ
 bNZ
-bhd
-bTb
+dii
+diz
 bgp
 bbq
 bbq
@@ -136174,12 +144322,12 @@ cfJ
 cfJ
 cgi
 cgi
-cgu
+cjV
 cgC
 cgK
-cgu
+cjV
 chc
-chc
+cjU
 cgu
 cgu
 chc
@@ -136187,8 +144335,8 @@ chc
 ciS
 cjw
 cjw
-cgL
-cln
+cxT
+dkS
 clW
 cmE
 cnl
@@ -136307,7 +144455,7 @@ amh
 anf
 ajn
 aoU
-aoU
+cYD
 aqO
 arD
 asA
@@ -136321,14 +144469,14 @@ aAK
 aBW
 aCU
 aEl
-anV
-aez
-aez
-aez
-aez
-afq
-aoy
-afq
+cZO
+cZW
+dag
+daq
+daB
+daL
+daQ
+aUW
 avh
 aPw
 aRd
@@ -136384,10 +144532,10 @@ bqf
 brF
 bsV
 buJ
-buJ
-buJ
-buJ
-buJ
+dfO
+dfP
+dfU
+dge
 bBq
 bCt
 bDO
@@ -136401,8 +144549,8 @@ bMS
 bLP
 bPH
 bNZ
-bhc
-bTb
+dij
+diA
 bgp
 bbq
 bbq
@@ -136433,19 +144581,19 @@ cgi
 cgi
 cgu
 cgD
-cgL
+cxT
 cgL
 cgL
 chb
 cgL
 chc
 cgL
-cgL
+cxT
 ciS
 cjw
 cjV
-ckG
-cln
+dkM
+clj
 clW
 clW
 clW
@@ -136576,17 +144724,17 @@ apQ
 azt
 aAL
 aBX
-aoU
-aEm
-anV
-aez
-aez
-aez
-aez
-aez
+cZA
+aEn
+cZP
+cZX
+dah
+dar
+daC
+daM
 afV
 aez
-adZ
+afV
 aLm
 aRe
 aRT
@@ -136596,7 +144744,7 @@ aUM
 ahr
 ahr
 apu
-aez
+afV
 aez
 aLm
 aNp
@@ -136658,7 +144806,7 @@ bMT
 bOb
 bPI
 bNZ
-bhd
+dik
 bTc
 bgr
 bbo
@@ -136691,23 +144839,23 @@ cgi
 cgu
 cgu
 cgM
-chb
+dkE
 cgL
 cgL
-cgL
+cxT
 cgL
 cgL
 cit
 chc
 chc
+cjU
+dkN
+clj
+cjU
+cjV
 chc
-ckH
-cln
-chc
-chc
-chc
-chc
-chc
+cjU
+cjU
 chc
 chc
 chc
@@ -136834,12 +144982,12 @@ aoU
 aoU
 aBX
 aoU
-cMb
-anV
-aez
-aez
-aez
-aez
+aEn
+cZQ
+cZY
+dai
+das
+daD
 anV
 anV
 anV
@@ -136850,10 +144998,10 @@ aRD
 aTa
 aPw
 alr
-afq
+aqH
 aoy
-afq
-aez
+afK
+afV
 aez
 aLm
 aXw
@@ -136915,8 +145063,8 @@ bMU
 bOc
 bPJ
 bNZ
-bjg
-bTb
+dil
+diB
 bgp
 bbq
 bbq
@@ -136953,21 +145101,21 @@ chc
 cgu
 cgu
 chc
+cjV
 chc
 chc
 chc
 chc
-chc
-chc
+cjU
 clq
-cgL
-chc
-cgL
-cnX
-chc
-cgL
-chc
-chc
+cll
+cjU
+dla
+dlg
+cjU
+dlr
+cjU
+cjV
 cjV
 csU
 clW
@@ -137090,13 +145238,13 @@ aoW
 aoW
 aoW
 aBY
-aCV
-aEn
-anV
-aez
-aez
-aez
-aez
+azy
+cZI
+cZR
+cZZ
+daj
+dat
+daE
 anV
 aMt
 aNu
@@ -137174,7 +145322,7 @@ bPK
 bNZ
 bQM
 bTd
-bgp
+bgs
 bbq
 bbq
 bbq
@@ -137215,15 +145363,15 @@ cgi
 cgi
 cgu
 cgu
-cgu
+cjU
 cjt
 cjT
 cjT
 cnm
 cjT
+dln
 cjT
-cjT
-cjT
+dls
 cng
 csm
 csV
@@ -137369,7 +145517,7 @@ aTG
 aWi
 aTG
 aWR
-aTG
+dbP
 aXy
 aTG
 aTG
@@ -137429,8 +145577,8 @@ cMD
 bOd
 bPL
 bNZ
-bhd
-bTb
+dim
+diC
 bgp
 bgp
 bbq
@@ -137472,18 +145620,18 @@ cgi
 cgi
 cgu
 cgu
-cgu
+cjU
 clr
 ckz
 cgL
 cln
 chb
 cgL
-cgL
-chb
-ckH
-cgL
-cpX
+cxT
+dlt
+cIc
+cHM
+dlu
 coJ
 cuF
 csC
@@ -137686,10 +145834,10 @@ bLP
 bOc
 bPM
 bNZ
-bhd
+din
 bTe
-bhf
-bgp
+bMb
+bgs
 bbq
 bbq
 bbo
@@ -137732,13 +145880,13 @@ cgu
 cgu
 chc
 cjU
-cmF
+dkY
 cnn
 ckz
 chc
+cjV
 chc
-chc
-chc
+cjU
 chc
 chX
 chX
@@ -137946,7 +146094,7 @@ bNZ
 bRU
 bTf
 bUe
-bgp
+bgr
 bbq
 bbq
 bbo
@@ -138202,8 +146350,8 @@ bLQ
 bQO
 bRV
 bTg
-bOn
-bgp
+bIO
+bgr
 bbq
 bbq
 bbo
@@ -138397,7 +146545,7 @@ aLm
 aWm
 aPI
 aUR
-aUR
+dbQ
 aXz
 aLm
 alx
@@ -138426,7 +146574,7 @@ bbq
 bbq
 bbq
 bbq
-bgp
+bgs
 bha
 bio
 bje
@@ -138457,10 +146605,10 @@ bMY
 bOf
 bPO
 bNZ
-bNZ
+bgq
 bTh
 bUf
-bgq
+bgs
 bbo
 bbo
 bbo
@@ -138653,7 +146801,7 @@ alx
 aLm
 aWn
 aOl
-aNp
+dbO
 aXe
 aXA
 aLm
@@ -138685,7 +146833,7 @@ bbq
 bbq
 bgp
 bhb
-bip
+ddo
 bjf
 bjW
 bkF
@@ -138713,10 +146861,10 @@ cKX
 bMZ
 bOg
 bLP
-bQP
 bNZ
+bgq
 bTi
-bRY
+diJ
 bgq
 bbo
 bbq
@@ -138940,10 +147088,10 @@ bbo
 bbo
 bbq
 bbq
-bgp
+bgr
 bhc
 bip
-bhd
+btq
 bjW
 bkG
 blJ
@@ -138971,9 +147119,9 @@ bIE
 bIE
 bNZ
 bNZ
-bNZ
-bTb
-bhd
+bgq
+diD
+diK
 bgq
 bbo
 bbq
@@ -139197,10 +147345,10 @@ bbo
 bbo
 bbo
 bbq
-bgp
+bgs
 bhd
 bip
-bjg
+ddH
 bjW
 bkH
 blI
@@ -139231,7 +147379,7 @@ bgq
 bgq
 bTe
 bUg
-bgs
+bgr
 bbo
 bbq
 bbq
@@ -139457,7 +147605,7 @@ bbo
 bgq
 bhd
 bip
-bhc
+ddI
 bjW
 bkI
 blK
@@ -139487,8 +147635,8 @@ bGk
 bgq
 bRW
 bTe
-bjg
-bgq
+diL
+bgs
 bbo
 bbq
 bbq
@@ -139666,17 +147814,17 @@ anV
 aHn
 aCW
 aoU
-aEn
+daF
 anV
 aez
 aez
 adZ
-adZ
-akq
+afV
+akp
 aSc
 cOD
-apO
-adZ
+dbK
+afS
 alx
 alx
 alx
@@ -139712,9 +147860,9 @@ bbo
 bbo
 bbo
 bgr
-bhe
+dcY
 bip
-bhd
+bhb
 bjW
 bkJ
 bkJ
@@ -139742,10 +147890,10 @@ bNb
 bOj
 bGk
 bQQ
-bhd
-bTb
-bhc
-bgq
+dio
+diE
+diM
+bgs
 bbo
 bbo
 bbo
@@ -139928,12 +148076,12 @@ anV
 aez
 aez
 adZ
-adZ
-amJ
-anz
-afq
-afq
-aez
+afS
+dbg
+dbm
+aiS
+afS
+afV
 and
 and
 and
@@ -139985,7 +148133,7 @@ buN
 bwm
 bya
 bzm
-bAt
+dgf
 bAt
 bCB
 bDY
@@ -140001,8 +148149,8 @@ bPP
 bQR
 bRX
 bTj
-bhd
-bgq
+diN
+bgr
 bbo
 bbo
 bbo
@@ -140184,13 +148332,13 @@ aKy
 aHp
 aez
 aez
-adZ
-afq
-amK
-afq
-afq
+afS
+dbd
+dbh
+akp
+akp
 aTL
-aez
+afS
 and
 and
 and
@@ -140226,9 +148374,9 @@ bbo
 bbo
 bbq
 bgq
-bhf
+dcZ
 bip
-bhb
+ddJ
 bjX
 bkL
 blL
@@ -140242,10 +148390,10 @@ buO
 bwn
 bya
 bzn
-bAu
+dgg
 bBw
 bAu
-bAu
+dgE
 bEX
 bGk
 bHt
@@ -140255,11 +148403,11 @@ bLV
 bII
 bOl
 cKZ
-bQS
-bOn
-bTb
-bhd
-bgq
+dhW
+bIO
+diF
+bMb
+bgs
 bbo
 bbo
 bbo
@@ -140442,15 +148590,15 @@ aHp
 aez
 aez
 aez
-afq
-amK
-afp
-afV
+dbe
+dbi
+aXh
+afS
 adZ
+afS
 aez
 aez
-aez
-aez
+afV
 aez
 and
 and
@@ -140484,7 +148632,7 @@ bbo
 bbq
 bgp
 bhg
-bip
+blR
 bji
 bjW
 bkM
@@ -140513,9 +148661,9 @@ bIJ
 cWD
 bGk
 bgq
-bOn
-bTb
-bhd
+dip
+bTd
+diO
 bgq
 bbo
 bbq
@@ -140701,13 +148849,13 @@ aez
 aez
 apx
 cOz
-aqH
+afV
 adZ
-adZ
-adZ
-adZ
-afq
+afS
+afV
+afS
 aWo
+afK
 afV
 afS
 afS
@@ -140742,25 +148890,25 @@ bbq
 bgp
 bhh
 bir
-bgq
+bgr
 bjW
 bjW
 bjW
-bjW
+dfc
 bnL
-bjW
-bjW
+dfy
+dfD
 brS
 bjY
 buQ
 bwp
 byb
-bya
-cKP
-bya
-bya
-bya
-bya
+dfV
+bkC
+bkB
+bkB
+dgF
+bkB
 bGk
 bHv
 bIK
@@ -140770,8 +148918,8 @@ bHv
 bHv
 bGk
 bgq
-bOn
-bTb
+bIO
+diG
 bUg
 bgr
 bbo
@@ -140954,15 +149102,15 @@ aJu
 aKB
 aHp
 adZ
-adZ
+afV
 afV
 alR
 amK
-afq
-adZ
-afq
-akq
-akq
+alS
+afV
+akp
+akp
+akp
 akq
 avh
 awu
@@ -140996,28 +149144,28 @@ aaa
 aaa
 bbo
 bbq
-bgp
+bgs
 bhd
 bip
+bgr
 bgq
 bgq
 bgq
-bgq
-bgq
-bgp
-bgp
-bgp
+bjY
+bnQ
+blN
+bnQ
 bjY
 bth
 buR
 bwq
 bjY
-bgq
-bAw
-bhb
+boU
+dgh
+bmz
 bCD
-bkR
-bgq
+dgG
+dgQ
 bGk
 cWy
 bHv
@@ -141027,10 +149175,10 @@ bIK
 cWy
 bGk
 bgq
-bOn
+bIO
 bTb
-bhd
-bgq
+bhb
+diS
 bbo
 bbq
 bbq
@@ -141212,15 +149360,15 @@ aKC
 aHp
 aHp
 aNw
-afq
-afq
+afS
+alS
 amK
-akq
-aEi
-akq
-akq
-aqH
-afq
+akp
+aOH
+akp
+akp
+dbM
+akp
 afp
 afV
 akq
@@ -141253,28 +149401,28 @@ aaa
 bbo
 bbo
 bbq
-bgp
-bhd
+bgr
+bhb
 bip
-bgq
-bgp
-bgp
-bgp
-bgq
+bgs
 bgp
 bgp
 bgp
 bjY
+dfl
+blP
+blP
+bjY
 bti
 bqp
 bpr
-bnM
-bhd
-bhd
-bhd
-bhd
-blR
-bgq
+bjY
+boU
+bmz
+bmz
+bmz
+dgH
+dgR
 bGk
 cWz
 bHv
@@ -141286,8 +149434,8 @@ bGk
 bgp
 bOn
 bTb
-buZ
-bgq
+diP
+bgr
 bbo
 bbo
 bbq
@@ -141453,7 +149601,7 @@ arP
 asH
 atI
 auN
-apQ
+cZe
 apQ
 axV
 azB
@@ -141471,14 +149619,14 @@ cOb
 cOf
 aOE
 cOs
-anz
-adZ
-adZ
+dbj
+afS
+afV
+afV
+afV
 aez
-aez
-aez
-adZ
-adZ
+afS
+afV
 afS
 akp
 aXg
@@ -141510,28 +149658,28 @@ bbo
 bbo
 bbo
 bbo
+bgr
+bQS
+ddp
 bgs
-bhe
-bip
-bgq
-bgq
+bgs
 bgp
 bgp
-bgp
-bgp
-bgp
-bgp
+bjY
+dfm
+dfz
+dfE
 bjY
 btj
 bqp
 bpr
-bnM
-bhc
-bhg
-blS
-bgq
-bye
-bhf
+bjY
+boU
+dgi
+dgn
+dgr
+dgI
+dgS
 bGk
 bGk
 bHv
@@ -141540,11 +149688,11 @@ bHv
 bHv
 bGk
 bGk
+bjg
+bPS
+diH
 bhd
-bOn
-bTb
-bhd
-bgq
+bgr
 bgq
 bbo
 bbo
@@ -141725,11 +149873,11 @@ aHp
 aHp
 aHp
 aHp
-aoR
-ahr
+daV
+aCr
 apu
-afq
-adZ
+dbk
+afS
 alx
 and
 and
@@ -141767,45 +149915,45 @@ aaa
 bbo
 bbo
 bbo
-bgq
-bhd
+bgs
+bhb
 bis
 bjj
-bgq
-bgq
-bgq
+bgr
 bgp
 bgp
-bgp
-bgq
+bjY
+dfn
+blP
+dfF
 bjY
 btk
 buS
 bwr
 bjY
-bgq
-bgq
-bgr
-bgq
-bip
-bhd
-bhh
+dfW
+bmz
+bmz
+bmz
+bmz
+bmz
+bkB
 bGk
 bGk
 bGk
 bGk
 bGk
 bGk
-bhd
+dhI
 bhd
 bOn
 bTb
 bhd
 bhd
-bgq
-bgq
-bgq
-bgp
+bgs
+bgs
+bgr
+bgs
 bbq
 bbo
 bbo
@@ -141974,18 +150122,18 @@ azD
 aAT
 ank
 adZ
-adZ
-adZ
+afS
+afV
 adZ
 adZ
 aJw
-ahr
-ahr
-ahr
+aCr
+daN
+aCr
 aNx
-aoy
+aus
 afq
-aez
+afV
 aez
 alx
 and
@@ -142026,43 +150174,43 @@ bbo
 bbq
 bgp
 bhd
-bhd
-bip
+bhb
+ddK
+bgr
+bgp
+bgp
 bjY
-bjY
-bjY
-bjY
-bjY
-bjY
-bjY
+dfo
+bnN
+dfG
 bjY
 bjY
 buQ
 bws
 bjY
-bgq
-bgq
-bgq
-bgq
-bip
-bhd
-bhd
+dfX
+bmz
+bmz
+bmz
+bmz
+dgT
+bkB
 bhg
 bhd
 bKu
 bhc
-bhd
+dhp
 bhd
 bPQ
 bQT
 bRY
 bTk
 bhd
-bhd
+bhf
 bhg
 bhd
 bXk
-bgp
+bgr
 bbq
 bbo
 aaa
@@ -142230,17 +150378,17 @@ avW
 azE
 avW
 ank
-apO
-aqH
+cZB
+cZJ
 aoR
 ahr
-ahr
+aqj
 apu
-afq
-aqH
-afq
+akq
+alS
+akp
 aNy
-afV
+afS
 adZ
 aez
 and
@@ -142283,27 +150431,27 @@ bbo
 bbq
 bgp
 bgq
-bhd
-bip
+bhb
+ddL
+bgr
+bgs
+bgr
 bjY
-bkN
-blN
-blP
-bnM
+bpr
 bpk
-bqn
+dfH
 brT
 bnM
 buT
 bwt
 bjY
-bgp
-bgp
-bgp
-bgp
-bis
-bjZ
-bjZ
+dfY
+dgj
+dgo
+dgs
+dgJ
+dgU
+dgZ
 bHw
 bjZ
 bjZ
@@ -142311,7 +150459,7 @@ bjZ
 bjZ
 bOm
 bPR
-bQU
+dhX
 bQU
 bTl
 bjZ
@@ -142490,7 +150638,7 @@ ank
 aDg
 auE
 apu
-afq
+aqH
 afq
 afq
 aKE
@@ -142540,15 +150688,15 @@ bbo
 bbq
 bbq
 bgq
-bhc
-bip
-bjY
+ddq
+ddM
+bgs
 bkO
-blO
-bmK
-bnN
-bpl
-bqo
+bkO
+bjY
+bpr
+bpr
+bqp
 brU
 btl
 bqp
@@ -142557,14 +150705,14 @@ bjY
 bjY
 bjY
 bjY
-bgp
-bgp
-bgp
-bhd
-bip
-bhd
-bgq
-bgq
+bkB
+bkB
+bkB
+bkB
+blR
+dhe
+bgr
+bgs
 bhd
 bOn
 bOn
@@ -142745,12 +150893,12 @@ azG
 aAV
 ank
 afK
-afq
+aUW
 aoy
 apx
 anN
-adZ
 afV
+afS
 adZ
 alx
 alx
@@ -142797,13 +150945,13 @@ baW
 bbq
 bbo
 bgq
-bhd
-bip
-bjY
+btq
+ddN
+bgr
 bkP
-blP
-bmL
-bnO
+bkP
+bjY
+dfp
 bpm
 bqp
 bkQ
@@ -142819,20 +150967,20 @@ bgp
 bgp
 bjg
 bip
-bgq
-bgq
-bgq
-bgq
-bOn
+bgs
+bgr
+bgr
+bgs
+dhy
 bOn
 bgq
 bgs
 bgq
 bgq
-bgq
+bgr
 bhd
-bhd
-bgs
+diY
+bgr
 bgs
 bgs
 abC
@@ -143001,9 +151149,9 @@ ank
 ank
 ank
 ank
-adZ
-adZ
 afV
+afS
+afS
 adZ
 adZ
 adZ
@@ -143053,14 +151201,14 @@ baW
 baW
 bbq
 bbo
-bgq
-bhd
-bip
+bgs
+btq
+ddO
+del
+dex
+bvb
 bjY
-bkQ
-bkQ
-bkQ
-bkQ
+dfq
 bpn
 bqq
 brV
@@ -143072,14 +151220,14 @@ bzp
 blP
 bjY
 bgp
-bgp
-bgp
+bgs
+bgr
 bhd
 bir
 bgq
 bgq
 bgq
-bgq
+bgs
 bOo
 bPS
 bgp
@@ -143087,9 +151235,9 @@ bbq
 bbq
 bgq
 bgq
-bgq
-bgq
-bgq
+bgs
+bgs
+bgr
 bgq
 aaa
 aaa
@@ -143310,15 +151458,15 @@ aaa
 baW
 bbq
 bbo
+bgr
+ddr
+ddP
 bgs
-bhe
-bip
+bkP
+bkP
 bjY
-bkN
-blN
-bmL
-bnO
-bpm
+blP
+bpr
 bqr
 brW
 bmK
@@ -143333,12 +151481,12 @@ bgs
 bhe
 bhd
 bip
+bgs
 bgq
 bgq
-bgq
-bgq
-bOn
-bOn
+bgs
+dhz
+dhJ
 bgp
 bbq
 bbq
@@ -143568,15 +151716,15 @@ baW
 bbq
 bbo
 bgq
-bhd
-bip
-bjY
-bkO
+btq
+ddQ
+bgs
+dey
 blQ
-bmK
-bnP
-bpl
-bqs
+bjY
+blP
+bpr
+bqp
 blP
 btn
 buX
@@ -143590,7 +151738,7 @@ bgq
 bhd
 bEa
 bEb
-bgq
+bgr
 bgq
 bgq
 bgq
@@ -143825,13 +151973,13 @@ baW
 bbo
 bbq
 bgp
-bhc
-bip
+dds
+ddR
+bgs
+bgr
+bgr
 bjY
-bkP
-blP
-blP
-bnM
+dfr
 bpo
 bqt
 brX
@@ -144081,14 +152229,14 @@ aaa
 baW
 bbo
 bbq
-bgp
-bhd
-bip
+bgs
+bhb
+ddS
+bgr
+bgs
+bgq
 bjY
 bjY
-bjY
-bjY
-bkQ
 bpp
 bqu
 bkQ
@@ -144100,12 +152248,12 @@ bjY
 bjY
 bjY
 bgq
-bgq
+bgs
 bhd
 bip
 bgs
 bIL
-bIN
+dhj
 bLY
 bNd
 bOr
@@ -144338,8 +152486,8 @@ abC
 bbp
 bbo
 bbq
-bgp
-bhd
+bgs
+bhb
 bis
 bjZ
 bkR
@@ -144355,9 +152503,9 @@ bjY
 byd
 bhd
 bAw
-bgq
+bgr
 bgp
-bgp
+bgr
 bhg
 bip
 bgr
@@ -144611,10 +152759,10 @@ cWv
 bjY
 bip
 buZ
+bgs
 bgp
 bgp
-bgp
-bgp
+bgr
 bhd
 bip
 bgr
@@ -144854,7 +153002,7 @@ aaa
 bbo
 bgq
 bgr
-bhe
+ddT
 bhd
 bhd
 blR
@@ -144870,12 +153018,12 @@ bir
 bhc
 bgp
 bgp
-bgp
-bgq
+bgs
+bgr
 bhd
 bip
 bgr
-bIO
+dhf
 bKx
 bMb
 bgr
@@ -145124,10 +153272,10 @@ bjY
 bgq
 bjg
 bye
-bjg
-bgp
-bgp
-bgp
+dfZ
+bgs
+bgr
+bgs
 bEa
 bjZ
 bGl
@@ -145368,8 +153516,8 @@ aaa
 bbo
 bbq
 bbq
-bgp
-bhd
+bgs
+dem
 bhd
 bip
 bjY
@@ -145383,7 +153531,7 @@ bhd
 bip
 bhd
 bhd
-bhd
+bhc
 bhd
 bip
 bhd
@@ -145537,7 +153685,7 @@ aab
 aac
 aac
 aac
-aac
+cYd
 aac
 aac
 aac
@@ -145628,7 +153776,7 @@ bbq
 bgp
 bgq
 bhd
-bis
+bVf
 bjZ
 bjZ
 bjZ
@@ -145643,8 +153791,8 @@ bjZ
 bjZ
 bjZ
 bEb
-bhd
-bgq
+dgV
+bgs
 bgs
 bIR
 bgs
@@ -145883,15 +154031,15 @@ aaa
 aaa
 bbq
 bbq
-bgp
-bgq
-blS
+bgr
+bgs
+deO
 bhd
 bhd
 bhd
 bqC
 blS
-bhb
+dfM
 bva
 bhd
 bhd
@@ -145900,8 +154048,8 @@ blS
 bhc
 bhd
 bhd
-bgq
-bgq
+bgs
+bgs
 aaa
 aaa
 abC
@@ -146142,22 +154290,22 @@ bbq
 bbq
 bbq
 bgq
-bgs
+bgr
 bgq
 bgq
-bhd
-bIQ
+dfA
+dfI
 bgs
 btp
 bgs
-bww
+bgr
 bgq
 bgq
 bgs
 bgq
-bgq
-bgq
-bgq
+bgr
+bgs
+bgs
 bbo
 aaa
 aaa
@@ -146407,7 +154555,7 @@ bqD
 brZ
 btq
 bvb
-bww
+bgr
 bgp
 bbq
 bbo
@@ -146659,8 +154807,8 @@ bbo
 bbq
 bbq
 bbq
-bpv
-bgs
+dfB
+bgr
 bgs
 btr
 bgs
@@ -147423,19 +155571,19 @@ aaa
 aaa
 aaa
 aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abD
+bgs
 bsb
 btu
 bsb
-abD
+bgs
 aaa
 aaa
 aaa
@@ -147680,11 +155828,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -147937,11 +156085,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -148194,11 +156342,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -148451,11 +156599,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -148708,11 +156856,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -148965,11 +157113,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -149222,11 +157370,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -149479,11 +157627,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -8106,6 +8106,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Command Escape Pod";
+	dir = 4;
+	icon_state = "camera"
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "apK" = (
@@ -13391,6 +13396,12 @@
 "azO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Gulag Shuttle Midsection";
+	dir = 9;
+	icon_state = "camera";
+	network = list("SS13")
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -21612,6 +21623,11 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Head of Personnel's Queue Line";
+	dir = 4;
+	icon_state = "camera"
+	},
 /turf/open/floor/plasteel/blue/side{
 	tag = "icon-blue (NORTHWEST)";
 	icon_state = "blue";
@@ -24590,6 +24606,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/neutral/corner{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -24608,6 +24629,16 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -25145,6 +25176,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -25174,6 +25210,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -25642,6 +25683,11 @@
 "aUj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -25666,6 +25712,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	on = 1
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/nuke_storage)
@@ -26104,6 +26155,13 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Custodial APC";
+	pixel_x = 23;
+	pixel_y = 2
+	},
+/obj/structure/cable/orange,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -26127,6 +26185,11 @@
 	on = 1;
 	scrub_Toxins = 0
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -26136,6 +26199,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -26366,6 +26434,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Vault APC";
+	pixel_x = 23;
+	pixel_y = 2
+	},
+/obj/structure/cable/orange,
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -39666,6 +39741,13 @@
 "brT" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/infections,
+/obj/machinery/camera{
+	c_tag = "Virology 2";
+	dir = 5;
+	icon_state = "camera";
+	network = list("SS13","CMO");
+	tag = "icon-camera (NORTHEAST)"
+	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -40603,6 +40685,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = 0;
 	pixel_y = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay Escape Pod"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_3)
@@ -67301,6 +67386,11 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/machinery/camera{
+	c_tag = "Escape Wing East";
+	dir = 8;
+	network = list("SS13")
+	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -68572,6 +68662,9 @@
 	},
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Research Escape Pod"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_2)
@@ -75378,6 +75471,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Research Xenobiology-Testing Airlock";
+	dir = 9;
+	icon_state = "camera";
+	network = list("SS13","RD");
+	tag = "icon-camera (NORTHWEST)"
+	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -76172,6 +76272,12 @@
 "cDB" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/o2,
+/obj/machinery/camera{
+	c_tag = "Research Treatment Center";
+	dir = 1;
+	icon_state = "camera";
+	network = list("SS13")
+	},
 /turf/open/floor/plasteel/whitepurple/side{
 	tag = "icon-whitepurple (SOUTHWEST)";
 	icon_state = "whitepurple";
@@ -78048,6 +78154,13 @@
 "cGG" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Research Testing Containment";
+	dir = 9;
+	icon_state = "camera";
+	network = list("SS13","RD");
+	tag = "icon-camera (NORTHWEST)"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -81712,6 +81825,12 @@
 "cOc" = (
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Holding Cell";
+	dir = 9;
+	icon_state = "camera";
+	network = list("SS13")
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -85742,6 +85861,287 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/toxins/mixing)
+"cYd" = (
+/obj/structure/sign/biohazard{
+	desc = "A sign stating that there are better, more efficient methods of suicide that don't cause extra work for security and the janitor. Volunteer to be miner bait, be voluntary specimen for Research, or just find your nearest external airlock! ";
+	name = "SUICIDE HOPLINE ISN'T THE WAY!";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/blue/side{
+	tag = "icon-blue (NORTH)";
+	icon_state = "blue";
+	dir = 1;
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/heads)
+"cYe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYo" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYr" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYv" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hallway/primary/fore)
+"cYy" = (
+/obj/structure/window/reinforced,
+/obj/machinery/camera{
+	c_tag = "Core-Command-Cargo Bridge Ceneter";
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/space)
 
 (1,1,1) = {"
 aaa
@@ -98024,7 +98424,7 @@ cgN
 ctW
 cXW
 cvW
-cXX
+cXW
 cvW
 cvW
 cvW
@@ -106892,7 +107292,7 @@ aNV
 aOV
 aPZ
 aRB
-aSl
+cYe
 cOS
 aTY
 afq
@@ -107149,7 +107549,7 @@ aNW
 aLm
 aQa
 aRt
-aSl
+cYf
 cOF
 anC
 aez
@@ -107406,7 +107806,7 @@ azY
 aLm
 aQb
 aRt
-aSl
+cYg
 cOF
 aTZ
 aez
@@ -107663,7 +108063,7 @@ aNX
 aLm
 aQc
 aRt
-aSl
+cYh
 cOV
 aTr
 cPs
@@ -107920,7 +108320,7 @@ aBx
 aOW
 aQd
 aRC
-aSz
+cYi
 aTr
 aUa
 cPt
@@ -108177,7 +108577,7 @@ akq
 akH
 aQa
 aRD
-aSl
+cYj
 aTq
 aUb
 cOV
@@ -108434,7 +108834,7 @@ aGE
 aGE
 aQe
 aRD
-aSl
+cYk
 aTq
 aUc
 aUX
@@ -108691,7 +109091,7 @@ aNY
 aGE
 aQa
 aRD
-aSl
+cYl
 aTq
 aUd
 aUc
@@ -108948,7 +109348,7 @@ aNZ
 aGE
 aQa
 aRD
-aSl
+cYm
 aTq
 aUe
 aUc
@@ -109205,7 +109605,7 @@ aHP
 aGE
 aQa
 aRD
-aSl
+cYn
 aTq
 aUf
 aUc
@@ -109462,7 +109862,7 @@ aOa
 aGE
 aQa
 aRE
-aSt
+cYo
 aTq
 aUg
 aUc
@@ -109719,7 +110119,7 @@ aGE
 aGE
 aQa
 aRD
-aSl
+cYp
 aTq
 aUh
 aUc
@@ -109976,7 +110376,7 @@ aOb
 are
 aQf
 aRF
-aSs
+cYq
 aTs
 aUi
 aUY
@@ -110490,7 +110890,7 @@ aOc
 are
 aQh
 aRD
-aSm
+cYr
 cOW
 aTr
 aTr
@@ -110747,7 +111147,7 @@ aOd
 are
 aQh
 aRD
-aSl
+cYs
 cOF
 acH
 acH
@@ -111004,7 +111404,7 @@ are
 are
 aQi
 aRD
-aSl
+cYt
 cOF
 acH
 acH
@@ -111261,7 +111661,7 @@ aFg
 aOX
 aQj
 aRH
-aSl
+cYu
 cOF
 acH
 acH
@@ -111518,7 +111918,7 @@ awy
 aOY
 aQk
 aRI
-aSt
+cYv
 aTu
 aUk
 aUk
@@ -111775,7 +112175,7 @@ atf
 aOZ
 aQl
 aRF
-aSs
+cYw
 aTv
 aUl
 aVa
@@ -112032,7 +112432,7 @@ cJZ
 are
 aQm
 aRJ
-aSl
+cYx
 aTw
 aUm
 aVb
@@ -115112,7 +115512,7 @@ aKg
 aLi
 aLU
 aHS
-aOf
+cYd
 aPe
 aQr
 aRD
@@ -117740,7 +118140,7 @@ bpQ
 bvz
 bxg
 byF
-cXB
+cWJ
 abC
 abC
 abC
@@ -117990,18 +118390,18 @@ blq
 bkw
 blq
 abC
-cXf
-cXp
-cXr
+cWJ
+cWJ
+cWJ
 cKE
 bvA
 bxh
 bms
-cXC
-cXI
-cXL
-cXO
-cXP
+cWJ
+cWJ
+cWJ
+cWJ
+cWJ
 cXQ
 bGP
 bIa
@@ -118501,10 +118901,10 @@ biO
 bjD
 bkx
 cWJ
-cWU
-cWW
-cXa
-cXg
+cWJ
+cWJ
+cWJ
+cWJ
 brf
 bsw
 buh
@@ -118757,24 +119157,24 @@ bhM
 biO
 bjD
 bkx
-cWK
+cWJ
 bms
 bnh
 bov
 bpR
 brg
 bsx
-cXs
+cWJ
 bvD
 bvD
 bvD
-cXD
+cWJ
 bAV
 bBV
 bDn
 bEs
 bFA
-cXR
+cXQ
 bId
 cMz
 bLo
@@ -119014,24 +119414,24 @@ bhM
 biO
 bjD
 bkx
-cWL
+cWJ
 bms
 bni
-cXb
+cWJ
 cKD
 brh
 bsy
-cXt
+cWJ
 bvE
 bvE
 byH
-cXE
+cWJ
 bAV
 bBW
 bDo
 bEt
 bFB
-cXS
+cXQ
 bIe
 bJK
 bLo
@@ -119271,20 +119671,20 @@ bhM
 biO
 bjD
 bkx
-cWM
+cWJ
 bmt
 bnj
 bow
-cXh
+cWJ
 bri
 bsz
-cXu
+cWJ
 bvF
 bxk
 bxk
 bsG
-cXJ
-cXM
+cWJ
+cWJ
 bDp
 bEt
 bFC
@@ -119528,14 +119928,14 @@ bhM
 biO
 bjD
 bkx
-cWN
+cWJ
 bmu
 bms
 bms
 cXi
 brj
 bsA
-cXv
+cWJ
 bvG
 bvG
 bvG
@@ -119785,11 +120185,11 @@ bhN
 cKx
 bjD
 bkx
-cWO
+cWJ
 bmv
 bms
 box
-cXj
+cXi
 brk
 brk
 bui
@@ -120042,14 +120442,14 @@ bhO
 biO
 bjD
 bkx
-cWP
+cWJ
 bmu
 bms
 bms
-cXk
+cXi
 brl
 bsB
-cXw
+cWJ
 bvI
 bvI
 bvI
@@ -120299,24 +120699,24 @@ bhP
 biO
 bjD
 bkx
-cWQ
+cWJ
 bmw
 cWX
 boy
-cXl
+cWJ
 cXq
 bsC
-cXx
+cWJ
 bvJ
 bxm
 bxm
 bzV
-cXK
-cXN
+cWJ
+cWJ
 bDt
 bEt
 bFC
-cXT
+cXQ
 bIh
 bJO
 bLq
@@ -120556,24 +120956,24 @@ bhP
 biO
 bjD
 bkx
-cWR
+cWJ
 bms
 bnl
-cXc
+cWJ
 cKE
 brh
 bsy
-cXy
+cWJ
 bvK
 bxn
 bvK
-cXF
+cWJ
 bAZ
 bBZ
 bDs
 bEt
 bFB
-cXU
+cXQ
 bIi
 bJK
 bLo
@@ -120813,24 +121213,24 @@ bhP
 biO
 bjD
 bkx
-cWS
+cWJ
 bms
-cWY
-cXd
+cWX
+cWX
 bpT
 bri
 bsD
-cXz
+cWJ
 bvL
 bvL
 bvL
-cXG
+cWJ
 bAZ
 bBZ
 bDs
 bEw
 bFG
-cXV
+cXQ
 bIj
 bJP
 bLr
@@ -121070,11 +121470,11 @@ bhP
 biO
 bjD
 bkx
-cWT
-cWV
-cWZ
-cXe
-cXm
+cWJ
+cWJ
+cWJ
+cWJ
+cWJ
 brh
 bsE
 buj
@@ -121331,7 +121731,7 @@ bkw
 blq
 bkw
 blq
-cXn
+cWJ
 brj
 bsF
 buk
@@ -121588,7 +121988,7 @@ bls
 bky
 bls
 bkx
-cXo
+cWJ
 brm
 bsG
 cKD
@@ -121848,11 +122248,11 @@ bls
 abC
 abC
 bsH
-cXA
+cWJ
 bvP
 bxq
 byL
-cXH
+cWJ
 abC
 abC
 abC
@@ -128994,7 +129394,7 @@ arz
 arz
 arz
 arz
-aSQ
+cYy
 aTD
 arw
 aaa


### PR DESCRIPTION
🆑 MMMiracles (Cerestation)
add: Departments have been given head offices for a more secure place to chill in their departments.
add: There is now a theatre on the service asteroid.
tweak: Maintenance visuals and loot have been overhauled to be more visually interesting and have more scattered bits of loot. 
fix: Various fixes with missing APCs, camera coverage, and misc things.
/🆑

- Added missing APCs to Vault and Custodial office.
- Added several cameras to areas that had sub-par camera coverage.
- Adds a sign warning the crew of the hazards of suicide hopline and more efficient methods of suicide that also increases station productivity.
- Each department has a head office for heads to stay in their department with their respective suit storage being moved there.
- Added a theatre on the service asteroid.
- Revamped maintenance visuals and loot spawns to be more visually interesting and have more junk/clutter to scavenge for whatever. Maintenance now looks more like a mixture of half-finished maintenance tunnels and dug-out areas.

Fixes #26269 