### PR TITLE
Adds a proc for copying languages from another thing

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -602,6 +602,10 @@
 	var/datum/language_holder/H = get_language_holder()
 	. = H.has_language(dt)
 
+/atom/movable/proc/copy_known_languages_from(thing, replace=FALSE)
+	var/datum/language_holder/H = get_language_holder()
+	. = H.copy_known_languages_from(thing, replace)
+
 // Whether an AM can speak in a language or not, independent of whether
 // it KNOWS the language
 /atom/movable/proc/could_speak_in_language(datum/language/dt)

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -64,6 +64,24 @@
 				return LANGUAGE_SHADOWED
 	return FALSE
 
+/datum/language_holder/proc/copy_known_languages_from(thing, replace=FALSE)
+	var/datum/language_holder/other
+	if(istype(thing, /datum/language_holder))
+		other = thing
+	else if(istype(thing, /atom/movable))
+		var/atom/movable/AM = thing
+		other = AM.get_language_holder()
+	else if(istype(thing, /datum/mind))
+		var/datum/mind/M = thing
+		other = M.get_language_holder()
+
+	if(replace)
+		src.remove_all_languages()
+
+	for(var/l in other.languages)
+		src.grant_language(l)
+
+
 /datum/language_holder/proc/open_language_menu(mob/user)
 	if(!language_menu)
 		language_menu = new(src)


### PR DESCRIPTION
This has been asked for by the design lead.

`bob.copy_known_languages_from(alice)` will grant Bob all of Alice's
known languages.

`bob.copy_known_languages_from(eve, replace=TRUE)` will replace all of
Bob's known languages with Eve's known language.

Valid arguments are language holders, mind datums, and atom/movables.