### PR TITLE
Wooden planks now sell for 50 instead of 25 cargo points

### DIFF
--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -88,7 +88,7 @@
 
 // Wood. Quite expensive in the grim and dark 26 century.
 /datum/export/stack/wood
-	cost = 25
+	cost = 50
 	unit_name = "wood plank"
 	export_types = list(/obj/item/stack/sheet/mineral/wood)
 


### PR DESCRIPTION
:cl: ma44
tweak: Doubles the amount of points wooden planks sell for (now 50 points)
/:cl:

[why]: Essentially just really worthless

stats
http://www.ss13.eu/tgdb/tg/latest_stats.html#exportscosts
6775 points or 271 sheets

http://www.ss13.eu/tgdb/tg/stats_2016-12-20_to_2017-01-19.html#exportscosts

275 points or 11 sheets

(yes it's outdated and all of that, it's literally the only stats, atlanta doesn't have export stats and for some reason this crap got wiped)