### PR TITLE
Flushes Ling & Alien HUD info with the edge of the screen

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -21,7 +21,7 @@
 #define ui_inventory "WEST:6,SOUTH:5"
 
 //Middle left indicators
-#define ui_lingchemdisplay "WEST:6,CENTER-1:15"
+#define ui_lingchemdisplay "WEST,CENTER-1:15"
 #define ui_lingstingdisplay "WEST:6,CENTER-3:11"
 #define ui_crafting	"12:-10,1:5"
 #define ui_building "12:-10,1:21"
@@ -103,12 +103,13 @@
 #define ui_health "EAST-1:28,CENTER-1:15"
 #define ui_internal "EAST-1:28,CENTER:17"
 
-//borgs and aliens
-#define ui_alien_nightvision "EAST-1:28,CENTER:17"
+//borgs 
 #define ui_borg_health "EAST-1:28,CENTER-1:15"		//borgs have the health display where humans have the pressure damage indicator.
-#define ui_alien_health "EAST-1:28,CENTER-1:15"	//aliens have the health display where humans have the pressure damage indicator.
-#define ui_alienplasmadisplay "EAST-1:28,CENTER-2:15"
-#define ui_alien_queen_finder "EAST-1:28,CENTER-3:15"
+
+//aliens
+#define ui_alien_health "EAST,CENTER-1:15"	//aliens have the health display where humans have the pressure damage indicator.
+#define ui_alienplasmadisplay "EAST,CENTER-2:15"
+#define ui_alien_queen_finder "EAST,CENTER-3:15"
 
 // AI
 


### PR DESCRIPTION
While most of our HUD looks good, I can't help but feel that the stuff that looks like it should be growing in from the edge of your vision shouldn't detached from the edge like it is now.

Screenshots:
http://imgur.com/a/5IjnG
http://imgur.com/a/kBw0G

If anyone can think of other examples, let me know and ill add them