### PR TITLE
Adds drones as a roundstart job

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -12,6 +12,7 @@
 #define ROBOTICIST		(1<<8)
 #define AI_JF				(1<<9)
 #define CYBORG			(1<<10)
+#define DRONE			(1<<11)
 
 
 #define MEDSCI			(1<<1)

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -31,6 +31,23 @@ AI
 		return 1
 	return 0
 
+
+//Drone
+/datum/job/drone
+	title = "Drone"
+	flag = DRONE
+	department_flag = ENGSEC
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 1
+	selection_color = "#ccffcc"
+	supervisors = "your laws"
+	req_admin_notify = 1
+	minimal_player_age = 30
+
+/datum/job/drone/equip(mob/living/carbon/human/H)
+	return H.dronize()
+
 /*
 Cyborg
 */

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -57,7 +57,8 @@ GLOBAL_LIST_INIT(security_positions, list(
 GLOBAL_LIST_INIT(nonhuman_positions, list(
 	"AI",
 	"Cyborg",
-	"pAI"))
+	"pAI",
+	"Drone"))
 
 
 /proc/guest_jobbans(job)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -495,6 +495,25 @@
 	. = new_corgi
 	qdel(src)
 
+/mob/living/carbon/human/proc/dronize()
+	if (notransform)
+		return
+	for(var/obj/item/W in src)
+		dropItemToGround(W)
+	regenerate_icons()
+	notransform = 1
+	canmove = 0
+	icon = null
+	invisibility = INVISIBILITY_MAXIMUM
+	for(var/t in bodyparts)	//this really should not be necessary
+		qdel(t)
+
+	var/mob/living/simple_animal/drone/D = new /mob/living/simple_animal/drone (loc)
+	D.key = key
+
+	. = D
+	qdel(src)
+
 /mob/living/carbon/human/Animalize()
 
 	var/list/mobtypes = typesof(/mob/living/simple_animal)


### PR DESCRIPTION
:cl: Tacolizard Forever: Autism Fort Overdrive
add: NanoTrasen has decided to ship drones to the station to help maintain it! Drones are now a selectable job.
/:cl:

[why]: I've heard many people asking for this during my time playing and to my surprise, this PR was easier to make than I expected. Yes, the drones in this PR still have the same laws as normal drones.

**lore**
NT decided that drones are useful enough that they now supply them to the station instead of requiring them to be built.