### PR TITLE
Fixes #26169, spawned humans no longer spawn eyeless (sprite)

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -301,14 +301,6 @@
 
 	var/obj/item/bodypart/head/HD = H.get_bodypart("head")
 
-
-	// eyes
-	var/has_eyes = TRUE
-
-	if(!H.getorgan(/obj/item/organ/eyes) && HD)
-		standing += image("icon"='icons/mob/human_face.dmi', "icon_state" = "eyes_missing", "layer" = -BODY_LAYER)
-		has_eyes = FALSE
-
 	if(!(H.disabilities & HUSK))
 		// lipstick
 		if(H.lip_style && (LIPS in species_traits) && HD)
@@ -318,7 +310,7 @@
 			standing	+= lips
 
 		// eyes
-		if((EYECOLOR in species_traits) && HD && has_eyes)
+		if((EYECOLOR in species_traits) && HD)
 			var/image/img_eyes = image("icon" = 'icons/mob/human_face.dmi', "icon_state" = "eyes", "layer" = -BODY_LAYER)
 			img_eyes.color = "#" + H.eye_color
 			img_eyes.pixel_y += face_y_offset


### PR DESCRIPTION
Fixes #26169
:cl: Davidj361
fix: Spawned humans no longer spawn eyeless (sprite)
/:cl:

Spoke with @KorPhaeron who made this line of code and he says it's probably not needed.

There is so many issues with code\modules\mob\living\carbon\human\species.dm, this is the 2nd bug fix I made in this file. The previous bug fix was #26173. This file is nothing but spaghetti code which needs to redesigned with intuitive stack traces.

Here are the oddities I found while debugging:

The game before would insert and remove eyes like 3 times.

```
Human gets initialized
   set_species
       handle_body
          remove eyes if no eyes organ (give eyeless sprite)
   create_internal_organs
      give eyes organ
```
Thus you have a human with eye organs but no sprite for it.

And the initialization for humans looked odd between player humans spawning and spawned humans.
The top is a player human that joins, the bottom is an admin spawned human
```
[11:59:56] Runtime in unsorted.dm,1242: initialize human
  proc name: stack trace (/proc/stack_trace)
  usr: Unknown () (/mob/living/carbon/human/dummy)
  src: null
  call stack:
  stack trace("initialize human")
  Unknown (/mob/living/carbon/human/dummy): Initialize(0)
  Unknown (/mob/living/carbon/human/dummy): New(0)
  Unknown (/mob/living/carbon/human/dummy): New(null)
  get flat human icon(null, /datum/job/chaplain (/datum/job/chaplain), /datum/preferences (/datum/preferences))
  /datum/datacore (/datum/datacore): get id photo( (/mob/living/carbon/human), PoopLicker (/client))
  /datum/datacore (/datum/datacore): manifest inject( (/mob/living/carbon/human), PoopLicker (/client))
  /datum/datacore (/datum/datacore): manifest()
  Ticker (/datum/controller/subsystem/ticker): setup()
  Ticker (/datum/controller/subsystem/ticker): fire()
  Ticker (/datum/controller/subsystem/ticker): fire(0)
  Ticker (/datum/controller/subsystem/ticker): ignite(0)

[12:01:16] Runtime in unsorted.dm,1242: initialize human
  proc name: stack trace (/proc/stack_trace)
  usr: Unknown () (/mob/living/carbon/human)
  usr.loc: The floor (32,20,1) (/turf/open/floor/plasteel)
  src: null
  call stack:
  stack trace("initialize human")
  Unknown (/mob/living/carbon/human): Initialize(0)
  Unknown (/mob/living/carbon/human): New(0)
  /datum/admins (/datum/admins): Topic("src=%5B0x21001ca4%5D&filter=hu...", /list (/list))
  PoopLicker (/client): Topic("src=%5B0x21001ca4%5D&filter=hu...", /list (/list), /datum/admins (/datum/admins))
```