### PR TITLE
Subsystem init order rework

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -13,8 +13,8 @@
 //subsystem should fire during pre-game lobby.
 #define SS_FIRE_IN_LOBBY 1
 
-//subsystem does not initialize.
-#define SS_NO_INIT 2
+//deprecated, can be replaced
+//#define SS_NO_INIT 2
 
 //subsystem does not fire.
 //	(like can_fire = 0, but keeps it from getting added to the processing subsystems list)
@@ -65,3 +65,5 @@
     PreInit();\
 }\
 /datum/controller/subsystem/processing/##X
+
+#define SUBSYSTEM_INIT_ORDER(X...) /datum/controller/master/var/static/list/subsystem_init_order = #X

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -30,7 +30,7 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 	return sorttext(a.ckey, b.ckey)
 
 /proc/cmp_subsystem_init(datum/controller/subsystem/a, datum/controller/subsystem/b)
-	return b.init_order - a.init_order
+	return a.initialize_order - b.initialize_order
 
 /proc/cmp_subsystem_display(datum/controller/subsystem/a, datum/controller/subsystem/b)
 	return sorttext(b.name, a.name)

--- a/code/controllers/init_order.dm
+++ b/code/controllers/init_order.dm
@@ -1,0 +1,23 @@
+//Order of SS types that initialize,
+//subsystems not in this list will not initialize
+
+SUBSYSTEM_INIT_ORDER(\
+    job,\
+    ticker,\
+    mapping,\
+    squeak,\
+    atoms,\
+    machines,\
+    events,\
+    shuttle,\
+    server_maint,\
+    weather,\
+    air,\
+    minimap,\
+    assets,\
+    icon_smooth,\
+    processing/overlays,\
+    ipintel,\
+    lighting,\
+    persistence\
+)

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -2,7 +2,7 @@
 /datum/controller/subsystem
 	// Metadata; you should define these.
 	name = "fire coderbus" //name of the subsystem
-	var/init_order = 0		//order of initialization. Higher numbers are initialized first, lower numbers later. Can be decimal and negative values.
+	var/initialize_order = 0		//order of initialization. Use the SUBSYSTEM_INIT_ORDER define in init_order.dm
 	var/wait = 20			//time to wait (in deciseconds) between each call to fire(). Must be a positive integer.
 	var/priority = 50		//When mutiple subsystems need to run in the same tick, higher priority subsystems will run first and be given a higher share of the tick before MC_TICK_CHECK triggers a sleep
 

--- a/code/controllers/subsystem/acid.dm
+++ b/code/controllers/subsystem/acid.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(acid)
 	name = "Acid"
 	priority = 40
-	flags = SS_NO_INIT|SS_BACKGROUND
+	flags = SS_BACKGROUND
 
 	var/list/currentrun = list()
 	var/list/processing = list()

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -8,7 +8,6 @@
 
 SUBSYSTEM_DEF(air)
 	name = "Air"
-	init_order = -1
 	priority = 20
 	wait = 5
 	flags = SS_BACKGROUND

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(assets)
 	name = "Assets"
-	init_order = -3
 	flags = SS_NO_FIRE
 	var/list/cache = list()
 

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -4,7 +4,6 @@
 
 SUBSYSTEM_DEF(atoms)
 	name = "Atoms"
-	init_order = 11
 	flags = SS_NO_FIRE
 
 	var/initialized = INITIALIZATION_INSSATOMS

--- a/code/controllers/subsystem/augury.dm
+++ b/code/controllers/subsystem/augury.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(augury)
 	name = "Augury"
-	flags = SS_NO_INIT
 
 	var/list/watchers = list()
 	var/list/doombringers = list()

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -3,7 +3,7 @@
 
 SUBSYSTEM_DEF(communications)
 	name = "Communications"
-	flags = SS_NO_INIT | SS_NO_FIRE
+	flags = SS_NO_FIRE
 
 	var/silicon_message_cooldown
 	var/nonsilicon_message_cooldown

--- a/code/controllers/subsystem/disease.dm
+++ b/code/controllers/subsystem/disease.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(disease)
 	name = "Disease"
-	flags = SS_KEEP_TIMING|SS_NO_INIT
+	flags = SS_KEEP_TIMING
 
 	var/list/currentrun = list()
 	var/list/processing = list()

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(events)
 	name = "Events"
-	init_order = 6
 
 	var/list/control = list()	//list of all datum/round_event_control. Used for selecting events based on weight and occurrences.
 	var/list/running = list()	//list of all existing /datum/round_event

--- a/code/controllers/subsystem/fire_burning.dm
+++ b/code/controllers/subsystem/fire_burning.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(fire_burning)
 	name = "Fire Burning"
 	priority = 40
-	flags = SS_NO_INIT|SS_BACKGROUND
+	flags = SS_BACKGROUND
 
 	var/list/currentrun = list()
 	var/list/processing = list()

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(garbage)
 	name = "Garbage"
 	priority = 15
 	wait = 5
-	flags = SS_FIRE_IN_LOBBY|SS_POST_FIRE_TIMING|SS_BACKGROUND|SS_NO_INIT
+	flags = SS_FIRE_IN_LOBBY|SS_POST_FIRE_TIMING|SS_BACKGROUND
 
 	var/collection_timeout = 3000// deciseconds to wait to let running procs finish before we just say fuck it and force del() the object
 	var/delslasttick = 0		// number of del()'s we've done this tick

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(icon_smooth)
 	name = "Icon Smoothing"
-	init_order = -5
 	wait = 1
 	priority = 35
 	flags = SS_TICKER

--- a/code/controllers/subsystem/inbounds.dm
+++ b/code/controllers/subsystem/inbounds.dm
@@ -1,7 +1,6 @@
 SUBSYSTEM_DEF(inbounds)
 	name = "Inbounds"
 	priority = 40
-	flags = SS_NO_INIT
 
 	var/list/processing = list()
 	var/list/currentrun = list()

--- a/code/controllers/subsystem/ipintel.dm
+++ b/code/controllers/subsystem/ipintel.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(ipintel)
 	name = "XKeyScore"
-	init_order = -10
 	flags = SS_NO_FIRE
 	var/enabled = 0 //disable at round start to avoid checking reconnects
 	var/throttle = 0

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(job)
 	name = "Jobs"
-	init_order = 14
 	flags = SS_NO_FIRE
 
 	var/list/occupations = list()		//List of all jobs

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -5,7 +5,6 @@ GLOBAL_LIST_EMPTY(lighting_update_objects) // List of lighting objects queued fo
 SUBSYSTEM_DEF(lighting)
 	name = "Lighting"
 	wait = 2
-	init_order = -20
 	flags = SS_TICKER
 
 	var/initialized = FALSE

--- a/code/controllers/subsystem/machines.dm
+++ b/code/controllers/subsystem/machines.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(machines)
 	name = "Machines"
-	init_order = 9
 	flags = SS_KEEP_TIMING
 	var/list/processing = list()
 	var/list/currentrun = list()

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(mapping)
 	name = "Mapping"
-	init_order = 12
 	flags = SS_NO_FIRE
 
 	var/list/nuke_tiles = list()
@@ -17,6 +16,7 @@ SUBSYSTEM_DEF(mapping)
 
 	var/list/shuttle_templates = list()
 	var/list/shelter_templates = list()
+	var/static/initialized = FALSE
 
 /datum/controller/subsystem/mapping/PreInit()
 	if(!config)
@@ -29,6 +29,8 @@ SUBSYSTEM_DEF(mapping)
 
 
 /datum/controller/subsystem/mapping/Initialize(timeofday)
+	if(initialized)
+		return
 	if(config.defaulted)
 		to_chat(world, "<span class='boldannounce'>Unable to load next map config, defaulting to Box Station</span>")
 	loadWorld()
@@ -57,6 +59,7 @@ SUBSYSTEM_DEF(mapping)
 
 	// Set up Z-level transistions.
 	setup_map_transitions()
+	initialized = TRUE
 	..()
 
 /* Nuke threats, for making the blue tiles on the station go RED
@@ -81,7 +84,6 @@ SUBSYSTEM_DEF(mapping)
 		C.update_icon()
 
 /datum/controller/subsystem/mapping/Recover()
-	flags |= SS_NO_INIT
 	map_templates = SSmapping.map_templates
 	ruins_templates = SSmapping.ruins_templates
 	space_ruins_templates = SSmapping.space_ruins_templates

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(minimap)
 	name = "Minimap"
-	init_order = -2
 	flags = SS_NO_FIRE
 	var/const/MINIMAP_SIZE = 2048
 	var/const/TILE_SIZE = 8

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -1,8 +1,7 @@
 SUBSYSTEM_DEF(mobs)
 	name = "Mobs"
-	init_order = 4
 	priority = 100
-	flags = SS_KEEP_TIMING|SS_NO_INIT
+	flags = SS_KEEP_TIMING
 
 	var/list/currentrun = list()
 

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -4,7 +4,7 @@
 
 SUBSYSTEM_DEF(npcpool)
 	name = "NPC Pool"
-	flags = SS_POST_FIRE_TIMING|SS_NO_INIT|SS_BACKGROUND
+	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND
 	priority = 20
 
 	var/list/canBeUsed = list()

--- a/code/controllers/subsystem/orbit.dm
+++ b/code/controllers/subsystem/orbit.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(orbit)
 	name = "Orbits"
 	priority = 35
 	wait = 2
-	flags = SS_NO_INIT|SS_TICKER
+	flags = SS_TICKER
 
 	var/list/currentrun = list()
 	var/list/processing = list()

--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(pai)
 	name = "pAI"
 
-	flags = SS_NO_INIT|SS_NO_FIRE
+	flags = SS_NO_FIRE
 
 	var/list/candidates = list()
 	var/ghost_spam = FALSE

--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(parallax)
 	name = "Parallax"
 	wait = 2
-	flags = SS_POST_FIRE_TIMING | SS_FIRE_IN_LOBBY | SS_BACKGROUND | SS_NO_INIT
+	flags = SS_POST_FIRE_TIMING | SS_FIRE_IN_LOBBY | SS_BACKGROUND
 	priority = 65
 	var/list/currentrun
 

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(persistence)
 	name = "Persistence"
-	init_order = -100
 	flags = SS_NO_FIRE
 	var/savefile/secret_satchels
 	var/list/satchel_blacklist 		= list() //this is a typecache

--- a/code/controllers/subsystem/ping.dm
+++ b/code/controllers/subsystem/ping.dm
@@ -3,7 +3,7 @@
 SUBSYSTEM_DEF(ping)
 	name = "Ping"
 	wait = 6
-	flags = SS_NO_INIT|SS_POST_FIRE_TIMING|SS_FIRE_IN_LOBBY
+	flags = SS_POST_FIRE_TIMING|SS_FIRE_IN_LOBBY
 	priority = 10
 	var/list/currentrun
 

--- a/code/controllers/subsystem/processing/flightpacks.dm
+++ b/code/controllers/subsystem/processing/flightpacks.dm
@@ -3,7 +3,7 @@ PROCESSING_SUBSYSTEM_DEF(flightpacks)
 	priority = 30
 	wait = 2
 	stat_tag = "FM"
-	flags = SS_NO_INIT|SS_TICKER|SS_KEEP_TIMING
+	flags = SS_TICKER|SS_KEEP_TIMING
 
 	var/flightsuit_processing = FLIGHTSUIT_PROCESSING_FULL
 

--- a/code/controllers/subsystem/processing/obj.dm
+++ b/code/controllers/subsystem/processing/obj.dm
@@ -1,7 +1,6 @@
 SUBSYSTEM_DEF(obj)
 	name = "Objects"
 	priority = 40
-	flags = SS_NO_INIT
 
 	var/list/processing = list()
 	var/list/currentrun = list()

--- a/code/controllers/subsystem/processing/overlays.dm
+++ b/code/controllers/subsystem/processing/overlays.dm
@@ -3,7 +3,6 @@ PROCESSING_SUBSYSTEM_DEF(overlays)
 	flags = SS_TICKER|SS_FIRE_IN_LOBBY
 	wait = 1
 	priority = 500
-	init_order = -6
 
 	stat_tag = "Ov"
 	currentrun = null

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -3,7 +3,7 @@
 SUBSYSTEM_DEF(processing)
 	name = "Processing"
 	priority = 25
-	flags = SS_BACKGROUND|SS_POST_FIRE_TIMING|SS_NO_INIT
+	flags = SS_BACKGROUND|SS_POST_FIRE_TIMING
 	wait = 10
 
 	var/stat_tag = "P" //Used for logging

--- a/code/controllers/subsystem/radio.dm
+++ b/code/controllers/subsystem/radio.dm
@@ -1,7 +1,6 @@
 SUBSYSTEM_DEF(radio)
 	name = "Radio"
-	init_order = 18
-	flags = SS_NO_FIRE|SS_NO_INIT
+	flags = SS_NO_FIRE
 
 	var/list/datum/radio_frequency/frequencies = list()
 

--- a/code/controllers/subsystem/religion.dm
+++ b/code/controllers/subsystem/religion.dm
@@ -1,7 +1,6 @@
 SUBSYSTEM_DEF(religion)
 	name = "Religion"
-	init_order = 19
-	flags = SS_NO_FIRE|SS_NO_INIT
+	flags = SS_NO_FIRE
 
 	var/religion
 	var/deity

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -3,7 +3,6 @@
 SUBSYSTEM_DEF(shuttle)
 	name = "Shuttle"
 	wait = 10
-	init_order = 3
 	flags = SS_KEEP_TIMING|SS_NO_TICK_CHECK
 
 	var/list/mobile = list()

--- a/code/controllers/subsystem/spacedrift.dm
+++ b/code/controllers/subsystem/spacedrift.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(spacedrift)
 	name = "Space Drift"
 	priority = 30
 	wait = 5
-	flags = SS_NO_INIT|SS_KEEP_TIMING
+	flags = SS_KEEP_TIMING
 
 	var/list/currentrun = list()
 	var/list/processing = list()

--- a/code/controllers/subsystem/squeak.dm
+++ b/code/controllers/subsystem/squeak.dm
@@ -11,6 +11,7 @@ SUBSYSTEM_DEF(squeak)
 
 /datum/controller/subsystem/squeak/Initialize(timeofday)
 	trigger_migration()
+	..()
 
 /datum/controller/subsystem/squeak/proc/trigger_migration(num_mice=10)
 	find_exposed_wires()

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(stickyban)
 	name = "Sticky Ban"
-	init_order = -10
 	flags = SS_NO_FIRE
 
 	var/list/cache = list()

--- a/code/controllers/subsystem/sun.dm
+++ b/code/controllers/subsystem/sun.dm
@@ -1,8 +1,7 @@
 SUBSYSTEM_DEF(sun)
 	name = "Sun"
 	wait = 600
-	init_order = 2
-	flags = SS_NO_TICK_CHECK|SS_NO_INIT
+	flags = SS_NO_TICK_CHECK
 	var/angle
 	var/dx
 	var/dy

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -1,8 +1,7 @@
 SUBSYSTEM_DEF(tgui)
 	name = "tgui"
 	wait = 9
-	init_order = 16
-	flags = SS_NO_INIT|SS_FIRE_IN_LOBBY
+	flags = SS_FIRE_IN_LOBBY
 	priority = 110
 
 	var/list/currentrun = list()

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -5,7 +5,7 @@ SUBSYSTEM_DEF(throwing)
 	name = "Throwing"
 	priority = 25
 	wait = 1
-	flags = SS_NO_INIT|SS_KEEP_TIMING|SS_TICKER
+	flags = SS_KEEP_TIMING|SS_TICKER
 
 	var/list/currentrun
 	var/list/processing = list()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -2,7 +2,6 @@
 
 SUBSYSTEM_DEF(ticker)
 	name = "Ticker"
-	init_order = 13
 
 	priority = 200
 	flags = SS_FIRE_IN_LOBBY|SS_KEEP_TIMING

--- a/code/controllers/subsystem/time_track.dm
+++ b/code/controllers/subsystem/time_track.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(time_track)
 	name = "Time Tracking"
 	wait = 600
-	flags = SS_NO_INIT|SS_FIRE_IN_LOBBY|SS_NO_TICK_CHECK
+	flags = SS_FIRE_IN_LOBBY|SS_NO_TICK_CHECK
 
 	var/time_dilation_current = 0
 

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -4,9 +4,8 @@
 SUBSYSTEM_DEF(timer)
 	name = "Timer"
 	wait = 1 //SS_TICKER subsystem, so wait is in ticks
-	init_order = 1
 
-	flags = SS_FIRE_IN_LOBBY|SS_TICKER|SS_NO_INIT
+	flags = SS_FIRE_IN_LOBBY|SS_TICKER
 
 	var/list/datum/timedevent/processing = list()
 	var/list/hashes = list()

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(title)
 	name = "Title Screen"
-	flags = SS_NO_FIRE|SS_NO_INIT
+	flags = SS_NO_FIRE
 
 	var/file_path
 	var/icon/icon

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(vote)
 	name = "Vote"
 	wait = 10
 
-	flags = SS_FIRE_IN_LOBBY|SS_KEEP_TIMING|SS_NO_INIT
+	flags = SS_FIRE_IN_LOBBY|SS_KEEP_TIMING
 
 	var/initiator = null
 	var/started_time = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -152,6 +152,7 @@
 #include "code\controllers\controller.dm"
 #include "code\controllers\failsafe.dm"
 #include "code\controllers\globals.dm"
+#include "code\controllers\init_order.dm"
 #include "code\controllers\master.dm"
 #include "code\controllers\subsystem.dm"
 #include "code\controllers\subsystem\acid.dm"


### PR DESCRIPTION
Removed the init_order var and SS_NO_INIT.

New file, init_order.dm. Simple list of the order in which subsystems init. Subsystems that are not in this list will not init.

It's much easier to visualize this way