### PR TITLE
Wizard rods now do less damage

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -82,13 +82,8 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		if(clong.density)
 			clong.ex_act(2)
 
-	else if(ismob(clong))
-		if(ishuman(clong))
-			var/mob/living/carbon/human/H = clong
-			H.visible_message("<span class='danger'>[H.name] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
-			H.adjustBruteLoss(160)
-		if(clong.density || prob(10))
-			clong.ex_act(2)
+	else if(isliving(clong))
+		penetrate(clong)
 	else if(istype(clong, type))
 		var/obj/effect/immovablerod/other = clong
 		visible_message("<span class='danger'>[src] collides with [other]!\
@@ -98,3 +93,11 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		smoke.start()
 		qdel(src)
 		qdel(other)
+
+/obj/effect/immovablerod/proc/penetrate(mob/living/L)
+	L.visible_message("<span class='danger'>[L] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.adjustBruteLoss(160)
+	if(L && (L.density || prob(10)))
+		L.ex_act(2)

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -41,3 +41,7 @@
 		wizard.notransform = 0
 		wizard.forceMove(get_turf(src))
 	return ..()
+
+/obj/effect/immovablerod/wizard/penetrate(mob/living/L)
+	L.visible_message("<span class='danger'>[L] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
+	L.adjustBruteLoss(50 + (maxdistance * 2))

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -17,6 +17,7 @@
 		var/obj/effect/immovablerod/wizard/W = new(start, get_ranged_target_turf(M, M.dir, (15 + spell_level * 3)))
 		W.wizard = M
 		W.max_distance += spell_level * 3 //You travel farther when you upgrade the spell
+		W.damage_bonus += spell_level * 10 //You do more damage when you upgrade the spell
 		W.start_turf = start
 		M.forceMove(W)
 		M.notransform = 1
@@ -26,6 +27,7 @@
 
 /obj/effect/immovablerod/wizard
 	var/max_distance = 13
+	var/damage_bonus = 0
 	var/mob/living/wizard
 	var/turf/start_turf
 	notify = FALSE
@@ -44,4 +46,4 @@
 
 /obj/effect/immovablerod/wizard/penetrate(mob/living/L)
 	L.visible_message("<span class='danger'>[L] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
-	L.adjustBruteLoss(50 + (maxdistance * 2))
+	L.adjustBruteLoss(60 + damage_bonus)


### PR DESCRIPTION
:cl: Joan
balance: Wizard rods now do less damage, and, unless the wizard has only used points on rod form, will not instantly put you into critical.
/:cl:

Very simple, means the rod won't instantly kill you or put you into crit unless the wizard has it as their literal only spell.
Closes #26537

Spell level scaling:
1. 60 damage
2. 70 damage
3. 80 damage
4. 90 damage
5. 100 damage