### PR TITLE
Misc logging changes

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -528,7 +528,7 @@
 		if(icon_vend) //Show the vending animation if needed
 			flick(icon_vend,src)
 		new R.product_path(get_turf(src))
-		feedback_add_details("vending_machine_usage","[R.product_path]|[src.type]")
+		feedback_add_details("vending_machine_usage","[src.type]|[R.product_path]")
 		vend_ready = 1
 		return
 

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -45,10 +45,7 @@
 			if(do_mob(user, C, 30) && (C.get_num_arms() >= 2 || C.get_arm_ignore()))
 				apply_cuffs(C,user)
 				to_chat(user, "<span class='notice'>You handcuff [C].</span>")
-				if(istype(src, /obj/item/weapon/restraints/handcuffs/cable))
-					feedback_add_details("handcuffs","C")
-				else
-					feedback_add_details("handcuffs","H")
+				feedback_add_details("handcuffs","[type]")
 
 				add_logs(user, C, "handcuffed")
 			else
@@ -278,7 +275,7 @@
 						C.legcuffed = src
 						src.loc = C
 						C.update_inv_legcuffed()
-						feedback_add_details("handcuffs","B") //Yes, I know they're legcuffs. Don't change this, no need for an extra variable. The "B" is used to tell them apart.
+						feedback_add_details("handcuffs","[type]")
 			else if(isanimal(L))
 				var/mob/living/simple_animal/SA = L
 				if(SA.mob_size > MOB_SIZE_TINY)
@@ -341,7 +338,7 @@
 		C.legcuffed = src
 		src.loc = C
 		C.update_inv_legcuffed()
-		feedback_add_details("handcuffs","B")
+		feedback_add_details("handcuffs","[type]")
 		to_chat(C, "<span class='userdanger'>\The [src] ensnares you!</span>")
 		C.Weaken(weaken)
 

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -78,7 +78,7 @@
 		triggering = FALSE
 		message_admins("[key_name_admin(usr)] cancelled event [name].")
 		log_admin_private("[key_name(usr)] cancelled event [name].")
-		feedback_add_details("admin_verb","Cancel Event: [typepath]")
+		feedback_add_details("event_admin_cancelled","[typepath]")
 
 /datum/round_event_control/proc/runEvent(random)
 	var/datum/round_event/E = new typepath()

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 
 /datum/uplink_item/proc/spawn_item(turf/loc, obj/item/device/uplink/U)
 	if(item)
-		feedback_add_details("traitor_uplink_items_bought", "[item]")
+		feedback_add_details("traitor_uplink_items_bought", "[name]|[cost]")
 		return new item(loc)
 
 /datum/uplink_item/proc/buy(mob/user, obj/item/device/uplink/U)
@@ -127,7 +127,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	if(src in GLOB.uplink_items)
 		GLOB.uplink_items -= src	//Take us out instead of leaving a null!
 	return ..()
-	
+
 //Discounts (dynamically filled above)
 /datum/uplink_item/discounts
 	category = "Discounted Gear"
@@ -1158,6 +1158,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 /datum/uplink_item/cyber_implants/spawn_item(turf/loc, obj/item/device/uplink/U)
 	if(item)
 		if(istype(item, /obj/item/organ))
+			feedback_add_details("traitor_uplink_items_bought", "[item]|[cost]")
 			return new /obj/item/weapon/storage/box/cyber_implants(loc, item)
 		else
 			return ..()
@@ -1325,12 +1326,12 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 		new I.item(C)
 		U.purchase_log += "<big>\icon[I.item]</big>"
 
+	feedback_add_details("traitor_uplink_items_bought", "[name]|[cost]")
 	return C
 
 /datum/uplink_item/badass/random
 	name = "Random Item"
-	desc = "Picking this will purchase a random item. Useful if you have some TC to spare or if you haven't \
-			decided on a strategy yet."
+	desc = "Picking this will purchase a random item. Useful if you have some TC to spare or if you haven't decided on a strategy yet."
 	item = /obj/item/weapon/paper
 	cost = 0
 	cant_discount = TRUE
@@ -1351,5 +1352,6 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 		var/datum/uplink_item/I = pick(possible_items)
 		U.telecrystals -= I.cost
 		U.spent_telecrystals += I.cost
-		feedback_add_details("traitor_uplink_items_bought","RN")
+		feedback_add_details("traitor_uplink_items_bought","[name]|[I.cost]")
+		feedback_add_details("traitor_random_uplink_items_gotten","[I.name]")
 		return new I.item(loc)


### PR DESCRIPTION
Restraints  now log by type
Admin event cancelling now uses its own stat rather than `"admin_verb"`
Traitor item buys now log name and cost, rather than type, and random items bought by traitors have their own logging stat(to avoid clogging up traitor item logging)