### PR TITLE
Add Slime Scanner to Autolathe

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -595,7 +595,17 @@ other types of metals and chemistry for reagents).
 	materials = list(MAT_METAL=200, MAT_GLASS=100)
 	build_path = /obj/item/weapon/disk/plantgene
 	category = list("Electronics")
-
+	
+/datum/design/slime_scanner
+	name = "Slime scanner"
+	desc = "A device that analyzes a slime's internal composition and measures its stats."
+	id = "slime_scanner"
+	req_tech = list("biotech" = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL=300, MAT_GLASS=200)
+	build_path = /obj/item/device/slime_scanner
+	category = list("Equipment")
+	
 /////////////////////////////////////////
 ////////////Janitor Designs//////////////
 /////////////////////////////////////////

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -597,7 +597,7 @@ other types of metals and chemistry for reagents).
 	category = list("Electronics")
 	
 /datum/design/slime_scanner
-	name = "Slime scanner"
+	name = "Slime Scanner"
 	desc = "A device that analyzes a slime's internal composition and measures its stats."
 	id = "slime_scanner"
 	req_tech = list("biotech" = 2)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -595,17 +595,7 @@ other types of metals and chemistry for reagents).
 	materials = list(MAT_METAL=200, MAT_GLASS=100)
 	build_path = /obj/item/weapon/disk/plantgene
 	category = list("Electronics")
-	
-/datum/design/slime_scanner
-	name = "Slime Scanner"
-	desc = "A device that analyzes a slime's internal composition and measures its stats."
-	id = "slime_scanner"
-	req_tech = list("biotech" = 2)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL=300, MAT_GLASS=200)
-	build_path = /obj/item/device/slime_scanner
-	category = list("Equipment")
-	
+
 /////////////////////////////////////////
 ////////////Janitor Designs//////////////
 /////////////////////////////////////////

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -786,7 +786,7 @@
 	
 /datum/design/slime_scanner
 	name = "Slime Scanner"
-	id = "healthanalyzer"
+	id = "slime_scanner"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 300, MAT_GLASS = 200)
 	build_path = /obj/item/device/slime_scanner

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -783,3 +783,12 @@
 	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
 	build_path = /obj/item/device/modular_computer/tablet
 	category = list("initial","Misc")
+	
+/datum/design/slime_scanner
+	name = "Slime Scanner"
+	id = "healthanalyzer"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 300, MAT_GLASS = 200)
+	build_path = /obj/item/device/slime_scanner
+	category = list("initial", "Misc")
+	


### PR DESCRIPTION
:cl: Penguaro
add: The Slime Scanner is available from the Autolathe.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
As mentioned in #26992, currently there are only the two scanners on station and if lost, they are gone for good. This allows their recreation from the autolathe.