### PR TITLE
Fixes some edges cases in the garbage controller

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -150,7 +150,7 @@ SUBSYSTEM_DEF(garbage)
 	var/ticktime = world.time
 	
 	var/type = A.type
-	var/refid = "\ref[A]"
+	var/refID = "\ref[A]"
 	
 	del(A)
 	

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -66,6 +66,9 @@ SUBSYSTEM_DEF(garbage)
 	HandleToBeQueued()
 	if(state == SS_RUNNING)
 		HandleQueue()
+	
+	if (state == SS_PAUSED) //make us wait again before the next run.
+		state = SS_RUNNING 
 
 //If you see this proc high on the profile, what you are really seeing is the garbage collection/soft delete overhead in byond.
 //Don't attempt to optimize, not worth the effort.
@@ -110,24 +113,9 @@ SUBSYSTEM_DEF(garbage)
 			var/type = A.type
 			testing("GC: -- \ref[A] | [type] was unable to be GC'd and was deleted --")
 			didntgc["[type]"]++
-			var/time = world.timeofday
-			var/tick = world.tick_usage
-			var/ticktime = world.time
+			
 			HardDelete(A)
-			tick = (world.tick_usage-tick+((world.time-ticktime)/world.tick_lag*100))
 
-			if (tick > highest_del_tickusage)
-				highest_del_tickusage = tick
-			time = world.timeofday - time
-			if (!time && TICK_DELTA_TO_MS(tick) > 1)
-				time = TICK_DELTA_TO_MS(tick)/100
-			if (time > highest_del_time)
-				highest_del_time = time
-			if (time > 10)
-				log_game("Error: [type]([refID]) took longer then 1 second to delete (took [time/10] seconds to delete)")
-				message_admins("Error: [type]([refID]) took longer then 1 second to delete (took [time/10] seconds to delete).")
-				postpone(time/5)
-				break
 			++delslasttick
 			++totaldels
 		else
@@ -157,8 +145,27 @@ SUBSYSTEM_DEF(garbage)
 
 //this is purely to seperate things profile wise.
 /datum/controller/subsystem/garbage/proc/HardDelete(datum/A)
+	var/time = world.timeofday
+	var/tick = world.tick_usage
+	var/ticktime = world.time
+	var/type = A.type
+	
 	del(A)
-
+	
+	tick = (world.tick_usage-tick+((world.time-ticktime)/world.tick_lag*100))
+	if (tick > highest_del_tickusage)
+		highest_del_tickusage = tick
+	time = world.timeofday - time
+	if (!time && TICK_DELTA_TO_MS(tick) > 1)
+		time = TICK_DELTA_TO_MS(tick)/100
+	if (time > highest_del_time)
+		highest_del_time = time
+	if (time > 10)
+		log_game("Error: [type]([refID]) took longer then 1 second to delete (took [time/10] seconds to delete)")
+		message_admins("Error: [type]([refID]) took longer then 1 second to delete (took [time/10] seconds to delete).")
+		postpone(time/5)
+		break
+	
 /datum/controller/subsystem/garbage/proc/HardQueue(datum/A)
 	if (istype(A) && A.gc_destroyed == GC_CURRENTLY_BEING_QDELETED)
 		tobequeued += A
@@ -211,7 +218,7 @@ SUBSYSTEM_DEF(garbage)
 			if (QDEL_HINT_HARDDEL)		//qdel should assume this object won't gc, and queue a hard delete using a hard reference to save time from the locate()
 				SSgarbage.HardQueue(D)
 			if (QDEL_HINT_HARDDEL_NOW)	//qdel should assume this object won't gc, and hard del it post haste.
-				del(D)
+				HardDelete(D)
 			if (QDEL_HINT_FINDREFERENCE)//qdel will, if TESTING is enabled, display all references to this object, then queue the object for deletion.
 				SSgarbage.QueueForQueuing(D)
 				#ifdef TESTING

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -148,7 +148,9 @@ SUBSYSTEM_DEF(garbage)
 	var/time = world.timeofday
 	var/tick = world.tick_usage
 	var/ticktime = world.time
+	
 	var/type = A.type
+	var/refid = "\ref[A]"
 	
 	del(A)
 	
@@ -164,7 +166,6 @@ SUBSYSTEM_DEF(garbage)
 		log_game("Error: [type]([refID]) took longer then 1 second to delete (took [time/10] seconds to delete)")
 		message_admins("Error: [type]([refID]) took longer then 1 second to delete (took [time/10] seconds to delete).")
 		postpone(time/5)
-		break
 	
 /datum/controller/subsystem/garbage/proc/HardQueue(datum/A)
 	if (istype(A) && A.gc_destroyed == GC_CURRENTLY_BEING_QDELETED)
@@ -218,7 +219,7 @@ SUBSYSTEM_DEF(garbage)
 			if (QDEL_HINT_HARDDEL)		//qdel should assume this object won't gc, and queue a hard delete using a hard reference to save time from the locate()
 				SSgarbage.HardQueue(D)
 			if (QDEL_HINT_HARDDEL_NOW)	//qdel should assume this object won't gc, and hard del it post haste.
-				HardDelete(D)
+				SSgarbage.HardDelete(D)
 			if (QDEL_HINT_FINDREFERENCE)//qdel will, if TESTING is enabled, display all references to this object, then queue the object for deletion.
 				SSgarbage.QueueForQueuing(D)
 				#ifdef TESTING


### PR DESCRIPTION
We no longer pause when we use up a tick, instead making us wait the delay between fires. (to cut down on lag from consecutive hard deletes) In a later pr I'll also make the MC punish subsystems who go over their allocated tick time with delayed fires and lower tick allotments.

Long hard delete logging moved to HardDelete proc so it can take effect on QDEL_HINT_HARDDEL items as well.

QDEL_HINT_HARDDEL_NOW uses the HardDelete proc now.

see #26568
closes #26528

:cl:
tweak: Tweaked how things were deleted to cut down on lag from consecutive deletes and provide better logging for things that cause lag when hard-deleted.
/:cl:
