### PR TITLE
Adjusts Meteor Shuttle name for grammar

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -72,7 +72,7 @@
 
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"
-	name = "An Asteroid With Engines Strapped To It"
+	name = "Asteroid With Engines Strapped To It"
 	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
 	credit_cost = -5000


### PR DESCRIPTION
:cl: Penguaro
tweak: Adjusts Meteor Shuttle Name
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Fixes #27020 Right now the game prefaces "The" in front the shuttle name when it impacts mobs in the Escape Hall. There may be a more elegant fix than this and I'm open to it.