### PR TITLE
Buffs honey

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -523,7 +523,6 @@
 		M.adjustFireLoss(-1*REM, 0)
 		M.adjustOxyLoss(-1*REM, 0)
 		M.adjustToxLoss(-1*REM, 0)
-		. = 1
 	..()
 
 /datum/reagent/consumable/mayonnaise

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -510,15 +510,20 @@
 /datum/reagent/consumable/honey
 	name = "honey"
 	id = "honey"
-	description = "Sweet sweet honey, decays into sugar."
+	description = "Sweet sweet honey, decays into sugar and has natural healing properties."
 	color = "#d3a308"
 	nutriment_factor = 15 * REAGENTS_METABOLISM
+	metabolization_rate = 1 * REAGENTS_METABOLISM
 	taste_description = "sweetness"
 
 /datum/reagent/consumable/honey/on_mob_life(mob/living/M)
 	M.reagents.add_reagent("sugar",3)
-	if(prob(20))
-		M.heal_bodypart_damage(3,1)
+	if(prob(70))
+		M.adjustBruteLoss(-1*REM, 0)
+		M.adjustFireLoss(-1*REM, 0)
+		M.adjustOxyLoss(-1*REM, 0)
+		M.adjustToxLoss(-1*REM, 0)
+		. = 1
 	..()
 
 /datum/reagent/consumable/mayonnaise

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -518,7 +518,7 @@
 
 /datum/reagent/consumable/honey/on_mob_life(mob/living/M)
 	M.reagents.add_reagent("sugar",3)
-	if(prob(70))
+	if(prob(55))
 		M.adjustBruteLoss(-1*REM, 0)
 		M.adjustFireLoss(-1*REM, 0)
 		M.adjustOxyLoss(-1*REM, 0)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -155,6 +155,12 @@
 		filling.color = mix_color_from_reagents(reagents.reagent_list)
 		add_overlay(filling)
 
+/obj/item/weapon/reagent_containers/glass/beaker/jar
+	name = "honey jar"
+	desc = "A jar for honey. It can hold up to 50 units of sweet delight."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "vapour"
+
 /obj/item/weapon/reagent_containers/glass/beaker/large
 	name = "large beaker"
 	desc = "A large beaker. Can hold up to 100 units."


### PR DESCRIPTION
:cl: Tacolizard Forever: It's hip to fuck bees
add: Added a honey jar item. It's not implemented yet.
balance: Honey is now more robust at healing, but don't eat too much or you'll turn into a fatty landwhale.
/:cl:

**Every 2 seconds/tick, honey now has a ~~70~~ 55 percent chance to heal 1 point of brute, burn, oxy and tox damage.**

I made this change because honey is currently rather difficult to get and doesn't have much of a use. Aside from being used in three foods, it is useless. It does have healing ability, but it only had a 20% chance of healing either brute or burn.

**This change is balanced by the fact that honey is massively sugar-filled and relatively hard/time consuming to get. It will make you fat if ingested in any large amount. Honey gives nutrients to its user 15 times faster than the default, and gives 3 units of sugar regardless of RNG**