### PR TITLE
Braining/debraining fixes

### DIFF
--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -74,6 +74,11 @@
 	if(ishuman(C))
 		var/datum/changelingprofile/prof = mind.changeling.add_new_profile(C, src)
 		mind.changeling.first_prof = prof
+
+		var/obj/item/organ/brain/B = C.getorganslot("brain")
+		if(B)
+			B.vital = FALSE
+			B.decoy_override = TRUE
 	return 1
 
 /datum/changeling/proc/reset()

--- a/code/game/gamemodes/changeling/powers/regenerate.dm
+++ b/code/game/gamemodes/changeling/powers/regenerate.dm
@@ -27,6 +27,9 @@
 			C.emote("scream")
 			C.regenerate_limbs(1)
 		C.regenerate_organs()
+		if(!user.getorganslot("brain"))
+			var/obj/item/organ/brain/changeling_brain/B = new()
+			B.Insert(C)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.restore_blood()

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -172,6 +172,11 @@
 
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src)
 
+	if(clonemind.changeling)
+		var/obj/item/organ/brain/B = H.getorganslot("brain")
+		B.vital = FALSE
+		B.decoy_override = TRUE
+
 	H.hardset_dna(ui, se, H.real_name, null, mrace, features)
 
 	if(efficiency > 2)

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -28,6 +28,8 @@
 	if(key)				//If there is a mob connected to this thing. Have to check key twice to avoid false death reporting.
 		if(stat!=DEAD)	//If not dead.
 			death(1)	//Brains can die again. AND THEY SHOULD AHA HA HA HA HA HA
+		if(mind)	//You aren't allowed to return to brains that don't exist
+			mind.current = null
 		ghostize()		//Ghostize checks for key so nothing else is necessary.
 	container = null
 	return ..()

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -7,15 +7,27 @@
 	layer = ABOVE_MOB_LAYER
 	zone = "head"
 	slot = "brain"
-	vital = 1
+	vital = TRUE
 	origin_tech = "biotech=5"
 	attack_verb = list("attacked", "slapped", "whacked")
 	var/mob/living/brain/brainmob = null
 	var/damaged_brain = FALSE //whether the brain organ is damaged.
 	var/decoy_override = FALSE	//I apologize to the security players, and myself, who abused this, but this is going to go.
 
+/obj/item/organ/brain/changeling_brain
+	vital = FALSE
+	decoy_override = TRUE
+
 /obj/item/organ/brain/Insert(mob/living/carbon/C, special = 0)
 	..()
+
+	if(C.mind && C.mind.changeling && C.stat)	//congrats, you're trapped in a body you don't control
+		if(brainmob && !(C.stat == DEAD || (C.status_flags & FAKEDEATH)))
+			to_chat(brainmob, "<span class = danger>You can't feel your body! You're still just a brain!</span>")
+		loc = C
+		C.update_hair()
+		return
+
 	name = "brain"
 	if(brainmob)
 		if(C.key)
@@ -37,7 +49,7 @@
 		if(C.has_brain_worms())
 			var/mob/living/simple_animal/borer/B = C.has_brain_worms()
 			B.leave_victim() //Should remove borer if the brain is removed - RR
-		transfer_identity(C)
+	transfer_identity(C)
 	C.update_hair()
 
 /obj/item/organ/brain/prepare_eat()
@@ -45,6 +57,8 @@
 
 /obj/item/organ/brain/proc/transfer_identity(mob/living/L)
 	name = "[L.name]'s brain"
+	if(brainmob || decoy_override)
+		return
 	brainmob = new(src)
 	brainmob.name = L.real_name
 	brainmob.real_name = L.real_name
@@ -54,7 +68,7 @@
 		if(!brainmob.stored_dna)
 			brainmob.stored_dna = new /datum/dna/stored(brainmob)
 		C.dna.copy_dna(brainmob.stored_dna)
-	if(L.mind && L.mind.current && (L.mind.current.stat == DEAD))
+	if(L.mind && L.mind.current)
 		L.mind.transfer_to(brainmob)
 	to_chat(brainmob, "<span class='notice'>You feel slightly disoriented. That's normal when you're just a brain.</span>")
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -21,14 +21,15 @@
 /obj/item/organ/brain/Insert(mob/living/carbon/C, special = 0)
 	..()
 
-	if(C.mind && C.mind.changeling && C.stat)	//congrats, you're trapped in a body you don't control
+	name = "brain"
+
+	if(C.mind && C.mind.changeling)	//congrats, you're trapped in a body you don't control
 		if(brainmob && !(C.stat == DEAD || (C.status_flags & FAKEDEATH)))
 			to_chat(brainmob, "<span class = danger>You can't feel your body! You're still just a brain!</span>")
 		loc = C
 		C.update_hair()
 		return
 
-	name = "brain"
 	if(brainmob)
 		if(C.key)
 			C.ghostize()
@@ -38,7 +39,7 @@
 		else
 			C.key = brainmob.key
 
-		qdel(brainmob)
+		QDEL_NULL(brainmob)
 
 	//Update the body's icon so it doesnt appear debrained anymore
 	C.update_hair()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -671,7 +671,7 @@
 	if(status_flags & GODMODE)
 		return
 	if(stat != DEAD)
-		if(health<= HEALTH_THRESHOLD_DEAD || !getorgan(/obj/item/organ/brain))
+		if(health<= HEALTH_THRESHOLD_DEAD)
 			death()
 			return
 		if(paralysis || sleeping || getOxyLoss() > 50 || (status_flags & FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -133,12 +133,12 @@
 	var/appears_dead = 0
 	if(stat == DEAD || (status_flags & FAKEDEATH))
 		appears_dead = 1
-		if(getorgan(/obj/item/organ/brain))//Only perform these checks if there is no brain
-			if(suiciding)
-				msg += "<span class='warning'>[t_He] appear[p_s()] to have commited suicide... there is no hope of recovery.</span>\n"
-			if(hellbound)
-				msg += "<span class='warning'>[t_His] soul seems to have been ripped out of [t_his] body.  Revival is impossible.</span>\n"
-			msg += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life"
+		if(suiciding)
+			msg += "<span class='warning'>[t_He] appear[p_s()] to have commited suicide... there is no hope of recovery.</span>\n"
+		if(hellbound)
+			msg += "<span class='warning'>[t_His] soul seems to have been ripped out of [t_his] body.  Revival is impossible.</span>\n"
+		msg += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life"
+		if(getorgan(/obj/item/organ/brain))
 			if(!key)
 				var/foundghost = 0
 				if(mind)
@@ -150,9 +150,10 @@
 							break
 				if(!foundghost)
 					msg += " and [t_his] soul has departed"
-			msg += "...</span>\n"
-		else if(get_bodypart("head")) //Brain is gone, doesn't matter if they are AFK or present. Check for head first tho. Decapitation has similar message.
-			msg += "<span class='deadsay'>It appears that [t_his] brain is missing...</span>\n"
+		msg += "...</span>\n"
+
+	if(get_bodypart("head") && !getorgan(/obj/item/organ/brain))
+		msg += "<span class='deadsay'>It appears that [t_his] brain is missing...</span>\n"
 
 	var/temp = getBruteLoss() //no need to calculate each of these twice
 

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -137,14 +137,10 @@
 	loc = LB
 
 /obj/item/organ/brain/transfer_to_limb(obj/item/bodypart/head/LB, mob/living/carbon/human/C)
-	if(C.mind && C.mind.changeling)
-		LB.brain = new //changeling doesn't lose its real brain organ, we drop a decoy.
-		LB.brain.loc = LB
-		LB.brain.decoy_override = TRUE
-	else			//if not a changeling, we put the brain organ inside the dropped head
-		Remove(C)	//and put the player in control of the brainmob
-		loc = LB
-		LB.brain = src
+	Remove(C)	//Changeling brain concerns are now handled in Remove
+	loc = LB
+	LB.brain = src
+	if(brainmob)
 		LB.brainmob = brainmob
 		brainmob = null
 		LB.brainmob.loc = LB

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -32,7 +32,7 @@
 		var/datum/action/A = X
 		A.Grant(M)
 
-
+//Special is for instant replacement like autosurgeons
 /obj/item/organ/proc/Remove(mob/living/carbon/M, special = 0)
 	owner = null
 	if(M)
@@ -78,7 +78,7 @@
 
 /obj/item/organ/Destroy()
 	if(owner)
-		Remove(owner, 1)
+		Remove(owner)
 	return ..()
 
 /obj/item/organ/attack(mob/living/carbon/M, mob/user)


### PR DESCRIPTION
:cl: QualityVan
fix: Changeling brains are now more fully vestigial
/:cl:

Fixes #26078 since it's the same areas.

Makes changelings not die from having their brain removed and allows them to grow a new fake brain by regenerating. If you put an inhabited brain in a changeling the changeling stays in control of their body and the brain stays inhabited and can be subsequently removed and borged/whatever. I was considering having the changeling fully absorb the person in the brain but that seemed like a feature.

Also lets people without brains appear dead.

Todo: add a way for lings to automatically enter stasis on brain removal. As is they have to do it manually if they wanna fake it if they're alive while being surgery'd.