### PR TITLE
Fixes flashlight eyes

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -884,11 +884,11 @@
 
 /obj/item/organ/eyes/robotic/flashlight/Insert(var/mob/living/carbon/M, var/special = 0)
 	..()
-	set_light(15)
+	M.set_light(M.light_range + 15, M.light_power + 1)
 
 
 /obj/item/organ/eyes/robotic/flashlight/Remove(var/mob/living/carbon/M, var/special = 0)
-	set_light(-15)
+	M.set_light(M.light_range -15, M.light_power - 1)
 	..()
 
 // Welding shield implant


### PR DESCRIPTION
:cl: XDTM
fix: Fixed bug where flashlight eyes weren't emitting light.
/:cl:

Fixes #26145

We could really use an adjust_light proc. The way i set it at least won't reset other lights to 0 when removed, but it still will override other light colors.
Or, alternatively, putting organs inside mobs instead of nullspace.