### PR TITLE
[Pubby] Adds APC to Engineering

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -47062,6 +47062,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bPR" = (
@@ -55914,6 +55919,20 @@
 /obj/machinery/light,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
+"cjQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/apc{
+	cell_type = 15000;
+	dir = 2;
+	name = "Engineering APC";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 
 (1,1,1) = {"
 aaa
@@ -89495,7 +89514,7 @@ bNt
 bOE
 bNt
 bNt
-bPE
+cjQ
 bMb
 bQy
 bMb


### PR DESCRIPTION
:cl: Penguaro
fix: Centcom Engineering has reviewed the power schematic for the engine room and added an Area Power Controller.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Fixes #27322 Pubby didn't have an APC for the engine room.