### PR TITLE
Adjusts ear/eye protection based on missing organs

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -2,16 +2,38 @@
 /mob/living/carbon/get_eye_protection()
 	var/number = ..()
 
+	if(istype(src.head, /obj/item/clothing/head))			//are they wearing something on their head
+		var/obj/item/clothing/head/HFP = src.head			//if yes gets the flash protection value from that item
+		number += HFP.flash_protect
+
+	if(istype(src.glasses, /obj/item/clothing/glasses))		//glasses
+		var/obj/item/clothing/glasses/GFP = src.glasses
+		number += GFP.flash_protect
+
+	if(istype(src.wear_mask, /obj/item/clothing/mask))		//mask
+		var/obj/item/clothing/mask/MFP = src.wear_mask
+		number += MFP.flash_protect
+
 	var/obj/item/organ/eyes/E = getorganslot("eye_sight")
 	if(!E)
 		number = INFINITY //Can't get flashed without eyes
 	else
 		number += E.flash_protect
+
 	return number
 
 /mob/living/carbon/get_ear_protection()
+	var/number = ..()
+	if(ears && HAS_SECONDARY_FLAG(ears, BANG_PROTECT))
+		number += 1
 	if(head && HAS_SECONDARY_FLAG(head, BANG_PROTECT))
-		return 1
+		number += 1
+	var/obj/item/organ/ears/E = getorganslot("ears")
+	if(!E)
+		number = INFINITY
+	else
+		number += E.bang_protect
+	return number
 
 /mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
@@ -274,25 +296,25 @@
 /mob/living/carbon/soundbang_act(intensity = 1, stun_pwr = 1, damage_pwr = 5, deafen_pwr = 15)
 	var/ear_safety = get_ear_protection()
 	var/obj/item/organ/ears/ears = getorganslot("ears")
-	if(ear_safety < 2) //has ears
-		var/effect_amount = intensity - ear_safety
-		if(effect_amount > 0)
-			if(stun_pwr)
-				Stun(stun_pwr*effect_amount)
-				Weaken(stun_pwr*effect_amount)
-			if(istype(ears) && (deafen_pwr || damage_pwr))
-				ears.ear_damage += damage_pwr * effect_amount
-				ears.deaf = max(ears.deaf, deafen_pwr * effect_amount)
+	var/effect_amount = intensity - ear_safety
+	if(effect_amount > 0)
+		if(stun_pwr)
+			Stun(stun_pwr*effect_amount)
+			Weaken(stun_pwr*effect_amount)
 
-				if(ears.ear_damage >= 15)
-					to_chat(src, "<span class='warning'>Your ears start to ring badly!</span>")
-					if(prob(ears.ear_damage - 5))
-						to_chat(src, "<span class='userdanger'>You can't hear anything!</span>")
-						ears.ear_damage = min(ears.ear_damage, UNHEALING_EAR_DAMAGE)
-						// you need earmuffs, inacusiate, or replacement
-				else if(ears.ear_damage >= 5)
-					to_chat(src, "<span class='warning'>Your ears start to ring!</span>")
-				src << sound('sound/weapons/flash_ring.ogg',0,1,0,250)
+		if(istype(ears) && (deafen_pwr || damage_pwr))
+			ears.ear_damage += damage_pwr * effect_amount
+			ears.deaf = max(ears.deaf, deafen_pwr * effect_amount)
+
+			if(ears.ear_damage >= 15)
+				to_chat(src, "<span class='warning'>Your ears start to ring badly!</span>")
+				if(prob(ears.ear_damage - 5))
+					to_chat(src, "<span class='userdanger'>You can't hear anything!</span>")
+					ears.ear_damage = min(ears.ear_damage, UNHEALING_EAR_DAMAGE)
+					// you need earmuffs, inacusiate, or replacement
+			else if(ears.ear_damage >= 5)
+				to_chat(src, "<span class='warning'>Your ears start to ring!</span>")
+			src << sound('sound/weapons/flash_ring.ogg',0,1,0,250)
 		return effect_amount //how soundbanged we are
 
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -31,25 +31,6 @@
 				protection += C.armor[d_type]
 	return protection
 
-///checkeyeprot()
-///Returns a number between -1 to 2
-/mob/living/carbon/human/get_eye_protection()
-	var/number = ..()
-	if(istype(src.head, /obj/item/clothing/head))			//are they wearing something on their head
-		var/obj/item/clothing/head/HFP = src.head			//if yes gets the flash protection value from that item
-		number += HFP.flash_protect
-	if(istype(src.glasses, /obj/item/clothing/glasses))		//glasses
-		var/obj/item/clothing/glasses/GFP = src.glasses
-		number += GFP.flash_protect
-	if(istype(src.wear_mask, /obj/item/clothing/mask))		//mask
-		var/obj/item/clothing/mask/MFP = src.wear_mask
-		number += MFP.flash_protect
-	return number
-
-/mob/living/carbon/human/get_ear_protection()
-	if((ears && HAS_SECONDARY_FLAG(ears, BANG_PROTECT)) || (head && HAS_SECONDARY_FLAG(head, BANG_PROTECT)))
-		return 1
-
 /mob/living/carbon/human/on_hit(obj/item/projectile/P)
 	dna.species.on_hit(P, src)
 

--- a/code/modules/mob/living/carbon/monkey/monkey_defense.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey_defense.dm
@@ -1,11 +1,3 @@
-
-/mob/living/carbon/monkey/get_eye_protection()
-	var/number = ..()
-	if(istype(src.wear_mask, /obj/item/clothing/mask))
-		var/obj/item/clothing/mask/MFP = src.wear_mask
-		number += MFP.flash_protect
-	return number
-
 /mob/living/carbon/monkey/help_shake_act(mob/living/carbon/M)
 	if(health < 0 && ishuman(M))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -15,6 +15,8 @@
 	// without external aid (earmuffs, drugs)
 	var/ear_damage = 0
 
+	var/bang_protect = 0	//Resistance against loud noises
+
 /obj/item/organ/ears/on_life()
 	if(!iscarbon(owner))
 		return


### PR DESCRIPTION
:cl: QualityVan
fix: People without eyes and ears are no longer susceptible to flashbangs they aren't directly on top of
/:cl:

Also moves some of get_ear_protection and get_eye_protection from human and monkey into carbon, since all the relevant slots are defined at that level anyway.

Fixes #27273 