### PR TITLE
Fixes objects being used on backpacks if they don't fit

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -405,6 +405,9 @@
 	if(iscyborg(user))
 		return	//Robots can't interact with storage items.
 
+	if(contents.len >= storage_slots) //don't use items on the backpack if they don't fit
+		return 1
+
 	if(!can_be_inserted(W, 0 , user))
 		return 0
 


### PR DESCRIPTION
:cl: XDTM
fix: Items will no longer be used on backpacks if they fail to insert when they're too full.
/:cl:

Fixes #26433

The check is also in can_be_inserted(), but making _that_ proc deny afterattacks will cause a lot more trouble.