### PR TITLE
Make Hermit Ruin more self-sufficient

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -84,6 +84,7 @@
 /area/ruin/powered)
 "p" = (
 /obj/structure/rack,
+/obj/item/weapon/storage/bag/plants/portaseeder,
 /obj/item/weapon/storage/bag/ore,
 /obj/item/weapon/storage/firstaid/regular,
 /turf/open/floor/plating/asteroid/basalt,


### PR DESCRIPTION
:cl: 
add: Hermit ruin now includes a portable seed extractor.
/:cl:

This ruin needed a portable seed extractor, I think.