### PR TITLE
Adds colours to languages that lack them

### DIFF
--- a/code/modules/language/drone.dm
+++ b/code/modules/language/drone.dm
@@ -4,7 +4,7 @@
 	speech_verb = "chitters"
 	ask_verb = "chitters inquisitively"
 	exclaim_verb = "chitters loudly"
-	spans = list(SPAN_ROBOT)
+	spans = list(SPAN_ROBOT, "drone")
 	key = "d"
 	flags = NO_STUTTER
 	syllables = list(".", "|")

--- a/code/modules/language/monkey.dm
+++ b/code/modules/language/monkey.dm
@@ -4,6 +4,7 @@
 	speech_verb = "chimpers"
 	ask_verb = "chimpers"
 	exclaim_verb = "screeches"
+	spans = list("monkey")
 	key = "1"
 	space_chance = 100
 	syllables = list("oop", "aak", "chee", "eek")

--- a/code/modules/language/swarmer.dm
+++ b/code/modules/language/swarmer.dm
@@ -4,7 +4,7 @@
 	speech_verb = "tones"
 	ask_verb = "tones inquisitively"
 	exclaim_verb = "tones loudly"
-	spans = list(SPAN_ROBOT)
+	spans = list(SPAN_ROBOT, "swarmer")
 	key = "s"
 	flags = NO_STUTTER
 	space_chance = 100

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -147,5 +147,7 @@ BIG IMG.icon 			{width: 32px; height: 32px;}
 .memoedit				{text-align: center;	font-size: 2;}
 .abductor				{color: #800080; font-style: italic;}
 .slime					{color: #00CED1;}
-
+.drone					{color: #848482;}
+.monkey					{color: #975032;}
+.swarmer				{color: #2C75FF;}
 </style>"}


### PR DESCRIPTION
:cl: coiax
add: Drone, monkey and swarmer language now have distinctive colours when
spoken.
/:cl:
BEFORE:
![image](https://cloud.githubusercontent.com/assets/609465/25052288/f74846a4-2148-11e7-987f-c72db89f5489.png)

AFTER:
![image](https://cloud.githubusercontent.com/assets/609465/25049860/cec8ca6c-213b-11e7-98ce-a705343cb852.png)
