### PR TITLE
Clowns get an automatic self-recharging pie cannon as a traitor item for 10TC

### DIFF
--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -242,7 +242,7 @@
 	range_multiplier = 3
 	fire_mode = PCANNON_FIFO
 	throw_amount = 1
-	maxWeightClass = 100	//50 pies. :^)
+	maxWeightClass = 150	//50 pies. :^)
 	clumsyCheck = FALSE
 
 /obj/item/weapon/pneumatic_cannon/pie/can_load_item(obj/item/I, mob/user)
@@ -250,3 +250,22 @@
 		return ..()
 	to_chat(user, "<span class='warning'>[src] only accepts pies!</span>")
 	return FALSE
+
+/obj/item/weapon/pneumatic_cannon/pie/selfcharge
+	automatic = TRUE
+	var/charge_amount = 1
+	var/charge_ticks = 1
+	var/charge_tick = 0
+	maxWeightClass = 60	//20 pies.
+
+/obj/item/weapon/pneumatic_cannon/pie/selfcharge/Initialize()
+	. = ..()
+	START_PROCESSING(SSobj, src)
+
+/obj/item/weapon/pneumatic_cannon/pie/selfcharge/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/weapon/pneumatic_cannon/pie/selfcharge/process()
+	if(++charge_tick >= charge_ticks)
+		fill_with_type(/obj/item/weapon/reagent_containers/food/snacks/pie, charge_amount)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1267,6 +1267,14 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
 
+/datum/uplink_item/role_restricted/pie_cannon
+	name = "Banana Cream Pie Cannon"
+	desc = "A special pie cannon for a special clown, this gadget can hold up to 20 pies and automatically fabricates one every two seconds!"
+	cost = 10
+	item = /obj/item/weapon/pneumatic_cannon/pie/selfcharge
+	restricted_roles = list("Clown")
+	surplus = 0	//No fun unless you're the clown!
+
 /datum/uplink_item/role_restricted/ancient_jumpsuit
 	name = "Ancient Jumpsuit"
 	desc = "A tattered old jumpsuit that will provide absolutely no benefit to you. It fills the wearer with a strange compulsion to blurt out 'glorf'."


### PR DESCRIPTION
Hey, it's less OP than the memebow.
20 max charges, 2 seconds/charge.

Question: Should I lower it to 10 max, and 6 seconds/charge, but let you add reagents to all of them by pouring reagents in? 