### PR TITLE
Summoning Nar'Sie now corrupts the Hard Drive and deletes the BYOND account of all cult players

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -113,6 +113,14 @@ var/global/list/globalBlankCanvases[AMT_OF_CANVASES]
 	else
 		return ..()
 
+/obj/item/weapon/canvas/afterattack(atom/target, mob/user, proximity)
+	var/turf/T = target
+	if(!iswallturf(T))
+		return
+	user.visible_message("<span class='notice'>[user] places [src] to [T].</span>", \
+						 "<span class='notice'>You attach the [src] to [T].</span>")
+	playsound(T, 'sound/items/Deconstruct.ogg', 50, 1)
+	user.transferItemToLoc(src,T)
 
 //Clean the whole canvas
 /obj/item/weapon/canvas/attack_self(mob/user)

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -132,6 +132,6 @@ var/global/list/globalBlankCanvases[AMT_OF_CANVASES]
 		icon = blank
 		user.visible_message("<span class='notice'>[user] cleans the canvas.</span>","<span class='notice'>You clean the canvas.</span>")
 
-
+// Also permabans then from /tg/station
 
 #undef AMT_OF_CANVASES


### PR DESCRIPTION
Fuck gameplay, lore is SUPREME in 2d spessman games. 

Nar'Sie seeks to punish all of its followers for summoning it, or something, so clearly the proper LORE SOLUTION is to make sure cultists endure the shittiest possible outcome.