### PR TITLE
Plasma golem tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -111,9 +111,12 @@
 	button_icon_state = "sacredflame"
 
 /datum/action/innate/ignite/Activate()
-	to_chat(owner, "<span class='notice'>You ignite yourself!</span>")
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
+		if(H.fire_stacks)
+			to_chat(owner, "<span class='notice'>You ignite yourself!</span>")
+		else
+			to_chat(owner, "<span class='warning'>You try ignite yourself, but fail!</span>")
 		H.IgniteMob() //firestacks are already there passively
 
 //Harder to hurt

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -60,7 +60,7 @@
 	info_text = "As an <span class='danger'>Adamantine Golem</span>, you possess special vocal cords allowing you to \"resonate\" messages to all golems."
 	prefix = "Adamantine"
 
-//Explodes on death
+//The suicide bombers of golemkind
 /datum/species/golem/plasma
 	name = "Plasma Golem"
 	id = "plasma golem"
@@ -68,19 +68,53 @@
 	meat = /obj/item/weapon/ore/plasma
 	//Can burn and takes damage from heat
 	species_traits = list(NOBREATH,RESISTCOLD,RESISTPRESSURE,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NODISMEMBER,MUTCOLORS,NO_UNDERWEAR)
-	info_text = "As a <span class='danger'>Plasma Golem</span>, you explode on death!"
-	burnmod = 1.5
+	info_text = "As a <span class='danger'>Plasma Golem</span>, you burn easily. Be careful, if you get hot enough while burning, you'll blow up!"
+	heatmod = 0 //fine until they blow up
 	prefix = "Plasma"
 	special_names = list("Flood","Fire","Bar","Man")
+	var/boom_warning = FALSE
+	var/datum/action/innate/ignite/ignite
 
 /datum/species/golem/plasma/spec_life(mob/living/carbon/human/H)
-	if(H.bodytemperature > 900 && H.on_fire)
+	if(H.bodytemperature > 750)
+		if(!boom_warning && H.on_fire)
+			to_chat(H, "<span class='userdanger'>You feel like you could blow up at any moment!<span>")
+			boom_warning = TRUE
+	else
+		if(boom_warning)
+			to_chat(H, "<span class='notice'>You feel more stable.<span>")
+			boom_warning = FALSE
+
+	if(H.bodytemperature > 850 && H.on_fire && prob(25))
 		explosion(get_turf(H),1,2,4,flame_range = 5)
 		if(H)
 			H.gib()
 	if(H.fire_stacks < 2) //flammable
 		H.adjust_fire_stacks(1)
 	..()
+
+/datum/species/golem/plasma/on_species_gain(mob/living/carbon/C, datum/species/old_species)
+	..()
+	if(ishuman(C))
+		ignite = new
+		ignite.Grant(C)
+
+/datum/species/golem/plasma/on_species_loss(mob/living/carbon/C)
+	if(ignite)
+		ignite.Remove(C)
+	..()
+
+/datum/action/innate/ignite
+	name = "Ignite"
+	desc = "Set yourself aflame, bringing yourself closer to exploding!"
+	check_flags = AB_CHECK_CONSCIOUS
+	button_icon_state = "sacredflame"
+
+/datum/action/innate/ignite/Activate()
+	to_chat(owner, "<span class='notice'>You ignite yourself!</span>")
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		H.IgniteMob() //firestacks are already there passively
 
 //Harder to hurt
 /datum/species/golem/diamond


### PR DESCRIPTION
:cl: optional name here
fix: Plasma Golems now have the correct updated tip.
tweak: Plasma Golems no longer take damage from fire, and take normal instead of increased burn damage from other sources. They will still explode if on fire and hot enough.
add: Plasma Golems can now self-ignite with an action button.
tweak: Plasma Golems are now warned when they're close to exploding.
tweak: Plasma Golems now have a constant chance of exploding after 850K instead of a precise threshold at 900K, making it less predictable.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)
# Why
Plasma Golems are kind of shunned, because their role is pretty much just a downside. Now it still is geared toward killing themselves spectacularly, but at least trying to do so doesn't require special equipment and doesn't require them to get hurt to crit first.

I'm considering increasing the explosion size a bit, given that they do kill themselves for it and are very visible when doing so. Also maybe increasing their speed while on fire.
