### PR TITLE
Fixes some facehugger bugs

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -47,8 +47,11 @@
 
 /obj/item/clothing/mask/facehugger/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	..()
-	if(integrity < 90)
+	if(obj_integrity < 90)
 		Die()
+
+/obj/item/clothing/mask/facehugger/attackby(obj/item/O,mob/m, params)
+	return O.attack_obj(src, user)
 
 /obj/item/clothing/mask/facehugger/attack_alien(mob/user) //can be picked up by aliens
 	attack_hand(user)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -50,7 +50,7 @@
 	if(obj_integrity < 90)
 		Die()
 
-/obj/item/clothing/mask/facehugger/attackby(obj/item/O,mob/m, params)
+/obj/item/clothing/mask/facehugger/attackby(obj/item/O, mob/user, params)
 	return O.attack_obj(src, user)
 
 /obj/item/clothing/mask/facehugger/attack_alien(mob/user) //can be picked up by aliens

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -20,6 +20,8 @@
 	tint = 3
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 	layer = MOB_LAYER
+	obj_integrity = 100
+	max_integrity = 100
 
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
 
@@ -42,6 +44,11 @@
 	icon_state = "facehugger_impregnated"
 	item_state = "facehugger_impregnated"
 	stat = DEAD
+
+/obj/item/clothing/mask/facehugger/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+	..()
+	if(integrity < 90)
+		Die()
 
 /obj/item/clothing/mask/facehugger/attack_alien(mob/user) //can be picked up by aliens
 	attack_hand(user)
@@ -70,19 +77,10 @@
 	if (sterile)
 		to_chat(user, "<span class='boldannounce'>It looks like the proboscis has been removed.</span>")
 
-/obj/item/clothing/mask/facehugger/attackby(obj/item/O,mob/m, params)
-	if(O.force)
-		Die()
-	return
-
-/obj/item/clothing/mask/facehugger/bullet_act(obj/item/projectile/P)
-	if(P.damage)
-		Die()
 
 /obj/item/clothing/mask/facehugger/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > 300)
 		Die()
-	return
 
 /obj/item/clothing/mask/facehugger/equipped(mob/M)
 	Attach(M)


### PR DESCRIPTION
Fixes #26429
Fixes #26428 
Fixes #26430

Apparently facehuggers forceMoved to the target before trying to equip. I have no idea why someone thought they would have to get inside the target in the first place, but basically it meant that if the mask stayed intact (for example, if it was another facehugger) they'd just teleport inside you.

Also the Attach() proc made them equip, and equipped() called Attach again. So i split the proc into Leap() and Attach(), where Leap calls equip if successful and lets the Attach() on equip do the rest.

Facehuggers now die if they take more than 10 damage, from any source.