### PR TITLE
Syndie Lavaland Base Flavortext Edit

### DIFF
--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -144,5 +144,9 @@
 	r_hand = /obj/item/weapon/melee/energy/sword/saber
 	mask = /obj/item/clothing/mask/chameleon
 	suit = /obj/item/clothing/suit/armor/vest
-	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. Unfortunatley, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. Do not abandon the base without good cause.</b> Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Remember, an enemy of our enemy is a friend, so also provide support to those that hinder Nanotrasen unless commanded otherwise by HQ. Do not let the base fall into enemy hands!</b>"
+	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. \n
+					Unfortunatley, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. <u> Do not abandon the base, activate the self destruct device if you are compromised.</u></b> \n
+					Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail.\n
+					<u> Remember, an enemy of our enemy is a friend, so also provide support to those that hinder Nanotrasen unless commanded otherwise by HQ. \n
+					Do not let the base fall into enemy hands!</u></font>"
 	pocket2 = /obj/item/weapon/card/id/syndicate/anyone

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -145,7 +145,7 @@
 	mask = /obj/item/clothing/mask/chameleon
 	suit = /obj/item/clothing/suit/armor/vest
 	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. \n +\
-					Unfortunatley, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. <u> Do not abandon the base, activate the self destruct device if you are compromised.</u></b> \n +\
+					Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. <u> Do not abandon the base, activate the self destruct device if you are compromised.</u></b> \n +\
 					Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail.\n +\
 					<u> Remember, an enemy of our enemy is a friend, so also provide support to those that hinder Nanotrasen unless commanded otherwise by HQ. \n +\
 					Do not let the base fall into enemy hands!</u></font>"

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -144,9 +144,9 @@
 	r_hand = /obj/item/weapon/melee/energy/sword/saber
 	mask = /obj/item/clothing/mask/chameleon
 	suit = /obj/item/clothing/suit/armor/vest
-	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. \n
-					Unfortunatley, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. <u> Do not abandon the base, activate the self destruct device if you are compromised.</u></b> \n
-					Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail.\n
-					<u> Remember, an enemy of our enemy is a friend, so also provide support to those that hinder Nanotrasen unless commanded otherwise by HQ. \n
+	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. \n +\
+					Unfortunatley, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. <u> Do not abandon the base, activate the self destruct device if you are compromised.</u></b> \n +\
+					Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail.\n +\
+					<u> Remember, an enemy of our enemy is a friend, so also provide support to those that hinder Nanotrasen unless commanded otherwise by HQ. \n +\
 					Do not let the base fall into enemy hands!</u></font>"
 	pocket2 = /obj/item/weapon/card/id/syndicate/anyone

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -144,5 +144,5 @@
 	r_hand = /obj/item/weapon/melee/energy/sword/saber
 	mask = /obj/item/clothing/mask/chameleon
 	suit = /obj/item/clothing/suit/armor/vest
-	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. Unfortunatley, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. Do not abandon the base without good cause.</b> Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!</b>"
+	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. Unfortunatley, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. Do not abandon the base without good cause.</b> Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Remember, an enemy of our enemy is a friend, so also provide support to those that hinder Nanotrasen unless commanded otherwise by HQ. Do not let the base fall into enemy hands!</b>"
 	pocket2 = /obj/item/weapon/card/id/syndicate/anyone


### PR DESCRIPTION
Why: Because people were outing antags [not traitors] via this and so I want to make it clear that's not really ok by explicitly adding that they should assist baddies instead of harm them [even those that aren't syndicate-aligned].

:cl: Cobby
add: Syndicate Lavabase now has more explicit instructions when it comes to outing non-syndicate affiliated enemies of Nanotrasen.
/:cl:


"Remember, an enemy of our enemy is a friend, so also provide support to those that hinder Nanotrasen unless commanded otherwise by HQ." was added to the flavor text.