### PR TITLE
Fixes drakes continuing to swoop when killed

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -187,8 +187,9 @@ Difficulty: Medium
 	animate(src, transform = matrix()*0.9, time = 3, easing = BOUNCE_EASING)
 	for(var/i in 1 to 3)
 		sleep(1)
-		if(QDELETED(src)) //we got hit and died, rip us
+		if(QDELETED(src) || stat == DEAD) //we got hit and died, rip us
 			qdel(F)
+			swooping &= ~SWOOP_DAMAGEABLE
 			return
 	animate(src, transform = matrix()*0.7, time = 7)
 	swooping |= SWOOP_INVULNERABLE


### PR DESCRIPTION
Fixes #26753

I forgot that, of all the megafauna, drakes don't actually get deleted on death.