### PR TITLE
Server hop can now be used in lobby

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -5,6 +5,11 @@
 		args[1] = FALSE
 		Initialize(arglist(args))	//EXIST DAMN YOU!!!
 
+/mob/dead/Initialize()
+	. = ..()
+	if(config.cross_allowed)
+		verbs += /mob/dead/proc/server_hop
+
 /mob/dead/dust()	//ghosts can't be vaporised.
 	return
 
@@ -13,3 +18,28 @@
 
 /mob/dead/ConveyorMove()	//lol
 	return
+
+
+
+/mob/dead/proc/server_hop()
+	set category = "OOC"
+	set name = "Server Hop!"
+	set desc= "Jump to the other server"
+	if(notransform)
+		return
+	if(!config.cross_allowed)
+		verbs -= /mob/dead/proc/server_hop
+		to_chat(src, "<span class='notice'>Server Hop has been disabled.</span>")
+		return
+	if (alert(src, "Jump to server running at [config.cross_address]?", "Server Hop", "Yes", "No") != "Yes")
+		return 0
+	if (client && config.cross_allowed)
+		to_chat(src, "<span class='notice'>Sending you to [config.cross_address].</span>")
+		new /obj/screen/splash(client)
+		notransform = TRUE
+		sleep(29)	//let the animation play
+		notransform = FALSE
+		winset(src, null, "command=.options") //other wise the user never knows if byond is downloading resources
+		client << link(config.cross_address + "?server_hop=[key]")
+	else
+		to_chat(src, "<span class='error'>There is no other server configured!</span>")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -58,9 +58,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
 	verbs += /mob/dead/observer/proc/dead_tele
 
-	if(config.cross_allowed)
-		verbs += /mob/dead/observer/proc/server_hop
-
 	if(icon_state in GLOB.ghost_forms_with_directions_list)
 		ghostimage_default = image(src.icon,src,src.icon_state + "_nodir")
 	else
@@ -584,29 +581,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	target.key = key
 	target.faction = list("neutral")
 	return 1
-
-/mob/dead/observer/proc/server_hop()
-	set category = "Ghost"
-	set name = "Server Hop!"
-	set desc= "Jump to the other server"
-	if(notransform)
-		return
-	if(!config.cross_allowed)
-		verbs -= /mob/dead/observer/proc/server_hop
-		to_chat(src, "<span class='notice'>Server Hop has been disabled.</span>")
-		return
-	if (alert(src, "Jump to server running at [config.cross_address]?", "Server Hop", "Yes", "No") != "Yes")
-		return 0
-	if (client && config.cross_allowed)
-		to_chat(src, "<span class='notice'>Sending you to [config.cross_address].</span>")
-		new /obj/screen/splash(client)
-		notransform = TRUE
-		sleep(29)	//let the animation play
-		notransform = FALSE
-		winset(src, null, "command=.options") //other wise the user never knows if byond is downloading resources
-		client << link(config.cross_address + "?server_hop=[key]")
-	else
-		to_chat(src, "<span class='error'>There is no other server configured!</span>")
 
 /proc/show_server_hop_transfer_screen(expected_key)
 	//only show it to incoming ghosts


### PR DESCRIPTION
:cl: 
tweak: Server hop verb moved to the OOC tab
add: Server hop verb can now be used in the lobby as well as while a ghost.
/:cl: