### PR TITLE
You can now mount canvases on walls

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -113,6 +113,14 @@ var/global/list/globalBlankCanvases[AMT_OF_CANVASES]
 	else
 		return ..()
 
+/obj/item/weapon/canvas/afterattack(atom/target, mob/user, proximity)
+	var/turf/T = target
+	if(!iswallturf(T))
+		return
+	user.visible_message("<span class='notice'>[user] places [src] to [T].</span>", \
+						 "<span class='notice'>You attach the [src] to [T].</span>")
+	playsound(T, 'sound/items/Deconstruct.ogg', 50, 1)
+	user.transferItemToLoc(src,T)
 
 //Clean the whole canvas
 /obj/item/weapon/canvas/attack_self(mob/user)


### PR DESCRIPTION
It always bugged me that once you "painted" something on a canvas your only choices for displaying it were leaving it on the floor or dragging around an easel. 

Now you can easily hang/remove it from a wall. 