### PR TITLE
Fixes linux runtimes

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -102,8 +102,8 @@
 	else
 		if(!recipient)
 			if(holder)
-				to_chat(src, "<font color='red'>Error: Admin-PM: Client not found.</font>")
 				to_chat(src, msg)
+				to_chat(src, "<font color='red'>Error: Admin-PM: Client not found.</font>")
 			else
 				current_ticket.MessageNoRecipient(msg)
 			return


### PR DESCRIPTION
So, for some devilish reason it was runtiming in linux when the `to_chat(src, msg)` was after the no client message. Why? No one knows.