### PR TITLE
ORM fixes

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -84,7 +84,7 @@
 	if(D.make_reagents.len)
 		return 0
 
-	var/build_amount = 1
+	var/build_amount = 0
 
 	for(var/mat_id in D.materials)
 		var/M = D.materials[mat_id]
@@ -93,7 +93,15 @@
 		if(!M || !redemption_mat)
 			return 0
 
-		build_amount = min(build_amount, round(redemption_mat.amount / M))
+		var/smeltable_sheets = round(redemption_mat.amount / M)
+
+		if(!smeltable_sheets)
+			return 0
+
+		if(!build_amount)
+			build_amount = smeltable_sheets
+
+		build_amount = min(build_amount, smeltable_sheets)
 
 	return build_amount
 
@@ -152,6 +160,7 @@
 	if(exchange_parts(user, W))
 		return
 	if(default_pry_open(W))
+		materials.retrieve_all()
 		return
 	if(default_unfasten_wrench(user, W))
 		return


### PR DESCRIPTION
Fixes the ORM not smelting more than one sheets of alloy at a time.
Fixes #26906

Also fixes depowered ORMs not dropping their content on crowbar prying (unreported).