### PR TITLE
Disables Gaia mutation

### DIFF
--- a/code/modules/hydroponics/grown/ambrosia.dm
+++ b/code/modules/hydroponics/grown/ambrosia.dm
@@ -39,7 +39,7 @@
 	species = "ambrosiadeus"
 	plantname = "Ambrosia Deus"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/deus
-	mutatelist = list(/obj/item/seeds/ambrosia/gaia)
+	mutatelist = list()
 	reagents_add = list("omnizine" = 0.15, "synaptizine" = 0.15, "space_drugs" = 0.1, "vitamin" = 0.04, "nutriment" = 0.05)
 	rarity = 40
 


### PR DESCRIPTION
I like Gaia. I really do. But it's hit the point where everyone's getting so mad over botany that they're trying to remove my weed codebabby.

Weed did nothing wrong. This war over how high botany can get has gone past the line.

Just upgrade the trays with T3/T4 parts. It'll last almost as long as Gaia does, with better stats to boot.