### PR TITLE
 Curator starts with the key to the display cases instead of being the key

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -283,7 +283,7 @@
 	if(user.is_holding_item_of_type(/obj/item/key/displaycase))
 		if(added_roundstart)
 			is_locked = !is_locked
-			to_chat(user, "You [!is_locked ? "un" : ""]lock the case."
+			to_chat(user, "You [!is_locked ? "un" : ""]lock the case.")
 		else
 			to_chat(user, "<span class='danger'>The lock is stuck shut!</span>")
 		return

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -256,6 +256,8 @@
 	var/trophy_message = ""
 	var/placer_key = ""
 	var/added_roundstart = TRUE
+	var/is_locked = TRUE
+
 	alert = TRUE
 	integrity_failure = 0
 
@@ -278,8 +280,20 @@
 	if(!user.Adjacent(src)) //no TK museology
 		return
 
-	if(!(user.mind && user.mind.assigned_role == "Curator"))
-		to_chat(user, "<span class='danger'>You're not sure how to work this. Maybe you should ask the curator for help.</span>")
+	if(user.is_holding_item_of_type(/obj/item/key/displaycase))
+		if(added_roundstart)
+			if(is_locked)
+				is_locked = FALSE
+				to_chat(user, "You unlock the case.")
+			else
+				is_locked = TRUE
+				to_chat(user, "You lock the case again.")
+		else
+			to_chat(user, "<span class='danger'>The lock is stuck shut!</span>")
+		return
+
+	if(is_locked)
+		to_chat(user, "<span class='danger'>The case is shut tight with an old fashioned physical lock. Maybe you should ask the curator for the key?</span>")
 		return
 
 	if(!added_roundstart)
@@ -335,6 +349,10 @@
 			QDEL_NULL(showpiece)
 		else
 			..()
+
+/obj/item/key/displaycase
+	name = "display case key"
+	desc = "The key to the curator's display cases."
 
 /obj/item/showpiece_dummy
 	name = "Cheap replica"

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -282,12 +282,8 @@
 
 	if(user.is_holding_item_of_type(/obj/item/key/displaycase))
 		if(added_roundstart)
-			if(is_locked)
-				is_locked = FALSE
-				to_chat(user, "You unlock the case.")
-			else
-				is_locked = TRUE
-				to_chat(user, "You lock the case again.")
+			is_locked = !is_locked
+			to_chat(user, "You [!is_locked ? "un" : ""]lock the case."
 		else
 			to_chat(user, "<span class='danger'>The lock is stuck shut!</span>")
 		return

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -137,11 +137,12 @@ Curator
 	belt = /obj/item/device/pda/curator
 	uniform = /obj/item/clothing/under/rank/curator
 	l_hand = /obj/item/weapon/storage/bag/books
-	r_pocket = /obj/item/weapon/barcodescanner
+	r_pocket = /obj/item/key/displaycase
 	l_pocket = /obj/item/device/laser_pointer
 	backpack_contents = list(
 		/obj/item/weapon/melee/curator_whip = 1,
-		/obj/item/soapstone = 1
+		/obj/item/soapstone = 1,
+		/obj/item/weapon/barcodescanner = 1
 	)
 
 


### PR DESCRIPTION
:cl: Incoming
tweak: Display cases now require a key to open, which the curator spawns with
/:cl:

Moves the curators ability to use display cases from an intrinsic to an extrinsic key that the curator starts with.

Reasoning:
1. Still locks out use of the display cases to people who aren't the curator in the same way the janicart is to the janitor.
2. Gives the curator something subjectively precious to guard.
3. Gives everyone else something subjectively precious to steal.
4. Acts as an "are you sure?" gate for putting items in the case.

Working off #26813
@KorPhaeron 