### PR TITLE
Adds pikes, unobtainable

### DIFF
--- a/code/game/objects/items/weapons/reachweapons.dm
+++ b/code/game/objects/items/weapons/reachweapons.dm
@@ -1,0 +1,20 @@
+/*For weapons that utilize reach.
+Currently contains:
+Pikes
+*/
+
+/obj/item/weapon/twohanded/spear/pike
+	name = "pike"
+	desc = "It's a spear with a much longer handle. A lot harder to maneuver in combat and probably less aerodynamic, but it should give you some extra reach."
+	throwforce = 10
+	throw_speed = 2
+	//could use sprites
+	reach = 2
+
+/obj/item/weapon/twohanded/spear/pike/attack(mob/living/target, mob/living/user)
+	var/dist = get_dist(target, user)
+	if(dist < reach)
+		to_chat(user, "<span class='warning'>You're too close to hit [target] effectively.</span>")
+		return
+	else
+		..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -791,6 +791,7 @@
 #include "code\game\objects\items\weapons\pneumaticCannon.dm"
 #include "code\game\objects\items\weapons\powerfist.dm"
 #include "code\game\objects\items\weapons\RCD.dm"
+#include "code\game\objects\items\weapons\reachweapons.dm"
 #include "code\game\objects\items\weapons\RPD.dm"
 #include "code\game\objects\items\weapons\RSF.dm"
 #include "code\game\objects\items\weapons\scrolls.dm"


### PR DESCRIPTION
Adds a new file for reach weapons

Adds pikes, just spears but with 2 reach and you MUST be attacking at reach in order to deal damage (there must be 1 tile of space between you and victim), and less effective when throwing.

Planned to be obtainable by slapping a spear onto a wired rod to extend the handle, I've neglected to include this for now because of discovering https://github.com/tgstation/tgstation/issues/26796 while testing (and also no unique sprites). As of right now it is unobtainable.