### PR TITLE
Dominators now require a significant amount of open turf around them

### DIFF
--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -50,7 +50,7 @@
 		var/time_remaining = gang.domination_time_remaining()
 		if(time_remaining > 0)
 			var/open = 0
-			for(var/turf/T in circleviewturfs(center=user,radius=3) 
+			for(var/turf/T in circleviewturfs(center=user,radius=3))
 				if(!istype(T, /turf/closed))
 					open++
 			if(open < 40)

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -51,7 +51,7 @@
 		if(time_remaining > 0)
 			var/open = 0
 			for(var/turf/T in circleviewturfs(center=user,radius=3) 
-				if(!istype(T, /turf/closed)
+				if(!istype(T, /turf/closed))
 					open++
 			if(open < 40)
 				gang.domination_timer += 2

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -1,3 +1,5 @@
+#define DOM_BLOCKED_SPAM_CAP 6
+
 /obj/machinery/dominator
 	name = "dominator"
 	desc = "A visibly sinister device. Looks like you can break it if you hit it enough."
@@ -13,7 +15,7 @@
 	var/datum/gang/gang
 	var/operating = 0	//0=standby or broken, 1=takeover
 	var/warned = 0	//if this device has set off the warning at <3 minutes yet
-	var/spam_prevention = 100
+	var/spam_prevention = DOM_BLOCKED_SPAM_CAP //first message is immediate
 	var/datum/effect_system/spark_spread/spark_system
 	var/obj/effect/countdown/dominator/countdown
 
@@ -56,11 +58,11 @@
 			if(open < 40)
 				gang.domination_timer += 2
 				playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
-				if(spam_prevention < 6)
+				if(spam_prevention < DOM_BLOCKED_SPAM_CAP)
 					spam_prevention++
 				else
-					gang.message_gangtools("Warning: There are too many walls around your dominator, its signal is being blocked!")
-					say("Warning: There are too many walls around your dominator, its signal is being blocked!")
+					gang.message_gangtools("Warning: There are too many walls around your gang's dominator, its signal is being blocked!")
+					say("Error: Takeover signal is currently blocked! There are too many walls within 3 standard units of this device.")
 					spam_prevention = 0
 				return
 			. = TRUE

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -50,7 +50,7 @@
 		var/time_remaining = gang.domination_time_remaining()
 		if(time_remaining > 0)
 			var/open = 0
-			for(var/turf/T in circleviewturfs(center=user,radius=3))
+			for(var/turf/T in circleviewturfs(center=src,radius=3))
 				if(!istype(T, /turf/closed))
 					open++
 			if(open < 40)

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -13,6 +13,7 @@
 	var/datum/gang/gang
 	var/operating = 0	//0=standby or broken, 1=takeover
 	var/warned = 0	//if this device has set off the warning at <3 minutes yet
+	var/spam_prevention = 100
 	var/datum/effect_system/spark_spread/spark_system
 	var/obj/effect/countdown/dominator/countdown
 
@@ -48,6 +49,20 @@
 	if(gang && gang.is_dominating)
 		var/time_remaining = gang.domination_time_remaining()
 		if(time_remaining > 0)
+			var/open = 0
+			for(var/turf/T in circleviewturfs(center=user,radius=3) 
+				if(!istype(T, /turf/closed)
+					open++
+			if(open < 40)
+				gang.domination_timer += 2
+				playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
+				if(spam_prevention < 6)
+					spam_prevention++
+				else
+					gang.message_gangtools("Warning: There are too many walls around your dominator, its signal is being blocked!")
+					say("Warning: There are too many walls around your dominator, its signal is being blocked!")
+					spam_prevention = 0
+				return
 			. = TRUE
 			playsound(loc, 'sound/items/timer.ogg', 10, 0)
 			if(!warned && (time_remaining < 180))

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -19,6 +19,16 @@
 	var/datum/effect_system/spark_spread/spark_system
 	var/obj/effect/countdown/dominator/countdown
 
+/proc/dominator_excessive_walls(atom/A)
+	var/open = 0
+	for(var/turf/T in circleviewturfs(center=A,radius=3))
+		if(!istype(T, /turf/closed))
+			open++
+	if(open < 40)
+		return TRUE
+	else 
+		return FALSE
+
 /obj/machinery/dominator/tesla_act()
 	qdel(src)
 
@@ -51,11 +61,7 @@
 	if(gang && gang.is_dominating)
 		var/time_remaining = gang.domination_time_remaining()
 		if(time_remaining > 0)
-			var/open = 0
-			for(var/turf/T in circleviewturfs(center=src,radius=3))
-				if(!istype(T, /turf/closed))
-					open++
-			if(open < 40)
+			if(dominator_excessive_walls(src))
 				gang.domination_timer += 2
 				playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
 				if(spam_prevention < DOM_BLOCKED_SPAM_CAP)
@@ -64,7 +70,7 @@
 					gang.message_gangtools("Warning: There are too many walls around your gang's dominator, its signal is being blocked!")
 					say("Error: Takeover signal is currently blocked! There are too many walls within 3 standard units of this device.")
 					spam_prevention = 0
-				return
+					return
 			. = TRUE
 			playsound(loc, 'sound/items/timer.ogg', 10, 0)
 			if(!warned && (time_remaining < 180))

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -285,13 +285,7 @@
 			to_chat(user, "<span class='warning'>There's not enough room here!</span>")
 			return FALSE
 	
-	var/open = 0
-	for(var/turf/T in circleviewturfs(center=user,radius=3))
-		if(!istype(T, /turf/closed))
-			open++
-	if(open < 40)
-		to_chat(user, "<span class='warning'>The <b>dominator</b> will not function here! The <b>dominator</b> requires an open space so that walls do not interfere with the signal.</span>")
-		return FALSE
+	dominator_area_check(user)
 
 	if(!(usrarea.type in gang.territory|gang.territory_new))
 		to_chat(user, "<span class='warning'>The <b>dominator</b> can be spawned only on territory controlled by your gang!</span>")

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -287,7 +287,7 @@
 	
 	var/open = 0
 	for(var/turf/T in circleviewturfs(center=user,radius=3) 
-		if(!istype(T, /turf/closed)
+		if(!istype(T, /turf/closed))
 			open++
 	if(open < 40)
 		to_chat(user, "<span class='warning'>The <b>dominator</b> will not function here! The <b>dominator</b> requires an open space so that walls do not interfere with the signal.</span>")

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -284,6 +284,14 @@
 		if(obj.density)
 			to_chat(user, "<span class='warning'>There's not enough room here!</span>")
 			return FALSE
+	
+	var/open = 0
+	for(var/turf/T in circleviewturfs(center=user,radius=3) 
+		if(!istype(T, /turf/closed)
+			open++
+	if(open < 40)
+		to_chat(user, "<span class='warning'>The <b>dominator</b> will not function here! The <b>dominator</b> requires an open space so that walls do not interfere with the signal.</span>")
+		return FALSE
 
 	if(!(usrarea.type in gang.territory|gang.territory_new))
 		to_chat(user, "<span class='warning'>The <b>dominator</b> can be spawned only on territory controlled by your gang!</span>")

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -285,8 +285,10 @@
 			to_chat(user, "<span class='warning'>There's not enough room here!</span>")
 			return FALSE
 	
-	dominator_area_check(user)
-
+	if(dominator_excessive_walls(user))
+		to_chat(user, "span class='warning'>The <b>dominator</b> will not function here! The <b>dominator</b> requires an open space within three standard units so that walls do not interfere with the signal.</span>")
+		return FALSE
+		
 	if(!(usrarea.type in gang.territory|gang.territory_new))
 		to_chat(user, "<span class='warning'>The <b>dominator</b> can be spawned only on territory controlled by your gang!</span>")
 		return FALSE

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -286,7 +286,7 @@
 			return FALSE
 	
 	var/open = 0
-	for(var/turf/T in circleviewturfs(center=user,radius=3) 
+	for(var/turf/T in circleviewturfs(center=user,radius=3))
 		if(!istype(T, /turf/closed))
 			open++
 	if(open < 40)


### PR DESCRIPTION
The dominator now does a "view" check of the turfs in a 3 tile range.

If it can't see at least 40 open turfs out of the 49 turfs checked, it will either refuse to deploy or will stop progressing and give obvious feedback explaining that the presence of too many walls is blocking the dominator's signal. 

The nature of the view check means that closer walls will "block" more tiles than farther ones.  This still lets you place strategic walls to block projectile fire, but you won't be able to "seal it off" with walls either . 

🆑 Robustin
tweak: Dominators now require a significant amount of open (non-walled) space around them in order to operate. 
/🆑