### PR TITLE
Adds a disk slot to the ORM, to allow the uploading of new smelter designs

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -23,6 +23,7 @@
 	var/list/ore_buffer = list()
 	var/datum/material_container/materials
 	var/datum/research/files
+	var/obj/item/weapon/disk/design_disk/inserted_disk
 
 /obj/machinery/mineral/ore_redemption/Initialize()
 	. = ..()
@@ -188,6 +189,11 @@
 		to_chat(user, "<span class='notice'>You change [src]'s I/O settings, setting the input to [dir2text(input_dir)] and the output to [dir2text(output_dir)].</span>")
 		return
 
+	if(istype(W, /obj/item/weapon/disk/design_disk))
+		if(user.transferItemToLoc(W, src))
+			inserted_disk = W
+			return TRUE
+
 	return ..()
 
 /obj/machinery/mineral/ore_redemption/on_deconstruction()
@@ -219,6 +225,8 @@
 			else
 				dat += "<span  class='linkOff'>Release</span><br>"
 
+	dat += "<br><b>Alloys: </b><br>"
+
 	for(var/v in files.known_designs)
 		var/datum/design/D = files.known_designs[v]
 		if(can_smelt_alloy(D))
@@ -227,6 +235,20 @@
 			dat += "[D.name]: <span class='linkOff'>Smelt</span><br>"
 
 	dat += "<br><div class='statusDisplay'><b>Mineral Value List:</b><br>[get_ore_values()]</div>"
+
+	if(inserted_disk)
+		dat += "<A href='?src=\ref[src];eject_disk=1'>Eject disk</A><br>"
+		dat += "<div class='statusDisplay'><b>Uploadable designs: </b><br>"
+
+		for(var/i in 1 to inserted_disk.max_blueprints)
+			if(inserted_disk.blueprints[i])
+				var/datum/design/D = inserted_disk.blueprints[i]
+				if(D.build_type & SMELTER)
+					dat += "Name: [D.name] <A href='?src=\ref[src];upload=[i]'>Upload to smelter</A>"
+
+		dat += "</div><br>"
+	else
+		dat += "<A href='?src=\ref[src];insert_disk=1'>Insert design disk</A><br><br>"
 
 	var/datum/browser/popup = new(user, "ore_redemption_machine", "Ore Redemption Machine", 400, 500)
 	popup.set_content(dat)
@@ -257,12 +279,26 @@
 	else if(href_list["insert_id"])
 		var/obj/item/weapon/card/id/I = usr.get_active_held_item()
 		if(istype(I))
-			if(!usr.drop_item())
+			if(!usr.transferItemToLoc(I,src))
 				return
-			I.forceMove(src)
 			inserted_id = I
 		else
 			to_chat(usr, "<span class='warning'>Not a valid ID!</span>")
+	if(href_list["eject_disk"])
+		if(inserted_disk)
+			inserted_disk.forceMove(loc)
+			inserted_disk = null
+	if(href_list["insert_disk"])
+		var/obj/item/weapon/disk/design_disk/D = usr.get_active_held_item()
+		if(istype(D))
+			if(!usr.transferItemToLoc(D,src))
+				return
+			inserted_disk = D
+	if(href_list["upload"])
+		var/n = text2num(href_list["upload"])
+		if(inserted_disk && inserted_disk.blueprints && inserted_disk.blueprints[n])
+			files.AddDesign2Known(inserted_disk.blueprints[n])
+
 	if(href_list["release"])
 		if(check_access(inserted_id) || allowed(usr)) //Check the ID inside, otherwise check the user
 			var/mat_id = href_list["release"]

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -653,14 +653,3 @@ other types of metals and chemistry for reagents).
 	materials = list(MAT_METAL = 1000, MAT_GLASS = 500, MAT_PLASMA = 1500, MAT_URANIUM = 200)
 	build_path = /obj/item/weapon/weldingtool/experimental
 	category = list("Equipment")
-
-
-/datum/design/alienalloy
-	name = "Alien Alloy"
-	desc = "A sheet of reverse-engineered alien alloy."
-	id = "alienalloy"
-	req_tech = list("abductor" = 1, "materials" = 7, "plasmatech" = 2)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 4000, MAT_PLASMA = 4000)
-	build_path = /obj/item/stack/sheet/mineral/abductor
-	category = list("Stock Parts")

--- a/code/modules/research/designs/smelting_designs.dm
+++ b/code/modules/research/designs/smelting_designs.dm
@@ -22,7 +22,7 @@
 	desc = "A sheet of reverse-engineered alien alloy."
 	id = "alienalloy"
 	req_tech = list("abductor" = 1, "materials" = 7, "plasmatech" = 2)
-	build_type = PROTOLATHE |SMELTER
+	build_type = PROTOLATHE | SMELTER
 	materials = list(MAT_METAL = 4000, MAT_PLASMA = 4000)
 	build_path = /obj/item/stack/sheet/mineral/abductor
 	category = list("Stock Parts")

--- a/code/modules/research/designs/smelting_designs.dm
+++ b/code/modules/research/designs/smelting_designs.dm
@@ -6,7 +6,7 @@
 	build_type = SMELTER
 	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT / 2, MAT_PLASMA = MINERAL_MATERIAL_AMOUNT / 2)
 	build_path = /obj/item/stack/sheet/plasteel
-	category = list("initial","Alloys")
+	category = list("initial")
 
 
 /datum/design/plastitanium_alloy
@@ -15,4 +15,14 @@
 	build_type = SMELTER
 	materials = list(MAT_TITANIUM = MINERAL_MATERIAL_AMOUNT / 2, MAT_PLASMA = MINERAL_MATERIAL_AMOUNT / 2)
 	build_path = /obj/item/stack/sheet/mineral/plastitanium
-	category = list("initial","Alloys")
+	category = list("initial")
+
+/datum/design/alienalloy
+	name = "Alien Alloy"
+	desc = "A sheet of reverse-engineered alien alloy."
+	id = "alienalloy"
+	req_tech = list("abductor" = 1, "materials" = 7, "plasmatech" = 2)
+	build_type = PROTOLATHE |SMELTER
+	materials = list(MAT_METAL = 4000, MAT_PLASMA = 4000)
+	build_path = /obj/item/stack/sheet/mineral/abductor
+	category = list("Stock Parts")

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -728,6 +728,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 						if(D.build_type & AUTOLATHE) dat += "Autolathe<BR>"
 						if(D.build_type & MECHFAB) dat += "Exosuit Fabricator<BR>"
 						if(D.build_type & BIOGENERATOR) dat += "Biogenerator<BR>"
+						if(D.build_type & LIMBGROWER) dat += "Limbgrower<BR>"
+						if(D.build_type & SMELTER) dat += "Smelter<BR>"
 					dat += "Required Materials:<BR>"
 					var/all_mats = D.materials + D.reagents_list
 					for(var/M in all_mats)


### PR DESCRIPTION
:cl: Profakos
add: Centcom has decided to upgrade the Ore Redemption machines with a floppy drive, intended for design disks.
/:cl:

This adds the ability to upload designs with the SMELTER buildtype to the Ore Redemption machine. Currently, the only transferable alloy is Alien Alloy (plastitanium and plasteel are known by the smelter by default). The ORM is not as efficient as the Protolathe, but at least it is conveniently close.
 
