### PR TITLE
Mindswap rebalancing

### DIFF
--- a/code/modules/spells/spell_types/mind_transfer.dm
+++ b/code/modules/spells/spell_types/mind_transfer.dm
@@ -9,8 +9,8 @@
 	invocation_type = "whisper"
 	range = 1
 	cooldown_min = 200 //100 deciseconds reduction per rank
-	var/paralysis_amount_caster = 15 //how much the caster is paralysed for after the spell
-	var/paralysis_amount_victim = 20 //how much the victim is paralysed for after the spell
+	var/paralysis_amount_caster = 10 //how much the caster is paralysed for after the spell
+	var/paralysis_amount_victim = 10 //how much the victim is paralysed for after the spell
 
 	action_icon_state = "mindswap"
 

--- a/code/modules/spells/spell_types/mind_transfer.dm
+++ b/code/modules/spells/spell_types/mind_transfer.dm
@@ -9,8 +9,7 @@
 	invocation_type = "whisper"
 	range = 1
 	cooldown_min = 200 //100 deciseconds reduction per rank
-	var/list/protected_roles = list("Wizard","Changeling","Cultist") //which roles are immune to the spell
-	var/paralysis_amount_caster = 20 //how much the caster is paralysed for after the spell
+	var/paralysis_amount_caster = 15 //how much the caster is paralysed for after the spell
 	var/paralysis_amount_victim = 20 //how much the victim is paralysed for after the spell
 
 	action_icon_state = "mindswap"
@@ -54,7 +53,7 @@ Also, you never added distance checking after target is selected. I've went ahea
 		to_chat(user, "<span class='warning'>You're killing yourself! You can't concentrate enough to do this!</span>")
 		return
 
-	if((target.mind.special_role in protected_roles) || cmptext(copytext(target.key,1,2),"@"))
+	if(cmptext(copytext(target.key,1,2),"@"))
 		to_chat(user, "<span class='warning'>[target.p_their(TRUE)] mind is resisting your spell!</span>")
 		return
 


### PR DESCRIPTION
:cl: Thunder12345
balance: Wizards, changelings and cultists are no longer immune to mindswap
balance: Mindswap knockout has been reduced to 20 seconds
/:cl:

Lings and cultists will basically never encounter mindswap anyway, and if a wizard isn't good enough to avoid a random crewmember with a spellbook mindswapping him, it's entirely deserved. Knockout reduction because 40 seconds is just insane.