### PR TITLE
Minor IV/bloodbag grammar fixes

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -200,7 +200,7 @@
 		if(beaker.reagents && beaker.reagents.reagent_list.len)
 			to_chat(usr, "<span class='notice'>Attached is \a [beaker] with [beaker.reagents.total_volume] units of liquid.</span>")
 		else
-			to_chat(usr, "<span class='notice'>Attached is an empty [beaker].</span>")
+			to_chat(usr, "<span class='notice'>Attached is an empty [beaker.name].</span>")
 	else
 		to_chat(usr, "<span class='notice'>No chemicals are attached.</span>")
 

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -25,13 +25,10 @@
 
 /obj/item/weapon/reagent_containers/blood/proc/update_pack_name()
 	if(!labelled)
-		if(volume)
-			if(blood_type)
-				name = "blood pack [blood_type]"
-			else
-				name = "blood pack"
+		if(blood_type)
+			name = "blood pack - [blood_type]"
 		else
-			name = "empty blood pack"
+			name = "blood pack"
 
 /obj/item/weapon/reagent_containers/blood/update_icon()
 	var/percent = round((reagents.total_volume / volume) * 100)
@@ -69,7 +66,7 @@
 	blood_type = "L"
 
 /obj/item/weapon/reagent_containers/blood/empty
-	name = "empty blood pack"
+	name = "blood pack"
 	icon_state = "empty"
 
 /obj/item/weapon/reagent_containers/blood/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
Fixes 'it has an empty the empty blood pack attached'.
Fixes autolabeled blood packs being visually distinct from manually labeled ones.