### PR TITLE
Buffs mercury and lithium

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -658,7 +658,7 @@
 	taste_mult = 0 // apparently tasteless.
 
 /datum/reagent/mercury/on_mob_life(mob/living/M)
-	if(M.canmove && isspaceturf(M.loc))
+	if(M.canmove && !isspaceturf(M.loc))
 		step(M, pick(GLOB.cardinal))
 	if(prob(5))
 		M.emote(pick("twitch","drool","moan"))
@@ -738,7 +738,7 @@
 	taste_description = "metal"
 
 /datum/reagent/lithium/on_mob_life(mob/living/M)
-	if(M.canmove && isspaceturf(M.loc))
+	if(M.canmove && !isspaceturf(M.loc))
 		step(M, pick(GLOB.cardinal))
 	if(prob(5))
 		M.emote(pick("twitch","drool","moan"))


### PR DESCRIPTION
:cl: Swindly
tweak: Mercury and Lithium make people move when not in space instead of when in space.
/:cl:

[why]:  (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Making the movement effects of mercury and lithium more like drugs will make them more useful because people are not in space more often than they are in space.