### PR TITLE
 ROBUSTIN: Gang mode now calls a 4 minute shuttle once 60% of the crew is dead""

### DIFF
--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -7,6 +7,7 @@ GLOBAL_LIST_INIT(gang_colors_pool, list("red","orange","yellow","green","blue","
 /datum/game_mode
 	var/list/datum/gang/gangs = list()
 	var/datum/gang_points/gang_points
+	var/forced_shuttle = FALSE
 
 /proc/is_gangster(var/mob/living/M)
 	return istype(M) && M.mind && M.mind.gang_datum
@@ -248,6 +249,19 @@ GLOBAL_LIST_INIT(gang_colors_pool, list("red","orange","yellow","green","blue","
 		gang_bosses += G.bosses
 	return gang_bosses
 
+/datum/game_mode/proc/shuttle_check()
+	if(forced_shuttle)
+		return
+	var/alive = 0
+	for(var/mob/living/L in GLOB.player_list)
+		if(L.stat != DEAD)
+			alive++
+	if(alive < LAZYLEN(GLOB.joined_player_list) * 0.4)
+		priority_announce("Catastrophic casualties detected: crisis shuttle protocols activated - jamming recall signals across all frequencies.")
+		forced_shuttle = TRUE
+		if(SSshuttle.emergency.timeLeft(1) < (SSshuttle.emergencyCallTime * 0.4))
+			SSshuttle.emergency.request(null, set_coefficient = 0.4)
+
 /proc/determine_domination_time(var/datum/gang/G)
 	return max(180,480 - (round((G.territory.len/GLOB.start_state.num_territories)*100, 1) * 9))
 
@@ -306,6 +320,8 @@ GLOBAL_LIST_INIT(gang_colors_pool, list("red","orange","yellow","green","blue","
 
 	if(world.time > next_point_time)
 		next_point_time = world.time + next_point_interval
+		SSticker.mode.shuttle_check()
+
 
 	if(winners.len)
 		if(winners.len > 1) //Edge Case: If more than one dominator complete at the same time

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -164,6 +164,9 @@
 /obj/item/device/gangtool/proc/recall(mob/user)
 	if(!can_use(user))
 		return 0
+		
+	if(SSticker.mode.forced_shuttle)
+		return 0
 
 	if(recalling)
 		to_chat(usr, "<span class='warning'>Error: Recall already in progress.</span>")


### PR DESCRIPTION
:cl: Oldman Robustin
tweak: Gang mode now calls a 4 minute shuttle once 60% of the crew is dead
/:cl:

Reverts tgstation/tgstation#27227

Reason: even if they broke a rule kor also did break rule by self-merging, let's keep this at 24 hours limit this time if that makes kor happy.