### PR TITLE
Even admin-called shuttles will be affected by alert level

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -208,12 +208,10 @@ SUBSYSTEM_DEF(shuttle)
 	var/emergency_reason = "\nNature of emergency:\n\n[call_reason]"
 	var/security_num = seclevel2num(get_security_level())
 	switch(security_num)
-		if(SEC_LEVEL_GREEN)
-			emergency.request(null, 2, signal_origin, html_decode(emergency_reason), 0)
-		if(SEC_LEVEL_BLUE)
-			emergency.request(null, 1, signal_origin, html_decode(emergency_reason), 0)
+		if(SEC_LEVEL_RED,SEC_LEVEL_DELTA)
+			emergency.request(null, signal_origin, html_decode(emergency_reason), 1) //There is a serious threat we gotta move no time to give them five minutes.
 		else
-			emergency.request(null, 0.5, signal_origin, html_decode(emergency_reason), 1) // There is a serious threat we gotta move no time to give them five minutes.
+			emergency.request(null, signal_origin, html_decode(emergency_reason), 0)
 
 	log_game("[key_name(user)] has called the shuttle.")
 	message_admins("[key_name_admin(user)] has called the shuttle.")
@@ -272,7 +270,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	if(callShuttle)
 		if(EMERGENCY_IDLE_OR_RECALLED)
-			emergency.request(null, 2.5)
+			emergency.request(null, set_coefficient = 2.5)
 			log_game("There is no means of calling the shuttle anymore. Shuttle automatically called.")
 			message_admins("All the communications consoles were destroyed and all AIs are inactive. Shuttle called.")
 

--- a/code/game/gamemodes/devil/devilinfo.dm
+++ b/code/game/gamemodes/devil/devilinfo.dm
@@ -287,7 +287,7 @@ GLOBAL_LIST_INIT(lawlorify, list (
 		notify_ghosts("An arch devil has ascended in \the [A.name]. Reach out to the devil to be given a new shell for your soul.", source = owner.current, action=NOTIFY_ATTACK)
 	sleep(50)
 	if(!SSticker.mode.devil_ascended)
-		SSshuttle.emergency.request(null, 0.3)
+		SSshuttle.emergency.request(null, set_coefficient = 0.3)
 	SSticker.mode.devil_ascended++
 	form = ARCH_DEVIL
 
@@ -449,7 +449,7 @@ GLOBAL_LIST_INIT(lawlorify, list (
 					A.convert_to_archdevil()
 	else
 		throw EXCEPTION("Unable to find a blobstart landmark for hellish resurrection")
-	
+
 
 /datum/devilinfo/proc/update_hud()
 	if(istype(owner.current, /mob/living/carbon))

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -166,7 +166,7 @@
 			var/obj/machinery/abductor/console/con = get_team_console(team_number)
 			var/datum/objective/objective = team_objectives[team_number]
 			if (con.experiment.points >= objective.target_amount)
-				SSshuttle.emergency.request(null, 0.5)
+				SSshuttle.emergency.request(null, set_coefficient = 0.5)
 				finished = 1
 				return ..()
 	return ..()

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -39,7 +39,7 @@
 	narsie_spawn_animation()
 
 	sleep(70)
-	SSshuttle.emergency.request(null, 0.1) // Cannot recall
+	SSshuttle.emergency.request(null, set_coefficient = 0.1) // Cannot recall
 
 
 /obj/singularity/narsie/large/attack_ghost(mob/dead/observer/user as mob)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -207,8 +207,17 @@
 
 	. = ..()
 
-/obj/docking_port/mobile/emergency/request(obj/docking_port/stationary/S, coefficient=1, area/signalOrigin, reason, redAlert)
-	var/call_time = SSshuttle.emergencyCallTime * coefficient
+/obj/docking_port/mobile/emergency/request(obj/docking_port/stationary/S, area/signalOrigin, reason, redAlert, set_coefficient=null)
+	if(!isnum(set_coefficient))
+		var/security_num = seclevel2num(get_security_level())
+		switch(security_num)
+			if(SEC_LEVEL_GREEN)
+				set_coefficient = 2
+			if(SEC_LEVEL_BLUE)
+				set_coefficient = 1
+			else
+				set_coefficient = 0.5
+	var/call_time = SSshuttle.emergencyCallTime * set_coefficient
 	switch(mode)
 		// The shuttle can not normally be called while "recalling", so
 		// if this proc is called, it's via admin fiat


### PR DESCRIPTION
As in, if you admin-call a shuttle at green, it'll start at 20 minutes instead of at 10, and at red it'll start at 5 instead of 10.