### PR TITLE
Fixes swarmers speaking common

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -5,6 +5,9 @@
 	icon = 'icons/mob/human.dmi'
 	icon_state = "caucasian_m"
 
+	 // ME TARZAN, YOU JANEBOT
+	initial_languages = list(/datum/language/common)
+
 
 
 /mob/living/carbon/human/dummy
@@ -41,8 +44,6 @@
 	martial_art = default_martial_art
 
 	handcrafting = new()
-
-	grant_language(/datum/language/common) // ME TARZAN, YOU JANEBOT
 
 	..()
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -141,9 +141,6 @@
 	//Gives a HUD view to player bots that use a HUD.
 	activate_data_hud()
 
-	grant_language(/datum/language/common)
-	grant_language(/datum/language/machine)
-
 
 /mob/living/simple_animal/bot/update_canmove()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -139,8 +139,6 @@
 	verbs -= /mob/living/simple_animal/drone/verb/toggle_light
 	verbs -= /mob/living/simple_animal/drone/verb/drone_ping
 
-	grant_language(/datum/language/ratvar)
-
 /mob/living/simple_animal/drone/cogscarab/Login()
 	..()
 	add_servant_of_ratvar(src, TRUE)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -7,6 +7,9 @@
 
 	status_flags = CANPUSH
 
+	// goats bray, cows go moo, and the fox says Geckers
+	initial_languages = list(/datum/language/common)
+
 	var/icon_living = ""
 	var/icon_dead = "" //icon when the animal is dead. Don't use animated icons for this.
 	var/icon_gib = null	//We only try to show a gibbing animation if this exists.
@@ -96,8 +99,6 @@
 	if(!loc)
 		stack_trace("Simple animal being instantiated in nullspace")
 
-	// goats bray, cows go moo, and the fox says Geckers
-	grant_language(/datum/language/common)
 
 /mob/living/simple_animal/Login()
 	if(src && src.client)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -18,6 +18,7 @@
 	emote_see = list("jiggles", "bounces in place")
 	speak_emote = list("telepathically chirps")
 	bubble_icon = "slime"
+	initial_languages = list(/datum/language/common, /datum/language/slime)
 
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 
@@ -91,7 +92,6 @@
 		E.Grant(src)
 	create_reagents(100)
 	set_colour(new_colour)
-	grant_language(/datum/language/slime)
 	..()
 
 /mob/living/simple_animal/slime/proc/set_colour(new_colour)

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -60,6 +60,7 @@
 	obj_integrity = 1000
 	max_integrity = 1000
 	verb_say = "chants"
+	initial_languages = list(/datum/language/common)
 	var/obj/machinery/power/emitter/energycannon/magical/our_statue
 	var/list/mob/living/sleepers = list()
 	var/never_spoken = TRUE
@@ -68,7 +69,6 @@
 /obj/structure/table/abductor/wabbajack/Initialize(mapload)
 	. = ..()
 	START_PROCESSING(SSobj, src)
-	grant_language(/datum/language/common)
 
 /obj/structure/table/abductor/wabbajack/Destroy()
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
:cl: coiax
fix: Swarmers now only speak their own language, rather than swarmer and
common.
/:cl:

- Also removes a bunch of unneeded `grant_language` procs in various mob
Initializes, this is now done by the `initial_languages` var.