### PR TITLE
GPS Personalizations [Post TGPSUI]

### DIFF
--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -120,7 +120,6 @@ GLOBAL_LIST_EMPTY(GPS_list)
 			var/a = input("Please enter desired tag.", name, gpstag) as text
 			a = copytext(sanitize(a), 1, 20)
 			gpstag = a
-			name = "global positioning system ([gpstag])"
 			. = TRUE
 		if("power")
 			toggletracking(usr)

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -7,6 +7,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = SLOT_BELT
 	origin_tech = "materials=2;magnets=1;bluespace=2"
+	unique_rename = TRUE
 	var/gpstag = "COM0"
 	var/emped = FALSE
 	var/turf/locked_location
@@ -117,7 +118,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	switch(action)
 		if("rename")
 			var/a = input("Please enter desired tag.", name, gpstag) as text
-			a = uppertext(copytext(sanitize(a), 1, 5))
+			a = copytext(sanitize(a), 1, 20)
 			gpstag = a
 			name = "global positioning system ([gpstag])"
 			. = TRUE


### PR DESCRIPTION
🆑 Cobby
tweak: The GPS set tag has gone from a limit of 5 characters to 20.
add: The GPS can now be personalized in both name and description using a pen.
/🆑

Allows players to rename GPS's and their tags because the automatic renaming was going to be really long and probably obnoxious, and for labelling, which allows them to better describe what is at that particular location or lure them to an area with false promises. Consequently, this will also help alleviate the problem of finding your tag within the mess of many GPSs since you can type more than the 5 character code which nearly every other GPS has.

GPS tag setting is no longer all uppercase for the same reason.


ONE DAY I'LL BE GOOD AT GITHUB I PROMISE