### PR TITLE
Fixed tech disk exports

### DIFF
--- a/code/modules/cargo/exports/research.dm
+++ b/code/modules/cargo/exports/research.dm
@@ -22,4 +22,4 @@
 		if(!V)
 			continue
 		var/datum/tech/tech = V
-		techLevels[tech.id] = tech.level
+		techLevels[tech.id] = max(techLevels[tech.id], tech.level)

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -203,7 +203,6 @@ research holder datum.
 	var/level = 1						//A simple number scale of the research level. Level 0 = Secret tech.
 	var/rare = 1						//How much CentCom wants to get that tech. Used in supply shuttle tech cost calculation.
 	var/list/req_tech = list()			//List of ids associated values of techs required to research this tech. "id" = #
-	var/exported_level = 0
 
 
 //Trunk Technologies (don't require any other techs and you start knowning them).
@@ -307,10 +306,6 @@ research holder datum.
 
 	if(current_level >= level)
 		return 0
-		
-	if(exported_level == level)
-		return 0
-	exported_level = level
 
 	var/cost = 0
 	for(var/i=current_level+1, i<=level, i++)


### PR DESCRIPTION
You can sell tech disks again.
You can no longer sell low-level tech disks and then re-sell higher level tech disks over and over again.
