### PR TITLE
Revert "Dominators now require a significant amount of open turf around them"

### DIFF
--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -1,5 +1,3 @@
-#define DOM_BLOCKED_SPAM_CAP 6
-
 /obj/machinery/dominator
 	name = "dominator"
 	desc = "A visibly sinister device. Looks like you can break it if you hit it enough."
@@ -15,19 +13,8 @@
 	var/datum/gang/gang
 	var/operating = 0	//0=standby or broken, 1=takeover
 	var/warned = 0	//if this device has set off the warning at <3 minutes yet
-	var/spam_prevention = DOM_BLOCKED_SPAM_CAP //first message is immediate
 	var/datum/effect_system/spark_spread/spark_system
 	var/obj/effect/countdown/dominator/countdown
-
-/proc/dominator_excessive_walls(atom/A)
-	var/open = 0
-	for(var/turf/T in circleviewturfs(center=A,radius=3))
-		if(!istype(T, /turf/closed))
-			open++
-	if(open < 40)
-		return TRUE
-	else 
-		return FALSE
 
 /obj/machinery/dominator/tesla_act()
 	qdel(src)
@@ -61,16 +48,6 @@
 	if(gang && gang.is_dominating)
 		var/time_remaining = gang.domination_time_remaining()
 		if(time_remaining > 0)
-			if(dominator_excessive_walls(src))
-				gang.domination_timer += 2
-				playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
-				if(spam_prevention < DOM_BLOCKED_SPAM_CAP)
-					spam_prevention++
-				else
-					gang.message_gangtools("Warning: There are too many walls around your gang's dominator, its signal is being blocked!")
-					say("Error: Takeover signal is currently blocked! There are too many walls within 3 standard units of this device.")
-					spam_prevention = 0
-					return
 			. = TRUE
 			playsound(loc, 'sound/items/timer.ogg', 10, 0)
 			if(!warned && (time_remaining < 180))

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -305,11 +305,7 @@
 		if(obj.density)
 			to_chat(user, "<span class='warning'>There's not enough room here!</span>")
 			return FALSE
-	
-	if(dominator_excessive_walls(user))
-		to_chat(user, "span class='warning'>The <b>dominator</b> will not function here! The <b>dominator</b> requires an open space within three standard units so that walls do not interfere with the signal.</span>")
-		return FALSE
-		
+
 	if(!(usrarea.type in gang.territory|gang.territory_new))
 		to_chat(user, "<span class='warning'>The <b>dominator</b> can be spawned only on territory controlled by your gang!</span>")
 		return FALSE


### PR DESCRIPTION
Because robustin cannot into circles, it is physically impossible for a gang to have enough space visible to dominate.