### PR TITLE
Free Golems can purchase their own royal capes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -148,10 +148,8 @@
 /area/ruin/powered/golem_ship)
 "u" = (
 /obj/structure/table/wood,
-/obj/item/weapon/bedsheet/rd{
-	desc = "Majestic.";
+/obj/item/weapon/bedsheet/rd/royal_cape{
 	layer = 3;
-	name = "Royal Cape of the Liberator";
 	pixel_x = 5;
 	pixel_y = 9
 	},

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -106,6 +106,11 @@ LINEN BINS
 	icon_state = "sheetrd"
 	item_color = "director"
 
+// for Free Golems.
+/obj/item/weapon/bedsheet/rd/royal_cape
+	name = "Royal Cape of the Liberator"
+	desc = "Majestic."
+
 /obj/item/weapon/bedsheet/medical
 	name = "medical blanket"
 	desc = "It's a sterilized* blanket commonly used in the Medbay.  *Sterilization is voided if a virologist is present onboard the station."

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -212,11 +212,10 @@
 		new /datum/data/mining_equipment("Monkey Cube",				/obj/item/weapon/reagent_containers/food/snacks/monkeycube,        		300),
 		new /datum/data/mining_equipment("Toolbelt",				/obj/item/weapon/storage/belt/utility,	    							350),
 		new /datum/data/mining_equipment("Sulphuric Acid",			/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,        		500),
-		new /datum/data/mining_equipment("Brute First-Aid Kit",		/obj/item/weapon/storage/firstaid/brute,						   		600),
 		new /datum/data/mining_equipment("Grey Slime Extract",		/obj/item/slime_extract/grey,				       		           		1000),
 		new /datum/data/mining_equipment("Modification Kit",    	/obj/item/borg/upgrade/modkit/trigger_guard, 		                	1700),
 		new /datum/data/mining_equipment("The Liberator's Legacy",  /obj/item/weapon/storage/box/rndboards,      			      			2000),
-
+		new /datum/data/mining_equipment("Royal Cape of the Liberator", /obj/item/weapon/bedsheet/rd/royal_cape, 500)
 		)
 
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/mining_equipment_vendor/golem(null)


### PR DESCRIPTION
:cl: coiax
add: Free Golems can purchase Royal Capes of the Liberator at their
mining equipment vendor.
/:cl:

- Golems can send ambassadors with their own capes to the station.
- Capes are cool.

- 500 seems enough for a completely non-combat item.

@XDTM @GunHog 