### PR TITLE
Organs are located inside mobs

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -162,12 +162,6 @@
 		show_message("<span class='userdanger'>The blob attacks!</span>")
 		adjustBruteLoss(10)
 
-/mob/living/carbon/emp_act(severity)
-	for(var/X in internal_organs)
-		var/obj/item/organ/O = X
-		O.emp_act(severity)
-	..()
-
 /mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, override = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
 	if(tesla_shock && HAS_SECONDARY_FLAG(src, TESLA_IGNORE))
 		return FALSE

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -54,6 +54,12 @@
 /obj/item/organ/proc/on_life()
 	return
 
+/obj/item/organ/Moved(atom/oldloc, dir)
+	..()
+
+	if(oldloc == owner)
+		Remove(owner)
+
 /obj/item/organ/examine(mob/user)
 	..()
 	if(status == ORGAN_ROBOTIC && crit_fail)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -27,7 +27,7 @@
 	owner = M
 	M.internal_organs |= src
 	M.internal_organs_slot[slot] = src
-	loc = null
+	forceMove(M)
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.Grant(M)
@@ -41,6 +41,8 @@
 			M.internal_organs_slot.Remove(slot)
 		if(vital && !special)
 			M.death()
+		if(loc == M)
+			forceMove(get_turf(src))
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.Remove(M)


### PR DESCRIPTION
:cl: coiax
experiment: Remember, your organs are inside your body.
/:cl:

Pretty simple to start with, the `loc` of all organs after `Insert` is
called is the mob. When `Remove` is called, if the organ is inside the
mob, it is dropped on the turf.

This will likely need some test merges, because lord knows what sort of
weird bugs are going to come out of this. But it's literally for the
best long term.

Fixes #26426.

### Bugs
- [ ] Roundstart AI spawns are a pile of organs
- [ ] Roundstart borg spawns are a pile of organs
- [ ] Nuke ops spawning seem to leave behind tongues of their original race
- [ ] Someone died after being turned into a monkey?