### PR TITLE
Makes minibot listen on a configurable port

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -1,6 +1,7 @@
 # Configuration for the minibot.py bot starts here
 server = "irc.rizon.net"
 port = 6667
+nudge_port = 45678
 
 channels = ["#asdfgbus", "#botbus"]
 defaultchannel = "#asdfgbus"

--- a/bot/minibot.py
+++ b/bot/minibot.py
@@ -73,7 +73,7 @@ def setup_irc_socket():
 
 def setup_nudge_socket():
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	s.bind(("", 45678))  # localhost:45678
+	s.bind(("", nudge_port))  # localhost:nudge_port
 	s.listen(5)
 	logger.info("Nudge socket up and listening")
 	return s

--- a/bot/nudge.py
+++ b/bot/nudge.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from config import *
 import sys
 import pickle
 import socket
@@ -16,7 +17,7 @@ def pack():
 
 def nudge(data):
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	s.connect(("localhost", 45678))
+	s.connect(("localhost", nudge_port))
 	s.send(data)
 	s.close()
 


### PR DESCRIPTION
Noticed this while doing TGS3. I changed it there to use a config, but this change should come deservedly sooner for master

>Hardcoded values

REEE

@MrStonedOne 