### PR TITLE
Syndicate Base Virology Smart Fridge now has Viruses in it

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -730,7 +730,7 @@
 	},
 /area/ruin/powered/syndicate_lava_base)
 "bN" = (
-/obj/machinery/smartfridge/chemistry/virology,
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/open/floor/plasteel/podhatch{
 	tag = "icon-podhatch (EAST)";
 	icon_state = "podhatch";


### PR DESCRIPTION
:cl: Penguaro
fix: Centcom Intelligence reports that the Hidden Syndicate Research Base may have received a shipment of viruses.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
The empty fridge was initially used on this lavaland ruin. It now has the standard preloaded version for virus research. Fixes #27288 