### PR TITLE
Fixes custom slices not inheriting name

### DIFF
--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -135,7 +135,6 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/slice, reagents_per_slice)
 	..()
-	slice.name = "[customname] [initial(slice.name)]"
 	slice.filling_color = filling_color
 	slice.update_overlays(src)
 

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -215,8 +215,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/proc/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/slice, reagents_per_slice)
 	slice.create_reagents(slice.volume)
 	reagents.trans_to(slice,reagents_per_slice)
-	if( name != initial(name) || desc != initial(desc) )
-		slice.name = "slice of [src]"
+	if(name != initial(name))
+		slice.name = "slice of [name]"
+	if(desc != initial(desc))
 		slice.desc = "[desc]"
 
 /obj/item/weapon/reagent_containers/food/snacks/proc/generate_trash(atom/location)


### PR DESCRIPTION
Turns out the customizable part was overwriting.