### PR TITLE
Fixes DVIEW runtimes in preferences.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1355,6 +1355,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	GLOB.dview_mob.see_invisible = invis_flags; \
 	for(type in view(range, GLOB.dview_mob))
 
+#define FOR_DVIEW_END GLOB.dview_mob.loc = null
+
 //can a window be here, or is there a window blocking it?
 /proc/valid_window_location(turf/T, dir_to_check)
 	if(!T)

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -232,6 +232,7 @@
 			spotlights+=L
 			continue
 		continue
+	FOR_DVIEW_END
 
 /obj/machinery/disco/proc/hierofunk()
 	for(var/i in 1 to 10)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -226,7 +226,7 @@
 
 		LAZYADD(T.affecting_lights, src)
 		affecting_turfs    += T
-
+	FOR_DVIEW_END
 	update_gen++
 
 /datum/light_source/proc/remove_lum()
@@ -267,6 +267,7 @@
 			C = thing
 			corners[C] = 0
 		turfs += T
+	FOR_DVIEW_END
 
 	var/list/L = turfs - affecting_turfs // New turfs, add us to the affecting lights of them.
 	affecting_turfs += L


### PR DESCRIPTION
Short story : No cleanup in FOR_DVIEW.

Long story : source_turf on light sources that never passed update loop pointed at the source atom so after FOR_DVIEW pass it was in the atom contents, atom got deleted, bye bye dview.

Technically this still can happen if someone would put deletion inside FOR_DVIEW loop, alternative would be forcing light source update immediately on creation but that might cause more issues and i don't have time to check for these today.