### PR TITLE
Fix current_ticket.initiator not being set when a client relogs

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -90,6 +90,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	C.current_ticket = CKey2ActiveTicket(C.ckey)
 	if(C.current_ticket)
 		C.current_ticket.AddInteraction("Client reconnected.")
+		C.current_ticket.initiator = C
 
 //Dissasociate ticket
 /datum/admin_help_tickets/proc/ClientLogout(client/C)


### PR DESCRIPTION
Fixes #26393

... Or I'm just a smooth brain.