### PR TITLE
[Box] Area Power Fixes

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -22256,7 +22256,7 @@
 "aYa" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "Locker Room Maintenance APC";
+	name = "Aft Port Maintenance APC";
 	pixel_x = -27;
 	pixel_y = 2
 	},

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -12442,7 +12442,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/fpmaint)
+/area/gateway)
 "aBj" = (
 /obj/structure/rack{
 	dir = 8;
@@ -25277,7 +25277,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/quartermaster/storage)
 "bfl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -27849,11 +27849,6 @@
 /area/bridge/meeting_room)
 "bkY" = (
 /obj/effect/landmark/blobstart,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -60892,7 +60887,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/security/detectives_office)
 "cCo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -91091,7 +91086,7 @@ bda
 bca
 bgJ
 aZP
-bjD
+bjB
 bkY
 bmo
 bnP
@@ -101939,7 +101934,7 @@ bVu
 bVu
 bVu
 bVu
-apQ
+bVu
 bVu
 csw
 csw


### PR DESCRIPTION
:cl: Penguaro
fix: Centcom Engineering has reviewed the plans for the Box series station and has addressed some concerns related to some APCs not affecting their designated section. APCs for the Detective's Office, Cargobay, and Gateway, now control those rooms. The Bridge Maintenance APC has been removed from future construction as it serves no purpose and thus is an unnecessary construction cost.
fix: The pipe from the station to the AI Satellite has been completed. 
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
There are several APCs that do not affect power in their sections. Changes as follows

Corrected the Areas for the APCs locations for Gateway, Detective's Office, Cargobay/Warehouse.
Removed the Bridge Maintenance APC as it controls nothing
Renamed the Locker Room Maintenance APC to Aft Port Maintenance APC as the lights affected by it are not near the Locker Room and could confuse someone as to what this APC actually controls.

As a miscellaneous fix, there was a missing atmo pipe going from the station to the AI Sat. I put it back in.