### PR TITLE
Revert "Mode.txt is no longer in the repo (#27182)"

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -280,12 +280,11 @@
 	world << sound(round_end_sound)
 
 /world/proc/load_mode()
-	var/mode = file2text("data/mode.txt")
-	if(mode)
-		GLOB.master_mode = mode
-	else
-		GLOB.master_mode = "extended"
-	log_game("Saved mode is '[GLOB.master_mode]'")	
+	var/list/Lines = world.file2list("data/mode.txt")
+	if(Lines.len)
+		if(Lines[1])
+			GLOB.master_mode = Lines[1]
+			GLOB.world_game_log << "Saved mode is '[GLOB.master_mode]'"
 
 /world/proc/save_mode(the_mode)
 	var/F = file("data/mode.txt")

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,0 +1,1 @@
+extended


### PR DESCRIPTION
This reverts commit ee4f4e4f0e7c91ca7b2eba58ec2bf88a2dbce304. (#27182)

@Cyberboss please stop making random unrelated changes without at least testing them.

`file2text()` includes trailing newlines, like the one `file << ` adds to any file.

This prevents modes from matching up correctly.

The amount of bugs caused because you made an unrelated change to some pr without testing it (usually because you saw something do something a different way then you would have done it and you just assumed that is was for no reason) is honestly getting annoying.

Changing this to file2text() was unrelated to the pr, you only needed to remove a file and add a default option. And if you are going to make these unrelated changes, You need to actually test them, and/or double check that it wasn't done that way for a reason.