### PR TITLE
Adds the spanish language

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -101,6 +101,9 @@
 	// TODO change to a lightbringer specific sign language
 	languages = list(/datum/language/slime)
 
+/datum/language_holder/spanish
+	languages = list(/datum/language/spanish)
+
 /datum/language_holder/synthetic
 	languages = list(/datum/language/common)
 	shadow_languages = list(/datum/language/machine, /datum/language/draconic)

--- a/code/modules/language/spanish.dm
+++ b/code/modules/language/spanish.dm
@@ -1,0 +1,18 @@
+/datum/language/spanish
+	name = "Old Earth Spanish"
+	desc = "A less common Earth language that's survived the ages, thanks to being so widespread for its time."
+	speech_verb = "says"
+	whisper_verb = "whispers"
+	key = "e"
+	flags = TONGUELESS_SPEECH | LANGUAGE_HIDE_ICON_IF_UNDERSTOOD
+	default_priority = 100
+
+	icon_state = "galcom"
+
+//Source: http://www.sttmedia.com/syllablefrequency-spanish
+
+/datum/language/spanish/syllables = list(
+"ad", "al", "an", "ar", "as", "ci", "co", "de", "do", "el", "en", "er", "es", "ei", "in", "la", "ue", "un",
+"lo", "me", "na", "no", "nt", "on", "or", "os", "pa", "qu", "ra", "re", "ro", "se", "st", "ta", "te", "to",
+"aci", "ada", "ado", "ant", "ara", "ció", "com", "con", "des", "dos", "ent", "era", "ero", "est", "ido", "ien", "una",
+"ier", "ión", "las", "los", "men", "nte", "nto", "par", "per", "por", "que", "res", "sta", "ste", "ten", "tra", "ver")

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -130,7 +130,8 @@
 		/datum/language/common,
 		/datum/language/draconic,
 		/datum/language/ratvar,
-		/datum/language/monkey))
+		/datum/language/monkey,
+		/datum/language/spanish))
 
 /obj/item/organ/tongue/alien/TongueSpeech(var/message)
 	playsound(owner, "hiss", 25, 1, 1)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1385,6 +1385,7 @@
 #include "code\modules\language\monkey.dm"
 #include "code\modules\language\ratvar.dm"
 #include "code\modules\language\slime.dm"
+#include "code\modules\language\spanish.dm"
 #include "code\modules\language\swarmer.dm"
 #include "code\modules\language\xenocommon.dm"
 #include "code\modules\library\lib_codex_gigas.dm"


### PR DESCRIPTION
The intent is to add this to the Janitor at roundstart, but since this will conflict with https://github.com/tgstation/tgstation/pull/26952 I am going to just open this now to make sure I haven't done anything wrong so far and finish it off when I fix conflicts.

@KorPhaeron What do you think of janitors *only* being able to speak spanish VS them and other janitors being able to speak it in addition to common? Or as a third option just adding it to all service jobs

Sprite: 
![spanish icon](https://cloud.githubusercontent.com/assets/8345184/25777562/a34e015c-3295-11e7-9753-0a9c290d5410.png)
