### PR TITLE
Removes Greytide

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -159,3 +159,4 @@
 	desc = "You got red text today kid, but it doesn't mean you have to like it."
 	icon_state = "curator"
 	armor = list(melee = 25, bullet = 5, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0, fire = 30, acid = 50)
+	pockets = /obj/item/weapon/storage/internal/pocket/small

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -182,7 +182,7 @@
 	item_state = "curator"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
-	allowed = list(/obj/item/weapon/tank/internals/emergency_oxygen, /obj/item/weapon/melee/curator_whip)
+	allowed = list(/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/weapon/tank/internals/plasmaman,/obj/item/weapon/tank/internals/oxygen, /obj/item/weapon/melee/curator_whip)
 	armor = list(melee = 25, bullet = 10, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 45)
 	cold_protection = CHEST|ARMS
 	heat_protection = CHEST|ARMS

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -128,7 +128,7 @@ Curator
 	outfit = /datum/outfit/job/curator
 
 	access = list(GLOB.access_library)
-	minimal_access = list(GLOB.access_library)
+	minimal_access = list(GLOB.access_library, GLOB.access_construction,GLOB.access_mining_station)
 
 /datum/outfit/job/curator
 	name = "Curator"

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -9,7 +9,7 @@ Chief Engineer=1,1
 Research Director=1,1
 Chief Medical Officer=1,1
 
-Assistant=-1,-1
+Assistant=0,0
 
 Quartermaster=1,1
 Cargo Technician=3,2
@@ -20,7 +20,7 @@ Cook=2,1
 Botanist=3,2
 Janitor=2,1
 
-Clown=1,1
+Clown=-1,-1
 Mime=1,1
 Curator=1,1
 Lawyer=2,2


### PR DESCRIPTION
:cl:
balance: You can no longer join as an assistant.
balance: There can now be an unlimited number of clowns.
/:cl:

Assistants are terrible. Nobody likes them, and they generally do nothing but ruin the game for everyone else. Therefore, I propose replacing them all with clowns.
