### PR TITLE
When jumpsuits take severe damage, their suit sensors break.

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -196,6 +196,21 @@ GLOBAL_LIST_EMPTY(bloody_footprints_cache)
 #define BLOOD_STATE_XENO			"xeno"
 #define BLOOD_STATE_OIL				"oil"
 #define BLOOD_STATE_NOT_BLOODY		"no blood whatsoever"
+
+//suit sensors: sensor_mode defines
+
+#define SENSOR_OFF 0
+#define SENSOR_LIVING 1
+#define SENSOR_VITALS 2
+#define SENSOR_COORDS 3
+
+//suit sensors: has_sensor defines
+
+#define BROKEN_SENSORS -1
+#define NO_SENSORS 0
+#define HAS_SENSORS 1
+#define LOCKED_SENSORS 2
+
 //Turf wet states
 #define TURF_DRY		0
 #define TURF_WET_WATER	1

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -24,7 +24,7 @@
 	if(!istype(H)) return 0
 	var/obj/item/clothing/under/U = H.w_uniform
 	if(!istype(U)) return 0
-	if(U.sensor_mode <= 2) return 0
+	if(U.sensor_mode <= SENSOR_VITALS) return 0
 	return 1
 
 /datum/atom_hud/data/human/medical/basic/add_to_single_hud(mob/M, mob/living/carbon/H)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -153,8 +153,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					U = H.w_uniform
 
 					// Are the suit sensors on?
-					if (U.has_sensor && U.sensor_mode)
-						pos = H.z == 0 || U.sensor_mode == 3 ? get_turf(H) : null
+					if ((U.has_sensor > 0) && U.sensor_mode)
+						pos = H.z == 0 || U.sensor_mode == SENSOR_COORDS ? get_turf(H) : null
 
 						// Special case: If the mob is inside an object confirm the z-level on turf level.
 						if (H.z == 0 && (!pos || pos.z != z)) continue
@@ -170,10 +170,10 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 							assignment = ""
 							ijob = 80
 
-						if (U.sensor_mode >= 1) life_status = (!H.stat ? "true" : "false")
+						if (U.sensor_mode >= SENSOR_LIVING) life_status = (!H.stat ? "true" : "false")
 						else                    life_status = null
 
-						if (U.sensor_mode >= 2)
+						if (U.sensor_mode >= SENSOR_VITALS)
 							dam1 = round(H.getOxyLoss(),1)
 							dam2 = round(H.getToxLoss(),1)
 							dam3 = round(H.getFireLoss(),1)
@@ -184,7 +184,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 							dam3 = null
 							dam4 = null
 
-						if (U.sensor_mode >= 3)
+						if (U.sensor_mode >= SENSOR_COORDS)
 							if (!pos) pos = get_turf(H)
 							var/area/player_area = get_area(H)
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -202,7 +202,7 @@
 	item_color = "black"
 	desc = "It's a plain jumpsuit. It has a small dial on the wrist."
 	origin_tech = "syndicate=2"
-	sensor_mode = 0 //Hey who's this guy on the Syndicate Shuttle??
+	sensor_mode = SENSOR_OFF //Hey who's this guy on the Syndicate Shuttle??
 	random_sensor = 0
 	resistance_flags = 0
 	armor = list(melee = 10, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 50)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -83,7 +83,7 @@
 		C.use(1)
 		update_clothes_damaged_state(FALSE)
 		obj_integrity = max_integrity
-		to_chat(user, "<span class='notice'>You fix the damages on [src] with [C].</span>")
+		to_chat(user, "<span class='notice'>You fix the damage on [src] with [C].</span>")
 		return 1
 	if(pockets)
 		var/i = pockets.attackby(W, user, params)
@@ -161,7 +161,7 @@
 /obj/item/clothing/obj_break(damage_flag)
 	if(!damaged_clothes)
 		update_clothes_damaged_state(TRUE)
-
+	to_chat(usr, "<span class='notice'>Your [src] starts to fall apart!")
 
 /obj/item/clothing/proc/update_clothes_damaged_state(damaging = TRUE)
 	var/index = "\ref[initial(icon)]-[initial(icon_state)]"
@@ -518,9 +518,9 @@ BLIND     // can't see anything
 	slot_flags = SLOT_ICLOTHING
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 	var/fitted = FEMALE_UNIFORM_FULL // For use in alternate clothing styles for women
-	var/has_sensor = 1//For the crew computer 2 = unable to change mode
+	var/has_sensor = HAS_SENSORS // For the crew computer
 	var/random_sensor = 1
-	var/sensor_mode = 0	/* 1 = Report living/dead, 2 = Report detailed damages, 3 = Report location */
+	var/sensor_mode = NO_SENSORS
 	var/can_adjust = 1
 	var/adjusted = NORMAL_STYLE
 	var/alt_covers_chest = 0 // for adjusted/rolled-down jumpsuits, 0 = exposes chest and arms, 1 = exposes arms only
@@ -545,16 +545,26 @@ BLIND     // can't see anything
 			tI.color = hastie.color
 			. += tI
 
+/obj/item/clothing/under/attackby(obj/item/W, mob/user, params)
+	if((has_sensor == BROKEN_SENSORS) && istype(W, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/C = W
+		C.use(1)
+		has_sensor = HAS_SENSORS
+		to_chat(user,"<span class='notice'>You repair the suit sensors on [src] with [C].</span>")
+		return 1
+
 /obj/item/clothing/under/update_clothes_damaged_state(damaging = TRUE)
 	..()
 	if(ismob(loc))
 		var/mob/M = loc
 		M.update_inv_w_uniform()
+	if(has_sensor > NO_SENSORS)
+		has_sensor = BROKEN_SENSORS
 
 /obj/item/clothing/under/New()
 	if(random_sensor)
 		//make the sensor mode favor higher levels, except coords.
-		sensor_mode = pick(0, 1, 1, 2, 2, 2, 3, 3)
+		sensor_mode = pick(SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS, SENSOR_COORDS)
 	adjusted = NORMAL_STYLE
 	..()
 
@@ -632,15 +642,18 @@ BLIND     // can't see anything
 			to_chat(user, "Alt-click on [src] to wear it normally.")
 		else
 			to_chat(user, "Alt-click on [src] to wear it casually.")
-	switch(sensor_mode)
-		if(0)
-			to_chat(user, "Its sensors appear to be disabled.")
-		if(1)
-			to_chat(user, "Its binary life sensors appear to be enabled.")
-		if(2)
-			to_chat(user, "Its vital tracker appears to be enabled.")
-		if(3)
-			to_chat(user, "Its vital tracker and tracking beacon appear to be enabled.")
+	if (has_sensor == BROKEN_SENSORS)
+		to_chat(user, "Its sensors appear to be shorted out.")
+	else if(has_sensor > NO_SENSORS)
+		switch(sensor_mode)
+			if(SENSOR_OFF)
+				to_chat(user, "Its sensors appear to be disabled.")
+			if(SENSOR_LIVING)
+				to_chat(user, "Its binary life sensors appear to be enabled.")
+			if(SENSOR_VITALS)
+				to_chat(user, "Its vital tracker appears to be enabled.")
+			if(SENSOR_COORDS)
+				to_chat(user, "Its vital tracker and tracking beacon appear to be enabled.")
 	if(hastie)
 		to_chat(user, "\A [hastie] is attached to it.")
 
@@ -660,10 +673,13 @@ BLIND     // can't see anything
 		return
 	if (!can_use(M))
 		return
-	if(src.has_sensor >= 2)
+	if(src.has_sensor == LOCKED_SENSORS)
 		to_chat(usr, "The controls are locked.")
 		return 0
-	if(src.has_sensor <= 0)
+	if(src.has_sensor == BROKEN_SENSORS)
+		to_chat(usr, "The sensors have shorted out!")
+		return 0
+	if(src.has_sensor <= NO_SENSORS)
 		to_chat(usr, "This suit does not have any sensors.")
 		return 0
 

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -14,7 +14,7 @@
 	icon_state = "captain"
 	item_state = "b_suit"
 	item_color = "captain"
-	sensor_mode = 3
+	sensor_mode = SENSOR_COORDS
 	random_sensor = 0
 
 /obj/item/clothing/under/rank/cargo

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -18,7 +18,7 @@
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0, fire = 30, acid = 30)
 	strip_delay = 50
 	alt_covers_chest = 1
-	sensor_mode = 3
+	sensor_mode = SENSOR_COORDS
 	random_sensor = 0
 
 /obj/item/clothing/under/rank/security/grey
@@ -27,7 +27,7 @@
 	icon_state = "security"
 	item_state = "gy_suit"
 	item_color = "security"
-	
+
 
 /obj/item/clothing/under/rank/warden
 	name = "security suit"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -61,8 +61,8 @@
 	icon_state = "prisoner"
 	item_state = "o_suit"
 	item_color = "prisoner"
-	has_sensor = 2
-	sensor_mode = 3
+	has_sensor = LOCKED_SENSORS
+	sensor_mode = SENSOR_COORDS
 	random_sensor = 0
 
 /obj/item/clothing/under/rank/mailman
@@ -404,7 +404,7 @@
 
 /obj/item/clothing/under/gladiator/ash_walker
 	desc = "This gladiator uniform appears to be covered in ash and fairly dated."
-	has_sensor = 0
+	has_sensor = NO_SENSORS
 
 /obj/item/clothing/under/sundress
 	name = "sundress"

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -4,7 +4,7 @@
 	icon_state = "syndicate"
 	item_state = "bl_suit"
 	item_color = "syndicate"
-	has_sensor = 0
+	has_sensor = NO_SENSORS
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 40)
 	alt_covers_chest = 1
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -420,7 +420,7 @@
 	item_color = "golem"
 	flags = ABSTRACT | NODROP
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	has_sensor = 0
+	has_sensor = NO_SENSORS
 
 /obj/item/clothing/suit/golem
 	name = "adamantine shell"


### PR DESCRIPTION
:cl:
tweak: When jumpsuits take severe damage, their suit sensors break. They can be fixed by applying a cable coil.
/:cl:


* Clothing that take substantial damage, for example from fire, has its suit sensors short out. This only happens when it gets to the point where the sprite looks raggedy.
* Broken suit sensors can be repaired with cable coil.
* Users receive feedback when their clothing takes damage. 
* Changed all suit sensor vars to defines. 

What this adds to the game: It's gotten better but suit sensors still have the problems of A) not having them on is an OK meta-tell you're an antag, and B) having them on, if anyone bothers to check the console, is often GG. This is a tiny step toward mitigating that. 

It also makes clothing damage have a point besides looking ugly, and spare jumpsuits have a point at all. 

In case it comes up: Any jumpsuits with locked suit sensors (prisoner jumpsuits, etc) will no longer be locked if they take damage and then get fixed. I considered patching this but it'd be kludgy and if a prisoner manages to set himself on fire, escapes, then find cable coil, then he honestly deserves to have the sensors usable.

In response to balance concerns: Traitors killing you can already strip your jumpsuit and deactivate the suit sensors. The main times this will come up is if there is an open fire or a bomb. One gives you more than enough time to stop, drop and roll before your jumpsuit gets to the damage point, the other, you're probably dead and/or everyone knows where the explosion was.