### PR TITLE
Adds acid-spraying floor tiles

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -214,3 +214,20 @@
 	materials = list() // All other Borg versions of items have no Metal or Glass - RR
 	is_cyborg = 1
 	cost = 125
+	
+/obj/item/stack/tile/acid_spray
+	name = "floor tile"
+	singular_name = "floor tile"
+	desc = "Those could work as a pretty decent throwing weapon."
+	icon_state = "tile"
+	force = 6
+	materials = list(MAT_METAL=500)
+	throwforce = 11
+	flags = CONDUCT
+	mineralType = "metal"
+	turf_type = /turf/open/floor/plasteel/acid_spray
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 100)
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+
+/obj/item/stack/tile/acid_spray/ten
+	amount = 10

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -268,6 +268,7 @@
 
 /turf/open/floor/plasteel/acid_spray
 	floor_tile = /obj/item/stack/tile/acid_spray
+	var/spray_reagent = "facid"
 	var/spray_amount = 35
 	var/cooldown = 150
 	var/last_spray = 0
@@ -289,11 +290,11 @@
 	playsound(src, 'sound/effects/spray2.ogg', 40, 1, -6)
 	var/obj/effect/decal/chempuff/A = new /obj/effect/decal/chempuff(src)
 	A.create_reagents(spray_amount)
-	A.reagents.add_reagent("facid", spray_amount)
+	A.reagents.add_reagent(spray_reagent, spray_amount)
 	A.color = mix_color_from_reagents(A.reagents.reagent_list)
-	for(var/atom/T in src)
-		if(T == A || T.invisibility)
-			continue
-		A.reagents.reaction(T, VAPOR)
+	for(var/mob/living/L in contents)
+		A.reagents.reaction(L, VAPOR)
+	for(var/obj/O in contents)
+		A.reagents.reaction(O, VAPOR)
 	QDEL_IN(A, 2)
 	last_spray = world.time

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -295,6 +295,5 @@
 		if(T == A || T.invisibility)
 			continue
 		A.reagents.reaction(T, VAPOR)
-	spawn(2)
-		qdel(A)
+	QDEL_IN(src, 2)
 	last_spray = world.time

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -273,8 +273,8 @@
 	var/last_spray = 0
 	var/primed = FALSE
 	
-/turf/open/floor/plasteel/acid_spray/New()
-	..()
+/turf/open/floor/plasteel/acid_spray/Initialize()
+	. = ..()
 	last_spray = world.time
 	primed = TRUE //prevents firing immediately when placed
 
@@ -295,5 +295,5 @@
 		if(T == A || T.invisibility)
 			continue
 		A.reagents.reaction(T, VAPOR)
-	QDEL_IN(src, 2)
+	QDEL_IN(A, 2)
 	last_spray = world.time

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -292,9 +292,9 @@
 	A.create_reagents(spray_amount)
 	A.reagents.add_reagent(spray_reagent, spray_amount)
 	A.color = mix_color_from_reagents(A.reagents.reagent_list)
-	for(var/mob/living/L in contents)
-		A.reagents.reaction(L, VAPOR)
-	for(var/obj/O in contents)
-		A.reagents.reaction(O, VAPOR)
+	for(var/atom/T in contents)
+		if((!isliving(T) && !isobj(T)) || T == A)
+			continue
+		A.reagents.reaction(T, VAPOR)
 	QDEL_IN(A, 2)
 	last_spray = world.time

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1253,6 +1253,14 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	restricted_roles = list("Curator")
 	limited_stock = 1 // please don't spam deadchat
 
+/datum/uplink_item/role_restricted/acid_spray
+	name = "Acid-Spraying Tiles"
+	desc = "A stack of ten ordinary-looking floor tiles that spray acid when their motion sensors are triggered. They have a short cooldown between sprays."
+	item = /obj/item/stack/tile/acid_spray/ten
+	cost = 4
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
+	restricted_roles = list("Station Engineer")
+
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1259,7 +1259,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	item = /obj/item/stack/tile/acid_spray/ten
 	cost = 4
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
-	restricted_roles = list("Station Engineer")
+	restricted_roles = list("Station Engineer", "Chief Engineer")
 
 // Pointless
 /datum/uplink_item/badass


### PR DESCRIPTION
:cl: Swindly
add: Added acid-spraying floor tiles. They spray fluorosulfuric acid when things cross over them. Traitorous engineers can buy a stack of 10 for 4 TC.
/:cl:

[why]: (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Acid-spraying floor tiles allow traitor engineers to kill in a unique way that encourages actually doing engineering stuff and subtlety or something.

Acid-spraying tiles look like plasteel floor tiles, but they spray acid when things cross them. There is a 15 second cooldown between sprays. 35 units of fluorosulfuric acid are sprayed. Each tile run over can nearly kill someone or only damage outer clothing, depending on what the person running over the tile is wearing. They're cheap because victims can run to a shower and then crowbar the tile up after being sprayed.