### PR TITLE
Trophy case hotfixes

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -114,6 +114,9 @@ SUBSYSTEM_DEF(persistence)
 	var/saved_json
 	trophy_sav >> saved_json
 
+	if(!saved_json)
+		return
+
 	var/decoded_json = json_decode(saved_json)
 
 	if(!islist(decoded_json))

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -316,7 +316,7 @@
 				to_chat(user, "You are too far to set the plaque's text.")
 
 		SSpersistence.SaveTrophy(src)
-		return 1
+		return TRUE
 
 	else
 		to_chat(user, "<span class='warning'>\The [W] is stuck to your hand, you can't put it in the [src.name]!</span>")

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -316,6 +316,7 @@
 				to_chat(user, "You are too far to set the plaque's text.")
 
 		SSpersistence.SaveTrophy(src)
+		return 1
 
 	else
 		to_chat(user, "<span class='warning'>\The [W] is stuck to your hand, you can't put it in the [src.name]!</span>")


### PR DESCRIPTION
Fixes two bugs I didn't catch during testing.

- Fixes LoadTrophies runtiming when the savefile is empty
- Prevents inserted items from calling afterattack (so cameras won't make one last photo before being inserted, for example).  [There really should be afterattack return hint defines to make this thing clearer]

fixes #26819
