### PR TITLE
Removes a unused chem

### DIFF
--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -432,11 +432,6 @@
 	update_filling()
 	user.update_inv_back() //for overlays update
 
-/obj/item/weapon/reagent_containers/chemtank/stim/New()
-	..()
-	reagents.add_reagent("stimulants_longterm", 300)
-	update_filling()
-
 //Operator backpack spray
 /obj/item/weapon/watertank/operator
 	name = "backpack water tank"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -867,44 +867,6 @@
 		. = 1
 	..()
 
-/datum/reagent/medicine/stimulants/longterm
-	name = "Stimulants"
-	id = "stimulants_longterm"
-	description = "Increases stun resistance and movement speed in addition to restoring minor damage and weakness. Highly addictive."
-	color = "#78008C"
-	metabolization_rate = 2 * REAGENTS_METABOLISM
-	overdose_threshold = 0
-	addiction_threshold = 5
-
-/datum/reagent/medicine/stimulants/longterm/addiction_act_stage1(mob/living/M)
-	M.adjustToxLoss(5*REM, 0)
-	M.adjustStaminaLoss(5*REM, 0)
-	..()
-	. = 1
-
-/datum/reagent/medicine/stimulants/longterm/addiction_act_stage2(mob/living/M)
-	M.adjustToxLoss(6*REM, 0)
-	M.adjustStaminaLoss(5*REM, 0)
-	M.Stun(2, 0)
-	..()
-	. = 1
-
-/datum/reagent/medicine/stimulants/longterm/addiction_act_stage3(mob/living/M)
-	M.adjustToxLoss(7*REM, 0)
-	M.adjustStaminaLoss(5*REM, 0)
-	M.adjustBrainLoss(1*REM)
-	M.Stun(2, 0)
-	..()
-	. = 1
-
-/datum/reagent/medicine/stimulants/longterm/addiction_act_stage4(mob/living/M)
-	M.adjustToxLoss(8*REM, 0)
-	M.adjustStaminaLoss(5*REM, 0)
-	M.adjustBrainLoss(2*REM)
-	M.Stun(2, 0)
-	..()
-	. = 1
-
 /datum/reagent/medicine/insulin
 	name = "Insulin"
 	id = "insulin"


### PR DESCRIPTION
[why]: # 
Besides it just appearing no where besides being in a tank, it also has no use as it will only last for a couple of seconds before addiction (oh hey, perma stunned at stage 2 and beyond) and will also overdose as it's a subtype of the original stimulants. 

