### PR TITLE
Fixes changelings being unable to revive from death without a brain

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -728,7 +728,7 @@
 
 /mob/living/carbon/can_be_revived()
 	. = ..()
-	if(!getorgan(/obj/item/organ/brain))
+	if(!getorgan(/obj/item/organ/brain) && (!mind || !mind.changeling))
 		return 0
 
 /mob/living/carbon/harvest(mob/living/user)


### PR DESCRIPTION
:cl: QualityVan
fix: Changelings can once again revive with their brain missing
/:cl: