### PR TITLE
Rod Form now costs 3 points

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -109,6 +109,7 @@
 /datum/spellbook_entry/rod_form
 	name = "Rod Form"
 	spell_type = /obj/effect/proc_holder/spell/targeted/rod_form
+	cost = 3
 
 /datum/spellbook_entry/magicm
 	name = "Magic Missile"


### PR DESCRIPTION
:cl: coiax
balance: The wizard spell Rod Form now costs 3 points, up from 2.
/:cl:

It's a one hit KO spell that also provides escape, mobility, on a really
short cooldown. Pretty much always picked up by any offensive mage.

Cost should be pushed up at the least.