### PR TITLE
Corrects Baseturfs for Dragoon Tomb

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/dragoontomb.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dragoontomb.dmm
@@ -6,7 +6,9 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered/no_grav)
 "c" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
+/turf/closed/mineral/volcanic/lava_land_surface{
+	baseturf = /turf/open/space
+	},
 /area/ruin/unpowered/no_grav)
 "d" = (
 /mob/living/simple_animal/hostile/flan/water,

--- a/_maps/RandomRuins/SpaceRuins/dragoontomb.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dragoontomb.dmm
@@ -7,7 +7,7 @@
 /area/ruin/unpowered/no_grav)
 "c" = (
 /turf/closed/mineral/volcanic/lava_land_surface{
-	baseturf = /turf/open/space
+	baseturf = /turf/open/floor/plating/asteroid
 	},
 /area/ruin/unpowered/no_grav)
 "d" = (


### PR DESCRIPTION
:cl: Penguaro
fix: There is now Space under the rocks at the Dragoon's Tomb
/:cl:

Fixes #27251 The baseturf for all of the rocks was lava before. It is now space.