### PR TITLE
Changed alternate appearances to  /datum/atom_hud s

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -38,10 +38,11 @@ GLOBAL_LIST_INIT(huds, list(
 
 /datum/atom_hud/proc/remove_from_hud(atom/A)
 	if(!A)
-		return
+		return FALSE
 	for(var/mob/M in hudusers)
 		remove_from_single_hud(M, A)
 	hudatoms -= A
+	return TRUE
 
 /datum/atom_hud/proc/remove_from_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client
 	if(!M || !M.client || !A)
@@ -58,10 +59,11 @@ GLOBAL_LIST_INIT(huds, list(
 
 /datum/atom_hud/proc/add_to_hud(atom/A)
 	if(!A)
-		return
+		return FALSE
 	hudatoms |= A
 	for(var/mob/M in hudusers)
 		add_to_single_hud(M, A)
+	return TRUE
 
 /datum/atom_hud/proc/add_to_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client
 	if(!M || !M.client || !A)
@@ -77,7 +79,7 @@ GLOBAL_LIST_INIT(huds, list(
 		for(var/datum/gang/G in SSticker.mode.gangs)
 			gang_huds += G.ganghud
 
-	for(var/datum/atom_hud/hud in (GLOB.huds|gang_huds))
+	for(var/datum/atom_hud/hud in (GLOB.huds|gang_huds|GLOB.active_alternate_appearances))
 		if(src in hud.hudusers)
 			hud.add_hud_to(src)
 

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT(huds, list(
 /datum/atom_hud/proc/add_hud_to(mob/M)
 	if(!M)
 		return
-	hudusers |= M
+	hudusers[M] = TRUE
 	for(var/atom/A in hudatoms)
 		add_to_single_hud(M, A)
 
@@ -80,7 +80,7 @@ GLOBAL_LIST_INIT(huds, list(
 			gang_huds += G.ganghud
 
 	for(var/datum/atom_hud/hud in (GLOB.huds|gang_huds|GLOB.active_alternate_appearances))
-		if(src in hud.hudusers)
+		if(hud.hudusers[src])
 			hud.add_hud_to(src)
 
 /mob/dead/new_player/reload_huds()

--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -1,164 +1,108 @@
-/*
-	Alternate Appearances! By RemieRichards
-	A framework for replacing an atom (and it's overlays) with an override = 1 image, that's less shit!
-	Example uses:
-		* hallucinating all mobs looking like skeletons
-		* people wearing cardborg suits appearing as Standard Cyborgs to the other Silicons
-		* !!use your imagination!!
-
-*/
-
-
-//This datum is built on-the-fly by some of the procs below
-//no need to instantiate it
-/datum/alternate_appearance
-	var/key = ""
-	var/image/img
-	var/list/viewers = list()
-	var/atom/owner = null
-
-
-/*
-	Displays the alternate_appearance
-	displayTo - a list of MOBS to show this appearance to
-*/
-/datum/alternate_appearance/proc/display_to(list/displayTo)
-	if(!displayTo || !displayTo.len)
-		return
-	for(var/m in displayTo)
-		var/mob/M = m
-		if(!M.viewing_alternate_appearances)
-			M.viewing_alternate_appearances = list()
-		viewers |= M
-		var/list/AAsiblings = M.viewing_alternate_appearances[key]
-		if(!AAsiblings)
-			AAsiblings = list()
-			M.viewing_alternate_appearances[key] = AAsiblings
-		AAsiblings |= src
-		if(M.client)
-			M.client.images |= img
-
-/*
-	Hides the alternate_appearance
-	hideFrom - optional list of MOBS to hide it from the list's mobs specifically
-*/
-/datum/alternate_appearance/proc/hide(list/hideFrom)
-	var/list/hiding = viewers
-	if(hideFrom)
-		hiding = hideFrom
-
-	for(var/m in hiding)
-		var/mob/M = m
-		if(M.client)
-			M.client.images -= img
-		if(M.viewing_alternate_appearances && M.viewing_alternate_appearances.len)
-			var/list/AAsiblings = M.viewing_alternate_appearances[key]
-			if(AAsiblings)
-				AAsiblings -= src
-				if(!AAsiblings.len)
-					M.viewing_alternate_appearances -= key
-					if(!M.viewing_alternate_appearances.len)
-						M.viewing_alternate_appearances = null
-		viewers -= M
-
-
-/*
-	Removes the alternate_appearance from its owner's alternate_appearances list, hiding it also
-*/
-/datum/alternate_appearance/proc/remove()
-	hide()
-	if(owner && owner.alternate_appearances)
-		owner.alternate_appearances -= key
-		if(!owner.alternate_appearances.len)
-			owner.alternate_appearances = null
-
-
-/datum/alternate_appearance/Destroy()
-	remove()
-	return ..()
-
+GLOBAL_LIST_EMPTY(active_alternate_appearances)
 
 
 /atom
-	var/list/alternate_appearances //the alternate appearances we own
-	var/list/viewing_alternate_appearances //this is an assoc list of lists, the keys being the AA's key
-	//inside these lists are the AAs themselves, this is to allow the atom to see multiple of the same type of AA
-	//eg: two (or more) people disguised as cardborgs, or two (or more) people disguised as plants
+	var/list/alternate_appearances
 
-/*
-	Builds an alternate_appearance datum for the supplied args, optionally displaying it straight away
-	key - the key to the assoc list of key = /datum/alternate_appearances
-	img - the image file to be the "alternate appearance"
-	WORKS BEST IF:
-		* it has override = 1 set
-		* the image's loc is the atom that will use the appearance (otherwise... it's not exactly an alt appearance of this atom is it?)
-	displayTo - optional list of MOBS to display to immediately
-
-	Example:
-	var/image/I = image(icon = 'disguise.dmi', icon_state = "disguise", loc = src)
-	I.override = 1
-	add_alt_appearance("super_secret_disguise", I, players)
-
-*/
-/atom/proc/add_alt_appearance(key, img, list/displayTo = list())
-	if(!key || !img)
-		return
-	if(!alternate_appearances)
-		alternate_appearances = list()
-
-	var/datum/alternate_appearance/AA = new()
-	AA.img = img
-	AA.key = key
-	AA.owner = src
-
-	alternate_appearances[key] = AA
-	if(displayTo && displayTo.len)
-		display_alt_appearance(key, displayTo)
-
-
-//////////////
-// WRAPPERS //
-//////////////
-
-/*
-	Removes an alternate_appearance from src's alternate_appearances list
-	Wrapper for: alternate_appearance/remove()
-	key - the key to the assoc list of key = /datum/alternate_appearance
-*/
 /atom/proc/remove_alt_appearance(key)
 	if(alternate_appearances)
-		if(alternate_appearances[key])
-			var/datum/alternate_appearance/AA = alternate_appearances[key]
-			qdel(AA)
+		for(var/K in alternate_appearances)
+			var/datum/atom_hud/alternate_appearance/AA = alternate_appearances[K]
+			if(AA.appearance_key == key)
+				AA.remove_from_hud(src)
 
-
-/*
-	Displays an alternate appearance from src's alternate_appearances list
-	Wrapper for: alternate_appearance/display_to()
-	key - the key to the assoc list of key = /datum/alternate_appearance
-	displayTo - a list of MOBS to show this appearance to
-*/
-/atom/proc/display_alt_appearance(key, list/displayTo)
-	if(!alternate_appearances || !key)
+/atom/proc/add_alt_appearance(type, key, ...)
+	if(!type || !key)
 		return
-	var/datum/alternate_appearance/AA = alternate_appearances[key]
-	if(!AA || !AA.img)
+	if(alternate_appearances && alternate_appearances[key])
 		return
-	AA.display_to(displayTo)
+	var/list/arguments = args.Copy(2)
+	new type(arglist(arguments))
 
 
-/*
-	Hides an alternate appearance from src's alternate_appearances list
-	Wrapper for: alternate_appearance/hide()
-	key - the key to the assoc list of key = /datum/alternate_appearance
-	hideFrom - optional list of MOBS to hide it from the list's mobs specifically
-*/
-/atom/proc/hide_alt_appearance(key, list/hideFrom)
-	if(!alternate_appearances || !key)
-		return
-	var/datum/alternate_appearance/AA = alternate_appearances[key]
-	if(!AA)
-		return
-	AA.hide(hideFrom)
+/datum/atom_hud/alternate_appearance
+	var/appearance_key
+
+/datum/atom_hud/alternate_appearance/New(key)
+	..()
+	GLOB.active_alternate_appearances += src
+	appearance_key = key
+
+/datum/atom_hud/alternate_appearance/Destroy()
+	if(!QDELETED(src))
+		for(var/v in hudusers)
+			remove_hud_from(v)
+		for(var/v in hudatoms)
+			remove_from_hud(v)
+		GLOB.active_alternate_appearances -= src
+	return ..()
+
+/datum/atom_hud/alternate_appearance/proc/onNewMob(mob/M)
+	if(mobShouldSee(M))
+		add_hud_to(M)
+
+/datum/atom_hud/alternate_appearance/proc/mobShouldSee(mob/M)
+	return FALSE
+
+/datum/atom_hud/alternate_appearance/add_to_hud(atom/A, image/I)
+	. = ..()
+	if(.)
+		LAZYINITLIST(A.alternate_appearances)
+		A.alternate_appearances[appearance_key] = src
+
+/datum/atom_hud/alternate_appearance/remove_from_hud(atom/A)
+	. = ..()
+	if(.)
+		LAZYREMOVE(A.alternate_appearances, appearance_key)
 
 
+//an alternate appearance that attaches a single image to a single atom
+/datum/atom_hud/alternate_appearance/basic
+	var/atom/target
+	var/image/theImage
+
+/datum/atom_hud/alternate_appearance/basic/New(key, image/I, target_sees_appearance = TRUE)
+	..()
+	theImage = I
+	target = I.loc
+	hud_icons = list(appearance_key)
+	add_to_hud(target, I)
+	if(target_sees_appearance && ismob(target))
+		add_hud_to(target)
+
+/datum/atom_hud/alternate_appearance/basic/add_to_hud(atom/A)
+	A.hud_list[appearance_key] = theImage
+	. = ..()
+
+/datum/atom_hud/alternate_appearance/basic/remove_from_hud(atom/A)
+	. = ..()
+	A.hud_list -= appearance_key
+
+/datum/atom_hud/alternate_appearance/basic/remove_from_hud(atom/A)
+	. = ..()
+	if(.)
+		qdel(src)
+
+/datum/atom_hud/alternate_appearance/basic/everyone
+
+/datum/atom_hud/alternate_appearance/basic/everyone/New()
+	..()
+	for(var/mob in GLOB.player_list)
+		if(mob)
+			add_hud_to(mob)
+
+/datum/atom_hud/alternate_appearance/basic/everyone/mobShouldSee(mob/M)
+	return TRUE
+
+/datum/atom_hud/alternate_appearance/basic/silicons
+
+/datum/atom_hud/alternate_appearance/basic/silicons/New()
+	..()
+	for(var/mob in GLOB.silicon_mobs)
+		if(mob)
+			add_hud_to(mob)
+
+/datum/atom_hud/alternate_appearance/basic/silicons/mobShouldSee(mob/M)
+	if(issilicon(M))
+		return TRUE
+	return FALSE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -77,15 +77,10 @@
 
 /atom/Destroy()
 	if(alternate_appearances)
-		for(var/aakey in alternate_appearances)
-			var/datum/alternate_appearance/AA = alternate_appearances[aakey]
-			qdel(AA)
-		alternate_appearances = null
-	if(viewing_alternate_appearances)
-		for(var/aakey in viewing_alternate_appearances)
-			for(var/aa in viewing_alternate_appearances[aakey])
-				var/datum/alternate_appearance/AA = aa
-				AA.hide(list(src))
+		for(var/K in alternate_appearances)
+			var/datum/atom_hud/alternate_appearance/AA = alternate_appearances[K]
+			AA.remove_from_hud(src)
+
 	if(reagents)
 		qdel(reagents)
 

--- a/code/game/gamemodes/antag_hud.dm
+++ b/code/game/gamemodes/antag_hud.dm
@@ -49,7 +49,7 @@
 
 /datum/mind/proc/leave_all_antag_huds()
 	for(var/datum/atom_hud/antag/hud in GLOB.huds)
-		if(current in hud.hudusers)
+		if(hud.hudusers[current])
 			hud.leave_hud(current)
 
 /datum/atom_hud/antag/gang

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -307,7 +307,7 @@
 /obj/structure/blob/examine(mob/user)
 	..()
 	var/datum/atom_hud/hud_to_check = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
-	if(user.research_scanner || (user in hud_to_check.hudusers))
+	if(user.research_scanner || hud_to_check.hudusers[user])
 		to_chat(user, "<b>Your HUD displays an extensive report...</b><br>")
 		chemeffectreport(user)
 		typereport(user)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -262,7 +262,7 @@
 /obj/item/weapon/twohanded/required/kirbyplants/equipped(mob/living/user)
 	var/image/I = image(icon = 'icons/obj/flora/plants.dmi' , icon_state = src.icon_state, loc = user)
 	I.override = 1
-	user.add_alt_appearance("sneaking_mission", I, GLOB.player_list)
+	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "sneaking_mission", I)
 	..()
 
 /obj/item/weapon/twohanded/required/kirbyplants/dropped(mob/living/user)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -957,7 +957,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 
 /client/proc/has_antag_hud()
 	var/datum/atom_hud/A = GLOB.huds[ANTAG_HUD_TRAITOR]
-	return mob in A.hudusers
+	return A.hudusers[mob]
 
 /client/proc/open_shuttle_manipulator()
 	set category = "Admin"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -179,7 +179,7 @@
 			var/image/I = image(icon = 'icons/mob/robots.dmi' , icon_state = "robot", loc = H)
 			I.override = 1
 			I.add_overlay(image(icon = 'icons/mob/robots.dmi' , icon_state = "robot_e")) //gotta look realistic
-			H.add_alt_appearance("standard_borg_disguise", I, GLOB.silicon_mobs+H) //you look like a robot to robots! (including yourself because you're totally a robot)
+			add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/silicons, "standard_borg_disguise", I) //you look like a robot to robots! (including yourself because you're totally a robot)
 
 
 /obj/item/clothing/suit/snowman

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -37,7 +37,7 @@
 		I.override = 1
 		I.pixel_x -= owner.pixel_x
 		I.pixel_y -= owner.pixel_y
-		owner.add_alt_appearance("smallqueen", I, list(owner))
+		owner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic, "smallqueen", I)
 
 		small = 1
 	else

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -37,12 +37,6 @@
 
 	client.sethotkeys() //set mob specific hotkeys
 
-	if(viewing_alternate_appearances && viewing_alternate_appearances.len)
-		for(var/aakey in viewing_alternate_appearances)
-			for(var/aa in viewing_alternate_appearances[aakey])
-				var/datum/alternate_appearance/AA = aa
-				AA.display_to(list(src))
-
 	update_client_colour()
 	if(client)
 		client.click_intercept = null

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -28,6 +28,9 @@
 		GLOB.living_mob_list += src
 	prepare_huds()
 	can_ride_typecache = typecacheof(can_ride_typecache)
+	for(var/v in GLOB.active_alternate_appearances)
+		var/datum/atom_hud/alternate_appearance/AA = v
+		AA.onNewMob(src)
 	..()
 
 /atom/proc/prepare_huds()


### PR DESCRIPTION
Fixes #26152 

Piggybacked alternate appearances onto data huds, which are generally pretty good at updating when they should. Also fixed the bug with latejoiners not seeing alternate appearances.