### PR TITLE
[Gang] The Hit Contract: The Non-Conversion Based Snowball Method.

### DIFF
--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -159,7 +159,7 @@ GLOBAL_LIST_INIT(gang_colors_pool, list("red","orange","yellow","green","blue","
 /datum/game_mode/proc/add_gangster(datum/mind/gangster_mind, datum/gang/G, check = 1)
 	if(!G || (gangster_mind in get_all_gangsters()) || (gangster_mind.enslaved_to && !is_gangster(gangster_mind.enslaved_to)))
 		return 0
-	if(check && gangster_mind.current.isloyal()) //Check to see if the potential gangster is implanted
+	if(check && (gangster_mind.current.isloyal() || (gangster_mind in G.prev_targets)) ) //Check to see if the potential gangster is implanted or was a target of a hit.
 		return 1
 	G.gangsters += gangster_mind
 	gangster_mind.gang_datum = G

--- a/code/game/gamemodes/gang/gang_datum.dm
+++ b/code/game/gamemodes/gang/gang_datum.dm
@@ -7,6 +7,7 @@
 	var/color_hex = "#FFFFFF"
 	var/list/datum/mind/gangsters = list() //gang B Members
 	var/list/datum/mind/bosses = list() //gang A Bosses
+	var/list/datum/mind/prev_targets = list() // Preventative Exploits in Hit system! Unable to be converted by the gang once on this list.
 	var/list/obj/item/device/gangtool/gangtools = list()
 	var/style
 	var/fighting_style = "normal"
@@ -38,6 +39,7 @@
 		/datum/gang_item/equipment/pen,
 		/datum/gang_item/equipment/gangtool,
 		/datum/gang_item/equipment/necklace,
+		/datum/gang_item/equipment/place_hit,
 		/datum/gang_item/equipment/dominator
 	)
 

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -329,11 +329,9 @@
 		to_chat(user, "You see [target]'s name appear several times throughout the paper. Probably not a good sign for them.")
 
 /obj/item/weapon/gang_hitman/process()
-	if(QDELETED(target))
-		return
 
-	if(target.stat == DEAD )
-		if(target.mind.gang_datum == null )
+	if(target.stat == DEAD || QDELETED(target) )
+		if(target.mind.gang_datum == null || target == null )
 			gang_ref.points += points_for_kill
 		if(target.mind.gang_datum != null)
 			if( (target in SSticker.mode.get_gang_bosses()) )

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -323,6 +323,11 @@
 	var/mob/living/target = null
 	var/points_for_kill = 50 // (Assuming Cost is 40 and this var is default) +10 for killing the poor sod, +25 if enemy gang, +35 if they're a ganghead
 
+/obj/item/weapon/gang_hitman/examine(mob/user)
+	..()
+	if(target)
+		to_chat(user, "You see [target]'s name appear several times throughout the paper. Probably not a good sign for them.")
+
 /obj/item/weapon/gang_hitman/process()
 	if(QDELETED(target))
 		return

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -318,6 +318,7 @@
 	desc = "A nice complement to life insurance."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paperslip"
+	w_class = WEIGHT_CLASS_SMALL //dunno the default so just going to add this here
 	var/used = FALSE
 	var/datum/gang/gang_ref = null
 	var/mob/living/target = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -13,7 +13,8 @@
 // END_PREFERENCES
 
 // BEGIN_INCLUDE
-#include "_maps\runtimestation.dm"
+#include "_maps\basemap.dm"
+#include "_maps\loadallmaps.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DATASTRUCTURES\globals.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -13,8 +13,7 @@
 // END_PREFERENCES
 
 // BEGIN_INCLUDE
-#include "_maps\basemap.dm"
-#include "_maps\loadallmaps.dm"
+#include "_maps\runtimestation.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DATASTRUCTURES\globals.dm"


### PR DESCRIPTION
:cl: Cobby
add: Influence can now be earned fairly rapidly by placing hits on people with the new hit contract. You get extra points if the target is a gang member, and even more if they are a gang head!
balance: Anyone who is a target of a hit cannot be converted by said gang.
balance: Contracts are tied to the gang that spawned them. If you are using another gang's contract, you can rack up points for them very easily. DON'T DO THIS! Just hide it from them, as they just lost 40 Influence for nothing.
/:cl:

**WARNING: This has NOT been tested to the fullest extent since it relies on multiple people being on at once. This was also "tested" in the morning hours so take that with a grain of salt.**

# Description
The Hit contract is a fairly high cost item/investment that allows for Rapid acquisition of points by killing particular people. It trades potential converts into blood-stained influence, with bonuses if they are in enemy gangs. Because of this, a new viable strategy is to rush tagging, save for the hit contract, then play ping pong and rack up points to give your entire [albeit small] gang tons of weaponry and ammo.

Targets are mind-based and won't appear again in the list of potential targets after a hit was placed on them by your gang, nor allow for conversion. This is to prevent exploits such as killing a non-gang target , cloning and repeat; killing a gang member, cloning, then penning them; or simply penning someone who you have a hit on. There are no tells for others if there's a hit on someone sans examining the document, so you as the gang leader have to coordinate with your team or you could get them outted as a leader.

The contract automatically checks to see if the target has died once a hit has been placed. It does not have to be at the gang's hands specifically, leaving room for beneficial accidents.

## Points Overview
Cost - 40
Target Is not a gang member or gets Deleted (bombs or badmins, or both!) - 50 [10 profit]
Target is a Gang Member, but not a boss - 65 [25 profit]
Target is a Gang Leader - 75 [35 profit]

As you can see, this always gives a full refund on a successful hit. This is not actual paper and will cost inventory slots, so you may have to hide the contracts later leaving room for a smart detective to stop you before you get too powerful.

# Reasoning
This was made as a way to deter conversion, which seemed to be a problem from the gang feedback thread. While you definitely want early conversion, mid-late game will now reward you for playing less conversion snowball [aka take 20 years for a gang round to end] and more aggressive PRECISE KILLING [if you murderbone you lose potential points] since conversion lowers your point potential while also increasing the point potential of others. Apart from that, you now have 2 general approaches you can take to gang: The Conversion ZergRush OR The High Octane Hit Squad, both being viable.

https://tgstation13.org/phpBB/viewtopic.php?f=10&t=9146#p264836

