### PR TITLE
Makes malf-hacked APCs vulnerable to aliens

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -671,11 +671,6 @@
 		return
 	..()
 
-/obj/machinery/power/apc/attack_alien(mob/living/carbon/alien/humanoid/user)
-	if(malfhack)
-		return
-	..()
-
 /obj/machinery/power/apc/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, \
 										datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)


### PR DESCRIPTION
:cl: XDTM
fix: APCs hacked by a malfunctioning AI are no longer immune to alien attacks.
/:cl:

Fixes #26265

This was intentional and apparently added by phil, but it doesn't seem to make sense since alien vs malf AI gameplay is not very frequent, and doesn't warrant special balancing.