### PR TITLE
Adds death checks to two hallucinations, preventing the dead from spasming

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -286,8 +286,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 		bubblegum = new(wall, target)
 		sleep(10) //ominous wait
 		var/charged = FALSE //only get hit once
-		while(get_turf(bubblegum) != landing && target)
-			if(target.stat==DEAD)break
+		while(get_turf(bubblegum) != landing && target && target.stat != DEAD)
 			bubblegum.forceMove(get_step_towards(bubblegum, landing))
 			bubblegum.setDir(get_dir(bubblegum, landing))
 			target.playsound_local(get_turf(bubblegum), 'sound/effects/meteorimpact.ogg', 150, 1)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -178,7 +178,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 
 /obj/effect/hallucination/simple/xeno/throw_impact(A)
 	update_icon("alienh_pounce")
-	if(A == target)
+	if(A == target && target.stat!=DEAD)
 		target.Weaken(5)
 		target.visible_message("<span class='danger'>[target] flails around wildly.</span>","<span class ='userdanger'>[name] pounces on you!</span>")
 
@@ -287,6 +287,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 		sleep(10) //ominous wait
 		var/charged = FALSE //only get hit once
 		while(get_turf(bubblegum) != landing && target)
+			if(target.stat==DEAD)break
 			bubblegum.forceMove(get_step_towards(bubblegum, landing))
 			bubblegum.setDir(get_dir(bubblegum, landing))
 			target.playsound_local(get_turf(bubblegum), 'sound/effects/meteorimpact.ogg', 150, 1)


### PR DESCRIPTION
Currently it is possible to start the bubblegum or xeno hallucinations, die, and then have them hit you - causing you to spasm while dead. I only check for death, and not crit, because I find the idea of someone about to die flailing at an imaginary xeno in their last moments hilarious.