### PR TITLE
Allows Mediborg organ storage to hold inorganic bodyparts

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -113,7 +113,7 @@
 		return
 	if(!isorgan(I) && !isbodypart(I))
 		to_chat(user, "<span class='notice'>[src] can only hold body parts!</span>")
-    	return
+		return
 		
 	user.visible_message("[user] puts [I] into [src].", "<span class='notice'>You put [I] inside [src].</span>")
 	icon_state = "evidence"

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -111,12 +111,8 @@
 	if(contents.len)
 		to_chat(user, "<span class='notice'>[src] already has something inside it.</span>")
 		return
-	if(isorgan(I))
-		var/obj/item/organ/O = I
-	else if(isbodypart(I))
-		var/obj/item/bodypart/BP = I
-	else
-		return
+    if(!isorgan(I) || !isbodypart(I))
+    return
 		
 	user.visible_message("[user] puts [I] into [src].", "<span class='notice'>You put [I] inside [src].</span>")
 	icon_state = "evidence"

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -112,7 +112,7 @@
 		to_chat(user, "<span class='notice'>[src] already has something inside it.</span>")
 		return
 	if(!isorgan(I) || !isbodypart(I))
-    return
+    	return
 		
 	user.visible_message("[user] puts [I] into [src].", "<span class='notice'>You put [I] inside [src].</span>")
 	icon_state = "evidence"

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -113,14 +113,8 @@
 		return
 	if(isorgan(I))
 		var/obj/item/organ/O = I
-		if(O.status != ORGAN_ORGANIC)
-			to_chat(user, "<span class='notice'>[src] can only hold organic body parts!</span>")
-			return
 	else if(isbodypart(I))
 		var/obj/item/bodypart/BP = I
-		if(BP.status != BODYPART_ORGANIC)
-			to_chat(user, "<span class='notice'>[src] can only hold organic body parts!</span>")
-			return
 	else
 		return
 		

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -111,7 +111,8 @@
 	if(contents.len)
 		to_chat(user, "<span class='notice'>[src] already has something inside it.</span>")
 		return
-	if(!isorgan(I) || !isbodypart(I))
+	if(!isorgan(I) && !isbodypart(I))
+		to_chat(user, "<span class='notice'>[src] can only hold body parts!</span>")
     	return
 		
 	user.visible_message("[user] puts [I] into [src].", "<span class='notice'>You put [I] inside [src].</span>")

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -111,7 +111,7 @@
 	if(contents.len)
 		to_chat(user, "<span class='notice'>[src] already has something inside it.</span>")
 		return
-    if(!isorgan(I) || !isbodypart(I))
+	if(!isorgan(I) || !isbodypart(I))
     return
 		
 	user.visible_message("[user] puts [I] into [src].", "<span class='notice'>You put [I] inside [src].</span>")


### PR DESCRIPTION
:cl:
tweak: Removes organic check from mediborg storage container
/:cl:

[why]: The organ storage container is a step into making the mediborg a useful module but it's still inferior to a carbon surgeon as a mediborg can't even use the surplus prosthetic limbs in medbay to replace someone's bodyparts. 

I scarcely know how coding works so if you see something wrong, explain it to me in simple English, I'm slow. Also this is my first Pull Request and Github is not a nice place to navigate for your first time.