### PR TITLE
C4 planting takes 3 seconds, down from 5

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -81,7 +81,7 @@
 
 	to_chat(user, "<span class='notice'>You start planting the bomb...</span>")
 
-	if(do_after(user, 50, target = AM))
+	if(do_after(user, 30, target = AM))
 		if(!user.temporarilyRemoveItemFromInventory(src))
 			return
 		src.target = AM

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -81,7 +81,7 @@
 
 	to_chat(user, "<span class='notice'>You start planting the bomb...</span>")
 
-	if(do_after(user, 30, target = AM))
+	if(do_after(user, 50, target = AM))
 		if(!user.temporarilyRemoveItemFromInventory(src))
 			return
 		src.target = AM

--- a/code/game/objects/items/weapons/grenades/plastic.dm
+++ b/code/game/objects/items/weapons/grenades/plastic.dm
@@ -96,7 +96,7 @@
 
 	to_chat(user, "<span class='notice'>You start planting the [src]. The timer is set to [det_time]...</span>")
 
-	if(do_after(user, 50, target = AM))
+	if(do_after(user, 30, target = AM))
 		if(!user.temporarilyRemoveItemFromInventory(src))
 			return
 		src.target = AM


### PR DESCRIPTION
C4 used to gib people and was one of the only ways to break bolted airlocks without tools or destroy certain machines. C4 throwing weapons were also viable.

Now all of that has changed. It doesn't make sense to keep the application timer so obnoxiously long. 

:cl: Robustin
tweak: c4 planting is now 40% faster
/:cl: