### PR TITLE
Lowers max list size in vv

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -445,7 +445,7 @@
 		var/list/L = value
 		var/list/items = list()
 
-		if (L.len > 0 && !(name == "underlays" || name == "overlays" || L.len > 500))
+		if (L.len > 0 && !(name == "underlays" || name == "overlays" || L.len > (IS_NORMAL_LIST(L) ? 50 : 150)))
 			for (var/i in 1 to L.len)
 				var/key = L[i]
 				var/val


### PR DESCRIPTION
Since you can vv lists now, this doesn't need to be as big.

Special byond lists still have a larger size, because they can't be vv'ed since the refid they generate is temp and expires at the end of the proc that generated them.