### PR TITLE
Adds Mass Insert proc to sql

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -84,19 +84,16 @@ SUBSYSTEM_DEF(blackbox)
 	if (!SSdbcore.Connect())
 		return
 
-	var/sqlrowlist = ""
+	var/list/sqlrowlist = list()
 
 	for (var/datum/feedback_variable/FV in feedback)
-		if (sqlrowlist != "")
-			sqlrowlist += ", " //a comma (,) at the start of the first row to insert will trigger a SQL error
+		sqlrowlist += list("time" = "Now()", "round_id" = GLOB.round_id, "var_name" =  "'[sanitizeSQL(FV.get_variable())]'", "var_value" = FV.get_value(), "details" = "'[sanitizeSQL(FV.get_details())]'")
 
-		sqlrowlist += "(null, Now(), [GLOB.round_id], \"[sanitizeSQL(FV.get_variable())]\", [FV.get_value()], \"[sanitizeSQL(FV.get_details())]\")"
-
-	if (sqlrowlist == "")
+	if (!length(sqlrowlist))
 		return
 
-	var/datum/DBQuery/query_feedback_save = SSdbcore.NewQuery("INSERT DELAYED IGNORE INTO [format_table_name("feedback")] VALUES " + sqlrowlist)
-	query_feedback_save.Execute()
+	SSdbcore.MassInsert(format_table_name("feedback"), sqlrowlist, ignore_errors = TRUE, delayed = TRUE)
+
 
 /datum/controller/subsystem/blackbox/proc/LogBroadcast(blackbox_msg, freq)
 	switch(freq)

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -99,12 +99,12 @@ You are expected to do your own escaping of the data, and expected to provide yo
 The duplicate_key arg can be true to automatically generate this part of the query
 	or set to a string that is appended to the end of the query
 Ignore_errors instructes mysql to continue inserting rows if some of them have errors.
-	 the errorous row(s) aren't inserted and there isn't really any way to know why or why errored
+	 the erroneous row(s) aren't inserted and there isn't really any way to know why or why errored
 Delayed insert mode was removed in mysql 7 and only works with MyISAM type tables,
 	It was included because it is still supported in mariadb.
 	It does not work with duplicate_key and the mysql server ignores it in those cases
 */
-/datum/controller/subsystem/dbcore/proc/MassInsert(table, list/rows, duplicate_key = FALSE, ignore_errors = FALSE, delayed = FALSE)
+/datum/controller/subsystem/dbcore/proc/MassInsert(table, list/rows, duplicate_key = FALSE, ignore_errors = FALSE, delayed = FALSE, warn = FALSE)
 	if (!table || !rows || !istype(rows))
 		return
 	var/list/columns = list()
@@ -153,7 +153,10 @@ Delayed insert mode was removed in mysql 7 and only works with MyISAM type table
 
 	sqlrowlist = "	[sqlrowlist.Join(",\n	")]"
 	var/datum/DBQuery/Query = NewQuery("INSERT[ignore_errors][delayed] INTO [table]\n([columns.Join(", ")])\nVALUES\n[sqlrowlist]\n[duplicate_key]")
-	return Query.Execute()
+	if (warn)
+		return Query.warn_execute()
+	else
+		return Query.Execute()
 
 
 /datum/DBQuery

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -77,18 +77,83 @@ SUBSYSTEM_DEF(dbcore)
 		return FALSE
 	return _dm_db_is_connected(_db_con)
 
-/datum/controller/subsystem/dbcore/proc/Quote(str) 
+/datum/controller/subsystem/dbcore/proc/Quote(str)
 	return _dm_db_quote(_db_con, str)
 
-/datum/controller/subsystem/dbcore/proc/ErrorMsg() 
+/datum/controller/subsystem/dbcore/proc/ErrorMsg()
 	if(!config.sql_enabled)
 		return "Database disabled by configuration"
 	return _dm_db_error_msg(_db_con)
 
 /datum/controller/subsystem/dbcore/proc/NewQuery(sql_query, cursor_handler = Default_Cursor)
 	if(IsAdminAdvancedProcCall())
-		log_admin_private("WARNING: Advanced admin proc call DB query created!: [sql_query]") 
+		log_admin_private("ERROR: Advanced admin proc call led to sql query: [sql_query]. Query has been blocked")
+		message_admins("ERROR: Advanced admin proc call led to sql query. Query has been blocked")
+		return FALSE
 	return new /datum/DBQuery(sql_query, src, cursor_handler)
+
+/*
+Takes a list of rows (each row being an associated list of column => value) and inserts them via a single mass query.
+Rows missing columns present in other rows will resolve to SQL NULL
+You are expected to do your own escaping of the data, and expected to provide your own quotes for strings.
+The duplicate_key arg can be true to automatically generate this part of the query
+	or set to a string that is appended to the end of the query
+Ignore_errors instructes mysql to continue inserting rows if some of them have errors.
+	 the errorous row(s) aren't inserted and there isn't really any way to know why or why errored
+Delayed insert mode was removed in mysql 7 and only works with MyISAM type tables,
+	It was included because it is still supported in mariadb.
+	It does not work with duplicate_key and the mysql server ignores it in those cases
+*/
+/datum/controller/subsystem/dbcore/proc/MassInsert(table, list/rows, duplicate_key = FALSE, ignore_errors = FALSE, delayed = FALSE)
+	if (!table || !rows || !istype(rows))
+		return
+	var/list/columns = list()
+	var/list/sorted_rows = list()
+
+	for (var/list/row in rows)
+		var/list/sorted_row = list()
+		sorted_row.len = columns.len
+		for (var/column in row)
+			var/idx = columns[column]
+			if (!idx)
+				idx = columns.len + 1
+				columns[column] = idx
+				sorted_row.len = columns.len
+
+			sorted_row[idx] = row[column]
+		sorted_rows[++sorted_rows.len] = sorted_row
+
+	if (duplicate_key == TRUE)
+		var/list/column_list = list()
+		for (var/column in columns)
+			column_list += "[column] = VALUES([column])"
+		duplicate_key = "ON DUPLICATE KEY UPDATE [column_list.Join(", ")]\n"
+	else if (duplicate_key == FALSE)
+		duplicate_key = null
+
+	if (ignore_errors)
+		ignore_errors = " IGNORE"
+	else
+		ignore_errors = null
+
+	if (delayed)
+		delayed = " DELAYED"
+	else
+		delayed = null
+
+	var/list/sqlrowlist = list()
+	var/len = columns.len
+	for (var/list/row in sorted_rows)
+		if (length(row) != len)
+			row.len = len
+		for (var/value in row)
+			if (value == null)
+				value = "NULL"
+		sqlrowlist += "([row.Join(", ")])"
+
+	sqlrowlist = "	[sqlrowlist.Join(",\n	")]"
+	var/datum/DBQuery/Query = NewQuery("INSERT[ignore_errors][delayed] INTO [table]\n([columns.Join(", ")])\nVALUES\n[sqlrowlist]\n[duplicate_key]")
+	return Query.Execute()
 
 
 /datum/DBQuery


### PR DESCRIPTION
Takes a table name and list of rows to insert, and inserts them

Rows are in the format of `row[column] = value`

Supports auto generated `ON DUPLICATE KEY UPDATE` querys as well as manually specifying that part of the query.

Generated queries are pretty formatted to make debugging sql errors easy.

Blackbox converted to use the system.

@Shadowlight213 
@optimumtact 
@Jordie0608 
