### PR TITLE
Remote ID Disabling

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -1,3 +1,4 @@
+GLOBAL_LIST_INIT(registered_id_cards, list())
 
 /datum/datacore
 	var/medical[] = list()
@@ -204,6 +205,10 @@
 			assignment = H.job
 		else
 			assignment = "Unassigned"
+
+		var/obj/item/weapon/card/id/card = H.get_idcard()
+		if(card && card.registered_name && card.tier != 0)
+			GLOB.registered_id_cards |= card
 
 		var/static/record_id_num = 1001
 		var/id = num2hex(record_id_num++,6)

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -245,22 +245,23 @@ GLOBAL_VAR_INIT(time_last_disabled_id, 0)
 			dat += "<td>[I.assignment]</td>"
 			dat += "<td>[I.disabled?"Disabled":"Enabled"]</td>"
 			dat += "<td>"
-			if(disable_id_cooldown < (world.time / 10) - GLOB.time_last_disabled_id)
-				if(!I.disabled)
+			if(!I.disabled)
+				if(disable_id_cooldown < (world.time / 10) - GLOB.time_last_disabled_id)
 					if(scan && scan.tier > I.tier && access_allowed)
 						dat += "<a href='?src=\ref[src];choice=disable;card=[GLOB.registered_id_cards.Find(I)]'>Disable</a><br>"
 					else
 						dat += "Disable"
 				else
-					if(scan && scan.tier > I.tier && access_allowed)
-						dat += "<a href='?src=\ref[src];choice=enable;card=[GLOB.registered_id_cards.Find(I)]'>Enable</a><br>"
-					else
-						dat += "Enable"
+					var/time_to_wait = round(disable_id_cooldown - ((world.time / 10) - GLOB.time_last_disabled_id), 1)
+					var/mins = round(time_to_wait / 60)
+					var/seconds = time_to_wait - (60*mins)
+					dat += "Cooldown ongoing: [mins]:[(seconds < 10) ? "0[seconds]" : "[seconds]"]"
 			else
-				var/time_to_wait = round(disable_id_cooldown - ((world.time / 10) - GLOB.time_last_disabled_id), 1)
-				var/mins = round(time_to_wait / 60)
-				var/seconds = time_to_wait - (60*mins)
-				dat += "Cooldown ongoing: [mins]:[(seconds < 10) ? "0[seconds]" : "[seconds]"]"
+				if(scan && scan.tier > I.tier && access_allowed)
+					dat += "<a href='?src=\ref[src];choice=enable;card=[GLOB.registered_id_cards.Find(I)]'>Enable</a><br>"
+				else
+					dat += "Enable"
+
 			dat += "</td></tr>"
 		dat += "</table>"
 
@@ -533,7 +534,6 @@ GLOBAL_VAR_INIT(time_last_disabled_id, 0)
 						return
 		if ("enable")
 			var/obj/item/weapon/card/id/target_id = GLOB.registered_id_cards[text2num(href_list["card"])]
-			GLOB.time_last_disabled_id = world.time / 10
 			target_id.disabled = FALSE
 
 		if ("disable")

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -84,6 +84,21 @@
 	var/registered_name = null // The name registered_name on the card
 	var/assignment = null
 	var/dorm = 0		// determines if this ID has claimed a dorm already
+	var/disabled = FALSE // if it has been remotely disabled
+	var/tier = 1 // level of the card for disabling purposes
+
+/obj/item/weapon/card/id/proc/tier2text()
+	switch(tier)
+		if(0,1)
+			return "Employee"
+		if(2)
+			return "Command"
+		if(3)
+			return "Captain"
+		if(4)
+			return "Centcomm Officer"
+		else
+			return "Corrupted ID"
 
 /obj/item/weapon/card/id/attack_self(mob/user)
 	user.visible_message("<span class='notice'>[user] shows you: \icon[src] [src.name].</span>", \
@@ -95,9 +110,14 @@
 	..()
 	if(mining_points)
 		to_chat(user, "There's [mining_points] mining equipment redemption point\s loaded onto this card.")
+	if(disabled)
+		to_chat(user, "<span class='warning'>It has been disabled.</span>")
 
 /obj/item/weapon/card/id/GetAccess()
-	return access
+	if(!disabled)
+		return access
+	else
+		return list()
 
 /obj/item/weapon/card/id/GetID()
 	return src
@@ -122,18 +142,21 @@ update_label("John Doe", "Clowny")
 	desc = "A silver card which shows honour and dedication."
 	icon_state = "silver"
 	item_state = "silver_id"
+	tier = 2
 
 /obj/item/weapon/card/id/gold
 	name = "gold identification card"
 	desc = "A golden card which shows power and might."
 	icon_state = "gold"
 	item_state = "gold_id"
+	tier = 3
 
 /obj/item/weapon/card/id/syndicate
 	name = "agent card"
 	access = list(GLOB.access_maint_tunnels, GLOB.access_syndicate)
 	origin_tech = "syndicate=1"
 	var/anyone = FALSE //Can anyone forge the ID or just syndicate?
+	tier = 0 //invisible to consoles
 
 /obj/item/weapon/card/id/syndicate/Initialize()
 	..()
@@ -182,6 +205,7 @@ update_label("John Doe", "Clowny")
 	registered_name = "Syndicate"
 	assignment = "Syndicate Overlord"
 	access = list(GLOB.access_syndicate)
+	tier = 0 //invisible to consoles
 
 /obj/item/weapon/card/id/captains_spare
 	name = "captain's spare ID"
@@ -190,10 +214,12 @@ update_label("John Doe", "Clowny")
 	item_state = "gold_id"
 	registered_name = "Captain"
 	assignment = "Captain"
+	tier = 3
 
 /obj/item/weapon/card/id/captains_spare/Initialize()
 	var/datum/job/captain/J = new/datum/job/captain
 	access = J.get_access()
+	GLOB.registered_id_cards += src
 	..()
 
 /obj/item/weapon/card/id/centcom
@@ -202,6 +228,7 @@ update_label("John Doe", "Clowny")
 	icon_state = "centcom"
 	registered_name = "Central Command"
 	assignment = "General"
+	tier = 4
 
 /obj/item/weapon/card/id/centcom/Initialize()
 	access = get_all_centcom_access()
@@ -213,6 +240,7 @@ update_label("John Doe", "Clowny")
 	icon_state = "centcom"
 	registered_name = "Emergency Response Team Commander"
 	assignment = "Emergency Response Team Commander"
+	tier = 4
 
 /obj/item/weapon/card/id/ert/Initialize()
 	access = get_all_accesses()+get_ert_access("commander")-GLOB.access_change_ids


### PR DESCRIPTION
:cl: XDTM
add: The Captain and Head of Personnel can now use an ID Console to remotely disable IDs. On top of ID access, doing so requires an ID of a higher tier than the target id (gold > silver, silver > basic). Agent IDs are unlisted and immune.
/:cl:

# How it works
The system requires an ID that:
- Has ID Modification access
- Is of higher tier than the target ID

Centcomm > Gold > Silver > Normal

Agent IDs are unlisted and immune, giving them an additional advantage: safe access stealing.

To prevent trolling by grabbing the captain's spare and disabling everyone's id, there's a cooldown between disabling (not re-enabling) IDs. It's currently set at 15s, but it's easily adjusted.

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 

## What does this add to the game
- It makes demotion feasible. Currently you have to catch the person to demote, which is likely running away to not lose their access, strip them of their id, drag both to the ID console and remove the access.
This is likely to result in escalation on both parts for an action that should be a basic deterrent tool for heads of staff.
With remote disabling, you can cut their access until they come back to the HoPline to get it restored (after it has been edited).

- It gives a countermeasure to all-access infection. When an assistant grabs hold of an all-access id, he can freely make copies and distribute them, usually resulting in complete disorder that the heads can do little about. With remote disabling, you can disable the copies (since the captain's spare would be immune). This is not foolproof, since someone can simply rename their ID, lay low, and dodge the disabling sweep.

- It makes sense to have as a system for high-value cards. IRL you can call your bank to disable your credit card if it gets stolen. If you somehow get cloned after being murdered and robbed, you can ask the HoP to disable your old card. This would be countered by hiding bodies, or at least disfiguring them as to not give hints about whose id got stolen.
