### PR TITLE
Fixes an inconsistency with the Banana Honk drink

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -966,7 +966,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "Only for the experienced. You think you see sand floating in the glass."
 
 /datum/reagent/consumable/ethanol/bananahonk
-	name = "Banana Mama"
+	name = "Banana Honk"
 	id = "bananahonk"
 	description = "A drink from Clown Heaven."
 	nutriment_factor = 1 * REAGENTS_METABOLISM


### PR DESCRIPTION
Fixes an inconsistency regarding the Banana Honk drink and its reagent name. Fixes #26690

literally unplayable

