### PR TITLE
Plasma vessels regenerate slowly off resin

### DIFF
--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -87,6 +87,8 @@
 			owner.adjustFireLoss(-heal_amt)
 			owner.adjustOxyLoss(-heal_amt)
 			owner.adjustCloneLoss(-heal_amt)
+	else
+		owner.adjustPlasma(plasma_rate * 0.1)
 
 /obj/item/organ/alien/plasmavessel/Insert(mob/living/carbon/M, special = 0)
 	..()


### PR DESCRIPTION
:cl: coiax
balance: Plasma vessels, the organs inside aliens that are responsible
for their internal plasma storage, will regenerate small amounts of
plasma even if the owner is not on resin weeds.
/:cl:

- Rate is 10% of normal. Stops aliens accidentally spending their plasma
poorly, and then being unable to plant weeds ever again. Breathing in
plasma is not really an option for most aliens, and not many people know
about it.
- This is an "anti-stupidity" feature, in essence.