### PR TITLE
Nerfs and buffs The Traps

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -252,7 +252,7 @@
 /datum/spellbook_entry/the_traps
 	name = "The Traps!"
 	spell_type = /obj/effect/proc_holder/spell/aoe_turf/conjure/the_traps
-	category = "Offensive"
+	category = "Defensive"
 	cost = 1
 
 

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -42,6 +42,11 @@
 			if(summon_lifespan)
 				QDEL_IN(summoned_object, summon_lifespan)
 
+			post_summon(summoned_object, user)
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/proc/post_summon(atom/summoned_object, mob/user)
+	return
+
 /obj/effect/proc_holder/spell/aoe_turf/conjure/summonEdSwarm //test purposes - Also a lot of fun
 	name = "Dispense Wizard Justice"
 	desc = "This spell dispenses wizard justice."

--- a/code/modules/spells/spell_types/the_traps.dm
+++ b/code/modules/spells/spell_types/the_traps.dm
@@ -3,7 +3,7 @@
 	desc = "Summon a number of traps to confuse and weaken your enemies, and possibly you."
 
 	charge_max = 250
-	cooldown_min = 100
+	cooldown_min = 50
 
 	clothes_req = 1
 	invocation = "CAVERE INSIDIAS"
@@ -14,10 +14,13 @@
 		/obj/structure/trap/stun,
 		/obj/structure/trap/fire,
 		/obj/structure/trap/chill,
-		/obj/structure/trap/damage,
-		/obj/structure/swarmer/trap
+		/obj/structure/trap/damage
 	)
-	summon_lifespan = 0
+	summon_lifespan = 3000
 	summon_amt = 5
 
 	action_icon_state = "the_traps"
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/the_traps/post_summon(obj/structure/trap/T, mob/user)
+	T.immune_minds += user.mind
+	T.charges = 1


### PR DESCRIPTION
:cl: coiax
del: Swarmer traps are no longer summoned by The Traps.
balance: Wizard traps automatically disappear five minutes after being
summoned.
balance: Wizard traps disappear after firing, whether triggered via
person or something being thrown across it.
balance: Wizards are immune to their own traps.
tweak: The Traps are now marked as a Defensive spell, rather than an
Offensive spell.
/:cl:

So a permanent structure that has to be beaten down in order to remove
isn't really fun in the long term. So instead, they fire once, and then
disappear. They also disappear after a bit, so they're not long term
hazards, but they do stick around long enough so the wizard can feel
comfortable running back into an area they've already trapped, for that
AREA CONTROL.