### PR TITLE
Fixes a nullrod runtime

### DIFF
--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -31,7 +31,8 @@ Chaplain
 		B.item_state = SSreligion.bible_item_state
 		to_chat(H, "There is already an established religion onboard the station. You are an acolyte of [SSreligion.deity]. Defer to the Chaplain.")
 		H.equip_to_slot_or_del(B, slot_in_backpack)
-		var/obj/item/weapon/nullrod/N = new (SSreligion.holy_weapon_type || /obj/item/weapon/nullrod) (H)
+		var/nrt = SSreligion.holy_weapon_type || /obj/item/weapon/nullrod
+		var/obj/item/weapon/nullrod/N = new nrt(H)
 		H.equip_to_slot_or_del(N, slot_in_backpack)
 		return
 

--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -31,7 +31,7 @@ Chaplain
 		B.item_state = SSreligion.bible_item_state
 		to_chat(H, "There is already an established religion onboard the station. You are an acolyte of [SSreligion.deity]. Defer to the Chaplain.")
 		H.equip_to_slot_or_del(B, slot_in_backpack)
-		var/obj/item/weapon/nullrod/N = new SSreligion.holy_weapon_type(H)
+		var/obj/item/weapon/nullrod/N = new (SSreligion.holy_weapon_type || /obj/item/weapon/nullrod) (H)
 		H.equip_to_slot_or_del(N, slot_in_backpack)
 		return
 


### PR DESCRIPTION
```
The following runtime has occurred 1 time(s).
runtime error: Cannot create objects of type null.
proc name: after spawn (/datum/job/chaplain/after_spawn)
  source file: civilian_chaplain.dm,34
  usr: Ballbunk (/mob/dead/new_player)
  src: /datum/job/chaplain (/datum/job/chaplain)
```

holy_weapon_type is only set if someone changes the default nullrod. So, if another chaplain joins and the first didn't do that, he fuked.