### PR TITLE
Syndicate borg/reinforcement spawners have a Never For This Round option.

### DIFF
--- a/code/_globalvars/lists/poll_ignore.dm
+++ b/code/_globalvars/lists/poll_ignore.dm
@@ -5,5 +5,6 @@
 #define POLL_IGNORE_POSSESSED_BLADE "possessed_blade"
 #define POLL_IGNORE_ALIEN_LARVA "alien_larva"
 #define POLL_IGNORE_CLOCKWORK_MARAUDER "clockwork_marauder"
+#define POLL_IGNORE_SYNDICATE "syndicate"
 
 GLOBAL_LIST_EMPTY(poll_ignore)

--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -155,7 +155,8 @@
 	if(!(check_usability(user)))
 		return
 
-	var/list/nuke_candidates = pollCandidatesForMob("Do you want to play as a syndicate [borg_to_spawn ? "[lowertext(borg_to_spawn)] cyborg":"operative"]?", ROLE_OPERATIVE, null, ROLE_OPERATIVE, 150, src)
+	to_chat(user, "<span class='notice'>You activate [src] and wait for confirmation.</span>")
+	var/list/nuke_candidates = pollCandidatesForMob("Do you want to play as a syndicate [borg_to_spawn ? "[lowertext(borg_to_spawn)] cyborg":"operative"]?", ROLE_OPERATIVE, null, ROLE_OPERATIVE, 150, POLL_IGNORE_SYNDICATE, src)
 	if(nuke_candidates.len)
 		if(!(check_usability(user)))
 			return


### PR DESCRIPTION
Does not exactly take care of https://github.com/tgstation/tgstation/issues/25254 but at least mitigates it.

Also gives a feedback message so at least players won't spam by accident.