### PR TITLE
Nerfs Manifest Spirit

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -28,7 +28,7 @@
 
 /obj/item/weapon/melee/cultblade/ghost
 	name = "eldritch sword"
-	force = 20
+	force = 19 //can't break normal airlocks
 	flags = NODROP|DROPDEL
 
 /obj/item/weapon/melee/cultblade/pickup(mob/living/user)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -943,6 +943,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 	new_human.apply_status_effect(STATUS_EFFECT_SUMMONEDGHOST) //ghosts can't summon more ghosts
 	..()
 	ghosts++
+	playsound(src, 'sound/magic/exit_blood.ogg', 50, 1)
+	user.apply_damage(10, BRUTE)
 	visible_message("<span class='warning'>A cloud of red mist forms above [src], and from within steps... a [new_human.gender == FEMALE ? "wo":""]man.</span>")
 	to_chat(user, "<span class='cultitalic'>Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely...</span>")
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
:cl: Joan
balance: The summoned ghosts from Manifest Spirit can no longer break airlocks with their standard blade.
balance: Manifest Spirit now does a small amount of damage when initially manifesting a ghost.
/:cl:

A single summoned ghost held security the fuck up and they hated it because it kept coming back. Admittedly, the summoner was largely immune to brute damage, but it's still kind of a pain.
