### PR TITLE
Remove atom stat cooldown

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -463,15 +463,6 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 		var/atom/A = a
 		A.HandleTurfChange(T)
 
-// Byond seemingly calls stat, each tick.
-// Calling things each tick can get expensive real quick.
-// So we slow this down a little.
-// See: http://www.byond.com/docs/ref/info.html#/client/proc/Stat
-/atom/Stat()
-	. = ..()
-	sleep(1)
-	stoplag()
-
 //the vision impairment to give to the mob whose perspective is set to that atom (e.g. an unfocused camera giving you an impaired vision when looking through it)
 /atom/proc/get_remote_view_fullscreens(mob/user)
 	return


### PR DESCRIPTION
We already do this in client/Stat, doing it per-atom as well was excessively costly