### PR TITLE
Fixes SDQL global procs

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -477,7 +477,7 @@
 	var/list/new_args = list()
 	for(var/arg in arguments)
 		new_args += SDQL_expression(source, arg)
-	if(object == world) // Global proc.
+	if(object == GLOB) // Global proc.
 		procname = "/proc/[procname]"
 		return WrapAdminProcCall(GLOBAL_PROC, procname, new_args)
 	return WrapAdminProcCall(object, procname, new_args)


### PR DESCRIPTION
I changed this with the GLOB while back so you could use SDQL var queries on it using "global." but apparently this check exists..