### PR TITLE
Tweaks the curator's access and clothing to improve his treasure hunting ability

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -159,3 +159,4 @@
 	desc = "You got red text today kid, but it doesn't mean you have to like it."
 	icon_state = "curator"
 	armor = list(melee = 25, bullet = 5, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0, fire = 30, acid = 50)
+	pockets = /obj/item/weapon/storage/internal/pocket/small

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -182,7 +182,7 @@
 	item_state = "curator"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
-	allowed = list(/obj/item/weapon/tank/internals/emergency_oxygen, /obj/item/weapon/melee/curator_whip)
+	allowed = list(/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/weapon/tank/internals/plasmaman,/obj/item/weapon/tank/internals/oxygen, /obj/item/weapon/melee/curator_whip)
 	armor = list(melee = 25, bullet = 10, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 45)
 	cold_protection = CHEST|ARMS
 	heat_protection = CHEST|ARMS

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -182,7 +182,7 @@
 	item_state = "curator"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
-	allowed = list(/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/weapon/tank/internals/plasmaman,/obj/item/weapon/tank/internals/oxygen, /obj/item/weapon/melee/curator_whip)
+	allowed = list(/obj/item/weapon/tank/internals, /obj/item/weapon/melee/curator_whip)
 	armor = list(melee = 25, bullet = 10, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 45)
 	cold_protection = CHEST|ARMS
 	heat_protection = CHEST|ARMS

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -128,7 +128,7 @@ Curator
 	outfit = /datum/outfit/job/curator
 
 	access = list(GLOB.access_library)
-	minimal_access = list(GLOB.access_library)
+	minimal_access = list(GLOB.access_library, GLOB.access_construction,GLOB.access_mining_station)
 
 /datum/outfit/job/curator
 	name = "Curator"


### PR DESCRIPTION
:cl:
rscadd: Curator's fedora has a pocket, like all the other fedoras.
tweak: Treasure hunter suits can now hold large internal tanks, to ease the exploration of lavaland.
tweak: The curator can now access the Auxillary Base and open doors on the mining station.
/:cl:

So I'm adjusting some things with the curator, since when I was playing these were the things I noticed that kind of suck, so I'm changing them to suck less. 