### PR TITLE
Removes changeling hivemind, I think

### DIFF
--- a/code/game/gamemodes/changeling/powers/hivemind.dm
+++ b/code/game/gamemodes/changeling/powers/hivemind.dm
@@ -1,23 +1,3 @@
-//HIVEMIND COMMUNICATION (:g)
-/obj/effect/proc_holder/changeling/hivemind_comms
-	name = "Hivemind Communication"
-	desc = "We tune our senses to the airwaves to allow us to discreetly communicate and exchange DNA with other changelings."
-	helptext = "We will be able to talk with other changelings with :g. Exchanged DNA do not count towards absorb objectives."
-	dna_cost = 0
-	chemical_cost = -1
-
-/obj/effect/proc_holder/changeling/hivemind_comms/on_purchase(mob/user, is_respec)
-	..()
-	var/datum/changeling/changeling=user.mind.changeling
-	changeling.changeling_speak = 1
-	to_chat(user, "<i><font color=#800080>Use say \":g message\" to communicate with the other changelings.</font></i>")
-	var/obj/effect/proc_holder/changeling/hivemind_upload/S1 = new
-	if(!changeling.has_sting(S1))
-		changeling.purchasedpowers+=S1
-	var/obj/effect/proc_holder/changeling/hivemind_download/S2 = new
-	if(!changeling.has_sting(S2))
-		changeling.purchasedpowers+=S2
-
 // HIVE MIND UPLOAD/DOWNLOAD DNA
 GLOBAL_LIST_EMPTY(hivemind_bank)
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -22,7 +22,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	// Species
 	"b" = "binary",
-	"g" = "changeling",
 	"a" = "alientalk",
 
 	// Admin
@@ -37,36 +36,36 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	//kinda localization -- rastaf0
 	//same keys as above, but on russian keyboard layout. This file uses cp1251 as encoding.
 	// Location
-	"ê" = "right hand",
-	"ä" = "left hand",
-	"ø" = "intercom",
+	"Ãª" = "right hand",
+	"Ã¤" = "left hand",
+	"Ã¸" = "intercom",
 
 	// Department
-	"ð" = "department",
-	"ñ" = "Command",
-	"ò" = "Science",
-	"ü" = "Medical",
-	"ó" = "Engineering",
-	"û" = "Security",
-	"ã" = "Supply",
-	"ì" = "Service",
+	"Ã°" = "department",
+	"Ã±" = "Command",
+	"Ã²" = "Science",
+	"Ã¼" = "Medical",
+	"Ã³" = "Engineering",
+	"Ã»" = "Security",
+	"Ã£" = "Supply",
+	"Ã¬" = "Service",
 
 	// Faction
-	"å" = "Syndicate",
-	"í" = "Centcom",
+	"Ã¥" = "Syndicate",
+	"Ã­" = "Centcom",
 
 	// Species
-	"è" = "binary",
-	"ï" = "changeling",
-	"ô" = "alientalk",
+	"Ã¨" = "binary",
+	"Ã¯" = "changeling",
+	"Ã´" = "alientalk",
 
 	// Admin
-	"ç" = "admin",
-	"â" = "deadmin",
+	"Ã§" = "admin",
+	"Ã¢" = "deadmin",
 
 	// Misc
-	"ù" = "AI Private",
-	"÷" = "cords"
+	"Ã¹" = "AI Private",
+	"Ã·" = "cords"
 ))
 
 /mob/living/say(message, bubble_type,var/list/spans = list(), sanitize = TRUE, datum/language/language = null)
@@ -313,44 +312,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return null
 
 /mob/living/proc/handle_inherent_channels(message, message_mode)
-	if(message_mode == MODE_CHANGELING)
-		switch(lingcheck())
-			if(3)
-				var/msg = "<i><font color=#800040><b>[src.mind]:</b> [message]</font></i>"
-				for(var/_M in GLOB.mob_list)
-					var/mob/M = _M
-					if(M in GLOB.dead_mob_list)
-						var/link = FOLLOW_LINK(M, src)
-						to_chat(M, "[link] [msg]")
-					else
-						switch(M.lingcheck())
-							if(3)
-								to_chat(M, msg)
-							if(2)
-								to_chat(M, msg)
-							if(1)
-								if(prob(40))
-									to_chat(M, "<i><font color=#800080>We can faintly sense an outsider trying to communicate through the hivemind...</font></i>")
-			if(2)
-				var/msg = "<i><font color=#800080><b>[mind.changeling.changelingID]:</b> [message]</font></i>"
-				log_say("[mind.changeling.changelingID]/[src.key] : [message]")
-				for(var/_M in GLOB.mob_list)
-					var/mob/M = _M
-					if(M in GLOB.dead_mob_list)
-						var/link = FOLLOW_LINK(M, src)
-						to_chat(M, "[link] [msg]")
-					else
-						switch(M.lingcheck())
-							if(3)
-								to_chat(M, msg)
-							if(2)
-								to_chat(M, msg)
-							if(1)
-								if(prob(40))
-									to_chat(M, "<i><font color=#800080>We can faintly sense another of our kind trying to communicate through the hivemind...</font></i>")
-			if(1)
-				to_chat(src, "<i><font color=#800080>Our senses have not evolved enough to be able to communicate this way...</font></i>")
-		return TRUE
 	if(message_mode == MODE_ALIEN)
 		if(hivecheck())
 			alien_talk(message)
@@ -404,15 +365,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			if(binarycheck())
 				robot_talk(message)
 			return ITALICS | REDUCE_RANGE //Does not return 0 since this is only reached by humans, not borgs or AIs.
-	return 0
-
-/mob/living/lingcheck() //1 is ling w/ no hivemind. 2 is ling w/hivemind. 3 is ling victim being linked into hivemind.
-	if(mind && mind.changeling)
-		if(mind.changeling.changeling_speak)
-			return 2
-		return 1
-	if(mind && mind.linglink)
-		return 3
 	return 0
 
 /mob/living/say_mod(input, message_mode)


### PR DESCRIPTION
:cl:
del: Removes changeling ability to communicate to each other through hivemind. From now on, they are on their own.
/:cl:

Changelings are not team antagonists, so they have no business creating kill-teams and holocausting the crew. Changelings are extremely powerful even on their own, so killing their ability to easily communicate and form alliances is a necessity. 

I think I did the thing correctly, but I'm not sure.