### PR TITLE
Blood cult runes can be drawn on shuttles

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -245,8 +245,6 @@ This file contains the arcane tome files.
 	SSblackbox.add_details("cult_runes_scribed", R.cultist_name)
 
 /obj/item/weapon/tome/proc/check_rune_turf(turf/T, mob/user)
-	var/area/A = get_area(T)
-
 	if(isspaceturf(T))
 		to_chat(user, "<span class='warning'>You cannot scribe runes in space!</span>")
 		return FALSE
@@ -257,10 +255,6 @@ This file contains the arcane tome files.
 
 	if(T.z != ZLEVEL_STATION && T.z != ZLEVEL_MINING)
 		to_chat(user, "<span class='warning'>The veil is not weak enough here.")
-		return FALSE
-
-	if(istype(A, /area/shuttle))
-		to_chat(user, "<span class='warning'>Interference from hyperspace engines disrupts the Geometer's power on shuttles.</span>")
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION
:cl: coiax
balance: Blood cult runes can be drawn on shuttles.
/:cl:

- This change was originally done before randomised space templates,
meaning that the white ship was easily recoverable and used as a flying
cult base. The white ship is no longer as easily findable.
- However, this means that blood cults are no longer able to fight on or
around shuttles, unlike brass cults, which have no such restriction.
- So this restriction seems like historical balance that is no longer
applicable.