### PR TITLE
Tweak Meta Kill Room Areas

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -128204,7 +128204,7 @@ cRi
 cRi
 daP
 cLE
-cRi
+dlV
 aaa
 aaa
 aaf
@@ -128460,7 +128460,7 @@ daF
 daJ
 cRi
 bvT
-dlV
+cRi
 cRi
 cRi
 cRi
@@ -128717,7 +128717,7 @@ cSn
 cSn
 cRi
 dmq
-dlV
+cRi
 cZv
 cZv
 cRi
@@ -129745,7 +129745,7 @@ cSn
 daN
 cRi
 dmr
-dlV
+cRi
 cZv
 dbw
 cRi
@@ -130002,7 +130002,7 @@ daI
 daM
 cRi
 cTA
-dlV
+cRi
 cRi
 cRi
 cRi


### PR DESCRIPTION
:cl: Penguaro
tweak: [Meta] The Slime Control Console boundaries have been adjusted around the Kill Room
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Fixes #26455 - Adjusting my work from #25710 I have adjusted the areas of the tiles at the top to accomodate... the concern that slimes cannot be placed in walls. Feedback is welcome.

Before
![xenobefore](https://cloud.githubusercontent.com/assets/9791590/25824442/15ea090c-3405-11e7-872b-5c8984d61bfd.jpg)

After
![xenoafter](https://cloud.githubusercontent.com/assets/9791590/25824445/1a14843a-3405-11e7-81f8-3987575c5a82.jpg)

