### PR TITLE
Zombie/limb refactors/fixes

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -390,7 +390,7 @@
 	desc = "A chainsaw that has replaced your arm."
 	icon_state = "chainsaw_on"
 	item_state = "mounted_chainsaw"
-	flags = NODROP | ABSTRACT
+	flags = NODROP | ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	force = 21
 	throwforce = 0
@@ -400,10 +400,17 @@
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 
-/obj/item/weapon/mounted_chainsaw/dropped()
-	..()
+/obj/item/weapon/mounted_chainsaw/Destroy()
+	var/obj/item/bodypart/part
 	new /obj/item/weapon/twohanded/required/chainsaw(get_turf(src))
-	qdel(src)
+	if(iscarbon(loc))
+		var/mob/living/carbon/holder = loc
+		var/index = holder.get_held_index_of_item(src)
+		if(index)
+			part = holder.hand_bodyparts[index]
+	. = ..()
+	if(part)
+		part.drop_limb()
 
 /obj/item/weapon/statuebust
 	name = "bust"

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -142,10 +142,12 @@
 	return not_handled //For future deeper overrides
 
 /mob/living/carbon/human/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE)
+	var/index = get_held_index_of_item(I)
 	. = ..() //See mob.dm for an explanation on this and some rage about people copypasting instead of calling ..() like they should.
 	if(!. || !I)
 		return
-
+	if(index && dna.species.mutanthands)
+		put_in_hand(new dna.species.mutanthands(), index)
 	if(I == wear_suit)
 		if(s_store && invdrop)
 			dropItemToGround(s_store, TRUE) //It makes no sense for your suit storage to stay on you if you drop your suit.

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -173,14 +173,18 @@
 	if(exotic_bloodtype && C.dna.blood_type != exotic_bloodtype)
 		C.dna.blood_type = exotic_bloodtype
 
+	if(old_species.mutanthands)
+		for(var/obj/item/I in C.held_items)
+			if(istype(I, old_species.mutanthands))
+				qdel(I)
+
 	if(mutanthands)
 		// Drop items in hands
 		// If you're lucky enough to have a NODROP item, then it stays.
 		for(var/V in C.held_items)
 			var/obj/item/I = V
 			if(istype(I))
-				if(C.dropItemToGround(I))
-					C.put_in_hands(new mutanthands())
+				C.dropItemToGround(I)
 			else	//Entries in the list should only ever be items or null, so if it's not an item, we can assume it's an empty hand
 				C.put_in_hands(new mutanthands())
 
@@ -189,10 +193,6 @@
 		C.dna.blood_type = random_blood_type()
 	if(DIGITIGRADE in species_traits)
 		C.Digitigrade_Leg_Swap(TRUE)
-	if(mutanthands)
-		for(var/obj/item/I in C.held_items)
-			if(istype(I, mutanthands))
-				qdel(I)
 
 /datum/species/proc/handle_hair(mob/living/carbon/human/H, forced_colour)
 	H.remove_overlay(HAIR_LAYER)

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -13,6 +13,7 @@
 	name = "Infectious Zombie"
 	id = "memezombies"
 	limbs_id = "zombie"
+	mutanthands = /obj/item/zombie_hand
 	no_equip = list(slot_wear_mask, slot_head)
 	armor = 20 // 120 damage to KO a zombie, which kills it
 	speedmod = 2
@@ -27,29 +28,15 @@
 
 /datum/species/zombie/infectious/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
-	// Drop items in hands
-	// If you're a zombie lucky enough to have a NODROP item, then it stays.
-	for(var/V in C.held_items)
-		var/obj/item/I = V
-		if(istype(I))
-			if(C.dropItemToGround(I))
-				var/obj/item/zombie_hand/zh = new /obj/item/zombie_hand()
-				C.put_in_hands(zh)
-		else	//Entries in the list should only ever be items or null, so if it's not an item, we can assume it's an empty hand
-			var/obj/item/zombie_hand/zh = new /obj/item/zombie_hand()
-			C.put_in_hands(zh)
 
-	// Next, deal with the source of this zombie corruption
+	// Deal with the source of this zombie corruption
+	//  Infection organ needs to be handled separately from mutant_organs
+	//  because it persists through species transitions
 	var/obj/item/organ/zombie_infection/infection
 	infection = C.getorganslot("zombie_infection")
 	if(!infection)
-		infection = new(C)
-
-/datum/species/zombie/infectious/on_species_loss(mob/living/carbon/C)
-	. = ..()
-	for(var/obj/item/I in C.held_items)
-		if(istype(I, /obj/item/zombie_hand))
-			qdel(I)
+		infection = new()
+		infection.Insert(C)
 
 
 // Your skin falls off

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1511,7 +1511,9 @@
 
 /datum/reagent/romerol/on_mob_life(mob/living/carbon/human/H)
 	// Silently add the zombie infection organ to be activated upon death
-	new /obj/item/organ/zombie_infection(H)
+	if(!H.getorganslot("zombie_infection"))
+		var/obj/item/organ/zombie_infection/ZI = new()
+		ZI.Insert(H)
 	..()
 
 /datum/reagent/growthserum

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -258,6 +258,8 @@
 		if(held_index > C.hand_bodyparts.len)
 			C.hand_bodyparts.len = held_index
 		C.hand_bodyparts[held_index] = src
+		if(C.dna.species.mutanthands && !is_pseudopart)
+			C.put_in_hand(new C.dna.species.mutanthands(), held_index)
 		if(C.hud_used)
 			var/obj/screen/inventory/hand/hand = C.hud_used.hand_slots["[held_index]"]
 			if(hand)
@@ -272,6 +274,9 @@
 				C.surgeries -= S
 				qdel(S)
 				break
+
+	for(var/obj/item/organ/O in contents)
+		O.Insert(C)
 
 	update_bodypart_damage_state()
 

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -58,9 +58,9 @@
 		user.visible_message("[user] successfully replaces [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You succeed in replacing [target]'s [parse_zone(target_zone)].</span>")
 		return 1
 	else
-		target.regenerate_limb(target_zone)
-		var/obj/item/bodypart/L = target.get_bodypart(target_zone)
+		var/obj/item/bodypart/L = target.newBodyPart(target_zone, FALSE, FALSE)
 		L.is_pseudopart = TRUE
+		L.attach_limb(target)
 		user.visible_message("[user] finishes attaching [tool]!", "<span class='notice'>You attach [tool].</span>")
 		qdel(tool)
 		if(istype(tool, /obj/item/weapon/twohanded/required/chainsaw))

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -46,7 +46,8 @@
 	var/obj/item/organ/zombie_infection/infection
 	infection = target.getorganslot("zombie_infection")
 	if(!infection)
-		infection = new(target)
+		infection = new()
+		infection.Insert(target)
 
 /obj/item/zombie_hand/proc/check_feast(mob/living/target, mob/living/user)
 	if(target.stat == DEAD)

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -5,7 +5,7 @@
 	slot = "zombie_infection"
 	icon_state = "blacktumor"
 	origin_tech = "biotech=5"
-	var/datum/species/old_species
+	var/datum/species/old_species = /datum/species/human
 	var/living_transformation_time = 3
 	var/converts_living = FALSE
 
@@ -26,6 +26,7 @@
 /obj/item/organ/zombie_infection/Insert(var/mob/living/carbon/M, special = 0)
 	. = ..()
 	START_PROCESSING(SSobj, src)
+	old_species = M.dna.species.type
 
 /obj/item/organ/zombie_infection/Remove(mob/living/carbon/M, special = 0)
 	. = ..()
@@ -63,6 +64,7 @@
 
 	if(!iszombie(owner))
 		old_species = owner.dna.species.type
+		owner.set_species(/datum/species/zombie/infectious)
 
 	if(!converts_living && owner.stat != DEAD)
 		return
@@ -70,7 +72,6 @@
 	var/stand_up = (owner.stat == DEAD) || (owner.stat == UNCONSCIOUS)
 
 	owner.grab_ghost()
-	owner.set_species(/datum/species/zombie/infectious)
 	owner.revive(full_heal = TRUE)
 	owner.visible_message("<span class='danger'>[owner] suddenly convulses, as [owner.p_they()][stand_up ? " stagger to [owner.p_their()] feet and" : ""] gain a ravenous hunger in [owner.p_their()] eyes!</span>", "<span class='alien'>You HUNGER!</span>")
 	playsound(owner.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -26,7 +26,6 @@
 /obj/item/organ/zombie_infection/Insert(var/mob/living/carbon/M, special = 0)
 	. = ..()
 	START_PROCESSING(SSobj, src)
-	old_species = M.dna.species.type
 
 /obj/item/organ/zombie_infection/Remove(mob/living/carbon/M, special = 0)
 	. = ..()


### PR DESCRIPTION
Fixes mounted chainsaws leaving a limb if acided
Adds species support for mutanthands, basically hard-equipped items like zombie claws
Fixes zombies not having claws on newly attached arms
Mobs manually set to zombie species revert to human when their infection is removed
Inserts organs back into the mob when a bodypart is reattached
No longer generates eyes or ears when a mob changes species without having a head
Gives zombies a claw when they somehow drop something from their hand

Fixes #23783, fixes #19969 (not really but it's fixed anyway and this'll make the bot close it)