### PR TITLE
Ash walkers speak Draconic by default, but still know common

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -48,6 +48,11 @@
 /obj/effect/mob_spawn/human/ash_walker/special(mob/living/new_spawn)
 	new_spawn.real_name = random_unique_lizard_name(gender)
 	to_chat(new_spawn, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Glory to the Necropolis!</b>")
+
+	new_spawn.grant_language(/datum/language/draconic)
+	var/datum/language_holder/holder = new_spawn.get_language_holder()
+	holder.selected_default_language = /datum/language/draconic
+
 	if(ishuman(new_spawn))
 		var/mob/living/carbon/human/H = new_spawn
 		H.underwear = "Nude"


### PR DESCRIPTION
:cl: coiax
add: Ash walkers now know and speak Draconic by default, but still know
Galactic Common. Remember, Galcom's language key is ",0" and you can
review your known languages with the Language Menu.
/:cl:

As lizards, ash walkers should speak Draconic, but let's not deprive
them of the chance to communicate with the smelly humans. It will just
be up to the ash walkers whether they want actually talk to the humans
or not.

Also acts as a teaching experience for people about how to use their
language menus.