### PR TITLE
pAI requests now tell ghosts who is making the request.

### DIFF
--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -150,7 +150,7 @@ SUBSYSTEM_DEF(pai)
 			if(!(ROLE_PAI in G.client.prefs.be_special))
 				continue
 			//G << 'sound/misc/server-ready.ogg' //Alerting them to their consideration
-			to_chat(G, "<span class='ghostalert'>Someone is requesting a pAI personality! Use the pAI button to submit yourself as one.</span>")
+			to_chat(G, "<span class='ghostalert'>[user] is requesting a pAI personality! Use the pAI button to submit yourself as one.</span>")
 		addtimer(CALLBACK(src, .proc/spam_again), spam_delay)
 	var/list/available = list()
 	for(var/datum/paiCandidate/c in SSpai.candidates)


### PR DESCRIPTION
:cl: bandit
tweak: Nanotrasen has enhanced personality matchmaking for its personal AIs. pAI candidates will now see who is requesting a pAI personality.
/:cl:

Why: Request from XDTM in Minor Suggestions: "Make pAI requests display the owner's name, so if BOBO THE PRANCING WIZARD activates one i actually accept instead of risking having to spend the rest of the round in a silent assistant's pocket."
