### PR TITLE
Omega Station has two APCs not wired properly

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -25691,6 +25691,10 @@
 	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
+/obj/structure/cable/white{
+	tag = "icon-0-8";
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel/green/corner{
 	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
@@ -35413,6 +35417,10 @@
 /obj/structure/cable/white{
 	tag = "icon-4-8";
 	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	tag = "icon-0-8";
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -72445,11 +72453,11 @@ aHl
 aIi
 aJs
 aKz
-buX
+buW
 aMR
 buZ
-bva
-bvb
+buZ
+buW
 aQL
 aRI
 aSS
@@ -72706,7 +72714,7 @@ aLP
 aMS
 aMS
 aOC
-bvc
+buW
 aQM
 aRJ
 aST
@@ -73734,7 +73742,7 @@ aLT
 aMW
 aMW
 aOD
-bve
+buW
 aQQ
 aRN
 aSX
@@ -73987,11 +73995,11 @@ aHr
 aIo
 aJw
 aKE
-buY
+buW
 aMX
 aMX
 aMX
-bvf
+buW
 aQR
 aRO
 aSY


### PR DESCRIPTION
:cl: flashdim
fix: Omega Station had two APCs not wired properly. (#26526)
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Central Hall and Primary Hall aren't getting power from SMEs.