### PR TITLE
Refactors leather with crafting, removed bio-generator designs + adds craftable muzzles

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -118,6 +118,9 @@ GLOBAL_LIST_INIT(xeno_recipes, list ( \
 	var/wetness = 30 //Reduced when exposed to high temperautres
 	var/drying_threshold_temperature = 500 //Kelvin to start drying
 
+/*
+ * Leather SHeet
+ */
 /obj/item/stack/sheet/leather
 	name = "leather"
 	desc = "The by-product of mob grinding."
@@ -127,19 +130,22 @@ GLOBAL_LIST_INIT(xeno_recipes, list ( \
 
 GLOBAL_LIST_INIT(leather_recipes, list ( \
 	new/datum/stack_recipe("wallet", /obj/item/weapon/storage/wallet, 1), \
-	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2), \  //I ate his liver with some fava beans and a nice chianti
+	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2), \
 	new/datum/stack_recipe("botany gloves", /obj/item/clothing/gloves/botanic_leather, 3), \
 	new/datum/stack_recipe("toolbelt", /obj/item/weapon/storage/belt/utility, 4), \
 	new/datum/stack_recipe("leather satchel", /obj/item/weapon/storage/backpack/satchel, 5), \
 	new/datum/stack_recipe("bandolier", /obj/item/weapon/storage/belt/bandolier, 5), \
 	new/datum/stack_recipe("leather jacket", /obj/item/clothing/suit/jacket/leather, 7), \
 	new/datum/stack_recipe("leather overcoat", /obj/item/clothing/suit/jacket/leather/overcoat, 10), \
-	))
+))
 
 /obj/item/stack/sheet/leather/Initialize(mapload, new_amount, merge = TRUE)
-		recipes = GLOB.leather_recipes
-		return ..()
+	recipes = GLOB.leather_recipes
+	return ..()
 
+/*
+ * Sinew
+ */
 /obj/item/stack/sheet/sinew
 	name = "watcher sinew"
 	icon = 'icons/obj/mining.dmi'
@@ -151,11 +157,12 @@ GLOBAL_LIST_INIT(leather_recipes, list ( \
 
 GLOBAL_LIST_INIT(sinew_recipes, list ( \
 	new/datum/stack_recipe("sinew restraints", /obj/item/weapon/restraints/handcuffs/sinew, 1, on_floor = 1), \
-	))
+))
 
 /obj/item/stack/sheet/sinew/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.sinew_recipes
 	return ..()
+
 		/*
  * Plates
  		*/

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -125,6 +125,21 @@ GLOBAL_LIST_INIT(xeno_recipes, list ( \
 	icon_state = "sheet-leather"
 	origin_tech = "materials=2"
 
+GLOBAL_LIST_INIT(leather_recipes, list ( \
+	new/datum/stack_recipe("wallet", /obj/item/weapon/storage/wallet, 1), \
+	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2), \  //I ate his liver with some fava beans and a nice chianti
+	new/datum/stack_recipe("botany gloves", /obj/item/clothing/gloves/botanic_leather, 3), \
+	new/datum/stack_recipe("toolbelt", /obj/item/weapon/storage/belt/utility, 4), \
+	new/datum/stack_recipe("leather satchel", /obj/item/weapon/storage/backpack/satchel, 5), \
+	new/datum/stack_recipe("bandolier", /obj/item/weapon/storage/belt/bandolier, 5), \
+	new/datum/stack_recipe("leather jacket", /obj/item/clothing/suit/jacket/leather, 7), \
+	new/datum/stack_recipe("leather overcoat", /obj/item/clothing/suit/jacket/leather/overcoat, 10), \
+	))
+
+/obj/item/stack/sheet/leather/Initialize(mapload, new_amount, merge = TRUE)
+		recipes = GLOB.leather_recipes
+		return ..()
+
 /obj/item/stack/sheet/sinew
 	name = "watcher sinew"
 	icon = 'icons/obj/mining.dmi'

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -115,28 +115,12 @@
 	build_path = /obj/item/stack/sheet/cloth
 	category = list("initial","Leather and Cloth")
 
-/datum/design/wallet
-	name = "Wallet"
-	id = "wallet"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 100)
-	build_path = /obj/item/weapon/storage/wallet
-	category = list("initial","Leather and Cloth")
-
-/datum/design/botany_gloves
-	name = "Botanical gloves"
-	id = "botany_gloves"
+/datum/design/leather
+	name = "Sheet of Leather"
+	id = "leather"
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 150)
-	build_path = /obj/item/clothing/gloves/botanic_leather
-	category = list("initial","Leather and Cloth")
-
-/datum/design/toolbelt
-	name = "Utility Belt"
-	id = "toolbelt"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 300)
-	build_path = /obj/item/weapon/storage/belt/utility
+	build_path = /obj/item/stack/sheet/leather
 	category = list("initial","Leather and Cloth")
 
 /datum/design/secbelt
@@ -163,44 +147,12 @@
 	build_path = /obj/item/weapon/storage/belt/janitor
 	category = list("initial","Leather and Cloth")
 
-/datum/design/bandolier
-	name = "Bandolier belt"
-	id = "bandolier"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 300)
-	build_path = /obj/item/weapon/storage/belt/bandolier
-	category = list("initial","Leather and Cloth")
-
 /datum/design/s_holster
 	name = "Shoulder holster"
 	id = "s_holster"
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 400)
 	build_path = /obj/item/weapon/storage/belt/holster
-	category = list("initial","Leather and Cloth")
-
-/datum/design/leather_satchel
-	name = "Leather satchel"
-	id = "leather_satchel"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 400)
-	build_path = /obj/item/weapon/storage/backpack/satchel
-	category = list("initial","Leather and Cloth")
-
-/datum/design/leather_jacket
-	name = "Leather jacket"
-	id = "leather_jacket"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 500)
-	build_path = /obj/item/clothing/suit/jacket/leather
-	category = list("initial","Leather and Cloth")
-
-/datum/design/leather_overcoat
-	name = "Leather overcoat"
-	id = "leather_overcoat"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 1000)
-	build_path = /obj/item/clothing/suit/jacket/leather/overcoat
 	category = list("initial","Leather and Cloth")
 
 /datum/design/rice_hat


### PR DESCRIPTION
:cl: Moonlighting Mac says
tweak: After a recent trade fair, employees have took it upon themselves to learn how to craft leather objects out of finished leather sheets, for novices they are pretty good at it! Try it yourself!
add: Muzzles to silence people are now craftable out of leather sheets.
del: You can no longer print off designs from a bio-generator that can now be crafted out of leather sheets.
tweak: Complete sheets of leather can be printed from the bio-generator for 150 biomass to accommodate for a loss of designs.
experiment: Specialist objects from the leather & cloth category bio-generator category were not removed as to encourage interdepartmental interaction & balance.
/:cl:

I felt that the leather stack item was neglected coding wise and far too much based within the biogenerator for common domestic objects such as simple wallets. It also allows universal low-tech crafting with leather as long as you go through the fundamental basis of wetting via a sink & drying (requiring power or surrounding temperatures) as a prerequisite to skinning wild animals for objects.

The muzzle object also included is a nice accompaniment to the biogenerators cloth production to make blindfolds as to create a full set. We might yet get some peace & quiet from WGW readers and other noisy delinquents.

![](http://puu.sh/vEn2y/c6cba3a178.png)