### PR TITLE
Fixes being unable to empty an emagged cloning pod via manual ejection.

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -312,7 +312,7 @@
 			return
 		else
 			connected_message("Authorized Ejection")
-			SPEAK("An authorized ejection of [occupant.real_name] has occurred.")
+			SPEAK("An authorized ejection [occupant ? "of [occupant.real_name] " : ""]has occurred.")
 			to_chat(user, "<span class='notice'>You force an emergency ejection. </span>")
 			go_out()
 	else

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -343,7 +343,7 @@
 	if(mess) //Clean that mess and dump those gibs!
 		mess = FALSE
 		for(var/obj/A in contents)
-			if(istype(A, /obj/item/organ) || istype(A, /obj/effect/decal/cleanable/blood/gibs))
+			if(istype(A, /obj/effect/decal/cleanable/blood/gibs))
 				A.forceMove(T)
 		audible_message("<span class='italics'>You hear a splat.</span>")
 		icon_state = "pod_0"
@@ -378,10 +378,13 @@
 		to_chat(occupant, "<span class='warning'><b>Agony blazes across your consciousness as your body is torn apart.</b><br><i>Is this what dying is like? Yes it is.</i></span>")
 		playsound(src.loc, 'sound/machines/warning-buzzer.ogg', 50, 0)
 		occupant << sound('sound/hallucinations/veryfar_noise.ogg',0,1,50)
-		var/obj/item/organ/brain/B = occupant.getorganslot("brain")
-		B.Remove(occupant)
-		B.forceMove(src)
-		occupant.gib(TRUE, TRUE, TRUE)
+		addtimer(CALLBACK(src, .proc/end_malfunction, occupant), 40)
+
+/obj/machinery/clonepod/proc/end_malfunction(mob/victim)
+	if(!istype(victim)) //Where the hell did they go?
+		return
+	victim.ghostize(FALSE)
+	victim.gib(TRUE, TRUE, TRUE)
 
 /obj/machinery/clonepod/relaymove(mob/user)
 	if(user.stat == CONSCIOUS)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -338,13 +338,9 @@
 /obj/machinery/clonepod/proc/go_out()
 	countdown.stop()
 
-	var/turf/T = get_turf(src)
-
 	if(mess) //Clean that mess and dump those gibs!
 		mess = FALSE
-		for(var/obj/A in contents)
-			if(istype(A, /obj/effect/decal/cleanable/blood/gibs))
-				A.forceMove(T)
+		new /obj/effect/gibspawner/generic(loc)
 		audible_message("<span class='italics'>You hear a splat.</span>")
 		icon_state = "pod_0"
 		return
@@ -357,6 +353,7 @@
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
 		occupant.flash_act()
 
+	var/turf/T = get_turf(src)
 	occupant.forceMove(T)
 	icon_state = "pod_0"
 	occupant.domutcheck(1) //Waiting until they're out before possible monkeyizing. The 1 argument forces powers to manifest.
@@ -378,14 +375,7 @@
 		to_chat(occupant, "<span class='warning'><b>Agony blazes across your consciousness as your body is torn apart.</b><br><i>Is this what dying is like? Yes it is.</i></span>")
 		playsound(src.loc, 'sound/machines/warning-buzzer.ogg', 50, 0)
 		occupant << sound('sound/hallucinations/veryfar_noise.ogg',0,1,50)
-		addtimer(CALLBACK(src, .proc/end_malfunction, occupant), 40)
-
-/obj/machinery/clonepod/proc/end_malfunction(mob/victim)
-	if(!istype(victim)) //Where the hell did they go?
-		return
-	victim.ghostize()
-	victim.mind.current = null
-	victim.gib(TRUE, TRUE, TRUE)
+		QDEL_IN(occupant, 40)
 
 /obj/machinery/clonepod/relaymove(mob/user)
 	if(user.stat == CONSCIOUS)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -383,7 +383,8 @@
 /obj/machinery/clonepod/proc/end_malfunction(mob/victim)
 	if(!istype(victim)) //Where the hell did they go?
 		return
-	victim.ghostize(FALSE)
+	victim.ghostize()
+	victim.mind.current = null
 	victim.gib(TRUE, TRUE, TRUE)
 
 /obj/machinery/clonepod/relaymove(mob/user)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -24,7 +24,8 @@
 	if(!no_bodyparts)
 		if(no_organs)//so the organs don't get transfered inside the bodyparts we'll drop.
 			for(var/X in internal_organs)
-				qdel(X)
+				if(no_brain || !istype(X, /obj/item/organ/brain))
+					qdel(X)
 		else //we're going to drop all bodyparts except chest, so the only organs that needs spilling are those inside it.
 			for(var/X in internal_organs)
 				var/obj/item/organ/O = X
@@ -40,6 +41,9 @@
 		for(var/X in internal_organs)
 			var/obj/item/organ/I = X
 			if(no_brain && istype(I, /obj/item/organ/brain))
+				qdel(I)
+				continue
+			if(no_organs && !istype(I, /obj/item/organ/brain))
 				qdel(I)
 				continue
 			I.Remove(src)


### PR DESCRIPTION
:cl: QualityVan
fix: You can hit emagged cloning pods with a medical ID to empty them
/:cl:

Without this you have to break the pod to get the blendered clone out. Incidentally fixes gib() producing a mob's organs or brains in some cases where it shouldn't.