### PR TITLE
Canisters only notify admins if they contain a meaningful amount of dangerous gas when opened

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -14,9 +14,9 @@
 #define GAS_META		3
 #define META_GAS_SPECIFIC_HEAT	1
 #define META_GAS_NAME			2
-#define META_GAS_OVERLAY		4
 #define META_GAS_MOLES_VISIBLE	3
-#define META_GAS_DANGER			4
+#define META_GAS_OVERLAY		4
+#define META_GAS_DANGER			5
 
 //stuff you should probably leave well alone!
 //ATMOS

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -16,6 +16,7 @@
 #define META_GAS_NAME			2
 #define META_GAS_OVERLAY		4
 #define META_GAS_MOLES_VISIBLE	3
+#define META_GAS_DANGER			4
 
 //stuff you should probably leave well alone!
 //ATMOS

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list("o2","n2","co2","plasma")) //the main fou
 /proc/meta_gas_list()
 	. = new /list
 	for(var/gas_path in subtypesof(/datum/gas))
-		var/list/gas_info = new(4)
+		var/list/gas_info = new(5)
 		var/datum/gas/gas = gas_path
 
 		gas_info[META_GAS_SPECIFIC_HEAT] = initial(gas.specific_heat)
@@ -11,6 +11,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list("o2","n2","co2","plasma")) //the main fou
 		gas_info[META_GAS_MOLES_VISIBLE] = initial(gas.moles_visible)
 		if(initial(gas.moles_visible) != null)
 			gas_info[META_GAS_OVERLAY] = new /obj/effect/overlay/gas(initial(gas.gas_overlay))
+		gas_info[META_GAS_DANGER] = initial(gas.dangerous)
 		.[initial(gas.id)] = gas_info
 
 /*||||||||||||||/----------\||||||||||||||*\
@@ -28,6 +29,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list("o2","n2","co2","plasma")) //the main fou
 	var/name = ""
 	var/gas_overlay = "" //icon_state in icons/effects/tile_effects.dmi
 	var/moles_visible = null
+	var/dangerous = FALSE //currently used by canisters
 
 /datum/gas/oxygen
 	id = "o2"
@@ -50,6 +52,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list("o2","n2","co2","plasma")) //the main fou
 	name = "Plasma"
 	gas_overlay = "plasma"
 	moles_visible = MOLES_PLASMA_VISIBLE
+	dangerous = TRUE
 
 /datum/gas/water_vapor
 	id = "water_vapor"
@@ -64,6 +67,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list("o2","n2","co2","plasma")) //the main fou
 	name = "Freon"
 	gas_overlay = "freon"
 	moles_visible = MOLES_PLASMA_VISIBLE
+	dangerous = TRUE
 
 /datum/gas/nitrous_oxide
 	id = "n2o"
@@ -71,6 +75,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list("o2","n2","co2","plasma")) //the main fou
 	name = "Nitrous Oxide"
 	gas_overlay = "nitrous_oxide"
 	moles_visible = 1
+	dangerous = TRUE
 
 /datum/gas/oxygen_agent_b
 	id = "agent_b"
@@ -86,6 +91,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list("o2","n2","co2","plasma")) //the main fou
 	id = "bz"
 	specific_heat = 20
 	name = "BZ"
+	dangerous = TRUE
 
 /obj/effect/overlay/gas
 	icon = 'icons/effects/tile_effects.dmi'

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -395,25 +395,20 @@
 			if(valve_open)
 				logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into \the [holding || "air"].<br>"
 				if(!holding)
-					var/plasma = air_contents.gases["plasma"]
-					var/n2o = air_contents.gases["n2o"]
-					var/bz = air_contents.gases["bz"]
-					var/freon = air_contents.gases["freon"]
-					if(n2o || plasma || bz || freon)
+					var/list/danger = list()
+					for(var/id in air_contents.gases)
+						var/gas = air_contents.gases[id]
+						if(!gas[GAS_META][META_GAS_DANGER])
+							continue
+						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_PLASMA_VISIBLE)) //if moles_visible is undefined, default to plasma visibility
+							danger += gas[GAS_META][META_GAS_NAME]
+
+					if(danger.len)
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following: [ADMIN_JMP(src)]")
 						log_admin("[key_name(usr)] opened a canister that contains the following at [COORD(src)]:")
-						if(plasma)
-							log_admin("Plasma")
-							message_admins("Plasma")
-						if(n2o)
-							log_admin("N2O")
-							message_admins("N2O")
-						if(bz)
-							log_admin("BZ Gas")
-							message_admins("BZ Gas")
-						if(freon)
-							log_admin("Freon")
-							message_admins("Freon")
+						for(var/name in danger)
+							log_admin(name)
+							message_admins(name)
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into \the [holding || "air"].<br>"
 			investigate_log(logmsg, "atmos")
@@ -448,5 +443,3 @@
 				holding = null
 				. = TRUE
 	update_icon()
-
-

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -401,14 +401,15 @@
 						if(!gas[GAS_META][META_GAS_DANGER])
 							continue
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_PLASMA_VISIBLE)) //if moles_visible is undefined, default to plasma visibility
-							danger += gas[GAS_META][META_GAS_NAME]
+							danger[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] //ex. "plasma" = 20
 
 					if(danger.len)
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following: [ADMIN_JMP(src)]")
 						log_admin("[key_name(usr)] opened a canister that contains the following at [COORD(src)]:")
 						for(var/name in danger)
-							log_admin(name)
-							message_admins(name)
+							var/msg = "[name]: [danger[name]] moles."
+							log_admin(msg)
+							message_admins(msg)
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into \the [holding || "air"].<br>"
 			investigate_log(logmsg, "atmos")


### PR DESCRIPTION
:cl:
tweak: opening a dangerous canister will only alert admins if it contains meaningful amounts of a dangerous gas. No more being bwoinked because you opened an empty canister that used to have plasma in it.
/:cl:
@bgobandit <3

Fixes #27062 