### PR TITLE
Curator display cases are no longer alarmed

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -258,7 +258,7 @@
 	var/added_roundstart = TRUE
 	var/is_locked = TRUE
 
-	alert = TRUE
+	alert = FALSE
 	integrity_failure = 0
 	openable = FALSE
 


### PR DESCRIPTION
:cl: coiax
del: Curator display cases no longer trigger a burglar alarm when
broken.
/:cl:

- Locking the library to stop someone absconding with ashes is a little
silly.