### PR TITLE
Removes 7 seconds from world init

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -866,7 +866,6 @@ The _flatIcons list is a cache for generated icon files.
 
 	var/image/text_image = new(loc = A)
 	text_image.maptext = "<font size = 4>[letter]</font>"
-	text_image.color = AverageColour(atom_icon)
 	text_image.pixel_x = 7
 	text_image.pixel_y = 5
 	qdel(atom_icon)
@@ -896,25 +895,6 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	// For debugging
 	final_image.text = initial(SA.name)
 	return final_image
-
-//Find's the average colour of the icon
-//By vg's ComicIronic
-/proc/AverageColour(icon/I)
-	var/list/colours = list()
-	for(var/x_pixel = 1 to I.Width())
-		for(var/y_pixel = 1 to I.Height())
-			var/this_colour = I.GetPixel(x_pixel, y_pixel)
-			if(this_colour)
-				colours.Add(this_colour)
-
-	if(!colours.len)
-		return null
-
-	var/final_average = colours[1]
-	for(var/colour in (colours - colours[1]))
-		final_average = BlendRGB(final_average, colour, 1)
-	return final_average
-
 
 //Interface for using DrawBox() to draw 1 pixel on a coordinate.
 //Returns the same icon specifed in the argument, but with the pixel drawn


### PR DESCRIPTION
Calculating the color accounted for 7 seconds of world init time, mostly spent on lavaland monsters.

That's in part because this takes 1024 readRGB operations per image, and does no caching or other optimizations

@RemieRichards @ComicIronic

This could also be made to cache it per-icon (or only check every other pixel), but i'm too lazy. 

I removed the entire helper proc because this is the only thing that used it and it was such cancer i figured it was better to just take it behind the shed then have it suffer thru chemo.