### PR TITLE
Removes that description on the Second MetaStation Sign

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -56825,7 +56825,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
-	desc = "";
 	icon_state = "L13";
 	name = "floor"
 	},
@@ -57517,7 +57516,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel{
-	desc = "";
 	icon_state = "L14"
 	},
 /area/hallway/primary/central)


### PR DESCRIPTION
Finishes fixing #26000 since apparently MetaStation has two of those signs... This removes the empty description tag from the top right of the lower sign.