### PR TITLE
Ashlizards can only speak and understand Draconic.

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -47,11 +47,13 @@
 
 /obj/effect/mob_spawn/human/ash_walker/special(mob/living/new_spawn)
 	new_spawn.real_name = random_unique_lizard_name(gender)
-	to_chat(new_spawn, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Glory to the Necropolis!</b>")
+	to_chat(new_spawn, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Glory to the Necropolis! You can only speak Draconic.</b>")
 	if(ishuman(new_spawn))
 		var/mob/living/carbon/human/H = new_spawn
 		H.underwear = "Nude"
 		H.update_body()
+		H.remove_language(/datum/language/common)
+		H.grant_language(/datum/language/draconic)
 
 /obj/effect/mob_spawn/human/ash_walker/New()
 	..()


### PR DESCRIPTION
:cl:
add: Ashlizards can only speak and understand Draconic, the language of the lizards.
/:cl:

This makes perfect sense, and also adds a challenge to playing as Ashlizards.
