### PR TITLE
Takes out an airlock in xenobiology's kill room [Pubby]

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -32850,10 +32850,6 @@
 /turf/open/floor/plasteel/white,
 /area/toxins/xenobiology)
 "bnU" = (
-/obj/machinery/door/airlock/research{
-	name = "Kill Room Access";
-	req_access_txt = "55"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},


### PR DESCRIPTION
Fixes #26835 

:cl: BeeSting12
fix: Pubbystation no longer has two airlocks stacked on top of each other leading into xenobiology's kill room.
/:cl:
