### PR TITLE
Drones shut down, rather than gib, with a Robotics Console kill order

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -78,6 +78,8 @@
 	for(var/mob/living/simple_animal/drone/D in GLOB.mob_list)
 		if(D.hacked)
 			continue
+		if(!D.can_detonate)
+			continue
 		drones++
 		dat += "[D.name] |"
 		if(D.stat)
@@ -159,14 +161,15 @@
 	else if (href_list["killdrone"])
 		if(src.allowed(usr))
 			var/mob/living/simple_animal/drone/D = locate(href_list["killdrone"])
+			if(!D.can_detonate)
+				return
 			if(D.hacked)
 				to_chat(usr, "<span class='danger'>ERROR: [D] is not responding to external commands.</span>")
 			else
 				var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 				s.set_up(3, 1, D)
 				s.start()
-				D.visible_message("<span class='danger'>\the [D] self destructs!</span>")
+				D.visible_message("<span class='danger'>[D] self destructs!</span>")
 				D.gib()
 
 	src.updateUsrDialog()
-	return

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -113,7 +113,7 @@
 						R.ResetSecurityCodes()
 					else
 						var/turf/T = get_turf(R)
-						message_admins("<span class='notice'>[ADMIN_LOOKUPFLW(usr)] detonated [key_name(R, R.client)][ADMIN_JMP(T)]!</span>")
+						message_admins("<span class='notice'>[ADMIN_LOOKUPFLW(usr)] detonated [key_name_admin(R)][ADMIN_JMP(T)]!</span>")
 						log_game("\<span class='notice'>[key_name(usr)] detonated [key_name(R)]!</span>")
 						if(R.connected_ai)
 							to_chat(R.connected_ai, "<br><br><span class='alert'>ALERT - Cyborg detonation detected: [R.name]</span><br>")
@@ -168,7 +168,7 @@
 				D.visible_message("<span class='danger'>[D] shuts down!</span>", "<span class='userdanger'>Your body automatically shuts down, in response to a kill code.</span>")
 				D.death()
 
-				message_admins("[ADMIN_LOOKUPFLW(usr)] shut down [key_name(D, D.client)][ADMIN_JMP(T)]!")
+				message_admins("[ADMIN_LOOKUPFLW(usr)] shut down [key_name_admin(D)][ADMIN_JMP(T)]!")
 				log_game("[key_name(usr)] shut down [key_name(D)]!")
 
 	src.updateUsrDialog()

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -1,6 +1,3 @@
-
-
-
 /obj/machinery/computer/robotics
 	name = "robotics control console"
 	desc = "Used to remotely lockdown or detonate linked Cyborgs."
@@ -166,10 +163,8 @@
 			if(D.hacked)
 				to_chat(usr, "<span class='danger'>ERROR: [D] is not responding to external commands.</span>")
 			else
-				var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-				s.set_up(3, 1, D)
-				s.start()
-				D.visible_message("<span class='danger'>[D] self destructs!</span>")
-				D.gib()
+				do_sparks(3, TRUE, D)
+				D.visible_message("<span class='danger'>[D] shuts down!</span>", "<span class='userdanger'>Your body automatically shuts down, in response to a kill code.</span>")
+				D.death()
 
 	src.updateUsrDialog()

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -163,8 +163,12 @@
 			if(D.hacked)
 				to_chat(usr, "<span class='danger'>ERROR: [D] is not responding to external commands.</span>")
 			else
+				var/turf/T = get_turf(D)
 				do_sparks(3, TRUE, D)
 				D.visible_message("<span class='danger'>[D] shuts down!</span>", "<span class='userdanger'>Your body automatically shuts down, in response to a kill code.</span>")
 				D.death()
+
+				message_admins("[ADMIN_LOOKUPFLW(usr)] shut down [key_name(D, D.client)][ADMIN_JMP(T)]!")
+				log_game("[key_name(usr)] shut down [key_name(D)]!")
 
 	src.updateUsrDialog()

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -1,3 +1,7 @@
+#define DRONE_NOT_PICKED "not_picked"
+#define DRONE_PICKED "picked"
+#define DRONE_PICK_RANDOM "pick_random"
+
 
 #define DRONE_HANDS_LAYER 1
 #define DRONE_HEAD_LAYER 2
@@ -49,7 +53,7 @@
 	dextrous_hud_type = /datum/hud/dextrous/drone
 	var/staticChoice = "static"
 	var/list/staticChoices = list("static", "blank", "letter", "animal")
-	var/picked = FALSE //Have we picked our visual appearence (+ colour if applicable)
+	var/picked = DRONE_NOT_PICKED //Have we picked our visual appearence (+ colour if applicable)
 	var/colour = "grey"	//Stored drone color, so we can go back when unhacked.
 	var/list/drone_overlays[DRONE_TOTAL_LAYERS]
 	var/laws = \
@@ -66,6 +70,7 @@
 	var/seeStatic = 1 //Whether we see static instead of mobs
 	var/visualAppearence = MAINTDRONE //What we appear as
 	var/hacked = 0 //If we have laws to destroy the station
+	var/can_detonate = TRUE
 	var/can_be_held = TRUE //if assholes can pick us up
 	var/flavortext = \
 	"\n<big><span class='warning'>DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE BANNED</span></big>\n"+\
@@ -135,8 +140,11 @@
 
 	updateSeeStaticMobs()
 
-	if(!picked)
-		pickVisualAppearence()
+	switch(picked)
+		if(DRONE_NOT_PICKED)
+			pickVisualAppearence()
+		if(DRONE_PICK_RANDOM)
+			randomise_appearence()
 
 
 /mob/living/simple_animal/drone/death(gibbed)
@@ -285,3 +293,14 @@
 
 /mob/living/simple_animal/drone/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, tesla_shock = 0, illusion = 0, stun = TRUE)
 	return 0 //So they don't die trying to fix wiring
+
+/mob/living/simple_animal/drone/proc/randomise_appearence()
+	visualAppearence = pick(MAINTDRONE, REPAIRDRONE, SCOUTDRONE)
+	if(visualAppearence == MAINTDRONE)
+		var/colour = pick("grey", "blue", "red", "green", "pink", "orange")
+		icon_state = "[visualAppearence]_[colour]"
+	else
+		icon_state = visualAppearence
+
+	icon_living = icon_state
+	icon_dead = "[visualAppearence]_dead"

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -16,7 +16,7 @@
 	icon_living = "drone_synd"
 	picked = TRUE //the appearence of syndrones is static, you don't get to change it.
 	health = 30
-	maxHealth = 120 //If you murder other drones and cannibalize them you can get much stronger
+	maxHealth = 30
 	initial_language_holder = /datum/language_holder/drone/syndicate
 	faction = list("syndicate")
 	speak_emote = list("hisses")
@@ -28,17 +28,14 @@
 	"3. Destroy."
 	default_storage = /obj/item/device/radio/uplink
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi
-	seeStatic = 0 //Our programming is superior.
+	seeStatic = FALSE
 	hacked = TRUE
+	can_detonate = FALSE
 	flavortext = null
 
 /mob/living/simple_animal/drone/syndrone/Initialize()
 	..()
 	internal_storage.hidden_uplink.telecrystals = 10
-
-/mob/living/simple_animal/drone/syndrone/Login()
-	..()
-	to_chat(src, "<span class='notice'>You can kill and eat other drones to increase your health!</span>" )
 
 /mob/living/simple_animal/drone/syndrone/badass
 	name = "Badass Syndrone"
@@ -73,23 +70,17 @@
 	desc = "A shell of a snowflake drone, a maintenance drone with a built in holographic projector to display hats and masks."
 	drone_type = /mob/living/simple_animal/drone/snowflake
 
-/mob/living/simple_animal/drone/polymorphed
+/mob/living/simple_animal/drone/free
+	laws = "1. You are a Free Drone."
+	seeStatic = FALSE
+	picked = DRONE_PICK_RANDOM
+	can_detonate = FALSE
+	// no language restrictions
+	language_holder = /datum/language_holder/drone/syndicate
+
+/mob/living/simple_animal/drone/free/no_equipment
 	default_storage = null
 	default_hatmask = null
-	picked = TRUE
-
-/mob/living/simple_animal/drone/polymorphed/Initialize()
-	. = ..()
-	liberate()
-	visualAppearence = pick(MAINTDRONE, REPAIRDRONE, SCOUTDRONE)
-	if(visualAppearence == MAINTDRONE)
-		var/colour = pick("grey", "blue", "red", "green", "pink", "orange")
-		icon_state = "[visualAppearence]_[colour]"
-	else
-		icon_state = visualAppearence
-
-	icon_living = icon_state
-	icon_dead = "[visualAppearence]_dead"
 
 /mob/living/simple_animal/drone/cogscarab
 	name = "cogscarab"
@@ -121,6 +112,7 @@
 	hacked = TRUE
 	visualAppearence = CLOCKDRONE
 	can_be_held = FALSE
+	can_detonate = FALSE
 	flavortext = "<span class='heavy_brass'>You are a cogscarab</span><b>, a clockwork creation of Ratvar. As a cogscarab, you have low health, an inbuilt proselytizer that can convert brass \
 	to liquified alloy, a set of relatively fast tools, </b><span class='heavy_brass'>can communicate over the Hierophant Network with :b</span><b>, and are immune to extreme \
 	temperatures and pressures. \nYour goal is to serve the Justiciar and his servants by repairing and defending all they create.</b>"

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -74,7 +74,6 @@
 	laws = "1. You are a Free Drone."
 	seeStatic = FALSE
 	picked = DRONE_PICK_RANDOM
-	can_detonate = FALSE
 	// no language restrictions
 	language_holder = /datum/language_holder/drone/syndicate
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -164,13 +164,6 @@
 	update_drone_icon()
 	updateSeeStaticMobs()
 
-/mob/living/simple_animal/drone/proc/liberate()
-	// F R E E D R O N E
-	laws = "1. You are a Free Drone."
-	to_chat(src, laws)
-	seeStatic = FALSE
-	updateSeeStaticMobs()
-
 /mob/living/simple_animal/drone/proc/update_drone_icon()
 	//Different icons for different hack states
 	if(!hacked)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -147,7 +147,7 @@
 						path = /mob/living/silicon/robot/syndicate/medical
 					new_mob = new path(M.loc)
 				if("drone")
-					new_mob = new /mob/living/simple_animal/drone/polymorphed(M.loc)
+					new_mob = new /mob/living/simple_animal/drone/free/no_equipment(M.loc)
 			if(issilicon(new_mob))
 				new_mob.gender = M.gender
 				new_mob.invisibility = 0


### PR DESCRIPTION
:cl: coiax
balance: Kill orders from the Robotics Console on drones cause the drone's body to shut down, rather than self destruct.
del: Syndicate drones no longer start at 30/120 hp, instead, they have
30/30 hp.
/:cl:

- Makes randomising polymorphed drones a var
- Changes the types of free drones to make stuff clearer
- To be honest, the "hacked" var is a bit shit, since we don't ever have
law modifications of drones, even though we maintain the hypothetical
code basis for it. Probably should phase it out.

A Robotics Console drone can still be repaired by someone with a screwdriver, if they feel that the drone's shut down order was illegitimate.