### PR TITLE
Gatfruit rebalance & Scaling

### DIFF
--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -71,7 +71,7 @@
 // Gatfruit
 /obj/item/seeds/gatfruit
 	name = "pack of gatfruit seeds"
-	desc = "These seeds grow into .357 revolvers."
+	desc = "These seeds grow into dangerous sulphuric plants."
 	icon_state = "seed-gatfruit"
 	species = "gatfruit"
 	plantname = "Gatfruit Tree"
@@ -82,7 +82,7 @@
 	maturation = 40
 	production = 10
 	yield = 2
-	potency = 60
+	potency = 15
 	growthstages = 2
 	rarity = 60 // Obtainable only with xenobio+superluck.
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
@@ -91,12 +91,26 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/shell/gatfruit
 	seed = /obj/item/seeds/gatfruit
 	name = "gatfruit"
-	desc = "It smells like burning."
+	desc = "It smells like burning, there is something hard and metallic within"
 	icon_state = "gatfruit"
 	origin_tech = "combat=6"
-	trash = /obj/item/weapon/gun/ballistic/revolver
+	trash = null
 	bitesize_mod = 2
 
+/obj/item/weapon/reagent_containers/food/snacks/grown/shell/gatfruit/add_juice()
+	..()
+	switch(seed.potency)
+		if(0 to 20)
+			trash= /obj/item/weapon/suppressor //basic entry level tool, and a reward for the patience and nurture of gatfruit seeds
+		if(20 to 40)
+			trash= /obj/item/ammo_box/magazine/m10mm
+		if(40 to 60)
+			trash= /obj/item/ammo_box/a357 //conteracts plant data disks (ideally) for access to instant gatfruit weaponry at roundstart or ASAP when gatfruit obtained
+		if(60 to 80)
+			trash= /obj/item/weapon/gun/ballistic/automatic/pistol //small risky mutational leap if 40 maturation is too long to wait for gene edits
+		if(80 to 100)
+			trash= /obj/item/weapon/gun/ballistic/revolver
+			
 //Cherry Bombs
 /obj/item/seeds/cherry/bomb
 	name = "pack of cherry bomb pits"


### PR DESCRIPTION
:cl: Moonlighting Mac Says
add: Gatfruit Tree produce now drops up to 5 potential different items as trash based on its current potency between 1 to a hundred. All of them deadly.
tweak: Gatfruit tree seeds now have base 15 potency reduced from 60
balance: Gatfruits no longer provide immediate access to weaponry without necessary genetic modification
/:cl:

First of all a large thank you to the coding input of @ChangelingRain for helping create & directing me to use the ('add_juice') that allows the scaling function to work, and to summarily helping me get started on the coding ladder.

This feature fundamentally changes the rare gatfruit to be a more versatile & varied plant by expanding its repertoire of weapons as based on the botanists skill to modify a very difficult plant for the rewards that it offers.

The self balancing aspect of this PR is that with a maturation speed of 40 & fiddlyness, it would take a expert & patient botanist to truly be able to harvest all of the different potency products. Initially at 15 potency, upon its first growth straight from the seed without modification botanists are rewarded with syndicate silencers (0-20 as a hint to non-code readers) as encouragement to grow more of them or compliment a weapon already in their possession.