### PR TITLE
Plastic sheet production - Chemistry recipe

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1549,14 +1549,9 @@
 /datum/reagent/plastic_polymers
 	name = "plastic polymers"
 	id = "plastic_polymers"
-	description = "the petroleum based components of plastic"
+	description = "the petroleum based components of plastic, contact a coder if you can actually see this" 
 	color = "#f7eded"
 	taste_description = "plastic"
-
-/datum/reagent/plastic_polymers/on_mob_life(mob/living/M)
-	M.adjustToxLoss(1, 0)
-	. = 1
-	..()
 
 /datum/reagent/glitter
 	name = "generic glitter"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1549,7 +1549,7 @@
 /datum/reagent/plastic_polymers
 	name = "plastic polymers"
 	id = "plastic_polymers"
-	description = "the petroleum based components of plastic, contact a coder if you can actually see this" 
+	description = "the petroleum based components of plastic."
 	color = "#f7eded"
 	taste_description = "plastic"
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1546,6 +1546,18 @@
 	M.update_transform()
 	..()
 
+/datum/reagent/plastic_polymers
+	name = "plastic polymers"
+	id = "plastic_polymers"
+	description = "the petroleum based components of plastic"
+	color = "#f7eded"
+	taste_description = "plastic"
+
+/datum/reagent/plastic_polymers/on_mob_life(mob/living/M)
+	M.adjustToxLoss(1, 0)
+	. = 1
+	..()
+
 /datum/reagent/glitter
 	name = "generic glitter"
 	id = "glitter"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -633,5 +633,5 @@
 
 /datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i in 1 to 10)
 		new /obj/item/stack/sheet/plastic(location)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -624,3 +624,14 @@
 	id = "laughter"
 	results = list("laughter" = 10) // Fuck it. I'm not touching this one.
 	required_reagents = list("sugar" = 1, "banana" = 1)
+
+datum/chemical_reation/plastic_polymers
+	name = "plastic polymers"
+	id = "plastic_polymers"
+	required reagents = list ("oil" = 5, "sodiumchloride" = 2, "ash" = 3)
+	required_temp = 374 //lazily consistent with soap & other crafted objects generically created with heat.
+
+/datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)
+	var/location = get_turf(holder.my_atom)
+	for(var/i = 1, i <= created_volume, i++)
+		new /obj/item/stack/sheet/plastic(location)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -625,10 +625,10 @@
 	results = list("laughter" = 10) // Fuck it. I'm not touching this one.
 	required_reagents = list("sugar" = 1, "banana" = 1)
 
-datum/chemical_reation/plastic_polymers
+/datum/chemical_reaction/plastic_polymers
 	name = "plastic polymers"
 	id = "plastic_polymers"
-	required reagents = list ("oil" = 5, "sodiumchloride" = 2, "ash" = 3)
+	required_reagents = list("oil" = 5, "sodiumchloride" = 2, "ash" = 3)
 	required_temp = 374 //lazily consistent with soap & other crafted objects generically created with heat.
 
 /datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)


### PR DESCRIPTION
:cl: Moonlighting Mac
Experiment: Due to budget cuts and oil synthesis replacing expensive processes of digging up haunted primeval ashwalker burial grounds, Nanotransen has taught chemists how to make plastic from chemicals in the hopes that new plastic products can reduce expenditure on metal and glass. 
add: you can now make plastic sheets from chemistry out of heated up crude oil, ash & sodium chloride
/:cl:

This Pr is atomised from what was originally planned but functionally it allows a methodical way of getting plastic within the game in a usually small quantity (100 units of formula = 10 sheets), making it over and over again would be tedious to discourage mass production and still keep some value to importing a lot of it if you need it.

Look forward to more plastic products in the future to compliment this.