### PR TITLE
DATUM VERBS AND MENUS!

### DIFF
--- a/code/__DEFINES/menu.dm
+++ b/code/__DEFINES/menu.dm
@@ -1,0 +1,3 @@
+#define CHECKBOX_NONE 0
+#define CHECKBOX_GROUP 1
+#define CHECKBOX_TOGGLE 2

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -457,6 +457,7 @@
 #define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= L.len ? L[I] : null) : L[I]) : null)
 #define LAZYLEN(L) length(L)
 #define LAZYCLEARLIST(L) if(L) L.Cut()
+#define SANITIZE_LIST(L) ( islist(L) ? L : list() )
 
 /* Definining a counter as a series of key -> numeric value entries
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -3,18 +3,13 @@ GLOBAL_PROTECT(admin_verbs_default)
 GLOBAL_LIST_INIT(admin_verbs_default, AVerbsDefault())
 /proc/AVerbsDefault()
 	return list(
-	/client/proc/toggleadminhelpsound,	/*toggles whether we hear a sound when adminhelps/PMs are used*/
-	/client/proc/toggleannouncelogin, /*toggles if an admin's login is announced during a round*/
 	/client/proc/deadmin,				/*destroys our own admin datum so we can play as a regular player*/
 	/client/proc/cmd_admin_say,			/*admin-only ooc chat*/
 	/client/proc/hide_verbs,			/*hides all our adminverbs*/
 	/client/proc/hide_most_verbs,		/*hides all our hideable adminverbs*/
 	/client/proc/debug_variables,		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
-	/client/proc/deadchat,				/*toggles deadchat on/off*/
+	/client/proc/admin_memo,			/*admin memo system. show/delete/write. +SERVER needed to delete admin memos of others*/
 	/client/proc/dsay,					/*talk in deadchat using our ckey/fakekey*/
-	/client/proc/toggleprayers,			/*toggles prayers on/off*/
-	/client/verb/toggleprayersounds,	/*Toggles prayer sounds (HALLELUJAH!)*/
-	/client/proc/toggle_hear_radio,		/*toggles whether we hear the radio*/
 	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
 	/client/proc/secrets,
 	/client/proc/reload_admins,
@@ -28,7 +23,6 @@ GLOBAL_PROTECT(admin_verbs_admin)
 GLOBAL_LIST_INIT(admin_verbs_admin, AVerbsAdmin())
 /proc/AVerbsAdmin()
 	return list(
-	/client/proc/player_panel_new,		/*shows an interface for all players, with links to various panels*/
 	/client/proc/invisimin,				/*allows our mob to go invisible/visible*/
 //	/datum/admins/proc/show_traitor_panel,	/*interface which shows a mob's mind*/ -Removed due to rare practical use. Moved to debug verbs ~Errorage
 	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
@@ -177,9 +171,6 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, AVerbsHideable())
 	/client/proc/set_ooc,
 	/client/proc/reset_ooc,
 	/client/proc/deadmin,
-	/client/proc/deadchat,
-	/client/proc/toggleprayers,
-	/client/proc/toggle_hear_radio,
 	/datum/admins/proc/show_traitor_panel,
 	/datum/admins/proc/toggleenter,
 	/datum/admins/proc/toggleguests,
@@ -393,12 +384,6 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, AVerbsHideable())
 			mob.invisibility = INVISIBILITY_OBSERVER
 			to_chat(mob, "<span class='adminnotice'><b>Invisimin on. You are now as invisible as a ghost.</b></span>")
 
-/client/proc/player_panel_new()
-	set name = "Player Panel"
-	set category = "Admin"
-	if(holder)
-		holder.player_panel_new()
-	feedback_add_details("admin_verb","Player Panel New") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/check_antagonists()
 	set name = "Check Antagonists"

--- a/code/modules/admin/adminmenu.dm
+++ b/code/modules/admin/adminmenu.dm
@@ -1,0 +1,11 @@
+/datum/menu/Admin/Generate_list(client/C)
+	if (C.holder)
+		. = ..()
+
+/datum/menu/Admin/proc/playerpanel()
+	set name = "Player Panel"
+	set desc = "Player Panel"
+	set category = "Admin"
+	usr.client.holder.player_panel_new()
+	feedback_add_details("admin_verb","Player Panel New") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -329,6 +329,28 @@ GLOBAL_LIST(external_rsc_urls)
 	if(!tooltips)
 		tooltips = new /datum/tooltip(src)
 
+	var/list/topmenus = menulist[/datum/menu]
+	for (var/thing in topmenus)
+		var/datum/menu/topmenu = thing
+		var/topmenuname = "[topmenu]"
+		if (topmenuname == "[topmenu.type]")
+			var/list/tree = splittext(topmenuname, "/")
+			topmenuname = tree[tree.len]
+		winset(src, "[topmenu.type]", "parent=menu;name=[url_encode(topmenuname)]")
+		src << {"winset(src, "[topmenu.type]", "parent=menu;name=[url_encode(topmenuname)]")"}
+		var/list/entries = topmenu.Generate_list(src)
+		for (var/child in entries)
+			winset(src, "[url_encode(child)]", "[entries[child]]")
+			src << {"winset(src, "[url_encode(child)]", "[entries[child]]")"}
+			if (!ispath(child, /datum/menu))
+				var/atom/verb/verbpath = child
+				if (copytext(verbpath.name,1,2) != "@")
+					new child(src)
+
+	for (var/thing in prefs.menuoptions)
+		var/datum/menu/menuitem = menulist[thing]
+		if (menuitem)
+			menuitem.Load_checked(src)
 
 //////////////
 //DISCONNECT//

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -102,6 +102,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/uplink_spawn_loc = UPLINK_PDA
 
+	var/list/menuoptions
+
 /datum/preferences/New(client/C)
 	parent = C
 	custom_names["ai"] = pick(GLOB.ai_names)
@@ -124,6 +126,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(!loaded_preferences_successfully)
 		save_preferences()
 	save_character()		//let's save this new random character so it doesn't keep generating new ones.
+	menuoptions = list()
 	return
 
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,5 +1,5 @@
 //This is the lowest supported version, anything below this is completely obsolete and the entire savefile will be wiped.
-#define SAVEFILE_VERSION_MIN	10
+#define SAVEFILE_VERSION_MIN	15
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
 #define SAVEFILE_VERSION_MAX	17
@@ -88,15 +88,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 
 /datum/preferences/proc/update_preferences(current_version, savefile/S)
-	if(current_version < 10)
-		toggles |= MEMBER_PUBLIC
-	if(current_version < 11)
-		chat_toggles = TOGGLES_DEFAULT_CHAT
-		toggles = TOGGLES_DEFAULT
-	if(current_version < 12)
-		ignoring = list()
-	if(current_version < 15)
-		toggles |= SOUND_ANNOUNCEMENTS
 
 
 //should this proc get fairly long (say 3 versions long),
@@ -106,16 +97,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 //It's only really meant to avoid annoying frequent players
 //if your savefile is 3 months out of date, then 'tough shit'.
 /datum/preferences/proc/update_character(current_version, savefile/S)
-	if(pref_species && !(pref_species.id in GLOB.roundstart_species))
-		var/rando_race = pick(config.roundstart_races)
-		pref_species = new rando_race()
-
-	if(current_version < 13 || !istext(backbag))
-		switch(backbag)
-			if(2)
-				backbag = DSATCHEL
-			else
-				backbag = DBACKPACK
 	if(current_version < 16)
 		var/berandom
 		S["userandomjob"] >> berandom
@@ -156,12 +137,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["tgui_fancy"]			>> tgui_fancy
 	S["tgui_lock"]			>> tgui_lock
 	S["windowflash"]		>> windowflashing
+	S["be_special"] 		>> be_special
 
-	if(islist(S["be_special"]))
-		S["be_special"] 	>> be_special
-	else //force update and store the old bitflag version of be_special
-		needs_update = 11
-		S["be_special"] 	>> old_be_special
 
 	S["default_slot"]		>> default_slot
 	S["chat_toggles"]		>> chat_toggles
@@ -177,6 +154,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["uses_glasses_colour"]>> uses_glasses_colour
 	S["clientfps"]			>> clientfps
 	S["parallax"]			>> parallax
+	S["menuoptions"]			>> menuoptions
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
@@ -199,6 +177,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	ghost_orbit 	= sanitize_inlist(ghost_orbit, GLOB.ghost_orbits, initial(ghost_orbit))
 	ghost_accs		= sanitize_inlist(ghost_accs, GLOB.ghost_accs_options, GHOST_ACCS_DEFAULT_OPTION)
 	ghost_others	= sanitize_inlist(ghost_others, GLOB.ghost_others_options, GHOST_OTHERS_DEFAULT_OPTION)
+	menuoptions		= SANITIZE_LIST(menuoptions)
+	be_special		= SANITIZE_LIST(be_special)
+
 
 	return 1
 
@@ -235,6 +216,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["uses_glasses_colour"]<< uses_glasses_colour
 	S["clientfps"]			<< clientfps
 	S["parallax"]			<< parallax
+	S["menuoptions"]		<< menuoptions
 
 	return 1
 
@@ -444,7 +426,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 #undef SAVEFILE_VERSION_MAX
 #undef SAVEFILE_VERSION_MIN
-/*
+
 //DEBUG
 //Some crude tools for testing savefiles
 //path is the savefile path
@@ -455,4 +437,4 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 /client/verb/savefile_import(path as text)
 	var/savefile/S = new /savefile(path)
 	S.ImportText("/",file("[path].txt"))
-*/
+

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -1,76 +1,115 @@
+//this works as is to create a single checked item, but has no back end code for toggleing the check yet
+#define TOGGLE_CHECKBOX(PARENT, CHILD) PARENT/CHILD/abstract = TRUE;PARENT/CHILD/checkbox = CHECKBOX_TOGGLE;PARENT/CHILD/verb/CHILD
+
+//Example usage TOGGLE_CHECKBOX(datum/menu/Settings/Ghost/chatterbox, toggle_ghost_ears)()
+
+/datum/menu/Settings/Load_checked(client/C)
+	return
+
+//override because we don't want to save preferences twice.
+/datum/menu/Settings/Set_checked(client/C, verbpath)
+	if (checkbox == CHECKBOX_GROUP)
+		C.prefs.menuoptions[src.type] = verbpath
+	else if (checkbox == CHECKBOX_TOGGLE)
+		var/checked = Get_checked(C)
+		C.prefs.menuoptions[type] = !checked
+		winset(C, "[verbpath]", "is-checked = [!checked]")
+
 //toggles
-/client/verb/toggle_ghost_ears()
+/datum/menu/Settings/Ghost/chatterbox
+	name = "Chat Box Spam"
+
+///datum/menu/Settings/Ghost/chatterbox/verb/toggle_ghost_ears()
+TOGGLE_CHECKBOX(datum/menu/Settings/Ghost/chatterbox, toggle_ghost_ears)()
 	set name = "Show/Hide GhostEars"
 	set category = "Preferences"
-	set desc = ".Toggle Between seeing all mob speech, and only speech of nearby mobs"
-	prefs.chat_toggles ^= CHAT_GHOSTEARS
-	to_chat(src, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTEARS) ? "see all speech in the world" : "only see speech from nearby mobs"].")
-	prefs.save_preferences()
+	set desc = "Show/Hide GhostEars"
+	usr.client.prefs.chat_toggles ^= CHAT_GHOSTEARS
+	to_chat(usr, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTEARS) ? "see all speech in the world" : "only see speech from nearby mobs"].")
+	usr.client.prefs.save_preferences()
 	feedback_add_details("preferences_verb","Toggle Ghost Ears|[prefs.chat_toggles & CHAT_GHOSTEARS]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Ghost/chatterbox/toggle_ghost_ears/Get_checked(client/C)
+	return C.prefs.chat_toggles & CHAT_GHOSTEARS
 
-/client/verb/toggle_ghost_sight()
+TOGGLE_CHECKBOX(datum/menu/Settings/Ghost/chatterbox, toggle_ghost_sight)()
 	set name = "Show/Hide GhostSight"
 	set category = "Preferences"
 	set desc = ".Toggle Between seeing all mob emotes, and only emotes of nearby mobs"
-	prefs.chat_toggles ^= CHAT_GHOSTSIGHT
-	to_chat(src, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTSIGHT) ? "see all emotes in the world" : "only see emotes from nearby mobs"].")
-	prefs.save_preferences()
+	usr.client.prefs.chat_toggles ^= CHAT_GHOSTSIGHT
+	to_chat(usr, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTSIGHT) ? "see all emotes in the world" : "only see emotes from nearby mobs"].")
+	usr.client.prefs.save_preferences()
 	feedback_add_details("preferences_verb","Toggle Ghost Sight|[prefs.chat_toggles & CHAT_GHOSTSIGHT]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Ghost/chatterbox/oggle_ghost_sight/Get_checked(client/C)
+	return C.prefs.chat_toggles & CHAT_GHOSTSIGHT
 
-/client/verb/toggle_ghost_whispers()
+TOGGLE_CHECKBOX(datum/menu/Settings/Ghost/chatterbox, toggle_ghost_whispers)()
 	set name = "Show/Hide GhostWhispers"
 	set category = "Preferences"
 	set desc = ".Toggle between hearing all whispers, and only whispers of nearby mobs"
-	prefs.chat_toggles ^= CHAT_GHOSTWHISPER
-	to_chat(src, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTWHISPER) ? "see all whispers in the world" : "only see whispers from nearby mobs"].")
-	prefs.save_preferences()
+	usr.client.prefs.chat_toggles ^= CHAT_GHOSTWHISPER
+	to_chat(usr, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTWHISPER) ? "see all whispers in the world" : "only see whispers from nearby mobs"].")
+	usr.client.prefs.save_preferences()
 	feedback_add_details("preferences_verb","Toggle Ghost Whispers|[prefs.chat_toggles & CHAT_GHOSTWHISPER]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Ghost/chatterbox/toggle_ghost_whispers/Get_checked(client/C)
+	return C.prefs.chat_toggles & CHAT_GHOSTWHISPER
 
-/client/verb/toggle_ghost_radio()
+TOGGLE_CHECKBOX(datum/menu/Settings/Ghost/chatterbox, toggle_ghost_radio)()
 	set name = "Show/Hide GhostRadio"
 	set category = "Preferences"
 	set desc = ".Enable or disable hearing radio chatter as a ghost"
-	prefs.chat_toggles ^= CHAT_GHOSTRADIO
-	to_chat(src, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTRADIO) ? "see radio chatter" : "not see radio chatter"].")
-	prefs.save_preferences()
+	usr.client.prefs.chat_toggles ^= CHAT_GHOSTRADIO
+	to_chat(usr, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTRADIO) ? "see radio chatter" : "not see radio chatter"].")
+	usr.client.prefs.save_preferences()
 	feedback_add_details("preferences_verb","Toggle Ghost Radio|[prefs.chat_toggles & CHAT_GHOSTRADIO]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc! //social experiment, increase the generation whenever you copypaste this shamelessly GENERATION 1
+/datum/menu/Settings/Ghost/chatterbox/toggle_ghost_radio/Get_checked(client/C)
+	return C.prefs.chat_toggles & CHAT_GHOSTRADIO
 
-/client/verb/toggle_ghost_pda()
+TOGGLE_CHECKBOX(datum/menu/Settings/Ghost/chatterbox, toggle_ghost_pda)()
 	set name = "Show/Hide GhostPDA"
 	set category = "Preferences"
 	set desc = ".Toggle Between seeing all mob pda messages, and only pda messages of nearby mobs"
-	prefs.chat_toggles ^= CHAT_GHOSTPDA
-	to_chat(src, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTPDA) ? "see all pda messages in the world" : "only see pda messages from nearby mobs"].")
-	prefs.save_preferences()
+	usr.client.prefs.chat_toggles ^= CHAT_GHOSTPDA
+	to_chat(usr, "As a ghost, you will now [(prefs.chat_toggles & CHAT_GHOSTPDA) ? "see all pda messages in the world" : "only see pda messages from nearby mobs"].")
+	usr.client.prefs.save_preferences()
 	feedback_add_details("preferences_verb","Toggle Ghost PDA|[prefs.chat_toggles & CHAT_GHOSTPDA]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Ghost/chatterbox/toggle_ghost_pda/Get_checked(client/C)
+	return C.prefs.chat_toggles & CHAT_GHOSTPDA
 
 //please be aware that the following two verbs have inverted stat output, so that "Toggle Deathrattle|1" still means you activated it
-/client/verb/toggle_deathrattle()
+TOGGLE_CHECKBOX(datum/menu/Settings/Ghost/chatterbox, toggle_deathrattle)()
 	set name = "Toggle Deathrattle"
 	set category = "Preferences"
 	set desc = "Toggle recieving a message in deadchat when sentient mobs die."
-	prefs.toggles ^= DISABLE_DEATHRATTLE
-	prefs.save_preferences()
+	usr.client.prefs.toggles ^= DISABLE_DEATHRATTLE
+	usr.client.prefs.save_preferences()
 	to_chat(usr, "You will [(prefs.toggles & DISABLE_DEATHRATTLE) ? "no longer" : "now"] get messages when a sentient mob dies.")
 	feedback_add_details("preferences_verb", "Toggle Deathrattle|[!(prefs.toggles & DISABLE_DEATHRATTLE)]") //If you are copy-pasting this, maybe you should spend some time reading the comments.
+/datum/menu/Settings/Ghost/chatterbox/toggle_deathrattle/Get_checked(client/C)
+	return !(C.prefs.toggles & DISABLE_DEATHRATTLE)
 
-/client/verb/toggle_arrivalrattle()
+TOGGLE_CHECKBOX(datum/menu/Settings/Ghost/chatterbox, toggle_arrivalrattle)()
 	set name = "Toggle Arrivalrattle"
 	set category = "Preferences"
 	set desc = "Toggle recieving a message in deadchat when someone joins the station."
-	prefs.toggles ^= DISABLE_ARRIVALRATTLE
+	usr.client.prefs.toggles ^= DISABLE_ARRIVALRATTLE
 	to_chat(usr, "You will [(prefs.toggles & DISABLE_ARRIVALRATTLE) ? "no longer" : "now"] get messages when someone joins the station.")
-	prefs.save_preferences()
+	usr.client.prefs.save_preferences()
 	feedback_add_details("preferences_verb", "Toggle Arrivalrattle|[!(prefs.toggles & DISABLE_ARRIVALRATTLE)]") //If you are copy-pasting this, maybe you should rethink where your life went so wrong.
+/datum/menu/Settings/Ghost/chatterbox/toggle_arrivalrattle/Get_checked(client/C)
+	return !(C.prefs.toggles & DISABLE_ARRIVALRATTLE)
 
-/client/verb/togglemidroundantag()
+TOGGLE_CHECKBOX(datum/menu/Settings/Ghost, togglemidroundantag)()
 	set name = "Toggle Midround Antagonist"
 	set category = "Preferences"
 	set desc = "Toggles whether or not you will be considered for antagonist status given during a round."
-	prefs.toggles ^= MIDROUND_ANTAG
-	prefs.save_preferences()
-	to_chat(src, "You will [(prefs.toggles & MIDROUND_ANTAG) ? "now" : "no longer"] be considered for midround antagonist positions.")
+	usr.client.prefs.toggles ^= MIDROUND_ANTAG
+	usr.client.prefs.save_preferences()
+	to_chat(usr, "You will [(prefs.toggles & MIDROUND_ANTAG) ? "now" : "no longer"] be considered for midround antagonist positions.")
 	feedback_add_details("preferences_verb","Toggle Midround Antag|[prefs.toggles & MIDROUND_ANTAG]") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+/datum/menu/Settings/Ghost/togglemidroundantag/Get_checked(client/C)
+	return C.prefs.toggles & MIDROUND_ANTAG
+
+#warn todo: Import the rest of this.
 
 /client/verb/toggletitlemusic()
 	set name = "Hear/Silence LobbyMusic"

--- a/code/world.dm
+++ b/code/world.dm
@@ -58,6 +58,10 @@
 
 	Master.Initialize(10, FALSE)
 
+	for (var/typepath in (typesof(/datum/menu)-/datum/menu))
+		new typepath()
+	return
+
 #define IRC_STATUS_THROTTLE 50
 /world/Topic(T, addr, master, key)
 	if(config && config.log_world_topic)

--- a/interface/menu.dm
+++ b/interface/menu.dm
@@ -1,0 +1,185 @@
+/*
+/datum/menu/Example/verb/Example()
+	set name = "" //if this starts with @ the verb is not created and name becomes the command to invoke.
+	set desc = "" //desc is the text given to this entry in the menu
+	//I should note, in these verbs, src will be unusable
+*/
+
+var/list/menulist = list()
+/datum/menu
+	var/name
+	var/list/children
+	var/datum/menu/myparent
+	var/list/verblist
+	var/checkbox = CHECKBOX_NONE //checkbox type.
+
+	//Set to true to append our children to our parent,
+	//Rather then add us as a node (used for having more then one checkgroups in the same menu)
+	var/abstract = FALSE
+
+/datum/menu/New()
+	var/ourentry = menulist[type]
+	children = list()
+	verblist = list()
+	if (islist(ourentry)) //some of our childern already loaded
+		Add_children(ourentry)
+
+	menulist[type] = src
+
+	Load_verbs(type, typesof("[type]/verb"))
+
+	var/datum/menu/parent = menulist[parent_type]
+	if (!parent)
+		menulist[parent_type] = list(src)
+	else if (islist(parent))
+		parent += src
+	else
+		parent.Add_children(src)
+
+/datum/menu/proc/Set_parent(datum/menu/parent)
+	myparent = parent
+	if (abstract)
+		myparent.Add_children(children)
+		var/list/verblistoftypes = list()
+		for(var/thing in verblist)
+			LAZYADD(verblistoftypes[verblist[thing]], thing)
+		for(var/verbparenttype in verblistoftypes)
+			myparent.Load_verbs(verbparenttype, verblistoftypes[verbparenttype])
+
+/datum/menu/proc/Add_children(list/kids)
+	if (abstract && myparent)
+		myparent.Add_children(kids)
+		return
+
+	for(var/thing in kids)
+		var/datum/menu/menuitem = thing
+		menuitem.Set_parent(src)
+		if (!menuitem.abstract)
+			children += menuitem
+
+/datum/menu/proc/Load_verbs(verb_parent_type, var/list/verbs)
+	if (abstract && myparent)
+		myparent.Load_verbs(verb_parent_type, verbs)
+		return
+
+	for (var/verbpath in verbs)
+		verblist[verbpath] = verb_parent_type
+
+/datum/menu/proc/Generate_list(client/C)
+	. = list()
+	if (length(children))
+		for (var/thing in children)
+			var/datum/menu/child = thing
+			var/list/childlist = child.Generate_list(C)
+			if (childlist)
+				var/childname = "[child]"
+				if (childname == "[child.type]")
+					var/list/tree = splittext(childname, "/")
+					childname = tree[tree.len]
+				.[child.type] = "parent=[url_encode(type)];name=[url_encode(childname)]"
+				. += childlist
+
+
+
+	for (var/thing in verblist)
+		var/atom/verb/verbpath = thing
+		var/list/entry = list()
+		entry["parent"] = "[type]"
+		entry["name"] = verbpath.desc
+		if (copytext(verbpath.name,1,2) == "@")
+			entry["command"] = copytext(verbpath.name,2)
+		else
+			entry["command"] = replacetext(verbpath.name, " ", "-")
+		var/datum/menu/verb_true_parent = menulist[verblist[verbpath]]
+		var/true_checkbox = verb_true_parent.checkbox
+		if (true_checkbox != CHECKBOX_NONE)
+			var/checkedverb = verb_true_parent.Get_checked(C)
+			if (checkbox == CHECKBOX_GROUP)
+				if (verbpath == checkedverb)
+					entry["is-checked"] = TRUE
+				else
+					entry["is-checked"] = FALSE
+			else if (checkbox == CHECKBOX_TOGGLE)
+				entry["is-checked"] = checkedverb
+
+			entry["command"] = ".updatemenuchecked \"[verb_true_parent.type]\" \"[verbpath]\"\n[entry["command"]]"
+			entry["can-check"] = TRUE
+			entry["group"] = "[verb_true_parent.type]"
+		.[verbpath] = list2params(entry)
+
+/datum/menu/proc/Get_checked(client/C)
+	return C.prefs.menuoptions[type]
+
+/datum/menu/proc/Load_checked(client/C) //So programmers can be lazy, we invoke the "checked" menu item on menu load.
+	var/atom/verb/verbpath = Get_checked(C)
+	if (!verbpath || !(verbpath in typesof("[type]/verb")))
+		return
+	if (copytext(verbpath.name,1,2) == "@")
+		winset(C, null, "command = [copytext(verbpath.name,2)]")
+	else
+		winset(C, null, "command = [replacetext(verbpath.name, " ", "-")]")
+
+/datum/menu/proc/Set_checked(client/C, verbpath)
+	if (checkbox == CHECKBOX_GROUP)
+		C.prefs.menuoptions[src.type] = verbpath
+		C.prefs.save_preferences()
+	else if (checkbox == CHECKBOX_TOGGLE)
+		var/checked = Get_checked(C)
+		C.prefs.menuoptions[type] = !checked
+		C.prefs.save_preferences()
+		winset(C, "[verbpath]", "is-checked = [!checked]")
+
+/client/verb/updatemenuchecked(menutype as text, verbpath as text)
+	set name = ".updatemenuchecked"
+	menutype = text2path(menutype)
+	verbpath = text2path(verbpath)
+	if (!menutype || !verbpath)
+		return
+	var/datum/menu/M = menulist[menutype]
+	if (!M)
+		return
+	if (!(verbpath in typesof("[menutype]/verb")))
+		return
+	M.Set_checked(src, verbpath)
+
+
+/datum/menu/Icon/Size
+	checkbox = CHECKBOX_GROUP
+
+/datum/menu/Icon/Size/verb/iconstretchtofit()
+	set name = "@.winset \"mapwindow.map.icon-size=0\""
+	set desc = "&Auto (stretch-to-fit)"
+
+/datum/menu/Icon/Size/verb/icon96()
+	set name = "@.winset \"mapwindow.map.icon-size=96\""
+	set desc = "&96x96 (3x)"
+
+/datum/menu/Icon/Size/verb/icon64()
+	set name = "@.winset \"mapwindow.map.icon-size=64\""
+	set desc = "&64x64 (2x)"
+
+/datum/menu/Icon/Size/verb/icon48()
+	set name = "@.winset \"mapwindow.map.icon-size=48\""
+	set desc = "&48x48 (1.5x)"
+
+/datum/menu/Icon/Size/verb/icon32()
+	set name = "@.winset \"mapwindow.map.icon-size=32\""
+	set desc = "&32x32 (1x)"
+
+
+/datum/menu/Icon/Scaling
+	checkbox = CHECKBOX_GROUP
+	name = "Scaling Mode"
+
+/datum/menu/Icon/Scaling/verb/icon64()
+	set name = "@.winset \"mapwindow.map.zoom-mode=distort\""
+	set desc = "Nearest Neighbor"
+
+/datum/menu/Icon/Scaling/verb/icon48()
+	set name = "@.winset \"mapwindow.map.zoom-mode=normal\""
+	set desc = "Point Sampling"
+
+/datum/menu/Icon/Scaling/verb/icon32()
+	set name = "@.winset \"mapwindow.map.zoom-mode=blur\""
+	set desc = "Bilinear"
+

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1039,60 +1039,6 @@ menu "menu"
 		is-disabled = false
 		saved-params = "is-checked"
 	elem 
-		name = "&Icons"
-		command = ""
-		category = ""
-		is-checked = false
-		can-check = false
-		group = ""
-		is-disabled = false
-		saved-params = "is-checked"
-	elem "auto"
-		name = "&Auto (stretch-to-fit)"
-		command = ".winset \"mapwindow.map.icon-size=0\""
-		category = "&Icons"
-		is-checked = true
-		can-check = true
-		group = "size"
-		is-disabled = false
-		saved-params = "is-checked"
-	elem "icon96"
-		name = "&96x96 (3x)"
-		command = ".winset \"mapwindow.map.icon-size=96\""
-		category = "&Icons"
-		is-checked = false
-		can-check = true
-		group = "size"
-		is-disabled = false
-		saved-params = "is-checked"
-	elem "icon64"
-		name = "&64x64 (2x)"
-		command = ".winset \"mapwindow.map.icon-size=64\""
-		category = "&Icons"
-		is-checked = false
-		can-check = true
-		group = "size"
-		is-disabled = false
-		saved-params = "is-checked"
-	elem "icon48"
-		name = "&48x48 (1.5x)"
-		command = ".winset \"mapwindow.map.icon-size=48\""
-		category = "&Icons"
-		is-checked = false
-		can-check = true
-		group = "size"
-		is-disabled = false
-		saved-params = "is-checked"
-	elem "icon32"
-		name = "&32x32"
-		command = ".winset \"mapwindow.map.icon-size=32\""
-		category = "&Icons"
-		is-checked = false
-		can-check = true
-		group = "size"
-		is-disabled = false
-		saved-params = "is-checked"
-	elem 
 		name = "&Help"
 		command = ""
 		category = ""
@@ -1359,6 +1305,7 @@ window "mapwindow"
 		on-show = ""
 		on-hide = ""
 		style = ""
+		zoom-mode = "distort"
 
 window "infowindow"
 	elem "infowindow"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -44,6 +44,7 @@
 #include "code\__DEFINES\maps.dm"
 #include "code\__DEFINES\math.dm"
 #include "code\__DEFINES\MC.dm"
+#include "code\__DEFINES\menu.dm"
 #include "code\__DEFINES\misc.dm"
 #include "code\__DEFINES\mobs.dm"
 #include "code\__DEFINES\monkeys.dm"
@@ -962,6 +963,7 @@
 #include "code\modules\admin\admin_investigate.dm"
 #include "code\modules\admin\admin_ranks.dm"
 #include "code\modules\admin\admin_verbs.dm"
+#include "code\modules\admin\adminmenu.dm"
 #include "code\modules\admin\banjob.dm"
 #include "code\modules\admin\create_mob.dm"
 #include "code\modules\admin\create_object.dm"
@@ -2080,6 +2082,7 @@
 #include "code\modules\zombie\organs.dm"
 #include "code\orphaned_procs\statistics.dm"
 #include "interface\interface.dm"
+#include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
 // END_INCLUDE


### PR DESCRIPTION
Note: I'm only re-opening this as a fuck you to @duncathan 
#23201

:cl:
add: Moved to a new system to make top menu items easier to edit.
tweak: Moved icon size stuff to a sub menu
add: Added option to change icon scaling mode.
fix: Byond added fancy shader supported scaling(Point Sampling), this sucks because it's blurry, the default for /tg/station has changed back to the old nearest neighbor scaling.
/:cl:

This allows you to define a top menu item by just defining a verb. the verb's type path will be used to figure out hierarchy.

eg: `/datum/menu/Icon/Size/verb/iconstretchtofit()` will create the menu entry `Icon`->`Size`->`Auto (stretch-to-fit)` (assuming `desc` is set to `Auto (stretch-to-fit)`)


Todo:
- [x] Testing
- [x] ~~Add admin verbs to this system (bonus points, we can remove the admin verb lists entirely with just a bit more boilerplate, the example i put in was mainly a proof of concept.) (even better, we can make a seperate system and move all of admin/topic to it.)~~ Todo for another pr.
- [ ] Add example admin modular verbs/topic system based off of this one.
- [ ] Moar Testing
- [x] Add preference verbs to this system
- [x] Add a toggle system for the toggle preferences so users can see whats on/off.
- [x] Add some of the ghost display/vision verbs
- [ ] More Testing
- [ ] Add the rest of the pref toggle verbs
- [ ] Look at other tabs for inspiration
- [x] Checkboxes don't save on dynamic menus. Find some way around this limitation.
- [ ] Testing.
- [ ] Remove debug lines

Screen:
![](https://cloud.githubusercontent.com/assets/7069733/22173862/843eae34-df83-11e6-9554-785fe2a09c89.png)

