### PR TITLE
Fixes #26048, mutant digitigrade legs re-added to the ashwalker species

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -111,6 +111,12 @@
 		var/obj/item/thing = C.get_item_by_slot(slot_id)
 		if(thing && (!thing.species_exception || !is_type_in_list(src,thing.species_exception)))
 			C.dropItemToGround(thing)
+	
+	// this needs to be FIRST because qdel calls update_body which checks if we have DIGITIGRADE legs or not and if not then removes DIGITIGRADE from species_traits
+	if(("legs" in C.dna.species.mutant_bodyparts) && C.dna.features["legs"] == "Digitigrade Legs")
+		species_traits += DIGITIGRADE
+	if(DIGITIGRADE in species_traits)
+		C.Digitigrade_Leg_Swap(FALSE)
 
 	var/obj/item/organ/heart/heart = C.getorganslot("heart")
 	var/obj/item/organ/lungs/lungs = C.getorganslot("lungs")
@@ -152,10 +158,6 @@
 
 	if(exotic_bloodtype && C.dna.blood_type != exotic_bloodtype)
 		C.dna.blood_type = exotic_bloodtype
-	if(("legs" in C.dna.species.mutant_bodyparts) && C.dna.features["legs"] == "Digitigrade Legs")
-		species_traits += DIGITIGRADE
-	if(DIGITIGRADE in species_traits)
-		C.Digitigrade_Leg_Swap(FALSE)
 
 /datum/species/proc/on_species_loss(mob/living/carbon/C)
 	if(C.dna.species.exotic_bloodtype)


### PR DESCRIPTION
Fixes #26048
:cl: Davidj361
fix: Mutant digitigrade legs re-added to the ashwalker species
/:cl:

I notice the problem is caused by qdel calling update_body, here's the call trace for when DIGITIGRADE gets removed from species_traits.

```
[01:31:38] Runtime in unsorted.dm,1242: DIGITIGRADE  got removed
  proc name: stack trace (/proc/stack_trace)
  usr: Grady Cowper (pooplicker) (/mob/living/carbon/human)
  usr.loc: The floor (33,20,1) (/turf/open/floor/plasteel)
  src: null
  call stack:
  stack trace("DIGITIGRADE  got removed")
  Ash Walker (/datum/species/lizard/ashwalker): handle mutant bodyparts(Grady Cowper (/mob/living/carbon/human), null)
  Ash Walker (/datum/species/lizard/ashwalker): handle body(Grady Cowper (/mob/living/carbon/human))
  Grady Cowper (/mob/living/carbon/human): update body()
  Grady Cowper (/mob/living/carbon/human): regenerate icons()
  the eyes (/obj/item/organ/eyes): Remove(Grady Cowper (/mob/living/carbon/human), 1)
  the eyes (/obj/item/organ/eyes): Destroy(0)
  qdel(the eyes (/obj/item/organ/eyes), 0)
  Ash Walker (/datum/species/lizard/ashwalker): on species gain(Grady Cowper (/mob/living/carbon/human), Human (/datum/species/human))
  Grady Cowper (/mob/living/carbon/human): set species(/datum/species/lizard/ashwalke... (/datum/species/lizard/ashwalker), 1)
  Grady Cowper (/mob/living/carbon/human): set species(/datum/species/lizard/ashwalke... (/datum/species/lizard/ashwalker), 1)
  PoopLicker (/client): view var Topic("_src_=vars;setspecies=\[mob_10...", /list (/list), null)
  PoopLicker (/client): Topic("_src_=vars;setspecies=\[mob_10...", /list (/list), null)
```