### PR TITLE
Lizardpeople have a chance to not know common on roundstart

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -19,6 +19,8 @@
 
 /datum/species/lizard/after_equip_job(datum/job/J, mob/living/carbon/human/H)
 	H.grant_language(/datum/language/draconic)
+	if(prob(60))	//some lizards are educated
+		H.remove_language(/datum/language/common)
 
 /datum/species/lizard/random_name(gender,unique,lastname)
 	if(unique)


### PR DESCRIPTION
Someone once mentioned to me that one of the best experiences they had was playing janitor on a russian station and having no idea what people were saying.

Plus, this increases the paranoia for lizards since they cant understand what people are saying. Just like with humans and lizards.
It's a 60% chance, so some lizards can work as translators.

:cl:
experiment: Due to relaxations in nanotransen educational requirements, some lizard hires have not learned galactic common. Please help them find a translator.
/:cl: