### PR TITLE
Revert "Tank suicide no longer gibs w/o enough pressure"

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -116,7 +116,7 @@
 	var/mob/living/carbon/human/H = user
 	user.visible_message("<span class='suicide'>[user] is putting [src]'s valve to [user.p_their()] lips! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
-	if (!QDELETED(H) && air_contents && air_contents.return_pressure() >= 1000)
+	if (H && !QDELETED(H))
 		for(var/obj/item/W in H)
 			H.dropItemToGround(W)
 			if(prob(50))


### PR DESCRIPTION
Reverts tgstation/tgstation#26597

why: This change is dumb and a lot of people dislike it. It's also not an actual gib which is part of the reasoning behind the PR, it just takes off all your body parts and your head. Your stuff remains.