### PR TITLE
Refactor for client images

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -220,6 +220,9 @@ GLOBAL_LIST(external_rsc_urls)
 
 	. = ..()	//calls mob.Login()
 
+	for(var/I in GLOB.client_images[ckey])
+		images += I
+
 	if(alert_mob_dupe_login)
 		set waitfor = FALSE
 		alert(mob, "You have logged in already with another key this round, please log out of this one NOW or risk being banned!")

--- a/code/modules/client/images.dm
+++ b/code/modules/client/images.dm
@@ -1,0 +1,72 @@
+GLOBAL_LIST_EMPTY(client_images)
+
+#define CI_ADD 1
+#define CI_OR 2
+#define CI_REMOVE 3
+
+/proc/ModifyClientOrMobImage(mob_or_client, images, action, is_mob)
+    if(isnull(images))
+        return
+    
+    if(!islist(images))
+        images = list(images)
+
+    var/ckey
+    var/client/C
+    var/mob/M
+
+    if(ismob(mob_or_client))
+        M = mob_or_client
+        ckey = M.ckey
+        C = M.client
+    else    //client
+        C = mob_or_client
+        M = C.mob
+        ckey = C.ckey
+
+    
+    var/list/current_client_images
+    if(ckey)
+        current_client_images = GLOB.client_images[ckey]
+        if(!current_client_images)
+            current_client_images = list()
+            GLOB.client_images[ckey] = current_client_images
+    var/list/current_mob_images = M.client_images
+    
+    var/list/modifying = is_mob ? current_mob_images : current_client_images
+    
+    switch(action)
+        if(CI_ADD)
+            modifying += images
+        if(CI_OR)
+            modifying |= images
+        if(CI_REMOVE)
+            modifying -= images
+        else
+            CRASH("Invalid client image action")
+
+    if(C)
+        C.images = current_client_images + current_mob_images
+
+/proc/AddClientImage(mob_or_client, image)
+    return ModifyClientImage(mob_or_client, image, CI_ADD, FALSE)
+
+/proc/OrClientImage(mob_or_client, image)
+    return ModifyClientImage(mob_or_client, image, CI_OR, FALSE)
+
+/proc/RemoveClientImage(mob_or_client, image)
+    return ModifyClientImage(mob_or_client, image, CI_REMOVE, FALSE)
+
+/proc/AddMobImage(mob_or_client, image)
+    return ModifyClientImage(mob_or_client, image, CI_ADD, TRUE)
+
+/proc/OrMobImage(mob_or_client, image)
+    return ModifyClientImage(mob_or_client, image, CI_OR, TRUE)
+
+/proc/RemoveMobImage(mob_or_client, image)
+    return ModifyClientImage(mob_or_client, image, CI_REMOVE, TRUE)
+
+
+#undef CI_ADD
+#undef CI_OR
+#undef CI_REMOVE

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -46,5 +46,7 @@
 	update_client_colour()
 	if(client)
 		client.click_intercept = null
+		for(var/I in client_images)
+			client.images += I
 
 	client.view = world.view // Resets the client.view in case it was changed.

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -26,6 +26,8 @@
 
 
 				send2irc("Server", "[cheesy_message]")
+	for(var/I in client_images)
+		client.images -= I
 	..()
 
 	if(isobj(loc))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -16,6 +16,7 @@
 		qdel(cc)
 	client_colours = null
 	ghostize()
+	client_images.Cut()	//above line will remove the images from the client
 	..()
 	return QDEL_HINT_HARDDEL
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -148,3 +148,4 @@
 
 	var/list/progressbars = null	//for stacking do_after bars
 	var/list/can_ride_typecache = list()
+	var/list/client_images = list()


### PR DESCRIPTION
Adds a system for modifying client images for the client or the current mob and persist them even if they disconnect. Should fix #26152 if I understand it correctly. Wanna get feedback before I continue with this.

@optimumtact @RemieRichards 