### PR TITLE
Makes golems able to transfer into empty shells

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -120,7 +120,7 @@
 		Serve [creator], and assist [creator.p_them()] in completing [creator.p_their()] goals at any cost."
 		owner = creator
 
-/obj/effect/mob_spawn/human/golem/special(mob/living/new_spawn)
+/obj/effect/mob_spawn/human/golem/special(mob/living/new_spawn, name)
 	var/datum/species/golem/X = mob_species
 	to_chat(new_spawn, "[initial(X.info_text)]")
 	if(!owner)
@@ -133,7 +133,10 @@
 	if(ishuman(new_spawn))
 		var/mob/living/carbon/human/H = new_spawn
 		H.set_cloned_appearance()
-		H.real_name = H.dna.species.random_name()
+		if(!name)
+			H.real_name = H.dna.species.random_name()
+		else
+			H.real_name = name
 
 /obj/effect/mob_spawn/human/golem/attack_hand(mob/user)
 	if(isgolem(user) && can_transfer)
@@ -142,7 +145,7 @@
 			return
 		log_game("[user.ckey] golem-swapped into [src]")
 		user.visible_message("<span class='notice'>A faint light leaves [user], moving to [src] and animating it!</span>","<span class='notice'>You leave your old body behind, and transfer into [src]!</span>")
-		create(ckey = user.ckey, flavour = FALSE)
+		create(ckey = user.ckey, flavour = FALSE, name = user.real_name)
 		user.death()
 		return
 	..()

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -101,6 +101,7 @@
 	death = FALSE
 	anchored = 0
 	density = 0
+	var/can_transfer = TRUE //if golems can switch bodies to this new shell
 	var/mob/living/owner = null //golem's owner if it has one
 	flavour_text = "<font size=3><b>Y</b></font><b>ou are a Free Golem. Your family worships <span class='danger'>The Liberator</span>. In his infinite and divine wisdom, he set your clan free to \
 	travel the stars with a single declaration: \"Yeah go do whatever.\" Though you are bound to the one who created you, it is customary in your society to repeat those same words to newborn \
@@ -134,12 +135,26 @@
 		H.set_cloned_appearance()
 		H.real_name = H.dna.species.random_name()
 
+/obj/effect/mob_spawn/human/golem/attack_hand(mob/user)
+	if(isgolem(user) && can_transfer)
+		var/transfer = alert("Transfer your soul to [src]? (Warning, your old body will die!)",,"Yes","No")
+		if(!transfer)
+			return
+		log_game("[user.ckey] golem-swapped into [src]")
+		user.visible_message("<span class='notice'>A faint light leaves [user], moving to [src] and animating it!</span>","<span class='notice'>You leave your old body behind, and transfer into [src]!</span>")
+		create(ckey = user.ckey, flavour = FALSE)
+		user.death()
+		return
+	..()
+
+
 /obj/effect/mob_spawn/human/golem/adamantine
 	name = "dust-caked golem shell"
 	desc = "A humanoid shape, empty, lifeless, and full of potential."
 	mob_name = "a free golem"
 	anchored = 1
 	density = 1
+	can_transfer = FALSE
 	mob_species = /datum/species/golem/adamantine
 
 //Malfunctioning cryostasis sleepers: Spawns in makeshift shelters in lavaland. Ghosts become hermits with knowledge of how they got to where they are now.

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -53,7 +53,7 @@
 /obj/effect/mob_spawn/proc/equip(mob/M)
 	return
 
-/obj/effect/mob_spawn/proc/create(ckey, flavour = TRUE)
+/obj/effect/mob_spawn/proc/create(ckey, flavour = TRUE, name)
 	var/mob/living/M = new mob_type(get_turf(src)) //living mobs only
 	if(!random)
 		M.real_name = mob_name ? mob_name : M.name
@@ -77,7 +77,7 @@
 		if(objectives)
 			for(var/objective in objectives)
 				MM.objectives += new/datum/objective(objective)
-		special(M)
+		special(M, name)
 		MM.name = M.real_name
 	if(uses > 0)
 		uses--

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -53,7 +53,7 @@
 /obj/effect/mob_spawn/proc/equip(mob/M)
 	return
 
-/obj/effect/mob_spawn/proc/create(ckey)
+/obj/effect/mob_spawn/proc/create(ckey, flavour = TRUE)
 	var/mob/living/M = new mob_type(get_turf(src)) //living mobs only
 	if(!random)
 		M.real_name = mob_name ? mob_name : M.name
@@ -71,7 +71,8 @@
 
 	if(ckey)
 		M.ckey = ckey
-		to_chat(M, "[flavour_text]")
+		if(flavour)
+			to_chat(M, "[flavour_text]")
 		var/datum/mind/MM = M.mind
 		if(objectives)
 			for(var/objective in objectives)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -501,6 +501,7 @@
 	sexes = FALSE
 	info_text = "As a <span class='danger'>Runic Golem</span>, you possess eldritch powers granted by the Elder God Nar'Sie."
 	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOFIRE,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NODISMEMBER) //no mutcolors
+	prefix = "Runic"
 
 	var/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/golem/phase_shift
 	var/obj/effect/proc_holder/spell/targeted/abyssal_gaze/abyssal_gaze

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -71,10 +71,14 @@
 	prefix = "Plasma"
 	special_names = list("Flood","Fire","Bar","Man")
 
-/datum/species/golem/plasma/spec_death(gibbed, mob/living/carbon/human/H)
-	explosion(get_turf(H),0,1,2,flame_range = 5)
-	if(H)
-		H.gib()
+/datum/species/golem/plasma/spec_life(mob/living/carbon/human/H)
+	if(H.bodytemperature > 900 && H.on_fire)
+		explosion(get_turf(H),1,2,4,flame_range = 5)
+		if(H)
+			H.gib()
+	if(H.fire_stacks < 2) //flammable
+		H.adjust_fire_stacks(1)
+	..()
 
 //Harder to hurt
 /datum/species/golem/diamond


### PR DESCRIPTION
:cl: XDTM
add: Golems can now click on empty golem shells to transfer into them.
tweak: Plasma Golems now no longer explode on death. They instead explode if they're on fire and are hot enough. The explosion size has been increased.
tweak: Plasma Golems are now always flammable.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Because iron/adamantine vanilla golems are usually the first ones, and usually the ones that worked the most in a golem ruin, and yet they aren't ever able to upgrade into a different or better golem type, so they're stuck into a basic shell while they watch the youngsters do cool stuff with expensive golems.
