### PR TITLE
Add CQC to traitor uplink for 20TCs

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -410,6 +410,14 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	cost = 1
 	include_modes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/stealthy_weapons/cqc2
+	name = "CQC Manual"
+	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing."
+	item = /obj/item/weapon/cqc_manual
+	exclude_modes = list(/datum/game_mode/nuclear)
+	cost = 20
+	surplus = 0
+
 /datum/uplink_item/ammo/revolver
 	name = ".357 Speed Loader"
 	desc = "A speed loader that contains seven additional .357 Magnum rounds; usable with the Syndicate revolver. \


### PR DESCRIPTION
[Changelogs]: Add CQC to the traitor uplink for 20 TCs

:cl: Nilons
add: CQC to the traitor uplink for 20TC
/:cl:

[why]: 20 TCs is specifically a highball because I would rather it be over expensive in practice than too cheap.  Thematically CQC makes more sense for a lone traitor as it gives them the opportunity to be stealthy as well as introducing more nonlethal options for them.  Although cool, its basically useless for nukeops who are constantly with a team, meaning they don't need to be able to use any of CQC's disabling abilities as an alternative to just killing people.  It's less robust than carp in actual combat, as it lacks the dodging capability, and having 4 out of 5 moves be to disable, sleep, or restrain people.

Pros:
-More thematically appropriate for traitors
-Gives players a nonlethal tool outside of an ebow, which is just used to kill people anyways.  More ways for traitors to deal with threats without removing people from the round is a win/win
-Discourages murderboning by being more useful in stealth or one on one situations
-Fun for people who like martial arts but don't want to be a cunt and murderbone

Cons
-Some people dislike having more martial arts in the game
-I don't have an accurate guess for how many TC's it should cost because its 13TC nuke op cost is also influenced by the number of TCs nuke ops gets, it and how its not useful.  Which is the reason for the highball

I understand PR's have been made for more martial arts to be added to the traitor uplink in the past, however, some of those were also proposing to add stupid martial arts that A: Didn't make sense to be in the uplink and B: Were much much more powerful than was appropriate.
CQC is different from things like plasma fist and wrestling because it puts a focus on disarms and stuns, and not only stuns, but nonlethal take downs.  Not like the ebow where sure you stun them but now kill them. As well as the fact that its much more interesting and likely
for a syndicate operative to know something like CQC than magical drunken kung fu that makes bullets curve around you.  Not to say that I'm advocating for the removal of Carp but I feel its soured a lot of people on traitor martial arts due to how it lends itself to 
murderboning and shittery inherently, while making it unfun for sec to try to take down the traitor using it.  While the argument could be made that people will just use the nonlethal takedowns to then kill people, I believe that again, an ebow will serve that purpose much better
as well as being cheaper.  Even though that is a player issue.  As for the price I'm open to anyone who wants to change it something they deem more fitting, but because you're able to use guns with CQC I don't think it's too out there for it to be expensive.

Side note: The iamgoofball PR that was just closed was because he used the code I made with lordpidey and vcordies assistance to open a meme pr because I said "<:^) freon" in the irc, which resulted in mine being redirected to his when I created the PR
