### PR TITLE
Small fixes to spatial gateways

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_effects/spatial_gateway.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/spatial_gateway.dm
@@ -15,9 +15,8 @@
 	var/obj/effect/clockwork/spatial_gateway/linked_gateway //The gateway linked to this one
 	var/timerid
 
-/obj/effect/clockwork/spatial_gateway/New()
-	..()
-	update_light()
+/obj/effect/clockwork/spatial_gateway/Initialize()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/check_setup), 1)
 
 /obj/effect/clockwork/spatial_gateway/Destroy()
@@ -99,12 +98,12 @@
 	if(severity == 1 && uses)
 		uses = 0
 		visible_message("<span class='warning'>[src] is disrupted!</span>")
-		animate(src, alpha = 0, transform = matrix()*2, time = 10)
+		animate(src, alpha = 0, transform = matrix()*2, time = 10, flags = ANIMATION_END_NOW)
 		deltimer(timerid)
 		timerid = QDEL_IN(src, 10)
 		linked_gateway.uses = 0
 		linked_gateway.visible_message("<span class='warning'>[linked_gateway] is disrupted!</span>")
-		animate(linked_gateway, alpha = 0, transform = matrix()*2, time = 10)
+		animate(linked_gateway, alpha = 0, transform = matrix()*2, time = 10, flags = ANIMATION_END_NOW)
 		deltimer(linked_gateway.timerid)
 		linked_gateway.timerid = QDEL_IN(linked_gateway, 10)
 		return TRUE
@@ -131,9 +130,9 @@
 	playsound(src, 'sound/effects/EMPulse.ogg', 50, 1)
 	playsound(linked_gateway, 'sound/effects/EMPulse.ogg', 50, 1)
 	transform = matrix() * 1.5
-	animate(src, transform = matrix() / 1.5, time = 10)
+	animate(src, transform = matrix() / 1.5, time = 10, flags = ANIMATION_END_NOW)
 	linked_gateway.transform = matrix() * 1.5
-	animate(linked_gateway, transform = matrix() / 1.5, time = 10)
+	animate(linked_gateway, transform = matrix() / 1.5, time = 10, flags = ANIMATION_END_NOW)
 	A.forceMove(get_turf(linked_gateway))
 	if(!no_cost)
 		uses = max(0, uses - 1)

--- a/code/game/gamemodes/clock_cult/clock_structures/clockwork_obelisk.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/clockwork_obelisk.dm
@@ -44,40 +44,43 @@
 
 /obj/structure/destructible/clockwork/powered/clockwork_obelisk/attack_hand(mob/living/user)
 	if(!is_servant_of_ratvar(user) || total_accessable_power() < hierophant_cost || !anchored)
-		to_chat(user, "<span class='warning'>You place your hand on the obelisk, but it doesn't react.</span>")
+		to_chat(user, "<span class='warning'>You place your hand on [src], but it doesn't react.</span>")
 		return
-	var/choice = alert(user,"You place your hand on the obelisk...",,"Hierophant Broadcast","Spatial Gateway","Cancel")
+	var/choice = alert(user,"You place your hand on [src]...",,"Hierophant Broadcast","Spatial Gateway","Cancel")
 	switch(choice)
 		if("Hierophant Broadcast")
 			if(active)
-				to_chat(user, "<span class='warning'>The obelisk is sustaining a gateway and cannot broadcast!</span>")
+				to_chat(user, "<span class='warning'>[src] is sustaining a gateway and cannot broadcast!</span>")
 				return
 			if(!user.can_speak_vocal())
-				to_chat(user, "<span class='warning'>You cannot speak through the obelisk!</span>")
+				to_chat(user, "<span class='warning'>You cannot speak through [src]!</span>")
 				return
 			var/input = stripped_input(usr, "Please choose a message to send over the Hierophant Network.", "Hierophant Broadcast", "")
 			if(!is_servant_of_ratvar(user) || !input || !user.canUseTopic(src, !issilicon(user)))
 				return
+			if(anchored)
+				to_chat(user, "<span class='warning'>[src] is no longer secured!</span>")
+				return FALSE
 			if(active)
-				to_chat(user, "<span class='warning'>The obelisk is sustaining a gateway and cannot broadcast!</span>")
+				to_chat(user, "<span class='warning'>[src] is sustaining a gateway and cannot broadcast!</span>")
 				return
 			if(!user.can_speak_vocal())
-				to_chat(user, "<span class='warning'>You cannot speak through the obelisk!</span>")
+				to_chat(user, "<span class='warning'>You cannot speak through [src]!</span>")
 				return
 			if(!try_use_power(hierophant_cost))
-				to_chat(user, "<span class='warning'>The obelisk lacks the power to broadcast!</span>")
+				to_chat(user, "<span class='warning'>[src] lacks the power to broadcast!</span>")
 				return
 			clockwork_say(user, text2ratvar("Hierophant Broadcast, activate! [html_decode(input)]"))
 			titled_hierophant_message(user, input, "big_brass", "large_brass")
 		if("Spatial Gateway")
 			if(active)
-				to_chat(user, "<span class='warning'>The obelisk is already sustaining a gateway!</span>")
+				to_chat(user, "<span class='warning'>[src] is already sustaining a gateway!</span>")
 				return
 			if(!user.can_speak_vocal())
 				to_chat(user, "<span class='warning'>You need to be able to speak to open a gateway!</span>")
 				return
 			if(!try_use_power(gateway_cost))
-				to_chat(user, "<span class='warning'>The obelisk lacks the power to open a gateway!</span>")
+				to_chat(user, "<span class='warning'>[src] lacks the power to open a gateway!</span>")
 				return
 			if(procure_gateway(user, round(100 * get_efficiency_mod(), 1), round(5 * get_efficiency_mod(), 1), 1))
 				process()

--- a/code/game/gamemodes/clock_cult/clock_structures/clockwork_obelisk.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/clockwork_obelisk.dm
@@ -61,11 +61,11 @@
 			if(active)
 				to_chat(user, "<span class='warning'>The obelisk is sustaining a gateway and cannot broadcast!</span>")
 				return
-			if(!try_use_power(hierophant_cost))
-				to_chat(user, "<span class='warning'>The obelisk lacks the power to broadcast!</span>")
-				return
 			if(!user.can_speak_vocal())
 				to_chat(user, "<span class='warning'>You cannot speak through the obelisk!</span>")
+				return
+			if(!try_use_power(hierophant_cost))
+				to_chat(user, "<span class='warning'>The obelisk lacks the power to broadcast!</span>")
 				return
 			clockwork_say(user, text2ratvar("Hierophant Broadcast, activate! [html_decode(input)]"))
 			titled_hierophant_message(user, input, "big_brass", "large_brass")
@@ -73,16 +73,18 @@
 			if(active)
 				to_chat(user, "<span class='warning'>The obelisk is already sustaining a gateway!</span>")
 				return
-			if(!try_use_power(gateway_cost))
-				to_chat(user, "<span class='warning'>The obelisk lacks the power to open a gateway!</span>")
-				return
 			if(!user.can_speak_vocal())
 				to_chat(user, "<span class='warning'>You need to be able to speak to open a gateway!</span>")
 				return
-			if(procure_gateway(user, round(100 * get_efficiency_mod(), 1), round(5 * get_efficiency_mod(), 1), 1) && !active)
-				clockwork_say(user, text2ratvar("Spatial Gateway, activate!"))
-			else
-				return_power(gateway_cost)
+			if(!try_use_power(gateway_cost))
+				to_chat(user, "<span class='warning'>The obelisk lacks the power to open a gateway!</span>")
+				return
+			if(procure_gateway(user, round(100 * get_efficiency_mod(), 1), round(5 * get_efficiency_mod(), 1), 1))
+				process()
+				if(!active)
+					clockwork_say(user, text2ratvar("Spatial Gateway, activate!"))
+					return
+			return_power(gateway_cost) //if we didn't return above, ie, successfully create a gateway, we give the power back
 
 /obj/structure/destructible/clockwork/powered/clockwork_obelisk/process()
 	if(!anchored)


### PR DESCRIPTION
Clockwork obelisks can no longer consume power without actually producing a gateway or sending a message.
Gateways now use ANIMATION_END_NOW for their animates.