### PR TITLE
Eightballs are tiny items

### DIFF
--- a/code/game/objects/items/eightball.dm
+++ b/code/game/objects/items/eightball.dm
@@ -4,6 +4,7 @@
 
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "eightball"
+	w_class = WEIGHT_CLASS_TINY
 
 	verb_say = "rattles"
 


### PR DESCRIPTION
:cl: coiax
balance: Magic eightballs are now tiny items, able to fit into a box and
pocket.
/:cl:

Was an oversight when I added them originally, they're about tiny sized
anyway.