### PR TITLE
Removes code featuring human riding

### DIFF
--- a/code/datums/riding.dm
+++ b/code/datums/riding.dm
@@ -328,55 +328,6 @@
 	else
 		to_chat(user, "<span class='notice'>You'll need something  to guide the [ridden.name].</span>")
 
-///////Humans. Yes, I said humans. No, this won't end well...//////////
-/datum/riding/human
-	keytype = null
-
-/datum/riding/human/ride_check(mob/living/M)
-	var/mob/living/carbon/human/H = ridden	//IF this runtimes I'm blaming the admins.
-	if(M.incapacitated(FALSE, TRUE) || H.incapacitated(FALSE, TRUE))
-		M.visible_message("<span class='warning'>[M] falls off [ridden]!</span>")
-		Unbuckle(M)
-		return FALSE
-	if(M.restrained(TRUE))
-		M.visible_message("<span class='warning'>[M] can't hang onto [ridden] with their hands cuffed!</span>")	//Honestly this should put the ridden mob in a chokehold.
-		Unbuckle(M)
-		return FALSE
-	if(H.pulling == M)
-		H.stop_pulling()
-
-/datum/riding/human/handle_vehicle_offsets()
-	for(var/mob/living/M in ridden.buckled_mobs)
-		M.setDir(ridden.dir)
-		switch(ridden.dir)
-			if(NORTH)
-				M.pixel_x = 0
-				M.pixel_y = 6
-			if(SOUTH)
-				M.pixel_x = 0
-				M.pixel_y = 6
-			if(EAST)
-				M.pixel_x = -6
-				M.pixel_y = 4
-			if(WEST)
-				M.pixel_x = 6
-				M.pixel_y = 4
-
-/datum/riding/human/handle_vehicle_layer()
-	if(ridden.buckled_mobs && ridden.buckled_mobs.len)
-		if(ridden.dir == SOUTH)
-			ridden.layer = ABOVE_MOB_LAYER
-		else
-			ridden.layer = OBJ_LAYER
-	else
-		ridden.layer = MOB_LAYER
-
-/datum/riding/human/force_dismount(mob/living/user)
-	ridden.unbuckle_mob(user)
-	user.Weaken(3)
-	user.Stun(3)
-	user.visible_message("<span class='warning'>[ridden] pushes [user] off of them!</span>")
-
 /datum/riding/cyborg
 	keytype = null
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -904,37 +904,3 @@
 	.["Make alien"] = "?_src_=vars;makealien=\ref[src]"
 	.["Make slime"] = "?_src_=vars;makeslime=\ref[src]"
 	.["Toggle Purrbation"] = "?_src_=vars;purrbation=\ref[src]"
-
-/mob/living/carbon/human/MouseDrop_T(mob/living/target, mob/living/user)
-	if((target != pulling) || (grab_state < GRAB_AGGRESSIVE) || (user != target) || !isliving(user) || stat || user.stat)//Get consent first :^)
-		. = ..()
-		return
-	buckle_mob(target, TRUE, TRUE)
-	. = ..()
-
-/mob/living/carbon/human/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
-	if(!force)//humans are only meant to be ridden through piggybacking and special cases
-		return
-	if(!is_type_in_typecache(M, can_ride_typecache))
-		M.visible_message("<span class='warning'>[M] really can't seem to mount [src]...</span>")
-		return
-	if(!riding_datum)
-		riding_datum = new /datum/riding/human(src)
-	if(buckled_mobs && ((M in buckled_mobs) || (buckled_mobs.len >= max_buckled_mobs)) || buckled || (M.stat != CONSCIOUS))
-		return
-	if(iscarbon(M))
-		if(M.incapacitated(FALSE, TRUE) || incapacitated(FALSE, TRUE))
-			M.visible_message("<span class='warning'>[M] can't hang onto [src]!</span>")
-			return
-		if(!riding_datum.equip_buckle_inhands(M, 2))	//MAKE SURE THIS IS LAST!!
-			M.visible_message("<span class='warning'>[M] can't climb onto [src]!</span>")
-			return
-	. = ..(M, force, check_loc)
-	stop_pulling()
-
-/mob/living/carbon/human/unbuckle_mob(mob/living/M, force=FALSE)
-	if(iscarbon(M))
-		if(riding_datum)
-			riding_datum.unequip_buckle_inhands(M)
-			riding_datum.restore_position(M)
-	. = ..(M, force)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -47,6 +47,3 @@
 
 	var/drunkenness = 0 //Overall drunkenness - check handle_alcohol() in life.dm for effects
 	var/datum/personal_crafting/handcrafting
-	can_buckle = TRUE
-	buckle_lying = FALSE
-	can_ride_typecache = list(/mob/living/carbon/human, /mob/living/simple_animal/slime, /mob/living/simple_animal/parrot)


### PR DESCRIPTION
:cl: 
del: Removes code featuring human riding
/:cl:

This is the ideal solution to the extremely buggy feature. Cyborg riding will be removed later if it proves to be a problem too.

Partial revert of #23623.