### PR TITLE
Remaps seed vault, adds bees and changes cherry to cherry bomb in random seed spawn

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -9,19 +9,89 @@
 /turf/closed/wall/r_wall,
 /area/ruin/powered)
 "d" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/weapon/lighter,
+/obj/item/weapon/lighter,
+/obj/item/weapon/storage/fancy/rollingpapers,
+/obj/item/weapon/storage/fancy/rollingpapers,
+/obj/item/weapon/storage/fancy/rollingpapers,
+/obj/item/weapon/storage/fancy/rollingpapers,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/area/ruin/powered)
 "e" = (
-/obj/machinery/smartfridge,
+/obj/structure/table/wood,
+/obj/item/weapon/storage/box/disks_plantgene,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
 "f" = (
+/obj/machinery/plantgenes/seedvault,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"g" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"h" = (
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"i" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/structure/beebox,
+/obj/item/weapon/melee/flyswatter,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/queen_bee/bought,
+/obj/item/clothing/head/beekeeper_head,
+/obj/item/clothing/suit/beekeeper_suit,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"j" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion";
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"k" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/seed_vault,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"l" = (
+/obj/machinery/door/airlock,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"m" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion";
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/lavaland/surface/outdoors)
+"n" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"o" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/weapon/cultivator,
 /obj/item/weapon/cultivator,
@@ -39,34 +109,22 @@
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"g" = (
+"p" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"h" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/seed_vault,
-/turf/open/floor/plasteel/freezer{
-	baseturf = /turf/open/floor/plating/lava/smooth
-	},
-/area/ruin/powered)
-"i" = (
-/obj/machinery/plantgenes/seedvault,
-/turf/open/floor/plasteel/freezer{
-	baseturf = /turf/open/floor/plating/lava/smooth
-	},
-/area/ruin/powered)
-"j" = (
+"q" = (
 /obj/item/weapon/hatchet,
 /obj/item/weapon/storage/bag/plants,
 /obj/item/weapon/reagent_containers/glass/bucket,
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"k" = (
+"r" = (
 /obj/structure/table/wood,
 /obj/item/weapon/storage/bag/plants,
 /obj/item/weapon/storage/bag/plants,
@@ -76,7 +134,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"l" = (
+"s" = (
 /obj/structure/table/wood,
 /obj/item/weapon/gun/energy/floragun,
 /obj/item/weapon/gun/energy/floragun,
@@ -87,25 +145,13 @@
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"m" = (
-/turf/open/floor/plasteel/freezer{
-	baseturf = /turf/open/floor/plating/lava/smooth
-	},
-/area/ruin/powered)
-"n" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"o" = (
+"t" = (
 /obj/effect/mob_spawn/human/seed_vault,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"p" = (
+"u" = (
 /obj/structure/sink{
 	icon_state = "sink";
 	dir = 8;
@@ -116,19 +162,19 @@
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"q" = (
+"v" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"r" = (
+"w" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"s" = (
+"x" = (
 /obj/machinery/reagentgrinder{
 	pixel_y = 5
 	},
@@ -141,7 +187,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"t" = (
+"y" = (
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -152,57 +198,51 @@
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"u" = (
-/obj/machinery/door/airlock,
-/turf/open/floor/plasteel/freezer{
-	baseturf = /turf/open/floor/plating/lava/smooth
-	},
-/area/ruin/powered)
-"v" = (
+"z" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"w" = (
+"A" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"x" = (
+"B" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"y" = (
+"C" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"z" = (
+"D" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"A" = (
-/obj/machinery/chem_dispenser/mutagen,
+"E" = (
+/obj/machinery/chem_dispenser/mutagensaltpeter,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"B" = (
+"F" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"C" = (
+"G" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/clothing/under/rank/hydroponics,
 /obj/item/clothing/under/rank/hydroponics,
@@ -212,13 +252,13 @@
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"D" = (
+"H" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"E" = (
+"I" = (
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/item/weapon/reagent_containers/glass/bucket,
@@ -228,25 +268,25 @@
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"F" = (
+"J" = (
 /obj/item/weapon/storage/toolbox/syndicate,
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered)
-"G" = (
+"K" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/ruin/powered)
-"H" = (
+"L" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"I" = (
+"M" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -284,10 +324,10 @@ a
 a
 a
 c
-o
-o
-o
-o
+t
+t
+t
+t
 c
 a
 a
@@ -299,17 +339,17 @@ b
 "}
 (3,1,1) = {"
 b
-b
+a
 a
 a
 a
 a
 c
 c
-m
-m
-m
-m
+h
+h
+h
+h
 c
 c
 a
@@ -321,16 +361,16 @@ b
 "}
 (4,1,1) = {"
 b
-b
 a
 a
-a
 c
 c
 c
 c
-u
-u
+c
+c
+l
+l
 c
 c
 c
@@ -344,18 +384,18 @@ a
 (5,1,1) = {"
 a
 a
-a
-a
-a
 c
-e
-m
-p
-m
-m
-p
-m
-p
+c
+k
+c
+n
+h
+u
+h
+h
+u
+h
+u
 c
 a
 a
@@ -366,18 +406,18 @@ a
 (6,1,1) = {"
 a
 a
-a
-a
-a
 c
-f
-m
-m
-m
-m
-m
-m
-C
+d
+h
+c
+o
+h
+h
+h
+h
+h
+h
+G
 c
 a
 a
@@ -388,18 +428,18 @@ a
 (7,1,1) = {"
 a
 a
-a
-a
-a
 c
-g
-m
-g
-m
-m
-g
-m
-g
+e
+h
+c
+p
+h
+p
+h
+h
+p
+h
+p
 c
 a
 a
@@ -408,44 +448,44 @@ a
 a
 "}
 (8,1,1) = {"
-a
-a
-a
-a
+b
 a
 c
+e
 h
-m
-q
-m
-m
-x
+l
+h
+h
+v
+h
+h
 B
-B
-G
-H
+F
+F
+K
+L
 a
 a
 a
 a
 "}
 (9,1,1) = {"
-a
-a
-a
-a
+b
 a
 c
-i
-m
-e
-m
-m
-y
-m
-m
+f
+h
 c
-I
+p
+h
+n
+h
+h
+C
+h
+k
+c
+M
 a
 a
 a
@@ -454,18 +494,18 @@ a
 (10,1,1) = {"
 a
 a
-a
-a
-a
 c
 g
-m
-r
-m
-m
-z
-m
-g
+h
+c
+p
+h
+w
+h
+h
+D
+h
+p
 c
 b
 a
@@ -476,18 +516,18 @@ a
 (11,1,1) = {"
 a
 a
-a
-a
-a
 c
-j
-m
-s
-m
-m
-A
-m
-D
+h
+h
+c
+q
+h
+x
+h
+h
+E
+h
+H
 c
 a
 a
@@ -496,20 +536,20 @@ a
 a
 "}
 (12,1,1) = {"
-a
-a
-a
-a
+b
 a
 c
-g
-m
-m
-m
-m
-m
-m
-g
+h
+h
+c
+p
+h
+h
+h
+h
+h
+h
+p
 c
 a
 a
@@ -520,18 +560,18 @@ a
 (13,1,1) = {"
 a
 a
-a
-a
-a
 c
-k
-m
-m
-g
-g
-m
-m
-E
+i
+h
+c
+r
+h
+h
+p
+p
+h
+h
+I
 c
 a
 a
@@ -542,18 +582,18 @@ a
 (14,1,1) = {"
 a
 a
-a
-a
-a
 c
-l
-m
-t
-m
-m
-t
-m
-F
+c
+i
+c
+s
+h
+y
+h
+h
+y
+h
+J
 c
 a
 a
@@ -564,15 +604,15 @@ a
 (15,1,1) = {"
 a
 a
-a
-a
-a
+b
 c
 c
 c
 c
-v
-v
+c
+c
+z
+z
 c
 c
 c
@@ -584,21 +624,21 @@ a
 a
 "}
 (16,1,1) = {"
-a
-a
 b
 a
-a
-d
-c
-n
+b
+j
 c
 m
-m
 c
-n
+j
 c
-n
+h
+h
+c
+j
+c
+j
 a
 a
 a
@@ -611,12 +651,12 @@ a
 a
 a
 a
-b
 a
-b
+a
+a
 c
-w
-w
+A
+A
 c
 b
 b

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -629,7 +629,7 @@ a
 b
 j
 c
-m
+j
 c
 j
 c

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -133,6 +133,7 @@
 		loc = BB
 		target = null
 		wanted_objects -= typecacheof(/obj/structure/beebox) //so we don't attack beeboxes when not going home
+		return //no don't attack the goddamm box
 	else
 		. = ..()
 		if(. && beegent && isliving(target))

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -367,3 +367,9 @@
 	desc = "Creates and dispenses mutagen."
 	dispensable_reagents = list("mutagen")
 	emagged_reagents = list("plasma")
+
+
+/obj/machinery/chem_dispenser/mutagensaltpeter
+	name = "mutagen and saltpeter dispenser"
+	desc = "Creates and dispenses mutagen and even saltpeter."
+	dispensable_reagents = list("mutagen", "saltpetre")

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -11,7 +11,7 @@
 	lootcount = 1
 
 	loot = list(/obj/item/seeds/gatfruit = 10,
-				/obj/item/seeds/cherry = 15,
+				/obj/item/seeds/cherry/bomb = 15,
 				/obj/item/seeds/berry/glow = 10,
 				/obj/item/seeds/sunflower/moonflower = 8
 				)

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -11,7 +11,7 @@
 	lootcount = 1
 
 	loot = list(/obj/item/seeds/gatfruit = 10,
-				/obj/item/seeds/cherry/bomb = 15,
+				/obj/item/seeds/cherry/bomb = 10,
 				/obj/item/seeds/berry/glow = 10,
 				/obj/item/seeds/sunflower/moonflower = 8
 				)


### PR DESCRIPTION
:cl: ma44
tweak: Seed vault remapped
tweak: The seed vault random seed spawner can now spawn cherry bombs instead of regular cherry seeds
add: BEES to plant vault
/:cl:

NEW: attempt to fix bees attacking bee box

Image of map
https://i.gyazo.com/53c1ede6d4f43d816ee8c94d43100d6b.png

[why]: 
Bees: Teaches people to use bees and mechanics associated with it, and it's also botany themed so it's slapped into the vault. Bee box isn't premade so miners walking in won't get killed by bees (bees are a bit robust, especially if it's premade as it has a lot of bees)

Gene manipulator position change: With tech disks being the main thing to use and keep next to the machine for easiest access, since there are no tables (in which about every map's gene manip has a table nearby) it's hard to store tech disks without just endlessly right clicking, this is solved by putting it in the back room with the bees and some tables. 

Zippos/rolling paper: Smoke weed everyday

Cherry to cherry bomb: I'm pretty sure this was meant to be a bomb, unless for some reason that a rare random speed spawn has to have a tier 1 plant included (and maybe or maybe not coincidentally a cherry)