### PR TITLE
Fixes #24629, monkeys won't bug out when in your stomach

### DIFF
--- a/code/modules/mob/living/carbon/monkey/combat.dm
+++ b/code/modules/mob/living/carbon/monkey/combat.dm
@@ -132,6 +132,10 @@
 	return 0
 
 /mob/living/carbon/monkey/proc/handle_combat()
+	// Don't do any AI if inside another mob (devoured)
+	if (ismob(loc))
+		// Really no idea what needs to be returned but everything else is TRUE
+		return TRUE
 
 	if(on_fire || buckled || restrained())
 		if(!resisting && prob(MONKEY_RESIST_PROB))


### PR DESCRIPTION
Fixes #24629
:cl: Davidj361
fix: Monkeys won't pickup items or rob you while they are in your stomach, neither walk out of your stomach.
/:cl:

[why]: See https://github.com/tgstation/tgstation/issues/24629