### PR TITLE
Abductor fixes and tweaks

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -14,12 +14,24 @@
 	origin_tech = "magnets=7;biotech=4;powerstorage=4;abductor=4"
 	armor = list(melee = 15, bullet = 15, laser = 15, energy = 15, bomb = 15, bio = 15, rad = 15, fire = 70, acid = 70)
 	actions_types = list(/datum/action/item_action/hands_free/activate)
+	allowed = list(
+		/obj/item/device/abductor,
+		/obj/item/weapon/abductor_baton,
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/gun/energy,
+		/obj/item/weapon/restraints/handcuffs
+		)
 	var/mode = VEST_STEALTH
 	var/stealth_active = 0
 	var/combat_cooldown = 10
 	var/datum/icon_snapshot/disguise
 	var/stealth_armor = list(melee = 15, bullet = 15, laser = 15, energy = 15, bomb = 15, bio = 15, rad = 15, fire = 70, acid = 70)
 	var/combat_armor = list(melee = 50, bullet = 50, laser = 50, energy = 50, bomb = 50, bio = 50, rad = 50, fire = 90, acid = 90)
+
+/obj/item/clothing/suit/armor/abductor/vest/proc/toggle_nodrop()
+	flags ^= NODROP
+	if(ismob(loc))
+		to_chat(loc, "<span class='notice'>Your vest is now [flags & NODROP ? "locked" : "unlocked"].</span>")
 
 /obj/item/clothing/suit/armor/abductor/vest/proc/flip_mode()
 	switch(mode)
@@ -107,6 +119,18 @@
 	if(combat_cooldown==initial(combat_cooldown))
 		STOP_PROCESSING(SSobj, src)
 
+/obj/item/clothing/suit/armor/abductor/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	for(var/obj/machinery/abductor/console/C in GLOB.machines)
+		if(C.vest == src)
+			C.vest = null
+			break
+	. = ..()
+
+
+/obj/item/device/abductor
+	icon = 'icons/obj/abductor.dmi'
+
 /obj/item/device/abductor/proc/AbductorCheck(user)
 	if(isabductor(user))
 		return TRUE
@@ -114,14 +138,19 @@
 	return FALSE
 
 /obj/item/device/abductor/proc/ScientistCheck(user)
+	if(!AbductorCheck(user))
+		return FALSE
+
 	var/mob/living/carbon/human/H = user
 	var/datum/species/abductor/S = H.dna.species
-	return S.scientist
+	if(S.scientist)
+		return TRUE
+	to_chat(user, "<span class='warning'>You're not trained to use this!</span>")
+	return FALSE
 
 /obj/item/device/abductor/gizmo
 	name = "science tool"
 	desc = "A dual-mode tool for retrieving specimens and scanning appearances. Scanning can be done through cameras."
-	icon = 'icons/obj/abductor.dmi'
 	icon_state = "gizmo_scan"
 	item_state = "silencer"
 	origin_tech = "engineering=7;magnets=4;bluespace=4;abductor=3"
@@ -130,11 +159,12 @@
 	var/obj/machinery/abductor/console/console
 
 /obj/item/device/abductor/gizmo/attack_self(mob/user)
-	if(!AbductorCheck(user))
-		return
 	if(!ScientistCheck(user))
-		to_chat(user, "<span class='warning'>You're not trained to use this!</span>")
 		return
+	if(!console)
+		to_chat(user, "<span class='warning'>The device is not linked to console!</span>")
+		return
+
 	if(mode == GIZMO_SCAN)
 		mode = GIZMO_MARK
 		icon_state = "gizmo_mark"
@@ -144,11 +174,12 @@
 	to_chat(user, "<span class='notice'>You switch the device to [mode==GIZMO_SCAN? "SCAN": "MARK"] MODE</span>")
 
 /obj/item/device/abductor/gizmo/attack(mob/living/M, mob/user)
-	if(!AbductorCheck(user))
-		return
 	if(!ScientistCheck(user))
-		to_chat(user, "<span class='notice'>You're not trained to use this</span>")
 		return
+	if(!console)
+		to_chat(user, "<span class='warning'>The device is not linked to console!</span>")
+		return
+
 	switch(mode)
 		if(GIZMO_SCAN)
 			scan(M, user)
@@ -159,11 +190,12 @@
 /obj/item/device/abductor/gizmo/afterattack(atom/target, mob/living/user, flag, params)
 	if(flag)
 		return
-	if(!AbductorCheck(user))
-		return
 	if(!ScientistCheck(user))
-		to_chat(user, "<span class='notice'>You're not trained to use this</span>")
 		return
+	if(!console)
+		to_chat(user, "<span class='warning'>The device is not linked to console!</span>")
+		return
+
 	switch(mode)
 		if(GIZMO_SCAN)
 			scan(target, user)
@@ -172,9 +204,8 @@
 
 /obj/item/device/abductor/gizmo/proc/scan(atom/target, mob/living/user)
 	if(ishuman(target))
-		if(console!=null)
-			console.AddSnapshot(target)
-			to_chat(user, "<span class='notice'>You scan [target] and add them to the database.</span>")
+		console.AddSnapshot(target)
+		to_chat(user, "<span class='notice'>You scan [target] and add them to the database.</span>")
 
 /obj/item/device/abductor/gizmo/proc/mark(atom/target, mob/living/user)
 	if(marked == target)
@@ -198,11 +229,15 @@
 		marked = target
 		to_chat(user, "<span class='notice'>You finish preparing [target] for transport.</span>")
 
+/obj/item/device/abductor/gizmo/Destroy()
+	if(console)
+		console.gizmo = null
+	. = ..()
+
 
 /obj/item/device/abductor/silencer
 	name = "abductor silencer"
 	desc = "A compact device used to shut down communications equipment."
-	icon = 'icons/obj/abductor.dmi'
 	icon_state = "silencer"
 	item_state = "gizmo"
 	origin_tech = "materials=4;programming=7;abductor=3"
@@ -419,10 +454,10 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 				if(!C.handcuffed)
 					C.handcuffed = new /obj/item/weapon/restraints/handcuffs/energy/used(C)
 					C.update_handcuffed()
-					to_chat(user, "<span class='notice'>You handcuff [C].</span>")
+					to_chat(user, "<span class='notice'>You restrain [C].</span>")
 					add_logs(user, C, "handcuffed")
 			else
-				to_chat(user, "<span class='warning'>You fail to handcuff [C].</span>")
+				to_chat(user, "<span class='warning'>You fail to restrain [C].</span>")
 		else
 			to_chat(user, "<span class='warning'>[C] doesn't have two hands...</span>")
 
@@ -471,11 +506,11 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	..()
 	switch(mode)
 		if(BATON_STUN)
-			user <<"<span class='warning'>The baton is in stun mode.</span>"
+			to_chat(user, "<span class='warning'>The baton is in stun mode.</span>")
 		if(BATON_SLEEP)
-			user <<"<span class='warning'>The baton is in sleep inducement mode.</span>"
+			to_chat(user, "<span class='warning'>The baton is in sleep inducement mode.</span>")
 		if(BATON_CUFF)
-			user <<"<span class='warning'>The baton is in restraining mode.</span>"
+			to_chat(user, "<span class='warning'>The baton is in restraining mode.</span>")
 		if(BATON_PROBE)
 			to_chat(user, "<span class='warning'>The baton is in probing mode.</span>")
 

--- a/code/game/gamemodes/miniantags/abduction/abduction_outfits.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_outfits.dm
@@ -22,13 +22,13 @@
 	if(console)
 		var/obj/item/clothing/suit/armor/abductor/vest/V = locate() in H
 		if(V)
-			console.vest = V
+			console.AddVest(V)
 			V.flags |= NODROP
 
-		var/obj/item/device/abductor/gizmo/G = locate() in H.getBackSlot()
-		if(G)
-			console.gizmo = G
-			G.console = console
+		var/obj/item/weapon/storage/backpack/B = locate() in H
+		if(B)
+			for(var/obj/item/device/abductor/gizmo/G in B.contents)
+				console.AddGizmo(G)
 
 /datum/outfit/abductor/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -40,10 +40,10 @@
 	name = "Abductor Agent"
 	head = /obj/item/clothing/head/helmet/abductor
 	suit = /obj/item/clothing/suit/armor/abductor/vest
+	suit_store = /obj/item/weapon/abductor_baton
 	belt = /obj/item/weapon/storage/belt/military/abductor/full
 
 	backpack_contents = list(
-		/obj/item/weapon/abductor_baton = 1,
 		/obj/item/weapon/gun/energy/alien = 1,
 		/obj/item/device/abductor/silencer = 1
 		)

--- a/code/game/gamemodes/miniantags/abduction/machinery/console.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/console.dm
@@ -7,7 +7,7 @@
 //Console
 
 /obj/machinery/abductor/console
-	name = "Abductor console"
+	name = "abductor console"
 	desc = "Ship command center."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "console"
@@ -32,7 +32,7 @@
 	var/dat = ""
 	dat += "<H3> Abductsoft 3000 </H3>"
 
-	if(experiment != null)
+	if(experiment)
 		var/points = experiment.points
 		var/credits = experiment.credits
 		dat += "Collected Samples : [points] <br>"
@@ -46,18 +46,18 @@
 	else
 		dat += "<span class='bad'>NO EXPERIMENT MACHINE DETECTED</span> <br>"
 
-	if(pad!=null)
+	if(pad)
 		dat += "<span class='bad'>Emergency Teleporter System.</span>"
 		dat += "<span class='bad'>Consider using primary observation console first.</span>"
 		dat += "<a href='?src=\ref[src];teleporter_send=1'>Activate Teleporter</A><br>"
-		if(gizmo!=null && gizmo.marked!=null)
+		if(gizmo && gizmo.marked)
 			dat += "<a href='?src=\ref[src];teleporter_retrieve=1'>Retrieve Mark</A><br>"
 		else
 			dat += "<span class='linkOff'>Retrieve Mark</span><br>"
 	else
 		dat += "<span class='bad'>NO TELEPAD DETECTED</span></br>"
 
-	if(vest!=null)
+	if(vest)
 		dat += "<h4> Agent Vest Mode </h4><br>"
 		var/mode = vest.mode
 		if(mode == VEST_STEALTH)
@@ -88,7 +88,8 @@
 	else if(href_list["flip_vest"])
 		FlipVest()
 	else if(href_list["toggle_vest"])
-		toggle_vest()
+		if(vest)
+			vest.toggle_nodrop()
 	else if(href_list["select_disguise"])
 		SelectDisguise()
 	else if(href_list["dispense"])
@@ -105,23 +106,22 @@
 				Dispense(/obj/item/clothing/suit/armor/abductor/vest)
 	updateUsrDialog()
 
-
 /obj/machinery/abductor/console/proc/TeleporterRetrieve()
-	if(gizmo!=null && pad!=null && gizmo.marked)
+	if(pad && gizmo && gizmo.marked)
 		pad.Retrieve(gizmo.marked)
 
 /obj/machinery/abductor/console/proc/TeleporterSend()
-	if(pad!=null)
+	if(pad)
 		pad.Send()
 
 /obj/machinery/abductor/console/proc/FlipVest()
-	if(vest!=null)
+	if(vest)
 		vest.flip_mode()
 
 /obj/machinery/abductor/console/proc/SelectDisguise(remote = 0)
 	var/entry_name = input( "Choose Disguise", "Disguise") as null|anything in disguises
 	var/datum/icon_snapshot/chosen = disguises[entry_name]
-	if(chosen && (remote || in_range(usr,src)))
+	if(chosen && vest && (remote || in_range(usr,src)))
 		vest.SetDisguise(chosen)
 
 /obj/machinery/abductor/console/proc/SetDroppoint(turf/open/location,user)
@@ -169,36 +169,48 @@
 		return
 	disguises[entry.name] = entry
 
+/obj/machinery/abductor/console/proc/AddGizmo(obj/item/device/abductor/gizmo/G)
+	if(G == gizmo && G.console == src)
+		return FALSE
+
+	if(G.console)
+		G.console.gizmo = null
+
+	gizmo = G
+	G.console = src
+	return TRUE
+
+/obj/machinery/abductor/console/proc/AddVest(obj/item/clothing/suit/armor/abductor/vest/V)
+	if(vest == V)
+		return FALSE
+
+	for(var/obj/machinery/abductor/console/C in GLOB.machines)
+		if(C.vest == V)
+			C.vest = null
+			break
+
+	vest = V
+	return TRUE
+
 /obj/machinery/abductor/console/attackby(obj/O, mob/user, params)
-	if(istype(O, /obj/item/device/abductor/gizmo))
-		var/obj/item/device/abductor/gizmo/G = O
+	if(istype(O, /obj/item/device/abductor/gizmo) && AddGizmo(O))
 		to_chat(user, "<span class='notice'>You link the tool to the console.</span>")
-		gizmo = G
-		G.console = src
-	else if(istype(O, /obj/item/clothing/suit/armor/abductor/vest))
-		var/obj/item/clothing/suit/armor/abductor/vest/V = O
+	else if(istype(O, /obj/item/clothing/suit/armor/abductor/vest) && AddVest(O))
 		to_chat(user, "<span class='notice'>You link the vest to the console.</span>")
-		if(istype(vest))
-			if(vest.flags & NODROP)
-				toggle_vest()
-		vest = V
 	else
 		return ..()
+
+
 
 /obj/machinery/abductor/console/proc/Dispense(item,cost=1)
 	if(experiment && experiment.credits >= cost)
 		experiment.credits -=cost
 		say("Incoming supply!")
+		var/drop_location = loc
 		if(pad)
 			flick("alien-pad", pad)
-			new item(pad.loc)
-		else
-			new item(loc)
+			drop_location = pad.loc
+		new item(drop_location)
+
 	else
 		say("Insufficent data!")
-
-/obj/machinery/abductor/console/proc/toggle_vest()
-	vest.flags ^= NODROP
-	var/mob/M = vest.loc
-	if(istype(M))
-		to_chat(M, "<span class='notice'>[src] is now [vest.flags & NODROP ? "locked" : "unlocked"].</span>")

--- a/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
@@ -1,5 +1,5 @@
 /obj/machinery/abductor/gland_dispenser
-	name = "Replacement Organ Storage"
+	name = "replacement organ storage"
 	desc = "A tank filled with replacement organs."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "dispenser"
@@ -49,7 +49,7 @@
 		var/g_color = gland_colors[i]
 		var/amount = amounts[i]
 		dat += "<a class='box gland' style='background-color:[g_color]' href='?src=\ref[src];dispense=[i]'>[amount]</a>"
-		if(item_count == 3) // Three boxes per line
+		if(item_count == 4) // Four boxes per line
 			dat +="</br></br>"
 			item_count = 0
 	var/datum/browser/popup = new(user, "glands", "Gland Dispenser", 200, 200)


### PR DESCRIPTION
* Fixes #26593 - gizmos are now synchronized with consoles properly, and new gizmos provide feedback messages if they are not synchronized.
* Fixes some `<<` in ayy code not being replaced with `to_chat`.
* Fixes rows in gland storage machine.
* Allows Abductor Agent vests to store Abductor devices and weapons in belt slot.
