### PR TITLE
Fixes #26076, you can't cheat with eyewear/eye-implants

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -95,7 +95,6 @@ obj/machinery/computer/camera_advanced/attack_ai(mob/user)
 	
 /mob/camera/aiEye/remote/update_remote_sight(mob/living/user)
 	user.see_invisible = SEE_INVISIBLE_LIVING //can't see ghosts through cameras
-	// NOTE: I took out a case for isXray() since we don't have that proc in here
 	user.sight = 0
 	user.see_in_dark = 2
 	return 1

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -92,6 +92,13 @@ obj/machinery/computer/camera_advanced/attack_ai(mob/user)
 	var/eye_initialized = 0
 	var/visible_icon = 0
 	var/image/user_image = null
+	
+/mob/camera/aiEye/remote/update_remote_sight(mob/living/user)
+	user.see_invisible = SEE_INVISIBLE_LIVING //can't see ghosts through cameras
+	// NOTE: I took out a case for isXray() since we don't have that proc in here
+	user.sight = 0
+	user.see_in_dark = 2
+	return 1
 
 /mob/camera/aiEye/remote/Destroy()
 	eye_user = null


### PR DESCRIPTION
Fixes #26076
:cl: Davidj361
fix: You can't cheat with eyewear/eye-implants when using advanced cameras
/:cl:

[why]: See https://github.com/tgstation/tgstation/issues/26076
Thanks to MrStonedOne for helping.