### PR TITLE
No longer kills people who become monkeys. Oops.

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -50,7 +50,8 @@
 		if(C.has_brain_worms())
 			var/mob/living/simple_animal/borer/B = C.has_brain_worms()
 			B.leave_victim() //Should remove borer if the brain is removed - RR
-	transfer_identity(C)
+	if(!gc_destroyed || (owner && !owner.gc_destroyed))
+		transfer_identity(C)
 	C.update_hair()
 
 /obj/item/organ/brain/prepare_eat()

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -60,7 +60,7 @@
 	name = "[L.name]'s brain"
 	if(brainmob || decoy_override)
 		return
-	if(L.mind.current != L)
+	if(!L.mind)
 		return
 	brainmob = new(src)
 	brainmob.name = L.real_name

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -60,6 +60,8 @@
 	name = "[L.name]'s brain"
 	if(brainmob || decoy_override)
 		return
+	if(L.mind.current != L)
+		return
 	brainmob = new(src)
 	brainmob.name = L.real_name
 	brainmob.real_name = L.real_name

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -728,7 +728,7 @@
 
 /mob/living/carbon/can_be_revived()
 	. = ..()
-	if(!getorgan(/obj/item/organ/brain))
+	if(!getorgan(/obj/item/organ/brain) && !(mind.changeling))
 		return 0
 
 /mob/living/carbon/harvest(mob/living/user)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -252,7 +252,8 @@
 		if(mind)
 			mind.transfer_to(O)
 			if(O.mind.changeling)
-				O.mind.changeling.purchasedpowers += new /obj/effect/proc_holder/changeling/humanform(null)
+				for(var/obj/effect/proc_holder/changeling/humanform/HF in O.mind.changeling.purchasedpowers)
+					mind.changeling.purchasedpowers -= HF
 
 		for(var/X in internal_organs)
 			var/obj/item/organ/I = X

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -13,12 +13,6 @@
 			stored_implants += IMP
 			IMP.removed(src, 1, 1)
 
-	if (tr_flags & TR_KEEPORGANS)
-		for(var/X in internal_organs)
-			var/obj/item/organ/I = X
-			int_organs += I
-			I.Remove(src, 1)
-
 	var/list/missing_bodyparts_zones = get_missing_limbs()
 
 	var/obj/item/cavity_object
@@ -95,11 +89,29 @@
 	//re-add organs to new mob
 	if(tr_flags & TR_KEEPORGANS)
 		for(var/X in O.internal_organs)
+			var/obj/item/organ/I = X
+			I.Remove(O, 1)
 			qdel(X)
+
+		if(mind)
+			mind.transfer_to(O)
+			if(O.mind.changeling)
+				O.mind.changeling.purchasedpowers += new /obj/effect/proc_holder/changeling/humanform(null)
+
+		for(var/X in internal_organs)
+			var/obj/item/organ/I = X
+			int_organs += I
+			I.Remove(src, 1)
 
 		for(var/X in int_organs)
 			var/obj/item/organ/I = X
 			I.Insert(O, 1)
+
+	if(!(tr_flags & TR_KEEPORGANS))
+		if(mind)
+			mind.transfer_to(O)
+			if(O.mind.changeling)
+				O.mind.changeling.purchasedpowers += new /obj/effect/proc_holder/changeling/humanform(null)
 
 	var/obj/item/bodypart/chest/torso = O.get_bodypart("chest")
 	if(cavity_object)
@@ -117,12 +129,6 @@
 						continue //so headless changelings don't lose their brain when transforming
 					qdel(G) //we lose the organs in the missing limbs
 		qdel(BP)
-
-	//transfer mind and delete old mob
-	if(mind)
-		mind.transfer_to(O)
-		if(O.mind.changeling)
-			O.mind.changeling.purchasedpowers += new /obj/effect/proc_holder/changeling/humanform(null)
 
 
 	if (tr_flags & TR_DEFAULTMSG)
@@ -153,12 +159,6 @@
 			var/obj/item/weapon/implant/IMP = X
 			stored_implants += IMP
 			IMP.removed(src, 1, 1)
-
-	if (tr_flags & TR_KEEPORGANS)
-		for(var/X in internal_organs)
-			var/obj/item/organ/I = X
-			int_organs += I
-			I.Remove(src, 1)
 
 	var/list/missing_bodyparts_zones = get_missing_limbs()
 
@@ -242,14 +242,26 @@
 			var/obj/item/weapon/implant/IMP = Y
 			IMP.implant(O, null, 1)
 
+	//re-add organs to new mob
 	if(tr_flags & TR_KEEPORGANS)
 		for(var/X in O.internal_organs)
+			var/obj/item/organ/I = X
+			I.Remove(O, 1)
 			qdel(X)
+
+		if(mind)
+			mind.transfer_to(O)
+			if(O.mind.changeling)
+				O.mind.changeling.purchasedpowers += new /obj/effect/proc_holder/changeling/humanform(null)
+
+		for(var/X in internal_organs)
+			var/obj/item/organ/I = X
+			int_organs += I
+			I.Remove(src, 1)
 
 		for(var/X in int_organs)
 			var/obj/item/organ/I = X
 			I.Insert(O, 1)
-
 
 	var/obj/item/bodypart/chest/torso = get_bodypart("chest")
 	if(cavity_object)
@@ -268,11 +280,12 @@
 					qdel(G) //we lose the organs in the missing limbs
 		qdel(BP)
 
-	if(mind)
-		mind.transfer_to(O)
-		if(O.mind.changeling)
-			for(var/obj/effect/proc_holder/changeling/humanform/HF in O.mind.changeling.purchasedpowers)
-				mind.changeling.purchasedpowers -= HF
+	if(!(tr_flags & TR_KEEPORGANS))
+		if(mind)
+			mind.transfer_to(O)
+			if(O.mind.changeling)
+				for(var/obj/effect/proc_holder/changeling/humanform/HF in O.mind.changeling.purchasedpowers)
+					mind.changeling.purchasedpowers -= HF
 
 	O.a_intent = INTENT_HELP
 	if (tr_flags & TR_DEFAULTMSG)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -253,7 +253,7 @@
 			mind.transfer_to(O)
 			if(O.mind.changeling)
 				for(var/obj/effect/proc_holder/changeling/humanform/HF in O.mind.changeling.purchasedpowers)
-					mind.changeling.purchasedpowers -= HF
+					O.mind.changeling.purchasedpowers -= HF
 
 		for(var/X in internal_organs)
 			var/obj/item/organ/I = X
@@ -286,7 +286,7 @@
 			mind.transfer_to(O)
 			if(O.mind.changeling)
 				for(var/obj/effect/proc_holder/changeling/humanform/HF in O.mind.changeling.purchasedpowers)
-					mind.changeling.purchasedpowers -= HF
+					O.mind.changeling.purchasedpowers -= HF
 
 	O.a_intent = INTENT_HELP
 	if (tr_flags & TR_DEFAULTMSG)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -39,7 +39,7 @@
 		M.internal_organs -= src
 		if(M.internal_organs_slot[slot] == src)
 			M.internal_organs_slot.Remove(slot)
-		if(vital && !special)
+		if(vital && !special && !(M.status_flags & GODMODE))
 			M.death()
 	for(var/X in actions)
 		var/datum/action/A = X


### PR DESCRIPTION
:panicbasket:
seriously though why did the new body qdel their organs when insertion and removal was handled fine in the rest of the proc

Has been more tested now, fixes all issues related to #26346 I'm aware of including:
Dummies with godmode dying when their brain is destroyed
Changelings not being able to revive without a brain(turns out the carbon revive() specifically checks for one)
People dying when transforming between monkeys and humans.
Ghosts teleporting to the arrivals shuttle if their mob is deleted, fixes #26641 