### PR TITLE
Upgrading RPG loot items modifies their name accordingly

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1,5 +1,9 @@
 GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/effects/fire.dmi', "icon_state" = "fire"))
 
+GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
+// if true, everyone item when created will have its name changed to be
+// more... RPG-like.
+
 /obj/item
 	name = "item"
 	icon = 'icons/obj/items.dmi'
@@ -99,6 +103,8 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/effects/fire.dmi',
 	// non-clothing items
 	var/datum/dog_fashion/dog_fashion = null
 
+	var/datum/rpg_loot/rpg_loot = null
+
 /obj/item/Initialize()
 	if (!materials)
 		materials = list()
@@ -107,6 +113,9 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/effects/fire.dmi',
 		new path(src)
 	actions_types = null
 
+	if(GLOB.rpg_loot_items)
+		rpg_loot = new(src)
+
 /obj/item/Destroy()
 	flags &= ~DROPDEL	//prevent reqdels
 	if(ismob(loc))
@@ -114,6 +123,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/effects/fire.dmi',
 		m.temporarilyRemoveItemFromInventory(src, TRUE)
 	for(var/X in actions)
 		qdel(X)
+	QDEL_NULL(rpg_loot)
 	return ..()
 
 /obj/item/device

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -6,27 +6,10 @@
 	earliest_start = 0
 
 /datum/round_event/wizard/rpgloot/start()
-	var/list/prefixespositive 	= list("greater", "major", "blessed", "superior", "enpowered", "honed", "true", "glorious", "robust")
-	var/list/prefixesnegative 	= list("lesser", "minor", "blighted", "inferior", "enfeebled", "rusted", "unsteady", "tragic", "gimped")
-	var/list/suffixes			= list("orc slaying", "elf slaying", "corgi slaying", "strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma", "the forest", "the hills", "the plains", "the sea", "the sun", "the moon", "the void", "the world", "the fool", "many secrets", "many tales", "many colors", "rending", "sundering", "the night", "the day")
-	var/upgrade_scroll_chance	= 0
+	var/upgrade_scroll_chance = 0
 	for(var/obj/item/I in world)
-		if(istype(I,/obj/item/organ/))
-			continue
-		var/quality = pick(1;15, 2;14, 2;13, 2;12, 3;11, 3;10, 3;9, 4;8, 4;7, 4;6, 5;5, 5;4, 5;3, 6;2, 6;1, 6;0)
-		if(prob(50))
-			quality = -quality
-		if(quality > 0)
-			I.name = "[pick(prefixespositive)] [I.name] of [pick(suffixes)] +[quality]"
-		else if(quality < 0)
-			I.name = "[pick(prefixesnegative)] [I.name] of [pick(suffixes)] [quality]"
-		else
-			I.name = "[I.name] of [pick(suffixes)]"
-
-		I.force 		= max(0,I.force + quality)
-		I.throwforce	= max(0,I.throwforce + quality)
-		for(var/value in I.armor)
-			I.armor[value] += quality
+		if(!istype(I.rpg_loot))
+			I.rpg_loot = new(I)
 
 		if(istype(I,/obj/item/weapon/storage))
 			var/obj/item/weapon/storage/S = I
@@ -36,28 +19,100 @@
 				upgrade_scroll_chance = max(0,upgrade_scroll_chance-100)
 			upgrade_scroll_chance += 25
 
+	GLOB.rpg_loot_items = TRUE
+
 /obj/item/upgradescroll
-	name = "Item Fortification Scroll"
+	name = "item fortification scroll"
 	desc = "Somehow, this piece of paper can be applied to items to make them \"better\". Apparently there's a risk of losing the item if it's already \"too good\". <i>This all feels so arbitrary...</i>"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll"
 	w_class = WEIGHT_CLASS_TINY
 
+	var/upgrade_amount = 1
+	var/can_backfire = TRUE
+	var/one_use = TRUE
+
 /obj/item/upgradescroll/afterattack(obj/item/target, mob/user , proximity)
 	if(!proximity || !istype(target))
 		return
-	var/quality = target.force - initial(target.force)
-	if(quality > 9 && prob((quality - 9)*10))
+
+	var/datum/rpg_loot/rpg_loot_datum = target.rpg_loot
+	if(!istype(rpg_loot_datum))
+		new rpg_loot_datum(target)
+
+	var/quality = rpg_loot_datum.quality
+
+	if(can_backfire && (quality > 9 && prob((quality - 9)*10)))
 		to_chat(user, "<span class='danger'>[target] catches fire!</span>")
 		if(target.resistance_flags & (LAVA_PROOF|FIRE_PROOF))
 			target.resistance_flags &= ~(LAVA_PROOF|FIRE_PROOF)
 			target.resistance_flags |= FLAMMABLE
 		target.fire_act()
+	else
+		rpg_loot_datum.modify(upgrade_amount)
+		to_chat(user, "<span class='notice'>[target] glows blue and seems vaguely \"better\"!</span>")
+
+	if(one_use)
 		qdel(src)
-		return
-	target.force 		+= 1
-	target.throwforce	+= 1
-	for(var/value in target.armor)
-		target.armor[value] += 1
-	to_chat(user, "<span class='notice'>[target] glows blue and seems vaguely \"better\"!</span>")
-	qdel(src)
+
+/obj/item/upgradescroll/unlimited
+	name = "unlimited foolproof item fortification scrol"
+	desc = "Somehow, this piece of paper can be applied to items to make them \"better\". This scroll is made from the tongues of dead paper wizards, and can be used an unlimited number of times, with no drawbacks.</i>"
+	one_use = FALSE
+	can_backfire = FALSE
+
+/datum/rpg_loot
+	var/positive_prefix = "okay"
+	var/negative_prefix = "weak"
+	var/suffix = "something profound"
+	var/quality = 0
+
+	var/obj/item/attached
+	var/original_name
+
+/datum/rpg_loot/New(attached_item=null)
+	attached = attached_item
+
+	randomise()
+
+/datum/rpg_loot/Destroy()
+	attached = null
+
+/datum/rpg_loot/proc/randomise()
+	var/list/prefixespositive 	= list("greater", "major", "blessed", "superior", "enpowered", "honed", "true", "glorious", "robust")
+	var/list/prefixesnegative 	= list("lesser", "minor", "blighted", "inferior", "enfeebled", "rusted", "unsteady", "tragic", "gimped")
+	var/list/suffixes			= list("orc slaying", "elf slaying", "corgi slaying", "strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma", "the forest", "the hills", "the plains", "the sea", "the sun", "the moon", "the void", "the world", "the fool", "many secrets", "many tales", "many colors", "rending", "sundering", "the night", "the day")
+
+	var/new_quality = pick(1;15, 2;14, 2;13, 2;12, 3;11, 3;10, 3;9, 4;8, 4;7, 4;6, 5;5, 5;4, 5;3, 6;2, 6;1, 6;0)
+
+	suffix = pick(suffixes)
+	positive_prefix = pick(prefixespositive)
+	negative_prefix = pick(prefixesnegative)
+
+	if(prob(50))
+		quality = -quality
+
+	modify(new_quality)
+
+/datum/rpg_loot/proc/rename()
+	var/obj/item/I = attached
+	if(!original_name)
+		original_name = I.name
+	if(quality < 0)
+		I.name = "[negative_prefix] [original_name] of [suffix] [quality]"
+	else if(quality == 0)
+		I.name = "[original_name] of [suffix]"
+	else if(quality > 0)
+		I.name = "[positive_prefix] [original_name] of [suffix] +[quality]"
+
+/datum/rpg_loot/proc/modify(quality_mod)
+	var/obj/item/I = attached
+	quality += quality_mod
+
+	I.force 		= max(0,I.force + quality_mod)
+	I.throwforce	= max(0,I.throwforce + quality_mod)
+
+	for(var/value in I.armor)
+		I.armor[value] += quality
+
+	rename()

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -43,14 +43,11 @@
 	var/quality = rpg_loot_datum.quality
 
 	if(can_backfire && (quality > 9 && prob((quality - 9)*10)))
-		to_chat(user, "<span class='danger'>[target] catches fire!</span>")
-		if(target.resistance_flags & (LAVA_PROOF|FIRE_PROOF))
-			target.resistance_flags &= ~(LAVA_PROOF|FIRE_PROOF)
-			target.resistance_flags |= FLAMMABLE
-		target.fire_act()
+		to_chat(user, "<span class='danger'>[target] violently glows blue for a while, then evaporates.</span>")
+		qdel(target)
 	else
-		rpg_loot_datum.modify(upgrade_amount)
 		to_chat(user, "<span class='notice'>[target] glows blue and seems vaguely \"better\"!</span>")
+		rpg_loot_datum.modify(upgrade_amount)
 
 	if(one_use)
 		qdel(src)
@@ -90,7 +87,7 @@
 	negative_prefix = pick(prefixesnegative)
 
 	if(prob(50))
-		quality = -quality
+		new_quality = -new_quality
 
 	modify(new_quality)
 

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -56,7 +56,7 @@
 		qdel(src)
 
 /obj/item/upgradescroll/unlimited
-	name = "unlimited foolproof item fortification scrol"
+	name = "unlimited foolproof item fortification scroll"
 	desc = "Somehow, this piece of paper can be applied to items to make them \"better\". This scroll is made from the tongues of dead paper wizards, and can be used an unlimited number of times, with no drawbacks.</i>"
 	one_use = FALSE
 	can_backfire = FALSE

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -57,7 +57,7 @@
 
 /obj/item/upgradescroll/unlimited
 	name = "unlimited foolproof item fortification scroll"
-	desc = "Somehow, this piece of paper can be applied to items to make them \"better\". This scroll is made from the tongues of dead paper wizards, and can be used an unlimited number of times, with no drawbacks.</i>"
+	desc = "Somehow, this piece of paper can be applied to items to make them \"better\". This scroll is made from the tongues of dead paper wizards, and can be used an unlimited number of times, with no drawbacks."
 	one_use = FALSE
 	can_backfire = FALSE
 

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -76,7 +76,7 @@
 	attached = null
 
 /datum/rpg_loot/proc/randomise()
-	var/statis/list/prefixespositive = list("greater", "major", "blessed", "superior", "enpowered", "honed", "true", "glorious", "robust")
+	var/static/list/prefixespositive = list("greater", "major", "blessed", "superior", "enpowered", "honed", "true", "glorious", "robust")
 	var/static/list/prefixesnegative = list("lesser", "minor", "blighted", "inferior", "enfeebled", "rusted", "unsteady", "tragic", "gimped")
 	var/static/list/suffixes = list("orc slaying", "elf slaying", "corgi slaying", "strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma", "the forest", "the hills", "the plains", "the sea", "the sun", "the moon", "the void", "the world", "the fool", "many secrets", "many tales", "many colors", "rending", "sundering", "the night", "the day")
 

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -38,7 +38,7 @@
 
 	var/datum/rpg_loot/rpg_loot_datum = target.rpg_loot
 	if(!istype(rpg_loot_datum))
-		new rpg_loot_datum(target)
+		rpg_loot_datum = new /datum/rpg_loot(target)
 
 	var/quality = rpg_loot_datum.quality
 

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -44,7 +44,7 @@
 
 	if(can_backfire && (quality > 9 && prob((quality - 9)*10)))
 		to_chat(user, "<span class='danger'>[target] violently glows blue for a while, then evaporates.</span>")
-		qdel(target)
+		target.burn()
 	else
 		to_chat(user, "<span class='notice'>[target] glows blue and seems vaguely \"better\"!</span>")
 		rpg_loot_datum.modify(upgrade_amount)
@@ -76,9 +76,9 @@
 	attached = null
 
 /datum/rpg_loot/proc/randomise()
-	var/list/prefixespositive 	= list("greater", "major", "blessed", "superior", "enpowered", "honed", "true", "glorious", "robust")
-	var/list/prefixesnegative 	= list("lesser", "minor", "blighted", "inferior", "enfeebled", "rusted", "unsteady", "tragic", "gimped")
-	var/list/suffixes			= list("orc slaying", "elf slaying", "corgi slaying", "strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma", "the forest", "the hills", "the plains", "the sea", "the sun", "the moon", "the void", "the world", "the fool", "many secrets", "many tales", "many colors", "rending", "sundering", "the night", "the day")
+	var/statis/list/prefixespositive = list("greater", "major", "blessed", "superior", "enpowered", "honed", "true", "glorious", "robust")
+	var/static/list/prefixesnegative = list("lesser", "minor", "blighted", "inferior", "enfeebled", "rusted", "unsteady", "tragic", "gimped")
+	var/static/list/suffixes = list("orc slaying", "elf slaying", "corgi slaying", "strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma", "the forest", "the hills", "the plains", "the sea", "the sun", "the moon", "the void", "the world", "the fool", "many secrets", "many tales", "many colors", "rending", "sundering", "the night", "the day")
 
 	var/new_quality = pick(1;15, 2;14, 2;13, 2;12, 3;11, 3;10, 3;9, 4;8, 4;7, 4;6, 5;5, 5;4, 5;3, 6;2, 6;1, 6;0)
 
@@ -106,8 +106,8 @@
 	var/obj/item/I = attached
 	quality += quality_mod
 
-	I.force 		= max(0,I.force + quality_mod)
-	I.throwforce	= max(0,I.throwforce + quality_mod)
+	I.force = max(0,I.force + quality_mod)
+	I.throwforce = max(0,I.throwforce + quality_mod)
 
 	for(var/value in I.armor)
 		I.armor[value] += quality


### PR DESCRIPTION
- the greater crowbar of many tales +2
- use item fortification scroll
- the greater crowbar of many tales +3

- Once the RPG loot event fires, a global is set which means all new
items will have rpg_loot datums attached to them.

Otherwise, everything functions the same. Item fortification scrolls are
only spawned when the event fires.

Using an admin spawned item fortification scroll on a non-rpg looted
item works, it'll grant that item only a RPG datum.

Made a /unlimited upgrade scroll if admins feel like buffing an item.