### PR TITLE
Dufflebags slow down while in hand

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -324,6 +324,10 @@
 	slowdown = 1
 	max_combined_w_class = 30
 
+/obj/item/weapon/storage/backpack/dufflebag/Initialize(mapload)
+	..()
+	SET_SECONDARY_FLAG(src, SLOWS_WHILE_IN_HAND)
+
 /obj/item/weapon/storage/backpack/dufflebag/captain
 	name = "captain's dufflebag"
 	desc = "A large dufflebag for holding extra captainly goods."


### PR DESCRIPTION
:cl: coiax
balance: Dufflebags slow you down while holding them in hand.
/:cl:

> Anonymous: if you want to remove storage creep, remove dufflebags
being carryable at normal speed in your hands

Seems a sensible.

Before you ask, since syndie dufflebags have no slowdown, they are
unaffected. Superior syndicate cloth, I guess.