### PR TITLE
~Rebalances~ Blood Loss

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -65,12 +65,8 @@
 			listclearnulls(BP.embedded_objects)
 			temp_bleed += 0.5*BP.embedded_objects.len
 
-			if(brutedamage > 30)
-				temp_bleed += 0.5
-			if(brutedamage > 50)
-				temp_bleed += 1
-			if(brutedamage > 70)
-				temp_bleed += 2
+			if(brutedamage >= 20)
+				temp_bleed += (brutedamage * 0.013)
 
 		bleed_rate = max(bleed_rate - 0.5, temp_bleed)//if no wounds, other bleed effects (heparin) naturally decreases
 


### PR DESCRIPTION
Currently bleeding is an arbitrary retarded rollercoaster.

With a stechkin, getting shot in the face, chest, and leg will currently not even make you lose blood. 

Getting shot twice in the face and once in the chest will give you about 4 minutes until you are "low on blood" and begin to take oxygen damage.

Getting shot in the chest three times will give you about 34 seconds until you are "low on blood" and begin to take oxygen damage. 

That means victim #3 is dead minutes before victim #2 even starts to feel side-effects from blood loss and victim #1 isn't even bleeding!

The threshold for bleeding is now do to 20 per limb, from 30. But blood loss now scales linearly instead of exponentially (31 damage to a limb is currently + 0.5 blood loss, 71 damage is 3.5 blood loss - aka pale in 30 seconds). This isn't a flat reduction in blood loss though. You will see more bleeding from 20-30 and 39-50 and are more likely to see bleeding occur from multiple body parts. It's just no longer an arbitrary scale where 71 damage to the chest has you gushing like you're in Kill Bill but 60 to the chest and 30 to the face has blood leaving you at a small trickle. 