### PR TITLE
SM speaks on engineering channel, now with 100% less freeze

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -114,6 +114,8 @@
 	var/config_hallucination_power = 0.1
 
 	var/obj/item/device/radio/radio
+	var/radio_key = /obj/item/device/encryptionkey/headset_eng
+	var/radio_channel = "Engineering"
 
 	//for logging
 	var/has_been_powered = 0
@@ -134,7 +136,9 @@
 	countdown.start()
 	GLOB.poi_list |= src
 	radio = new(src)
+	radio.keyslot = new radio_key
 	radio.listening = 0
+	radio.recalculateChannels()
 	investigate_log("has been created.", "supermatter")
 
 
@@ -341,26 +345,27 @@
 
 			if(damage > emergency_point)
 				SPEAK("[emergency_alert] Instability: [stability]%")
+				SPEAK("[emergency_alert] Instability: [stability]%", radio_channel)
 				lastwarning = REALTIMEOFDAY
 				if(!has_reached_emergency)
 					investigate_log("has reached the emergency point for the first time.", "supermatter")
 					message_admins("[src] has reached the emergency point [ADMIN_JMP(src)].")
 					has_reached_emergency = 1
 			else if(damage >= damage_archived) // The damage is still going up
-				SPEAK("[warning_alert] Instability: [stability]%")
+				SPEAK("[warning_alert] Instability: [stability]%", radio_channel)
 				lastwarning = REALTIMEOFDAY - (WARNING_DELAY * 5)
 
 			else                                                 // Phew, we're safe
-				SPEAK("[safe_alert] Instability: [stability]%")
+				SPEAK("[safe_alert] Instability: [stability]%", radio_channel)
 				lastwarning = REALTIMEOFDAY
 
 			if(power > POWER_PENALTY_THRESHOLD)
-				SPEAK("Warning: Hyperstructure has reached dangerous power level.")
+				SPEAK("Warning: Hyperstructure has reached dangerous power level.", radio_channel)
 				if(powerloss_inhibitor < 0.5)
-					SPEAK("DANGER: CHARGE INERTIA CHAIN REACTION IN PROGRESS.")
+					SPEAK("DANGER: CHARGE INERTIA CHAIN REACTION IN PROGRESS.", radio_channel)
 
 			if(combined_gas > MOLE_PENALTY_THRESHOLD)
-				SPEAK("Warning: Critical coolant mass reached.")
+				SPEAK("Warning: Critical coolant mass reached.", radio_channel)
 
 		if(damage > explosion_point)
 			for(var/mob in GLOB.living_mob_list)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -48,9 +48,6 @@
 #define FLUX_ANOMALY "flux_anomaly"
 #define PYRO_ANOMALY "pyro_anomaly"
 
-#define SPEAK(message) radio.talk_into(src, message, null, get_spans(), get_default_language())
-
-
 /obj/machinery/power/supermatter_shard
 	name = "supermatter shard"
 	desc = "A strangely translucent and iridescent crystal that looks like it used to be part of a larger structure."
@@ -115,7 +112,8 @@
 
 	var/obj/item/device/radio/radio
 	var/radio_key = /obj/item/device/encryptionkey/headset_eng
-	var/radio_channel = "Engineering"
+	var/engineering_channel = "Engineering"
+	var/common_channel = null
 
 	//for logging
 	var/has_been_powered = 0
@@ -344,28 +342,27 @@
 			var/stability = num2text(round((damage / explosion_point) * 100))
 
 			if(damage > emergency_point)
-				SPEAK("[emergency_alert] Instability: [stability]%")
-				SPEAK("[emergency_alert] Instability: [stability]%", radio_channel)
+				radio.talk_into(src, "[emergency_alert] Instability: [stability]%", common_channel, get_spans(), get_default_language())
 				lastwarning = REALTIMEOFDAY
 				if(!has_reached_emergency)
 					investigate_log("has reached the emergency point for the first time.", "supermatter")
 					message_admins("[src] has reached the emergency point [ADMIN_JMP(src)].")
 					has_reached_emergency = 1
 			else if(damage >= damage_archived) // The damage is still going up
-				SPEAK("[warning_alert] Instability: [stability]%", radio_channel)
+				radio.talk_into(src, "[warning_alert] Instability: [stability]%", engineering_channel, get_spans(), get_default_language())
 				lastwarning = REALTIMEOFDAY - (WARNING_DELAY * 5)
 
 			else                                                 // Phew, we're safe
-				SPEAK("[safe_alert] Instability: [stability]%", radio_channel)
+				radio.talk_into(src, "[safe_alert] Instability: [stability]%", engineering_channel, get_spans(), get_default_language())
 				lastwarning = REALTIMEOFDAY
 
 			if(power > POWER_PENALTY_THRESHOLD)
-				SPEAK("Warning: Hyperstructure has reached dangerous power level.", radio_channel)
+				radio.talk_into(src, "Warning: Hyperstructure has reached dangerous power level.", engineering_channel, get_spans(), get_default_language())
 				if(powerloss_inhibitor < 0.5)
-					SPEAK("DANGER: CHARGE INERTIA CHAIN REACTION IN PROGRESS.", radio_channel)
+					radio.talk_into(src, "DANGER: CHARGE INERTIA CHAIN REACTION IN PROGRESS.", engineering_channel, get_spans(), get_default_language())
 
 			if(combined_gas > MOLE_PENALTY_THRESHOLD)
-				SPEAK("Warning: Critical coolant mass reached.", radio_channel)
+				radio.talk_into(src, "Warning: Critical coolant mass reached.", engineering_channel, get_spans(), get_default_language())
 
 		if(damage > explosion_point)
 			for(var/mob in GLOB.living_mob_list)


### PR DESCRIPTION
:cl: Qbopper
tweak: The supermatter crystal now sends its warning messages to the engineering channel. (if it's in critical condition the message will be sent to the common radio channel as before)
/:cl:

TL;DR: Supermatter messages now go to the engineering channel. Emergency alert messages will still broadcast to general radio.

A little old, but: https://tgstation13.org/phpBB/viewtopic.php?f=10&t=10445#p275368

I PR'd this during the freeze like a dope, here it is again, I hope it didn't break again. A few people said to make the messages transmit to general around 40% instability or so, but others say this is fine, so I'll PR this as is and if people really want lower %s on general chat I can look into doing that