### PR TITLE
Wraiths now refund part of Phase Shift's cooldown by attacking

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -171,9 +171,9 @@
 	attacktext = "slashes"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift)
-	playstyle_string = "<b>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</b>"
+	playstyle_string = "<b>You are a Wraith. Though relatively fragile, you are fast, deadly, can phase through walls, and your attacks will lower the cooldown on phasing.</b>"
 	var/attack_refund = 5 //half a second per attack
-	var/crit_refund = 30 //3 seconds when putting a target into critical
+	var/crit_refund = 50 //5 seconds when putting a target into critical
 	var/kill_refund = 250 //full refund on kills
 
 /mob/living/simple_animal/hostile/construct/wraith/AttackingTarget() //refund jaunt cooldown when attacking living targets

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -172,6 +172,29 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift)
 	playstyle_string = "<b>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</b>"
+	var/attack_refund = 5 //half a second per attack
+	var/crit_refund = 30 //3 seconds when putting a target into critical
+	var/kill_refund = 250 //full refund on kills
+
+/mob/living/simple_animal/hostile/construct/wraith/AttackingTarget() //refund jaunt cooldown when attacking living targets
+	var/prev_stat
+	if(isliving(target) && !iscultist(target))
+		var/mob/living/L = target
+		prev_stat = L.stat
+
+	. = ..()
+
+	if(. && isnum(prev_stat))
+		var/mob/living/L = target
+		var/refund = 0
+		if(QDELETED(L) || (L.stat == DEAD && prev_stat != DEAD)) //they're dead, you killed them
+			refund += kill_refund
+		else if(L.InCritical() && prev_stat == CONSCIOUS) //you knocked them into critical
+			refund += crit_refund
+		if(L.stat != DEAD && prev_stat != DEAD)
+			refund += attack_refund
+		for(var/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/S in mob_spell_list)
+			S.charge_counter = min(S.charge_counter + refund, S.charge_max)
 
 /mob/living/simple_animal/hostile/construct/wraith/hostile //actually hostile, will move around, hit things
 	AIStatus = AI_ON

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -172,7 +172,7 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift)
 	playstyle_string = "<b>You are a Wraith. Though relatively fragile, you are fast, deadly, can phase through walls, and your attacks will lower the cooldown on phasing.</b>"
-	var/attack_refund = 5 //half a second per attack
+	var/attack_refund = 10 //1 second per attack
 	var/crit_refund = 50 //5 seconds when putting a target into critical
 	var/kill_refund = 250 //full refund on kills
 

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -118,7 +118,7 @@
 	desc = "This spell allows you to pass through walls"
 
 	school = "transmutation"
-	charge_max = 200
+	charge_max = 250
 	clothes_req = 0
 	invocation = "none"
 	invocation_type = "none"


### PR DESCRIPTION
:cl: Joan
rscadd: Wraiths now refund Phase Shift's cooldown by attacking; 1 second on normal attacks, 5 seconds when putting a target into critical, and a full refund when killing a target.
balance: Increased Phase Shift's cooldown from 20 seconds to 25 seconds.
/:cl:

This should focus them more on successfully assassinating targets, because doing so will allow them to escape rapidly, but failing will put them in a worse situation than before, because phase shift's cooldown is higher.