### PR TITLE
Gangs now start with 3 leaders

### DIFF
--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -58,13 +58,19 @@ GLOBAL_LIST_INIT(gang_colors_pool, list("red","orange","yellow","green","blue","
 		gangs += G
 
 		//Now assign a boss for the gang
-		var/datum/mind/boss = pick(antag_candidates)
-		antag_candidates -= boss
-		G.bosses += boss
-		boss.gang_datum = G
-		boss.special_role = "[G.name] Gang Boss"
-		boss.restricted_roles = restricted_jobs
-		log_game("[boss.key] has been selected as the Boss for the [G.name] Gang")
+		for(var/n in 1 to 3)
+			var/datum/mind/boss = pick(antag_candidates)
+			antag_candidates -= boss
+			G.bosses += boss
+			boss.gang_datum = G
+			var/title
+			if(n == 1)
+				title = "Boss"
+			else
+				title = "Lieutenant"
+			boss.special_role = "[G.name] Gang [title]"
+			boss.restricted_roles = restricted_jobs
+			log_game("[boss.key] has been selected as the [title] for the [G.name] Gang")
 
 	if(gangs.len < 2) //Need at least two gangs
 		return 0


### PR DESCRIPTION
Promotion is a problematic mechanic. It allows people like me to immediately metagame the best players online and make sure they're my lieutenants. Within 5 minutes the game is already snowballing in my favor.

Meanwhile the inexperienced boss barely understands the implications of promoting and when they do promote its generally whoever happens to be standing in front of them, even if they're just as clueless as they are.

The result is that Gangs remain very snowbally. The best players get the best lieutenants and the best lieutenants then make sure to use points intelligently, recruit other key players, etc. 

Randomly assigning the leadership roles will still produced unbalanced outcomes, but less often than the current system. It makes it more likely that a robust gang boss doesn't get his two metabuddies as lieutenants or that the newbie boss isn't doomed from the moment the round starts. 

Also I'm streamlining the whole gang round to hopefully get to the fun stuff faster and resolve the conflict in a reasonable time period - the promotion phase only serves as a window for sec to crush the gangs in their infancy and start stockpiling more implants than there are gangsters on the station. 

There is still a designated "boss" and two lieutenants. The gang tool code should automatically prevent promotions once 3 leaders exist. 

Edit: Also this change is required for my next PR because its not compatible with promotion.