### PR TITLE
Enable Ambrosia Gaia, attempt balance

### DIFF
--- a/code/modules/hydroponics/grown/ambrosia.dm
+++ b/code/modules/hydroponics/grown/ambrosia.dm
@@ -39,7 +39,7 @@
 	species = "ambrosiadeus"
 	plantname = "Ambrosia Deus"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/deus
-	mutatelist = list()
+	mutatelist = list(/obj/item/seeds/ambrosia/gaia)
 	reagents_add = list("omnizine" = 0.15, "synaptizine" = 0.15, "space_drugs" = 0.1, "vitamin" = 0.04, "nutriment" = 0.05)
 	rarity = 40
 
@@ -59,7 +59,7 @@
 	species = "ambrosia_gaia"
 	plantname = "Ambrosia Gaia"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/gaia
-	mutatelist = list()
+	mutatelist = list(/obj/item/seeds/ambrosia/deus)
 	reagents_add = list("earthsblood" = 0.05, "nutriment" = 0.06, "vitamin" = 0.05)
 	rarity = 30 //These are some pretty good plants right here
 	genes = list()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -331,6 +331,9 @@
 	if(!self_sustaining)
 		to_chat(user, "<span class='info'>Water: [waterlevel]/[maxwater]</span>")
 		to_chat(user, "<span class='info'>Nutrient: [nutrilevel]/[maxnutri]</span>")
+		if(self_sufficiency_progress > 0)
+			var/percent_progress = round(self_sufficiency_progress * 100 / self_sufficiency_req)
+			to_chat(user, "<span class='info'>Treatment for self-sustenance are [percent_progress]% complete.</span>")
 	else
 		to_chat(user, "<span class='info'>It doesn't require any water or nutrients.</span>")
 
@@ -510,7 +513,10 @@
 	// Ambrosia Gaia produces earthsblood.
 	if(S.has_reagent("earthsblood"))
 		self_sufficiency_progress += S.get_reagent_amount("earthsblood")
-		//if(self_sufficiency_progress >= self_sufficiency_req)
+		if(self_sufficiency_progress >= self_sufficiency_req)
+			become_self_sufficient()
+		else if(!self_sustaining)
+			to_chat(user, "<span class='notice'>[src] warms as it might on a spring day under a genuine Sun.</span>")
 
 	// Antitoxin binds shit pretty well. So the tox goes significantly down
 	if(S.has_reagent("charcoal", 1))
@@ -911,6 +917,10 @@
 	var/mob/living/simple_animal/hostile/C = new chosen
 	C.faction = list("plants")
 
+/obj/machinery/hydroponics/proc/become_self_sufficient() // Ambrosia Gaia effect
+	visible_message("<span class='boldnotice'>[src] begins to glow with a beautiful light!</span>")
+	self_sustaining = TRUE
+	update_icon()
 
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -682,33 +682,7 @@
 
 /obj/machinery/hydroponics/attackby(obj/item/O, mob/user, params)
 	//Called when mob user "attacks" it with object O
-	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/gaia)) //Checked early on so it doesn't have to deal with composting checks
-		if(self_sustaining)
-			to_chat(user, "<span class='warning'>This [name] is already self-sustaining!</span>")
-			return
-		if(myseed || weedlevel)
-			to_chat(user, "<span class='warning'>[src] needs to be clear of plants and weeds!</span>")
-			return
-		if(alert(user, "This will make [src] self-sustaining but consume [O] forever. Are you sure?", "[name]", "I'm Sure", "Abort") == "Abort" || !user)
-			return
-		if(!O || QDELETED(O))
-			return
-		if(!Adjacent(user))
-			return
-		if(self_sustaining)
-			to_chat(user, "<span class='warning'>This [name] is already self-sustaining!</span>")
-			return
-		if(myseed || weedlevel)
-			to_chat(user, "<span class='warning'>[src] needs to be clear of plants and weeds!</span>")
-			return
-		user.visible_message("<span class='notice'>[user] gently pulls open the soil for [O] and places it inside.</span>", "<span class='notice'>You tenderly root [O] into [src].</span>")
-		user.drop_item()
-		qdel(O)
-		visible_message("<span class='boldnotice'>[src] begins to glow with a beautiful light!</span>")
-		self_sustaining = TRUE
-		update_icon()
-
-	else if(istype(O, /obj/item/weapon/reagent_containers) )  // Syringe stuff (and other reagent containers now too)
+	if(istype(O, /obj/item/weapon/reagent_containers) )  // Syringe stuff (and other reagent containers now too)
 		var/obj/item/weapon/reagent_containers/reagent_source = O
 
 		if(istype(reagent_source, /obj/item/weapon/reagent_containers/syringe))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -27,6 +27,8 @@
 	var/unwrenchable = 1
 	var/recent_bee_visit = FALSE //Have we been visited by a bee recently, so bees dont overpollinate one plant
 	var/using_irrigation = FALSE //If the tray is connected to other trays via irrigation hoses
+	var/self_sufficiency_req = 20 //Required total dose to make a self-sufficient hydro tray. 1:1 with earthsblood.
+	var/self_sufficiency_progress = 0
 	var/self_sustaining = FALSE //If the tray generates nutrients and water on its own
 
 
@@ -504,6 +506,11 @@
 		yieldmod = 1.3
 		mutmod = 0
 		adjustNutri(round(S.get_reagent_amount("robustharvestnutriment") *1 ))
+	
+	// Ambrosia Gaia produces earthsblood.
+	if(S.has_reagent("earthsblood"))
+		self_sufficiency_progress += S.get_reagent_amount("earthsblood")
+		//if(self_sufficiency_progress >= self_sufficiency_req)
 
 	// Antitoxin binds shit pretty well. So the tox goes significantly down
 	if(S.has_reagent("charcoal", 1))


### PR DESCRIPTION
Ambrosia Deus can mutate into Gaia, and A. Gaia can mutate into Deus.
A sufficiently high dose of the Earthsblood reagent produced in Ambrosia Gaia will make a hydroponics tray self-sufficient.

:cl:
add: Ambrosia Deus can now mutate into Gaia, and Gaia into Deus.
del: A single branch of Ambrosia Gaia will not immediately make a hydroponics tray self-sufficient.
balance: A (total) dose of 20u Earthsblood (from Gaia) will make a hydroponics tray self-sufficient.
/:cl:

A dose of 20 u is about 4 full-potency Gaia branches.
Gaia -> Deus because of routine meta of rushing past Deus to get that sweet, golden Gaia.