### PR TITLE
Makes a global list of all items

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -29,6 +29,7 @@ GLOBAL_LIST_EMPTY(zombie_infection_list) 		// A list of all zombie_infection org
 GLOBAL_LIST_EMPTY(meteor_list)				// List of all meteors.
 GLOBAL_LIST_EMPTY(active_jammers)             // List of active radio jammers
 GLOBAL_LIST_EMPTY(ladders)
+GLOBAL_LIST_EMPTY(all_items_list)
 
 GLOBAL_LIST_EMPTY(wire_color_directory)
 GLOBAL_LIST_EMPTY(wire_name_directory)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -116,6 +116,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(GLOB.rpg_loot_items)
 		rpg_loot = new(src)
 
+	GLOB.all_items_list[src] = TRUE
+
 /obj/item/Destroy()
 	flags &= ~DROPDEL	//prevent reqdels
 	if(ismob(loc))
@@ -124,6 +126,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	for(var/X in actions)
 		qdel(X)
 	QDEL_NULL(rpg_loot)
+
+	GLOB.all_items_list -= src
+
 	return ..()
 
 /obj/item/device

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -116,7 +116,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(GLOB.rpg_loot_items)
 		rpg_loot = new(src)
 
-	GLOB.all_items_list[src] = TRUE
+	GLOB.all_items_list += src
 
 /obj/item/Destroy()
 	flags &= ~DROPDEL	//prevent reqdels

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -7,7 +7,8 @@
 
 /datum/round_event/wizard/rpgloot/start()
 	var/upgrade_scroll_chance = 0
-	for(var/obj/item/I in world)
+	for(var/i in shuffle(GLOB.all_items_list))
+		var/obj/item/I = i
 		if(!istype(I.rpg_loot))
 			I.rpg_loot = new(I)
 


### PR DESCRIPTION
Iterating through `world` is bad, and I think other projects/plans would
like to operate over all items as well. So let's have a global list,
trading memory for performance.

- Also, shuffles the list when performing RPG loot, because otherwise I
have a niggling suspicion that the item fortification scrolls may be
placed in a slightly more predictable pattern then they should.