### PR TITLE
Adds persistent trophy cases

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -29,6 +29,7 @@ GLOBAL_LIST_EMPTY(zombie_infection_list) 		// A list of all zombie_infection org
 GLOBAL_LIST_EMPTY(meteor_list)				// List of all meteors.
 GLOBAL_LIST_EMPTY(active_jammers)             // List of active radio jammers
 GLOBAL_LIST_EMPTY(ladders)
+GLOBAL_LIST_EMPTY(trophy_cases)
 
 GLOBAL_LIST_EMPTY(wire_color_directory)
 GLOBAL_LIST_EMPTY(wire_name_directory)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -142,7 +142,7 @@ SUBSYSTEM_DEF(persistence)
 		if(!path)
 			continue
 
-		T.showpiece = new path
+		T.showpiece = new /obj/item/showpiece_dummy(T, path)
 		T.trophy_message = chosen_trophy["message"]
 		T.placer_key = chosen_trophy["placer_key"]
 		T.update_icon()

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -156,12 +156,9 @@ SUBSYSTEM_DEF(persistence)
 
 
 /datum/controller/subsystem/persistence/proc/CollectTrophies()
-	for(var/A in GLOB.trophy_cases)
-		var/obj/structure/displaycase/trophy/T = A
-		TrySaveTrophy(T)
 	trophy_sav << old_trophy_list
 
-/datum/controller/subsystem/persistence/proc/TrySaveTrophy(obj/structure/displaycase/trophy/T)
+/datum/controller/subsystem/persistence/proc/SaveTrophy(obj/structure/displaycase/trophy/T)
 	if(!T.added_roundstart && T.showpiece)
 		old_trophy_list += "[T.showpiece.type]|[T.trophy_message]#"
 

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -158,9 +158,12 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/CollectTrophies()
 	for(var/A in GLOB.trophy_cases)
 		var/obj/structure/displaycase/trophy/T = A
-		if(T.showpiece)
-			old_trophy_list += "[T.showpiece.type]|[T.trophy_message]#"
+		TrySaveTrophy(T)
 	trophy_sav << old_trophy_list
+
+/datum/controller/subsystem/persistence/proc/TrySaveTrophy(obj/structure/displaycase/trophy/T)
+	if(!T.added_roundstart && T.showpiece)
+		old_trophy_list += "[T.showpiece.type]|[T.trophy_message]#"
 
 /datum/controller/subsystem/persistence/proc/SetUpTrophies(list/expanded_trophy_items)
 	for(var/A in GLOB.trophy_cases)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -325,3 +325,13 @@
 			QDEL_NULL(showpiece)
 		else
 			..()
+
+/obj/item/showpiece_dummy
+	name = "Cheap replica"
+
+/obj/item/showpiece_dummy/Initialize(mapload, path)
+	. = ..()
+	var/obj/item/I = path
+	name = initial(I.name)
+	icon = initial(I.icon)
+	icon_state = initial(I.icon_state)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -31,10 +31,10 @@
 
 /obj/structure/displaycase/examine(mob/user)
 	..()
-	if(showpiece)
-		to_chat(user, "<span class='notice'>There's [showpiece] inside.</span>")
 	if(alert)
 		to_chat(user, "<span class='notice'>Hooked up with an anti-theft system.</span>")
+	if(showpiece)
+		to_chat(user, "<span class='notice'>There's [showpiece] inside.</span>")
 
 
 /obj/structure/displaycase/proc/dump()
@@ -263,10 +263,8 @@
 	GLOB.trophy_cases += src
 
 /obj/structure/displaycase/trophy/Destroy()
-	if(showpiece)
-		SSpersistence.TrySaveTrophy(src)
 	GLOB.trophy_cases -= src
-	. = ..()
+	return ..()
 
 /obj/structure/displaycase/trophy/examine(mob/user)
 	..()
@@ -309,6 +307,7 @@
 			else
 				to_chat(user, "You are too far to set the plaque's text.")
 
+		SSpersistence.SaveTrophy(src)
 
 	else
 		to_chat(user, "<span class='warning'>\The [W] is stuck to your hand, you can't put it in the [src.name]!</span>")
@@ -322,5 +321,4 @@
 			new /obj/effect/decal/cleanable/ash(loc)
 			QDEL_NULL(showpiece)
 		else
-			SSpersistence.TrySaveTrophy(src)
 			..()

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -24,11 +24,9 @@
 
 /obj/structure/displaycase/Destroy()
 	if(electronics)
-		qdel(electronics)
-		electronics = null
+		QDEL_NULL(electronics)
 	if(showpiece)
-		qdel(showpiece)
-		showpiece = null
+		QDEL_NULL(showpiece)
 	return ..()
 
 /obj/structure/displaycase/examine(mob/user)
@@ -176,8 +174,8 @@
 /obj/structure/displaycase/attack_hand(mob/user)
 	user.changeNext_move(CLICK_CD_MELEE)
 	if (showpiece && (broken || open))
-		dump()
 		to_chat(user, "<span class='notice'>You deactivate the hover field built into the case.</span>")
+		dump()
 		src.add_fingerprint(user)
 		update_icon()
 		return
@@ -255,7 +253,6 @@
 /obj/structure/displaycase/trophy
 	name = "trophy display case"
 	desc = "Store your trophies of accomplishment in here, and they will stay forever."
-	resistance_flags = ALL
 	var/trophy_message = ""
 	var/added_roundstart = TRUE
 
@@ -264,6 +261,8 @@
 	GLOB.trophy_cases += src
 
 /obj/structure/displaycase/trophy/Destroy()
+	if(showpiece)
+		SSpersistence.TrySaveTrophy(src)
 	GLOB.trophy_cases -= src
 	. = ..()
 
@@ -287,9 +286,7 @@
 
 		if(showpiece)
 			to_chat(user, "You press a button, and [showpiece] descends into the floor of the case.")
-			SSpersistence.old_trophy_list += "[showpiece.type]|[trophy_message]#"
-			qdel(showpiece)
-			showpiece = null
+			QDEL_NULL(showpiece)
 
 		to_chat(user, "You insert [W] into the case.")
 		W.forceMove(src)
@@ -305,7 +302,13 @@
 			to_chat(user, "You set the plaque's text.")
 
 	else
-		to_chat(user, "<span class='warning'>\The [W] is stuck to your hand, you cannot put it in the [src.name]!</span>")
+		to_chat(user, "<span class='warning'>\The [W] is stuck to your hand, you can't put it in the [src.name]!</span>")
 
 	return
 
+/obj/structure/displaycase/trophy/dump()
+	if (showpiece)
+		SSpersistence.TrySaveTrophy(src)
+		visible_message("<span class='danger'>The [showpiece] crumbles to dust!</span>")
+		new /obj/effect/decal/cleanable/ash(loc)
+		QDEL_NULL(showpiece)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -254,6 +254,7 @@
 	name = "trophy display case"
 	desc = "Store your trophies of accomplishment in here, and they will stay forever."
 	var/trophy_message = ""
+	var/placer_key = ""
 	var/added_roundstart = TRUE
 	alert = TRUE
 	integrity_failure = 0
@@ -296,6 +297,8 @@
 		showpiece = W
 		added_roundstart = FALSE
 		update_icon()
+
+		placer_key = user.ckey
 
 		trophy_message = W.desc //default value
 

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -283,8 +283,13 @@
 		return
 
 	if(is_type_in_typecache(W, GLOB.blacklisted_cargo_types))
-		to_chat(user, "You think putting [W] in would be a bad idea.")
+		to_chat(user, "<span class='danger'>The case rejects the [W].</span>")
 		return
+
+	for(var/a in W.GetAllContents())
+		if(is_type_in_typecache(a, GLOB.blacklisted_cargo_types))
+			to_chat(user, "<span class='danger'>The case rejects the [W].</span>")
+			return
 
 	if(user.drop_item())
 

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -255,6 +255,8 @@
 	desc = "Store your trophies of accomplishment in here, and they will stay forever."
 	var/trophy_message = ""
 	var/added_roundstart = TRUE
+	alert = TRUE
+	integrity_failure = 0
 
 /obj/structure/displaycase/trophy/Initialize()
 	. = ..()
@@ -273,6 +275,9 @@
 		to_chat(user, trophy_message)
 
 /obj/structure/displaycase/trophy/attackby(obj/item/weapon/W, mob/user, params)
+
+	if(!user.Adjacent(src)) //no TK museology
+		return
 
 	if(!added_roundstart)
 		to_chat(user, "You've already put something new in this case.")
@@ -296,10 +301,14 @@
 
 		trophy_message = W.desc //default value
 
-		var/chosen_plaque = stripped_input(user, "What would you like the plaque to say? Default value is item's description", "Trophy Plaque")
-		if(chosen_plaque && user.Adjacent(src))
-			trophy_message = chosen_plaque
-			to_chat(user, "You set the plaque's text.")
+		var/chosen_plaque = stripped_input(user, "What would you like the plaque to say? Default value is item's description.", "Trophy Plaque")
+		if(chosen_plaque)
+			if(user.Adjacent(src))
+				trophy_message = chosen_plaque
+				to_chat(user, "You set the plaque's text.")
+			else
+				to_chat(user, "You are too far to set the plaque's text.")
+
 
 	else
 		to_chat(user, "<span class='warning'>\The [W] is stuck to your hand, you can't put it in the [src.name]!</span>")
@@ -308,7 +317,10 @@
 
 /obj/structure/displaycase/trophy/dump()
 	if (showpiece)
-		SSpersistence.TrySaveTrophy(src)
-		visible_message("<span class='danger'>The [showpiece] crumbles to dust!</span>")
-		new /obj/effect/decal/cleanable/ash(loc)
-		QDEL_NULL(showpiece)
+		if(added_roundstart)
+			visible_message("<span class='danger'>The [showpiece] crumbles to dust!</span>")
+			new /obj/effect/decal/cleanable/ash(loc)
+			QDEL_NULL(showpiece)
+		else
+			SSpersistence.TrySaveTrophy(src)
+			..()


### PR DESCRIPTION
I got permission for it, so I remade and tweaked version of #22312 

Tweaks from the previous PR:
When a new item is inserted into a trophy case, it will be added to the old_trophy_list, to be saved at the end of the game. The global list of trophy cases is still required to set them up though, we just don't need to poll them anymore. I suppose they can still be used for a possible Reroll Trophy Cases admin button in the future. 

If the case gets enough damage, instead of breaking, it will always deconstruct. If the item inside was a roundstart showpiece, it will crumble to dust, otherwise you can recover it.

Saving uses JSON instead of strings! It also logs the ckey of the person who  placed the item inside.

Trophy cases also have a burglar alarm because it felt thematic.

Also updates display cases to use Initialize and QDEL_NULL where needed.

I thought about using the persistence_replacement type of saved items, but the only relevant item that would causes issues, the nuclear authentication disk, can not be placed there in the first place, thanks to the cargo blacklist.

:cl: Kor, Goof and Plizzard
add: Adds persistent trophy cases. They are not on any map yet.
/:cl:
