### PR TITLE
Makes a change_bodypart_status call use defines

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -12,7 +12,7 @@
 	. = ..()
 	for(var/X in C.bodyparts)
 		var/obj/item/bodypart/O = X
-		O.change_bodypart_status(BODYPART_ROBOTIC, 0, 1)
+		O.change_bodypart_status(BODYPART_ROBOTIC, FALSE, TRUE)
 
 /datum/species/android/on_species_loss(mob/living/carbon/C)
 	. = ..()

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -127,3 +127,4 @@ Sweaterkittens = Game Master
 Feemjmeem = Game Master
 JStheguy = Game Master
 excessiveuseofcobby = Game Master
+Plizzard = Game Master


### PR DESCRIPTION
No mechanical change, just changing a the arguments to defines. Missed this one somehow last time, sorry.

Also adds myself to the admin.txt for testing.