### PR TITLE
Cultists can no longer delay the shuttle after Nar'sie is summoned

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -281,6 +281,10 @@
 	if(curselimit > 1)
 		to_chat(user, "<span class='notice'>We have exhausted our ability to curse the shuttle.</span>")
 		return
+	if(locate(/obj/singularity/narsie) in GLOB.poi_list)
+		to_chat(user, "<span class='warning'>Nar-Sie is already on this plane, there is no delaying the end of all things.</span>")
+		return
+
 	if(SSshuttle.emergency.mode == SHUTTLE_CALL)
 		var/cursetime = 1800
 		var/timer = SSshuttle.emergency.timeLeft(1) + cursetime


### PR DESCRIPTION
:cl: coiax
fix: The shuttle's arrival can no longer be delayed after Nar-Sie's
arrival. The End cannot be delayed.
/:cl:

- Also, I have a feeling that it might be possible if timed well to
actually recall the shuttle with the use of two shuttle curses after
Nar-Sie's arrival. And that would be bad.