### PR TITLE
Changes /obj/machinery to have atom/movable occupants

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -111,18 +111,18 @@
 	else
 		dat += "<span class='linkOff'>Experiment </span>"
 
-	if(!isliving(occupant))
+	if(!occupant)
 		dat += "<h3>Machine Unoccupied</h3>"
 	else
 		dat += "<h3>Subject Status : </h3>"
 		dat += "[occupant.name] => "
 		var/mob/living/mob_occupant = occupant
 		switch(mob_occupant.stat)
-			if(0)
+			if(CONSCIOUS)
 				dat += "<span class='good'>Conscious</span>"
-			if(1)
+			if(UNCONSCIOUS)
 				dat += "<span class='average'>Unconscious</span>"
-			else
+			else // DEAD
 				dat += "<span class='bad'>Deceased</span>"
 	dat += "<br>"
 	dat += "[flash]"
@@ -147,7 +147,7 @@
 	if(href_list["close"])
 		close_machine()
 		return
-	if(isliving(occupant))
+	if(occupant)
 		var/mob/living/mob_occupant = occupant
 		if(mob_occupant.stat != DEAD)
 			if(href_list["experiment"])

--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -111,12 +111,13 @@
 	else
 		dat += "<span class='linkOff'>Experiment </span>"
 
-	if(!occupant)
+	if(!isliving(occupant))
 		dat += "<h3>Machine Unoccupied</h3>"
 	else
 		dat += "<h3>Subject Status : </h3>"
 		dat += "[occupant.name] => "
-		switch(occupant.stat)
+		var/mob/living/mob_occupant = occupant
+		switch(mob_occupant.stat)
 			if(0)
 				dat += "<span class='good'>Conscious</span>"
 			if(1)
@@ -146,9 +147,11 @@
 	if(href_list["close"])
 		close_machine()
 		return
-	if(occupant && occupant.stat != DEAD)
-		if(href_list["experiment"])
-			flash = Experiment(occupant,href_list["experiment"])
+	if(isliving(occupant))
+		var/mob/living/mob_occupant = occupant
+		if(mob_occupant.stat != DEAD)
+			if(href_list["experiment"])
+				flash = Experiment(occupant,href_list["experiment"])
 	updateUsrDialog()
 	add_fingerprint(usr)
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -79,7 +79,8 @@
 /obj/machinery/sleeper/close_machine(mob/user)
 	if((isnull(user) || istype(user)) && state_open && !panel_open)
 		..(user)
-		if(occupant && occupant.stat != DEAD)
+		var/mob/living/mob_occupant = occupant
+		if(mob_occupant && mob_occupant.stat != DEAD)
 			to_chat(occupant, "<span class='notice'><b>You feel cool air surround you. You go numb as your senses turn inward.</b></span>")
 
 /obj/machinery/sleeper/emp_act(severity)
@@ -128,21 +129,22 @@
 		data["chems"] += list(list("name" = R.name, "id" = R.id, "allowed" = chem_allowed(chem)))
 
 	data["occupant"] = list()
-	if(occupant)
-		data["occupant"]["name"] = occupant.name
-		data["occupant"]["stat"] = occupant.stat
-		data["occupant"]["health"] = occupant.health
-		data["occupant"]["maxHealth"] = occupant.maxHealth
+	if(isliving(occupant))
+		var/mob/living/mob_occupant = occupant
+		data["occupant"]["name"] = mob_occupant.name
+		data["occupant"]["stat"] = mob_occupant.stat
+		data["occupant"]["health"] = mob_occupant.health
+		data["occupant"]["maxHealth"] = mob_occupant.maxHealth
 		data["occupant"]["minHealth"] = HEALTH_THRESHOLD_DEAD
-		data["occupant"]["bruteLoss"] = occupant.getBruteLoss()
-		data["occupant"]["oxyLoss"] = occupant.getOxyLoss()
-		data["occupant"]["toxLoss"] = occupant.getToxLoss()
-		data["occupant"]["fireLoss"] = occupant.getFireLoss()
-		data["occupant"]["cloneLoss"] = occupant.getCloneLoss()
-		data["occupant"]["brainLoss"] = occupant.getBrainLoss()
+		data["occupant"]["bruteLoss"] = mob_occupant.getBruteLoss()
+		data["occupant"]["oxyLoss"] = mob_occupant.getOxyLoss()
+		data["occupant"]["toxLoss"] = mob_occupant.getToxLoss()
+		data["occupant"]["fireLoss"] = mob_occupant.getFireLoss()
+		data["occupant"]["cloneLoss"] = mob_occupant.getCloneLoss()
+		data["occupant"]["brainLoss"] = mob_occupant.getBrainLoss()
 		data["occupant"]["reagents"] = list()
 		if(occupant.reagents.reagent_list.len)
-			for(var/datum/reagent/R in occupant.reagents.reagent_list)
+			for(var/datum/reagent/R in mob_occupant.reagents.reagent_list)
 				data["occupant"]["reagents"] += list(list("name" = R.name, "volume" = R.volume))
 	return data
 
@@ -158,9 +160,10 @@
 			. = TRUE
 		if("inject")
 			var/chem = params["chem"]
-			if(!is_operational() || !occupant)
+			if(!is_operational() || !isliving(occupant))
 				return
-			if(occupant.health < min_health && chem != "epinephrine")
+			var/mob/living/mob_occupant = occupant
+			if(mob_occupant.health < min_health && chem != "epinephrine")
 				return
 			if(inject_chem(chem))
 				. = TRUE
@@ -177,10 +180,11 @@
 		return TRUE
 
 /obj/machinery/sleeper/proc/chem_allowed(chem)
-	if(!occupant)
+	if(!isliving(occupant))
 		return
-	var/amount = occupant.reagents.get_reagent_amount(chem) + 10 <= 20 * efficiency
-	var/occ_health = occupant.health > min_health || chem == "epinephrine"
+	var/mob/living/mob_occupant = occupant
+	var/amount = mob_occupant.reagents.get_reagent_amount(chem) + 10 <= 20 * efficiency
+	var/occ_health = mob_occupant.health > min_health || chem == "epinephrine"
 	return amount && occ_health
 
 /obj/machinery/sleeper/proc/reset_chem_buttons()

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -129,8 +129,8 @@
 		data["chems"] += list(list("name" = R.name, "id" = R.id, "allowed" = chem_allowed(chem)))
 
 	data["occupant"] = list()
-	if(isliving(occupant))
-		var/mob/living/mob_occupant = occupant
+	var/mob/living/mob_occupant = occupant
+	if(mob_occupant)
 		data["occupant"]["name"] = mob_occupant.name
 		data["occupant"]["stat"] = mob_occupant.stat
 		data["occupant"]["health"] = mob_occupant.health
@@ -151,6 +151,8 @@
 /obj/machinery/sleeper/ui_act(action, params)
 	if(..())
 		return
+	var/mob/living/mob_occupant = occupant
+
 	switch(action)
 		if("door")
 			if(state_open)
@@ -160,9 +162,8 @@
 			. = TRUE
 		if("inject")
 			var/chem = params["chem"]
-			if(!is_operational() || !isliving(occupant))
+			if(!is_operational() || mob_occupant)
 				return
-			var/mob/living/mob_occupant = occupant
 			if(mob_occupant.health < min_health && chem != "epinephrine")
 				return
 			if(inject_chem(chem))
@@ -180,9 +181,9 @@
 		return TRUE
 
 /obj/machinery/sleeper/proc/chem_allowed(chem)
-	if(!isliving(occupant))
-		return
 	var/mob/living/mob_occupant = occupant
+	if(!mob_occupant)
+		return
 	var/amount = mob_occupant.reagents.get_reagent_amount(chem) + 10 <= 20 * efficiency
 	var/occ_health = mob_occupant.health > min_health || chem == "epinephrine"
 	return amount && occ_health

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -123,8 +123,10 @@
 	..()
 	if(mess)
 		to_chat(user, "It's filled with blood and viscera. You swear you can see it moving...")
-	if (is_operational() && (!isnull(occupant)) && (occupant.stat != DEAD))
-		to_chat(user, "Current clone cycle is [round(get_completion())]% complete.")
+	if(is_operational() && isliving(occupant))
+		var/mob/living/mob_occupant = occupant
+		if(mob_occupant.stat != DEAD)
+			to_chat(user, "Current clone cycle is [round(get_completion())]% complete.")
 
 /obj/machinery/clonepod/return_air()
 	// We want to simulate the clone not being in contact with
@@ -136,7 +138,10 @@
 	return GM
 
 /obj/machinery/clonepod/proc/get_completion()
-	. = (100 * ((occupant.health + 100) / (heal_level + 100)))
+	. = FALSE
+	if(isliving(occupant))
+		var/mob/living/mob_occupant = occupant
+		. = (100 * ((mob_occupant.health + 100) / (heal_level + 100)))
 
 /obj/machinery/clonepod/attack_ai(mob/user)
 	return examine(user)
@@ -223,25 +228,26 @@
 
 //Grow clones to maturity then kick them out.  FREELOADERS
 /obj/machinery/clonepod/process()
+	var/mob/living/mob_occupant = occupant
 
 	if(!is_operational()) //Autoeject if power is lost
 		if (occupant)
 			go_out()
 			connected_message("Clone Ejected: Loss of power.")
 
-	else if((occupant) && (occupant.loc == src))
-		if((occupant.stat == DEAD) || (occupant.suiciding) || occupant.hellbound)  //Autoeject corpses and suiciding dudes.
+	else if(isliving(mob_occupant) && (mob_occupant.loc == src))
+		if((mob_occupant.stat == DEAD) || (mob_occupant.suiciding) || mob_occupant.hellbound)  //Autoeject corpses and suiciding dudes.
 			connected_message("Clone Rejected: Deceased.")
-			SPEAK("The cloning of [occupant.real_name] has been \
+			SPEAK("The cloning of [mob_occupant.real_name] has been \
 				aborted due to unrecoverable tissue failure.")
 			go_out()
 
-		else if(occupant.cloneloss > (100 - heal_level))
-			occupant.Paralyse(4)
+		else if(mob_occupant.cloneloss > (100 - heal_level))
+			mob_occupant.Paralyse(4)
 
 			 //Slowly get that clone healed and finished.
-			occupant.adjustCloneLoss(-((speed_coeff/2) * config.damage_multiplier))
-			var/progress = CLONE_INITIAL_DAMAGE - occupant.getCloneLoss()
+			mob_occupant.adjustCloneLoss(-((speed_coeff/2) * config.damage_multiplier))
+			var/progress = CLONE_INITIAL_DAMAGE - mob_occupant.getCloneLoss()
 			// To avoid the default cloner making incomplete clones
 			progress += (100 - MINIMUM_HEAL_LEVEL)
 			var/milestone = CLONE_INITIAL_DAMAGE / flesh_number
@@ -252,24 +258,24 @@
 				var/obj/item/I = pick_n_take(unattached_flesh)
 				if(isorgan(I))
 					var/obj/item/organ/O = I
-					O.Insert(occupant)
+					O.Insert(mob_occupant)
 				else if(isbodypart(I))
 					var/obj/item/bodypart/BP = I
-					BP.attach_limb(occupant)
+					BP.attach_limb(mob_occupant)
 
 			//Premature clones may have brain damage.
-			occupant.adjustBrainLoss(-((speed_coeff/2) * config.damage_multiplier))
+			mob_occupant.adjustBrainLoss(-((speed_coeff/2) * config.damage_multiplier))
 
 			check_brine()
 
 			use_power(7500) //This might need tweaking.
 
-		else if((occupant.cloneloss <= (100 - heal_level)))
+		else if((mob_occupant.cloneloss <= (100 - heal_level)))
 			connected_message("Cloning Process Complete.")
-			SPEAK("The cloning cycle of [occupant.real_name] is complete.")
+			SPEAK("The cloning cycle of [mob_occupant.real_name] is complete.")
 			go_out()
 
-	else if ((!occupant) || (occupant.loc != src))
+	else if ((!isliving(mob_occupant)) || (mob_occupant.loc != src))
 		occupant = null
 		if (!mess && !panel_open)
 			icon_state = "pod_0"
@@ -313,6 +319,7 @@
 			to_chat(user, "<span class='danger'>Error: Pod has no occupant.</span>")
 			return
 		else
+			var/mob/living/mob_occupant
 			connected_message("Authorized Ejection")
 			SPEAK("An authorized ejection of [clonemind.name] has occurred.")
 			to_chat(user, "<span class='notice'>You force an emergency ejection. </span>")
@@ -347,22 +354,26 @@
 		icon_state = "pod_0"
 		return
 
-	if(!occupant)
+	if(!isliving(occupant))
 		return
 
+	var/mob/living/mob_occupant = occupant
+
 	if(grab_ghost_when == CLONER_MATURE_CLONE)
-		occupant.grab_ghost()
+		mob_occupant.grab_ghost()
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
-		occupant.flash_act()
+		mob_occupant.flash_act()
 
 	var/turf/T = get_turf(src)
 	occupant.forceMove(T)
 	icon_state = "pod_0"
-	occupant.domutcheck(1) //Waiting until they're out before possible monkeyizing. The 1 argument forces powers to manifest.
+	mob_occupant.domutcheck(1) //Waiting until they're out before possible monkeyizing. The 1 argument forces powers to manifest.
+
 	occupant = null
 
 /obj/machinery/clonepod/proc/malfunction()
-	if(occupant)
+	if(isliving(occupant))
+		var/mob/living/mob_occupant = occupant
 		connected_message("Critical Error!")
 		SPEAK("Critical error! Please contact a Thinktronic Systems \
 			technician, as your warranty may be affected.")
@@ -370,23 +381,30 @@
 		for(var/obj/item/O in unattached_flesh)
 			qdel(O)
 		icon_state = "pod_g"
-		if(occupant.mind != clonemind)
-			clonemind.transfer_to(occupant)
-		occupant.grab_ghost() // We really just want to make you suffer.
-		flash_color(occupant, flash_color="#960000", flash_time=100)
-		to_chat(occupant, "<span class='warning'><b>Agony blazes across your consciousness as your body is torn apart.</b><br><i>Is this what dying is like? Yes it is.</i></span>")
+		if(mob_occupant.mind != clonemind)
+			clonemind.transfer_to(mob_occupant)
+		mob_occupant.grab_ghost() // We really just want to make you suffer.
+		flash_color(mob_occupant, flash_color="#960000", flash_time=100)
+		to_chat(mob_occupant, "<span class='warning'><b>Agony blazes across your consciousness as your body is torn apart.</b><br><i>Is this what dying is like? Yes it is.</i></span>")
 		playsound(src.loc, 'sound/machines/warning-buzzer.ogg', 50, 0)
-		occupant << sound('sound/hallucinations/veryfar_noise.ogg',0,1,50)
-		QDEL_IN(occupant, 40)
+		mob_occupant << sound('sound/hallucinations/veryfar_noise.ogg',0,1,50)
+		QDEL_IN(mob_occupant, 40)
 
 /obj/machinery/clonepod/relaymove(mob/user)
 	if(user.stat == CONSCIOUS)
 		go_out()
 
 /obj/machinery/clonepod/emp_act(severity)
+<<<<<<< HEAD
 	if((occupant || mess) && prob(100/(severity*efficiency)))
 		connected_message(Gibberish("EMP-caused Accidental Ejection", 0))
 		SPEAK(Gibberish("Exposure to electromagnetic fields has caused the ejection of [clonemind.name] prematurely." ,0))
+=======
+	if(isliving(occupant) && prob(100/(severity*efficiency)))
+		var/mob/living/mob_occupant = occupant
+		connected_message(Gibberish("EMP-caused Accidental Ejection", 0))
+		SPEAK(Gibberish("Exposure to electromagnetic fields has caused the ejection of [mob_occupant.real_name] prematurely." ,0))
+>>>>>>> Changes /obj/machinery to have atom/movable occupants
 		go_out()
 	..()
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -121,10 +121,10 @@
 
 /obj/machinery/clonepod/examine(mob/user)
 	..()
+	var/mob/living/mob_occupant = occupant
 	if(mess)
 		to_chat(user, "It's filled with blood and viscera. You swear you can see it moving...")
-	if(is_operational() && isliving(occupant))
-		var/mob/living/mob_occupant = occupant
+	if(is_operational() && mob_occupant)
 		if(mob_occupant.stat != DEAD)
 			to_chat(user, "Current clone cycle is [round(get_completion())]% complete.")
 
@@ -139,8 +139,8 @@
 
 /obj/machinery/clonepod/proc/get_completion()
 	. = FALSE
-	if(isliving(occupant))
-		var/mob/living/mob_occupant = occupant
+	var/mob/living/mob_occupant = occupant
+	if(mob_occupant)
 		. = (100 * ((mob_occupant.health + 100) / (heal_level + 100)))
 
 /obj/machinery/clonepod/attack_ai(mob/user)
@@ -231,11 +231,11 @@
 	var/mob/living/mob_occupant = occupant
 
 	if(!is_operational()) //Autoeject if power is lost
-		if (occupant)
+		if(mob_occupant)
 			go_out()
 			connected_message("Clone Ejected: Loss of power.")
 
-	else if(isliving(mob_occupant) && (mob_occupant.loc == src))
+	else if(mob_occupant && (mob_occupant.loc == src))
 		if((mob_occupant.stat == DEAD) || (mob_occupant.suiciding) || mob_occupant.hellbound)  //Autoeject corpses and suiciding dudes.
 			connected_message("Clone Rejected: Deceased.")
 			SPEAK("The cloning of [mob_occupant.real_name] has been \
@@ -275,7 +275,7 @@
 			SPEAK("The cloning cycle of [mob_occupant.real_name] is complete.")
 			go_out()
 
-	else if ((!isliving(mob_occupant)) || (mob_occupant.loc != src))
+	else if (!mob_occupant || mob_occupant.loc != src)
 		occupant = null
 		if (!mess && !panel_open)
 			icon_state = "pod_0"
@@ -311,15 +311,15 @@
 			to_chat(user, "<font color = #666633>-% Successfully stored \ref[P.buffer] [P.buffer.name] in buffer %-</font color>")
 		return
 
+	var/mob/living/mob_occupant = occupant
 	if(W.GetID())
 		if(!check_access(W))
 			to_chat(user, "<span class='danger'>Access Denied.</span>")
 			return
-		if(!(occupant || mess))
+		if(!(mob_occupant || mess))
 			to_chat(user, "<span class='danger'>Error: Pod has no occupant.</span>")
 			return
 		else
-			var/mob/living/mob_occupant
 			connected_message("Authorized Ejection")
 			SPEAK("An authorized ejection of [clonemind.name] has occurred.")
 			to_chat(user, "<span class='notice'>You force an emergency ejection. </span>")
@@ -346,6 +346,7 @@
 
 /obj/machinery/clonepod/proc/go_out()
 	countdown.stop()
+	var/mob/living/mob_occupant = occupant
 
 	if(mess) //Clean that mess and dump those gibs!
 		mess = FALSE
@@ -354,10 +355,9 @@
 		icon_state = "pod_0"
 		return
 
-	if(!isliving(occupant))
+	if(!mob_occupant)
 		return
 
-	var/mob/living/mob_occupant = occupant
 
 	if(grab_ghost_when == CLONER_MATURE_CLONE)
 		mob_occupant.grab_ghost()
@@ -372,8 +372,8 @@
 	occupant = null
 
 /obj/machinery/clonepod/proc/malfunction()
-	if(isliving(occupant))
-		var/mob/living/mob_occupant = occupant
+	var/mob/living/mob_occupant = occupant
+	if(mob_occupant)
 		connected_message("Critical Error!")
 		SPEAK("Critical error! Please contact a Thinktronic Systems \
 			technician, as your warranty may be affected.")
@@ -395,16 +395,10 @@
 		go_out()
 
 /obj/machinery/clonepod/emp_act(severity)
-<<<<<<< HEAD
-	if((occupant || mess) && prob(100/(severity*efficiency)))
-		connected_message(Gibberish("EMP-caused Accidental Ejection", 0))
-		SPEAK(Gibberish("Exposure to electromagnetic fields has caused the ejection of [clonemind.name] prematurely." ,0))
-=======
-	if(isliving(occupant) && prob(100/(severity*efficiency)))
-		var/mob/living/mob_occupant = occupant
+	var/mob/living/mob_occupant = occupant
+	if(mob_occupant && prob(100/(severity*efficiency)))
 		connected_message(Gibberish("EMP-caused Accidental Ejection", 0))
 		SPEAK(Gibberish("Exposure to electromagnetic fields has caused the ejection of [mob_occupant.real_name] prematurely." ,0))
->>>>>>> Changes /obj/machinery to have atom/movable occupants
 		go_out()
 	..()
 

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -189,14 +189,15 @@
 				dat += "<h3>Scanner Functions</h3>"
 
 				dat += "<div class='statusDisplay'>"
-				if (!src.scanner.occupant)
+				if (!isliving(scanner.occupant))
 					dat += "Scanner Unoccupied"
 				else if(loading)
 					dat += "[src.scanner.occupant] => Scanning..."
 				else
-					if (src.scanner.occupant.ckey != scantemp_ckey)
+					var/mob/living/mob_occupant = scanner.occupant
+					if (mob_occupant.ckey != scantemp_ckey)
 						scantemp = "Ready to Scan"
-						scantemp_ckey = src.scanner.occupant.ckey
+						scantemp_ckey = mob_occupant.ckey
 					dat += "[src.scanner.occupant] => [scantemp]"
 				dat += "</div>"
 

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -186,22 +186,23 @@
 			// Scanner
 			if (!isnull(src.scanner))
 
+				var/mob/living/scanner_occupant = scanner.occupant
+
 				dat += "<h3>Scanner Functions</h3>"
 
 				dat += "<div class='statusDisplay'>"
-				if (!isliving(scanner.occupant))
+				if(!scanner_occupant)
 					dat += "Scanner Unoccupied"
 				else if(loading)
-					dat += "[src.scanner.occupant] => Scanning..."
+					dat += "[scanner_occupant] => Scanning..."
 				else
-					var/mob/living/mob_occupant = scanner.occupant
-					if (mob_occupant.ckey != scantemp_ckey)
+					if(scanner_occupant.ckey != scantemp_ckey)
 						scantemp = "Ready to Scan"
-						scantemp_ckey = mob_occupant.ckey
-					dat += "[src.scanner.occupant] => [scantemp]"
+						scantemp_ckey = scanner_occupant.ckey
+					dat += "[scanner_occupant] => [scantemp]"
 				dat += "</div>"
 
-				if (src.scanner.occupant)
+				if(scanner_occupant)
 					dat += "<a href='byond://?src=\ref[src];scan=1'>Start Scan</a>"
 					dat += "<br><a href='byond://?src=\ref[src];lock=1'>[src.scanner.locked ? "Unlock Scanner" : "Lock Scanner"]</a>"
 				else

--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -105,8 +105,8 @@
 	..()
 
 	// search for ghosts, if the corpse is empty and the scanner is connected to a cloner
-	if(isliving(occupant))
-		var/mob/living/mob_occupant = occupant
+	var/mob/living/mob_occupant = occupant
+	if(mob_occupant)
 		if(locate(/obj/machinery/computer/cloning, get_step(src, NORTH)) \
 			|| locate(/obj/machinery/computer/cloning, get_step(src, SOUTH)) \
 			|| locate(/obj/machinery/computer/cloning, get_step(src, EAST)) \

--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -105,13 +105,14 @@
 	..()
 
 	// search for ghosts, if the corpse is empty and the scanner is connected to a cloner
-	if(occupant)
+	if(isliving(occupant))
+		var/mob/living/mob_occupant = occupant
 		if(locate(/obj/machinery/computer/cloning, get_step(src, NORTH)) \
 			|| locate(/obj/machinery/computer/cloning, get_step(src, SOUTH)) \
 			|| locate(/obj/machinery/computer/cloning, get_step(src, EAST)) \
 			|| locate(/obj/machinery/computer/cloning, get_step(src, WEST)))
-			if(!occupant.suiciding && !(occupant.disabilities & NOCLONE) && !occupant.hellbound)
-				occupant.notify_ghost_cloning("Your corpse has been placed into a cloning scanner. Re-enter your corpse if you want to be cloned!", source = src)
+			if(!mob_occupant.suiciding && !(mob_occupant.disabilities & NOCLONE) && !mob_occupant.hellbound)
+				mob_occupant.notify_ghost_cloning("Your corpse has been placed into a cloning scanner. Re-enter your corpse if you want to be cloned!", source = src)
 
 		var/obj/machinery/computer/scan_consolenew/console
 		for(dir in list(NORTH,EAST,SOUTH,WEST))

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -136,13 +136,14 @@ The console is located at computer/gulag_teleporter.dm
 /obj/machinery/gulag_teleporter/proc/strip_occupant()
 	if(linked_reclaimer)
 		linked_reclaimer.stored_items[occupant] = list()
-	for(var/obj/item/W in occupant)
-		if(!is_type_in_typecache(W, required_items) && occupant.temporarilyRemoveItemFromInventory(W))
+	var/mob/living/mob_occupant = occupant
+	for(var/obj/item/W in mob_occupant)
+		if(!is_type_in_typecache(W, required_items) && mob_occupant.temporarilyRemoveItemFromInventory(W))
 			if(istype(W, /obj/item/weapon/restraints/handcuffs))
 				W.forceMove(get_turf(src))
 				continue
 			if(linked_reclaimer)
-				linked_reclaimer.stored_items[occupant] += W
+				linked_reclaimer.stored_items[mob_occupant] += W
 				linked_reclaimer.contents += W
 				W.forceMove(linked_reclaimer)
 			else

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -1,8 +1,8 @@
 /*
 Overview:
-   Used to create objects that need a per step proc call.  Default definition of 'New()'
+   Used to create objects that need a per step proc call.  Default definition of 'Initialize()'
    stores a reference to src machine in global 'machines list'.  Default definition
-   of 'Del' removes reference to src machine in global 'machines list'.
+   of 'Destroy' removes reference to src machine in global 'machines list'.
 
 Class Variables:
    use_power (num)
@@ -44,7 +44,7 @@ Class Variables:
          EMPED:16 -- temporary broken by EMP pulse
 
 Class Procs:
-   New()                     'game/machinery/machine.dm'
+   Initialize()                     'game/machinery/machine.dm'
 
    Destroy()                   'game/machinery/machine.dm'
 
@@ -118,14 +118,15 @@ Class Procs:
 	var/panel_open = 0
 	var/state_open = 0
 	var/critical_machine = FALSE //If this machine is critical to station operation and should have the area be excempted from power failures.
-	var/mob/living/occupant = null
+	var/list/occupant_typecache = list(/mob/living) // turned into typecache in Initialize
+	var/atom/movable/occupant = null
 	var/unsecuring_tool = /obj/item/weapon/wrench
 	var/interact_open = 0 // Can the machine be interacted with when in maint/when the panel is open.
 	var/interact_offline = 0 // Can the machine be interacted with while de-powered.
 	var/speed_process = 0 // Process as fast as possible?
 
 /obj/machinery/Initialize()
-	if (!armor)
+	if(!armor)
 		armor = list(melee = 25, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70)
 	. = ..()
 	GLOB.machines += src
@@ -134,6 +135,8 @@ Class Procs:
 	else
 		START_PROCESSING(SSfastprocess, src)
 	power_change()
+
+	occupant_typecache = typecacheof(occupant_typecache)
 
 /obj/machinery/Destroy()
 	GLOB.machines.Remove(src)
@@ -176,16 +179,24 @@ Class Procs:
 			L.update_canmove()
 	occupant = null
 
-/obj/machinery/proc/close_machine(mob/living/target = null)
+/obj/machinery/proc/close_machine(atom/movable/target = null)
 	state_open = 0
 	density = 1
 	if(!target)
-		for(var/mob/living/carbon/C in loc)
-			if(C.buckled || C.has_buckled_mobs())
+		for(var/am in loc)
+			if(!is_type_in_typecache(am, occupant_typecache))
 				continue
-			else
-				target = C
-	if(target && !target.buckled && !target.has_buckled_mobs())
+			var/atom/movable/AM = am
+			if(AM.has_buckled_mobs())
+				continue
+			if(isliving(AM))
+				var/mob/living/L = am
+				if(L.buckled)
+					continue
+			target = am
+
+	var/mob/living/mobtarget = target
+	if(target && !target.has_buckled_mobs() && (!isliving(target) || !mobtarget.buckled))
 		occupant = target
 		target.forceMove(src)
 	updateUsrDialog()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -211,7 +211,7 @@
 		uv = TRUE
 		locked = TRUE
 		update_icon()
-		if(isliving(occupant))
+		if(occupant)
 			var/mob/living/mob_occupant = occupant
 			if(uv_super)
 				mob_occupant.adjustFireLoss(rand(20, 36))
@@ -368,7 +368,7 @@
 			else if(!helmet && !mask && !suit && !storage && !occupant)
 				return
 			else
-				if(isliving(occupant))
+				if(occupant)
 					var/mob/living/mob_occupant = occupant
 					to_chat(mob_occupant, "<span class='userdanger'>[src]'s confines grow warm, then hot, then scorching. You're being burned [!mob_occupant.stat ? "alive" : "away"]!</span>")
 				cook()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -211,13 +211,13 @@
 		uv = TRUE
 		locked = TRUE
 		update_icon()
-		if(occupant)
+		if(isliving(occupant))
+			var/mob/living/mob_occupant = occupant
 			if(uv_super)
-				occupant.adjustFireLoss(rand(20, 36))
+				mob_occupant.adjustFireLoss(rand(20, 36))
 			else
-				occupant.adjustFireLoss(rand(10, 16))
-			if(iscarbon(occupant))
-				occupant.emote("scream")
+				mob_occupant.adjustFireLoss(rand(10, 16))
+			mob_occupant.emote("scream")
 		addtimer(CALLBACK(src, .proc/cook), 50)
 	else
 		uv_cycles = initial(uv_cycles)
@@ -368,14 +368,15 @@
 			else if(!helmet && !mask && !suit && !storage && !occupant)
 				return
 			else
-				if(occupant)
-					to_chat(occupant, "<span class='userdanger'>[src]'s confines grow warm, then hot, then scorching. You're being burned [!occupant.stat ? "alive" : "away"]!</span>")
+				if(isliving(occupant))
+					var/mob/living/mob_occupant = occupant
+					to_chat(mob_occupant, "<span class='userdanger'>[src]'s confines grow warm, then hot, then scorching. You're being burned [!mob_occupant.stat ? "alive" : "away"]!</span>")
 				cook()
 				. = TRUE
 		if("dispense")
 			if(!state_open)
 				return
-			
+
 			var/static/list/valid_items = list("helmet", "suit", "mask", "storage")
 			var/item_name = params["item"]
 			if(item_name in valid_items)

--- a/code/game/objects/items/weapons/implants/implantchair.dm
+++ b/code/game/objects/items/weapons/implants/implantchair.dm
@@ -41,9 +41,10 @@
 	data["open"] = state_open
 
 	data["occupant"] = list()
-	if(occupant)
-		data["occupant"]["name"] = occupant.name
-		data["occupant"]["stat"] = occupant.stat
+	if(isliving(occupant))
+		var/mob/living/mob_occupant = occupant
+		data["occupant"]["name"] = mob_occupant.name
+		data["occupant"]["stat"] = mob_occupant.stat
 
 	data["special_name"] = special ? special_name : null
 	data["ready_implants"]  = ready_implants

--- a/code/game/objects/items/weapons/implants/implantchair.dm
+++ b/code/game/objects/items/weapons/implants/implantchair.dm
@@ -41,7 +41,7 @@
 	data["open"] = state_open
 
 	data["occupant"] = list()
-	if(isliving(occupant))
+	if(occupant)
 		var/mob/living/mob_occupant = occupant
 		data["occupant"]["name"] = mob_occupant.name
 		data["occupant"]["stat"] = mob_occupant.stat

--- a/code/modules/VR/vr_sleeper.dm
+++ b/code/modules/VR/vr_sleeper.dm
@@ -9,6 +9,7 @@
 	icon_state = "sleeper"
 	state_open = TRUE
 	anchored = TRUE
+	occupant_typecache = list(/mob/living/carbon/human) // turned into typecache in Initialize
 	var/you_die_in_the_game_you_die_for_real = FALSE
 	var/datum/effect_system/spark_spread/sparks
 	var/mob/living/carbon/human/virtual_reality/vr_human
@@ -93,7 +94,7 @@
 	switch(action)
 		if("vr_connect")
 			var/mob/living/carbon/human/human_occupant = occupant
-			if(ishuman(occupant) && human_occupant.mind)
+			if(human_occupant && human_occupant.mind)
 				to_chat(occupant, "<span class='warning'>Transfering to virtual reality...</span>")
 				if(vr_human)
 					vr_human.revert_to_reality(FALSE, FALSE)

--- a/code/modules/VR/vr_sleeper.dm
+++ b/code/modules/VR/vr_sleeper.dm
@@ -92,11 +92,12 @@
 		return
 	switch(action)
 		if("vr_connect")
-			if(ishuman(occupant) && occupant.mind)
+			var/mob/living/carbon/human/human_occupant = occupant
+			if(ishuman(occupant) && human_occupant.mind)
 				to_chat(occupant, "<span class='warning'>Transfering to virtual reality...</span>")
 				if(vr_human)
 					vr_human.revert_to_reality(FALSE, FALSE)
-					occupant.mind.transfer_to(vr_human)
+					human_occupant.mind.transfer_to(vr_human)
 					vr_human.real_me = occupant
 					to_chat(vr_human, "<span class='notice'>Transfer successful! you are now playing as [vr_human] in VR!</span>")
 					SStgui.close_user_uis(vr_human, src)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -110,8 +110,9 @@
 		return
 	var/datum/gas_mixture/air1 = AIR1
 	var/turf/T = get_turf(src)
-	if(occupant)
-		if(occupant.health >= 100) // Don't bother with fully healed people.
+	if(isliving(occupant))
+		var/mob/living/mob_occupant
+		if(mob_occupant.health >= 100) // Don't bother with fully healed people.
 			on = FALSE
 			update_icon()
 			playsound(T, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
@@ -120,15 +121,15 @@
 				radio.talk_into(src, "Auto ejecting patient now", radio_channel, get_spans(), get_default_language())
 				open_machine()
 			return
-		else if(occupant.stat == DEAD) // We don't bother with dead people.
+		else if(mob_occupant.stat == DEAD) // We don't bother with dead people.
 			return
 			if(autoeject) // Eject if configured.
 				open_machine()
 			return
 		if(air1.gases.len)
-			if(occupant.bodytemperature < T0C) // Sleepytime. Why? More cryo magic.
-				occupant.Sleeping((occupant.bodytemperature / sleep_factor) * 100)
-				occupant.Paralyse((occupant.bodytemperature / paralyze_factor) * 100)
+			if(mob_occupant.bodytemperature < T0C) // Sleepytime. Why? More cryo magic.
+				mob_occupant.Sleeping((mob_occupant.bodytemperature / sleep_factor) * 100)
+				mob_occupant.Paralyse((mob_occupant.bodytemperature / paralyze_factor) * 100)
 
 			if(beaker)
 				if(reagent_transfer == 0) // Magically transfer reagents. Because cryo magic.
@@ -148,20 +149,21 @@
 		on = FALSE
 		update_icon()
 		return
-	if(occupant)
+	if(isliving(occupant))
+		var/mob/living/mob_occupant = occupant
 		var/cold_protection = 0
 		var/mob/living/carbon/human/H = occupant
 		if(istype(H))
 			cold_protection = H.get_cold_protection(air1.temperature)
 
-		var/temperature_delta = air1.temperature - occupant.bodytemperature // The only semi-realistic thing here: share temperature between the cell and the occupant.
+		var/temperature_delta = air1.temperature - mob_occupant.bodytemperature // The only semi-realistic thing here: share temperature between the cell and the occupant.
 		if(abs(temperature_delta) > 1)
 			var/air_heat_capacity = air1.heat_capacity()
 			var/heat = ((1 - cold_protection) / 10 + conduction_coefficient) \
 						* temperature_delta * \
 						(air_heat_capacity * heat_capacity / (air_heat_capacity + heat_capacity))
 			air1.temperature = max(air1.temperature - heat / air_heat_capacity, TCMB)
-			occupant.bodytemperature = max(occupant.bodytemperature + heat / heat_capacity, TCMB)
+			mob_occupant.bodytemperature = max(mob_occupant.bodytemperature + heat / heat_capacity, TCMB)
 
 		air1.gases["o2"][MOLES] -= 0.5 / efficiency // Magically consume gas? Why not, we run on cryo magic.
 
@@ -253,17 +255,18 @@
 	data["autoEject"] = autoeject
 
 	var/list/occupantData = list()
-	if(occupant)
-		occupantData["name"] = occupant.name
-		occupantData["stat"] = occupant.stat
-		occupantData["health"] = occupant.health
-		occupantData["maxHealth"] = occupant.maxHealth
+	if(isliving(occupant))
+		var/mob/living/mob_occupant = occupant
+		occupantData["name"] = mob_occupant.name
+		occupantData["stat"] = mob_occupant.stat
+		occupantData["health"] = mob_occupant.health
+		occupantData["maxHealth"] = mob_occupant.maxHealth
 		occupantData["minHealth"] = HEALTH_THRESHOLD_DEAD
-		occupantData["bruteLoss"] = occupant.getBruteLoss()
-		occupantData["oxyLoss"] = occupant.getOxyLoss()
-		occupantData["toxLoss"] = occupant.getToxLoss()
-		occupantData["fireLoss"] = occupant.getFireLoss()
-		occupantData["bodyTemperature"] = occupant.bodytemperature
+		occupantData["bruteLoss"] = mob_occupant.getBruteLoss()
+		occupantData["oxyLoss"] = mob_occupant.getOxyLoss()
+		occupantData["toxLoss"] = mob_occupant.getToxLoss()
+		occupantData["fireLoss"] = mob_occupant.getFireLoss()
+		occupantData["bodyTemperature"] = mob_occupant.bodytemperature
 	data["occupant"] = occupantData
 
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -110,8 +110,8 @@
 		return
 	var/datum/gas_mixture/air1 = AIR1
 	var/turf/T = get_turf(src)
-	if(isliving(occupant))
-		var/mob/living/mob_occupant
+	if(occupant)
+		var/mob/living/mob_occupant = occupant
 		if(mob_occupant.health >= 100) // Don't bother with fully healed people.
 			on = FALSE
 			update_icon()
@@ -149,7 +149,7 @@
 		on = FALSE
 		update_icon()
 		return
-	if(isliving(occupant))
+	if(occupant)
 		var/mob/living/mob_occupant = occupant
 		var/cold_protection = 0
 		var/mob/living/carbon/human/H = occupant
@@ -255,7 +255,7 @@
 	data["autoEject"] = autoeject
 
 	var/list/occupantData = list()
-	if(isliving(occupant))
+	if(occupant)
 		var/mob/living/mob_occupant = occupant
 		occupantData["name"] = mob_occupant.name
 		occupantData["stat"] = mob_occupant.stat

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -168,13 +168,14 @@
 
 	var/offset = prob(50) ? -2 : 2
 	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
-	var/sourcename = src.occupant.real_name
+	var/mob/living/mob_occupant = occupant
+	var/sourcename = mob_occupant.real_name
 	var/sourcejob
 	if(ishuman(occupant))
 		var/mob/living/carbon/human/gibee = occupant
 		sourcejob = gibee.job
-	var/sourcenutriment = src.occupant.nutrition / 15
-	var/sourcetotalreagents = src.occupant.reagents.total_volume
+	var/sourcenutriment = mob_occupant.nutrition / 15
+	var/sourcetotalreagents = mob_occupant.reagents.total_volume
 	var/gibtype = /obj/effect/decal/cleanable/blood/gibs
 	var/typeofmeat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human
 	var/typeofskin = /obj/item/stack/sheet/animalhide/human
@@ -212,8 +213,8 @@
 		allskin = newskin
 
 	add_logs(user, occupant, "gibbed")
-	src.occupant.death(1)
-	src.occupant.ghostize()
+	mob_occupant.death(1)
+	mob_occupant.ghostize()
 	qdel(src.occupant)
 	spawn(src.gibtime)
 		playsound(src.loc, 'sound/effects/splat.ogg', 50, 1)


### PR DESCRIPTION
Currently `occupant` in /obj/machinery is a /mob/living type. I have
changed it to /atom/movable, and made a type cache to determine what to
"look for" when `close_machine()` is called.

This means that machines can have non-mob occupants. I have some design
ideas for this, but that's after the freeze.