### PR TITLE
Buffs nitrous oxide

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1111,7 +1111,7 @@
 	description = "A potent oxidizer used as fuel in rockets and as an anaesthetic during surgery."
 	reagent_state = LIQUID
 	color = "#808080"
-	taste_description = "numbness"
+	taste_description = "sweetness"
 
 /datum/reagent/nitrous_oxide/reaction_obj(obj/O, reac_volume)
 	if((!O) || (!reac_volume))
@@ -1122,7 +1122,19 @@
 	if(istype(T))
 		T.atmos_spawn_air("n2o=[reac_volume/5];TEMP=[T20C]")
 
-
+/datum/reagent/nitrous_oxide/reaction_mob(mob/M, method=TOUCH, reac_volume)
+	if(method == VAPOR)
+		M.drowsyness += max(round(reac_volume, 1), 2)
+		
+/datum/reagent/nitrous_oxide/on_mob_life(mob/living/M)
+	M.drowsyness += 2
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.blood_volume -= 2.5
+	if(prob(20))
+		M.losebreath += 2
+		M.confused = min(M.confused + 2, 5)
+	..()
 
 /////////////////////////Coloured Crayon Powder////////////////////////////
 //For colouring in /proc/mix_color_from_reagents

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1110,6 +1110,7 @@
 	id = "nitrous_oxide"
 	description = "A potent oxidizer used as fuel in rockets and as an anaesthetic during surgery."
 	reagent_state = LIQUID
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	color = "#808080"
 	taste_description = "sweetness"
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1130,7 +1130,7 @@
 	M.drowsyness += 2
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.blood_volume -= 2.5
+		H.blood_volume = max(H.blood_volume - 2.5, 0)
 	if(prob(20))
 		M.losebreath += 2
 		M.confused = min(M.confused + 2, 5)


### PR DESCRIPTION
:cl: Swindly
balance: Nitrous oxide now causes anemia.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Let's see how many units of nitrous oxide have been made in [the](https://atlantaned.space/newSS13tools/stats/monthlyStats.php?year=2017&month=02&stat=chemical_reaction) [three](https://atlantaned.space/newSS13tools/stats/monthlyStats.php?year=2017&month=03&stat=chemical_reaction) [months](https://atlantaned.space/newSS13tools/stats/monthlyStats.php?year=2017&month=04&stat=chemical_reaction) it's been tracked:

48

Putting barriers of production on an explosive over which a strict improvement exists was a mistake. Giving it another use will give people reason to make it.