### PR TITLE
Rod Form's damage now scales with how much it's upgraded

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -109,7 +109,6 @@
 /datum/spellbook_entry/rod_form
 	name = "Rod Form"
 	spell_type = /obj/effect/proc_holder/spell/targeted/rod_form
-	cost = 3
 
 /datum/spellbook_entry/magicm
 	name = "Magic Missile"

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -82,13 +82,8 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		if(clong.density)
 			clong.ex_act(2)
 
-	else if(ismob(clong))
-		if(ishuman(clong))
-			var/mob/living/carbon/human/H = clong
-			H.visible_message("<span class='danger'>[H.name] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
-			H.adjustBruteLoss(160)
-		if(clong.density || prob(10))
-			clong.ex_act(2)
+	else if(isliving(clong))
+		penetrate(clong)
 	else if(istype(clong, type))
 		var/obj/effect/immovablerod/other = clong
 		visible_message("<span class='danger'>[src] collides with [other]!\
@@ -98,3 +93,11 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		smoke.start()
 		qdel(src)
 		qdel(other)
+
+/obj/effect/immovablerod/proc/penetrate(mob/living/L)
+	L.visible_message("<span class='danger'>[L] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.adjustBruteLoss(160)
+	if(L && (L.density || prob(10)))
+		L.ex_act(2)

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -17,6 +17,7 @@
 		var/obj/effect/immovablerod/wizard/W = new(start, get_ranged_target_turf(M, M.dir, (15 + spell_level * 3)))
 		W.wizard = M
 		W.max_distance += spell_level * 3 //You travel farther when you upgrade the spell
+		W.damage_bonus += spell_level * 20 //You do more damage when you upgrade the spell
 		W.start_turf = start
 		M.forceMove(W)
 		M.notransform = 1
@@ -26,6 +27,7 @@
 
 /obj/effect/immovablerod/wizard
 	var/max_distance = 13
+	var/damage_bonus = 0
 	var/mob/living/wizard
 	var/turf/start_turf
 	notify = FALSE
@@ -41,3 +43,7 @@
 		wizard.notransform = 0
 		wizard.forceMove(get_turf(src))
 	return ..()
+
+/obj/effect/immovablerod/wizard/penetrate(mob/living/L)
+	L.visible_message("<span class='danger'>[L] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
+	L.adjustBruteLoss(70 + damage_bonus)


### PR DESCRIPTION
:cl: Joan
balance: Rod Form now costs 2 points, from 3.
balance: Rod Form now does 70 damage, from 160, but gains 20 damage, per upgrade, when upgraded. This means you'll need to spend 6 points on it to instantly crit people from full health.
/:cl:

Very simple, means the rod won't instantly kill you or put you into crit unless the wizard has spent 6 points on it.

Spell level scaling:
1. 70 damage
2. 90 damage
3. 110 damage
4. 130 damage
5. 150 damage