### PR TITLE
Some more logging

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -44,7 +44,6 @@
 
 
 /turf/closed/mineral/attackby(obj/item/weapon/pickaxe/P, mob/user, params)
-
 	if (!user.IsAdvancedToolUser())
 		to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
@@ -67,18 +66,16 @@
 				feedback_add_details("pick_used_mining","[P.type]")
 	else
 		return attack_hand(user)
-	return
 
 /turf/closed/mineral/proc/gets_drilled()
 	if (mineralType && (src.mineralAmt > 0) && (src.mineralAmt < 11))
 		var/i
-		for (i=0;i<mineralAmt;i++)
+		for(i in 1 to mineralAmt)
 			new mineralType(src)
-		feedback_add_details("ore_mined","[mineralType]|[mineralAmt]")
+			feedback_add_details("ore_mined",mineralType)
 	ChangeTurf(turf_type, defer_change)
 	addtimer(CALLBACK(src, .proc/AfterChange), 1, TIMER_UNIQUE)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, 1) //beautiful destruction
-	return
 
 /turf/closed/mineral/attack_animal(mob/living/simple_animal/user)
 	if(user.environment_smash >= 2)

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -68,7 +68,7 @@
 
 /obj/item/device/wormhole_jaunter/attack_self(mob/user)
 	user.visible_message("<span class='notice'>[user.name] activates the [src.name]!</span>")
-	feedback_add_details("jaunter", "U") // user activated
+	feedback_add_details("jaunter", "User") // user activated
 	activate(user)
 
 /obj/item/device/wormhole_jaunter/proc/turf_check(mob/user)
@@ -124,13 +124,13 @@
 
 	if(triggered)
 		usr.visible_message("<span class='warning'>The [src] overloads and activates!</span>")
-		feedback_add_details("jaunter","E") // EMP accidental activation
+		feedback_add_details("jaunter","EMP") // EMP accidental activation
 		activate(usr)
 
 /obj/item/device/wormhole_jaunter/proc/chasm_react(mob/user)
 	if(user.get_item_by_slot(slot_belt) == src)
 		to_chat(user, "Your [src] activates, saving you from the chasm!</span>")
-		feedback_add_details("jaunter","C") // chasm automatic activation
+		feedback_add_details("jaunter","Chasm") // chasm automatic activation
 		activate(user)
 	else
 		to_chat(user, "The [src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>")

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -87,7 +87,7 @@
 		user.sight |= SEE_MOBS
 		icon_state = "lantern"
 		wisp.orbit(user, 20)
-		feedback_add_details("wisp_lantern","F") // freed
+		feedback_add_details("wisp_lantern","Freed") // freed
 
 	else
 		to_chat(user, "<span class='notice'>You return the wisp to the lantern.</span>")
@@ -102,7 +102,7 @@
 		wisp.stop_orbit()
 		wisp.loc = src
 		icon_state = "lantern-blue"
-		feedback_add_details("wisp_lantern","R") // returned
+		feedback_add_details("wisp_lantern","Returned") // returned
 
 /obj/item/device/wisp_lantern/Initialize()
 	..()
@@ -229,7 +229,7 @@
 
 /obj/item/device/immortality_talisman/attack_self(mob/user)
 	if(cooldown < world.time)
-		feedback_add_details("immortality_talisman","U") // usage
+		feedback_add_details("immortality_talisman","Activated") // usage
 		cooldown = world.time + 600
 		user.visible_message("<span class='danger'>[user] vanishes from reality, leaving a a hole in [user.p_their()] place!</span>")
 		var/obj/effect/immortality_talisman/Z = new(get_turf(src.loc))

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -110,7 +110,7 @@
 	..()
 	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
-/datum/chemical_reaction/slime/slimemobspawn/proc/summon_mobs(turf/T)
+/datum/chemical_reaction/slime/slimemobspawn/proc/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
 	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime"), 50)
 
@@ -119,7 +119,7 @@
 	id = "m_tele3"
 	required_reagents = list("blood" = 1)
 
-/datum/chemical_reaction/slime/slimemobspawn/lesser/summon_mobs(turf/T)
+/datum/chemical_reaction/slime/slimemobspawn/lesser/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
 	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", "neutral"), 50)
 
@@ -128,7 +128,7 @@
 	id = "m_tele5"
 	required_reagents = list("water" = 1)
 
-/datum/chemical_reaction/slime/slimemobspawn/friendly/summon_mobs(turf/T)
+/datum/chemical_reaction/slime/slimemobspawn/friendly/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
 	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", "neutral"), 50)
 
@@ -405,7 +405,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/docility/on_reaction(datum/reagents/holder)
-	var/obj/item/slimepotion/docility/P = new /obj/item/slimepotion/docility(get_turf(holder.my_atom))
+	new /obj/item/slimepotion/docility(get_turf(holder.my_atom))
 	..()
 
 /datum/chemical_reaction/slime/gender
@@ -475,9 +475,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimepotion2/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/slimepotion/sentience/P = new /obj/item/slimepotion/sentience
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/slimepotion/sentience
 	..()
 
 //Adamantine
@@ -489,10 +487,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimegolem/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/effect/golemrune/Z = new /obj/effect/golemrune
-	Z.loc = get_turf(holder.my_atom)
-	notify_ghosts("Golem rune created in [get_area(Z)].", 'sound/effects/ghost2.ogg', source = Z)
+	new /obj/effect/golemrune(get_turf(holder.my_atom))
 	..()
 
 /datum/chemical_reaction/slime/slimegolem2
@@ -503,9 +498,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimegolem2/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/golem_shell/artificial/Z = new /obj/item/golem_shell/artificial
-	Z.loc = get_turf(holder.my_atom)
+	new /obj/item/golem_shell/artificial(get_turf(holder.my_atom))
 	..()
 
 //Bluespace

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -416,7 +416,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/gender/on_reaction(datum/reagents/holder)
-	 new /obj/item/slimepotion/genderchange(get_turf(holder.my_atom))
+	new /obj/item/slimepotion/genderchange(get_turf(holder.my_atom))
 	..()
 
 //Black

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -1,8 +1,11 @@
 
 /datum/chemical_reaction/slime
+	var/deletes_extract = TRUE
 
 /datum/chemical_reaction/slime/on_reaction(datum/reagents/holder)
-	delete_extract(holder)
+	feedback_add_details("slime_cores_used","[type]")
+	if(deletes_extract)
+		delete_extract(holder)
 
 /datum/chemical_reaction/slime/proc/delete_extract(datum/reagents/holder)
 	var/obj/item/slime_extract/M = holder.my_atom
@@ -19,12 +22,9 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimespawn/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
 	var/mob/living/simple_animal/slime/S
 	S = new(get_turf(holder.my_atom), "grey")
-	S.visible_message("<span class='danger'>Infused with plasma, the \
-		core begins to quiver and grow, and soon a new baby slime \
-		emerges from it!</span>")
+	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and a new baby slime emerges from it!</span>")
 	..()
 
 /datum/chemical_reaction/slime/slimeinaprov
@@ -35,10 +35,6 @@
 	required_other = 1
 	required_container = /obj/item/slime_extract/grey
 
-/datum/chemical_reaction/slime/slimeinaprov/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	..()
-
 /datum/chemical_reaction/slime/slimemonkey
 	name = "Slime Monkey"
 	id = "m_monkey"
@@ -47,10 +43,8 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimemonkey/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	for(var/i = 1, i <= 3, i++)
-		var /obj/item/weapon/reagent_containers/food/snacks/monkeycube/M = new /obj/item/weapon/reagent_containers/food/snacks/monkeycube
-		M.loc = get_turf(holder.my_atom)
+	for(var/i in 1 to 3)
+		new /obj/item/weapon/reagent_containers/food/snacks/monkeycube(get_turf(holder.my_atom))
 	..()
 
 //Green
@@ -62,10 +56,6 @@
 	required_other = 1
 	required_container = /obj/item/slime_extract/green
 
-/datum/chemical_reaction/slime/slimemutate/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	..()
-
 //Mutated Green
 /datum/chemical_reaction/slime/slimemutate_unstable
 	name = "Unstable Mutation Toxin"
@@ -76,10 +66,6 @@
 	required_container = /obj/item/slime_extract/green
 	mix_message = "<span class='info'>The mixture rapidly expands and contracts, its appearance shifting into a sickening green.</span>"
 
-/datum/chemical_reaction/slime/slimemutate_unstable/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	..()
-
 //Metal
 /datum/chemical_reaction/slime/slimemetal
 	name = "Slime Metal"
@@ -89,10 +75,9 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimemetal/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
 	var/turf/location = get_turf(holder.my_atom)
-	new /obj/item/stack/sheet/plasteel (location, 5)
-	new /obj/item/stack/sheet/metal (location, 15)
+	new /obj/item/stack/sheet/plasteel(location, 5)
+	new /obj/item/stack/sheet/metal(location, 15)
 	..()
 
 /datum/chemical_reaction/slime/slimeglass
@@ -103,60 +88,49 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimeglass/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
 	var/turf/location = get_turf(holder.my_atom)
-	new /obj/item/stack/sheet/rglass (location, 5)
-	new /obj/item/stack/sheet/glass (location, 15)
+	new /obj/item/stack/sheet/rglass(location, 5)
+	new /obj/item/stack/sheet/glass(location, 15)
 	..()
 
 //Gold
-/datum/chemical_reaction/slime/slimecrit
+/datum/chemical_reaction/slime/slimemobspawn
 	name = "Slime Crit"
 	id = "m_tele"
 	required_reagents = list("plasma" = 1)
 	required_container = /obj/item/slime_extract/gold
 	required_other = 1
+	deletes_extract = FALSE //we do delete, but we don't do so instantly
 
-/datum/chemical_reaction/slime/slimecrit/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
+/datum/chemical_reaction/slime/slimemobspawn/on_reaction(datum/reagents/holder)
 	var/turf/T = get_turf(holder.my_atom)
-	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime"), 50)
+	summon_mobs(T)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
+	..()
 	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
-/datum/chemical_reaction/slime/slimecritlesser
+/datum/chemical_reaction/slime/slimemobspawn/proc/summon_mobs(turf/T)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime"), 50)
+
+/datum/chemical_reaction/slime/slimemobspawn/lesser
 	name = "Slime Crit Lesser"
 	id = "m_tele3"
 	required_reagents = list("blood" = 1)
-	required_container = /obj/item/slime_extract/gold
-	required_other = 1
 
-/datum/chemical_reaction/slime/slimecritlesser/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/turf/T = get_turf(holder.my_atom)
-	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
+/datum/chemical_reaction/slime/slimemobspawn/lesser/summon_mobs(turf/T)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
 	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", "neutral"), 50)
-	var/obj/item/slime_extract/M = holder.my_atom
-	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
-/datum/chemical_reaction/slime/slimecritfriendly
+/datum/chemical_reaction/slime/slimemobspawn/friendly
 	name = "Slime Crit Friendly"
 	id = "m_tele5"
 	required_reagents = list("water" = 1)
-	required_container = /obj/item/slime_extract/gold
-	required_other = 1
 
-/datum/chemical_reaction/slime/slimecritfriendly/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/turf/T = get_turf(holder.my_atom)
-	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
+/datum/chemical_reaction/slime/slimemobspawn/friendly/summon_mobs(turf/T)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
 	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", "neutral"), 50)
-	var/obj/item/slime_extract/M = holder.my_atom
-	deltimer(M.qdel_timer)
-	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
 //Silver
 /datum/chemical_reaction/slime/slimebork
@@ -167,8 +141,24 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimebork/on_reaction(datum/reagents/holder)
+	//BORK BORK BORK
+	var/list/borks = getborks()
+	var/turf/T = get_turf(holder.my_atom)
 
-	feedback_add_details("slime_cores_used","[type]")
+	playsound(T, 'sound/effects/phasein.ogg', 100, 1)
+
+	for(var/mob/living/carbon/C in viewers(T, null))
+		C.flash_act()
+
+	for(var/i in 1 to 4 + rand(1,2))
+		var/chosen = pick(borks)
+		var/obj/B = new chosen(T)
+		if(prob(50))
+			for(var/j in 1 to rand(1, 3))
+				step(B, pick(NORTH,SOUTH,EAST,WEST))
+	..()
+
+/datum/chemical_reaction/slime/slimebork/proc/getborks()
 	var/list/blocked = list(/obj/item/weapon/reagent_containers/food/snacks,
 		/obj/item/weapon/reagent_containers/food/snacks/store/bread,
 		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
@@ -188,53 +178,15 @@
 		)
 	blocked |= typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable)
 
-	var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/snacks) - blocked
-	// BORK BORK BORK
+	return typesof(/obj/item/weapon/reagent_containers/food/snacks) - blocked
 
-	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
-
-	for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
-		C.flash_act()
-
-	for(var/i = 1, i <= 4 + rand(1,2), i++)
-		var/chosen = pick(borks)
-		var/obj/B = new chosen
-		if(B)
-			B.loc = get_turf(holder.my_atom)
-			if(prob(50))
-				for(var/j = 1, j <= rand(1, 3), j++)
-					step(B, pick(NORTH,SOUTH,EAST,WEST))
-	..()
-
-
-/datum/chemical_reaction/slime/slimebork2
+/datum/chemical_reaction/slime/slimebork/drinks
 	name = "Slime Bork 2"
 	id = "m_tele4"
 	required_reagents = list("water" = 1)
-	required_container = /obj/item/slime_extract/silver
-	required_other = 1
 
-/datum/chemical_reaction/slime/slimebork2/on_reaction(datum/reagents/holder)
-
-	feedback_add_details("slime_cores_used","[type]")
-	var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/drinks)
-	// BORK BORK BORK
-
-	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
-
-	for(var/mob/living/carbon/M in viewers(get_turf(holder.my_atom), null))
-		M.flash_act()
-
-	for(var/i = 1, i <= 4 + rand(1,2), i++)
-		var/chosen = pick(borks)
-		var/obj/B = new chosen
-		if(B)
-			B.loc = get_turf(holder.my_atom)
-			if(prob(50))
-				for(var/j = 1, j <= rand(1, 3), j++)
-					step(B, pick(NORTH,SOUTH,EAST,WEST))
-	..()
-
+/datum/chemical_reaction/slime/slimebork/drinks/getborks()
+	return subtypesof(/obj/item/weapon/reagent_containers/food/drinks)
 
 //Blue
 /datum/chemical_reaction/slime/slimefrost
@@ -245,11 +197,6 @@
 	required_container = /obj/item/slime_extract/blue
 	required_other = 1
 
-/datum/chemical_reaction/slime/slimefrost/on_reaction(datum/reagents/holder)
-		feedback_add_details("slime_cores_used","[type]")
-		..()
-
-
 /datum/chemical_reaction/slime/slimestabilizer
 	name = "Slime Stabilizer"
 	id = "m_slimestabilizer"
@@ -258,11 +205,8 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimestabilizer/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/slimepotion/stabilizer/P = new /obj/item/slimepotion/stabilizer
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/slimepotion/stabilizer(get_turf(holder.my_atom))
 	..()
-
 
 /datum/chemical_reaction/slime/slimefoam
 	name = "Slime Foam"
@@ -271,11 +215,6 @@
 	required_reagents = list("water" = 5)
 	required_container = /obj/item/slime_extract/blue
 	required_other = 1
-
-/datum/chemical_reaction/slime/slimefoam/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	..()
-
 
 //Dark Blue
 /datum/chemical_reaction/slime/slimefreeze
@@ -286,12 +225,12 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimefreeze/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
 	addtimer(CALLBACK(src, .proc/freeze, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
+	..()
 	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
 /datum/chemical_reaction/slime/slimefreeze/proc/freeze(datum/reagents/holder)
@@ -299,8 +238,6 @@
 		var/turf/open/T = get_turf(holder.my_atom)
 		if(istype(T))
 			T.atmos_spawn_air("freon=50;TEMP=120")
-
-
 
 /datum/chemical_reaction/slime/slimefireproof
 	name = "Slime Fireproof"
@@ -310,9 +247,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimefireproof/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/slimepotion/fireproof/P = new /obj/item/slimepotion/fireproof
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/slimepotion/fireproof(get_turf(holder.my_atom))
 	..()
 
 //Orange
@@ -324,24 +259,21 @@
 	required_container = /obj/item/slime_extract/orange
 	required_other = 1
 
-/datum/chemical_reaction/slime/slimecasp/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	..()
-
 /datum/chemical_reaction/slime/slimefire
 	name = "Slime fire"
 	id = "m_fire"
 	required_reagents = list("plasma" = 1)
 	required_container = /obj/item/slime_extract/orange
 	required_other = 1
+	deletes_extract = FALSE
 
 /datum/chemical_reaction/slime/slimefire/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/turf/TU = get_turf(holder.my_atom)
-	TU.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
 	addtimer(CALLBACK(src, .proc/slime_burn, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
+	..()
 	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
 /datum/chemical_reaction/slime/slimefire/proc/slime_burn(datum/reagents/holder)
@@ -359,12 +291,7 @@
 	required_container = /obj/item/slime_extract/orange
 	required_other = 1
 
-/datum/chemical_reaction/slime/slimesmoke/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	..()
-
 //Yellow
-
 /datum/chemical_reaction/slime/slimeoverload
 	name = "Slime EMP"
 	id = "m_emp"
@@ -373,10 +300,8 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimeoverload/on_reaction(datum/reagents/holder, created_volume)
-	feedback_add_details("slime_cores_used","[type]")
 	empulse(get_turf(holder.my_atom), 3, 7)
 	..()
-
 
 /datum/chemical_reaction/slime/slimecell
 	name = "Slime Powercell"
@@ -386,9 +311,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimecell/on_reaction(datum/reagents/holder, created_volume)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/weapon/stock_parts/cell/high/slime/P = new /obj/item/weapon/stock_parts/cell/high/slime
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/weapon/stock_parts/cell/high/slime(get_turf(holder.my_atom))
 	..()
 
 /datum/chemical_reaction/slime/slimeglow
@@ -399,15 +322,12 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimeglow/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
 	var/turf/T = get_turf(holder.my_atom)
 	T.visible_message("<span class='danger'>The slime begins to emit a soft light. Squeezing it will cause it to grow brightly.</span>")
-	var/obj/item/device/flashlight/slime/F = new /obj/item/device/flashlight/slime
-	F.loc = get_turf(holder.my_atom)
+	new /obj/item/device/flashlight/slime(T)
 	..()
 
 //Purple
-
 /datum/chemical_reaction/slime/slimepsteroid
 	name = "Slime Steroid"
 	id = "m_steroid"
@@ -416,9 +336,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimepsteroid/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/slimepotion/steroid/P = new /obj/item/slimepotion/steroid
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/slimepotion/steroid(get_turf(holder.my_atom))
 	..()
 
 /datum/chemical_reaction/slime/slimejam
@@ -429,11 +347,6 @@
 	required_container = /obj/item/slime_extract/purple
 	required_other = 1
 
-/datum/chemical_reaction/slime/slimejam/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	..()
-
-
 //Dark Purple
 /datum/chemical_reaction/slime/slimeplasma
 	name = "Slime Plasma"
@@ -443,9 +356,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimeplasma/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/turf/location = get_turf(holder.my_atom)
-	new /obj/item/stack/sheet/mineral/plasma (location, 3)
+	new /obj/item/stack/sheet/mineral/plasma(get_turf(holder.my_atom), 3)
 	..()
 
 //Red
@@ -458,9 +369,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimemutator/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/slimepotion/mutator/P = new /obj/item/slimepotion/mutator
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/slimepotion/mutator(get_turf(holder.my_atom))
 	..()
 
 /datum/chemical_reaction/slime/slimebloodlust
@@ -471,12 +380,10 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimebloodlust/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
 	for(var/mob/living/simple_animal/slime/slime in viewers(get_turf(holder.my_atom), null))
 		slime.rabid = 1
 		slime.visible_message("<span class='danger'>The [slime] is driven into a frenzy!</span>")
 	..()
-
 
 /datum/chemical_reaction/slime/slimespeed
 	name = "Slime Speed"
@@ -486,11 +393,8 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimespeed/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/slimepotion/speed/P = new /obj/item/slimepotion/speed
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/slimepotion/speed(get_turf(holder.my_atom))
 	..()
-
 
 //Pink
 /datum/chemical_reaction/slime/docility
@@ -501,9 +405,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/docility/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/slimepotion/docility/P = new /obj/item/slimepotion/docility
-	P.loc = get_turf(holder.my_atom)
+	var/obj/item/slimepotion/docility/P = new /obj/item/slimepotion/docility(get_turf(holder.my_atom))
 	..()
 
 /datum/chemical_reaction/slime/gender
@@ -514,9 +416,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/gender/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/slimepotion/genderchange/G = new /obj/item/slimepotion/genderchange
-	G.loc = get_turf(holder.my_atom)
+	 new /obj/item/slimepotion/genderchange(get_turf(holder.my_atom))
 	..()
 
 //Black
@@ -528,10 +428,6 @@
 	required_other = 1
 	required_container = /obj/item/slime_extract/black
 
-/datum/chemical_reaction/slime/slimemutate2/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	..()
-
 //Oil
 /datum/chemical_reaction/slime/slimeexplosion
 	name = "Slime Explosion"
@@ -539,9 +435,9 @@
 	required_reagents = list("plasma" = 1)
 	required_container = /obj/item/slime_extract/oil
 	required_other = 1
+	deletes_extract = FALSE
 
 /datum/chemical_reaction/slime/slimeexplosion/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
 	var/turf/T = get_turf(holder.my_atom)
 	var/lastkey = holder.my_atom.fingerprintslast
 	var/touch_msg = "N/A"
@@ -554,6 +450,7 @@
 	addtimer(CALLBACK(src, .proc/boom, holder), 50)
 	var/obj/item/slime_extract/M = holder.my_atom
 	deltimer(M.qdel_timer)
+	..()
 	M.qdel_timer = addtimer(CALLBACK(src, .proc/delete_extract, holder), 55, TIMER_STOPPABLE)
 
 /datum/chemical_reaction/slime/slimeexplosion/proc/boom(datum/reagents/holder)
@@ -568,10 +465,6 @@
 	required_reagents = list("blood" = 1)
 	required_container = /obj/item/slime_extract/oil
 	required_other = 1
-
-/datum/chemical_reaction/slime/slimecornoil/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	..()
 
 //Light Pink
 /datum/chemical_reaction/slime/slimepotion2
@@ -624,10 +517,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimefloor2/on_reaction(datum/reagents/holder, created_volume)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/stack/tile/bluespace/P = new /obj/item/stack/tile/bluespace
-	P.amount = 25
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/stack/tile/bluespace(get_turf(holder.my_atom), 25)
 	..()
 
 
@@ -639,10 +529,8 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimecrystal/on_reaction(datum/reagents/holder, created_volume)
-	feedback_add_details("slime_cores_used","[type]")
-	if(holder.my_atom)
-		var/obj/item/weapon/ore/bluespace_crystal/BC = new(get_turf(holder.my_atom))
-		BC.visible_message("<span class='notice'>The [BC.name] appears out of thin air!</span>")
+	var/obj/item/weapon/ore/bluespace_crystal/BC = new (get_turf(holder.my_atom))
+	BC.visible_message("<span class='notice'>The [BC.name] appears out of thin air!</span>")
 	..()
 
 //Cerulean
@@ -654,11 +542,8 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimepsteroid2/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/slimepotion/enhancer/P = new /obj/item/slimepotion/enhancer
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/slimepotion/enhancer(get_turf(holder.my_atom))
 	..()
-
 
 /datum/chemical_reaction/slime/slime_territory
 	name = "Slime Territory"
@@ -668,9 +553,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slime_territory/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/areaeditor/blueprints/slime/P = new /obj/item/areaeditor/blueprints/slime
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/areaeditor/blueprints/slime(get_turf(holder.my_atom))
 	..()
 
 //Sepia
@@ -682,14 +565,11 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimestop/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/mob/mob = get_mob_by_key(holder.my_atom.fingerprintslast)
 	var/obj/effect/timestop/T = new /obj/effect/timestop
-	T.loc = get_turf(holder.my_atom)
-	T.immune += mob
+	T.forceMove(get_turf(holder.my_atom))
+	T.immune += get_mob_by_key(holder.my_atom.fingerprintslast)
 	T.timestop()
 	..()
-
 
 /datum/chemical_reaction/slime/slimecamera
 	name = "Slime Camera"
@@ -699,11 +579,8 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimecamera/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/device/camera/P = new /obj/item/device/camera
-	P.loc = get_turf(holder.my_atom)
-	var/obj/item/device/camera_film/Z = new /obj/item/device/camera_film
-	Z.loc = get_turf(holder.my_atom)
+	new /obj/item/device/camera(get_turf(holder.my_atom))
+	new /obj/item/device/camera_film(get_turf(holder.my_atom))
 	..()
 
 /datum/chemical_reaction/slime/slimefloor
@@ -714,16 +591,10 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimefloor/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/stack/tile/sepia/P = new /obj/item/stack/tile/sepia
-	P.amount = 25
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/stack/tile/sepia(get_turf(holder.my_atom), 25)
 	..()
 
-
 //Pyrite
-
-
 /datum/chemical_reaction/slime/slimepaint
 	name = "Slime Paint"
 	id = "s_paint"
@@ -732,14 +603,9 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimepaint/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/list/paints = subtypesof(/obj/item/weapon/paint)
-	var/chosen = pick(paints)
-	var/obj/P = new chosen
-	if(P)
-		P.loc = get_turf(holder.my_atom)
+	var/chosen = pick(subtypesof(/obj/item/weapon/paint))
+	var/obj/P = new chosen(get_turf(holder.my_atom))
 	..()
-
 
 /datum/chemical_reaction/slime/slimecrayon
 	name = "Slime Crayon"
@@ -749,12 +615,8 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimecrayon/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/list/crayons = difflist(subtypesof(/obj/item/toy/crayon),typesof(/obj/item/toy/crayon/spraycan))
-	var/chosen = pick(crayons)
-	var/obj/P = new chosen
-	if(P)
-		P.loc = get_turf(holder.my_atom)
+	var/chosen = pick(difflist(subtypesof(/obj/item/toy/crayon),typesof(/obj/item/toy/crayon/spraycan)))
+	new chosen(get_turf(holder.my_atom))
 	..()
 
 //Rainbow :o)
@@ -766,12 +628,8 @@
 	required_container = /obj/item/slime_extract/rainbow
 
 /datum/chemical_reaction/slime/slimeRNG/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/mob/living/simple_animal/slime/random/S
-	S = new(get_turf(holder.my_atom))
-	S.visible_message("<span class='danger'>Infused with plasma, the \
-		core begins to quiver and grow, and soon a new baby slime emerges \
-		from it!</span>")
+	var/mob/living/simple_animal/slime/random/S = new (get_turf(holder.my_atom))
+	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and a new baby slime emerges from it!</span>")
 	..()
 
 /datum/chemical_reaction/slime/slime_transfer
@@ -782,9 +640,7 @@
 	required_container = /obj/item/slime_extract/rainbow
 
 /datum/chemical_reaction/slime/slime_transfer/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	var/obj/item/slimepotion/transference/P = new /obj/item/slimepotion/transference
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/slimepotion/transference(get_turf(holder.my_atom))
 	..()
 
 /datum/chemical_reaction/slime/flight_potion
@@ -795,7 +651,6 @@
 	required_container = /obj/item/slime_extract/rainbow
 
 /datum/chemical_reaction/slime/flight_potion/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-	new/obj/item/weapon/reagent_containers/glass/bottle/potion/flight(get_turf(holder.my_atom))
+	new /obj/item/weapon/reagent_containers/glass/bottle/potion/flight(get_turf(holder.my_atom))
 	..()
 

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -597,7 +597,7 @@
 
 /datum/chemical_reaction/slime/slimepaint/on_reaction(datum/reagents/holder)
 	var/chosen = pick(subtypesof(/obj/item/weapon/paint))
-	var/obj/P = new chosen(get_turf(holder.my_atom))
+	new chosen(get_turf(holder.my_atom))
 	..()
 
 /datum/chemical_reaction/slime/slimecrayon

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -482,9 +482,14 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = TURF_LAYER
 
-/obj/effect/golemrune/New()
-	..()
+/obj/effect/golemrune/Initialize()
+	. = ..()
 	START_PROCESSING(SSobj, src)
+	notify_ghosts("Golem rune created in [get_area(src)].", 'sound/effects/ghost2.ogg', source = src)
+
+/obj/effect/golemrune/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
 
 /obj/effect/golemrune/process()
 	var/mob/dead/observer/ghost


### PR DESCRIPTION
Ore mining no longer gives you the amount of ore mined per tile; this isn't really useful information, except for checking byond randomization. Instead, it logs once for each piece of ore.
Jaunter logging now tells you what activated it exactly, instead of just letter keys.
Wisp Lantern logging now uses actual words instead of letter keys.
The slime logging line, `feedback_add_details("slime_cores_used","[type]")`, is no longer duplicated for every slime core reaction. Some other code is also less duplicated, as well.