### PR TITLE
Fixes rollies and pipes spawning with nicotine

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -261,6 +261,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	..()
 	src.pixel_x = rand(-5, 5)
 	src.pixel_y = rand(-5, 5)
+	reagents.remove_reagent("nicotine", 15)
 
 /obj/item/clothing/mask/cigarette/rollie/trippy/New()
 	..()
@@ -343,6 +344,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/pipe/New()
 	..()
 	name = "empty [initial(name)]"
+	reagents.remove_reagent("nicotine", 15)
 
 /obj/item/clothing/mask/cigarette/pipe/Destroy()
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
The New() proc remove the 15u of nicotine that pipes and rollies inherit from cigs.