### PR TITLE
Servant golems do not have special names

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -140,7 +140,10 @@
 		var/mob/living/carbon/human/H = new_spawn
 		H.set_cloned_appearance()
 		if(!name)
-			H.real_name = H.dna.species.random_name()
+			if(has_owner)
+				H.real_name = "[initial(X.prefix)] Golem ([rand(1,999)])"
+			else
+				H.real_name = H.dna.species.random_name()
 		else
 			H.real_name = name
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -25,14 +25,16 @@
 
 	var/prefix = "Iron"
 	var/list/special_names
+	var/human_surname_chance = 3
+	var/special_name_chance = 5
 
 /datum/species/golem/random_name(gender,unique,lastname)
 	var/golem_surname = pick(GLOB.golem_names)
 	// 3% chance that our golem has a human surname, because
 	// cultural contamination
-	if(prob(3))
+	if(prob(human_surname_chance))
 		golem_surname = pick(GLOB.last_names)
-	else if(special_names && prob(5))
+	else if(special_names && special_names.len && prob(special_name_chance))
 		golem_surname = pick(special_names)
 
 	var/golem_name = "[prefix] [golem_surname]"
@@ -212,7 +214,7 @@
 	id = "alloy golem"
 	fixed_mut_color = "333"
 	meat = /obj/item/stack/sheet/mineral/abductor
-	mutant_organs = list(/obj/item/organ/tongue/abductor) //abductor tongue
+	mutanttongue = /obj/item/organ/tongue/abductor
 	speedmod = 1 //faster
 	info_text = "As an <span class='danger'>Alloy Golem</span>, you are made of advanced alien materials: you are faster and regenerate over time. You are, however, only able to be heard by other alloy golems."
 	prefix = "Alien"
@@ -239,12 +241,9 @@
 	heatmod = 1.5
 	info_text = "As a <span class='danger'>Wooden Golem</span>, you have plant-like traits: you take damage from extreme temperatures, can be set on fire, and have lower armor than a normal golem. You regenerate when in the light and wither in the darkness."
 	prefix = "Wooden"
-
-/datum/species/golem/wood/random_name(gender,unique,lastname)
-	var/plant_name = pick("Tomato", "Potato", "Broccoli", "Carrot", "Ambrosia", "Pumpkin", "Ivy", "Kudzu", "Banana", "Moss", "Flower", "Bloom", "Root", "Bark", "Glowshroom", "Petal", "Leaf", \
-	"Venus", "Sprout","Cocoa", "Strawberry", "Citrus", "Oak", "Cactus", "Pepper", "Juniper")
-	var/golem_name = "[prefix] [plant_name]"
-	return golem_name
+	special_names = list("Tomato", "Potato", "Broccoli", "Carrot", "Ambrosia", "Pumpkin", "Ivy", "Kudzu", "Banana", "Moss", "Flower", "Bloom", "Root", "Bark", "Glowshroom", "Petal", "Leaf", "Venus", "Sprout","Cocoa", "Strawberry", "Citrus", "Oak", "Cactus", "Pepper", "Juniper")
+	human_surname_chance = 0
+	special_name_chance = 100
 
 /datum/species/golem/wood/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()


### PR DESCRIPTION
:cl: coiax
add: Servant golems now follow the "Material Golem (123)" naming scheme.
/:cl:

How to tell the difference between a free and a servant golem. The Free
Golem has a cooler name.

- Also some tidying of golem code, no gameplay changes.