### PR TITLE
You can now buy double eswords from the uplink, but you can no longer use two eswords to construct them

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -16,7 +16,7 @@
 	var/brightness_on = 3
 
 /obj/item/weapon/melee/energy/Initialize()
-	..()
+	. = ..()
 	if(LAZYLEN(possible_colors))
 		item_color = pick(possible_colors)
 		switch(item_color)//Only run this check if the color was picked randomly, so that colors can be manually set for non-random colored energy weapons.
@@ -183,8 +183,8 @@
 	light_color = "#40ceff"
 	possible_colors = null
 
-/obj/item/weapon/melee/energy/sword/cyborg/saw/New()
-	..()
+/obj/item/weapon/melee/energy/sword/cyborg/saw/Initialize()
+	. = ..()
 	icon_state = "esaw_0"
 	item_color = null
 
@@ -207,19 +207,9 @@
 
 
 /obj/item/weapon/melee/energy/sword/saber/attackby(obj/item/weapon/W, mob/living/user, params)
-	if(istype(W, /obj/item/weapon/melee/energy/sword/saber))
-		to_chat(user, "<span class='notice'>You attach the ends of the two energy swords, making a single double-bladed weapon! You're cool.</span>")
-		var/obj/item/weapon/melee/energy/sword/saber/other_esword = W
-		var/obj/item/weapon/twohanded/dualsaber/newSaber = new(user.loc)
-		if(hacked || other_esword.hacked)
-			newSaber.hacked = TRUE
-			newSaber.item_color = "rainbow"
-		qdel(W)
-		qdel(src)
-		user.put_in_hands(newSaber)
-	else if(istype(W, /obj/item/device/multitool))
-		if(hacked == 0)
-			hacked = 1
+	if(istype(W, /obj/item/device/multitool))
+		if(!hacked)
+			hacked = TRUE
 			item_color = "rainbow"
 			to_chat(user, "<span class='warning'>RNBW_ENGAGE</span>")
 
@@ -253,13 +243,11 @@
 	sharpness = IS_SHARP
 
 //Most of the other special functions are handled in their own files. aka special snowflake code so kewl
-/obj/item/weapon/melee/energy/blade/New()
+/obj/item/weapon/melee/energy/blade/Initialize()
+	. = ..()
 	spark_system = new /datum/effect_system/spark_spread()
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
-
-/obj/item/weapon/melee/energy/blade/dropped()
-	..()
 
 /obj/item/weapon/melee/energy/blade/attack_self(mob/user)
 	return

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -92,8 +92,7 @@
 			new /obj/item/pizzabox/bomb
 
 		if("darklord") //20 tc + tk + summon item close enough for now
-			new /obj/item/weapon/melee/energy/sword/saber(src)
-			new /obj/item/weapon/melee/energy/sword/saber(src)
+			new /obj/item/weapon/twohanded/dualsaber(src)
 			new /obj/item/weapon/dnainjector/telemut/darkbundle(src)
 			new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
 			new /obj/item/weapon/card/id/syndicate(src)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -262,11 +262,11 @@
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
 	var/hacked = 0
-	var/brightness_on = 6//TWICE AS BRIGHT AS A REGULAR ESWORD
+	var/brightness_on = 6 //TWICE AS BRIGHT AS A REGULAR ESWORD
 	var/list/possible_colors = list("red", "blue", "green", "purple")
 
 /obj/item/weapon/twohanded/dualsaber/Initialize()
-	..()
+	. = ..()
 	if(LAZYLEN(possible_colors))
 		item_color = pick(possible_colors)
 		switch(item_color)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -276,11 +276,16 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 /datum/uplink_item/dangerous/sword
 	name = "Energy Sword"
 	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be \
-			pocketed when inactive. Activating it produces a loud, distinctive noise. One can combine two \
-			energy swords to create a double energy sword, which must be wielded in two hands but is more robust \
-			and deflects all energy projectiles."
+			pocketed when inactive. Activating it produces a loud, distinctive noise."
 	item = /obj/item/weapon/melee/energy/sword/saber
 	cost = 8
+
+/datum/uplink_item/dangerous/doublesword
+	name = "Double-Bladed Energy Sword"
+	desc = "The double-bladed energy sword does slightly more damage than a standard energy sword and will deflect \
+			all energy projectiles, but requires two hands to wield."
+	item = /obj/item/weapon/twohanded/dualsaber
+	cost = 16
 
 /datum/uplink_item/dangerous/powerfist
 	name = "Power Fist"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -288,6 +288,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	desc = "The double-bladed energy sword does slightly more damage than a standard energy sword and will deflect \
 			all energy projectiles, but requires two hands to wield."
 	item = /obj/item/weapon/twohanded/dualsaber
+	player_minimum = 25
 	cost = 16
 
 /datum/uplink_item/dangerous/doublesword/get_discount()

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	for(var/i in 1 to 3)
 		var/datum/uplink_item/I = pick_n_take(sale_items)
 		var/datum/uplink_item/A = new I.type
-		var/discount = pick(4;0.75,2;0.5,1;0.25)
+		var/discount = A.get_discount()
 		var/list/disclaimer = list("Void where prohibited.", "Not recommended for children.", "Contains small parts.", "Check local laws for legality in region.", "Do not taunt.", "Not responsible for direct, indirect, incidental or consequential damages resulting from any defect, error or failure to perform.", "Keep away from fire or flames.", "Product is provided \"as is\" without any implied or expressed warranties.", "As seen on TV.", "For recreational use only.", "Use only as directed.", "16% sales tax will be charged for orders originating within Space Nebraska.")
 		A.limited_stock = 1
 		I.refundable = FALSE //THIS MAN USES ONE WEIRD TRICK TO GAIN FREE TC, CODERS HATES HIM!
@@ -85,6 +85,9 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	var/list/restricted_roles = list() //If this uplink item is only available to certain roles. Roles are dependent on the frequency chip or stored ID.
 	var/player_minimum //The minimum crew size needed for this item to be added to uplinks.
 	var/purchase_log_vis = TRUE // Visible in the purchase log?
+
+/datum/uplink_item/proc/get_discount()
+	return pick(4;0.75,2;0.5,1;0.25)
 
 /datum/uplink_item/proc/spawn_item(turf/loc, obj/item/device/uplink/U)
 	if(item)
@@ -286,6 +289,9 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 			all energy projectiles, but requires two hands to wield."
 	item = /obj/item/weapon/twohanded/dualsaber
 	cost = 16
+
+/datum/uplink_item/dangerous/doublesword/get_discount()
+	return pick(4;0.8,2;0.65,1;0.5)
 
 /datum/uplink_item/dangerous/powerfist
 	name = "Power Fist"


### PR DESCRIPTION
:cl: Joan
rscadd: You can now buy double eswords from the uplink for 16 telecrystals. They cannot be bought below 25 players.
rscdel: You can no longer use two eswords to construct a double esword.
/:cl:

Closes #27076
A sensible change that lets us tweak the price of one of these items without affecting the other.
## The point of this is that getting two eswords won't let you get a double esword and we don't have to balance anything around that.
