### PR TITLE
Removes Rest from Voice of God

### DIFF
--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -175,7 +175,7 @@
 
 	var/static/regex/stun_words = regex("stop|wait|stand still|hold on|halt")
 	var/static/regex/weaken_words = regex("drop|fall|trip|weaken")
-	var/static/regex/sleep_words = regex("sleep|slumber")
+	var/static/regex/sleep_words = regex("sleep|slumber|rest")
 	var/static/regex/vomit_words = regex("vomit|throw up")
 	var/static/regex/silence_words = regex("shut up|silence|ssh|quiet|hush")
 	var/static/regex/hallucinate_words = regex("see the truth|hallucinate")
@@ -206,7 +206,6 @@
 	var/static/regex/throwmode_words = regex("throw|catch")
 	var/static/regex/flip_words = regex("flip|rotate|revolve|roll|somersault")
 	var/static/regex/speak_words = regex("speak|say something")
-	var/static/regex/rest_words = regex("rest")
 	var/static/regex/getup_words = regex("get up")
 	var/static/regex/sit_words = regex("sit")
 	var/static/regex/stand_words = regex("stand")
@@ -443,17 +442,9 @@
 			L.say(pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage"))
 			sleep(5) //So the chat flows more naturally
 
-	//REST
-	else if((findtext(message, rest_words)))
-		cooldown = COOLDOWN_MEME
-		for(var/V in listeners)
-			var/mob/living/L = V
-			if(!L.resting)
-				L.lay_down()
-
 	//GET UP
 	else if((findtext(message, getup_words)))
-		cooldown = COOLDOWN_DAMAGE
+		cooldown = COOLDOWN_DAMAGE //because stun removal
 		for(var/V in listeners)
 			var/mob/living/L = V
 			if(L.resting)


### PR DESCRIPTION
:cl: XDTM
del: Voice of God's Rest command now no longer makes listeners rest. It instead activates the sleep command.
/:cl:

Initially i thought that resting was harmless, but then i realized that with the time people need to get to the IC tab and press rest, it usually ends up being the best stun available, on a shorter cooldown than other stuns. Plus new players may not know about resting and unresting, and in general the 'duration' varies wildly in an unbalanceable way. So it's going away.

