### PR TITLE
Revert "[FUN REMOVAL] Makes fire not able to become ice."

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -64,8 +64,6 @@
 	setDir(pick(GLOB.cardinal))
 	air_update_turf()
 
-/obj/effect/hotspot/make_frozen_visual()
-	return	//you take my fun i take yours
 
 /obj/effect/hotspot/proc/perform_exposure()
 	var/turf/open/location = loc


### PR DESCRIPTION
reason: the removal was unnecessary and freon has LORE.

it's a powerful meme gas that can freeze literally -anything-, this PR detracts from that which is stupid.

aside from that, the pr owner didnt give a reason for the pr but lzi, the same person who closes pr for NO REASONING I MIGHT AS WELL CLOSE THIS, still merged this :thinking: 

in addition, realism isnt a good reason for a PR like this and im pretty sure i dont need to repeat what many have already said about realism in ss13