### PR TITLE
Sigils of Transgression are slightly more visible and glow very faintly

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -54,8 +54,11 @@
 	clockwork_desc = "A sigil that will stun the next non-Servant to cross it."
 	icon_state = "sigildull"
 	layer = HIGH_SIGIL_LAYER
-	alpha = 60
+	alpha = 75
 	color = "#FAE48C"
+	light_range = 1.4
+	light_power = 0.4
+	light_color = "#FAE48C"
 	sigil_name = "Sigil of Transgression"
 
 /obj/effect/clockwork/sigil/transgression/sigil_effects(mob/living/L)


### PR DESCRIPTION
:cl: Joan
balance: Sigils of Transgression are slightly more visible and glow very faintly.
/:cl:

In dark maint conditions, from no glow at all:
![](https://puu.sh/vFk3J/109bd9ac6d.png)
In well-lit clockwork floor conditions:
![](https://puu.sh/vFk9X/b9edc7ef09.png)

I think these were a little too invisible previously.