### PR TITLE
t-ray mode on goggles resets lighting

### DIFF
--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -18,6 +18,7 @@
 		vision_flags = 0
 		darkness_view = 2
 		invis_view = SEE_INVISIBLE_LIVING
+		lighting_alpha = null
 		to_chat(user, "<span class='notice'>You toggle the goggles' scanning mode to \[T-Ray].</span>")
 	else
 		STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
:cl:
fix: Fixes t-ray mode on engineering goggles not resetting the lighting override properly.
/:cl:
fixes #27031