### PR TITLE
Adds new debug verb for highlighting roundstart ATs

### DIFF
--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -54,3 +54,4 @@ GLOBAL_LIST_EMPTY(awaydestinations)	//a list of landmarks that the warpgate can 
 GLOBAL_LIST_EMPTY(sortedAreas)
 
 GLOBAL_LIST_EMPTY(transit_markers)
+GLOBAL_LIST_EMPTY(all_abstract_markers)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -299,7 +299,7 @@ SUBSYSTEM_DEF(air)
 		var/timer = world.timeofday
 		warning("There are [starting_ats] active turfs at roundstart, this is a mapping error caused by a difference of the air between the adjacent turfs. You can see its coordinates using \"Mapping -> Show roundstart AT list\" verb (debug verbs required)")
 		for(var/turf/T in active_turfs)
-			GLOB.active_turfs_startlist += text("[T.x], [T.y], [T.z]\n")
+			GLOB.active_turfs_startlist += T
 
 		//now lets clear out these active turfs
 		var/list/turfs_to_check = active_turfs.Copy()

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -31,3 +31,22 @@
 	plane = LIGHTING_PLANE
 	layer = LIGHTING_LAYER
 	blend_mode = BLEND_ADD
+
+/obj/effect/abstract/marker
+	name = "marker"
+	icon = 'icons/effects/effects.dmi'
+	anchored = TRUE
+	icon_state = "wave3"
+	layer = RIPPLE_LAYER
+
+/obj/effect/abstract/marker/Initialize(mapload)
+	. = ..()
+	GLOB.all_abstract_markers += src
+
+/obj/effect/abstract/marker/Destroy()
+	GLOB.all_abstract_markers -= src
+	. = ..()
+
+/obj/effect/abstract/marker/at
+	name = "active turf marker"
+

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -41,7 +41,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug_mapping, list(
 	/client/proc/disable_communication,
 	/client/proc/print_pointers,
 	/client/proc/cmd_show_at_list,
-	/client/proc/cmd_show_at_list,
+	/client/proc/cmd_show_at_markers,
 	/client/proc/manipulate_organs
 ))
 
@@ -154,13 +154,34 @@ GLOBAL_LIST_INIT(admin_verbs_debug_mapping, list(
 	var/dat = {"<b>Coordinate list of Active Turfs at Roundstart</b>
 	 <br>Real-time Active Turfs list you can see in Air Subsystem at active_turfs var<br>"}
 
-	for(var/i=1; i<=GLOB.active_turfs_startlist.len; i++)
-		dat += GLOB.active_turfs_startlist[i]
+	for(var/t in GLOB.active_turfs_startlist)
+		var/turf/T = t
+		dat += "[T.x], [T.y], [T.z]\n"
 		dat += "<br>"
 
 	usr << browse(dat, "window=at_list")
 
 	SSblackbox.add_details("admin_verb","Show Roundstart Active Turfs") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/cmd_show_at_markers()
+	set category = "Mapping"
+	set name = "Show roundstart AT markers"
+	set desc = "Places a marker on all active-at-roundstart turfs"
+
+	var/count = 0
+	for(var/obj/effect/abstract/marker/at/AT in GLOB.all_abstract_markers)
+		qdel(AT)
+		count++
+
+	if(count)
+		to_chat(usr, "[count] AT markers removed.")
+	else
+		for(var/t in GLOB.active_turfs_startlist)
+			new /obj/effect/abstract/marker/at(t)
+			count++
+		to_chat(usr, "[count] AT markers placed.")
+
+	feedback_add_details("admin_verb", "Show Roundstart Active Turf Markers")
 
 /client/proc/enable_debug_verbs()
 	set category = "Debug"

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug_mapping, list(
 
 	for(var/t in GLOB.active_turfs_startlist)
 		var/turf/T = t
-		dat += "[T.x], [T.y], [T.z]\n"
+		dat += "[ADMIN_COORDJMP(T)]\n"
 		dat += "<br>"
 
 	usr << browse(dat, "window=at_list")
@@ -181,7 +181,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug_mapping, list(
 			count++
 		to_chat(usr, "[count] AT markers placed.")
 
-	feedback_add_details("admin_verb", "Show Roundstart Active Turf Markers")
+	SSblackbox.add_details("admin_verb","Show Roundstart Active Turf Markers")
 
 /client/proc/enable_debug_verbs()
 	set category = "Debug"


### PR DESCRIPTION
Debug -> Debug Verbs enable
then
Mapping -> Show roundstart AT markers

Will highlight AT turfs, for easier location and comprehension rather
than looking at the list of coords. List of coords still works fine
though.