### PR TITLE
Removes CMO autosurgeon; replaced with just the implant

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -69,7 +69,7 @@
 	new /obj/item/weapon/storage/belt/medical(src)
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/weapon/reagent_containers/hypospray/CMO(src)
-	new /obj/item/device/autosurgeon/cmo(src)
+	new /obj/item/organ/cyberimp/eyes/hud/medical(src)
 	new /obj/item/weapon/door_remote/chief_medical_officer(src)
 
 /obj/structure/closet/secure_closet/animal

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -65,12 +65,6 @@
 			if(!uses)
 				desc = "[initial(desc)] Looks like it's been used up."
 
-/obj/item/device/autosurgeon/cmo
-	desc = "A single use autosurgeon that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1
-	starting_organ = /obj/item/organ/cyberimp/eyes/hud/medical
-
-
 /obj/item/device/autosurgeon/thermal_eyes
 	starting_organ = /obj/item/organ/eyes/robotic/thermals
 


### PR DESCRIPTION
Closes #27331.

:cl: coiax
del: The CMO no longer has an autosurgeon for their mediHUD implant,
they have to get someone to put it in.
/:cl:

This was pretty classic removal of vulnerability for "quality of life".
As mentioned in the other PR, autosurgeons don't really exist
in-universe, just being a timesaver for nuke ops, who are definitely not
going to betray each other.

Now the CMO has to actually get someone to do the surgery, and possibly
murdered on the table.