### PR TITLE
Adds ahelp jobbans

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -62,6 +62,12 @@
 		body+= "<A href='?_src_=holder;jobban3=OOC;jobban4=\ref[M]'><font color=red>OOCBan</font></A> | "
 	else
 		body+= "<A href='?_src_=holder;jobban3=OOC;jobban4=\ref[M]'>OOCBan</A> | "
+
+	if(jobban_isbanned(M, "AHELP"))
+		body+= "<A href='?_src_=holder;jobban3=AHELP;jobban4=\ref[M]'><font color=red>AHELPBan</font></A> | "
+	else
+		body+= "<A href='?_src_=holder;jobban3=AHELP;jobban4=\ref[M]'>AHELPBan</A> | "
+
 	if(jobban_isbanned(M, "emote"))
 		body+= "<A href='?_src_=holder;jobban3=emote;jobban4=\ref[M]'><font color=red>EmoteBan</font></A> | "
 	else

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -459,7 +459,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	set name = "Adminhelp"
 
 	if(jobban_isbanned(src, "AHELP"))
-		src << "<span class='danger'>You have been banned from adminhelping. You will have to appeal this ban on the forums.</span>"
+		to_chat(src, "<span class='danger'>You have been banned from adminhelping. You will have to appeal this ban on the forums.</span>")
 		return
 
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -458,6 +458,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	set category = "Admin"
 	set name = "Adminhelp"
 
+	if(jobban_isbanned(src, "AHELP"))
+		src << "<span class='danger'>You have been banned from adminhelping. You will have to appeal this ban on the forums.</span>"
+		return
+
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return


### PR DESCRIPTION
:cl: Kor
add: Admins can now ban people from admin helping, to discourage frivolous and malicious ahelps. Admin helps are not meant as a method of OOC revenge when you've been obnoxious IC, so please don't use them as such.
/:cl:

Why:

DEAD: John Sweeps says, "i can also ahelp constantly about it until i get someone sympathetic"
DEAD: John Sweeps says, "so even if 90% of admins don't care if I get that 10% that do"
DEAD: John Sweeps says, "they get baned and I win"

KyrahAbattoir: ahelp is free and there is a small chance to turn around the situation, why not use it basically anytime someone bests you. [To be clear Kyrah does not think this is a good thing they are not a bad player!]

I think we need a way to slap people on the wrist for ahelping after they instigated a fight and got killed, but admins rarely want to jump to a full server ban, so maybe this can be a middleground.

>WHAT IF THE GUY GETS GRIEFED FOR REAL WHILE HE IS AHELP BANNED

Then he shouldn't have cried wolf so much and wasted everyones time/tried to use the support line to grief people beforehand