### PR TITLE
Removes "telepathic" from slime's say verbs

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -16,7 +16,7 @@
 	response_disarm = "shoos"
 	response_harm   = "stomps on"
 	emote_see = list("jiggles", "bounces in place")
-	speak_emote = list("telepathically chirps")
+	speak_emote = list("chirps")
 	bubble_icon = "slime"
 	initial_languages = list(/datum/language/common, /datum/language/slime)
 
@@ -31,10 +31,10 @@
 
 	see_in_dark = 8
 
-	verb_say = "telepathically chirps"
-	verb_ask = "telepathically asks"
-	verb_exclaim = "telepathically cries"
-	verb_yell = "telephatically cries"
+	verb_say = "chirps"
+	verb_ask = "asks"
+	verb_exclaim = "cries"
+	verb_yell = "cries"
 
 	// canstun and canweaken don't affect slimes because they ignore stun and weakened variables
 	// for the sake of cleanliness, though, here they are.


### PR DESCRIPTION
:cl: coiax
fix: Reminder, slimes are not telepathic, they just chirp at people.
/:cl:

I'm told that "telepathic chirping" is a holdover from when xenobio used
to breed metroids. Regardless, they're not telepathic, considering they
make sounds that are blocked by no air and are picked up on the radio.

Brings them in line with jellypeople "chirping".