### PR TITLE
Blood Cult removals and tweaks

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -639,9 +639,9 @@ var/list/teleport_runes = list()
 	qdel(src) //delete before pulsing because it's a delay reee
 	empulse(E, 9*invokers.len, 12*invokers.len) // Scales now, from a single room to most of the station depending on # of chanters
 
-//Rite of Astral Communion: Separates one's spirit from their body. They will take damage while it is active.
-/obj/effect/rune/astral
-	cultist_name = "Astral Communion"
+//Rite of Spirit Sight: Separates one's spirit from their body. They will take damage while it is active.
+/obj/effect/rune/spirit
+	cultist_name = "Spirit Sight"
 	cultist_desc = "severs the link between one's spirit and body. This effect is taxing and one's physical body will take damage while this is active."
 	invocation = "Fwe'sh mah erl nyag r'ya!"
 	icon_state = "7"
@@ -650,24 +650,24 @@ var/list/teleport_runes = list()
 	construct_invoke = 0
 	var/mob/living/affecting = null
 
-/obj/effect/rune/astral/examine(mob/user)
+/obj/effect/rune/spirit/examine(mob/user)
 	..()
 	if(affecting)
 		to_chat(user, "<span class='cultitalic'>A translucent field encases [user] above the rune!</span>")
 
-/obj/effect/rune/astral/can_invoke(mob/living/user)
+/obj/effect/rune/spirit/can_invoke(mob/living/user)
 	if(rune_in_use)
 		to_chat(user, "<span class='cultitalic'>[src] cannot support more than one body!</span>")
-		log_game("Astral Communion rune failed - more than one user")
+		log_game("Spirit Sight rune failed - more than one user")
 		return list()
 	var/turf/T = get_turf(src)
 	if(!(user in T))
 		to_chat(user, "<span class='cultitalic'>You must be standing on top of [src]!</span>")
-		log_game("Astral Communion rune failed - user not standing on rune")
+		log_game("Spirit Sight rune failed - user not standing on rune")
 		return list()
 	return ..()
 
-/obj/effect/rune/astral/invoke(var/list/invokers)
+/obj/effect/rune/spirit/invoke(var/list/invokers)
 	var/mob/living/user = invokers[1]
 	..()
 	var/turf/T = get_turf(src)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -214,7 +214,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		log_game("Talisman Creation rune failed - already in use")
 		return
 
-	for(var/I in subtypesof(/obj/item/weapon/paper/talisman) - /obj/item/weapon/paper/talisman/malformed - /obj/item/weapon/paper/talisman/supply - /obj/item/weapon/paper/talisman/supply/weak)
+	for(var/I in subtypesof(/obj/item/weapon/paper/talisman) - /obj/item/weapon/paper/talisman/malformed - /obj/item/weapon/paper/talisman/supply - /obj/item/weapon/paper/talisman/supply/weak - /obj/item/weapon/paper/talisman/summon_tome)
 		var/obj/item/weapon/paper/talisman/J = I
 		var/talisman_cult_name = initial(J.cultist_name)
 		if(talisman_cult_name)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -520,7 +520,7 @@ var/list/teleport_runes = list()
 
 //Rite of Resurrection: Requires the corpse of a cultist and that there have been less revives than the number of people sacrificed
 /obj/effect/rune/raise_dead
-	cultist_name = "Raise Dead"
+	cultist_name = "Resurrect Cultist"
 	cultist_desc = "requires the corpse of a cultist placed upon the rune. Provided there have been sufficient sacrifices, they will be revived."
 	invocation = null //Depends on the name of the user - see below
 	icon_state = "1"
@@ -850,7 +850,7 @@ var/list/wall_runes = list()
 	light_color = LIGHT_COLOR_LAVA
 	req_cultists = 3
 	construct_invoke = 0
-	var/tick_damage = 25
+	var/tick_damage = 30
 	rune_in_use = FALSE
 
 /obj/effect/rune/blood_boil/do_invoke_glow()
@@ -905,45 +905,6 @@ var/list/wall_runes = list()
 			L.take_overall_damage(tick_damage*multiplier, tick_damage*multiplier)
 			if(is_servant_of_ratvar(L))
 				L.adjustStaminaLoss(tick_damage*0.5)
-
-
-//Deals brute damage to all targets on the rune and heals the invoker for each target drained.
-/obj/effect/rune/leeching
-	cultist_name = "Drain Life"
-	cultist_desc = "drains the life of all targets on the rune, restoring life to the user."
-	invocation = "Yu'gular faras desdae. Umathar uf'kal thenar!"
-	icon_state = "3"
-	color = "#9F1C34"
-
-/obj/effect/rune/leeching/can_invoke(mob/living/user)
-	if(world.time <= user.next_move)
-		return list()
-	var/turf/T = get_turf(src)
-	var/list/potential_targets = list()
-	for(var/mob/living/carbon/M in T.contents - user)
-		if(M.stat != DEAD)
-			potential_targets += M
-	if(!potential_targets.len)
-		to_chat(user, "<span class='cultitalic'>There must be at least one valid target on the rune!</span>")
-		log_game("Leeching rune failed - no valid targets")
-		return list()
-	return ..()
-
-/obj/effect/rune/leeching/invoke(var/list/invokers)
-	var/mob/living/user = invokers[1]
-	user.changeNext_move(CLICK_CD_CLICK_ABILITY)
-	..()
-	var/turf/T = get_turf(src)
-	for(var/mob/living/carbon/M in T.contents - user)
-		if(M.stat != DEAD)
-			var/drained_amount = rand(10,20)
-			M.apply_damage(drained_amount, BRUTE, "chest")
-			user.adjustBruteLoss(-drained_amount)
-			to_chat(M, "<span class='cultitalic'>You feel extremely weak.</span>")
-	user.Beam(T,icon_state="drainbeam",time=5)
-	user.visible_message("<span class='warning'>Blood flows from the rune into [user]!</span>", \
-	"<span class='cult'>Blood flows into you, healing your wounds and revitalizing your spirit.</span>")
-
 
 //Rite of Spectral Manifestation: Summons a ghost on top of the rune as a cultist human with no items. User must stand on the rune at all times, and takes damage for each summoned ghost.
 /obj/effect/rune/manifest

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -850,7 +850,7 @@ var/list/wall_runes = list()
 	light_color = LIGHT_COLOR_LAVA
 	req_cultists = 3
 	construct_invoke = 0
-	var/tick_damage = 30
+	var/tick_damage = 25
 	rune_in_use = FALSE
 
 /obj/effect/rune/blood_boil/do_invoke_glow()

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -176,7 +176,7 @@
 	invocation = "Kla'atu barada nikt'o!"
 	health_cost = 1
 	creation_time = 30
-	uses = 2
+	uses = 6
 	var/revealing = FALSE //if it reveals or not
 
 /obj/item/weapon/paper/talisman/true_sight/invoke(mob/living/user, successfuluse = 1)
@@ -186,29 +186,13 @@
 			"<span class='cultitalic'>You speak the words of the talisman, hiding nearby runes.</span>")
 		invocation = "Nikt'o barada kla'atu!"
 		revealing = TRUE
-		for(var/obj/effect/rune/R in range(3,user))
+		for(var/obj/effect/rune/R in range(4,user))
 			R.talismanhide()
 	else
 		user.visible_message("<span class='warning'>A flash of light shines from [user]'s hand!</span>", \
 			 "<span class='cultitalic'>You speak the words of the talisman, revealing nearby runes.</span>")
 		for(var/obj/effect/rune/R in range(3,user))
 			R.talismanreveal()
-
-//Rite of False Truths: Same as rune
-/obj/item/weapon/paper/talisman/make_runes_fake
-	cultist_name = "Talisman of Disguising"
-	cultist_desc = "A talisman that will make nearby runes appear fake."
-	color = "#ff80d5" // honk
-	invocation = "By'o nar'nar!"
-	creation_time = 20
-
-/obj/item/weapon/paper/talisman/make_runes_fake/invoke(mob/living/user, successfuluse = 1)
-	. = ..()
-	user.visible_message("<span class='warning'>Dust flows from [user]s hand.</span>", \
-						 "<span class='cultitalic'>You speak the words of the talisman, making nearby runes appear fake.</span>")
-	for(var/obj/effect/rune/R in orange(6,user))
-		R.desc = "A rune vandalizing the station."
-
 
 //Rite of Disruption: Weaker than rune
 /obj/item/weapon/paper/talisman/emp
@@ -379,7 +363,7 @@
 	cultist_desc = "Use this talisman on a victim to handcuff them with dark bindings."
 	invocation = "In'totum Lig'abis!"
 	color = "#B27300" // burnt-orange
-	uses = 4
+	uses = 6
 
 /obj/item/weapon/paper/talisman/shackle/invoke(mob/living/user, successfuluse = 0)
 	if(successfuluse) //if we're forced to be successful(we normally aren't) then do the normal stuff


### PR DESCRIPTION
My philosophy for blood cult was always "easy to learn, hard to master". The first part got most of the emphasis last year as I gut the useless and redundant runes and talismans and streamlined most of the mechanics. 

I plan on adding new cult content, including runes and talismans, but until then I feel some housekeeping is in order because I put a pretty strict limit on making sure you can view all runes and talismans without having to scroll. 

I'm reverting Joan's reversion of my removal of the Drain Life rune. It is a consistently unused that does nothing but clutter and confuse. 

I'm also removing the fake runes talisman. I don't think I've ever seen it used and the new cult mechanics (tomes appearing on convertees, animated runes, the inevitable blood/tomes/gibs that tend to accumulate in any base where you could create a fake-rune talisman) make it all but useless. 

The veiling talisman and the shackling talisman have gained more charges before they are depleted. 

"Raise Dead" is now renamed "Resurrect Cultist". Considering theres another rune that actually brings ghosts to life, the name clarity was needed.

"Astral Communion" is now "Spirit Sight". We get 1% more flavor from obtuse names but far less usability, see: Clock Cult. 