### PR TITLE
Space vines can no longer spread on transit turfs

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -555,6 +555,10 @@
 /obj/structure/spacevine/proc/spread()
 	var/direction = pick(GLOB.cardinal)
 	var/turf/stepturf = get_step(src,direction)
+
+	if(istype(/turf/open/space/transit, stepturf))
+		return
+
 	for(var/datum/spacevine_mutation/SM in mutations)
 		SM.on_spread(src, stepturf)
 		stepturf = get_step(src,direction) //in case turf changes, to make sure no runtimes happen

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -556,7 +556,7 @@
 	var/direction = pick(GLOB.cardinal)
 	var/turf/stepturf = get_step(src,direction)
 
-	if(istype(/turf/open/space/transit, stepturf))
+	if(istype(stepturf, /turf/open/space/transit))
 		return
 
 	for(var/datum/spacevine_mutation/SM in mutations)


### PR DESCRIPTION
:cl: coiax
fix: Spacevines can no longer spread on space transit turfs.
/:cl:

Transit turfs aren't actual locations, they're the hyperspace whizzing
past the shuttle. Otherwise there's a strong possibility of being able
to grief Z2 with vines by planting them on a shuttle.