### PR TITLE
Prevents mutation toxin from working on nonhumans, removes a spawn

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -396,22 +396,24 @@
 
 /datum/reagent/stableslimetoxin/on_mob_life(mob/living/carbon/human/H)
 	..()
+	if(!istype(H))
+		return
 	to_chat(H, "<span class='warning'><b>You crumple in agony as your flesh wildly morphs into new forms!</b></span>")
 	H.visible_message("<b>[H]</b> falls to the ground and screams as [H.p_their()] skin bubbles and froths!") //'froths' sounds painful when used with SKIN.
 	H.Weaken(3, 0)
-	spawn(30)
-		if(!H || QDELETED(H))
-			return
+	addtimer(CALLBACK(src, .proc/mutate, H), 30)
+	return
 
-		var/current_species = H.dna.species.type
-		var/datum/species/mutation = race
-		if(mutation && mutation != current_species)
-			to_chat(H, mutationtext)
-			H.set_species(mutation)
-		else
-			to_chat(H, "<span class='danger'>The pain vanishes suddenly. You feel no different.</span>")
-
-	return 1
+/datum/reagent/stableslimetoxin/proc/mutate(mob/living/carbon/human/H)
+	if(QDELETED(H))
+		return
+	var/current_species = H.dna.species.type
+	var/datum/species/mutation = race
+	if(mutation && mutation != current_species)
+		to_chat(H, mutationtext)
+		H.set_species(mutation)
+	else
+		to_chat(H, "<span class='danger'>The pain vanishes suddenly. You feel no different.</span>")
 
 /datum/reagent/stableslimetoxin/classic //The one from plasma on green slimes
 	name = "Mutation Toxin"


### PR DESCRIPTION
Fixes #26253

Supporting monkey race mutation could be a feature down the line, but mutation toxins should be humanoids-only right now.
