### PR TITLE
Seed vault lavaland ruin can only spawn once

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -42,6 +42,7 @@
 	However, all the inhabitants seem to do is grow drugs and guns."
 	suffix = "lavaland_surface_seed_vault.dmm"
 	cost = 10
+	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/ash_walker
 	name = "Ash Walker Nest"


### PR DESCRIPTION
:cl: coiax
tweak: The lavaland Seed Vault ruin can spawn only once.
/:cl:

I don't think more than 4 people will want to be pod people, it's
digging in our precious ruin budget.