### PR TITLE
Librarians can speak any language

### DIFF
--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -143,6 +143,15 @@ Librarian
 		/obj/item/soapstone = 1
 	)
 
+
+/datum/outfit/job/librarian/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+
+	if(visualsOnly)
+		return
+
+	H.grant_all_languages(omnitongue=TRUE)
+
 /*
 Lawyer
 */


### PR DESCRIPTION
:cl: Kor
add: Librarians can speak any language
/:cl:

[why]:

It's a useful and fluffy perk that doesnt involve killing people and librarian is by far the most neglected job. pAIs are a roundstart thing and can understand any language so I dont think it will be a huge balance change either.
