### PR TITLE
Buffs plasma and nerfs snow

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -307,7 +307,6 @@ GLOBAL_LIST_INIT(plastitanium_recipes, list ( \
 	force = 1
 	throwforce = 2
 	origin_tech = "materials=1"
-	sheettype = "snow"
 
 GLOBAL_LIST_INIT(snow_recipes, list ( \
 	new/datum/stack_recipe("Snow Wall",/turf/closed/wall/mineral/snow, 5, one_per_turf = 1, on_floor = 1), \

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -158,12 +158,12 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 		var/turf/T = get_turf(src)
 		message_admins("Plasma sheets ignited by [ADMIN_LOOKUPFLW(user)] in [ADMIN_COORDJMP(T)]",0,1)
 		log_game("Plasma sheets ignited by [key_name(user)] in [COORD(T)]")
-		fire_act()
+		fire_act(W.is_hot())
 	else
 		return ..()
 
 /obj/item/stack/sheet/mineral/plasma/fire_act(exposed_temperature, exposed_volume)
-	atmos_spawn_air("plasma=[amount*10];TEMP=1000")
+	atmos_spawn_air("plasma=[amount*10];TEMP=[exposed_temperature]")
 	qdel(src)
 
 /*

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -40,7 +40,7 @@
 
 /turf/open/floor/mineral/plasma/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > 300)
-		PlasmaBurn()
+		PlasmaBurn(exposed_temperature)
 
 /turf/open/floor/mineral/plasma/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if(W.is_hot() > 300)//If the temperature of the object is over 300, then ignite
@@ -50,13 +50,13 @@
 		return
 	..()
 
-/turf/open/floor/mineral/plasma/proc/PlasmaBurn()
+/turf/open/floor/mineral/plasma/proc/PlasmaBurn(temperature)
 	make_plating()
-	atmos_spawn_air("plasma=20;TEMP=1000")
+	atmos_spawn_air("plasma=20;TEMP=[temperature]")
 
 /turf/open/floor/mineral/plasma/proc/ignite(exposed_temperature)
 	if(exposed_temperature > 300)
-		PlasmaBurn()
+		PlasmaBurn(exposed_temperature)
 
 
 //GOLD

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -111,7 +111,7 @@
 	new girder_type(src)
 	src.ChangeTurf(/turf/open/floor/plasteel)
 	var/turf/open/T = src
-	T.atmos_spawn_air("plasma=400;TEMP=1000")
+	T.atmos_spawn_air("plasma=400;TEMP=[temperature]")
 
 /turf/closed/wall/mineral/plasma/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)//Doesn't fucking work because walls don't interact with air :(
 	if(exposed_temperature > 300)
@@ -153,8 +153,14 @@
 	icon = 'icons/turf/walls/snow_wall.dmi'
 	icon_state = "snow"
 	hardness = 80
+	explosion_block = 0
+	slicing_duration = 30
 	sheet_type = /obj/item/stack/sheet/mineral/snow
 	canSmoothWith = null
+	girder_type = null
+	
+/turf/closed/wall/mineral/snow/devastate_wall()
+	new sheet_type(src, sheet_amount)
 
 /turf/closed/wall/mineral/abductor
 	name = "alien wall"

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -158,9 +158,6 @@
 	sheet_type = /obj/item/stack/sheet/mineral/snow
 	canSmoothWith = null
 	girder_type = null
-	
-/turf/closed/wall/mineral/snow/devastate_wall()
-	new sheet_type(src, sheet_amount)
 
 /turf/closed/wall/mineral/abductor
 	name = "alien wall"

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -50,7 +50,8 @@
 
 /turf/closed/wall/proc/devastate_wall()
 	new sheet_type(src, sheet_amount)
-	new /obj/item/stack/sheet/metal(src)
+	if(girder_type)
+		new /obj/item/stack/sheet/metal(src)
 
 /turf/closed/wall/ex_act(severity, target)
 	if(target == src)


### PR DESCRIPTION
:cl: Swindly
tweak: Solid plasma now begins burning at the temperature at which it was ignited.
balance: Snow walls no longer block explosions, are deconstructed faster, and no longer leave girders when deconstructed.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Plasma walls appear to have been intended to have different burning temperatures for different sources of ignition, but this was not implemented. Plasma floors and sheets should copy the behavior for consistency.
Snow walls should not leave girders behind because they are created through snow's crafting menu. Snow should also not be better than gold at blocking explosions and should melt faster when welded because fire.