### PR TITLE
Makes dental implants move through dismemberment

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -218,6 +218,14 @@
 		for(var/X in list(owner.glasses, owner.ears, owner.wear_mask, owner.head))
 			var/obj/item/I = X
 			owner.dropItemToGround(I, TRUE)
+
+	//Handle dental implants
+	for(var/datum/action/item_action/hands_free/activate_pill/AP in owner.actions)
+		AP.Remove(owner)
+		var/obj/pill = AP.target
+		if(pill)
+			pill.forceMove(src)
+
 	name = "[owner.real_name]'s head"
 	..()
 
@@ -305,6 +313,14 @@
 		C.real_name = real_name
 	real_name = ""
 	name = initial(name)
+
+	//Handle dental implants
+	for(var/obj/item/weapon/reagent_containers/pill/P in src)
+		for(var/datum/action/item_action/hands_free/activate_pill/AP in P.actions)
+			P.forceMove(C)
+			AP.Grant(C)
+			break
+
 	..()
 
 

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -48,7 +48,10 @@
 			brain = null
 			update_icon_dropped()
 		else
-			I.loc = T
+			if(istype(I, /obj/item/weapon/reagent_containers/pill))
+				for(var/datum/action/item_action/hands_free/activate_pill/AP in I.actions)
+					qdel(AP)
+			I.forceMove(T)
 
 /obj/item/bodypart/head/update_limb(dropping_limb, mob/living/carbon/source)
 	var/mob/living/carbon/C

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -18,10 +18,10 @@
 	user.drop_item()
 	tool.loc = target
 
-	var/datum/action/item_action/hands_free/activate_pill/P = new
+	var/datum/action/item_action/hands_free/activate_pill/P = new(tool)
 	P.button.name = "Activate [tool.name]"
 	P.target = tool
-	P.Grant(target)
+	P.Grant(target)	//The pill never actually goes in an inventory slot, so the owner doesn't inherit actions from it
 
 	user.visible_message("[user] wedges \the [tool] into [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You wedge [tool] into [target]'s [parse_zone(target_zone)].</span>")
 	return 1
@@ -37,6 +37,5 @@
 	if(target.reagents.total_volume)
 		target.reagents.reaction(owner, INGEST)
 		target.reagents.trans_to(owner, target.reagents.total_volume)
-	Remove(owner)
 	qdel(target)
 	return 1


### PR DESCRIPTION
:cl: QualityVan
fix: Dental implants stay with the head they're in
/:cl:

Makes removing and attaching heads remove/grant any associated pill consumption actions. If you cut open a head that contains an implanted pill, the pill is recovered and the action is destroyed.