### PR TITLE
Removes CMO autosurgeon; the CMO starts with a medihud implant

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -69,7 +69,6 @@
 	new /obj/item/weapon/storage/belt/medical(src)
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/weapon/reagent_containers/hypospray/CMO(src)
-	new /obj/item/device/autosurgeon/cmo(src)
 	new /obj/item/weapon/door_remote/chief_medical_officer(src)
 
 /obj/structure/closet/secure_closet/animal

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -133,6 +133,7 @@
 	shoes = /obj/item/clothing/shoes/sneakers/black
 
 	var/list/implants = null
+	var/list/organs = null
 
 	var/backpack = /obj/item/weapon/storage/backpack
 	var/satchel  = /obj/item/weapon/storage/backpack/satchel
@@ -188,3 +189,8 @@
 		for(var/implant_type in implants)
 			var/obj/item/weapon/implant/I = new implant_type(H)
 			I.implant(H, null, silent=TRUE)
+
+	if(organs)
+		for(var/organ_type in organs)
+			var/obj/item/organ/O = new organ_type(H)
+			O.Insert(H, drop_if_replaced=FALSE)

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -41,6 +41,7 @@ Chief Medical Officer
 	backpack = /obj/item/weapon/storage/backpack/medic
 	satchel = /obj/item/weapon/storage/backpack/satchel/med
 	dufflebag = /obj/item/weapon/storage/backpack/dufflebag/med
+	organs = list(/obj/item/organ/cyberimp/eyes/hud/medical)
 
 /*
 Medical Doctor

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -14,7 +14,7 @@
 	slot = "eye_hud"
 	var/HUD_type = 0
 
-/obj/item/organ/cyberimp/eyes/hud/Insert(var/mob/living/carbon/M, var/special = 0)
+/obj/item/organ/cyberimp/eyes/hud/Insert(var/mob/living/carbon/M, var/special = 0, drop_if_replaced = TRUE)
 	..()
 	if(HUD_type)
 		var/datum/atom_hud/H = GLOB.huds[HUD_type]

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -65,11 +65,6 @@
 			if(!uses)
 				desc = "[initial(desc)] Looks like it's been used up."
 
-/obj/item/device/autosurgeon/cmo
-	desc = "A single use autosurgeon that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1
-	starting_organ = /obj/item/organ/cyberimp/eyes/hud/medical
-
 
 /obj/item/device/autosurgeon/thermal_eyes
 	starting_organ = /obj/item/organ/eyes/robotic/thermals


### PR DESCRIPTION
Closes #27332.

:cl: coiax
del: The CMO no longer has an autosurgeon, they instead start with the
mediHUD implant as part of their shift start equipment.
/:cl:

Autosurgeons don't really exist canonically, they exist for nuke ops so
they can skip a long laboured surgery step, because they know they're
not going to be betrayed.

So the notion of a magical surgery machine, even if it is only one use
(which makes very little sense). So I propose we get rid of it, and give
the CMO their implant at roundstart.