### PR TITLE
Revert "Capitalizes machine names when they talk on radio"

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -296,7 +296,6 @@
 	// --- Cold, emotionless machines. ---
 	else if(isobj(M))
 		jobname = "Machine"
-		voice = capitalize(voice)
 
 	// --- Unidentifiable mob ---
 	else


### PR DESCRIPTION
Reverts tgstation/tgstation#27059

- Having the capitalization happen during radio processing is really weird, it doesn't apply if it speaks out loud
- Capitalizing objects names means its harder to tell that they're objects
- You're only capitalizing the first letter "Cloning pod", "Cryo tube", and it looks awful