### PR TITLE
Travis CI build script fix

### DIFF
--- a/tools/travis/build_byond.sh
+++ b/tools/travis/build_byond.sh
@@ -9,7 +9,7 @@ if [ "$BUILD_TOOLS" = false ]; then
     	echo "step_[xy] variables detected in maps, please remove them."
     	exit 1
 	fi;
-	if grep '/turf\s*[,\){]' _maps/**/*.dmm; then
+	if grep '\W\/turf\s*[,\){]' _maps/**/*.dmm; then
     	echo "base /turf path use detected in maps, please replace with proper paths."
     	exit 1
 	fi;


### PR DESCRIPTION
No changelog as this fix doesn't affect players.

If you're using an object in a map, for example let's say /obj/machinery/meter/turf, and it ends in /turf, at the moment the build script will issue a false positive for a use of the base /turf.

This minor edit of the regex should fix this problem. Why \W? I tried \B but for whatever reason it didn't seem to work.