### PR TITLE
Makes beakers craftable

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -10,6 +10,14 @@
 	var/category = CAT_NONE //where it shows up in the crafting UI
 
 
+/datum/crafting_recipe/beaker
+	name = "Beaker"
+	result = /obj/item/weapon/reagent_containers/glass/beaker
+	reqs = list(/obj/item/stack/sheet/glass = 1)
+	tools = list(/obj/item/weapon/weldingtool)
+	time = 50
+	category = CAT_MISC
+
 /datum/crafting_recipe/pin_removal
 	name = "Pin Removal"
 	result = /obj/item/weapon/gun


### PR DESCRIPTION
:cl: Tacolizard
add: You can now craft beakers using a sheet of glass and a welder.
/:cl:

This was a long-needed feature. This limitation prevented grenade building from being even remotely practical.
