### PR TITLE
Configuration option for number of roundstart mice

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -258,6 +258,8 @@
 	var/arrivals_shuttle_dock_window = 55	//Time from when a player late joins on the arrivals shuttle to when the shuttle docks on the station
 	var/arrivals_shuttle_require_safe_latejoin = FALSE	//Require the arrivals shuttle to be operational in order for latejoiners to join
 
+	var/mice_roundstart = 10 // how many wire chewing rodents spawn at roundstart.
+
 /datum/configuration/New()
 	gamemode_cache = typecacheof(/datum/game_mode,TRUE)
 	for(var/T in gamemode_cache)
@@ -768,6 +770,8 @@
 					arrivals_shuttle_dock_window = max(PARALLAX_LOOP_TIME, text2num(value))
 				if("arrivals_shuttle_require_safe_latejoin")
 					arrivals_shuttle_require_safe_latejoin = text2num(value)
+				if("mice_roundstart")
+					mice_roundstart = text2num(value)
 				else
 					GLOB.diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/controllers/subsystem/squeak.dm
+++ b/code/controllers/subsystem/squeak.dm
@@ -10,9 +10,11 @@ SUBSYSTEM_DEF(squeak)
 	var/list/exposed_wires = list()
 
 /datum/controller/subsystem/squeak/Initialize(timeofday)
-	trigger_migration()
+	trigger_migration(config.mice_roundstart)
 
 /datum/controller/subsystem/squeak/proc/trigger_migration(num_mice=10)
+	if(!num_mice)
+		return
 	find_exposed_wires()
 
 	var/mob/living/simple_animal/mouse/M

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -484,3 +484,8 @@ ARRIVALS_SHUTTLE_DOCK_WINDOW 55
 
 #Set this to 1 to prevent late join players from spawning if the arrivals shuttle is depressurized
 ARRIVALS_SHUTTLE_REQUIRE_SAFE_LATEJOIN 0
+
+# How many wirechewing rodents you want to spawn on exposed maintenane wires at the start of the round. You may wish to set this to 0 if you're testing powernets.
+
+MICE_ROUNDSTART 10
+


### PR DESCRIPTION
This was actually requested, because it turns out testing powernets is
hard if mice randomly chew wires sometimes.