### PR TITLE
Fixes loading ammo for the L6-SAW

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -333,10 +333,7 @@
 
 
 /obj/item/weapon/gun/ballistic/automatic/l6_saw/attackby(obj/item/A, mob/user, params)
-	. = ..()
-	if(.)
-		return
-	if(!cover_open)
+	if(!cover_open && istype(A, mag_type))
 		to_chat(user, "<span class='warning'>[src]'s cover is closed! You can't insert a new mag.</span>")
 		return
 	..()


### PR DESCRIPTION
Makes it so you actually can't load new ammo boxes into an L6-SAW(or its foam version) unless the cover is open. There was already code there that tried to prevent it, it just didn't work.