### PR TITLE
Removes failed to get byond age message

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -294,8 +294,6 @@ GLOBAL_LIST(external_rsc_urls)
 		message_admins("[key_name_admin(src)] (IP: [address], ID: [computer_id]) is a new BYOND account [account_age] day[(account_age==1?"":"s")] old, created on [account_join_date].")
 		if (config.irc_first_connection_alert)
 			send2irc_adminless_only("new_byond_user", "[key_name(src)] (IP: [address], ID: [computer_id]) is a new BYOND account [account_age] day[(account_age==1?"":"s")] old, created on [account_join_date].")
-	else //We failed to get an age for this user, let admins know they need to keep an eye on them
-		message_admins("Failed to get BYOND account age for [key_name_admin(src)]")
 	get_message_output("watchlist entry", ckey)
 	check_ip_intel()
 


### PR DESCRIPTION
This was triggering for people that were above the notify age. It already logs when it fails(it could be changed to warn admins, but I really don't think it's needed).