### PR TITLE
Fixes engraved messages

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -176,9 +176,6 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/CollectChiselMessages()
 	var/savefile/chisel_messages_sav = new /savefile("data/npc_saves/ChiselMessages.sav")
 
-	// For debugging purposes.
-	chisel_messages_sav.ExportText("/", "data/npc_saves/ChiselMessages.txt")
-
 	for(var/obj/structure/chisel_message/M in chisel_messages)
 		saved_messages += list(M.pack())
 

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -9,7 +9,6 @@ SUBSYSTEM_DEF(persistence)
 
 	var/list/obj/structure/chisel_message/chisel_messages = list()
 	var/list/saved_messages = list()
-	var/savefile/chisel_messages_sav
 
 	var/savefile/trophy_sav
 	var/list/saved_trophies = list()
@@ -75,7 +74,7 @@ SUBSYSTEM_DEF(persistence)
 		break //Who's been duping the bird?!
 
 /datum/controller/subsystem/persistence/proc/LoadChiselMessages()
-	chisel_messages_sav = new /savefile("data/npc_saves/ChiselMessages.sav")
+	var/savefile/chisel_messages_sav = new /savefile("data/npc_saves/ChiselMessages.sav")
 	var/saved_json
 	chisel_messages_sav[SSmapping.config.map_name] >> saved_json
 
@@ -104,10 +103,8 @@ SUBSYSTEM_DEF(persistence)
 
 		var/obj/structure/chisel_message/M = new(T)
 
-		M.unpack(item)
-		if(!M.loc)
-			M.persists = FALSE
-			qdel(M)
+		if(!QDELETED(M))
+			M.unpack(item)
 
 /datum/controller/subsystem/persistence/proc/LoadTrophies()
 	trophy_sav = new /savefile("data/npc_saves/TrophyItems.sav")
@@ -175,6 +172,11 @@ SUBSYSTEM_DEF(persistence)
 	secret_satchels[SSmapping.config.map_name] << old_secret_satchels
 
 /datum/controller/subsystem/persistence/proc/CollectChiselMessages()
+	var/savefile/chisel_messages_sav = new /savefile("data/npc_saves/ChiselMessages.sav")
+
+	// For debugging purposes.
+	chisel_messages_sav.ExportText("/", "data/npc_saves/ChiselMessages.txt")
+
 	for(var/obj/structure/chisel_message/M in chisel_messages)
 		saved_messages += list(M.pack())
 

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -106,7 +106,7 @@ SUBSYSTEM_DEF(persistence)
 		if(!QDELETED(M))
 			M.unpack(item)
 
-	world.log << "Loaded [saved_messages.len] engraved messages on map [SSmapping.config.map_name]"
+	log_world("Loaded [saved_messages.len] engraved messages on map [SSmapping.config.map_name]")
 
 /datum/controller/subsystem/persistence/proc/LoadTrophies()
 	trophy_sav = new /savefile("data/npc_saves/TrophyItems.sav")
@@ -182,7 +182,7 @@ SUBSYSTEM_DEF(persistence)
 	for(var/obj/structure/chisel_message/M in chisel_messages)
 		saved_messages += list(M.pack())
 
-	world.log << "Saved [saved_messages.len] engraved messages on map [SSmapping.config.map_name]"
+	log_world("Saved [saved_messages.len] engraved messages on map [SSmapping.config.map_name]")
 
 	chisel_messages_sav[SSmapping.config.map_name] << json_encode(saved_messages)
 

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -81,7 +81,7 @@ SUBSYSTEM_DEF(persistence)
 	if(!saved_json)
 		return
 
-	var/saved_messages = json_decode(saved_json)
+	var/list/saved_messages = json_decode(saved_json)
 
 	for(var/item in saved_messages)
 		if(!islist(item))
@@ -105,6 +105,8 @@ SUBSYSTEM_DEF(persistence)
 
 		if(!QDELETED(M))
 			M.unpack(item)
+
+	world.log << "Loaded [saved_messages.len] engraved messages on map [SSmapping.config.map_name]"
 
 /datum/controller/subsystem/persistence/proc/LoadTrophies()
 	trophy_sav = new /savefile("data/npc_saves/TrophyItems.sav")
@@ -179,6 +181,8 @@ SUBSYSTEM_DEF(persistence)
 
 	for(var/obj/structure/chisel_message/M in chisel_messages)
 		saved_messages += list(M.pack())
+
+	world.log << "Saved [saved_messages.len] engraved messages on map [SSmapping.config.map_name]"
 
 	chisel_messages_sav[SSmapping.config.map_name] << json_encode(saved_messages)
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1688,15 +1688,6 @@
 					/obj/item/toy/crayon/rainbow)
 	crate_name = "art supply crate"
 
-/datum/supply_pack/misc/soapstone
-	name = "Curator Engraving/Scribbling Crate"
-	crate_name = "curator engraving/scribbling crate"
-	cost = 3000
-	contains = list(/obj/item/soapstone)
-	access = GLOB.access_library
-	crate_type = /obj/structure/closet/crate/secure
-
-
 /datum/supply_pack/misc/bsa
 	name = "Bluespace Artillery Parts"
 	cost = 15000

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -277,4 +277,4 @@ Janitor
 	belt = /obj/item/device/pda/janitor
 	ears = /obj/item/device/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/janitor
-	backpack_contents = list(/obj/item/device/modular_computer/tablet/preset/advanced=1, /obj/item/soapstone/empty=1)
+	backpack_contents = list(/obj/item/device/modular_computer/tablet/preset/advanced=1)


### PR DESCRIPTION
:cl: coiax
fix: Curator soapstones now successfully leave messages for future
shifts.
del: Soapstones can no longer be purchased in cargo.
del: The janitor no longer starts with an empty soapstone.
experiment: Engraved messages can be left anywhere in the world, but be
wary that the terrain of places like lavaland and space can change shift
to shift.
/:cl:

- Curators are now the sole owners of soapstones at shift start. This
means that a huge cargo point bounty shift will not overwhelm the
station with messages.
- Curators have an additional thing to curate.
- All the snowflake name bullshit is dumb, they're called soapstones,
they're plasma bluespace chisels, okay