### PR TITLE
Capitalizes machine names when they talk on radio

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -296,6 +296,7 @@
 	// --- Cold, emotionless machines. ---
 	else if(isobj(M))
 		jobname = "Machine"
+		voice = capitalize(voice)
 
 	// --- Unidentifiable mob ---
 	else


### PR DESCRIPTION
:cl: QualityVan
tweak: Machine names will be capitalized when they talk on radio
/:cl:

Apparently their being lowercase was a nuisance for some people.