### PR TITLE
Manifest Spirit is better for summoning cannon fodder but slightly worse for instantly summoning Nar-Sie

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -38,3 +38,5 @@
 #define MANIA_DAMAGE_TO_CONVERT 90 //how much damage is required before it'll convert affected targets
 
 #define STATUS_EFFECT_HISWRATH /datum/status_effect/his_wrath //His Wrath.
+
+#define STATUS_EFFECT_SUMMONEDGHOST /datum/status_effect/cultghost //is a cult ghost and can't use manifest runes

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -162,3 +162,8 @@
 				owner.confused = min(owner.confused + round(severity * 0.025, 1), 25) //2.5% of severity per second above 20 severity
 			owner.adjustToxLoss(severity * 0.02, TRUE, TRUE) //2% of severity per second
 		severity--
+
+/datum/status_effect/cultghost //is a cult ghost and can't use manifest runes
+	id = "cult_ghost"
+	duration = -1
+	alert_type = null

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -26,6 +26,11 @@
 		return
 	..()
 
+/obj/item/weapon/melee/cultblade/ghost
+	name = "eldritch sword"
+	force = 20
+	flags = NODROP|DROPDEL
+
 /obj/item/weapon/melee/cultblade/pickup(mob/living/user)
 	..()
 	if(!iscultist(user))
@@ -100,11 +105,17 @@
 	icon_state = "cult_hoodalt"
 	item_state = "cult_hoodalt"
 
+/obj/item/clothing/head/culthood/alt/ghost
+	flags = NODROP|DROPDEL
+
 /obj/item/clothing/suit/cultrobes/alt
 	name = "cultist robes"
 	desc = "An armored set of robes worn by the followers of Nar-Sie."
 	icon_state = "cultrobesalt"
 	item_state = "cultrobesalt"
+
+/obj/item/clothing/suit/cultrobes/alt/ghost
+	flags = NODROP|DROPDEL
 
 
 /obj/item/clothing/head/magus

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -890,6 +890,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 	icon_state = "6"
 	construct_invoke = 0
 	color = "#C80000"
+	var/ghost_limit = 5
+	var/ghosts = 0
 
 /obj/effect/rune/manifest/Initialize()
 	. = ..()
@@ -900,6 +902,16 @@ structure_check() searches for nearby cultist structures required for the invoca
 		to_chat(user, "<span class='cultitalic'>You must be standing on [src]!</span>")
 		fail_invoke()
 		log_game("Manifest rune failed - user not standing on rune")
+		return list()
+	if(user.has_status_effect(STATUS_EFFECT_SUMMONEDGHOST))
+		to_chat(user, "<span class='cultitalic'>Ghosts can't summon more ghosts!</span>")
+		fail_invoke()
+		log_game("Manifest rune failed - user is a ghost")
+		return list()
+	if(ghosts >= ghost_limit)
+		to_chat(user, "<span class='cultitalic'>You are sustaining too many ghosts to summon more!</span>")
+		fail_invoke()
+		log_game("Manifest rune failed - too many summoned ghosts")
 		return list()
 	var/list/ghosts_on_rune = list()
 	for(var/mob/dead/observer/O in get_turf(src))
@@ -923,7 +935,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 	new_human.real_name = ghost_to_spawn.real_name
 	new_human.alpha = 150 //Makes them translucent
 	new_human.equipOutfit(/datum/outfit/ghost_cultist) //give them armor
+	new_human.apply_status_effect(STATUS_EFFECT_SUMMONEDGHOST) //ghosts can't summon more ghosts
 	..()
+	ghosts++
 	visible_message("<span class='warning'>A cloud of red mist forms above [src], and from within steps... a [new_human.gender == FEMALE ? "wo":""]man.</span>")
 	to_chat(user, "<span class='cultitalic'>Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely...</span>")
 	var/turf/T = get_turf(src)
@@ -933,13 +947,14 @@ structure_check() searches for nearby cultist structures required for the invoca
 	SSticker.mode.add_cultist(new_human.mind, 0)
 	to_chat(new_human, "<span class='cultitalic'><b>You are a servant of the Geometer. You have been made semi-corporeal by the cult of Nar-Sie, and you are to serve them at all costs.</b></span>")
 
-	while((user in T) && new_human)
-		if(user.stat || new_human.stat)
+	while(!QDELETED(src) && !QDELETED(user) && !QDELETED(new_human) && (user in T))
+		if(user.stat || new_human.InCritical())
 			break
 		user.apply_damage(0.1, BRUTE)
 		sleep(1)
 
 	qdel(N)
+	ghosts--
 	if(new_human)
 		new_human.visible_message("<span class='warning'>[new_human] suddenly dissolves into bones and ashes.</span>", \
 								  "<span class='cultlarge'>Your link to the world fades. Your form breaks apart.</span>")

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -891,8 +891,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 	construct_invoke = 0
 	color = "#C80000"
 
-/obj/effect/rune/manifest/New(loc)
-	..()
+/obj/effect/rune/manifest/Initialize()
+	. = ..()
 	notify_ghosts("Manifest rune created in [get_area(src)].", 'sound/effects/ghost2.ogg', source = src)
 
 /obj/effect/rune/manifest/can_invoke(mob/living/user)
@@ -922,8 +922,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 	var/mob/living/carbon/human/new_human = new(get_turf(src))
 	new_human.real_name = ghost_to_spawn.real_name
 	new_human.alpha = 150 //Makes them translucent
+	new_human.equipOutfit(/datum/outfit/ghost_cultist) //give them armor
 	..()
-	visible_message("<span class='warning'>A cloud of red mist forms above [src], and from within steps... a man.</span>")
+	visible_message("<span class='warning'>A cloud of red mist forms above [src], and from within steps... a [new_human.gender == FEMALE ? "wo":""]man.</span>")
 	to_chat(user, "<span class='cultitalic'>Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely...</span>")
 	var/turf/T = get_turf(src)
 	var/obj/structure/emergency_shield/invoker/N = new(T)
@@ -943,5 +944,5 @@ structure_check() searches for nearby cultist structures required for the invoca
 		new_human.visible_message("<span class='warning'>[new_human] suddenly dissolves into bones and ashes.</span>", \
 								  "<span class='cultlarge'>Your link to the world fades. Your form breaks apart.</span>")
 		for(var/obj/I in new_human)
-			new_human.dropItemToGround(I)
+			new_human.dropItemToGround(I, TRUE)
 		new_human.dust()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -932,11 +932,11 @@ structure_check() searches for nearby cultist structures required for the invoca
 	SSticker.mode.add_cultist(new_human.mind, 0)
 	to_chat(new_human, "<span class='cultitalic'><b>You are a servant of the Geometer. You have been made semi-corporeal by the cult of Nar-Sie, and you are to serve them at all costs.</b></span>")
 
-	while(user in T)
-		if(user.stat)
+	while((user in T) && new_human)
+		if(user.stat || new_human.stat)
 			break
 		user.apply_damage(0.1, BRUTE)
-		sleep(3)
+		sleep(1)
 
 	qdel(N)
 	if(new_human)

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -242,6 +242,15 @@
 	R.set_frequency(GLOB.CENTCOM_FREQ)
 	R.freqlock = 1
 
+/datum/outfit/ghost_cultist
+	name = "Cultist Ghost"
+
+	uniform = /obj/item/clothing/under/color/black
+	suit = /obj/item/clothing/suit/cultrobes/alt/ghost
+	shoes = /obj/item/clothing/shoes/cult/alt/ghost
+	head = /obj/item/clothing/head/culthood/alt/ghost
+	r_hand = /obj/item/weapon/melee/cultblade/ghost
+
 /datum/outfit/wizard
 	name = "Blue Wizard"
 

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -245,7 +245,7 @@
 /datum/outfit/ghost_cultist
 	name = "Cultist Ghost"
 
-	uniform = /obj/item/clothing/under/color/black
+	uniform = /obj/item/clothing/under/color/black/ghost
 	suit = /obj/item/clothing/suit/cultrobes/alt/ghost
 	shoes = /obj/item/clothing/shoes/cult/alt/ghost
 	head = /obj/item/clothing/head/culthood/alt/ghost

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -142,6 +142,9 @@
 	name = "cultist boots"
 	icon_state = "cultalt"
 
+/obj/item/clothing/shoes/cult/alt/ghost
+	flags = NODROP|DROPDEL
+
 /obj/item/clothing/shoes/cyborg
 	name = "cyborg boots"
 	desc = "Shoes for a cyborg costume."

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -16,6 +16,9 @@
 	item_color = "black"
 	resistance_flags = 0
 
+/obj/item/clothing/under/color/black/ghost
+	flags = NODROP|DROPDEL
+
 /obj/item/clothing/under/color/grey
 	name = "grey jumpsuit"
 	desc = "A tasteful grey jumpsuit that reminds you of the good old days."

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -241,7 +241,7 @@
 		return 1
 
 /mob/living/proc/InCritical()
-	return (src.health < 0 && src.health > -95 && stat == UNCONSCIOUS)
+	return (health < 0 && health > -100 && stat == UNCONSCIOUS)
 
 //This proc is used for mobs which are affected by pressure to calculate the amount of pressure that actually
 //affects them once clothing is factored in. ~Errorage


### PR DESCRIPTION
:cl: Joan
tweak: Manifest Spirit will no longer continue to cost the user health if the summoned ghost is put into critical or gibbed.
rscadd: Ghosts summoned by Manifest Spirit are outfitted with ghostly armor and a ghostly cult blade that does slightly less damage than a normal cult blade.
balance: Manifest Spirit now consumes 1 health per second per summoned ghost, from 0.333~.
balance: Manifest Spirit can now only summon a maximum of 5 ghosts per rune, and the summoned ghosts cannot use Manifest Spirit to summon more ghosts.
/:cl:

Summoning an army of ghosts for the Nar-Sie rune is less practical, especially if you misplace the rune, but using them as disposable fighters is more practical because they'll start armored and with a weapon.