### PR TITLE
Drones see pAIs in mobile form without filters

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -240,3 +240,6 @@
 /mob/living/silicon/pai/process()
 	emitterhealth = Clamp((emitterhealth + emitterregen), -50, emittermaxhealth)
 	hit_slowdown = Clamp((hit_slowdown - 1), 0, 100)
+
+/mob/living/silicon/pai/generateStaticOverlay()
+	return


### PR DESCRIPTION
Consistency. Drones are allowed to interact with pAIs, code should
reflect that.

:cl: coiax
add: Since drones are allowed to interact with pAIs, pAIs in mobile
chassis form are no longer distorted to drone viewpoints.
/:cl: