### PR TITLE
Fixes the recycler gibbing brainmobs

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -121,7 +121,7 @@
 		var/atom/movable/AM = i
 		var/obj/item/bodypart/head/as_head = AM
 		var/obj/item/device/mmi/as_mmi = AM
-		var/brain_holder = istype(AM, /obj/item/organ/brain) || (istype(as_head) && as_head.brain) || (istype(as_mmi) && as_mmi.brain)
+		var/brain_holder = istype(AM, /obj/item/organ/brain) || (istype(as_head) && as_head.brain) || (istype(as_mmi) && as_mmi.brain) || istype(AM, /mob/living/brain)
 		if(isliving(AM) || brain_holder)
 			if(emagged)
 				if(!brain_holder)


### PR DESCRIPTION
So it turns out that one apparent intent of the recycler was to prevent brains/heads/mmis from being destroyed, even when it was set to gib people(which it only does via var editing). Thing is, it still tried to destroy all of the object's contents. And for some reason, gibbing a brainmob makes the brain/head it's in disappear. What this meant was that if you threw an unoccupied head in the recycler, nothing would happen, but if you put one in that had someone in it the head would vanish.

Fixes some of #27142