### PR TITLE
Clones are ghosted on each process tick of a cloner; ghost verb changes

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -202,9 +202,6 @@
 	H.grab_ghost()
 	to_chat(H, "<span class='notice'><b>Consciousness slowly creeps over you as your body regenerates.</b><br><i>So this is what cloning feels like?</i></span>")
 
-	if(grab_ghost_when == CLONER_MATURE_CLONE)
-		addtimer(CALLBACK(src, .proc/occupant_dreams), 100)
-
 	if(H)
 		H.faction |= factions
 
@@ -213,11 +210,6 @@
 		H.suiciding = FALSE
 	attempting = FALSE
 	return TRUE
-
-/obj/machinery/clonepod/proc/occupant_dreams()
-	if(occupant)
-		to_chat(occupant, "<span class='revennotice'>While your body grows, you have the strangest dream, like you can see yourself from the outside.</span>")
-		occupant.ghostize(TRUE)
 
 //Grow clones to maturity then kick them out.  FREELOADERS
 /obj/machinery/clonepod/process()
@@ -235,6 +227,9 @@
 			go_out()
 
 		else if(occupant.cloneloss > (100 - heal_level))
+			if(occupant.key && grab_ghost_when == CLONER_MATURE_CLONE)
+				to_chat(occupant, "<span class='revennotice'>While your body grows, you have the strangest dream, like you can see yourself from the outside.</span>")
+				occupant.ghostize(can_reenter_corpse=TRUE)
 			occupant.Paralyse(4)
 
 			 //Slowly get that clone healed and finished.

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -262,7 +262,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/reply = alert(src, "Succumb to your injuries? You will die.", "Succumb?", "Succumb", "Do not Succumb")
 		if(reply == "Succumb")
 			succumb()
-	else if(stat == DEAD)
+
+	if(stat == DEAD) // and if we succumbed, we're dead.
 		ghostize(1)
 	else
 		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -258,16 +258,17 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Ghost"
 	set desc = "Relinquish your life and enter the land of the dead."
 
-	if(stat != DEAD)
-		succumb()
-	if(stat == DEAD)
+	if(InCritical())
+		var/reply = alert(src, "Succumb to your injuries? You will die.", "Succumb?", "Succumb", "Do not Succumb")
+		if(reply == "Succumb")
+			succumb()
+	else if(stat == DEAD)
 		ghostize(1)
 	else
 		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
 		if(response != "Ghost")
 			return	//didn't want to ghost after-all
 		ghostize(0)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
-	return
 
 
 /mob/dead/observer/Move(NewLoc, direct)


### PR DESCRIPTION
:cl: coiax
add: Clones are ghosted (harmlessly) immediately after the clone starts
growing, rather than after 10 seconds.
add: Using the "Ghost" verb while in critical will ask the person if
they want to succumb.
/:cl:

People are accidentally killing themselves while cloning by using the
Ghost verb. Two pronged fix, 1) kick them out of the pod immediately,
and then kick them out if they enter it again, 2) prompt if you want to
succumb if the person is in crit.