### PR TITLE
Adds badmin abuse limits to petsplosions

### DIFF
--- a/code/modules/events/wizard/petsplosion.dm
+++ b/code/modules/events/wizard/petsplosion.dm
@@ -4,14 +4,29 @@
 	typepath = /datum/round_event/wizard/petsplosion
 	max_occurrences = 1 //Exponential growth is nothing to sneeze at!
 	earliest_start = 0
+	var/mobs_to_dupe = 0
+
+/datum/round_event_control/wizard/petsplosion/preRunEvent()
+	for(var/mob/living/simple_animal/F in GLOB.living_mob_list)
+		if(!ishostile(F) && F.z == ZLEVEL_STATION)
+			mobs_to_dupe++
+	if(mobs_to_dupe > 100 || !mobs_to_dupe)
+		return EVENT_CANT_RUN
+
+	..()
 
 /datum/round_event/wizard/petsplosion
 	endWhen = 61 //1 minute (+1 tick for endWhen not to interfere with tick)
 	var/countdown = 0
+	var/mobs_duped = 0
 
 /datum/round_event/wizard/petsplosion/tick()
 	if(activeFor >= 30 * countdown) // 0 seconds : 2 animals | 30 seconds : 4 animals | 1 minute : 8 animals
 		countdown += 1
 		for(var/mob/living/simple_animal/F in GLOB.living_mob_list) //If you cull the heard before the next replication, things will be easier for you
-			if(!ishostile(F))
+			if(!ishostile(F) && F.z == ZLEVEL_STATION)
 				new F.type(F.loc)
+				mobs_duped++
+				if(mobs_duped > 400)
+					kill()
+


### PR DESCRIPTION
* Event won't run if initial pet population on station is greater than 100 pets.
* Event won't continue after creating 400 pets.
* Pets off station won't be affected by the petsplosion.

Fixes #26338