### PR TITLE
Makes surplus crates less likely to contain implants

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1100,7 +1100,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 // Implants
 /datum/uplink_item/implants
 	category = "Implants"
-	surplus=50
+	surplus = 50
 
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1100,6 +1100,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 // Implants
 /datum/uplink_item/implants
 	category = "Implants"
+	surplus=50
 
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"


### PR DESCRIPTION
:cl:
tweak: Syndicate surplus crates now contain fewer implants
/:cl:

Since implants inherit the default surplus chance of 100%, and are also a small category, you get a huge number of redundant implants in surplus crates.
