### PR TITLE
Moves `tesla_ignore` from var on /mob/living to secondary flag

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -42,6 +42,9 @@
 // those restrictions.
 #define OMNITONGUE "omnitongue"
 
+// TESLA_IGNORE grants immunity from being targeted by tesla-style electricity
+#define TESLA_IGNORE "tesla_ignore"
+
 //turf-only flags
 #define NOJAUNT		1
 #define UNUSED_TRANSIT_TURF 2

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -213,7 +213,7 @@
 
 /datum/spellbook_entry/lightningbolt/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book) //return 1 on success
 	. = ..()
-	user.tesla_ignore = TRUE
+	SET_SECONDARY_FLAG(user, TESLA_IGNORE)
 
 /datum/spellbook_entry/infinite_guns
 	name = "Lesser Summon Guns"

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -169,7 +169,7 @@
 	..()
 
 /mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, override = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
-	if(tesla_shock && tesla_ignore)
+	if(tesla_shock && HAS_SECONDARY_FLAG(src, TESLA_IGNORE))
 		return FALSE
 	shock_damage *= siemens_coeff
 	if(dna && dna.species)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -456,7 +456,7 @@
 			else if(S.siemens_coefficient == (-1))
 				total_coeff -= 1
 		siemens_coeff = total_coeff
-		if(tesla_ignore)
+		if(HAS_SECONDARY_FLAG(src, TESLA_IGNORE))
 			siemens_coeff = 0
 	else if(!safety)
 		var/gloves_siemens_coeff = 1

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -271,7 +271,7 @@
 	return 1
 
 /mob/living/proc/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
-	if(tesla_shock && tesla_ignore)
+	if(tesla_shock && HAS_SECONDARY_FLAG(src, TESLA_IGNORE))
 		return FALSE
 	if(shock_damage > 0)
 		if(!illusion)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -70,7 +70,6 @@
 	var/list/status_effects //a list of all status effects the mob has
 
 	var/list/implants = null
-	var/tesla_ignore = FALSE
 
 	var/datum/riding/riding_datum
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -203,7 +203,7 @@ GLOBAL_LIST_INIT(blacklisted_tesla_types, typecacheof(list(/obj/machinery/atmosp
 		else if(isliving(A))
 			var/dist = get_dist(source, A)
 			var/mob/living/L = A
-			if(dist <= zap_range && (dist < closest_dist || !closest_mob) && L.stat != DEAD && !L.tesla_ignore)
+			if(dist <= zap_range && (dist < closest_dist || !closest_mob) && L.stat != DEAD && !HAS_SECONDARY_FLAG(L, TESLA_IGNORE))
 				closest_mob = L
 				closest_atom = A
 				closest_dist = dist


### PR DESCRIPTION
Only granted by wizards learning the spell lightning bolt, so I don't
think it needs to be a var on /mob/living.