### PR TITLE
Plastic golems

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -646,3 +646,18 @@
 	if(P.is_hot())
 		visible_message("<span class='danger'>[src] bursts into flames!</span>")
 		fire_act()
+
+/datum/species/golem/plastic
+	name = "Plastic"
+	id = "plastic golem"
+	prefix = "Plastic"
+	fixed_mut_color = "fff"
+	info_text = "As a <span class='danger'>Plastic Golem</span>, you are capable of ventcrawling, and passing through plastic flaps."
+
+/datum/species/golem/plastic/on_species_gain(mob/living/carbon/C, datum/species/old_species)
+	. = ..()
+	C.ventcrawler = VENTCRAWLER_ALWAYS
+
+/datum/species/golem/plastic/on_species_loss(mob/living/carbon/C)
+	. = ..()
+	C.ventcrawler = initial(C.ventcrawler)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -656,7 +656,7 @@
 
 /datum/species/golem/plastic/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
-	C.ventcrawler = VENTCRAWLER_ALWAYS
+	C.ventcrawler = VENTCRAWLER_NUDE
 
 /datum/species/golem/plastic/on_species_loss(mob/living/carbon/C)
 	. = ..()

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -107,6 +107,9 @@
 		if(istype(O, /obj/item/stack/sheet/mineral/adamantine))
 			species = /datum/species/golem/adamantine
 
+		if(istype(O, /obj/item/stack/sheet/plastic))
+			species = /datum/species/golem/plastic
+
 		if(species)
 			if(O.use(10))
 				to_chat(user, "You finish up the golem shell with ten sheets of [O].")


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/609465/25727281/4827aa7e-3120-11e7-93e4-332cf1463b06.png)

:cl: coiax
add: It is now possible to make plastic golems, who are made of a material
flexible enough to crawl through vents (while not carrying equipment). They also can pass through plastic flaps.
/:cl:

Pretty simple. Plastic golems (remember, we actually have plastic as a
material) can ventcrawl, which also gives them the ability to go through
plastic flaps. They are otherwise the same as iron golems.

More uses of plastic are good, and this seems appropriate for a flexible
material to make flexible golems. Very much a material only found on the
station, and thus having an ability that really only makes sense on the
station.

@XDTM