### PR TITLE
Nuke op TC consoles can donate all TCs at once, and other small changes.

### DIFF
--- a/code/game/machinery/computer/telecrystalconsoles.dm
+++ b/code/game/machinery/computer/telecrystalconsoles.dm
@@ -205,8 +205,9 @@ GLOBAL_LIST_INIT(possible_uplinker_IDs, list("Alfa","Bravo","Charlie","Delta","E
 
 	if(href_list["give"])
 		var/tcamt = text2num(href_list["give"])
-		var/obj/machinery/computer/telecrystals/uplinker/A = locate(href_list["target"])
-		A.giveTC(tcamt)
+		if(TCstations.len) // sanity
+			var/obj/machinery/computer/telecrystals/uplinker/A = locate(href_list["target"]) in TCstations
+			A.giveTC(tcamt)
 
 	if(href_list["distrib"])
 		var/sanity = 0

--- a/code/game/machinery/computer/telecrystalconsoles.dm
+++ b/code/game/machinery/computer/telecrystalconsoles.dm
@@ -58,7 +58,12 @@ GLOBAL_LIST_INIT(possible_uplinker_IDs, list("Alfa","Bravo","Charlie","Delta","E
 
 /obj/machinery/computer/telecrystals/uplinker/proc/donateTC(amt, addLog = 1)
 	if(uplinkholder && linkedboss)
-		if(amt <= uplinkholder.hidden_uplink.telecrystals)
+		if(amt < 0)
+			linkedboss.storedcrystals += uplinkholder.hidden_uplink.telecrystals
+			if(addLog)
+				linkedboss.logTransfer("[src] donated [uplinkholder.hidden_uplink.telecrystals] telecrystals to [linkedboss].")
+			uplinkholder.hidden_uplink.telecrystals = 0
+		else if(amt <= uplinkholder.hidden_uplink.telecrystals)
 			uplinkholder.hidden_uplink.telecrystals -= amt
 			linkedboss.storedcrystals += amt
 			if(addLog)
@@ -66,7 +71,12 @@ GLOBAL_LIST_INIT(possible_uplinker_IDs, list("Alfa","Bravo","Charlie","Delta","E
 
 /obj/machinery/computer/telecrystals/uplinker/proc/giveTC(amt, addLog = 1)
 	if(uplinkholder && linkedboss)
-		if(amt <= linkedboss.storedcrystals)
+		if(amt < 0)
+			uplinkholder.hidden_uplink.telecrystals += linkedboss.storedcrystals
+			if(addLog)
+				linkedboss.logTransfer("[src] received [linkedboss.storedcrystals] telecrystals from [linkedboss].")
+			linkedboss.storedcrystals = 0
+		else if(amt <= linkedboss.storedcrystals)
 			uplinkholder.hidden_uplink.telecrystals += amt
 			linkedboss.storedcrystals -= amt
 			if(addLog)
@@ -89,7 +99,7 @@ GLOBAL_LIST_INIT(possible_uplinker_IDs, list("Alfa","Bravo","Charlie","Delta","E
 	if(uplinkholder)
 		dat += "[uplinkholder.hidden_uplink.telecrystals] telecrystals remain in this uplink.<BR>"
 		if(linkedboss)
-			dat += "Donate TC: <a href='byond://?src=\ref[src];donate1=1'>1</a> | <a href='byond://?src=\ref[src];donate5=1'>5</a>"
+			dat += "Donate TC: <a href='byond://?src=\ref[src];donate=1'>1</a> | <a href='byond://?src=\ref[src];donate=5'>5</a> | <a href='byond://?src=\ref[src];donate=-1'>All</a>"
 		dat += "<br><a href='byond://?src=\ref[src];eject=1'>Eject Uplink</a>"
 
 
@@ -103,11 +113,9 @@ GLOBAL_LIST_INIT(possible_uplinker_IDs, list("Alfa","Bravo","Charlie","Delta","E
 	if(..())
 		return
 
-	if(href_list["donate1"])
-		donateTC(1)
-
-	if(href_list["donate5"])
-		donateTC(5)
+	if(href_list["donate"])
+		var/tcamt = text2num(href_list["donate"])
+		donateTC(tcamt)
 
 	if(href_list["eject"])
 		ejectuplink()
@@ -162,7 +170,7 @@ GLOBAL_LIST_INIT(possible_uplinker_IDs, list("Alfa","Bravo","Charlie","Delta","E
 
 	var/dat = ""
 	dat += "<a href='byond://?src=\ref[src];scan=1'>Scan for TC stations.</a><BR>"
-	dat += "This [src] has [storedcrystals] telecrystals available for distribution. <BR>"
+	dat += "[storedcrystals] telecrystals are available for distribution. <BR>"
 	dat += "<BR><BR>"
 
 
@@ -171,10 +179,10 @@ GLOBAL_LIST_INIT(possible_uplinker_IDs, list("Alfa","Bravo","Charlie","Delta","E
 		if(A.uplinkholder)
 			dat += "[A.uplinkholder.hidden_uplink.telecrystals] telecrystals."
 		if(storedcrystals)
-			dat+= "<BR>Add TC: <a href ='?src=\ref[src];give1=\ref[A]'>1</a> | <a href ='?src=\ref[src];give5=\ref[A]'>5</a>"
+			dat+= "<BR>Add TC: <a href ='?src=\ref[src];target=\ref[A];give=1'>1</a> | <a href ='?src=\ref[src];target=\ref[A];give=5'>5</a> | <a href ='?src=\ref[src];target=\ref[A];give=-1'>All</a>"
 		dat += "<BR>"
 
-	if(TCstations.len)
+	if(TCstations.len && storedcrystals)
 		dat += "<BR><BR><a href='byond://?src=\ref[src];distrib=1'>Evenly distribute remaining TC.</a><BR><BR>"
 
 
@@ -195,13 +203,10 @@ GLOBAL_LIST_INIT(possible_uplinker_IDs, list("Alfa","Bravo","Charlie","Delta","E
 	if(href_list["scan"])
 		scanUplinkers()
 
-	if(href_list["give1"])
-		var/obj/machinery/computer/telecrystals/uplinker/A = locate(href_list["give1"])
-		A.giveTC(1)
-
-	if(href_list["give5"])
-		var/obj/machinery/computer/telecrystals/uplinker/A = locate(href_list["give5"])
-		A.giveTC(5)
+	if(href_list["give"])
+		var/tcamt = text2num(href_list["give"])
+		var/obj/machinery/computer/telecrystals/uplinker/A = locate(href_list["target"])
+		A.giveTC(tcamt)
 
 	if(href_list["distrib"])
 		var/sanity = 0

--- a/code/game/machinery/computer/telecrystalconsoles.dm
+++ b/code/game/machinery/computer/telecrystalconsoles.dm
@@ -179,7 +179,7 @@ GLOBAL_LIST_INIT(possible_uplinker_IDs, list("Alfa","Bravo","Charlie","Delta","E
 		if(A.uplinkholder)
 			dat += "[A.uplinkholder.hidden_uplink.telecrystals] telecrystals."
 		if(storedcrystals)
-			dat+= "<BR>Add TC: <a href ='?src=\ref[src];target=\ref[A];give=1'>1</a> | <a href ='?src=\ref[src];target=\ref[A];give=5'>5</a> | <a href ='?src=\ref[src];target=\ref[A];give=-1'>All</a>"
+			dat+= "<BR>Add TC: <a href ='?src=\ref[src];target=\ref[A];give=1'>1</a> | <a href ='?src=\ref[src];target=\ref[A];give=5'>5</a> | <a href ='?src=\ref[src];target=\ref[A];give=10'>10</a> | <a href ='?src=\ref[src];target=\ref[A];give=-1'>All</a>"
 		dat += "<BR>"
 
 	if(TCstations.len && storedcrystals)


### PR DESCRIPTION
:cl: bgobandit
tweak: The Syndicate has added basic functionality to their state-of-the-art equipment. Nuke ops can now donate all TCs at once.
/:cl:

Why it is worth adding: "I love mashing the Donate 5 button over and over," said literally no one ever. 

Other changes:

- The master TC console can now give 10 TCs at a time, as well as 1 and 5. With higher round pops the number can get into the hundreds so this extra gradation may be useful.
- You can no longer attempt to distribute TCs with an empty console.
- Fixed a grammar error that rustled my jimmies.