### PR TITLE
Replaces stun/weaken from Miner's salve

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -347,10 +347,9 @@
 /datum/reagent/medicine/mine_salve/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
 		if(method in list(INGEST, VAPOR, INJECT))
-			M.Stun(4)
-			M.Weaken(4)
+			M.nutrition -= 5
 			if(show_message)
-				to_chat(M, "<span class='warning'>Your stomach agonizingly cramps!</span>")
+				to_chat(M, "<span class='warning'>Your stomach feels empty and cramps!</span>")
 		else
 			var/mob/living/carbon/C = M
 			for(var/s in C.surgeries)


### PR DESCRIPTION
:cl: 
add: Reduction to nutrition when consuming Miner's salve.
del: Stun/weaken that bypasses bugged chemical protection when consuming Miner's salve.
/:cl:

why does this chem have a more reliable stun than pepperspray?