### PR TITLE
Zombies can see in the dark

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -17,6 +17,7 @@
 	no_equip = list(slot_wear_mask, slot_head)
 	armor = 20 // 120 damage to KO a zombie, which kills it
 	speedmod = 2
+	mutanteyes = /obj/item/organ/eyes/night_vision
 
 /datum/species/zombie/infectious/spec_life(mob/living/carbon/C)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -17,7 +17,7 @@
 	no_equip = list(slot_wear_mask, slot_head)
 	armor = 20 // 120 damage to KO a zombie, which kills it
 	speedmod = 2
-	mutanteyes = /obj/item/organ/eyes/night_vision
+	mutanteyes = /obj/item/organ/eyes/night_vision/zombie
 
 /datum/species/zombie/infectious/spec_life(mob/living/carbon/C)
 	. = ..()

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -64,6 +64,9 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	sight_flags = SEE_MOBS
 
+/obj/item/organ/eyes/night_vision/zombie
+	name = "undead eyes"
+	desc = "Somewhat counterintuitively, these half rotten eyes actually have superior vision to those of a living human."
 
 ///Robotic
 


### PR DESCRIPTION
:cl: optional name here
add: Zombies can now see in the dark. If you steal their eyes you'll be able to see in the dark as well!
/:cl:

Why: Playing any sort of mob without hands that can't see in the dark sucks, zombies are supposed to be spooky and spooky things go in the dark. They're also slow as hell so creating dark areas will help them ambush unwary people.