### PR TITLE
Arbitary code cleaning

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -9,8 +9,7 @@
 /obj/structure/closet/crate/necropolis/tendril
 	desc = "It's watching you suspiciously."
 
-/obj/structure/closet/crate/necropolis/tendril/Initialize()
-	..()
+/obj/structure/closet/crate/necropolis/tendril/PopulateContents()
 	var/loot = rand(1,25)
 	switch(loot)
 		if(1)
@@ -87,7 +86,7 @@
 		user.sight |= SEE_MOBS
 		icon_state = "lantern"
 		wisp.orbit(user, 20)
-		feedback_add_details("wisp_lantern","Freed") // freed
+		feedback_add_details("wisp_lantern","Freed")
 
 	else
 		to_chat(user, "<span class='notice'>You return the wisp to the lantern.</span>")
@@ -102,7 +101,7 @@
 		wisp.stop_orbit()
 		wisp.loc = src
 		icon_state = "lantern-blue"
-		feedback_add_details("wisp_lantern","Returned") // returned
+		feedback_add_details("wisp_lantern","Returned")
 
 /obj/item/device/wisp_lantern/Initialize()
 	..()
@@ -239,13 +238,15 @@
 		user.forceMove(Z)
 		user.notransform = 1
 		user.status_flags |= GODMODE
-		spawn(100)
-			user.status_flags &= ~GODMODE
-			user.notransform = 0
-			user.forceMove(get_turf(Z))
-			user.visible_message("<span class='danger'>[user] pops back into reality!</span>")
-			Z.can_destroy = TRUE
-			qdel(Z)
+		addtimer(CALLBACK(src, .proc/return_to_reality, user, Z), 100)
+
+/obj/item/device/immortality_talisman/proc/return_to_reality(mob/user, obj/effect/immortality_talisman/Z)
+	user.status_flags &= ~GODMODE
+	user.notransform = 0
+	user.forceMove(get_turf(Z))
+	user.visible_message("<span class='danger'>[user] pops back into reality!</span>")
+	Z.can_destroy = TRUE
+	qdel(Z)
 
 /obj/effect/immortality_talisman
 	icon_state = "blank"
@@ -453,8 +454,7 @@
 /obj/structure/closet/crate/necropolis/dragon
 	name = "dragon chest"
 
-/obj/structure/closet/crate/necropolis/dragon/Initialize()
-	..()
+/obj/structure/closet/crate/necropolis/dragon/PopulateContents()
 	var/loot = rand(1,4)
 	switch(loot)
 		if(1)
@@ -689,9 +689,8 @@
 
 /obj/item/mayhem/attack_self(mob/user)
 	for(var/mob/living/carbon/human/H in range(7,user))
-		spawn()
-			var/obj/effect/mine/pickup/bloodbath/B = new(H)
-			B.mineEffect(H)
+		var/obj/effect/mine/pickup/bloodbath/B = new(H)
+		INVOKE_ASYNC(B, /obj/effect/mine/pickup/bloodbath/.proc/mineEffect, H)
 	to_chat(user, "<span class='notice'>You shatter the bottle!</span>")
 	playsound(user.loc, 'sound/effects/Glassbr1.ogg', 100, 1)
 	qdel(src)
@@ -699,8 +698,7 @@
 /obj/structure/closet/crate/necropolis/bubblegum
 	name = "bubblegum chest"
 
-/obj/structure/closet/crate/necropolis/bubblegum/Initialize()
-	..()
+/obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
 	var/loot = rand(1,3)
 	switch(loot)
 		if(1)
@@ -743,9 +741,8 @@
 		L.mind.objectives += survive
 		to_chat(L, "<span class='userdanger'>You've been marked for death! Don't let the demons get you!</span>")
 		L.add_atom_colour("#FF0000", ADMIN_COLOUR_PRIORITY)
-		spawn()
-			var/obj/effect/mine/pickup/bloodbath/B = new(L)
-			B.mineEffect(L)
+		var/obj/effect/mine/pickup/bloodbath/B = new(L)
+		INVOKE_ASYNC(B, /obj/effect/mine/pickup/bloodbath/.proc/mineEffect, L)
 
 		for(var/mob/living/carbon/human/H in GLOB.player_list)
 			if(H == L)

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -100,6 +100,7 @@
 		var/mob/living/carbon/alien/A = M
 		A.updatePlasmaDisplay()
 
+#define QUEEN_DEATH_DEBUFF_DURATION 2400
 
 /obj/item/organ/alien/hivenode
 	name = "hive node"
@@ -140,15 +141,19 @@
 
 	recent_queen_death = 1
 	owner.throw_alert("alien_noqueen", /obj/screen/alert/alien_vulnerable)
-	spawn(2400) //four minutes
-		if(QDELETED(src)) //In case the node is deleted
-			return
-		recent_queen_death = 0
-		if(!owner) //In case the xeno is butchered or subjected to surgery after death.
-			return
-		to_chat(owner, "<span class='noticealien'>The pain of the queen's death is easing. You begin to hear the hivemind again.</span>")
-		owner.clear_alert("alien_noqueen")
+	addtimer(CALLBACK(src, .proc/clear_queen_death), QUEEN_DEATH_DEBUFF_DURATION)
 
+
+/obj/item/organ/alien/hivenode/proc/clear_queen_death()
+	if(QDELETED(src)) //In case the node is deleted
+		return
+	recent_queen_death = 0
+	if(!owner) //In case the xeno is butchered or subjected to surgery after death.
+		return
+	to_chat(owner, "<span class='noticealien'>The pain of the queen's death is easing. You begin to hear the hivemind again.</span>")
+	owner.clear_alert("alien_noqueen")
+
+#undef QUEEN_DEATH_DEBUFF_DURATION
 
 /obj/item/organ/alien/resinspinner
 	name = "resin spinner"

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -106,9 +106,11 @@
 		return
 	if(stat == CONSCIOUS)
 		icon_state = "[initial(icon_state)]_thrown"
-		spawn(15)
-			if(icon_state == "[initial(icon_state)]_thrown")
-				icon_state = "[initial(icon_state)]"
+		addtimer(CALLBACK(src, .proc/clear_throw_icon_state), 15)
+
+/obj/item/clothing/mask/facehugger/proc/clear_throw_icon_state()
+	if(icon_state == "[initial(icon_state)]_thrown")
+		icon_state = "[initial(icon_state)]"
 
 /obj/item/clothing/mask/facehugger/throw_impact(atom/hit_atom)
 	..()
@@ -171,8 +173,7 @@
 	// early returns and validity checks done: attach.
 	attached++
 	//ensure we detach once we no longer need to be attached
-	spawn(MAX_IMPREGNATION_TIME)
-		attached = 0
+	addtimer(CALLBACK(src, .proc/detach), MAX_IMPREGNATION_TIME)
 
 	if (iscorgi(M))
 		var/mob/living/simple_animal/pet/dog/corgi/C = M
@@ -186,10 +187,12 @@
 
 	GoIdle() //so it doesn't jump the people that tear it off
 
-	spawn(rand(MIN_IMPREGNATION_TIME,MAX_IMPREGNATION_TIME))
-		Impregnate(M)
+	addtimer(CALLBACK(src, .proc/Impregnate, M), rand(MIN_IMPREGNATION_TIME, MAX_IMPREGNATION_TIME))
 
 	return TRUE // time for a smoke
+
+/obj/item/clothing/mask/facehugger/proc/detach()
+	attached = 0
 
 /obj/item/clothing/mask/facehugger/proc/Impregnate(mob/living/target)
 	if(!target || target.stat == DEAD) //was taken off or something
@@ -234,9 +237,7 @@
 	stat = UNCONSCIOUS
 	icon_state = "[initial(icon_state)]_inactive"
 
-	spawn(rand(MIN_ACTIVE_TIME,MAX_ACTIVE_TIME))
-		GoActive()
-	return
+	addtimer(CALLBACK(src, .proc/GoActive), rand(MIN_ACTIVE_TIME, MAX_ACTIVE_TIME))
 
 /obj/item/clothing/mask/facehugger/proc/Die()
 	if(stat == DEAD)
@@ -266,3 +267,9 @@
 			return 0
 		return 1
 	return 0
+
+#undef MIN_ACTIVE_TIME
+#undef MAX_ACTIVE_TIME
+
+#undef MIN_IMPREGNATION_TIME
+#undef MAX_IMPREGNATION_TIME

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -89,13 +89,13 @@
 	..()
 	update_icon()
 
-	spawn(4)
-		if(skin)
-			add_overlay(image('icons/mob/aibots.dmi', "medskin_[skin]"))
+	if(skin)
+		add_overlay(image('icons/mob/aibots.dmi', "medskin_[skin]"))
 
-		var/datum/job/doctor/J = new/datum/job/doctor
-		access_card.access += J.get_access()
-		prev_access = access_card.access
+	var/datum/job/doctor/J = new /datum/job/doctor
+	access_card.access += J.get_access()
+	prev_access = access_card.access
+	qdel(J)
 
 /mob/living/simple_animal/bot/medbot/bot_reset()
 	..()
@@ -536,13 +536,11 @@
 	..()
 
 /mob/living/simple_animal/bot/medbot/proc/declare(crit_patient)
-	if(declare_cooldown)
+	if(declare_cooldown > world.time)
 		return
 	var/area/location = get_area(src)
 	speak("Medical emergency! [crit_patient ? "<b>[crit_patient]</b>" : "A patient"] is in critical condition at [location]!",radio_channel)
-	declare_cooldown = 1
-	spawn(200) //Twenty seconds
-		declare_cooldown = 0
+	declare_cooldown = world.time + 200
 
 /obj/machinery/bot_core/medbot
 	req_one_access =list(GLOB.access_medical, GLOB.access_robotics)


### PR DESCRIPTION
- Removed spawns from medbots.
- Made facehuggers use timers, added #undefs.
- Made hive nodes use timers for clearing the queen death debuff.
- Make necropolis chests use PopulateContents()
- Use INVOKE_ASYNC for making bloodbath mines apply their affects
- Replaced spawn with addtimer for immortality talisman