### PR TITLE
Cerestation Tweaks MKIV

### DIFF
--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -54946,6 +54946,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/yellow/side{
 	tag = "icon-yellow (NORTH)";
 	icon_state = "yellow";
@@ -55707,6 +55712,12 @@
 /area/engine/engine_smes)
 "bSP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -56328,6 +56339,12 @@
 /area/engine/engine_smes)
 "bTQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -56891,6 +56908,11 @@
 /area/atmos)
 "bUR" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/yellow/side{
 	tag = "icon-yellow (SOUTHWEST)";
 	icon_state = "yellow";
@@ -56905,6 +56927,11 @@
 	dir = 1;
 	icon_state = "camera";
 	network = list("SS13","CE")
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -57375,6 +57402,12 @@
 	name = "Central Asteroid Maintenance";
 	req_access_txt = "10"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -57784,6 +57817,12 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -59669,6 +59708,11 @@
 "caf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (NORTHEAST)";
+	icon_state = "intact";
+	dir = 5
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90903,6 +90947,11 @@
 	})
 "dgP" = (
 /obj/item/stack/rods,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -92357,6 +92406,11 @@
 "djR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -95048,6 +95102,1559 @@
 /area/maintenance/starboard{
 	name = "Starboard Asteroid Maintenance"
 	})
+"dpi" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix To Incinerator";
+	on = 0
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpj" = (
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden{
+	tag = "icon-manifold (NORTH)";
+	icon_state = "manifold";
+	dir = 1
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpk" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpl" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpm" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpn" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpo" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpp" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpr" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dps" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpt" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpu" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpv" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpw" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpx" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpy" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpz" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpB" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpD" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpE" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpF" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpH" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpJ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpK" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpL" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (NORTHEAST)";
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpM" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpN" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpP" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (NORTHEAST)";
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpQ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpS" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (NORTHEAST)";
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpT" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpV" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpW" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dpZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqa" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (NORTHEAST)";
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqb" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqc" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqd" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqe" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqf" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqg" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqh" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqi" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dql" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqm" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqp" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqr" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqs" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqt" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqu" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	req_access_txt = "32"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqv" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqw" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqx" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqy" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqz" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance";
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/maintcentral{
+	name = "Central Asteroid Maintenance"
+	})
+"dqJ" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqK" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "input gas connector port"
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqL" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "plasma tank pump"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4;
+	initialize_directions = 11
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqN" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/weapon/extinguisher,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqO" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqP" = (
+/obj/machinery/power/smes{
+	capacity = 9e+006;
+	charge = 10000
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqQ" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqR" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqS" = (
+/obj/machinery/atmospherics/components/unary/tank/toxins{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqT" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "plasma tank pump"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqU" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general{
+	level = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqV" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqX" = (
+/obj/machinery/airalarm{
+	desc = "This particular atmos control unit appears to have no access restrictions.";
+	dir = 8;
+	icon_state = "alarm0";
+	locked = 0;
+	name = "all-access air alarm";
+	pixel_x = 24;
+	req_access = "0";
+	req_one_access = "0"
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	name = "output gas connector port"
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqY" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dqZ" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dra" = (
+/obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Incinerator APC";
+	pixel_x = -23;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drc" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	name = "Mix to Space"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drd" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dre" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drf" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Incinerator to Output";
+	on = 0
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drg" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drh" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dri" = (
+/obj/structure/table,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drj" = (
+/obj/machinery/computer/turbine_computer{
+	id = "incineratorturbine"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drk" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drl" = (
+/obj/machinery/button/door{
+	id = "auxincineratorvent";
+	name = "Auxiliary Vent Control";
+	pixel_x = 6;
+	pixel_y = -24;
+	req_access_txt = "32"
+	},
+/obj/machinery/button/door{
+	id = "turbinevent";
+	name = "Turbine Vent Control";
+	pixel_x = -6;
+	pixel_y = -24;
+	req_access_txt = "32"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/incinerator)
+"drm" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "Incinerator to Space"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/incinerator)
+"drn" = (
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "incinerator_airlock_exterior";
+	idSelf = "incinerator_access_control";
+	idInterior = "incinerator_airlock_interior";
+	name = "Incinerator Access Console";
+	pixel_x = 6;
+	pixel_y = -26;
+	req_access_txt = "12"
+	},
+/obj/machinery/button/ignition{
+	id = "Incinerator";
+	pixel_x = -6;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4;
+	initialize_directions = 11
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/incinerator)
+"dro" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drp" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drq" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drs" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drt" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 2
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dru" = (
+/obj/machinery/door/airlock/glass{
+	autoclose = 0;
+	frequency = 1449;
+	heat_proof = 1;
+	icon_state = "door_locked";
+	id_tag = "incinerator_airlock_interior";
+	locked = 1;
+	name = "Turbine Interior Airlock";
+	req_access_txt = "32"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/maintenance/incinerator)
+"drv" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drw" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drx" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	name = "Incinerator Output Pump";
+	on = 1
+	},
+/turf/open/space,
+/area/maintenance/incinerator)
+"dry" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drz" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	on = 1
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "incinerator_airlock_exterior";
+	idSelf = "incinerator_access_control";
+	layer = 3.1;
+	name = "Incinerator airlock control";
+	pixel_x = 8;
+	pixel_y = -24
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/fire{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/maintenance/incinerator)
+"drA" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/maintenance/incinerator)
+"drB" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	on = 1
+	},
+/obj/structure/sign/fire{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/machinery/doorButtons/access_button{
+	idSelf = "incinerator_access_control";
+	idDoor = "incinerator_airlock_interior";
+	name = "Incinerator airlock control";
+	pixel_x = -8;
+	pixel_y = 24
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/engine,
+/area/maintenance/incinerator)
+"drC" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drD" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/space,
+/area/maintenance/incinerator)
+"drE" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drF" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 2
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drG" = (
+/obj/machinery/door/airlock/glass{
+	autoclose = 0;
+	frequency = 1449;
+	heat_proof = 1;
+	icon_state = "door_locked";
+	id_tag = "incinerator_airlock_exterior";
+	locked = 1;
+	name = "Turbine Exterior Airlock";
+	req_access_txt = "32"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/maintenance/incinerator)
+"drH" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drI" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drJ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/space,
+/area/maintenance/incinerator)
+"drK" = (
+/obj/machinery/door/poddoor{
+	id = "auxincineratorvent";
+	name = "Auxiliary Incinerator Vent"
+	},
+/turf/open/floor/engine/vacuum{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drL" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "inc_in"
+	},
+/turf/open/floor/engine/vacuum{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drM" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/igniter{
+	icon_state = "igniter0";
+	id = "Incinerator";
+	luminosity = 2;
+	on = 0
+	},
+/turf/open/floor/engine/vacuum{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	external_pressure_bound = 0;
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 0;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/turf/open/floor/engine/vacuum{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drO" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/incinerator)
+"drP" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/space,
+/area/maintenance/incinerator)
+"drQ" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/incinerator)
+"drR" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/incinerator)
+"drS" = (
+/obj/machinery/power/compressor{
+	comp_id = "incineratorturbine";
+	dir = 1;
+	luminosity = 2
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/vacuum{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drT" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/incinerator)
+"drU" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/incinerator)
+"drV" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/space,
+/area/maintenance/incinerator)
+"drW" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/incinerator)
+"drX" = (
+/obj/machinery/power/turbine{
+	luminosity = 2
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/engine/vacuum{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"drY" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/incinerator)
+"drZ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/maintenance/incinerator)
+"dsa" = (
+/obj/structure/sign/fire{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/incinerator)
+"dsb" = (
+/obj/machinery/door/poddoor{
+	id = "turbinevent";
+	name = "Turbine Vent"
+	},
+/turf/open/floor/engine/vacuum{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/incinerator)
+"dsc" = (
+/obj/structure/sign/fire{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/incinerator)
 
 (1,1,1) = {"
 aaa
@@ -110765,7 +112372,7 @@ aeY
 afs
 afM
 ags
-doY
+doX
 dpa
 aiJ
 akw
@@ -121654,26 +123261,26 @@ aZt
 bAd
 bAd
 byQ
-byP
-byP
-byP
-byO
-dgD
-bvU
-dht
-cbr
-cbr
-cbr
-dfU
-cbr
-cbr
-dfU
-cbr
-cbr
-cbr
-cbr
-dfU
-dfU
+bEj
+dpl
+dpm
+dpn
+dpo
+dpp
+dpq
+dpr
+dps
+dpt
+dpu
+dpv
+dpw
+dpx
+dpy
+dpz
+dpB
+dpD
+dpF
+dpH
 caf
 bBN
 bBN
@@ -121911,7 +123518,7 @@ aZt
 bBN
 cMH
 bDb
-byP
+bEk
 bGE
 bGE
 bGE
@@ -121931,8 +123538,8 @@ cbr
 djb
 diU
 cbr
-cbr
-cbr
+dpJ
+dpL
 bAd
 aZt
 aZt
@@ -122168,7 +123775,7 @@ aZt
 bBN
 byS
 byQ
-byP
+bEk
 bGE
 bHH
 bHH
@@ -122189,7 +123796,7 @@ bOM
 bOM
 bOM
 dgQ
-djm
+dpM
 byS
 bAd
 bBN
@@ -122425,7 +124032,7 @@ aZt
 bAd
 bAd
 byQ
-byO
+dpk
 bGE
 bHI
 bJv
@@ -122446,8 +124053,8 @@ bYp
 bXG
 bOM
 cbr
-cbr
-cbr
+dpN
+dpP
 cMH
 byS
 cbr
@@ -122682,7 +124289,7 @@ aZH
 bAd
 bAd
 bEi
-byP
+bEk
 bGE
 bHJ
 bHJ
@@ -122704,8 +124311,8 @@ bXG
 bOM
 byS
 dfU
-cbr
-cbr
+dpQ
+dpS
 byS
 cbr
 dgD
@@ -122939,7 +124546,7 @@ aZH
 bAd
 cMH
 byQ
-byP
+bEk
 bGE
 bHK
 bHK
@@ -122962,10 +124569,10 @@ bOM
 bAd
 diS
 djs
-dgD
-bvU
-dht
-cbr
+dpT
+dpW
+dpY
+dqa
 cMH
 cMH
 byS
@@ -123195,8 +124802,8 @@ aZt
 aZH
 bBN
 bCZ
-byP
-byP
+bEj
+bEl
 bGE
 bGE
 bGE
@@ -123222,7 +124829,7 @@ cMH
 byS
 cMH
 dfU
-cbr
+dqb
 byS
 byS
 aZt
@@ -123452,7 +125059,7 @@ aZt
 bAd
 byS
 bAf
-byP
+bEk
 bAd
 bGE
 bHL
@@ -123479,8 +125086,8 @@ cMV
 cbr
 byS
 cbr
-cbr
-djM
+dqc
+djm
 bAd
 aZt
 aZt
@@ -123736,8 +125343,8 @@ cbr
 dgD
 cNc
 dht
-cbr
-djm
+dqd
+djO
 byS
 aZH
 aZt
@@ -123966,7 +125573,7 @@ aZt
 bAd
 bAd
 dgC
-byP
+dpi
 bFq
 bGG
 bHN
@@ -123993,8 +125600,8 @@ cMW
 cbr
 cMH
 bAd
-cbr
-djO
+dqe
+djP
 djl
 aZH
 aZt
@@ -124223,7 +125830,7 @@ bal
 bal
 bal
 bDb
-bEj
+dpj
 bFr
 bGH
 bHO
@@ -124250,12 +125857,12 @@ bOM
 bOM
 bOM
 byS
-cbr
-djP
+dqf
+bAe
 cMH
 aZH
 aZt
-aaa
+abC
 aaa
 aaa
 aaa
@@ -124507,13 +126114,13 @@ cbi
 cbi
 bOM
 dge
-cbr
-bAe
-byS
-aZH
-aZt
-aZt
-aaa
+dqg
+dqr
+dqJ
+dqR
+dqZ
+drh
+drp
 aaa
 aaa
 aaa
@@ -124764,13 +126371,13 @@ cbj
 cbP
 bOM
 dfU
-cbr
-bBN
-bBN
-aZH
-aZt
-aZt
-aaa
+dqh
+dqs
+dqK
+dqS
+dra
+dri
+drq
 aaa
 aaa
 aaa
@@ -125021,19 +126628,19 @@ cbi
 cbi
 bOM
 cbr
-cbr
-bBN
-aZH
-aZH
-aZt
-aZt
-aZt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dqi
+dqt
+dqL
+dqT
+drb
+drj
+drr
+drx
+drD
+drJ
+drP
+drV
+drZ
 aaa
 aaa
 aaa
@@ -125278,19 +126885,19 @@ bOM
 bOM
 bOM
 djb
-cbr
-cMH
-aZH
-aZH
-aZt
-aZt
-aZt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dqj
+dqu
+dqM
+dqU
+drc
+drk
+drs
+dry
+drE
+drK
+drQ
+arw
+arw
 aaa
 aaa
 aaa
@@ -125535,19 +127142,19 @@ cbk
 cbk
 bOM
 cbr
-djm
-cMH
-aZt
-aZt
-aZt
-aZt
-aZt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dqk
+dqv
+dqN
+dqV
+drd
+drl
+drt
+drz
+drF
+drL
+drR
+drW
+dsa
 aaa
 aaa
 aaa
@@ -125792,19 +127399,19 @@ cbl
 cbQ
 bOM
 cbr
-cbr
-bAd
-aZH
-aZt
-aZt
-aZt
-aZt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dql
+dqw
+dqO
+dqW
+dre
+drm
+dru
+drA
+drG
+drM
+drS
+drX
+dsb
 aaa
 aaa
 aaa
@@ -126049,19 +127656,19 @@ cbk
 cbk
 bOM
 cbr
-dfU
-bAd
-aZH
-aZH
-aZt
-aZt
-aZt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dqm
+dqx
+dqP
+dqX
+drf
+drn
+drv
+drB
+drH
+drN
+drT
+drY
+dsc
 aaa
 aaa
 aaa
@@ -126306,19 +127913,19 @@ bOM
 bOM
 bOM
 cbr
-cbr
-byS
-bBN
-aZH
-aZt
-aZt
-aZt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dqn
+dqy
+dqQ
+dqY
+drg
+dro
+drw
+drC
+drI
+drO
+drU
+arw
+arw
 aaa
 aaa
 aaa
@@ -126563,15 +128170,15 @@ cbm
 cbm
 bOM
 djs
-cbr
+dqo
 dgE
 byS
 aZH
 aZt
 aZt
 aZt
-aaa
-aaa
+abC
+abC
 aaa
 aaa
 aaa
@@ -126820,7 +128427,7 @@ cbn
 cbR
 bOM
 djF
-cbr
+dqp
 djR
 cMH
 aZH
@@ -127078,7 +128685,7 @@ cbm
 bOM
 bAd
 dgQ
-bvU
+dqz
 bBN
 aZH
 aZt
@@ -127335,7 +128942,7 @@ bOM
 bOM
 cbr
 diU
-caf
+dqA
 byS
 aZH
 aZt
@@ -127592,7 +129199,7 @@ cbo
 bOM
 djG
 bAd
-cbr
+dqB
 bBN
 aZH
 aZt
@@ -127849,27 +129456,27 @@ cbS
 bOM
 bAd
 byS
-cbr
+dqC
 byS
 aZH
 aZH
 aZH
 aZt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -128106,27 +129713,27 @@ cbo
 bOM
 bAd
 cMH
-cbr
+dqD
 byS
 aZH
 aZH
 aZH
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -128363,27 +129970,27 @@ bOM
 bOM
 bAd
 bAd
-cbr
+dqE
 bBN
 aZH
 aZH
 aZH
 aaa
-aaa
-aaa
 cKF
 cKF
 cKF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -128620,27 +130227,27 @@ byS
 bAd
 byS
 cbr
-cbr
+dqF
 bBN
 aZH
 aZH
 aZH
 aaa
-aaa
-aaa
 cKF
 cKF
 cKF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -128877,27 +130484,27 @@ djv
 byS
 bPt
 byP
-cbr
+dqG
 djk
 aZH
 aZt
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa
@@ -129122,19 +130729,19 @@ bTP
 bUR
 bVQ
 bWD
-cbr
-cbr
-cbr
-cbr
-cbr
-cMV
-cbr
-cbr
-cbr
+dpA
+dpC
+dpE
+dpG
+dpI
+dpK
+dpO
+dpR
+dpU
 djw
 byP
 byP
-cbr
+dqH
 cMH
 aZH
 aZt
@@ -129144,17 +130751,17 @@ cKF
 cKF
 cKF
 cKF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aac
 aad
@@ -129387,11 +130994,11 @@ bAe
 djk
 cbr
 byP
-byP
-byP
-byP
-byP
-byP
+dpV
+dpX
+dpZ
+dqq
+dqI
 byS
 aZH
 aaa
@@ -129401,17 +131008,17 @@ cKF
 cKF
 cKF
 cKF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aab
 aad
 aad
@@ -129658,17 +131265,17 @@ cKF
 cKF
 cKF
 cKF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
 aab
 aab
 aad
@@ -129915,17 +131522,17 @@ cKF
 cKF
 cKF
 cKF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aaa
-aad
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+cKF
+aab
 aab
 aad
 aac
@@ -130181,7 +131788,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aab
 aab
 aab
 aad

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -4425,39 +4425,28 @@
 	},
 /area/security/prison)
 "aiI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Armory Desk";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/window/brigdoor/southleft{
+	name = "Armory Desk";
+	req_one_access_txt = "38;2"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/prison)
+/area/ai_monitored/security/armory)
 "aiJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/door/poddoor/shutters{
+	id = "armoryaccess";
+	name = "Armory Shutters"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/prison)
+/area/ai_monitored/security/armory)
 "aiK" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Armory";
@@ -4891,11 +4880,6 @@
 "ajD" = (
 /obj/structure/cable/orange{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
@@ -5316,7 +5300,6 @@
 	},
 /area/security/prison)
 "akv" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -5465,7 +5448,7 @@
 	})
 "akL" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment{
@@ -5534,7 +5517,7 @@
 	})
 "akP" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment{
@@ -6692,7 +6675,7 @@
 "amY" = (
 /obj/machinery/power/apc{
 	dir = 2;
-	name = "AI Asteroid APC";
+	name = "AI Asteroid Maintenance APC";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -9298,8 +9281,6 @@
 	},
 /area/security/warden)
 "asa" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -9318,6 +9299,15 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "prisonbreak";
 	name = "emergency prisoner containment blast door"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "Secure Desk";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/window/eastleft{
+	name = "Secure Desk";
+	req_one_access_txt = "38;2"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -11808,7 +11798,16 @@
 	name = "Chief Medical Officer's Private Quarters"
 	})
 "awH" = (
-/obj/structure/closet/secure_closet/CMO,
+/obj/structure/closet{
+	icon_door = "blue";
+	name = "Chief Medical Officer's Uniform"
+	},
+/obj/item/clothing/shoes/sneakers/brown/cmo,
+/obj/item/clothing/under/rank/chief_medical_officer,
+/obj/item/clothing/suit/toggle/labcoat/cmo,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/storage/backpack/medic,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -11953,7 +11952,14 @@
 	name = "Chief Engineer's Private Quarters"
 	})
 "awX" = (
-/obj/structure/closet/secure_closet/engineering_chief,
+/obj/structure/closet{
+	icon_door = "yellow";
+	name = "Chief Engineer's Uniform"
+	},
+/obj/item/clothing/shoes/sneakers/brown/ce,
+/obj/item/clothing/under/rank/chief_engineer,
+/obj/item/weapon/storage/backpack/industrial,
+/obj/item/clothing/gloves/color/black/ce,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -15146,7 +15152,16 @@
 	name = "Research Director's Private Quarters"
 	})
 "aCS" = (
-/obj/structure/closet/secure_closet/RD,
+/obj/structure/closet{
+	icon_door = "pink";
+	name = "Research Director's Uniform"
+	},
+/obj/item/clothing/shoes/sneakers/brown/rd,
+/obj/item/clothing/under/rank/research_director,
+/obj/item/clothing/under/rank/research_director/turtleneck,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/suit/toggle/labcoat,
+/obj/item/weapon/storage/backpack/science,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -18324,7 +18339,14 @@
 	name = "Quartermaster's Private Quarters"
 	})
 "aId" = (
-/obj/structure/closet/secure_closet/quartermaster,
+/obj/structure/closet{
+	icon_door = "orange";
+	name = "Quartermaster's Uniform"
+	},
+/obj/item/clothing/shoes/sneakers/brown/qm,
+/obj/item/clothing/under/rank/cargo,
+/obj/item/weapon/storage/backpack,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -22442,7 +22464,7 @@
 /area/hallway/primary/fore)
 "aPk" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -22582,7 +22604,7 @@
 	})
 "aPv" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/structure/cable/orange{
@@ -22598,7 +22620,7 @@
 	})
 "aPw" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating{
@@ -25230,7 +25252,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	id_tag = "GulagCivExit3";
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating{
@@ -25391,7 +25413,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25402,7 +25424,7 @@
 "aTB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /turf/open/floor/plasteel{
@@ -27746,7 +27768,7 @@
 /area/hallway/primary/fore)
 "aXx" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/structure/cable{
@@ -31061,7 +31083,7 @@
 /area/hallway/primary/central)
 "bdv" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/structure/cable{
@@ -31118,7 +31140,7 @@
 /area/hallway/primary/central)
 "bdz" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32016,7 +32038,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32246,7 +32268,7 @@
 /area/hallway/primary/port)
 "bfv" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/structure/cable{
@@ -33117,7 +33139,7 @@
 /area/hallway/primary/starboard)
 "bgY" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36659,7 +36681,7 @@
 	pixel_x = 0
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36824,7 +36846,7 @@
 	pixel_x = 0
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37001,7 +37023,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating{
@@ -41853,7 +41875,7 @@
 /area/space)
 "bvx" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45583,7 +45605,7 @@
 	})
 "bBO" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating{
@@ -52668,16 +52690,20 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "bNV" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "bNW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -52911,7 +52937,7 @@
 	})
 "bOq" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment{
@@ -53628,7 +53654,7 @@
 /area/hallway/primary/starboard)
 "bPv" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53682,7 +53708,7 @@
 /area/hallway/primary/starboard)
 "bPz" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -53700,7 +53726,9 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "bPA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -53719,7 +53747,9 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "bPB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53738,7 +53768,9 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "bPD" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "External Maintenance Access";
@@ -55166,14 +55198,18 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "bRS" = (
 /obj/structure/table,
 /obj/structure/table,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "bRT" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -55617,6 +55653,7 @@
 /obj/machinery/keycard_auth{
 	pixel_y = -28
 	},
+/obj/structure/closet/secure_closet/engineering_chief,
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -56447,7 +56484,9 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "bUe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -56990,7 +57029,9 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 "bVf" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -61449,7 +61490,7 @@
 /area/hallway/primary/port)
 "cdJ" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63428,7 +63469,7 @@
 /area/hallway/primary/starboard)
 "chv" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/structure/cable{
@@ -67090,7 +67131,7 @@
 /area/hallway/primary/aft)
 "cob" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "External Maintenance Access";
+	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -77659,6 +77700,7 @@
 	dir = 10
 	},
 /obj/machinery/light,
+/obj/effect/landmark/xmastree/rdrod,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/hor)
 "cFl" = (
@@ -90004,6 +90046,14 @@
 /area/hallway/primary/starboard)
 "dfg" = (
 /obj/machinery/computer/card/minor/cmo,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer RC";
+	pixel_x = -30;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/barber{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -93876,7 +93926,6 @@
 	},
 /area/crew_quarters/hor)
 "dmN" = (
-/obj/effect/landmark/xmastree/rdrod,
 /obj/machinery/airalarm{
 	dir = 4;
 	icon_state = "alarm0";
@@ -93885,6 +93934,7 @@
 /obj/machinery/keycard_auth{
 	pixel_y = -28
 	},
+/obj/structure/closet/secure_closet/RD,
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -94882,6 +94932,122 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/assembly/robotics)
+"doV" = (
+/obj/machinery/ai_status_display,
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/ai_monitored/security/armory)
+"doW" = (
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/ai_monitored/security/armory)
+"doX" = (
+/turf/open/floor/plasteel/darkred{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/ai_monitored/security/armory)
+"doY" = (
+/turf/open/floor/plasteel/darkred{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/ai_monitored/security/armory)
+"doZ" = (
+/obj/machinery/button/door{
+	id = "armoryaccess";
+	name = "Armory Shutter Access";
+	pixel_x = -28
+	},
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/darkred{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/ai_monitored/security/armory)
+"dpa" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/ai_monitored/security/armory)
+"dpb" = (
+/obj/structure/closet/secure_closet/CMO,
+/turf/open/floor/plasteel/barber{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/medical/cmo)
+"dpc" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dpd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dpe" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dpf" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dpg" = (
+/obj/structure/table,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dph" = (
+/obj/machinery/door/airlock/glass_external{
+	cyclelinkeddir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
 
 (1,1,1) = {"
 aaa
@@ -100104,10 +100270,10 @@ aab
 aab
 dnS
 dnZ
-dog
-don
+dnN
+dnS
 dou
-doB
+dnN
 aac
 aac
 aac
@@ -100359,13 +100525,13 @@ aaa
 aab
 aad
 dnM
-dnT
+dnS
 doa
-doh
-doo
+dnP
+doa
 dov
-doC
-doI
+dnN
+dnN
 aac
 aac
 aad
@@ -100616,13 +100782,13 @@ aad
 aad
 aad
 dnN
-dnU
-dob
-doi
+dnS
+dnZ
+dnV
 dop
-dow
+doa
 doD
-doJ
+dnS
 aac
 aac
 aad
@@ -100872,14 +101038,14 @@ aac
 aac
 aad
 aad
-dnO
+dnM
 dnV
-doc
+dnP
 doj
-doq
+dnV
 dox
 doE
-doK
+dnS
 aac
 aad
 aad
@@ -101130,13 +101296,13 @@ aac
 aad
 aad
 dnP
-dnW
-dod
-dok
-dor
+dnV
+dnV
+dnP
+doa
 doy
 doF
-doL
+dnP
 aac
 aad
 aab
@@ -101386,14 +101552,14 @@ aaa
 aad
 aac
 aac
-dnQ
+dnN
 dnX
-doe
-dol
+dnV
+dnV
 dos
 doz
 doG
-doM
+dnN
 aac
 aad
 aab
@@ -101643,14 +101809,14 @@ aaa
 aad
 aac
 aac
-dnR
-dnY
-dof
-dom
-dot
-doA
-doH
-doN
+dnN
+dnN
+dnM
+dnS
+dnS
+dnM
+dnN
+dnS
 aad
 aad
 aab
@@ -107838,10 +108004,10 @@ aYP
 aYT
 aYT
 aYT
-aZm
-aZm
+aZY
+aZY
 bdQ
-aZm
+aZY
 dch
 bgu
 bgu
@@ -110084,7 +110250,7 @@ acO
 acO
 acO
 acO
-acO
+doW
 acO
 acO
 afr
@@ -110342,10 +110508,10 @@ aeB
 aeB
 aeB
 agr
-acO
-aia
+doX
+doZ
 aiI
-ajB
+akw
 akv
 ajB
 afr
@@ -110599,12 +110765,12 @@ aeY
 afs
 afM
 ags
-ahn
-aib
+doY
+dpa
 aiJ
-ajC
 akw
 akw
+ajB
 afr
 ams
 anr
@@ -111897,7 +112063,7 @@ cJv
 aog
 aqf
 arc
-arW
+arX
 asU
 aub
 aog
@@ -112391,7 +112557,7 @@ abW
 abW
 acO
 acO
-acO
+doV
 acO
 acO
 acO
@@ -113522,7 +113688,7 @@ bvm
 bCR
 doR
 bFj
-doT
+doR
 bBL
 bJq
 bKT
@@ -142568,11 +142734,11 @@ bIu
 bKa
 bLC
 bEK
-bNT
+dpc
 bPA
-bex
+dpd
 bRR
-bbR
+dph
 bUd
 bVe
 bVV
@@ -142825,13 +142991,13 @@ bIv
 bHh
 bLD
 bEK
-bey
-bPB
-bey
-bdG
-baS
-baS
-baS
+dhy
+bIO
+dhy
+dpf
+bgs
+bgs
+bgs
 aaa
 aaa
 aaa
@@ -143082,11 +143248,11 @@ bIw
 bHh
 bLE
 bEK
-bey
-bPB
-bey
-ber
-baS
+dhy
+bIO
+dhy
+dpg
+bgs
 bbo
 bbo
 aaa
@@ -143341,9 +143507,9 @@ bLF
 bEK
 bNU
 bPC
-bQL
+dpe
 bRS
-baS
+bgs
 bbo
 bbo
 bbo
@@ -143597,10 +143763,10 @@ bKb
 bLG
 bEK
 bNV
-bPD
-baS
-baS
-baS
+bOq
+bgs
+bgs
+bgs
 bbo
 bbo
 bbo
@@ -144603,7 +144769,7 @@ bja
 bjS
 deo
 blC
-deY
+dpb
 bnC
 deY
 dfC

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -1862,7 +1862,7 @@
 	c_tag = "AI Hallway";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/circuit{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -3630,6 +3630,11 @@
 	network = list("SS13")
 	},
 /obj/item/device/radio/beacon,
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -4278,6 +4283,11 @@
 "aiv" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light,
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -5145,9 +5155,7 @@
 /obj/structure/disposaloutlet{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating/airless,
 /area/quartermaster/sorting)
 "akd" = (
@@ -5603,10 +5611,6 @@
 	},
 /area/quartermaster/sorting)
 "akW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/mineral/stacking_unit_console{
 	dir = 2;
 	machinedir = 8
@@ -6486,7 +6490,7 @@
 	dir = 9;
 	icon_state = "camera";
 	network = list("SS13");
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /obj/item/weapon/bedsheet,
 /turf/open/floor/plasteel/floorgrime{
@@ -7154,8 +7158,8 @@
 /area/space)
 "anT" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 8
+	icon_state = "pipe-j1";
+	dir = 1
 	},
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -12310,7 +12314,7 @@
 	pixel_x = 0
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/computer/robotics,
+/obj/machinery/computer/cargo/request,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -12747,7 +12751,7 @@
 	dir = 9;
 	icon_state = "camera";
 	network = list("SS13");
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /obj/item/weapon/bedsheet,
 /turf/open/floor/plasteel/floorgrime{
@@ -16027,7 +16031,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("SS13","QM");
-	tag = "icon-camera (WEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -19700,7 +19704,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("SS13","QM");
-	tag = "icon-camera (WEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/red/side{
 	icon_state = "red";
@@ -20686,7 +20690,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("SS13","QM");
-	tag = "icon-camera (WEST)"
+	tag = ""
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -21048,7 +21052,7 @@
 	c_tag = "Courtroom Jury East";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/vault{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -21108,7 +21112,7 @@
 	c_tag = "Dorm Lockers";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -22638,7 +22642,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("SS13","QM");
-	tag = "icon-camera (WEST)"
+	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/brown/corner{
@@ -25839,7 +25843,7 @@
 	c_tag = "Vault Airlock";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/black,
@@ -26354,7 +26358,7 @@
 	c_tag = "Command Atmospherics Checkpoint";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -26416,7 +26420,7 @@
 	c_tag = "Cargo Atmospherics Checkpoint";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -26774,7 +26778,7 @@
 	c_tag = "Custodials";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /obj/item/key/janitor,
 /turf/open/floor/plasteel{
@@ -26909,7 +26913,7 @@
 	c_tag = "Command Asteroid Hall 10";
 	dir = 8;
 	icon_state = "camera";
-	tag = "icon-camera (WEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -27884,7 +27888,7 @@
 	c_tag = "Vault";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
@@ -30632,7 +30636,7 @@
 	c_tag = "Bar Backroom";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/wood{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -31688,7 +31692,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("SS13","QM");
-	tag = "icon-camera (WEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	tag = "icon-neutralcorner (EAST)";
@@ -34131,7 +34135,7 @@
 	c_tag = "Bar";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
@@ -34414,7 +34418,7 @@
 	c_tag = "EVA Storage";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/blue/side{
 	tag = "icon-blue (EAST)";
@@ -35178,7 +35182,7 @@
 	c_tag = "Service Atmospherics Checkpoint";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -37181,7 +37185,7 @@
 	c_tag = "Surgery Observation";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -37607,7 +37611,7 @@
 	c_tag = "Engineering Asteroid Hallway 2";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	tag = "icon-neutralcorner (EAST)";
@@ -38183,7 +38187,7 @@
 	dir = 5;
 	icon_state = "camera";
 	network = list("SS13","CMO");
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -38259,7 +38263,7 @@
 	c_tag = "Primary Tool Storage North";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -39515,7 +39519,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("SS13","QM");
-	tag = "icon-camera (WEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -39849,7 +39853,7 @@
 	dir = 5;
 	icon_state = "camera";
 	network = list("SS13","CMO");
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /obj/machinery/requests_console{
 	department = "Virology";
@@ -41591,7 +41595,7 @@
 	dir = 5;
 	icon_state = "camera";
 	network = list("SS13","CMO");
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	tag = "icon-whitegreen (WEST)";
@@ -42133,7 +42137,7 @@
 	dir = 9;
 	icon_state = "camera";
 	network = list("SS13","CE");
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -44021,7 +44025,7 @@
 	c_tag = "Medbay Atmospherics Checkpoint";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -44136,7 +44140,7 @@
 	c_tag = "Medbay East";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /obj/structure/noticeboard{
 	dir = 8;
@@ -44188,7 +44192,7 @@
 	c_tag = "Cyrotubes";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -44975,7 +44979,7 @@
 	c_tag = "Primary Tool Storage South";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/vault{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -45581,7 +45585,7 @@
 	c_tag = "Hydroponics Backroom";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -47161,7 +47165,7 @@
 	c_tag = "Hydroponics East";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /obj/structure/sink{
 	dir = 4;
@@ -47486,7 +47490,7 @@
 	c_tag = "Engineering Security Checkpoint";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -48155,7 +48159,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("SS13","QM");
-	tag = "icon-camera (WEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -52097,7 +52101,7 @@
 	dir = 9;
 	icon_state = "camera";
 	network = list("SS13","CE");
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/yellow/side{
 	tag = "icon-yellow (EAST)";
@@ -52523,7 +52527,7 @@
 	dir = 9;
 	icon_state = "camera";
 	network = list("SS13","CE");
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -53269,7 +53273,7 @@
 	dir = 5;
 	icon_state = "camera";
 	network = list("SS13","CE");
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -53933,7 +53937,7 @@
 	dir = 10;
 	icon_state = "camera";
 	network = list("SS13","CMO");
-	tag = "icon-camera (SOUTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -54175,7 +54179,7 @@
 	c_tag = "Library East";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/wood{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -54318,7 +54322,7 @@
 	},
 /obj/machinery/button/door{
 	id = "engineeringlockdown";
-	name = "Engineering SMES Blast Door Control";
+	name = "Engineering Emergency Lockdown Control";
 	pixel_x = -24;
 	pixel_y = 8;
 	req_access_txt = "10;11"
@@ -56202,7 +56206,7 @@
 	dir = 5;
 	icon_state = "camera";
 	network = list("SS13","CE");
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -57030,7 +57034,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("SS13","QM");
-	tag = "icon-camera (WEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -57628,7 +57632,7 @@
 	c_tag = "Library Explicits";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/grimy{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -58074,7 +58078,7 @@
 	dir = 9;
 	icon_state = "camera";
 	network = list("SS13","CE");
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -59355,7 +59359,7 @@
 	c_tag = "Chapel West";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/chapel{
 	tag = "icon-chapel (NORTH)";
@@ -59877,7 +59881,7 @@
 	c_tag = "Chapel East";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/grimy{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -61346,7 +61350,7 @@
 	c_tag = "Chapel Office";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/grimy{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -61759,7 +61763,7 @@
 	c_tag = "Chapel Coffins";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -62415,7 +62419,7 @@
 	c_tag = "Crematorium";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -63045,7 +63049,7 @@
 	c_tag = "Docking Atmospherics Checkpoint";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -63245,7 +63249,7 @@
 	c_tag = "Service-Research Bridge";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine{
@@ -65728,7 +65732,7 @@
 	c_tag = "Research Asteroid Hallway 1";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	tag = "icon-neutralcorner (NORTH)";
@@ -66358,7 +66362,7 @@
 	c_tag = "Research Atmospherics Checkpoint";
 	dir = 5;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHEAST)"
+	tag = ""
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -67539,7 +67543,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("SS13","QM");
-	tag = "icon-camera (WEST)"
+	tag = ""
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -71759,7 +71763,7 @@
 	dir = 8;
 	icon_state = "camera";
 	network = list("SS13","QM");
-	tag = "icon-camera (WEST)"
+	tag = ""
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -73312,7 +73316,7 @@
 	dir = 9;
 	icon_state = "camera";
 	network = list("SS13","RD");
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	tag = "icon-whitepurple (EAST)";
@@ -75081,7 +75085,7 @@
 	c_tag = "Docking Asteroid Hall 13";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -75151,7 +75155,7 @@
 	c_tag = "Docking Asteroid Hall 9";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -75889,7 +75893,7 @@
 	dir = 9;
 	icon_state = "camera";
 	network = list("SS13","RD");
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -77743,7 +77747,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -23
 	},
-/obj/item/weapon/twohanded/required/kirbyplants/dead,
+/obj/machinery/computer/robotics,
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -78187,7 +78191,7 @@
 	c_tag = "Docking Asteroid Hall 12";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -78230,7 +78234,7 @@
 	c_tag = "Docking Asteroid Hall 8";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -78310,7 +78314,7 @@
 	dir = 9;
 	icon_state = "camera";
 	network = list("SS13","RD");
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -78591,7 +78595,7 @@
 	dir = 9;
 	icon_state = "camera";
 	network = list("SS13","RD");
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -85929,7 +85933,7 @@
 	c_tag = "Genetics Monkey Dome";
 	dir = 9;
 	icon_state = "camera";
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/grass{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -93606,7 +93610,7 @@
 	dir = 9;
 	icon_state = "camera";
 	network = list("SS13","RD");
-	tag = "icon-camera (NORTHWEST)"
+	tag = ""
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -94367,6 +94371,135 @@
 /area/maintenance/aft{
 	name = "Aft Asteroid Maintenance"
 	})
+"dnz" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/circuit{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/ai_monitored/turret_protected/ai)
+"dnA" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dnB" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dnC" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"dnD" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/airless/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/mine/unexplored{
+	name = "Cargo Asteroid"
+	})
+"dnE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/sorting)
+"dnF" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/door/window/eastright{
+	name = "Mail Chute";
+	req_access_txt = "31"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/quartermaster/sorting)
+"dnG" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/airless/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/mine/unexplored{
+	name = "Cargo Asteroid"
+	})
+"dnH" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/airless/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/mine/unexplored{
+	name = "Cargo Asteroid"
+	})
+"dnI" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/airless/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/mine/unexplored{
+	name = "Cargo Asteroid"
+	})
+"dnJ" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dnK" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/astplate{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/maintenance/starboard{
+	name = "Starboard Asteroid Maintenance"
+	})
+"dnL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/weapon/twohanded/required/kirbyplants/dead,
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/hor)
 
 (1,1,1) = {"
 aaa
@@ -110512,7 +110645,7 @@ czu
 cAn
 cBj
 cBY
-cCP
+dnL
 cCP
 dmB
 cES
@@ -136544,7 +136677,7 @@ aca
 aax
 acv
 aax
-aaw
+dnz
 aal
 adh
 adx
@@ -142984,9 +143117,9 @@ aaa
 aaa
 ajj
 akc
+anQ
+dnE
 ajn
-alx
-alx
 aez
 afS
 afV
@@ -143240,9 +143373,9 @@ aaa
 aaa
 aaa
 ajk
+alE
 akd
-ajn
-ajn
+dnF
 ajn
 ajn
 aUW
@@ -145554,7 +145687,7 @@ aaa
 aaa
 ajn
 akj
-ajl
+ajn
 alD
 aml
 anj
@@ -145811,12 +145944,12 @@ aaa
 aaa
 aaa
 aaa
-ajm
-alE
-alE
-alE
-anQ
-aoX
+ajn
+ajn
+ajn
+ajn
+ajn
+aoU
 aoU
 aoY
 arI
@@ -146072,7 +146205,7 @@ aaa
 akR
 akR
 akR
-anR
+anV
 aoY
 aoY
 aoY
@@ -146329,7 +146462,7 @@ aaa
 aaa
 aaa
 abC
-anS
+arw
 aoZ
 aoZ
 aoZ
@@ -146586,7 +146719,7 @@ aaa
 aaa
 aaa
 abC
-anS
+arw
 aoZ
 apR
 apR
@@ -146843,7 +146976,7 @@ aaa
 aaa
 aaa
 abC
-anS
+arw
 aoZ
 apR
 apR
@@ -147100,7 +147233,7 @@ aaa
 aaa
 aaa
 abC
-anS
+arw
 aoZ
 apR
 apR
@@ -147357,7 +147490,7 @@ aaa
 aaa
 aaa
 abC
-anS
+arw
 aoZ
 apR
 apR
@@ -147614,7 +147747,7 @@ aaa
 aaa
 aaa
 abC
-anS
+arw
 aoZ
 apR
 apR
@@ -147871,7 +148004,7 @@ aaa
 aaa
 aaa
 abC
-anS
+arw
 aoZ
 aoZ
 aoZ
@@ -148123,12 +148256,12 @@ aaa
 aaa
 aaa
 aaa
+dnA
 aaa
-aaa
 akR
 akR
 akR
-anR
+anV
 aoY
 aoY
 aoY
@@ -148380,11 +148513,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-akR
-akR
-akR
-alx
+dnB
+dnD
+dnG
+dnH
+dnI
 anT
 aoX
 aoU
@@ -148637,10 +148770,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
+dnC
 akR
-alx
-alx
+akR
+akR
 alx
 anU
 apa
@@ -148896,7 +149029,7 @@ aaa
 aaa
 aaa
 akR
-alx
+akR
 alx
 alx
 anV
@@ -153858,9 +153991,9 @@ bjZ
 bjZ
 bjZ
 bqA
+dnJ
 bjZ
-bjZ
-bjZ
+dnK
 bjZ
 byf
 bjZ
@@ -154113,12 +154246,12 @@ bgs
 deO
 bhd
 bhd
-bhd
-bqC
-blS
-dfM
-bva
-bhd
+dfA
+dfI
+bgs
+btp
+bgs
+bgs
 bhd
 bhd
 blS
@@ -154370,11 +154503,11 @@ bgq
 bgr
 bgq
 bgq
-dfA
-dfI
-bgs
-btp
-bgs
+bpu
+bqD
+brZ
+btq
+bvb
 bgr
 bgq
 bgq
@@ -154627,11 +154760,11 @@ bbo
 bbq
 bbq
 bgp
-bpu
-bqD
-brZ
-btq
-bvb
+dfB
+bgr
+bgs
+btr
+bgs
 bgr
 bgp
 bbq
@@ -154884,11 +155017,11 @@ bbo
 bbq
 bbq
 bbq
-dfB
-bgr
+bpv
 bgs
-btr
-bgs
+bsa
+bts
+bsa
 bww
 bbq
 bbq
@@ -155141,11 +155274,11 @@ aaa
 bbo
 bbo
 bbo
-bpv
+bpw
 bgs
-bsa
-bts
-bsa
+bsb
+btt
+bsb
 bgs
 bbq
 bbo
@@ -155398,10 +155531,10 @@ aaa
 aaa
 aaa
 bbo
-bpw
+aaa
 bgs
 bsb
-btt
+btu
 bsb
 bgs
 bbq
@@ -155658,7 +155791,7 @@ aaa
 aaa
 bgs
 bsb
-btu
+btv
 bsb
 bgs
 aaa
@@ -155914,9 +156047,9 @@ aaa
 aaa
 aaa
 aaa
-bsb
-btv
-bsb
+aaa
+btw
+aaa
 aaa
 aaa
 aaa
@@ -156169,11 +156302,11 @@ cKF
 cKF
 aaa
 aaa
-aaa
-aaa
-aaa
-btw
-aaa
+cKF
+cKF
+cKF
+cKF
+cKF
 aaa
 aaa
 aaa

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -16030,8 +16030,7 @@
 	c_tag = "Cargo Hall East";
 	dir = 8;
 	icon_state = "camera";
-	network = list("SS13","QM");
-	tag = ""
+	network = list("SS13","QM")
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -19703,8 +19702,7 @@
 	c_tag = "Cargo Security Checkpoint";
 	dir = 8;
 	icon_state = "camera";
-	network = list("SS13","QM");
-	tag = ""
+	network = list("SS13","QM")
 	},
 /turf/open/floor/plasteel/red/side{
 	icon_state = "red";
@@ -20689,8 +20687,7 @@
 	c_tag = "Docking Quantum Pad";
 	dir = 8;
 	icon_state = "camera";
-	network = list("SS13","QM");
-	tag = ""
+	network = list("SS13","QM")
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -21051,8 +21048,7 @@
 /obj/machinery/camera{
 	c_tag = "Courtroom Jury East";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/vault{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -21111,8 +21107,7 @@
 /obj/machinery/camera{
 	c_tag = "Dorm Lockers";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -22641,8 +22636,7 @@
 	c_tag = "Cargo Lobby";
 	dir = 8;
 	icon_state = "camera";
-	network = list("SS13","QM");
-	tag = ""
+	network = list("SS13","QM")
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/brown/corner{
@@ -23585,8 +23579,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -24113,8 +24106,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -25566,8 +25558,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -25842,8 +25833,7 @@
 /obj/machinery/camera{
 	c_tag = "Vault Airlock";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/black,
@@ -26357,8 +26347,7 @@
 /obj/machinery/camera{
 	c_tag = "Command Atmospherics Checkpoint";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -26419,8 +26408,7 @@
 /obj/machinery/camera{
 	c_tag = "Cargo Atmospherics Checkpoint";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -26777,8 +26765,7 @@
 /obj/machinery/camera{
 	c_tag = "Custodials";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /obj/item/key/janitor,
 /turf/open/floor/plasteel{
@@ -26912,8 +26899,7 @@
 /obj/machinery/camera{
 	c_tag = "Command Asteroid Hall 10";
 	dir = 8;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -27010,8 +26996,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -27798,8 +27783,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -27840,8 +27824,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/girder,
 /obj/structure/grille,
@@ -27887,8 +27870,7 @@
 /obj/machinery/camera{
 	c_tag = "Vault";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
@@ -28390,8 +28372,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -28407,8 +28388,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -29158,8 +29138,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -29532,8 +29511,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -30069,8 +30047,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -30190,8 +30167,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -30635,8 +30611,7 @@
 /obj/machinery/camera{
 	c_tag = "Bar Backroom";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/wood{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -31181,8 +31156,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -31691,8 +31665,7 @@
 	c_tag = "Medbay Asteroid Hallway 6";
 	dir = 8;
 	icon_state = "camera";
-	network = list("SS13","QM");
-	tag = ""
+	network = list("SS13","QM")
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	tag = "icon-neutralcorner (EAST)";
@@ -31718,8 +31691,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -33025,8 +32997,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -33842,8 +33813,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34134,8 +34104,7 @@
 /obj/machinery/camera{
 	c_tag = "Bar";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
@@ -34417,8 +34386,7 @@
 /obj/machinery/camera{
 	c_tag = "EVA Storage";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/blue/side{
 	tag = "icon-blue (EAST)";
@@ -34457,8 +34425,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -34653,11 +34620,6 @@
 /area/crew_quarters/bar)
 "bjs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/button/door{
-	id = "kitchen";
-	name = "Privacy Shutters";
-	pixel_x = -24
-	},
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -35181,8 +35143,7 @@
 /obj/machinery/camera{
 	c_tag = "Service Atmospherics Checkpoint";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -36317,9 +36278,6 @@
 	},
 /area/engine/supermatter)
 "bmt" = (
-/obj/machinery/power/emitter{
-	state = 2
-	},
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1;
@@ -36329,6 +36287,10 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -36346,9 +36308,6 @@
 	},
 /area/engine/supermatter)
 "bmv" = (
-/obj/machinery/power/emitter{
-	state = 2
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -36359,17 +36318,22 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/engine/supermatter)
 "bmw" = (
-/obj/machinery/power/emitter{
-	state = 2
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -36728,8 +36692,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -36948,8 +36911,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -37077,8 +37039,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37095,8 +37056,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -37184,8 +37144,7 @@
 /obj/machinery/camera{
 	c_tag = "Surgery Observation";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -37361,16 +37320,16 @@
 /area/crew_quarters/bar)
 "boe" = (
 /obj/machinery/vending/cola,
-/obj/structure/sign/poster/random{
-	name = "random official poster";
-	pixel_x = 32;
-	random_basetype = /obj/structure/sign/poster/official
-	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 0;
 	pixel_y = -28
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -37380,6 +37339,11 @@
 /obj/machinery/food_cart,
 /obj/machinery/light_switch{
 	pixel_x = -25
+	},
+/obj/machinery/button/door{
+	id = "kitchen";
+	name = "Privacy Shutters";
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -37500,8 +37464,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -37610,8 +37573,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Asteroid Hallway 2";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	tag = "icon-neutralcorner (EAST)";
@@ -37781,8 +37743,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -38186,8 +38147,7 @@
 	c_tag = "Virology Breakroom";
 	dir = 5;
 	icon_state = "camera";
-	network = list("SS13","CMO");
-	tag = ""
+	network = list("SS13","CMO")
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -38262,8 +38222,7 @@
 /obj/machinery/camera{
 	c_tag = "Primary Tool Storage North";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -39518,8 +39477,7 @@
 	c_tag = "Medbay Asteroid Hallway 3";
 	dir = 8;
 	icon_state = "camera";
-	network = list("SS13","QM");
-	tag = ""
+	network = list("SS13","QM")
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -39827,8 +39785,7 @@
 	c_tag = "Virology 2";
 	dir = 5;
 	icon_state = "camera";
-	network = list("SS13","CMO");
-	tag = ""
+	network = list("SS13","CMO")
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -39852,8 +39809,7 @@
 	c_tag = "Virology";
 	dir = 5;
 	icon_state = "camera";
-	network = list("SS13","CMO");
-	tag = ""
+	network = list("SS13","CMO")
 	},
 /obj/machinery/requests_console{
 	department = "Virology";
@@ -41322,8 +41278,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -41594,8 +41549,7 @@
 	c_tag = "Virology Airlocks";
 	dir = 5;
 	icon_state = "camera";
-	network = list("SS13","CMO");
-	tag = ""
+	network = list("SS13","CMO")
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	tag = "icon-whitegreen (WEST)";
@@ -42136,8 +42090,7 @@
 	c_tag = "SM East";
 	dir = 9;
 	icon_state = "camera";
-	network = list("SS13","CE");
-	tag = ""
+	network = list("SS13","CE")
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -43494,8 +43447,7 @@
 "bxY" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell{
 	dir = 8;
-	icon_state = "cell-off";
-	tag = ""
+	icon_state = "cell-off"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -44024,8 +43976,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Atmospherics Checkpoint";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -44139,8 +44090,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay East";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /obj/structure/noticeboard{
 	dir = 8;
@@ -44191,8 +44141,7 @@
 /obj/machinery/camera{
 	c_tag = "Cyrotubes";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -44552,8 +44501,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -44729,8 +44677,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	tag = "icon-yellowcorner (NORTH)";
@@ -44978,8 +44925,7 @@
 /obj/machinery/camera{
 	c_tag = "Primary Tool Storage South";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/vault{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -45033,6 +44979,11 @@
 /area/hydroponics)
 "bAG" = (
 /obj/machinery/vending/hydronutrients,
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 0;
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel/green/side{
 	tag = "icon-green (NORTH)";
 	icon_state = "green";
@@ -45436,8 +45387,7 @@
 	c_tag = "Medbay West";
 	dir = 5;
 	icon_state = "camera";
-	network = list("SS13");
-	tag = ""
+	network = list("SS13")
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -45572,6 +45522,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Hydroponics East";
+	dir = 9;
+	icon_state = "camera"
+	},
 /turf/open/floor/plasteel/darkgreen/side{
 	tag = "icon-darkgreen (NORTHEAST)";
 	icon_state = "darkgreen";
@@ -45584,8 +45539,7 @@
 /obj/machinery/camera{
 	c_tag = "Hydroponics Backroom";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -46259,7 +46213,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall{
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/hydroponics)
@@ -46497,8 +46453,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine{
@@ -46622,8 +46577,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -46766,8 +46720,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating/airless,
@@ -47374,8 +47327,7 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -47489,8 +47441,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Security Checkpoint";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -48158,8 +48109,7 @@
 	c_tag = "Medbay Asteroid Hallway 2";
 	dir = 8;
 	icon_state = "camera";
-	network = list("SS13","QM");
-	tag = ""
+	network = list("SS13","QM")
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -48639,6 +48589,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -49470,6 +49421,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel/yellow/side{
 	tag = "icon-yellow (EAST)";
 	icon_state = "yellow";
@@ -50341,8 +50293,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
@@ -50410,8 +50361,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -50601,8 +50551,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -51195,8 +51144,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -51216,8 +51164,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -52023,6 +51970,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -52100,8 +52048,7 @@
 	c_tag = "Engineering East";
 	dir = 9;
 	icon_state = "camera";
-	network = list("SS13","CE");
-	tag = ""
+	network = list("SS13","CE")
 	},
 /turf/open/floor/plasteel/yellow/side{
 	tag = "icon-yellow (EAST)";
@@ -52526,8 +52473,7 @@
 	c_tag = "Atmospherics North";
 	dir = 9;
 	icon_state = "camera";
-	network = list("SS13","CE");
-	tag = ""
+	network = list("SS13","CE")
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -53272,8 +53218,7 @@
 	c_tag = "Atmospherics Airlock";
 	dir = 5;
 	icon_state = "camera";
-	network = list("SS13","CE");
-	tag = ""
+	network = list("SS13","CE")
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -53726,8 +53671,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53748,8 +53692,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53765,8 +53708,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53936,8 +53878,7 @@
 	c_tag = "Medbay Storage";
 	dir = 10;
 	icon_state = "camera";
-	network = list("SS13","CMO");
-	tag = ""
+	network = list("SS13","CMO")
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -54178,8 +54119,7 @@
 /obj/machinery/camera{
 	c_tag = "Library East";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/wood{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -54422,8 +54362,7 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
@@ -56205,8 +56144,7 @@
 	c_tag = "Atmospheric Tanks 2";
 	dir = 5;
 	icon_state = "camera";
-	network = list("SS13","CE");
-	tag = ""
+	network = list("SS13","CE")
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -57033,8 +56971,7 @@
 	c_tag = "Medbay Asteroid Hallway 1";
 	dir = 8;
 	icon_state = "camera";
-	network = list("SS13","QM");
-	tag = ""
+	network = list("SS13","QM")
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -57631,8 +57568,7 @@
 /obj/machinery/camera{
 	c_tag = "Library Explicits";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/grimy{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -58077,8 +58013,7 @@
 	c_tag = "Atmospherics Distro";
 	dir = 9;
 	icon_state = "camera";
-	network = list("SS13","CE");
-	tag = ""
+	network = list("SS13","CE")
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -59358,8 +59293,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel West";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/chapel{
 	tag = "icon-chapel (NORTH)";
@@ -59880,8 +59814,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel East";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/grimy{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -61349,8 +61282,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/grimy{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -61509,8 +61441,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -61528,8 +61459,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
@@ -61543,8 +61473,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -61762,8 +61691,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel Coffins";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -62418,8 +62346,7 @@
 /obj/machinery/camera{
 	c_tag = "Crematorium";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -62766,8 +62693,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -63048,8 +62974,7 @@
 /obj/machinery/camera{
 	c_tag = "Docking Atmospherics Checkpoint";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -63248,8 +63173,7 @@
 /obj/machinery/camera{
 	c_tag = "Service-Research Bridge";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine{
@@ -63482,8 +63406,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -63494,8 +63417,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -63513,8 +63435,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -63704,8 +63625,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -63720,8 +63640,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -64205,8 +64124,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating/airless/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -64221,8 +64139,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -64295,8 +64212,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -65731,8 +65647,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Asteroid Hallway 1";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	tag = "icon-neutralcorner (NORTH)";
@@ -65890,8 +65805,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -65903,8 +65817,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/floorgrime{
@@ -66361,8 +66274,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Atmospherics Checkpoint";
 	dir = 5;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -67223,8 +67135,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/door/airlock/atmos{
 	name = "Research Atmospherics Checkpoint";
@@ -67330,8 +67241,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -67345,8 +67255,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -67542,8 +67451,7 @@
 	c_tag = "Docking Quantum Pad";
 	dir = 8;
 	icon_state = "camera";
-	network = list("SS13","QM");
-	tag = ""
+	network = list("SS13","QM")
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -69048,8 +68956,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -69080,8 +68987,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	tag = "icon-neutralcorner (NORTH)";
@@ -69098,8 +69004,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/sign/map/left/ceres{
 	pixel_y = 32
@@ -69119,8 +69024,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/camera{
 	c_tag = "Research Asteroid Hallway 2"
@@ -69140,8 +69044,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -69165,8 +69068,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -69188,8 +69090,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	tag = "icon-neutralcorner (NORTH)";
@@ -69206,8 +69107,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/light{
 	dir = 1
@@ -69227,8 +69127,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -69248,8 +69147,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
@@ -69267,8 +69165,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/camera{
 	c_tag = "Research Asteroid Hallway 3"
@@ -69285,8 +69182,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -69305,8 +69201,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -71762,8 +71657,7 @@
 	c_tag = "Science SMES";
 	dir = 8;
 	icon_state = "camera";
-	network = list("SS13","QM");
-	tag = ""
+	network = list("SS13","QM")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -73315,8 +73209,7 @@
 	c_tag = "Toxins Mixing";
 	dir = 9;
 	icon_state = "camera";
-	network = list("SS13","RD");
-	tag = ""
+	network = list("SS13","RD")
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	tag = "icon-whitepurple (EAST)";
@@ -75084,8 +74977,7 @@
 /obj/machinery/camera{
 	c_tag = "Docking Asteroid Hall 13";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -75154,8 +75046,7 @@
 /obj/machinery/camera{
 	c_tag = "Docking Asteroid Hall 9";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -75892,8 +75783,7 @@
 	c_tag = "Research Xenobiology-Testing Airlock";
 	dir = 9;
 	icon_state = "camera";
-	network = list("SS13","RD");
-	tag = ""
+	network = list("SS13","RD")
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -78190,8 +78080,7 @@
 /obj/machinery/camera{
 	c_tag = "Docking Asteroid Hall 12";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -78233,8 +78122,7 @@
 /obj/machinery/camera{
 	c_tag = "Docking Asteroid Hall 8";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/plasteel/neutral{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -78313,8 +78201,7 @@
 	c_tag = "Testing Lab";
 	dir = 9;
 	icon_state = "camera";
-	network = list("SS13","RD");
-	tag = ""
+	network = list("SS13","RD")
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -78594,8 +78481,7 @@
 	c_tag = "Research Testing Containment";
 	dir = 9;
 	icon_state = "camera";
-	network = list("SS13","RD");
-	tag = ""
+	network = list("SS13","RD")
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -81760,8 +81646,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -85064,8 +84949,7 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral/corner{
@@ -85932,8 +85816,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Monkey Dome";
 	dir = 9;
-	icon_state = "camera";
-	tag = ""
+	icon_state = "camera"
 	},
 /turf/open/floor/grass{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -89770,8 +89653,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91373,8 +91255,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Chief Engineer's Office";
@@ -93609,8 +93490,7 @@
 	c_tag = "Toxins Storage";
 	dir = 9;
 	icon_state = "camera";
-	network = list("SS13","RD");
-	tag = ""
+	network = list("SS13","RD")
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -94500,6 +94380,508 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/crew_quarters/hor)
+"dnM" = (
+/turf/closed/mineral,
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnN" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnO" = (
+/turf/closed/mineral,
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnP" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnQ" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnR" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnS" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnT" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnU" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnV" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnW" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnX" = (
+/obj/structure/closet,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnY" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dnZ" = (
+/obj/machinery/door/airlock/glass_external{
+	cyclelinkeddir = 8
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doa" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dob" = (
+/obj/machinery/door/airlock/glass_external{
+	cyclelinkeddir = 8
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doc" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dod" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doe" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dof" = (
+/turf/closed/mineral,
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dog" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doh" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doi" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doj" = (
+/obj/item/weapon/twohanded/required/kirbyplants{
+	icon_state = "plant-20";
+	light_color = "#E1E17D";
+	light_range = 5;
+	luminosity = 2;
+	tag = "icon-plant-20"
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dok" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dol" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dom" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"don" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doo" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dop" = (
+/obj/structure/bed,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doq" = (
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dor" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dos" = (
+/obj/structure/sign/map/left/ceres{
+	pixel_x = 32
+	},
+/obj/structure/closet/crate/bin,
+/obj/item/weapon/paper/crumpled{
+	info = "...SOMETHING IN THE ROCKS, IT WATCHES US ALL..."
+	},
+/obj/item/weapon/paper/crumpled{
+	info = "...THEY SENT US HERE FOR A REASON...TERRIBLE..."
+	},
+/obj/item/weapon/paper/crumpled{
+	info = "...EMPTY HALLS...USELESS SPACE..."
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dot" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dou" = (
+/turf/closed/mineral/random/low_chance,
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dov" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/weapon/paper/crumpled{
+	info = "I can't be here for much longer, this station is too empty for its own good.  Something is wrong..."
+	},
+/obj/item/weapon/paper{
+	info = "<b><center>2XXX - 2nd Trimestor</center></b><br><br><center>I hide in here, away from the masses, not like it matters much considering how fucking huge this place is. ";
+	name = "Journal Log"
+	},
+/obj/item/weapon/paper{
+	info = "<b><center>2XXX - 3rd Trimestor</center></b><br><br><center>I hear strange whispers from the halls, longing for blood. Something isn't right here. Why did they transfer us here to work in the first place? ";
+	name = "Journal Log 2"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dow" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"dox" = (
+/obj/item/weapon/paper/crumpled/bloody{
+	info = "...THE HOPLINE CALLS...IT THIRSTS FOR BLOOD...I MUST GO..."
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doy" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doz" = (
+/obj/structure/table,
+/obj/item/weapon/pen,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doA" = (
+/turf/closed/mineral,
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doB" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doC" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doD" = (
+/obj/structure/sign/map/left{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doE" = (
+/obj/structure/table,
+/obj/structure/sign/map/right{
+	pixel_y = -32
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doF" = (
+/obj/structure/table,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doG" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plasteel/floorgrime{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doH" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doI" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doJ" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doK" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doL" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doM" = (
+/turf/closed/wall/rust{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doN" = (
+/turf/closed/wall{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/derelict/secret{
+	valid_territory = 0
+	})
+"doO" = (
+/obj/machinery/smartfridge/food,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/kitchen)
+"doP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	name = "Kitchen Pick-Up";
+	req_access_txt = "28"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/cafeteria{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/crew_quarters/kitchen)
+"doQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southleft{
+	name = "Hydroponics Pick-Up";
+	req_access_txt = "35"
+	},
+/turf/open/floor/plasteel/darkgreen{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hydroponics)
+"doR" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hydroponics)
+"doS" = (
+/obj/machinery/plantgenes,
+/turf/open/floor/plasteel/black{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hydroponics)
+"doT" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/hydroponics)
+"doU" = (
+/obj/machinery/recharge_station,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/assembly/robotics)
 
 (1,1,1) = {"
 aaa
@@ -98692,12 +99074,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aad
+aab
+aab
+aab
+aab
+aad
 aaa
 aaa
 aaa
@@ -98947,16 +99329,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aad
+aab
+aab
+aab
+aab
+aab
+aab
+aad
+aab
+aab
 aaa
 aaa
 aaa
@@ -99204,17 +99586,17 @@ aaa
 aag
 aaa
 aaa
-aaa
-aaa
+aab
+aab
+aab
+aab
 aad
-aaa
-aaa
-aaa
-aaa
-aaa
 aad
-aaa
-aaa
+aad
+aad
+aab
+aab
+aad
 aaa
 aaa
 aaa
@@ -99461,17 +99843,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
+aab
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 aaa
 aaa
 aaa
@@ -99717,19 +100099,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aad
+aab
+aab
+dnS
+dnZ
+dog
+don
+dou
+doB
+aac
+aac
+aac
+aad
 aaa
 aaa
 aaa
@@ -99974,19 +100356,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
 aad
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dnM
+dnT
+doa
+doh
+doo
+dov
+doC
+doI
 aac
+aac
+aad
 aad
 aab
 aaa
@@ -100232,19 +100614,19 @@ aaa
 aaa
 aad
 aad
-aab
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
+aad
+dnN
+dnU
+dob
+doi
+dop
+dow
+doD
+doJ
 aac
-aab
-aab
-aab
 aac
+aad
+aad
 aab
 aaa
 aaa
@@ -100489,21 +100871,21 @@ aaa
 aac
 aac
 aad
-aab
-aab
-aab
-aab
-aab
-aaa
 aad
-aad
+dnO
+dnV
+doc
+doj
+doq
+dox
+doE
+doK
 aac
-aab
-aab
-aab
 aad
 aad
-aaa
+aad
+aab
+aab
 aaa
 aaa
 aaa
@@ -100747,21 +101129,21 @@ aac
 aac
 aad
 aad
+dnP
+dnW
+dod
+dok
+dor
+doy
+doF
+doL
 aac
-aac
-aac
+aad
 aab
+aad
+aad
+aad
 aab
-aac
-aac
-aac
-aab
-aab
-aab
-aac
-aac
-aaa
-aaa
 aad
 aaa
 aaa
@@ -101004,22 +101386,22 @@ aaa
 aad
 aac
 aac
+dnQ
+dnX
+doe
+dol
+dos
+doz
+doG
+doM
 aac
-aac
-aac
+aad
 aab
+aac
+aad
+aad
+aad
 aab
-aac
-aac
-aac
-aab
-aab
-aab
-aac
-aac
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -101261,24 +101643,24 @@ aaa
 aad
 aac
 aac
-aac
-aaa
-aaa
-aaa
-aaa
-aac
-aac
-aac
+dnR
+dnY
+dof
+dom
+dot
+doA
+doH
+doN
 aad
 aad
 aab
+aac
+aac
+aac
 aad
 aad
-aaa
-aaa
-aaa
-aaa
-aaa
+aad
+aad
 aaa
 aaa
 aaa
@@ -101517,26 +101899,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aac
+aac
 aad
+aad
+aac
+aac
+aac
 aac
 aad
 aad
 aad
+aab
+aac
+aac
+aac
 aad
 aab
 aab
 aad
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aad
 aaa
 aaa
 abC
@@ -101777,23 +102159,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aad
+aac
+aac
+aac
+aac
+aad
+aab
+aad
+aad
+aad
+aad
+aad
 aab
 aab
-aab
-aab
-aab
-aab
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aad
+aad
 aaa
 aaa
 abC
@@ -102034,19 +102416,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aad
+aad
+aad
+aad
+aad
+aad
+aab
+aad
+aad
+aad
 aab
 aab
 aab
-aab
-aab
-aab
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -102293,13 +102675,13 @@ aaa
 aaa
 aaa
 aaa
+aad
 aaa
-aaa
 aab
 aab
 aab
 aab
-aaa
+aab
 aaa
 aaa
 aad
@@ -107808,7 +108190,7 @@ crg
 cqo
 cgN
 cta
-cuY
+doU
 cuY
 cwS
 cLE
@@ -111341,7 +111723,7 @@ byr
 bCN
 bAI
 bFg
-byr
+doS
 bBL
 bJj
 bKP
@@ -111836,7 +112218,7 @@ bfF
 bgy
 bhs
 biD
-bjr
+blh
 bkl
 blh
 bmk
@@ -112093,7 +112475,7 @@ cKo
 bch
 bch
 biE
-bch
+doO
 bkm
 bli
 bli
@@ -112870,18 +113252,18 @@ blj
 bml
 bjw
 bjw
-bch
+doP
 bqU
 bax
 btO
-bBL
-bwN
+doQ
+bAJ
 byt
 bzF
 bAJ
 bBI
 bCQ
-bEg
+bAJ
 bFi
 bGA
 bBL
@@ -113138,9 +113520,9 @@ bzG
 bvm
 bvm
 bCR
-bvm
+doR
 bFj
-bvm
+doT
 bBL
 bJq
 bKT
@@ -113908,7 +114290,7 @@ byw
 bzJ
 byw
 bBJ
-bCU
+byw
 bEh
 bFl
 bGC
@@ -129809,8 +130191,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cKF
+cKF
 aaa
 aaa
 aZf
@@ -130068,7 +130450,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cKF
 aaa
 aZf
 aZt
@@ -148515,9 +148897,9 @@ aaa
 aaa
 dnB
 dnD
-dnG
-dnH
-dnI
+dnD
+dnD
+dnD
 anT
 aoX
 aoU


### PR DESCRIPTION
Fixes #26437
Fixes #26439
Fixes #26438
Fixes #26440

- Adds a mail chute to cargo's mail office
- Moves the medbay emergency pod back to prevent corpses getting stuck
- Kitchen and Hydroponics now have a side desk for tossing stuff to each other.
- Kitchen now has a smartfridge.
- Emitters in SM should be properly set now.
- Added some lights to dimmer areas.
- Armory now has a secure desk and shutters for rapid deployment of gear.
- Brig control now has a secure desk for depositing gear to the Warden/HoS
- CMO's Office now has a request console
- Head rooms on the bridge have had their secure lockers moved to their respective department offices and given respective uniform closets in their place.
- External Maintenance Airlocks are now named "External Airlock Access" in hopes of lessening confusion on why those rooms are not rad-proof.
- Added an incinerator room with a turbine on the south section of the Engineering asteroid.