### PR TITLE
Disables Emergency Pods for a testmerge

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -331,6 +331,8 @@
 			success &= (check_transit_zone() == TRANSIT_READY)
 			for(var/A in SSshuttle.mobile)
 				var/obj/docking_port/mobile/M = A
+				if(istype(M, /obj/docking_port/mobile/pod))
+					continue
 				if(M.launch_status == UNLAUNCHED)
 					success &= (M.check_transit_zone() == TRANSIT_READY)
 			if(!success)
@@ -347,6 +349,8 @@
 				//move each escape pod (or applicable spaceship) to its corresponding transit dock
 				for(var/A in SSshuttle.mobile)
 					var/obj/docking_port/mobile/M = A
+					if(istype(M, /obj/docking_port/mobile/pod))
+						continue
 					if(M.launch_status == UNLAUNCHED) //Pods will not launch from the mine/planet, and other ships won't launch unless we tell them to.
 						M.launch_status = ENDGAME_LAUNCHED
 						M.enterTransit()
@@ -375,6 +379,8 @@
 				parallax_slowdown()
 				for(var/A in SSshuttle.mobile)
 					var/obj/docking_port/mobile/M = A
+					if(istype(M, /obj/docking_port/mobile/pod))
+						continue
 					if(M.launch_status == ENDGAME_LAUNCHED)
 						if(istype(M, /obj/docking_port/mobile/pod))
 							M.parallax_slowdown()
@@ -383,6 +389,8 @@
 				//move each escape pod to its corresponding escape dock
 				for(var/A in SSshuttle.mobile)
 					var/obj/docking_port/mobile/M = A
+					if(istype(M, /obj/docking_port/mobile/pod))
+						continue
 					if(M.launch_status == ENDGAME_LAUNCHED)
 						if(istype(M, /obj/docking_port/mobile/pod))
 							M.dock(SSshuttle.getDock("[M.id]_away")) //Escape pods dock at centcomm
@@ -411,15 +419,7 @@
 	launch_status = UNLAUNCHED
 
 /obj/docking_port/mobile/pod/request()
-	var/obj/machinery/computer/shuttle/S = getControlConsole()
-
-	if(GLOB.security_level == SEC_LEVEL_RED || GLOB.security_level == SEC_LEVEL_DELTA || (S && S.emagged))
-		if(launch_status == UNLAUNCHED)
-			launch_status = EARLY_LAUNCHED
-			return ..()
-	else
-		to_chat(usr, "<span class='warning'>Escape pods will only launch during \"Code Red\" security alert.</span>")
-		return 1
+	return 1
 
 /obj/docking_port/mobile/pod/Initialize()
 	. = ..()


### PR DESCRIPTION
Someone suggested this on the forums. Why not? It'll be a fun test.