### PR TITLE
Repaths /obj/effect/overlay/temp to /obj/effect/temp_visual

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -13,7 +13,7 @@
 /atom/proc/attack_tk(mob/user)
 	if(user.stat)
 		return
-	new /obj/effect/overlay/temp/telekinesis(loc)
+	new /obj/effect/temp_visual/telekinesis(loc)
 	user.UnarmedAttack(src,0) // attack_hand, attack_paw, etc
 	return
 
@@ -163,7 +163,7 @@
 /obj/item/tk_grab/proc/apply_focus_overlay()
 	if(!focus)
 		return
-	new /obj/effect/overlay/temp/telekinesis(get_turf(focus))
+	new /obj/effect/temp_visual/telekinesis(get_turf(focus))
 
 /obj/item/tk_grab/update_icon()
 	cut_overlays()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -36,7 +36,7 @@ Bonus
 /datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A)
 	var/heal_amt = 0.5
 	if(M.toxloss > 0 && prob(20))
-		new /obj/effect/overlay/temp/heal(get_turf(M), "#66FF99")
+		new /obj/effect/temp_visual/heal(get_turf(M), "#66FF99")
 	M.adjustToxLoss(-heal_amt)
 	return 1
 
@@ -67,7 +67,7 @@ Bonus
 /datum/symptom/heal/plus/Heal(mob/living/M, datum/disease/advance/A)
 	var/heal_amt = 1
 	if(M.toxloss > 0 && prob(20))
-		new /obj/effect/overlay/temp/heal(get_turf(M), "#00FF00")
+		new /obj/effect/temp_visual/heal(get_turf(M), "#00FF00")
 	M.adjustToxLoss(-heal_amt)
 	return 1
 
@@ -110,7 +110,7 @@ Bonus
 			M.update_damage_overlays()
 
 	if(prob(20))
-		new /obj/effect/overlay/temp/heal(get_turf(M), "#FF3333")
+		new /obj/effect/temp_visual/heal(get_turf(M), "#FF3333")
 
 	return 1
 
@@ -148,7 +148,7 @@ Bonus
 	if(M.getCloneLoss() > 0)
 		M.adjustCloneLoss(-1)
 		M.take_bodypart_damage(0, 1) //Deals BURN damage, which is not cured by this symptom
-		new /obj/effect/overlay/temp/heal(get_turf(M), "#33FFCC")
+		new /obj/effect/temp_visual/heal(get_turf(M), "#33FFCC")
 
 	if(!parts.len)
 		return
@@ -158,7 +158,7 @@ Bonus
 			M.update_damage_overlays()
 
 	if(prob(20))
-		new /obj/effect/overlay/temp/heal(get_turf(M), "#CC1100")
+		new /obj/effect/temp_visual/heal(get_turf(M), "#CC1100")
 
 	return 1
 
@@ -201,7 +201,7 @@ Bonus
 			M.update_damage_overlays()
 
 	if(prob(20))
-		new /obj/effect/overlay/temp/heal(get_turf(M), "#FF9933")
+		new /obj/effect/temp_visual/heal(get_turf(M), "#FF9933")
 	return 1
 
 
@@ -248,7 +248,7 @@ Bonus
 			M.update_damage_overlays()
 
 	if(prob(20))
-		new /obj/effect/overlay/temp/heal(get_turf(M), "#CC6600")
+		new /obj/effect/temp_visual/heal(get_turf(M), "#CC6600")
 	return 1
 
 

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -32,7 +32,7 @@
 /mob/living/simple_animal/hostile/blob/blob_act(obj/structure/blob/B)
 	if(stat != DEAD && health < maxHealth)
 		for(var/i in 1 to 2)
-			var/obj/effect/overlay/temp/heal/H = new /obj/effect/overlay/temp/heal(get_turf(src)) //hello yes you are being healed
+			var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(src)) //hello yes you are being healed
 			if(overmind)
 				H.color = overmind.blob_reagent_datum.complementary_color
 			else

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -140,7 +140,7 @@
 		loc.blob_act(src) //don't ask how a wall got on top of the core, just eat it
 
 /obj/structure/blob/proc/blob_attack_animation(atom/A = null, controller) //visually attacks an atom
-	var/obj/effect/overlay/temp/blob/O = new /obj/effect/overlay/temp/blob(src.loc)
+	var/obj/effect/temp_visual/blob/O = new /obj/effect/temp_visual/blob(src.loc)
 	O.setDir(dir)
 	if(controller)
 		var/mob/camera/blob/BO = controller
@@ -208,7 +208,7 @@
 		if(overmind)
 			overmind.blob_reagent_datum.emp_reaction(src, severity)
 		if(prob(100 - severity * 30))
-			new /obj/effect/overlay/temp/emp(get_turf(src))
+			new /obj/effect/temp_visual/emp(get_turf(src))
 
 /obj/structure/blob/tesla_act(power)
 	..()

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -73,7 +73,7 @@
 	L.visible_message("<span class='warning'>[src] appears around [L] in a burst of light!</span>", \
 	"<span class='userdanger'>[target_flashed ? "An unseen force":"The glowing sigil around you"] holds you in place!</span>")
 	L.Stun(5)
-	new /obj/effect/overlay/temp/ratvar/sigil/transgression(get_turf(src))
+	new /obj/effect/temp_visual/ratvar/sigil/transgression(get_turf(src))
 	qdel(src)
 
 
@@ -102,7 +102,7 @@
 	L.visible_message("<span class='warning'>[src] begins to glow a piercing magenta!</span>", "<span class='sevtug'>You feel something start to invade your mind...</span>")
 	var/oldcolor = color
 	animate(src, color = "#AF0AAF", time = convert_time)
-	var/obj/effect/overlay/temp/ratvar/sigil/glow
+	var/obj/effect/temp_visual/ratvar/sigil/glow
 	if(glow_type)
 		glow = new glow_type(get_turf(src))
 		animate(glow, alpha = 255, time = convert_time)
@@ -158,7 +158,7 @@
 	light_color = "#A97F1B"
 	delete_on_finish = FALSE
 	sigil_name = "Sigil of Accession"
-	glow_type = /obj/effect/overlay/temp/ratvar/sigil/accession
+	glow_type = /obj/effect/temp_visual/ratvar/sigil/accession
 	resist_string = "glows bright orange"
 
 /obj/effect/clockwork/sigil/submission/accession/post_channel(mob/living/L)
@@ -321,14 +321,14 @@
 	while(L && (!is_servant_of_ratvar(L) || (is_servant_of_ratvar(L) && (GLOB.ratvar_awakens || vitality))) && get_turf(L) == get_turf(src))
 		sigil_active = TRUE
 		if(animation_number >= 4)
-			new /obj/effect/overlay/temp/ratvar/sigil/vitality(get_turf(src))
+			new /obj/effect/temp_visual/ratvar/sigil/vitality(get_turf(src))
 			animation_number = 0
 		animation_number++
 		if(!is_servant_of_ratvar(L))
 			var/vitality_drained = 0
 			if(L.stat == DEAD)
 				vitality_drained = L.maxHealth
-				var/obj/effect/overlay/temp/ratvar/sigil/vitality/V = new /obj/effect/overlay/temp/ratvar/sigil/vitality(get_turf(src))
+				var/obj/effect/temp_visual/ratvar/sigil/vitality/V = new /obj/effect/temp_visual/ratvar/sigil/vitality(get_turf(src))
 				animate(V, alpha = 0, transform = matrix()*2, time = 8)
 				playsound(L, 'sound/magic/WandODeath.ogg', 50, 1)
 				L.visible_message("<span class='warning'>[L] collapses in on [L.p_them()]self as [src] flares bright blue!</span>")
@@ -356,7 +356,7 @@
 					if(ghost)
 						ghost.reenter_corpse()
 					L.revive(1, 1)
-					var/obj/effect/overlay/temp/ratvar/sigil/vitality/V = new /obj/effect/overlay/temp/ratvar/sigil/vitality(get_turf(src))
+					var/obj/effect/temp_visual/ratvar/sigil/vitality/V = new /obj/effect/temp_visual/ratvar/sigil/vitality(get_turf(src))
 					animate(V, alpha = 0, transform = matrix()*2, time = 8)
 					playsound(L, 'sound/magic/Staff_Healing.ogg', 50, 1)
 					L.visible_message("<span class='warning'>[L] suddenly gets back up, [GLOB.ratvar_awakens ? "[L.p_their()] body dripping blue ichor":"even as [src] scatters into blue sparks around [L.p_them()]"]!</span>", \

--- a/code/game/gamemodes/clock_cult/clock_helpers/component_helpers.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/component_helpers.dm
@@ -124,15 +124,15 @@
 /proc/get_component_animation_type(id)
 	switch(id)
 		if(BELLIGERENT_EYE)
-			return /obj/effect/overlay/temp/ratvar/component
+			return /obj/effect/temp_visual/ratvar/component
 		if(VANGUARD_COGWHEEL)
-			return /obj/effect/overlay/temp/ratvar/component/cogwheel
+			return /obj/effect/temp_visual/ratvar/component/cogwheel
 		if(GEIS_CAPACITOR)
-			return /obj/effect/overlay/temp/ratvar/component/capacitor
+			return /obj/effect/temp_visual/ratvar/component/capacitor
 		if(REPLICANT_ALLOY)
-			return /obj/effect/overlay/temp/ratvar/component/alloy
+			return /obj/effect/temp_visual/ratvar/component/alloy
 		if(HIEROPHANT_ANSIBLE)
-			return /obj/effect/overlay/temp/ratvar/component/ansible
+			return /obj/effect/temp_visual/ratvar/component/ansible
 		else
 			return null
 

--- a/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/proselytizer_helpers.dm
@@ -90,7 +90,7 @@
 			no_delete = TRUE
 			use(amount_temp)
 		amount_temp *= 12.5 //each tile is 12.5 power so this is 2 tiles to 25 power
-		return list("operation_time" = 0, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "power_cost" = -amount_temp, "spawn_dir" = SOUTH, "no_target_deletion" = no_delete)
+		return list("operation_time" = 0, "new_obj_type" = /obj/effect/temp_visual/ratvar/beam/itemconsume, "power_cost" = -amount_temp, "spawn_dir" = SOUTH, "no_target_deletion" = no_delete)
 	if(amount_temp >= 20)
 		var/sheets_to_make = round(amount_temp * 0.05) //and 20 to 1 brass
 		var/used = sheets_to_make * 20
@@ -108,7 +108,7 @@
 	if(source)
 		return FALSE
 	if(proselytizer.metal_to_power)
-		return list("operation_time" = 0, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "power_cost" = -(amount*POWER_ROD), "spawn_dir" = SOUTH)
+		return list("operation_time" = 0, "new_obj_type" = /obj/effect/temp_visual/ratvar/beam/itemconsume, "power_cost" = -(amount*POWER_ROD), "spawn_dir" = SOUTH)
 	if(get_amount() >= 10)
 		var/sheets_to_make = round(get_amount() * 0.1)
 		var/used = sheets_to_make * 10
@@ -126,7 +126,7 @@
 	if(source)
 		return FALSE
 	if(proselytizer.metal_to_power)
-		return list("operation_time" = 0, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "power_cost" = -(amount*POWER_METAL), "spawn_dir" = SOUTH)
+		return list("operation_time" = 0, "new_obj_type" = /obj/effect/temp_visual/ratvar/beam/itemconsume, "power_cost" = -(amount*POWER_METAL), "spawn_dir" = SOUTH)
 	if(get_amount() >= 5)
 		var/sheets_to_make = round(get_amount() * 0.2)
 		var/used = sheets_to_make * 5
@@ -144,7 +144,7 @@
 	if(source)
 		return FALSE
 	if(proselytizer.metal_to_power)
-		return list("operation_time" = 0, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "power_cost" = -(amount*POWER_PLASTEEL), "spawn_dir" = SOUTH)
+		return list("operation_time" = 0, "new_obj_type" = /obj/effect/temp_visual/ratvar/beam/itemconsume, "power_cost" = -(amount*POWER_PLASTEEL), "spawn_dir" = SOUTH)
 	if(get_amount() >= 2)
 		var/sheets_to_make = round(get_amount() * 0.5)
 		var/used = sheets_to_make * 2
@@ -162,7 +162,7 @@
 /obj/item/stack/tile/brass/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
 	if(source)
 		return FALSE
-	return list("operation_time" = 0, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "power_cost" = -(amount*POWER_FLOOR), "spawn_dir" = SOUTH)
+	return list("operation_time" = 0, "new_obj_type" = /obj/effect/temp_visual/ratvar/beam/itemconsume, "power_cost" = -(amount*POWER_FLOOR), "spawn_dir" = SOUTH)
 
 //Airlock conversion
 /obj/machinery/door/airlock/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
@@ -375,16 +375,16 @@
 
 //Convert shards and gear bits directly to power
 /obj/item/clockwork/alloy_shards/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
-	return list("operation_time" = 0, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "power_cost" = -POWER_STANDARD, "spawn_dir" = SOUTH)
+	return list("operation_time" = 0, "new_obj_type" = /obj/effect/temp_visual/ratvar/beam/itemconsume, "power_cost" = -POWER_STANDARD, "spawn_dir" = SOUTH)
 
 /obj/item/clockwork/alloy_shards/medium/gear_bit/large/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
-	return list("operation_time" = 0, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "power_cost" = -(CLOCKCULT_POWER_UNIT*0.08), "spawn_dir" = SOUTH)
+	return list("operation_time" = 0, "new_obj_type" = /obj/effect/temp_visual/ratvar/beam/itemconsume, "power_cost" = -(CLOCKCULT_POWER_UNIT*0.08), "spawn_dir" = SOUTH)
 
 /obj/item/clockwork/alloy_shards/large/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
-	return list("operation_time" = 0, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "power_cost" = -(CLOCKCULT_POWER_UNIT*0.06), "spawn_dir" = SOUTH)
+	return list("operation_time" = 0, "new_obj_type" = /obj/effect/temp_visual/ratvar/beam/itemconsume, "power_cost" = -(CLOCKCULT_POWER_UNIT*0.06), "spawn_dir" = SOUTH)
 
 /obj/item/clockwork/alloy_shards/medium/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
-	return list("operation_time" = 0, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "power_cost" = -(CLOCKCULT_POWER_UNIT*0.04), "spawn_dir" = SOUTH)
+	return list("operation_time" = 0, "new_obj_type" = /obj/effect/temp_visual/ratvar/beam/itemconsume, "power_cost" = -(CLOCKCULT_POWER_UNIT*0.04), "spawn_dir" = SOUTH)
 
 /obj/item/clockwork/alloy_shards/small/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
-	return list("operation_time" = 0, "new_obj_type" = /obj/effect/overlay/temp/ratvar/beam/itemconsume, "power_cost" = -(CLOCKCULT_POWER_UNIT*0.02), "spawn_dir" = SOUTH)
+	return list("operation_time" = 0, "new_obj_type" = /obj/effect/temp_visual/ratvar/beam/itemconsume, "power_cost" = -(CLOCKCULT_POWER_UNIT*0.02), "spawn_dir" = SOUTH)

--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -124,7 +124,7 @@
 			L.adjustToxLoss(totaldamage * 0.5, TRUE, TRUE)
 			var/healseverity = max(round(totaldamage*0.05, 1), 1) //shows the general severity of the damage you just healed, 1 glow per 20
 			for(var/i in 1 to healseverity)
-				new /obj/effect/overlay/temp/heal(targetturf, "#1E8CE1")
+				new /obj/effect/temp_visual/heal(targetturf, "#1E8CE1")
 			clockwork_say(ranged_ability_user, text2ratvar("Mend wounded flesh!"))
 			add_logs(ranged_ability_user, L, "healed with Sentinel's Compromise")
 		else
@@ -173,7 +173,7 @@
 				if(usable_power > 0 && C.cell.use(usable_power))
 					multiplier += (usable_power * 0.001)
 		qdel(VC)
-		new/obj/effect/overlay/temp/ratvar/volt_hit/true(targetturf, ranged_ability_user, multiplier)
+		new/obj/effect/temp_visual/ratvar/volt_hit/true(targetturf, ranged_ability_user, multiplier)
 		add_logs(ranged_ability_user, targetturf, "fired a volt ray")
 		remove_ranged_ability()
 

--- a/code/game/gamemodes/clock_cult/clock_items/ratvarian_spear.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/ratvarian_spear.dm
@@ -96,13 +96,13 @@
 		impale_cooldown = world.time + initial(impale_cooldown)
 		attack_cooldown = world.time + initial(attack_cooldown) //can't attack until we're done impaling
 		if(target)
-			new /obj/effect/overlay/temp/dir_setting/bloodsplatter(get_turf(target), get_dir(user, target))
+			new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(target), get_dir(user, target))
 			target.Stun(2) //brief stun
 			to_chat(user, "<span class='brass'>You prepare to remove your ratvarian spear from [target]...</span>")
 			var/remove_verb = pick("pull", "yank", "drag")
 			if(do_after(user, 10, 1, target))
 				var/turf/T = get_turf(target)
-				var/obj/effect/overlay/temp/dir_setting/bloodsplatter/B = new /obj/effect/overlay/temp/dir_setting/bloodsplatter(T, get_dir(target, user))
+				var/obj/effect/temp_visual/dir_setting/bloodsplatter/B = new /obj/effect/temp_visual/dir_setting/bloodsplatter(T, get_dir(target, user))
 				playsound(T, 'sound/misc/splort.ogg', 200, 1)
 				playsound(T, 'sound/weapons/pierce.ogg', 200, 1)
 				if(target.stat != CONSCIOUS)
@@ -151,5 +151,5 @@
 			T = get_turf(src)
 		if(T) //make sure we're not in null or something
 			T.visible_message("<span class='warning'>[src] [pick("cracks in two and fades away", "snaps in two and dematerializes")]!</span>")
-			new /obj/effect/overlay/temp/ratvar/spearbreak(T)
+			new /obj/effect/temp_visual/ratvar/spearbreak(T)
 		qdel(src)

--- a/code/game/gamemodes/clock_cult/clock_mobs/clockwork_marauder.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs/clockwork_marauder.dm
@@ -150,7 +150,7 @@
 	if(iscarbon(host))
 		resulthealth = round((abs(HEALTH_THRESHOLD_DEAD - host.health) / abs(HEALTH_THRESHOLD_DEAD - host.maxHealth)) * 100)
 	if(GLOB.ratvar_awakens || resulthealth <= MARAUDER_EMERGE_THRESHOLD)
-		new /obj/effect/overlay/temp/heal(host.loc, "#AF0AAF")
+		new /obj/effect/temp_visual/heal(host.loc, "#AF0AAF")
 		host.heal_ordered_damage(4, damage_heal_order)
 
 /mob/living/simple_animal/hostile/clockwork/marauder/adjustHealth(amount, updating_health = TRUE, forced = FALSE)

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
@@ -114,7 +114,7 @@
 				for(var/i in 1 to heal_attempts)
 					if(S.health < S.maxHealth)
 						S.adjustHealth(-heal_amount)
-						new /obj/effect/overlay/temp/heal(T, "#1E8CE1")
+						new /obj/effect/temp_visual/heal(T, "#1E8CE1")
 						if(i == heal_attempts && S.health >= S.maxHealth) //we finished healing on the last tick, give them the message
 							to_chat(S, "<span class='inathneq'>\"[text2ratvar(pick(heal_finish_messages))]\"</span>")
 							break
@@ -129,7 +129,7 @@
 				for(var/i in 1 to heal_attempts)
 					if(S.health < S.maxHealth)
 						S.heal_ordered_damage(heal_amount, damage_heal_order)
-						new /obj/effect/overlay/temp/heal(T, "#1E8CE1")
+						new /obj/effect/temp_visual/heal(T, "#1E8CE1")
 						if(i == heal_attempts && S.health >= S.maxHealth)
 							to_chat(S, "<span class='inathneq'>\"[text2ratvar(pick(heal_finish_messages))]\"</span>")
 							break
@@ -158,7 +158,7 @@
 					for(var/i in 1 to heal_ticks)
 						if(H.health < H.maxHealth)
 							H.heal_ordered_damage(heal_amount, damage_heal_order)
-							new /obj/effect/overlay/temp/heal(T, "#1E8CE1")
+							new /obj/effect/temp_visual/heal(T, "#1E8CE1")
 							if(i == heal_ticks && H.health >= H.maxHealth)
 								to_chat(H, "<span class='inathneq'>\"[text2ratvar(pick(heal_finish_messages))]\"</span>")
 								break
@@ -174,10 +174,10 @@
 				if(C.obj_integrity < C.max_integrity)
 					C.obj_integrity = min(C.obj_integrity + 5, C.max_integrity)
 					C.update_icon()
-					new /obj/effect/overlay/temp/heal(T, "#1E8CE1")
+					new /obj/effect/temp_visual/heal(T, "#1E8CE1")
 				else
 					break
-	new /obj/effect/overlay/temp/ratvar/mending_mantra(get_turf(invoker))
+	new /obj/effect/temp_visual/ratvar/mending_mantra(get_turf(invoker))
 	return TRUE
 
 
@@ -389,7 +389,7 @@
 						usable_power = min(Floor(C.cell.charge * 0.2, MIN_CLOCKCULT_POWER), 1000) - prev_power
 						if(usable_power > 0 && C.cell.use(usable_power))
 							multiplier += (usable_power * 0.0005)
-				var/obj/effect/overlay/temp/ratvar/volt_hit/VH = new /obj/effect/overlay/temp/ratvar/volt_hit(get_turf(invoker), null, multiplier)
+				var/obj/effect/temp_visual/ratvar/volt_hit/VH = new /obj/effect/temp_visual/ratvar/volt_hit(get_turf(invoker), null, multiplier)
 				invoker.visible_message("<span class='warning'>[invoker] is struck by [invoker.p_their()] own [VH.name]!</span>", "<span class='userdanger'>You're struck by your own [VH.name]!</span>")
 				invoker.adjustFireLoss(VH.damage) //you have to fail all five blasts to die to this
 				playsound(invoker, 'sound/machines/defib_zap.ogg', VH.damage, 1, -1)

--- a/code/game/gamemodes/clock_cult/clock_structure.dm
+++ b/code/game/gamemodes/clock_cult/clock_structure.dm
@@ -131,7 +131,7 @@
 	if(anchored && unanchored_icon)
 		anchored = FALSE
 		update_anchored(null, obj_integrity > max_integrity * 0.25)
-		new /obj/effect/overlay/temp/emp(loc)
+		new /obj/effect/temp_visual/emp(loc)
 
 
 //for the ark and Ratvar
@@ -222,7 +222,7 @@
 
 /obj/structure/destructible/clockwork/powered/emp_act(severity)
 	if(forced_disable(TRUE))
-		new /obj/effect/overlay/temp/emp(loc)
+		new /obj/effect/temp_visual/emp(loc)
 
 /obj/structure/destructible/clockwork/powered/proc/total_accessable_power() //how much power we have and can use
 	if(!needs_power || GLOB.ratvar_awakens)

--- a/code/game/gamemodes/clock_cult/clock_structures/geis_binding.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/geis_binding.dm
@@ -31,7 +31,7 @@
 	return
 
 /obj/structure/destructible/clockwork/geis_binding/emp_act(severity)
-	new /obj/effect/overlay/temp/emp(loc)
+	new /obj/effect/temp_visual/emp(loc)
 	qdel(src)
 
 /obj/structure/destructible/clockwork/geis_binding/post_buckle_mob(mob/living/M)
@@ -54,8 +54,8 @@
 		if(!can_resist)
 			repair_and_interrupt()
 	else
-		var/obj/effect/overlay/temp/ratvar/geis_binding/G = new /obj/effect/overlay/temp/ratvar/geis_binding(M.loc)
-		var/obj/effect/overlay/temp/ratvar/geis_binding/T = new /obj/effect/overlay/temp/ratvar/geis_binding/top(M.loc)
+		var/obj/effect/temp_visual/ratvar/geis_binding/G = new /obj/effect/temp_visual/ratvar/geis_binding(M.loc)
+		var/obj/effect/temp_visual/ratvar/geis_binding/T = new /obj/effect/temp_visual/ratvar/geis_binding/top(M.loc)
 		G.layer = mob_layer - 0.01
 		T.layer = mob_layer + 0.01
 		G.alpha = alpha
@@ -93,10 +93,10 @@
 				var/mob/living/carbon/C = L
 				C.silent += 4
 	visible_message("<span class='sevtug'>[src] flares brightly!</span>")
-	var/obj/effect/overlay/temp/ratvar/geis_binding/G1 = new /obj/effect/overlay/temp/ratvar/geis_binding(loc)
-	var/obj/effect/overlay/temp/ratvar/geis_binding/G2 = new /obj/effect/overlay/temp/ratvar/geis_binding(loc)
-	var/obj/effect/overlay/temp/ratvar/geis_binding/T1 = new /obj/effect/overlay/temp/ratvar/geis_binding/top(loc)
-	var/obj/effect/overlay/temp/ratvar/geis_binding/T2 = new /obj/effect/overlay/temp/ratvar/geis_binding/top(loc)
+	var/obj/effect/temp_visual/ratvar/geis_binding/G1 = new /obj/effect/temp_visual/ratvar/geis_binding(loc)
+	var/obj/effect/temp_visual/ratvar/geis_binding/G2 = new /obj/effect/temp_visual/ratvar/geis_binding(loc)
+	var/obj/effect/temp_visual/ratvar/geis_binding/T1 = new /obj/effect/temp_visual/ratvar/geis_binding/top(loc)
+	var/obj/effect/temp_visual/ratvar/geis_binding/T2 = new /obj/effect/temp_visual/ratvar/geis_binding/top(loc)
 	G1.layer = mob_layer - 0.01
 	G2.layer = mob_layer - 0.01
 	T1.layer = mob_layer + 0.01

--- a/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
@@ -87,7 +87,7 @@
 				var/obj/mecha/M = target
 				M.take_damage(damage_per_tick * get_efficiency_mod(), BURN, "melee", 1, get_dir(src, M))
 
-			new /obj/effect/overlay/temp/ratvar/ocular_warden(get_turf(target))
+			new /obj/effect/temp_visual/ratvar/ocular_warden(get_turf(target))
 
 			setDir(get_dir(get_turf(src), get_turf(target)))
 	if(!target)

--- a/code/game/gamemodes/clock_cult/clock_structures/wall_gear.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/wall_gear.dm
@@ -19,7 +19,7 @@
 
 /obj/structure/destructible/clockwork/wall_gear/Initialize()
 	. = ..()
-	new /obj/effect/overlay/temp/ratvar/gear(get_turf(src))
+	new /obj/effect/temp_visual/ratvar/gear(get_turf(src))
 
 /obj/structure/destructible/clockwork/wall_gear/emp_act(severity)
 	return

--- a/code/game/gamemodes/cult/cult_comms.dm
+++ b/code/game/gamemodes/cult/cult_comms.dm
@@ -177,13 +177,13 @@
 					var/turf/mobloc = get_turf(B.current)
 					switch(i)
 						if(1)
-							new /obj/effect/overlay/temp/cult/sparks(mobloc, B.current.dir)
+							new /obj/effect/temp_visual/cult/sparks(mobloc, B.current.dir)
 							playsound(mobloc, "sparks", 50, 1)
 						if(2)
-							new /obj/effect/overlay/temp/dir_setting/cult/phase/out(mobloc, B.current.dir)
+							new /obj/effect/temp_visual/dir_setting/cult/phase/out(mobloc, B.current.dir)
 							playsound(mobloc, "sparks", 75, 1)
 						if(3)
-							new /obj/effect/overlay/temp/dir_setting/cult/phase(mobloc, B.current.dir)
+							new /obj/effect/temp_visual/dir_setting/cult/phase(mobloc, B.current.dir)
 							playsound(mobloc, "sparks", 100, 1)
 						if(4)
 							playsound(mobloc, 'sound/magic/exit_blood.ogg', 100, 1)
@@ -193,7 +193,7 @@
 									var/obj/item/device/soulstone/S = B.current.loc
 									S.release_shades(owner)
 								B.current.setDir(SOUTH)
-								new /obj/effect/overlay/temp/cult/blood(final)
+								new /obj/effect/temp_visual/cult/blood(final)
 								addtimer(CALLBACK(B.current, /mob/.proc/reckon, final), 10)
 		else
 			return
@@ -201,7 +201,7 @@
 	Remove(owner)
 
 /mob/proc/reckon(turf/final)
-	new /obj/effect/overlay/temp/cult/blood/out(get_turf(src))
+	new /obj/effect/temp_visual/cult/blood/out(get_turf(src))
 	forceMove(final)
 
 /datum/action/innate/cult/master/finalreck/proc/chant(chant_number)

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -204,7 +204,7 @@
 	if(current_charges)
 		owner.visible_message("<span class='danger'>\The [attack_text] is deflected in a burst of blood-red sparks!</span>")
 		current_charges--
-		new /obj/effect/overlay/temp/cult/sparks(get_turf(owner))
+		new /obj/effect/temp_visual/cult/sparks(get_turf(owner))
 		if(!current_charges)
 			owner.visible_message("<span class='danger'>The runed shield around [owner] suddenly disappears!</span>")
 			owner.update_inv_wear_suit()
@@ -356,14 +356,14 @@
 		if(uses <= 0)
 			icon_state ="shifter_drained"
 		playsound(mobloc, "sparks", 50, 1)
-		new /obj/effect/overlay/temp/dir_setting/cult/phase/out(mobloc, C.dir)
+		new /obj/effect/temp_visual/dir_setting/cult/phase/out(mobloc, C.dir)
 
 		var/atom/movable/pulled = handle_teleport_grab(destination, C)
 		C.forceMove(destination)
 		if(pulled)
 			C.start_pulling(pulled) //forcemove resets pulls, so we need to re-pull
 
-		new /obj/effect/overlay/temp/dir_setting/cult/phase(destination, C.dir)
+		new /obj/effect/temp_visual/dir_setting/cult/phase(destination, C.dir)
 		playsound(destination, 'sound/effects/phasein.ogg', 25, 1)
 		playsound(destination, "sparks", 50, 1)
 

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -152,7 +152,7 @@
 		for(var/mob/living/L in range(5, src))
 			if(iscultist(L) || isshade(L) || isconstruct(L))
 				if(L.health != L.maxHealth)
-					new /obj/effect/overlay/temp/heal(get_turf(src), "#960000")
+					new /obj/effect/temp_visual/heal(get_turf(src), "#960000")
 					if(ishuman(L))
 						L.adjustBruteLoss(-1, 0)
 						L.adjustFireLoss(-1, 0)
@@ -190,7 +190,7 @@
 		else
 			var/turf/open/floor/engine/cult/F = safepick(cultturfs)
 			if(F)
-				new /obj/effect/overlay/temp/cult/turf/floor(F)
+				new /obj/effect/temp_visual/cult/turf/floor(F)
 			else
 				// Are we in space or something? No cult turfs or
 				// convertable turfs?

--- a/code/game/gamemodes/cult/rune_spawn_action.dm
+++ b/code/game/gamemodes/cult/rune_spawn_action.dm
@@ -7,9 +7,9 @@
 	var/scribe_time = 100
 	var/damage_interrupt = TRUE
 	var/action_interrupt = TRUE
-	var/obj/effect/overlay/temp/cult/rune_spawn/rune_word_type
-	var/obj/effect/overlay/temp/cult/rune_spawn/rune_innerring_type
-	var/obj/effect/overlay/temp/cult/rune_spawn/rune_center_type
+	var/obj/effect/temp_visual/cult/rune_spawn/rune_word_type
+	var/obj/effect/temp_visual/cult/rune_spawn/rune_innerring_type
+	var/obj/effect/temp_visual/cult/rune_spawn/rune_center_type
 	var/rune_color
 
 /datum/action/innate/cult/create_rune/IsAvailable()
@@ -27,15 +27,15 @@
 		if(!chosen_keyword)
 			return
 //the outer ring is always the same across all runes
-	var/obj/effect/overlay/temp/cult/rune_spawn/R1 = new(owner.loc, scribe_time, rune_color)
+	var/obj/effect/temp_visual/cult/rune_spawn/R1 = new(owner.loc, scribe_time, rune_color)
 //the rest are not always the same, so we need types for em
-	var/obj/effect/overlay/temp/cult/rune_spawn/R2
+	var/obj/effect/temp_visual/cult/rune_spawn/R2
 	if(rune_word_type)
 		R2 = new rune_word_type(owner.loc, scribe_time, rune_color)
-	var/obj/effect/overlay/temp/cult/rune_spawn/R3
+	var/obj/effect/temp_visual/cult/rune_spawn/R3
 	if(rune_innerring_type)
 		R3 = new rune_innerring_type(owner.loc, scribe_time, rune_color)
-	var/obj/effect/overlay/temp/cult/rune_spawn/R4
+	var/obj/effect/temp_visual/cult/rune_spawn/R4
 	if(rune_center_type)
 		R4 = new rune_center_type(owner.loc, scribe_time, rune_color)
 
@@ -64,7 +64,7 @@
 /datum/action/innate/cult/create_rune/tele
 	button_icon_state = "telerune"
 	rune_type = /obj/effect/rune/teleport
-	rune_word_type = /obj/effect/overlay/temp/cult/rune_spawn/rune2
-	rune_innerring_type = /obj/effect/overlay/temp/cult/rune_spawn/rune2/inner
-	rune_center_type = /obj/effect/overlay/temp/cult/rune_spawn/rune2/center
+	rune_word_type = /obj/effect/temp_visual/cult/rune_spawn/rune2
+	rune_innerring_type = /obj/effect/temp_visual/cult/rune_spawn/rune2/inner
+	rune_center_type = /obj/effect/temp_visual/cult/rune_spawn/rune2/center
 	rune_color = RUNE_COLOR_TELEPORT

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -410,7 +410,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	else
 		GLOB.sacrificed += sacrificial
 
-	new /obj/effect/overlay/temp/cult/sac(get_turf(src))
+	new /obj/effect/temp_visual/cult/sac(get_turf(src))
 	for(var/M in invokers)
 		if(big_sac)
 			to_chat(M, "<span class='cultlarge'>\"Yes! This is the one I desire! You have done well.\"</span>")

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -328,7 +328,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 /obj/effect/meteor/tunguska/Move()
 	. = ..()
 	if(.)
-		new /obj/effect/overlay/temp/revenant(get_turf(src))
+		new /obj/effect/temp_visual/revenant(get_turf(src))
 
 /obj/effect/meteor/tunguska/meteor_effect()
 	..()

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -64,7 +64,7 @@
 	stealth_active = 1
 	if(ishuman(loc))
 		var/mob/living/carbon/human/M = loc
-		new /obj/effect/overlay/temp/dir_setting/ninja/cloak(get_turf(M), M.dir)
+		new /obj/effect/temp_visual/dir_setting/ninja/cloak(get_turf(M), M.dir)
 		M.name_override = disguise.name
 		M.icon = disguise.icon
 		M.icon_state = disguise.icon_state
@@ -78,7 +78,7 @@
 	stealth_active = 0
 	if(ishuman(loc))
 		var/mob/living/carbon/human/M = loc
-		new /obj/effect/overlay/temp/dir_setting/ninja(get_turf(M), M.dir)
+		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(M), M.dir)
 		M.name_override = null
 		M.cut_overlays()
 		M.regenerate_icons()

--- a/code/game/gamemodes/miniantags/abduction/machinery/pad.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/pad.dm
@@ -16,38 +16,38 @@
 	flick("alien-pad", src)
 	for(var/mob/living/target in loc)
 		target.forceMove(teleport_target)
-		new /obj/effect/overlay/temp/dir_setting/ninja(get_turf(target), target.dir)
+		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
 		to_chat(target, "<span class='warning'>The instability of the warp leaves you disoriented!</span>")
 		target.Stun(3)
 
 /obj/machinery/abductor/pad/proc/Retrieve(mob/living/target)
 	flick("alien-pad", src)
-	new /obj/effect/overlay/temp/dir_setting/ninja(get_turf(target), target.dir)
+	new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
 	Warp(target)
 
 /obj/machinery/abductor/pad/proc/MobToLoc(place,mob/living/target)
-	new /obj/effect/overlay/temp/teleport_abductor(place)
+	new /obj/effect/temp_visual/teleport_abductor(place)
 	sleep(80)
 	flick("alien-pad", src)
 	target.forceMove(place)
-	new /obj/effect/overlay/temp/dir_setting/ninja(get_turf(target), target.dir)
+	new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
 
 /obj/machinery/abductor/pad/proc/PadToLoc(place)
-	new /obj/effect/overlay/temp/teleport_abductor(place)
+	new /obj/effect/temp_visual/teleport_abductor(place)
 	sleep(80)
 	flick("alien-pad", src)
 	for(var/mob/living/target in get_turf(src))
 		target.forceMove(place)
-		new /obj/effect/overlay/temp/dir_setting/ninja(get_turf(target), target.dir)
+		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
 
 
-/obj/effect/overlay/temp/teleport_abductor
+/obj/effect/temp_visual/teleport_abductor
 	name = "Huh"
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "teleport"
 	duration = 80
 
-/obj/effect/overlay/temp/teleport_abductor/Initialize()
+/obj/effect/temp_visual/teleport_abductor/Initialize()
 	. = ..()
 	var/datum/effect_system/spark_spread/S = new
 	S.set_up(10,0,loc)

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -435,7 +435,7 @@
 		resources += resource_gain
 		do_attack_animation(target)
 		changeNext_move(CLICK_CD_MELEE)
-		var/obj/effect/overlay/temp/swarmer/integrate/I = new /obj/effect/overlay/temp/swarmer/integrate(get_turf(target))
+		var/obj/effect/temp_visual/swarmer/integrate/I = new /obj/effect/temp_visual/swarmer/integrate(get_turf(target))
 		I.pixel_x = target.pixel_x
 		I.pixel_y = target.pixel_y
 		I.pixel_z = target.pixel_z
@@ -452,7 +452,7 @@
 
 
 /mob/living/simple_animal/hostile/swarmer/proc/DisIntegrate(atom/movable/target)
-	new /obj/effect/overlay/temp/swarmer/disintegration(get_turf(target))
+	new /obj/effect/temp_visual/swarmer/disintegration(get_turf(target))
 	do_attack_animation(target)
 	changeNext_move(CLICK_CD_MELEE)
 	target.ex_act(3)
@@ -497,7 +497,7 @@
 /mob/living/simple_animal/hostile/swarmer/proc/DismantleMachine(obj/machinery/target)
 	do_attack_animation(target)
 	to_chat(src, "<span class='info'>We begin to dismantle this machine. We will need to be uninterrupted.</span>")
-	var/obj/effect/overlay/temp/swarmer/dismantle/D = new /obj/effect/overlay/temp/swarmer/dismantle(get_turf(target))
+	var/obj/effect/temp_visual/swarmer/dismantle/D = new /obj/effect/temp_visual/swarmer/dismantle(get_turf(target))
 	D.pixel_x = target.pixel_x
 	D.pixel_y = target.pixel_y
 	D.pixel_z = target.pixel_z
@@ -507,7 +507,7 @@
 		M.amount = 5
 		for(var/obj/item/I in target.component_parts)
 			I.loc = M.loc
-		var/obj/effect/overlay/temp/swarmer/disintegration/N = new /obj/effect/overlay/temp/swarmer/disintegration(get_turf(target))
+		var/obj/effect/temp_visual/swarmer/disintegration/N = new /obj/effect/temp_visual/swarmer/disintegration(get_turf(target))
 		N.pixel_x = target.pixel_x
 		N.pixel_y = target.pixel_y
 		N.pixel_z = target.pixel_z
@@ -519,23 +519,23 @@
 		qdel(target)
 
 
-/obj/effect/overlay/temp/swarmer //temporary swarmer visual feedback objects
+/obj/effect/temp_visual/swarmer //temporary swarmer visual feedback objects
 	icon = 'icons/mob/swarmer.dmi'
 	layer = BELOW_MOB_LAYER
 
-/obj/effect/overlay/temp/swarmer/disintegration
+/obj/effect/temp_visual/swarmer/disintegration
 	icon_state = "disintegrate"
 	duration = 10
 
-/obj/effect/overlay/temp/swarmer/disintegration/Initialize()
+/obj/effect/temp_visual/swarmer/disintegration/Initialize()
 	. = ..()
 	playsound(loc, "sparks", 100, 1)
 
-/obj/effect/overlay/temp/swarmer/dismantle
+/obj/effect/temp_visual/swarmer/dismantle
 	icon_state = "dismantle"
 	duration = 25
 
-/obj/effect/overlay/temp/swarmer/integrate
+/obj/effect/temp_visual/swarmer/integrate
 	icon_state = "integrate"
 	duration = 5
 

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -202,7 +202,7 @@
 		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 		s.set_up(4, 0, L)
 		s.start()
-		new /obj/effect/overlay/temp/revenant(L.loc)
+		new /obj/effect/temp_visual/revenant(L.loc)
 		sleep(20)
 		if(!L.on) //wait, wait, don't shock me
 			return
@@ -237,7 +237,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile/proc/defile(turf/T)
 	if(T.flags & NOJAUNT)
 		T.flags -= NOJAUNT
-		new /obj/effect/overlay/temp/revenant(T)
+		new /obj/effect/temp_visual/revenant(T)
 	if(!istype(T, /turf/open/floor/plating) && !istype(T, /turf/open/floor/engine/cult) && isfloorturf(T) && prob(15))
 		var/turf/open/floor/floor = T
 		if(floor.intact && floor.floor_tile)
@@ -246,10 +246,10 @@
 		floor.burnt = 0
 		floor.make_plating(1)
 	if(T.type == /turf/closed/wall && prob(15))
-		new /obj/effect/overlay/temp/revenant(T)
+		new /obj/effect/temp_visual/revenant(T)
 		T.ChangeTurf(/turf/closed/wall/rust)
 	if(T.type == /turf/closed/wall/r_wall && prob(10))
-		new /obj/effect/overlay/temp/revenant(T)
+		new /obj/effect/temp_visual/revenant(T)
 		T.ChangeTurf(/turf/closed/wall/r_wall/rust)
 	for(var/obj/structure/closet/closet in T.contents)
 		closet.open()
@@ -261,7 +261,7 @@
 	for(var/obj/structure/window/window in T)
 		window.take_damage(rand(30,80))
 		if(window && window.fulltile)
-			new /obj/effect/overlay/temp/revenant/cracks(window.loc)
+			new /obj/effect/temp_visual/revenant/cracks(window.loc)
 	for(var/obj/machinery/light/light in T)
 		light.flicker(20) //spooky
 
@@ -284,7 +284,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction/proc/malfunction(turf/T, mob/user)
 	for(var/mob/living/simple_animal/bot/bot in T)
 		if(!bot.emagged)
-			new /obj/effect/overlay/temp/revenant(bot.loc)
+			new /obj/effect/temp_visual/revenant(bot.loc)
 			bot.locked = 0
 			bot.open = 1
 			bot.emag_act()
@@ -292,21 +292,21 @@
 		if(human == user)
 			continue
 		to_chat(human, "<span class='revenwarning'>You feel [pick("your sense of direction flicker out", "a stabbing pain in your head", "your mind fill with static")].</span>")
-		new /obj/effect/overlay/temp/revenant(human.loc)
+		new /obj/effect/temp_visual/revenant(human.loc)
 		human.emp_act(1)
 	for(var/obj/thing in T)
 		if(istype(thing, /obj/machinery/dominator) || istype(thing, /obj/machinery/power/apc) || istype(thing, /obj/machinery/power/smes)) //Doesn't work on dominators, SMES and APCs, to prevent kekkery
 			continue
 		if(prob(20))
 			if(prob(50))
-				new /obj/effect/overlay/temp/revenant(thing.loc)
+				new /obj/effect/temp_visual/revenant(thing.loc)
 			thing.emag_act(null)
 		else
 			if(!istype(thing, /obj/machinery/clonepod)) //I hate everything but mostly the fact there's no better way to do this without just not affecting it at all
 				thing.emp_act(1)
 	for(var/mob/living/silicon/robot/S in T) //Only works on cyborgs, not AI
 		playsound(S, 'sound/machines/warning-buzzer.ogg', 50, 1)
-		new /obj/effect/overlay/temp/revenant(S.loc)
+		new /obj/effect/temp_visual/revenant(S.loc)
 		S.spark_system.start()
 		S.emp_act(1)
 
@@ -329,7 +329,7 @@
 	for(var/mob/living/mob in T)
 		if(mob == user)
 			continue
-		new /obj/effect/overlay/temp/revenant(mob.loc)
+		new /obj/effect/temp_visual/revenant(mob.loc)
 		if(iscarbon(mob))
 			if(ishuman(mob))
 				var/mob/living/carbon/human/H = mob
@@ -350,14 +350,14 @@
 			mob.adjustToxLoss(5)
 	for(var/obj/structure/spacevine/vine in T) //Fucking with botanists, the ability.
 		vine.add_atom_colour("#823abb", TEMPORARY_COLOUR_PRIORITY)
-		new /obj/effect/overlay/temp/revenant(vine.loc)
+		new /obj/effect/temp_visual/revenant(vine.loc)
 		QDEL_IN(vine, 10)
 	for(var/obj/structure/glowshroom/shroom in T)
 		shroom.add_atom_colour("#823abb", TEMPORARY_COLOUR_PRIORITY)
-		new /obj/effect/overlay/temp/revenant(shroom.loc)
+		new /obj/effect/temp_visual/revenant(shroom.loc)
 		QDEL_IN(shroom, 10)
 	for(var/obj/machinery/hydroponics/tray in T)
-		new /obj/effect/overlay/temp/revenant(tray.loc)
+		new /obj/effect/temp_visual/revenant(tray.loc)
 		tray.pestlevel = rand(8, 10)
 		tray.weedlevel = rand(8, 10)
 		tray.toxic = rand(45, 55)

--- a/code/game/gamemodes/miniantags/revenant/revenant_blight.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_blight.dm
@@ -33,11 +33,11 @@
 			to_chat(affected_mob, "<span class='revennotice'>You suddenly feel [pick("sick and tired", "disoriented", "tired and confused", "nauseated", "faint", "dizzy")]...</span>")
 			affected_mob.confused += 8
 			affected_mob.adjustStaminaLoss(8)
-			new /obj/effect/overlay/temp/revenant(affected_mob.loc)
+			new /obj/effect/temp_visual/revenant(affected_mob.loc)
 		if(stagedamage < stage)
 			stagedamage++
 			affected_mob.adjustToxLoss(stage*2) //should, normally, do about 30 toxin damage.
-			new /obj/effect/overlay/temp/revenant(affected_mob.loc)
+			new /obj/effect/temp_visual/revenant(affected_mob.loc)
 		if(prob(45))
 			affected_mob.adjustStaminaLoss(stage)
 	..() //So we don't increase a stage before applying the stage damage.
@@ -56,7 +56,7 @@
 				finalstage = TRUE
 				to_chat(affected_mob, "<span class='revenbignotice'>You feel like [pick("nothing's worth it anymore", "nobody ever needed your help", "nothing you did mattered", "everything you tried to do was worthless")].</span>")
 				affected_mob.adjustStaminaLoss(45)
-				new /obj/effect/overlay/temp/revenant(affected_mob.loc)
+				new /obj/effect/temp_visual/revenant(affected_mob.loc)
 				if(affected_mob.dna && affected_mob.dna.species)
 					affected_mob.dna.species.handle_mutant_bodyparts(affected_mob,"#1d2953")
 					affected_mob.dna.species.handle_hair(affected_mob,"#1d2953")

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -584,7 +584,7 @@
 	var/turf/T = get_turf(user)
 	playsound(T,'sound/magic/WarpWhistle.ogg', 200, 1)
 	user.canmove = 0
-	new /obj/effect/overlay/temp/tornado(T)
+	new /obj/effect/temp_visual/tornado(T)
 	sleep(20)
 	if(interrupted(user))
 		return
@@ -602,7 +602,7 @@
 			T = potential_T
 			break
 		breakout += 1
-	new /obj/effect/overlay/temp/tornado(T)
+	new /obj/effect/temp_visual/tornado(T)
 	sleep(20)
 	if(interrupted(user))
 		return
@@ -620,7 +620,7 @@
 		last_user.canmove = 1
 	return ..()
 
-/obj/effect/overlay/temp/tornado
+/obj/effect/temp_visual/tornado
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "tornado"
 	name = "tornado"
@@ -630,6 +630,6 @@
 	duration = 40
 	pixel_x = 500
 
-/obj/effect/overlay/temp/tornado/Initialize()
+/obj/effect/temp_visual/tornado/Initialize()
 	. = ..()
 	animate(src, pixel_x = -500, time = 40)

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -236,7 +236,7 @@
 
 /obj/machinery/disco/proc/hierofunk()
 	for(var/i in 1 to 10)
-		spawn_atom_to_turf(/obj/effect/overlay/temp/hierophant/telegraph/edge, src, 1, FALSE)
+		spawn_atom_to_turf(/obj/effect/temp_visual/hierophant/telegraph/edge, src, 1, FALSE)
 		sleep(5)
 
 /obj/machinery/disco/proc/lights_spin()

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -363,7 +363,7 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_cult
 	hackProof = 1
 	aiControlDisabled = 1
-	var/openingoverlaytype = /obj/effect/overlay/temp/cult/door
+	var/openingoverlaytype = /obj/effect/temp_visual/cult/door
 	var/friendly = FALSE
 
 /obj/machinery/door/airlock/cult/New()
@@ -380,7 +380,7 @@
 		new openingoverlaytype(loc)
 		return 1
 	else
-		new /obj/effect/overlay/temp/cult/sac(loc)
+		new /obj/effect/temp_visual/cult/sac(loc)
 		var/atom/throwtarget
 		throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(M, src)))
 		M << pick(sound('sound/hallucinations/turn_around1.ogg',0,1,50), sound('sound/hallucinations/turn_around2.ogg',0,1,50))
@@ -407,7 +407,7 @@
 	icon = 'icons/obj/doors/airlocks/cult/unruned/cult.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/cult/unruned/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_cult/unruned
-	openingoverlaytype = /obj/effect/overlay/temp/cult/door/unruned
+	openingoverlaytype = /obj/effect/temp_visual/cult/door/unruned
 
 /obj/machinery/door/airlock/cult/unruned/friendly
 	friendly = TRUE
@@ -438,8 +438,8 @@
 /obj/machinery/door/airlock/clockwork/New()
 	..()
 	var/turf/T = get_turf(src)
-	new /obj/effect/overlay/temp/ratvar/door(T)
-	new /obj/effect/overlay/temp/ratvar/beam/door(T)
+	new /obj/effect/temp_visual/ratvar/door(T)
+	new /obj/effect/temp_visual/ratvar/beam/door(T)
 	change_construction_value(5)
 
 /obj/machinery/door/airlock/clockwork/Destroy()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -328,7 +328,7 @@
 
 /obj/machinery/door/window/clockwork/setDir(direct)
 	if(!made_glow)
-		var/obj/effect/E = new /obj/effect/overlay/temp/ratvar/door/window(get_turf(src))
+		var/obj/effect/E = new /obj/effect/temp_visual/ratvar/door/window(get_turf(src))
 		E.setDir(direct)
 		made_glow = TRUE
 	..()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -159,7 +159,7 @@ Class Procs:
 /obj/machinery/emp_act(severity)
 	if(use_power && !stat)
 		use_power(7500/severity)
-		new /obj/effect/overlay/temp/emp(loc)
+		new /obj/effect/temp_visual/emp(loc)
 	..()
 
 /obj/machinery/proc/open_machine(drop = 1)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -8,7 +8,7 @@
 	var/variance = 0
 	var/randomspread = 0 //use random spread for machineguns, instead of shotgun scatter
 	var/projectile_delay = 0
-	var/firing_effect_type = /obj/effect/overlay/temp/dir_setting/firing_effect	//the visual effect appearing when the weapon is fired.
+	var/firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect	//the visual effect appearing when the weapon is fired.
 
 /obj/item/mecha_parts/mecha_equipment/weapon/can_attach(obj/mecha/combat/M)
 	if(..())
@@ -60,7 +60,7 @@
 //Base energy weapon type
 /obj/item/mecha_parts/mecha_equipment/weapon/energy
 	name = "general energy weapon"
-	firing_effect_type = /obj/effect/overlay/temp/dir_setting/firing_effect/energy
+	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/get_shot_amount()
 	return min(round(chassis.cell.charge / energy_drain), projectiles_per_shot)

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -1,11 +1,11 @@
-/obj/effect/overlay/temp/point
+/obj/effect/temp_visual/point
 	name = "pointer"
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "arrow"
 	layer = POINT_LAYER
 	duration = 25
 
-/obj/effect/overlay/temp/point/Initialize(mapload, set_invis = 0)
+/obj/effect/temp_visual/point/Initialize(mapload, set_invis = 0)
 	..()
 	var/atom/old_loc = loc
 	loc = get_turf(src)

--- a/code/game/objects/effects/spawners/xeno_egg_delivery.dm
+++ b/code/game/objects/effects/spawners/xeno_egg_delivery.dm
@@ -10,7 +10,7 @@
 	var/area/A = get_area(T)
 
 	new /obj/structure/alien/egg(T)
-	new /obj/effect/overlay/temp/gravpush(T)
+	new /obj/effect/temp_visual/gravpush(T)
 	playsound(T, 'sound/items/party_horn.ogg', 50, 1, -1)
 
 	message_admins("An alien egg has been delivered to [A] at [ADMIN_COORDJMP(T)].")

--- a/code/game/objects/effects/temporary_visuals/clockcult.dm
+++ b/code/game/objects/effects/temporary_visuals/clockcult.dm
@@ -1,68 +1,68 @@
-//temporary visual effects(/obj/effect/overlay/temp) used by clockcult stuff
-/obj/effect/overlay/temp/ratvar
+//temporary visual effects(/obj/effect/temp_visual) used by clockcult stuff
+/obj/effect/temp_visual/ratvar
 	name = "ratvar's light"
 	icon = 'icons/effects/clockwork_effects.dmi'
 	duration = 8
 	randomdir = 0
 	layer = ABOVE_NORMAL_TURF_LAYER
 
-/obj/effect/overlay/temp/ratvar/door
+/obj/effect/temp_visual/ratvar/door
 	icon_state = "ratvardoorglow"
 	layer = CLOSED_DOOR_LAYER //above closed doors
 
-/obj/effect/overlay/temp/ratvar/door/window
+/obj/effect/temp_visual/ratvar/door/window
 	icon_state = "ratvarwindoorglow"
 	layer = ABOVE_WINDOW_LAYER
 
-/obj/effect/overlay/temp/ratvar/beam
+/obj/effect/temp_visual/ratvar/beam
 	icon_state = "ratvarbeamglow"
 
-/obj/effect/overlay/temp/ratvar/beam/door
+/obj/effect/temp_visual/ratvar/beam/door
 	layer = CLOSED_DOOR_LAYER
 
-/obj/effect/overlay/temp/ratvar/beam/grille
+/obj/effect/temp_visual/ratvar/beam/grille
 	layer = BELOW_OBJ_LAYER
 
-/obj/effect/overlay/temp/ratvar/beam/itemconsume
+/obj/effect/temp_visual/ratvar/beam/itemconsume
 	layer = HIGH_OBJ_LAYER
 
-/obj/effect/overlay/temp/ratvar/beam/falsewall
+/obj/effect/temp_visual/ratvar/beam/falsewall
 	layer = OBJ_LAYER
 
-/obj/effect/overlay/temp/ratvar/beam/catwalk
+/obj/effect/temp_visual/ratvar/beam/catwalk
 	layer = LATTICE_LAYER
 
-/obj/effect/overlay/temp/ratvar/wall
+/obj/effect/temp_visual/ratvar/wall
 	icon_state = "ratvarwallglow"
 
-/obj/effect/overlay/temp/ratvar/wall/false
+/obj/effect/temp_visual/ratvar/wall/false
 	layer = OBJ_LAYER
 
-/obj/effect/overlay/temp/ratvar/floor
+/obj/effect/temp_visual/ratvar/floor
 	icon_state = "ratvarfloorglow"
 
-/obj/effect/overlay/temp/ratvar/floor/catwalk
+/obj/effect/temp_visual/ratvar/floor/catwalk
 	layer = LATTICE_LAYER
 
-/obj/effect/overlay/temp/ratvar/window
+/obj/effect/temp_visual/ratvar/window
 	icon_state = "ratvarwindowglow"
 	layer = ABOVE_OBJ_LAYER
 
-/obj/effect/overlay/temp/ratvar/window/single
+/obj/effect/temp_visual/ratvar/window/single
 	icon_state = "ratvarwindowglow_s"
 
-/obj/effect/overlay/temp/ratvar/gear
+/obj/effect/temp_visual/ratvar/gear
 	icon_state = "ratvargearglow"
 	layer = BELOW_OBJ_LAYER
 
-/obj/effect/overlay/temp/ratvar/grille
+/obj/effect/temp_visual/ratvar/grille
 	icon_state = "ratvargrilleglow"
 	layer = BELOW_OBJ_LAYER
 
-/obj/effect/overlay/temp/ratvar/grille/broken
+/obj/effect/temp_visual/ratvar/grille/broken
 	icon_state = "ratvarbrokengrilleglow"
 
-/obj/effect/overlay/temp/ratvar/mending_mantra
+/obj/effect/temp_visual/ratvar/mending_mantra
 	layer = ABOVE_MOB_LAYER
 	duration = 20
 	alpha = 200
@@ -70,7 +70,7 @@
 	light_range = 1.5
 	light_color = "#1E8CE1"
 
-/obj/effect/overlay/temp/ratvar/mending_mantra/Initialize(mapload)
+/obj/effect/temp_visual/ratvar/mending_mantra/Initialize(mapload)
 	. = ..()
 	transform = matrix()*2
 	var/matrix/M = transform
@@ -78,7 +78,7 @@
 	animate(src, alpha = 20, time = duration, easing = BOUNCE_EASING, flags = ANIMATION_PARALLEL)
 	animate(src, transform = M, time = duration, flags = ANIMATION_PARALLEL)
 
-/obj/effect/overlay/temp/ratvar/volt_hit
+/obj/effect/temp_visual/ratvar/volt_hit
 	name = "volt blast"
 	layer = ABOVE_MOB_LAYER
 	duration = 5
@@ -89,13 +89,13 @@
 	var/mob/user
 	var/damage = 20
 
-/obj/effect/overlay/temp/ratvar/volt_hit/Initialize(mapload, caster, multiplier)
+/obj/effect/temp_visual/ratvar/volt_hit/Initialize(mapload, caster, multiplier)
 	if(multiplier)
 		damage *= multiplier
 	duration = max(round(damage * 0.2), 1)
 	. = ..()
 
-/obj/effect/overlay/temp/ratvar/volt_hit/true/Initialize(mapload, caster, multiplier)
+/obj/effect/temp_visual/ratvar/volt_hit/true/Initialize(mapload, caster, multiplier)
 	. = ..()
 	user = caster
 	if(user)
@@ -104,7 +104,7 @@
 		transform = M
 	INVOKE_ASYNC(src, .proc/volthit)
 
-/obj/effect/overlay/temp/ratvar/volt_hit/proc/volthit()
+/obj/effect/temp_visual/ratvar/volt_hit/proc/volthit()
 	if(user)
 		Beam(get_turf(user), "volt_ray", time=duration, maxdistance=8, beam_type=/obj/effect/ebeam/volt_ray)
 	var/hit_amount = 0
@@ -134,61 +134,61 @@
 	else
 		playsound(src, "sparks", 50, 1)
 
-/obj/effect/overlay/temp/ratvar/ocular_warden
+/obj/effect/temp_visual/ratvar/ocular_warden
 	name = "warden's gaze"
 	layer = ABOVE_MOB_LAYER
 	icon_state = "warden_gaze"
 	duration = 3
 
-/obj/effect/overlay/temp/ratvar/ocular_warden/Initialize()
+/obj/effect/temp_visual/ratvar/ocular_warden/Initialize()
 	. = ..()
 	pixel_x = rand(-8, 8)
 	pixel_y = rand(-10, 10)
 	animate(src, alpha = 0, time = 3, easing = EASE_OUT)
 
-/obj/effect/overlay/temp/ratvar/spearbreak
+/obj/effect/temp_visual/ratvar/spearbreak
 	icon = 'icons/effects/64x64.dmi'
 	icon_state = "ratvarspearbreak"
 	layer = BELOW_MOB_LAYER
 	pixel_y = -16
 	pixel_x = -16
 
-/obj/effect/overlay/temp/ratvar/geis_binding
+/obj/effect/temp_visual/ratvar/geis_binding
 	icon_state = "geisbinding"
 
-/obj/effect/overlay/temp/ratvar/geis_binding/top
+/obj/effect/temp_visual/ratvar/geis_binding/top
 	icon_state = "geisbinding_top"
 
-/obj/effect/overlay/temp/ratvar/component
+/obj/effect/temp_visual/ratvar/component
 	icon = 'icons/obj/clockwork_objects.dmi'
 	icon_state = "belligerent_eye"
 	layer = ABOVE_MOB_LAYER
 	duration = 10
 
-/obj/effect/overlay/temp/ratvar/component/Initialize()
+/obj/effect/temp_visual/ratvar/component/Initialize()
 	. = ..()
 	transform = matrix()*0.75
 	pixel_x = rand(-10, 10)
 	pixel_y = rand(-10, -2)
 	animate(src, pixel_y = pixel_y + 10, alpha = 50, time = 10, easing = EASE_OUT)
 
-/obj/effect/overlay/temp/ratvar/component/cogwheel
+/obj/effect/temp_visual/ratvar/component/cogwheel
 	icon_state = "vanguard_cogwheel"
 
-/obj/effect/overlay/temp/ratvar/component/capacitor
+/obj/effect/temp_visual/ratvar/component/capacitor
 	icon_state = "geis_capacitor"
 
-/obj/effect/overlay/temp/ratvar/component/alloy
+/obj/effect/temp_visual/ratvar/component/alloy
 	icon_state = "replicant_alloy"
 
-/obj/effect/overlay/temp/ratvar/component/ansible
+/obj/effect/temp_visual/ratvar/component/ansible
 	icon_state = "hierophant_ansible"
 
-/obj/effect/overlay/temp/ratvar/sigil
+/obj/effect/temp_visual/ratvar/sigil
 	name = "glowing circle"
 	icon_state = "sigildull"
 
-/obj/effect/overlay/temp/ratvar/sigil/transgression
+/obj/effect/temp_visual/ratvar/sigil/transgression
 	color = "#FAE48C"
 	layer = ABOVE_MOB_LAYER
 	duration = 70
@@ -196,13 +196,13 @@
 	light_power = 2
 	light_color = "#FAE48C"
 
-/obj/effect/overlay/temp/ratvar/sigil/transgression/Initialize()
+/obj/effect/temp_visual/ratvar/sigil/transgression/Initialize()
 	. = ..()
 	var/oldtransform = transform
 	animate(src, transform = matrix()*2, time = 5)
 	animate(transform = oldtransform, alpha = 0, time = 65)
 
-/obj/effect/overlay/temp/ratvar/sigil/vitality
+/obj/effect/temp_visual/ratvar/sigil/vitality
 	color = "#1E8CE1"
 	icon_state = "sigilactivepulse"
 	layer = ABOVE_MOB_LAYER
@@ -210,7 +210,7 @@
 	light_power = 0.5
 	light_color = "#1E8CE1"
 
-/obj/effect/overlay/temp/ratvar/sigil/accession
+/obj/effect/temp_visual/ratvar/sigil/accession
 	color = "#AF0AAF"
 	layer = ABOVE_MOB_LAYER
 	duration = 70

--- a/code/game/objects/effects/temporary_visuals/cult.dm
+++ b/code/game/objects/effects/temporary_visuals/cult.dm
@@ -1,58 +1,58 @@
-//temporary visual effects(/obj/effect/overlay/temp) used by cult stuff
-/obj/effect/overlay/temp/cult
+//temporary visual effects(/obj/effect/temp_visual) used by cult stuff
+/obj/effect/temp_visual/cult
 	icon = 'icons/effects/cult_effects.dmi'
 	randomdir = 0
 	duration = 10
 
-/obj/effect/overlay/temp/cult/sparks
+/obj/effect/temp_visual/cult/sparks
 	randomdir = 1
 	name = "blood sparks"
 	icon_state = "bloodsparkles"
 
-/obj/effect/overlay/temp/cult/blood  // The traditional teleport
+/obj/effect/temp_visual/cult/blood  // The traditional teleport
 	name = "blood jaunt"
 	duration = 12
 	icon_state = "bloodin"
 
-/obj/effect/overlay/temp/cult/blood/out
+/obj/effect/temp_visual/cult/blood/out
 	icon_state = "bloodout"
 
-/obj/effect/overlay/temp/dir_setting/cult/phase  // The veil shifter teleport
+/obj/effect/temp_visual/dir_setting/cult/phase  // The veil shifter teleport
 	name = "phase glow"
 	duration = 7
 	icon_state = "cultin"
 
-/obj/effect/overlay/temp/dir_setting/cult/phase/out
+/obj/effect/temp_visual/dir_setting/cult/phase/out
 	icon_state = "cultout"
 
-/obj/effect/overlay/temp/cult/sac
+/obj/effect/temp_visual/cult/sac
 	name = "maw of Nar-Sie"
 	icon_state = "sacconsume"
 
-/obj/effect/overlay/temp/cult/door
+/obj/effect/temp_visual/cult/door
 	name = "unholy glow"
 	icon_state = "doorglow"
 	layer = CLOSED_FIREDOOR_LAYER //above closed doors
 
-/obj/effect/overlay/temp/cult/door/unruned
+/obj/effect/temp_visual/cult/door/unruned
 	icon_state = "unruneddoorglow"
 
-/obj/effect/overlay/temp/cult/turf
+/obj/effect/temp_visual/cult/turf
 	name = "unholy glow"
 	icon_state = "wallglow"
 	layer = ABOVE_NORMAL_TURF_LAYER
 
-/obj/effect/overlay/temp/cult/turf/floor
+/obj/effect/temp_visual/cult/turf/floor
 	icon_state = "floorglow"
 	duration = 5
 
 //visuals for runes being magically created
-/obj/effect/overlay/temp/cult/rune_spawn
+/obj/effect/temp_visual/cult/rune_spawn
 	icon_state = "runeouter"
 	alpha = 0
 	var/turnedness = 179 //179 turns counterclockwise, 181 turns clockwise
 
-/obj/effect/overlay/temp/cult/rune_spawn/Initialize(mapload, set_duration, set_color)
+/obj/effect/temp_visual/cult/rune_spawn/Initialize(mapload, set_duration, set_color)
 	if(isnum(set_duration))
 		duration = set_duration
 	if(set_color)
@@ -66,79 +66,79 @@
 	animate(src, alpha = 255, time = duration, easing = BOUNCE_EASING, flags = ANIMATION_PARALLEL)
 	animate(src, transform = oldtransform, time = duration, flags = ANIMATION_PARALLEL)
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune1
+/obj/effect/temp_visual/cult/rune_spawn/rune1
 	icon_state = "rune1words"
 	turnedness = 181
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune1/inner
+/obj/effect/temp_visual/cult/rune_spawn/rune1/inner
 	icon_state = "rune1inner"
 	turnedness = 179
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune1/center
+/obj/effect/temp_visual/cult/rune_spawn/rune1/center
 	icon_state = "rune1center"
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune2
+/obj/effect/temp_visual/cult/rune_spawn/rune2
 	icon_state = "rune2words"
 	turnedness = 181
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune2/inner
+/obj/effect/temp_visual/cult/rune_spawn/rune2/inner
 	icon_state = "rune2inner"
 	turnedness = 179
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune2/center
+/obj/effect/temp_visual/cult/rune_spawn/rune2/center
 	icon_state = "rune2center"
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune3
+/obj/effect/temp_visual/cult/rune_spawn/rune3
 	icon_state = "rune3words"
 	turnedness = 181
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune3/inner
+/obj/effect/temp_visual/cult/rune_spawn/rune3/inner
 	icon_state = "rune3inner"
 	turnedness = 179
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune3/center
+/obj/effect/temp_visual/cult/rune_spawn/rune3/center
 	icon_state = "rune3center"
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune4
+/obj/effect/temp_visual/cult/rune_spawn/rune4
 	icon_state = "rune4words"
 	turnedness = 181
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune4/inner
+/obj/effect/temp_visual/cult/rune_spawn/rune4/inner
 	icon_state = "rune4inner"
 	turnedness = 179
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune4/center
+/obj/effect/temp_visual/cult/rune_spawn/rune4/center
 	icon_state = "rune4center"
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune5
+/obj/effect/temp_visual/cult/rune_spawn/rune5
 	icon_state = "rune5words"
 	turnedness = 181
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune5/inner
+/obj/effect/temp_visual/cult/rune_spawn/rune5/inner
 	icon_state = "rune5inner"
 	turnedness = 179
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune5/center
+/obj/effect/temp_visual/cult/rune_spawn/rune5/center
 	icon_state = "rune5center"
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune6
+/obj/effect/temp_visual/cult/rune_spawn/rune6
 	icon_state = "rune6words"
 	turnedness = 181
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune6/inner
+/obj/effect/temp_visual/cult/rune_spawn/rune6/inner
 	icon_state = "rune6inner"
 	turnedness = 179
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune6/center
+/obj/effect/temp_visual/cult/rune_spawn/rune6/center
 	icon_state = "rune6center"
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune7
+/obj/effect/temp_visual/cult/rune_spawn/rune7
 	icon_state = "rune7words"
 	turnedness = 181
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune7/inner
+/obj/effect/temp_visual/cult/rune_spawn/rune7/inner
 	icon_state = "rune7inner"
 	turnedness = 179
 
-/obj/effect/overlay/temp/cult/rune_spawn/rune7/center
+/obj/effect/temp_visual/cult/rune_spawn/rune7/center
 	icon_state = "rune7center"

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -1,12 +1,12 @@
 //unsorted miscellaneous temporary visuals
-/obj/effect/overlay/temp/dir_setting/bloodsplatter
+/obj/effect/temp_visual/dir_setting/bloodsplatter
 	icon = 'icons/effects/blood.dmi'
 	duration = 5
 	randomdir = FALSE
 	layer = BELOW_MOB_LAYER
 	var/splatter_type = "splatter"
 
-/obj/effect/overlay/temp/dir_setting/bloodsplatter/Initialize(mapload, set_dir)
+/obj/effect/temp_visual/dir_setting/bloodsplatter/Initialize(mapload, set_dir)
 	if(set_dir in GLOB.diagonals)
 		icon_state = "[splatter_type][pick(1, 2, 6)]"
 	else
@@ -40,22 +40,22 @@
 			layer = ABOVE_MOB_LAYER
 	animate(src, pixel_x = target_pixel_x, pixel_y = target_pixel_y, alpha = 0, time = duration)
 
-/obj/effect/overlay/temp/dir_setting/bloodsplatter/xenosplatter
+/obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter
 	splatter_type = "xsplatter"
 
-/obj/effect/overlay/temp/dir_setting/speedbike_trail
+/obj/effect/temp_visual/dir_setting/speedbike_trail
 	name = "speedbike trails"
 	icon_state = "ion_fade"
 	layer = BELOW_MOB_LAYER
 	duration = 10
 	randomdir = 0
 
-/obj/effect/overlay/temp/dir_setting/firing_effect
+/obj/effect/temp_visual/dir_setting/firing_effect
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "firing_effect"
 	duration = 2
 
-/obj/effect/overlay/temp/dir_setting/firing_effect/setDir(newdir)
+/obj/effect/temp_visual/dir_setting/firing_effect/setDir(newdir)
 	switch(newdir)
 		if(NORTH)
 			layer = BELOW_MOB_LAYER
@@ -69,84 +69,84 @@
 			pixel_y = rand(-1,1)
 	..()
 
-/obj/effect/overlay/temp/dir_setting/firing_effect/energy
+/obj/effect/temp_visual/dir_setting/firing_effect/energy
 	icon_state = "firing_effect_energy"
 	duration = 3
 
-/obj/effect/overlay/temp/dir_setting/firing_effect/magic
+/obj/effect/temp_visual/dir_setting/firing_effect/magic
 	icon_state = "shieldsparkles"
 	duration = 3
 
-/obj/effect/overlay/temp/dir_setting/ninja
+/obj/effect/temp_visual/dir_setting/ninja
 	name = "ninja shadow"
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "uncloak"
 	duration = 9
 
-/obj/effect/overlay/temp/dir_setting/ninja/cloak
+/obj/effect/temp_visual/dir_setting/ninja/cloak
 	icon_state = "cloak"
 
-/obj/effect/overlay/temp/dir_setting/ninja/shadow
+/obj/effect/temp_visual/dir_setting/ninja/shadow
 	icon_state = "shadow"
 
-/obj/effect/overlay/temp/dir_setting/ninja/phase
+/obj/effect/temp_visual/dir_setting/ninja/phase
 	name = "ninja energy"
 	icon_state = "phasein"
 
-/obj/effect/overlay/temp/dir_setting/ninja/phase/out
+/obj/effect/temp_visual/dir_setting/ninja/phase/out
 	icon_state = "phaseout"
 
-/obj/effect/overlay/temp/dir_setting/wraith
+/obj/effect/temp_visual/dir_setting/wraith
 	name = "blood"
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "phase_shift2"
 	duration = 12
 
-/obj/effect/overlay/temp/dir_setting/wraith/out
+/obj/effect/temp_visual/dir_setting/wraith/out
 	icon_state = "phase_shift"
 
-/obj/effect/overlay/temp/dir_setting/tailsweep
+/obj/effect/temp_visual/dir_setting/tailsweep
 	icon_state = "tailsweep"
 	duration = 4
 
-/obj/effect/overlay/temp/wizard
+/obj/effect/temp_visual/wizard
 	name = "water"
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "reappear"
 	duration = 5
 
-/obj/effect/overlay/temp/wizard/out
+/obj/effect/temp_visual/wizard/out
 	icon_state = "liquify"
 	duration = 12
 
-/obj/effect/overlay/temp/monkeyify
+/obj/effect/temp_visual/monkeyify
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "h2monkey"
 	duration = 22
 
-/obj/effect/overlay/temp/monkeyify/humanify
+/obj/effect/temp_visual/monkeyify/humanify
 	icon_state = "monkey2h"
 
-/obj/effect/overlay/temp/borgflash
+/obj/effect/temp_visual/borgflash
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "blspell"
 	duration = 5
 
-/obj/effect/overlay/temp/guardian
+/obj/effect/temp_visual/guardian
 	randomdir = 0
 
-/obj/effect/overlay/temp/guardian/phase
+/obj/effect/temp_visual/guardian/phase
 	duration = 5
 	icon_state = "phasein"
 
-/obj/effect/overlay/temp/guardian/phase/out
+/obj/effect/temp_visual/guardian/phase/out
 	icon_state = "phaseout"
 
-/obj/effect/overlay/temp/decoy
+/obj/effect/temp_visual/decoy
 	desc = "It's a decoy!"
 	duration = 15
 
-/obj/effect/overlay/temp/decoy/Initialize(mapload, atom/mimiced_atom)
+/obj/effect/temp_visual/decoy/Initialize(mapload, atom/mimiced_atom)
 	. = ..()
 	alpha = initial(alpha)
 	if(mimiced_atom)
@@ -155,95 +155,95 @@
 		setDir(mimiced_atom.dir)
 		mouse_opacity = 0
 
-/obj/effect/overlay/temp/decoy/fading/Initialize(mapload, atom/mimiced_atom)
+/obj/effect/temp_visual/decoy/fading/Initialize(mapload, atom/mimiced_atom)
 	. = ..()
 	animate(src, alpha = 0, time = duration)
 
-/obj/effect/overlay/temp/decoy/fading/fivesecond
+/obj/effect/temp_visual/decoy/fading/fivesecond
 	duration = 50
 
-/obj/effect/overlay/temp/small_smoke
+/obj/effect/temp_visual/small_smoke
 	icon_state = "smoke"
 	duration = 50
 
-/obj/effect/overlay/temp/fire
+/obj/effect/temp_visual/fire
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "3"
 	duration = 20
 
-/obj/effect/overlay/temp/revenant
+/obj/effect/temp_visual/revenant
 	name = "spooky lights"
 	icon_state = "purplesparkles"
 
-/obj/effect/overlay/temp/revenant/cracks
+/obj/effect/temp_visual/revenant/cracks
 	name = "glowing cracks"
 	icon_state = "purplecrack"
 	duration = 6
 
-/obj/effect/overlay/temp/gravpush
+/obj/effect/temp_visual/gravpush
 	name = "gravity wave"
 	icon_state = "shieldsparkles"
 	duration = 5
 
-/obj/effect/overlay/temp/telekinesis
+/obj/effect/temp_visual/telekinesis
 	name = "telekinetic force"
 	icon_state = "empdisable"
 	duration = 5
 
-/obj/effect/overlay/temp/emp
+/obj/effect/temp_visual/emp
 	name = "emp sparks"
 	icon_state = "empdisable"
 
-/obj/effect/overlay/temp/emp/pulse
+/obj/effect/temp_visual/emp/pulse
 	name = "emp pulse"
 	icon_state = "emppulse"
 	duration = 8
 	randomdir = 0
 
-/obj/effect/overlay/temp/gib_animation
+/obj/effect/temp_visual/gib_animation
 	icon = 'icons/mob/mob.dmi'
 	duration = 15
 
-/obj/effect/overlay/temp/gib_animation/Initialize(mapload, gib_icon)
+/obj/effect/temp_visual/gib_animation/Initialize(mapload, gib_icon)
 	icon_state = gib_icon // Needs to be before ..() so icon is correct
 	. = ..()
 
-/obj/effect/overlay/temp/gib_animation/animal
+/obj/effect/temp_visual/gib_animation/animal
 	icon = 'icons/mob/animal.dmi'
 
-/obj/effect/overlay/temp/dust_animation
+/obj/effect/temp_visual/dust_animation
 	icon = 'icons/mob/mob.dmi'
 	duration = 15
 
-/obj/effect/overlay/temp/dust_animation/Initialize(mapload, dust_icon)
+/obj/effect/temp_visual/dust_animation/Initialize(mapload, dust_icon)
 	icon_state = dust_icon // Before ..() so the correct icon is flick()'d
 	. = ..()
 
-/obj/effect/overlay/temp/mummy_animation
+/obj/effect/temp_visual/mummy_animation
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "mummy_revive"
 	duration = 20
 
-/obj/effect/overlay/temp/heal //color is white by default, set to whatever is needed
+/obj/effect/temp_visual/heal //color is white by default, set to whatever is needed
 	name = "healing glow"
 	icon_state = "heal"
 	duration = 15
 
-/obj/effect/overlay/temp/heal/Initialize(mapload, set_color)
+/obj/effect/temp_visual/heal/Initialize(mapload, set_color)
 	if(set_color)
 		add_atom_colour(set_color, FIXED_COLOUR_PRIORITY)
 	. = ..()
 	pixel_x = rand(-12, 12)
 	pixel_y = rand(-9, 0)
 
-/obj/effect/overlay/temp/kinetic_blast
+/obj/effect/temp_visual/kinetic_blast
 	name = "kinetic explosion"
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "kinetic_blast"
 	layer = ABOVE_ALL_MOB_LAYER
 	duration = 4
 
-/obj/effect/overlay/temp/explosion
+/obj/effect/temp_visual/explosion
 	name = "explosion"
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "explosion"
@@ -251,22 +251,22 @@
 	pixel_y = -32
 	duration = 8
 
-/obj/effect/overlay/temp/explosion/fast
+/obj/effect/temp_visual/explosion/fast
 	icon_state = "explosionfast"
 	duration = 4
 
-/obj/effect/overlay/temp/blob
+/obj/effect/temp_visual/blob
 	name = "blob"
 	icon_state = "blob_attack"
 	alpha = 140
 	randomdir = 0
 	duration = 6
 
-/obj/effect/overlay/temp/impact_effect
+/obj/effect/temp_visual/impact_effect
 	icon_state = "impact_bullet"
 	duration = 5
 
-/obj/effect/overlay/temp/impact_effect/Initialize(mapload, atom/target, obj/item/projectile/P)
+/obj/effect/temp_visual/impact_effect/Initialize(mapload, atom/target, obj/item/projectile/P)
 	if(target == P.original) //the projectile hit the target originally clicked
 		pixel_x = P.p_x + target.pixel_x - 16 + rand(-4,4)
 		pixel_y = P.p_y + target.pixel_y - 16 + rand(-4,4)
@@ -275,37 +275,37 @@
 		pixel_y = target.pixel_y + rand(-4,4)
 	. = ..()
 
-/obj/effect/overlay/temp/impact_effect/red_laser
+/obj/effect/temp_visual/impact_effect/red_laser
 	icon_state = "impact_laser"
 	duration = 4
 
-/obj/effect/overlay/temp/impact_effect/red_laser/wall
+/obj/effect/temp_visual/impact_effect/red_laser/wall
 	icon_state = "impact_laser_wall"
 	duration = 10
 
-/obj/effect/overlay/temp/impact_effect/blue_laser
+/obj/effect/temp_visual/impact_effect/blue_laser
 	icon_state = "impact_laser_blue"
 	duration = 4
 
-/obj/effect/overlay/temp/impact_effect/green_laser
+/obj/effect/temp_visual/impact_effect/green_laser
 	icon_state = "impact_laser_green"
 	duration = 4
 
-/obj/effect/overlay/temp/impact_effect/purple_laser
+/obj/effect/temp_visual/impact_effect/purple_laser
 	icon_state = "impact_laser_purple"
 	duration = 4
 
-/obj/effect/overlay/temp/impact_effect/ion
+/obj/effect/temp_visual/impact_effect/ion
 	icon_state = "shieldsparkles"
 	duration = 6
 
-/obj/effect/overlay/temp/heart
+/obj/effect/temp_visual/heart
 	name = "heart"
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "heart"
 	duration = 25
 
-/obj/effect/overlay/temp/heart/Initialize(mapload)
+/obj/effect/temp_visual/heart/Initialize(mapload)
 	. = ..()
 	pixel_x = rand(-4,4)
 	pixel_y = rand(-4,4)

--- a/code/game/objects/effects/temporary_visuals/temporary_visual.dm
+++ b/code/game/objects/effects/temporary_visuals/temporary_visual.dm
@@ -1,5 +1,5 @@
 //temporary visual effects
-/obj/effect/overlay/temp
+/obj/effect/temp_visual
 	icon_state = "nothing"
 	anchored = 1
 	layer = ABOVE_MOB_LAYER
@@ -8,30 +8,30 @@
 	var/randomdir = TRUE
 	var/timerid
 
-/obj/effect/overlay/temp/Initialize()
+/obj/effect/temp_visual/Initialize()
 	. = ..()
 	if(randomdir)
 		setDir(pick(GLOB.cardinal))
 
 	timerid = QDEL_IN(src, duration)
 
-/obj/effect/overlay/temp/Destroy()
+/obj/effect/temp_visual/Destroy()
 	. = ..()
 	deltimer(timerid)
 
-/obj/effect/overlay/temp/singularity_act()
+/obj/effect/temp_visual/singularity_act()
 	return
 
-/obj/effect/overlay/temp/singularity_pull()
+/obj/effect/temp_visual/singularity_pull()
 	return
 
-/obj/effect/overlay/temp/ex_act()
+/obj/effect/temp_visual/ex_act()
 	return
 
-/obj/effect/overlay/temp/dir_setting
+/obj/effect/temp_visual/dir_setting
 	randomdir = FALSE
 
-/obj/effect/overlay/temp/dir_setting/Initialize(mapload, set_dir)
+/obj/effect/temp_visual/dir_setting/Initialize(mapload, set_dir)
 	if(set_dir)
 		setDir(set_dir)
 	. = ..()

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -9,7 +9,7 @@
 		log_game("EMP with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
 
 	if(heavy_range > 1)
-		new /obj/effect/overlay/temp/emp/pulse(epicenter)
+		new /obj/effect/temp_visual/emp/pulse(epicenter)
 
 	if(heavy_range > light_range)
 		light_range = heavy_range

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -56,13 +56,13 @@
 		qdel(active_dummy)
 		active_dummy = null
 		to_chat(usr, "<span class='notice'>You deactivate \the [src].</span>")
-		new /obj/effect/overlay/temp/emp/pulse(get_turf(src))
+		new /obj/effect/temp_visual/emp/pulse(get_turf(src))
 	else
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
 		var/obj/effect/dummy/chameleon/C = new/obj/effect/dummy/chameleon(usr.loc)
 		C.activate(usr, saved_appearance, src)
 		to_chat(usr, "<span class='notice'>You activate \the [src].</span>")
-		new /obj/effect/overlay/temp/emp/pulse(get_turf(src))
+		new /obj/effect/temp_visual/emp/pulse(get_turf(src))
 
 /obj/item/device/chameleon/proc/disrupt(delete_dummy = 1)
 	if(active_dummy)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -162,18 +162,18 @@
 			return
 		var/T = get_turf(target)
 		if(locate(/mob/living) in T)
-			new /obj/effect/overlay/temp/medical_holosign(T,user) //produce a holographic glow
+			new /obj/effect/temp_visual/medical_holosign(T,user) //produce a holographic glow
 			holo_cooldown = world.time + 100
 			return
 	..()
 
-/obj/effect/overlay/temp/medical_holosign
+/obj/effect/temp_visual/medical_holosign
 	name = "medical holosign"
 	desc = "A small holographic glow that indicates a medic is coming to treat a patient."
 	icon_state = "medi_holo"
 	duration = 30
 
-/obj/effect/overlay/temp/medical_holosign/Initialize(mapload, creator)
+/obj/effect/temp_visual/medical_holosign/Initialize(mapload, creator)
 	. = ..()
 	playsound(loc, 'sound/machines/ping.ogg', 50, 0) //make some noise!
 	if(creator)

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -80,7 +80,7 @@
 	target.apply_damage(force * fisto_setting, BRUTE)
 	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as they punch [target.name]!</span>", \
 		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
-	new /obj/effect/overlay/temp/kinetic_blast(target.loc)
+	new /obj/effect/temp_visual/kinetic_blast(target.loc)
 	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
 	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
 

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -331,8 +331,8 @@
 /obj/structure/falsewall/brass/New(loc)
 	..()
 	var/turf/T = get_turf(src)
-	new /obj/effect/overlay/temp/ratvar/wall/false(T)
-	new /obj/effect/overlay/temp/ratvar/beam/falsewall(T)
+	new /obj/effect/temp_visual/ratvar/wall/false(T)
+	new /obj/effect/temp_visual/ratvar/beam/falsewall(T)
 	change_construction_value(4)
 
 /obj/structure/falsewall/brass/Destroy()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -254,10 +254,10 @@
 /obj/structure/grille/ratvar/New()
 	..()
 	if(broken)
-		new /obj/effect/overlay/temp/ratvar/grille/broken(get_turf(src))
+		new /obj/effect/temp_visual/ratvar/grille/broken(get_turf(src))
 	else
-		new /obj/effect/overlay/temp/ratvar/grille(get_turf(src))
-		new /obj/effect/overlay/temp/ratvar/beam/grille(get_turf(src))
+		new /obj/effect/temp_visual/ratvar/grille(get_turf(src))
+		new /obj/effect/temp_visual/ratvar/beam/grille(get_turf(src))
 
 /obj/structure/grille/ratvar/narsie_act()
 	take_damage(rand(1, 3), BRUTE)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -102,8 +102,8 @@
 
 /obj/structure/lattice/catwalk/clockwork/Initialize(mapload)
 	..()
-	new /obj/effect/overlay/temp/ratvar/floor/catwalk(loc)
-	new /obj/effect/overlay/temp/ratvar/beam/catwalk(loc)
+	new /obj/effect/temp_visual/ratvar/floor/catwalk(loc)
+	new /obj/effect/temp_visual/ratvar/beam/catwalk(loc)
 
 /obj/structure/lattice/catwalk/clockwork/ratvar_act()
 	return

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -545,7 +545,7 @@
 		qdel(I)
 	var/amount_of_gears = 2
 	if(fulltile)
-		new /obj/effect/overlay/temp/ratvar/window(get_turf(src))
+		new /obj/effect/temp_visual/ratvar/window(get_turf(src))
 		amount_of_gears = 4
 	for(var/i in 1 to amount_of_gears)
 		debris += new/obj/item/clockwork/alloy_shards/medium/gear_bit()
@@ -553,7 +553,7 @@
 
 /obj/structure/window/reinforced/clockwork/setDir(direct)
 	if(!made_glow)
-		var/obj/effect/E = new /obj/effect/overlay/temp/ratvar/window/single(get_turf(src))
+		var/obj/effect/E = new /obj/effect/temp_visual/ratvar/window/single(get_turf(src))
 		E.setDir(direct)
 		made_glow = TRUE
 	..()

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -133,8 +133,8 @@
 
 /turf/open/floor/clockwork/Initialize()
 	..()
-	new /obj/effect/overlay/temp/ratvar/floor(src)
-	new /obj/effect/overlay/temp/ratvar/beam(src)
+	new /obj/effect/temp_visual/ratvar/floor(src)
+	new /obj/effect/temp_visual/ratvar/beam(src)
 	realappearence = new /obj/effect/clockwork/overlay/floor(src)
 	realappearence.linked = src
 	change_construction_value(1)

--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -108,7 +108,7 @@
 
 /turf/open/floor/engine/cult/Initialize()
 	..()
-	new /obj/effect/overlay/temp/cult/turf/floor(src)
+	new /obj/effect/temp_visual/cult/turf/floor(src)
 	realappearence = new /obj/effect/clockwork/overlay/floor/bloodcult(src)
 	realappearence.linked = src
 

--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -10,7 +10,7 @@
 	girder_type = /obj/structure/girder/cult
 
 /turf/closed/wall/mineral/cult/Initialize()
-	new /obj/effect/overlay/temp/cult/turf(src)
+	new /obj/effect/temp_visual/cult/turf(src)
 	. = ..()
 
 /turf/closed/wall/mineral/cult/devastate_wall()
@@ -39,11 +39,11 @@
 	desc = "A cold stone wall engraved with indecipherable symbols. Studying them causes your head to pound."
 
 /turf/closed/wall/mineral/cult/artificer/break_wall()
-	new /obj/effect/overlay/temp/cult/turf(get_turf(src))
+	new /obj/effect/temp_visual/cult/turf(get_turf(src))
 	return null //excuse me we want no runed metal here
 
 /turf/closed/wall/mineral/cult/artificer/devastate_wall()
-	new /obj/effect/overlay/temp/cult/turf(get_turf(src))
+	new /obj/effect/temp_visual/cult/turf(get_turf(src))
 
 //Clockwork wall: Causes nearby tinkerer's caches to generate components.
 /turf/closed/wall/clockwork
@@ -60,8 +60,8 @@
 
 /turf/closed/wall/clockwork/Initialize()
 	..()
-	new /obj/effect/overlay/temp/ratvar/wall(src)
-	new /obj/effect/overlay/temp/ratvar/beam(src)
+	new /obj/effect/temp_visual/ratvar/wall(src)
+	new /obj/effect/temp_visual/ratvar/beam(src)
 	realappearence = new /obj/effect/clockwork/overlay/wall(src)
 	realappearence.linked = src
 	change_construction_value(5)

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -60,7 +60,7 @@
 		message_admins("[key_name_admin(ghost)] has taken control of ([key_name_admin(body)])")
 		body.ghostize(0)
 		body.key = ghost.key
-		new /obj/effect/overlay/temp/gravpush(get_turf(body))
+		new /obj/effect/temp_visual/gravpush(get_turf(body))
 
 /obj/effect/fun_balloon/sentience/emergency_shuttle
 	name = "shuttle sentience fun balloon"
@@ -79,7 +79,7 @@
 /obj/effect/fun_balloon/scatter/effect()
 	for(var/mob/living/M in range(effect_range, get_turf(src)))
 		var/turf/T = find_safe_turf()
-		new /obj/effect/overlay/temp/gravpush(get_turf(M))
+		new /obj/effect/temp_visual/gravpush(get_turf(M))
 		M.forceMove(T)
 		to_chat(M, "<span class='notice'>Pop!</span>")
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -172,11 +172,11 @@
 
 /obj/item/device/assembly/flash/cyborg/attack(mob/living/M, mob/user)
 	..()
-	new /obj/effect/overlay/temp/borgflash(get_turf(src))
+	new /obj/effect/temp_visual/borgflash(get_turf(src))
 
 /obj/item/device/assembly/flash/cyborg/attack_self(mob/user)
 	..()
-	new /obj/effect/overlay/temp/borgflash(get_turf(src))
+	new /obj/effect/temp_visual/borgflash(get_turf(src))
 
 /obj/item/device/assembly/flash/cyborg/attackby(obj/item/weapon/W, mob/user, params)
 	return

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -433,7 +433,7 @@
 
 /obj/item/projectile/beam/ctf/red
 	icon_state = "laser"
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/red_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 
 // BLUE TEAM GUNS
 
@@ -448,7 +448,7 @@
 
 /obj/item/projectile/beam/ctf/blue
 	icon_state = "bluelaser"
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/blue_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 
 /datum/outfit/ctf
 	name = "CTF"

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -447,10 +447,10 @@
 			minerals += M
 	if(minerals.len)
 		for(var/turf/closed/mineral/M in minerals)
-			var/obj/effect/overlay/temp/mining_overlay/C = new /obj/effect/overlay/temp/mining_overlay(M)
+			var/obj/effect/temp_visual/mining_overlay/C = new /obj/effect/temp_visual/mining_overlay(M)
 			C.icon_state = M.scan_state
 
-/obj/effect/overlay/temp/mining_overlay
+/obj/effect/temp_visual/mining_overlay
 	layer = FLASH_LAYER
 	icon = 'icons/turf/smoothrocks.dmi'
 	anchored = 1
@@ -543,7 +543,7 @@
 		var/target_turf = get_turf(target)
 		if(ismineralturf(target_turf))
 			var/turf/closed/mineral/M = target_turf
-			new /obj/effect/overlay/temp/kinetic_blast(M)
+			new /obj/effect/temp_visual/kinetic_blast(M)
 			M.gets_drilled(firer)
 	..()
 
@@ -568,7 +568,7 @@
 		return
 	if(proximity_flag && target == mark && isliving(target))
 		var/mob/living/L = target
-		new /obj/effect/overlay/temp/kinetic_blast(get_turf(L))
+		new /obj/effect/temp_visual/kinetic_blast(get_turf(L))
 		mark = 0
 		if(L.mob_size >= MOB_SIZE_LARGE)
 			L.underlays -= marked_underlay

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -672,7 +672,7 @@
 		if(!istype(T))
 			return
 		if(!istype(T, turf_type))
-			var/obj/effect/overlay/temp/lavastaff/L = new /obj/effect/overlay/temp/lavastaff(T)
+			var/obj/effect/temp_visual/lavastaff/L = new /obj/effect/temp_visual/lavastaff(T)
 			L.alpha = 0
 			animate(L, alpha = 255, time = create_delay)
 			user.visible_message("<span class='danger'>[user] points [src] at [T]!</span>")
@@ -695,7 +695,7 @@
 				timer = world.time + reset_cooldown
 				playsound(T,'sound/magic/Fireball.ogg', 200, 1)
 
-/obj/effect/overlay/temp/lavastaff
+/obj/effect/temp_visual/lavastaff
 	icon_state = "lavastaff_warn"
 	duration = 50
 
@@ -820,7 +820,7 @@
 			timer = world.time + cooldown_time
 			if(isliving(target) && chaser_timer <= world.time) //living and chasers off cooldown? fire one!
 				chaser_timer = world.time + chaser_cooldown
-				new /obj/effect/overlay/temp/hierophant/chaser(get_turf(user), user, target, chaser_speed, friendly_fire_check)
+				new /obj/effect/temp_visual/hierophant/chaser(get_turf(user), user, target, chaser_speed, friendly_fire_check)
 				add_logs(user, target, "fired a chaser at", src)
 			else
 				INVOKE_ASYNC(src, .proc/cardinal_blasts, T, user) //otherwise, just do cardinal blast
@@ -875,7 +875,7 @@
 			if(do_after(user, 50, target = user) && !beacon)
 				var/turf/T = get_turf(user)
 				playsound(T,'sound/magic/Blind.ogg', 200, 1, -4)
-				new /obj/effect/overlay/temp/hierophant/telegraph/teleport(T, user)
+				new /obj/effect/temp_visual/hierophant/telegraph/teleport(T, user)
 				beacon = new/obj/effect/hierophant(T)
 				user.update_action_buttons_icon()
 				user.visible_message("<span class='hierophant_warning'>[user] places a strange machine beneath [user.p_their()] feet!</span>", \
@@ -902,8 +902,8 @@
 	timer = world.time + 50
 	INVOKE_ASYNC(src, .proc/prepare_icon_update)
 	beacon.icon_state = "hierophant_tele_on"
-	var/obj/effect/overlay/temp/hierophant/telegraph/edge/TE1 = new /obj/effect/overlay/temp/hierophant/telegraph/edge(user.loc)
-	var/obj/effect/overlay/temp/hierophant/telegraph/edge/TE2 = new /obj/effect/overlay/temp/hierophant/telegraph/edge(beacon.loc)
+	var/obj/effect/temp_visual/hierophant/telegraph/edge/TE1 = new /obj/effect/temp_visual/hierophant/telegraph/edge(user.loc)
+	var/obj/effect/temp_visual/hierophant/telegraph/edge/TE2 = new /obj/effect/temp_visual/hierophant/telegraph/edge(beacon.loc)
 	if(do_after(user, 40, target = user) && user && beacon)
 		var/turf/T = get_turf(beacon)
 		var/turf/source = get_turf(user)
@@ -915,8 +915,8 @@
 			INVOKE_ASYNC(src, .proc/prepare_icon_update)
 			beacon.icon_state = "hierophant_tele_off"
 			return
-		new /obj/effect/overlay/temp/hierophant/telegraph(T, user)
-		new /obj/effect/overlay/temp/hierophant/telegraph(source, user)
+		new /obj/effect/temp_visual/hierophant/telegraph(T, user)
+		new /obj/effect/temp_visual/hierophant/telegraph(source, user)
 		playsound(T,'sound/magic/Wand_Teleport.ogg', 200, 1)
 		playsound(source,'sound/machines/AirlockOpen.ogg', 200, 1)
 		if(!do_after(user, 3, target = user) || !user || !beacon || QDELETED(beacon)) //no walking away shitlord
@@ -937,13 +937,13 @@
 			beacon.icon_state = "hierophant_tele_off"
 			return
 		add_logs(user, beacon, "teleported self from ([source.x],[source.y],[source.z]) to")
-		new /obj/effect/overlay/temp/hierophant/telegraph/teleport(T, user)
-		new /obj/effect/overlay/temp/hierophant/telegraph/teleport(source, user)
+		new /obj/effect/temp_visual/hierophant/telegraph/teleport(T, user)
+		new /obj/effect/temp_visual/hierophant/telegraph/teleport(source, user)
 		for(var/t in RANGE_TURFS(1, T))
-			var/obj/effect/overlay/temp/hierophant/blast/B = new /obj/effect/overlay/temp/hierophant/blast(t, user, TRUE) //blasts produced will not hurt allies
+			var/obj/effect/temp_visual/hierophant/blast/B = new /obj/effect/temp_visual/hierophant/blast(t, user, TRUE) //blasts produced will not hurt allies
 			B.damage = 30
 		for(var/t in RANGE_TURFS(1, source))
-			var/obj/effect/overlay/temp/hierophant/blast/B = new /obj/effect/overlay/temp/hierophant/blast(t, user, TRUE) //but absolutely will hurt enemies
+			var/obj/effect/temp_visual/hierophant/blast/B = new /obj/effect/temp_visual/hierophant/blast(t, user, TRUE) //but absolutely will hurt enemies
 			B.damage = 30
 		for(var/mob/living/L in range(1, source))
 			INVOKE_ASYNC(src, .proc/teleport_mob, source, L, T, user) //regardless, take all mobs near us along
@@ -988,10 +988,10 @@
 /obj/item/weapon/hierophant_club/proc/cardinal_blasts(turf/T, mob/living/user) //fire cardinal cross blasts with a delay
 	if(!T)
 		return
-	new /obj/effect/overlay/temp/hierophant/telegraph/cardinal(T, user)
+	new /obj/effect/temp_visual/hierophant/telegraph/cardinal(T, user)
 	playsound(T,'sound/effects/bin_close.ogg', 200, 1)
 	sleep(2)
-	new /obj/effect/overlay/temp/hierophant/blast(T, user, friendly_fire_check)
+	new /obj/effect/temp_visual/hierophant/blast(T, user, friendly_fire_check)
 	for(var/d in GLOB.cardinal)
 		INVOKE_ASYNC(src, .proc/blast_wall, T, d, user)
 
@@ -1004,15 +1004,15 @@
 	for(var/i in 1 to range)
 		if(!J)
 			return
-		new /obj/effect/overlay/temp/hierophant/blast(J, user, friendly_fire_check)
+		new /obj/effect/temp_visual/hierophant/blast(J, user, friendly_fire_check)
 		previousturf = J
 		J = get_step(previousturf, dir)
 
 /obj/item/weapon/hierophant_club/proc/aoe_burst(turf/T, mob/living/user) //make a 3x3 blast around a target
 	if(!T)
 		return
-	new /obj/effect/overlay/temp/hierophant/telegraph(T, user)
+	new /obj/effect/temp_visual/hierophant/telegraph(T, user)
 	playsound(T,'sound/effects/bin_close.ogg', 200, 1)
 	sleep(2)
 	for(var/t in RANGE_TURFS(1, T))
-		new /obj/effect/overlay/temp/hierophant/blast(t, user, friendly_fire_check)
+		new /obj/effect/temp_visual/hierophant/blast(t, user, friendly_fire_check)

--- a/code/modules/mob/living/carbon/alien/death.dm
+++ b/code/modules/mob/living/carbon/alien/death.dm
@@ -5,10 +5,10 @@
 		new /obj/effect/gibspawner/xenobodypartless(loc,viruses)
 
 /mob/living/carbon/alien/gib_animation()
-	new /obj/effect/overlay/temp/gib_animation(loc, "gibbed-a")
+	new /obj/effect/temp_visual/gib_animation(loc, "gibbed-a")
 
 /mob/living/carbon/alien/spawn_dust()
 	new /obj/effect/decal/remains/xeno(loc)
 
 /mob/living/carbon/alien/dust_animation()
-	new /obj/effect/overlay/temp/dust_animation(loc, "dust-a")
+	new /obj/effect/temp_visual/dust_animation(loc, "dust-a")

--- a/code/modules/mob/living/carbon/alien/larva/death.dm
+++ b/code/modules/mob/living/carbon/alien/larva/death.dm
@@ -13,10 +13,10 @@
 		new /obj/effect/gibspawner/larvabodypartless(loc,viruses)
 
 /mob/living/carbon/alien/larva/gib_animation()
-	new /obj/effect/overlay/temp/gib_animation(loc, "gibbed-l")
+	new /obj/effect/temp_visual/gib_animation(loc, "gibbed-l")
 
 /mob/living/carbon/alien/larva/spawn_dust()
 	new /obj/effect/decal/remains/xeno(loc)
 
 /mob/living/carbon/alien/larva/dust_animation()
-	new /obj/effect/overlay/temp/dust_animation(loc, "dust-l")
+	new /obj/effect/temp_visual/dust_animation(loc, "dust-l")

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/human/gib_animation()
-	new /obj/effect/overlay/temp/gib_animation(loc, "gibbed-h")
+	new /obj/effect/temp_visual/gib_animation(loc, "gibbed-h")
 
 /mob/living/carbon/human/dust_animation()
-	new /obj/effect/overlay/temp/dust_animation(loc, "dust-h")
+	new /obj/effect/temp_visual/dust_animation(loc, "dust-h")
 
 /mob/living/carbon/human/spawn_gibs(with_bodyparts)
 	if(with_bodyparts)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -664,7 +664,7 @@
 		return
 
 	invisibility = INVISIBILITY_MAXIMUM //disappear before the animation
-	new /obj/effect/overlay/temp/mummy_animation(get_turf(src))
+	new /obj/effect/temp_visual/mummy_animation(get_turf(src))
 	if(cloth_golem.revive(full_heal = TRUE, admin_revive = TRUE))
 		cloth_golem.grab_ghost() //won't pull if it's a suicide
 	sleep(20)

--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/monkey/gib_animation()
-	new /obj/effect/overlay/temp/gib_animation(loc, "gibbed-m")
+	new /obj/effect/temp_visual/gib_animation(loc, "gibbed-m")
 
 /mob/living/carbon/monkey/dust_animation()
-	new /obj/effect/overlay/temp/dust_animation(loc, "dust-m")
+	new /obj/effect/temp_visual/dust_animation(loc, "dust-m")

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -1,6 +1,6 @@
 
 /mob/living/silicon/robot/gib_animation()
-	new /obj/effect/overlay/temp/gib_animation(loc, "gibbed-r")
+	new /obj/effect/temp_visual/gib_animation(loc, "gibbed-r")
 
 /mob/living/silicon/robot/dust()
 	if(mmi)
@@ -11,7 +11,7 @@
 	new /obj/effect/decal/remains/robot(loc)
 
 /mob/living/silicon/robot/dust_animation()
-	new /obj/effect/overlay/temp/dust_animation(loc, "dust-r")
+	new /obj/effect/temp_visual/dust_animation(loc, "dust-r")
 
 /mob/living/silicon/robot/death(gibbed)
 	if(stat == DEAD)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -198,9 +198,9 @@
 /obj/item/weapon/robot_module/proc/do_transform_animation()
 	var/mob/living/silicon/robot/R = loc
 	R.notransform = TRUE
-	var/obj/effect/overlay/temp/decoy/fading/fivesecond/ANM = new /obj/effect/overlay/temp/decoy/fading/fivesecond(R.loc, R)
+	var/obj/effect/temp_visual/decoy/fading/fivesecond/ANM = new /obj/effect/temp_visual/decoy/fading/fivesecond(R.loc, R)
 	ANM.layer = R.layer - 0.01
-	new /obj/effect/overlay/temp/small_smoke(R.loc)
+	new /obj/effect/temp_visual/small_smoke(R.loc)
 	if(R.hat)
 		R.hat.forceMove(get_turf(R))
 		R.hat = null

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -299,7 +299,7 @@
 /mob/living/simple_animal/bot/emp_act(severity)
 	var/was_on = on
 	stat |= EMPED
-	new /obj/effect/overlay/temp/emp(loc)
+	new /obj/effect/temp_visual/emp(loc)
 	if(paicard)
 		paicard.emp_act(severity)
 		src.visible_message("[paicard] is flies out of [bot_name]!","<span class='warning'>You are forcefully ejected from [bot_name]!</span>")

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -444,7 +444,7 @@ Auto Patrol[]"},
 	if(severity==2 && prob(70))
 		..(severity-1)
 	else
-		new /obj/effect/overlay/temp/emp(loc)
+		new /obj/effect/temp_visual/emp(loc)
 		var/list/mob/living/carbon/targets = new
 		for(var/mob/living/carbon/C in view(12,src))
 			if(C.stat==2)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -215,7 +215,7 @@
 	if(change)
 		if(change > 0)
 			if(M && stat != DEAD)
-				new /obj/effect/overlay/temp/heart(loc)
+				new /obj/effect/temp_visual/heart(loc)
 				emote("me", 1, "purrs!")
 		else
 			if(M && stat != DEAD)

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -552,7 +552,7 @@
 	if(change)
 		if(change > 0)
 			if(M && stat != DEAD) // Added check to see if this mob (the dog) is dead to fix issue 2454
-				new /obj/effect/overlay/temp/heart(loc)
+				new /obj/effect/temp_visual/heart(loc)
 				emote("me", 1, "yaps happily!")
 		else
 			if(M && stat != DEAD) // Same check here, even though emote checks it as well (poor form to check it only in the help case)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -175,9 +175,9 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 			if(istype(summoner.loc, /obj/effect))
 				Recall(TRUE)
 			else
-				new /obj/effect/overlay/temp/guardian/phase/out(loc)
+				new /obj/effect/temp_visual/guardian/phase/out(loc)
 				forceMove(summoner.loc)
-				new /obj/effect/overlay/temp/guardian/phase(loc)
+				new /obj/effect/temp_visual/guardian/phase(loc)
 
 /mob/living/simple_animal/hostile/guardian/canSuicide()
 	return 0
@@ -315,7 +315,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 		return FALSE
 	if(loc == summoner)
 		forceMove(summoner.loc)
-		new /obj/effect/overlay/temp/guardian/phase(loc)
+		new /obj/effect/temp_visual/guardian/phase(loc)
 		cooldown = world.time + 10
 		return TRUE
 	return FALSE
@@ -323,7 +323,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 /mob/living/simple_animal/hostile/guardian/proc/Recall(forced)
 	if(!summoner || loc == summoner || (cooldown > world.time && !forced))
 		return FALSE
-	new /obj/effect/overlay/temp/guardian/phase/out(loc)
+	new /obj/effect/temp_visual/guardian/phase/out(loc)
 
 	forceMove(summoner)
 	cooldown = world.time + 10

--- a/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
@@ -72,7 +72,7 @@
 		armour_penetration = 100
 		obj_damage = 0
 		environment_smash = 0
-		new /obj/effect/overlay/temp/guardian/phase/out(get_turf(src))
+		new /obj/effect/temp_visual/guardian/phase/out(get_turf(src))
 		alpha = 15
 		if(!forced)
 			to_chat(src, "<span class='danger'><B>You enter stealth, empowering your next attack.</span></B>")

--- a/code/modules/mob/living/simple_animal/guardian/types/charger.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/charger.dm
@@ -40,7 +40,7 @@
 
 /mob/living/simple_animal/hostile/guardian/charger/Move()
 	if(charging)
-		new /obj/effect/overlay/temp/decoy/fading(loc,src)
+		new /obj/effect/temp_visual/decoy/fading(loc,src)
 	. = ..()
 
 /mob/living/simple_animal/hostile/guardian/charger/snapback()

--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -21,14 +21,14 @@
 	if(. && prob(40) && isliving(target))
 		var/mob/living/M = target
 		if(!M.anchored && M != summoner && !hasmatchingsummoner(M))
-			new /obj/effect/overlay/temp/guardian/phase/out(get_turf(M))
+			new /obj/effect/temp_visual/guardian/phase/out(get_turf(M))
 			do_teleport(M, M, 10)
 			for(var/mob/living/L in range(1, M))
 				if(hasmatchingsummoner(L)) //if the summoner matches don't hurt them
 					continue
 				if(L != src && L != summoner)
 					L.apply_damage(15, BRUTE)
-			new /obj/effect/overlay/temp/explosion(get_turf(M))
+			new /obj/effect/temp_visual/explosion(get_turf(M))
 
 /mob/living/simple_animal/hostile/guardian/bomb/AltClickOn(atom/movable/A)
 	if(!istype(A))
@@ -75,7 +75,7 @@
 			var/turf/T = get_turf(src)
 			stored_obj.forceMove(T)
 			playsound(T,'sound/effects/Explosion2.ogg', 200, 1)
-			new /obj/effect/overlay/temp/explosion(T)
+			new /obj/effect/temp_visual/explosion(T)
 			user.ex_act(2)
 			qdel(src)
 		else

--- a/code/modules/mob/living/simple_animal/guardian/types/protector.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/protector.dm
@@ -63,6 +63,6 @@
 			else
 				to_chat(summoner, "<span class='holoparasite'>You moved out of range, and were pulled back! You can only move [range] meters from <font color=\"[namedatum.colour]\"><b>[real_name]</b></font>!</span>")
 				summoner.visible_message("<span class='danger'>\The [summoner] jumps back to [summoner.p_their()] protector.</span>")
-				new /obj/effect/overlay/temp/guardian/phase/out(get_turf(summoner))
+				new /obj/effect/temp_visual/guardian/phase/out(get_turf(summoner))
 				summoner.forceMove(get_turf(src))
-				new /obj/effect/overlay/temp/guardian/phase(get_turf(summoner))
+				new /obj/effect/temp_visual/guardian/phase(get_turf(summoner))

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -34,7 +34,7 @@
 		C.adjustFireLoss(-5)
 		C.adjustOxyLoss(-5)
 		C.adjustToxLoss(-5)
-		var/obj/effect/overlay/temp/heal/H = new /obj/effect/overlay/temp/heal(get_turf(C))
+		var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(C))
 		if(namedatum)
 			H.color = namedatum.colour
 		if(C == summoner)
@@ -136,11 +136,11 @@
 		to_chat(src, "<span class='danger'><B>You need to hold still!</span></B>")
 		return
 
-	new /obj/effect/overlay/temp/guardian/phase/out(T)
+	new /obj/effect/temp_visual/guardian/phase/out(T)
 	if(isliving(A))
 		var/mob/living/L = A
 		L.flash_act()
 	A.visible_message("<span class='danger'>[A] disappears in a flash of light!</span>", \
 	"<span class='userdanger'>Your vision is obscured by a flash of light!</span>")
 	do_teleport(A, beacon, 0)
-	new /obj/effect/overlay/temp/guardian/phase(get_turf(A))
+	new /obj/effect/temp_visual/guardian/phase(get_turf(A))

--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -16,7 +16,7 @@
 	melee_damage_upper = 20
 	health = 1000
 	maxHealth = 1000
-	loot = list(/obj/effect/overlay/temp/paperwiz_dying)
+	loot = list(/obj/effect/temp_visual/paperwiz_dying)
 	projectiletype = /obj/item/projectile/temp
 	projectilesound = 'sound/weapons/emitter.ogg'
 	attack_sound = 'sound/hallucinations/growl1.ogg'
@@ -129,7 +129,7 @@
 	qdel(src) //I see through your ruse!
 
 //fancy effects
-/obj/effect/overlay/temp/paper_scatter
+/obj/effect/temp_visual/paper_scatter
 	name = "scattering paper"
 	desc = "Pieces of paper scattering to the wind."
 	layer = ABOVE_OPEN_TURF_LAYER
@@ -139,7 +139,7 @@
 	duration = 5
 	randomdir = FALSE
 
-/obj/effect/overlay/temp/paperwiz_dying
+/obj/effect/temp_visual/paperwiz_dying
 	name = "craft portal"
 	desc = "A wormhole sucking the wizard into the void. Neat."
 	layer = ABOVE_OPEN_TURF_LAYER
@@ -149,18 +149,18 @@
 	duration = 18
 	randomdir = FALSE
 
-/obj/effect/overlay/temp/paperwiz_dying/Initialize()
+/obj/effect/temp_visual/paperwiz_dying/Initialize()
 	. = ..()
 	visible_message("<span class='boldannounce'>The wizard cries out in pain as a gate appears behind him, sucking him in!</span>")
 	playsound(get_turf(src),'sound/magic/MandSwap.ogg', 50, 1, 1)
 	playsound(get_turf(src),'sound/hallucinations/wail.ogg', 50, 1, 1)
 
-/obj/effect/overlay/temp/paperwiz_dying/Destroy()
+/obj/effect/temp_visual/paperwiz_dying/Destroy()
 	for(var/mob/M in range(7,src))
 		shake_camera(M, 7, 1)
 	var/turf/T = get_turf(src)
 	playsound(T,'sound/magic/Summon_Magic.ogg', 50, 1, 1)
-	new /obj/effect/overlay/temp/paper_scatter(T)
+	new /obj/effect/temp_visual/paper_scatter(T)
 	new /obj/item/clothing/suit/wizrobe/paper(T)
 	new /obj/item/clothing/head/collectable/paper(T)
 	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -134,7 +134,7 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Move()
 	if(charging)
-		new /obj/effect/overlay/temp/decoy/fading(loc,src)
+		new /obj/effect/temp_visual/decoy/fading(loc,src)
 		DestroySurroundings()
 	. = ..()
 	if(!stat && .)
@@ -150,12 +150,12 @@ Difficulty: Hard
 	var/turf/T = get_turf(target)
 	if(!T || T == loc)
 		return
-	new /obj/effect/overlay/temp/dragon_swoop/bubblegum(T)
+	new /obj/effect/temp_visual/dragon_swoop/bubblegum(T)
 	charging = TRUE
 	DestroySurroundings()
 	walk(src, 0)
 	setDir(get_dir(src, T))
-	var/obj/effect/overlay/temp/decoy/D = new /obj/effect/overlay/temp/decoy(loc,src)
+	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(loc,src)
 	animate(D, alpha = 0, color = "#FF0000", transform = matrix()*2, time = 3)
 	sleep(3)
 	throw_at(T, get_dist(src, T), 1, src, 0, callback = CALLBACK(src, .charge_end, bonus_charges))
@@ -245,9 +245,9 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/bloodsmack(turf/T, handedness)
 	if(handedness)
-		new /obj/effect/overlay/temp/bubblegum_hands/rightsmack(T)
+		new /obj/effect/temp_visual/bubblegum_hands/rightsmack(T)
 	else
-		new /obj/effect/overlay/temp/bubblegum_hands/leftsmack(T)
+		new /obj/effect/temp_visual/bubblegum_hands/leftsmack(T)
 	sleep(2.5)
 	for(var/mob/living/L in T)
 		if(!faction_check_mob(L))
@@ -259,11 +259,11 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/bloodgrab(turf/T, handedness)
 	if(handedness)
-		new /obj/effect/overlay/temp/bubblegum_hands/rightpaw(T)
-		new /obj/effect/overlay/temp/bubblegum_hands/rightthumb(T)
+		new /obj/effect/temp_visual/bubblegum_hands/rightpaw(T)
+		new /obj/effect/temp_visual/bubblegum_hands/rightthumb(T)
 	else
-		new /obj/effect/overlay/temp/bubblegum_hands/leftpaw(T)
-		new /obj/effect/overlay/temp/bubblegum_hands/leftthumb(T)
+		new /obj/effect/temp_visual/bubblegum_hands/leftpaw(T)
+		new /obj/effect/temp_visual/bubblegum_hands/leftthumb(T)
 	sleep(6)
 	for(var/mob/living/L in T)
 		if(!faction_check_mob(L))
@@ -276,31 +276,31 @@ Difficulty: Hard
 				addtimer(CALLBACK(src, .proc/devour, L), 2)
 	sleep(1)
 
-/obj/effect/overlay/temp/dragon_swoop/bubblegum
+/obj/effect/temp_visual/dragon_swoop/bubblegum
 	duration = 10
 
-/obj/effect/overlay/temp/bubblegum_hands
+/obj/effect/temp_visual/bubblegum_hands
 	icon = 'icons/effects/bubblegum.dmi'
 	duration = 9
 
-/obj/effect/overlay/temp/bubblegum_hands/rightthumb
+/obj/effect/temp_visual/bubblegum_hands/rightthumb
 	icon_state = "rightthumbgrab"
 
-/obj/effect/overlay/temp/bubblegum_hands/leftthumb
+/obj/effect/temp_visual/bubblegum_hands/leftthumb
 	icon_state = "leftthumbgrab"
 
-/obj/effect/overlay/temp/bubblegum_hands/rightpaw
+/obj/effect/temp_visual/bubblegum_hands/rightpaw
 	icon_state = "rightpawgrab"
 	layer = BELOW_MOB_LAYER
 
-/obj/effect/overlay/temp/bubblegum_hands/leftpaw
+/obj/effect/temp_visual/bubblegum_hands/leftpaw
 	icon_state = "leftpawgrab"
 	layer = BELOW_MOB_LAYER
 
-/obj/effect/overlay/temp/bubblegum_hands/rightsmack
+/obj/effect/temp_visual/bubblegum_hands/rightsmack
 	icon_state = "rightsmack"
 
-/obj/effect/overlay/temp/bubblegum_hands/leftsmack
+/obj/effect/temp_visual/bubblegum_hands/leftsmack
 	icon_state = "leftsmack"
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_warp()
@@ -316,7 +316,7 @@ Difficulty: Hard
 	if(!pools.len)
 		return FALSE
 
-	var/obj/effect/overlay/temp/decoy/DA = new /obj/effect/overlay/temp/decoy(loc,src)
+	var/obj/effect/temp_visual/decoy/DA = new /obj/effect/temp_visual/decoy(loc,src)
 	DA.color = "#FF0000"
 	var/oldtransform = DA.transform
 	DA.transform = matrix()*2
@@ -358,7 +358,7 @@ Difficulty: Hard
 	new /obj/effect/decal/cleanable/blood/bubblegum(J)
 	for(var/i in 1 to range)
 		J = get_step(previousturf, targetdir)
-		new /obj/effect/overlay/temp/dir_setting/bloodsplatter(previousturf, get_dir(previousturf, J))
+		new /obj/effect/temp_visual/dir_setting/bloodsplatter(previousturf, get_dir(previousturf, J))
 		playsound(previousturf,'sound/effects/splat.ogg', 100, 1, -1)
 		if(!J || !previousturf.atmos_adjacent_turfs || !previousturf.atmos_adjacent_turfs[J])
 			break

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -95,7 +95,7 @@ Difficulty: Very Hard
 	..()
 	internal = new/obj/item/device/gps/internal/colossus(src)
 
-/obj/effect/overlay/temp/at_shield
+/obj/effect/temp_visual/at_shield
 	name = "anti-toolbox field"
 	desc = "A shimmering forcefield protecting the colossus."
 	icon = 'icons/effects/effects.dmi'
@@ -105,14 +105,14 @@ Difficulty: Very Hard
 	duration = 8
 	var/target
 
-/obj/effect/overlay/temp/at_shield/Initialize(mapload, new_target)
+/obj/effect/temp_visual/at_shield/Initialize(mapload, new_target)
 	. = ..()
 	target = new_target
 	INVOKE_ASYNC(src, /atom/movable/proc/orbit, target, 0, FALSE, 0, 0, FALSE, TRUE)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/bullet_act(obj/item/projectile/P)
 	if(!stat)
-		var/obj/effect/overlay/temp/at_shield/AT = new /obj/effect/overlay/temp/at_shield(src.loc, src)
+		var/obj/effect/temp_visual/at_shield/AT = new /obj/effect/temp_visual/at_shield(src.loc, src)
 		var/random_x = rand(-32, 32)
 		AT.pixel_x += random_x
 
@@ -581,7 +581,7 @@ Difficulty: Very Hard
 	if(..())
 		for(var/i in range(1, src))
 			if(isturf(i))
-				new /obj/effect/overlay/temp/cult/sparks(i)
+				new /obj/effect/temp_visual/cult/sparks(i)
 				continue
 			if(ishuman(i))
 				var/mob/living/carbon/human/H = i
@@ -675,7 +675,7 @@ Difficulty: Very Hard
 		var/mob/living/L = target
 		if(L.stat != DEAD)
 			L.heal_overall_damage(heal_power, heal_power)
-			new /obj/effect/overlay/temp/heal(get_turf(target), "#80F5FF")
+			new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 
 /mob/living/simple_animal/hostile/lightgeist/ghostize()
 	. = ..()
@@ -699,7 +699,7 @@ Difficulty: Very Hard
 	if(..())
 		var/list/L = list()
 		var/turf/T = get_step(src, dir)
-		new /obj/effect/overlay/temp/emp/pulse(T)
+		new /obj/effect/temp_visual/emp/pulse(T)
 		for(var/i in T)
 			if(istype(i, /obj/item) && !is_type_in_typecache(i, banned_items_typecache))
 				var/obj/item/W = i

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -124,7 +124,7 @@ Difficulty: Medium
 	target.visible_message("<span class='boldwarning'>Fire rains from the sky!</span>")
 	for(var/turf/turf in range(9,get_turf(target)))
 		if(prob(11))
-			new /obj/effect/overlay/temp/target(turf)
+			new /obj/effect/temp_visual/target(turf)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/fire_walls()
 	playsound(get_turf(src),'sound/magic/Fireball.ogg', 200, 1)
@@ -179,7 +179,7 @@ Difficulty: Medium
 		negative = FALSE
 	else if(target.x == initial_x) //if their x is the same, pick a direction
 		negative = prob(50)
-	var/obj/effect/overlay/temp/dragon_flight/F = new /obj/effect/overlay/temp/dragon_flight(loc, negative)
+	var/obj/effect/temp_visual/dragon_flight/F = new /obj/effect/temp_visual/dragon_flight(loc, negative)
 
 	negative = !negative //invert it for the swoop down later
 
@@ -208,7 +208,7 @@ Difficulty: Medium
 				if(L.stat == DEAD)
 					break //target is dead and we're on em, slam they
 		if(fire_rain)
-			new /obj/effect/overlay/temp/target(loc, flame_hit)
+			new /obj/effect/temp_visual/target(loc, flame_hit)
 		forceMove(get_step(src, get_dir(src, target)))
 		if(loc == get_turf(target))
 			if(!fire_rain)
@@ -228,8 +228,8 @@ Difficulty: Medium
 	else
 		if(IsInRange(x, initial_x - DRAKE_SWOOP_DIRECTION_CHANGE_RANGE, initial_x - 1))
 			negative = TRUE
-	new /obj/effect/overlay/temp/dragon_flight/end(loc, negative)
-	new /obj/effect/overlay/temp/dragon_swoop(loc)
+	new /obj/effect/temp_visual/dragon_flight/end(loc, negative)
+	new /obj/effect/temp_visual/dragon_swoop(loc)
 	animate(src, transform = oldtransform, time = 5)
 	sleep(5)
 	swooping &= ~SWOOP_INVULNERABLE
@@ -271,7 +271,7 @@ Difficulty: Medium
 	invisibility = 100
 
 
-/obj/effect/overlay/temp/fireball
+/obj/effect/temp_visual/fireball
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "fireball"
 	name = "fireball"
@@ -281,28 +281,28 @@ Difficulty: Medium
 	duration = 9
 	pixel_z = DRAKE_SWOOP_HEIGHT
 
-/obj/effect/overlay/temp/fireball/Initialize()
+/obj/effect/temp_visual/fireball/Initialize()
 	. = ..()
 	animate(src, pixel_z = 0, time = duration)
 
-/obj/effect/overlay/temp/target
+/obj/effect/temp_visual/target
 	icon = 'icons/mob/actions.dmi'
 	icon_state = "sniper_zoom"
 	layer = BELOW_MOB_LAYER
 	light_range = 2
 	duration = 9
 
-/obj/effect/overlay/temp/target/ex_act()
+/obj/effect/temp_visual/target/ex_act()
 	return
 
-/obj/effect/overlay/temp/target/Initialize(mapload, list/flame_hit)
+/obj/effect/temp_visual/target/Initialize(mapload, list/flame_hit)
 	. = ..()
 	INVOKE_ASYNC(src, .proc/fall, flame_hit)
 
-/obj/effect/overlay/temp/target/proc/fall(list/flame_hit)
+/obj/effect/temp_visual/target/proc/fall(list/flame_hit)
 	var/turf/T = get_turf(src)
 	playsound(T,'sound/magic/Fireball.ogg', 80, 1)
-	new /obj/effect/overlay/temp/fireball(T)
+	new /obj/effect/temp_visual/fireball(T)
 	sleep(duration)
 	if(ismineralturf(T))
 		var/turf/closed/mineral/M = T
@@ -320,7 +320,7 @@ Difficulty: Medium
 		else
 			L.adjustFireLoss(10) //if we've already hit them, do way less damage
 
-/obj/effect/overlay/temp/dragon_swoop
+/obj/effect/temp_visual/dragon_swoop
 	name = "certain death"
 	desc = "Don't just stand there, move!"
 	icon = 'icons/effects/96x96.dmi'
@@ -331,7 +331,7 @@ Difficulty: Medium
 	color = "#FF0000"
 	duration = 5
 
-/obj/effect/overlay/temp/dragon_flight
+/obj/effect/temp_visual/dragon_flight
 	icon = 'icons/mob/lavaland/dragon.dmi'
 	icon_state = "dragon"
 	layer = ABOVE_ALL_MOB_LAYER
@@ -339,11 +339,11 @@ Difficulty: Medium
 	duration = 10
 	randomdir = FALSE
 
-/obj/effect/overlay/temp/dragon_flight/Initialize(mapload, negative)
+/obj/effect/temp_visual/dragon_flight/Initialize(mapload, negative)
 	. = ..()
 	INVOKE_ASYNC(src, .proc/flight, negative)
 
-/obj/effect/overlay/temp/dragon_flight/proc/flight(negative)
+/obj/effect/temp_visual/dragon_flight/proc/flight(negative)
 	if(negative)
 		animate(src, pixel_x = -DRAKE_SWOOP_HEIGHT*0.10, pixel_z = DRAKE_SWOOP_HEIGHT*0.15, time = 3, easing = BOUNCE_EASING)
 	else
@@ -355,12 +355,12 @@ Difficulty: Medium
 	else
 		animate(src, pixel_x = DRAKE_SWOOP_HEIGHT, pixel_z = DRAKE_SWOOP_HEIGHT, time = 7)
 
-/obj/effect/overlay/temp/dragon_flight/end
+/obj/effect/temp_visual/dragon_flight/end
 	pixel_x = DRAKE_SWOOP_HEIGHT
 	pixel_z = DRAKE_SWOOP_HEIGHT
 	duration = 5
 
-/obj/effect/overlay/temp/dragon_flight/end/flight(negative)
+/obj/effect/temp_visual/dragon_flight/end/flight(negative)
 	if(negative)
 		pixel_x = -DRAKE_SWOOP_HEIGHT
 		animate(src, pixel_x = -16, pixel_z = 0, time = 5)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -150,7 +150,7 @@ Difficulty: Hard
 		var/prevloc = loc
 		. = ..()
 		if(!stat && .)
-			var/obj/effect/overlay/temp/hierophant/squares/HS = new /obj/effect/overlay/temp/hierophant/squares(prevloc)
+			var/obj/effect/temp_visual/hierophant/squares/HS = new /obj/effect/temp_visual/hierophant/squares(prevloc)
 			HS.dir = dir
 			playsound(loc, 'sound/mecha/mechmove04.ogg', 150, 1, -4)
 			if(target)
@@ -250,7 +250,7 @@ Difficulty: Hard
 							pickedtarget = pick_n_take(targets)
 						if(!istype(pickedtarget) || pickedtarget.stat == DEAD)
 							pickedtarget = target
-						var/obj/effect/overlay/temp/hierophant/chaser/C = new /obj/effect/overlay/temp/hierophant/chaser(loc, src, pickedtarget, chaser_speed, FALSE)
+						var/obj/effect/temp_visual/hierophant/chaser/C = new /obj/effect/temp_visual/hierophant/chaser(loc, src, pickedtarget, chaser_speed, FALSE)
 						C.moving = 3
 						C.moving_dir = pick_n_take(cardinal_copy)
 						sleep(10)
@@ -280,10 +280,10 @@ Difficulty: Hard
 			else
 				INVOKE_ASYNC(src, .proc/diagonal_blasts, target)
 	else if(chaser_cooldown < world.time) //if chasers are off cooldown, fire some!
-		var/obj/effect/overlay/temp/hierophant/chaser/C = new /obj/effect/overlay/temp/hierophant/chaser(loc, src, target, chaser_speed, FALSE)
+		var/obj/effect/temp_visual/hierophant/chaser/C = new /obj/effect/temp_visual/hierophant/chaser(loc, src, target, chaser_speed, FALSE)
 		chaser_cooldown = world.time + initial(chaser_cooldown)
 		if((prob(anger_modifier) || target.Adjacent(src)) && target != src)
-			var/obj/effect/overlay/temp/hierophant/chaser/OC = new /obj/effect/overlay/temp/hierophant/chaser(loc, src, target, max(1.5, 5 - anger_modifier * 0.07), FALSE)
+			var/obj/effect/temp_visual/hierophant/chaser/OC = new /obj/effect/temp_visual/hierophant/chaser(loc, src, target, max(1.5, 5 - anger_modifier * 0.07), FALSE)
 			OC.moving = 4
 			OC.moving_dir = pick(GLOB.cardinal - C.moving_dir)
 	else //just release a burst of power
@@ -293,10 +293,10 @@ Difficulty: Hard
 	var/turf/T = get_turf(victim)
 	if(!T)
 		return
-	new /obj/effect/overlay/temp/hierophant/telegraph/diagonal(T, src)
+	new /obj/effect/temp_visual/hierophant/telegraph/diagonal(T, src)
 	playsound(T,'sound/effects/bin_close.ogg', 200, 1)
 	sleep(2)
-	new /obj/effect/overlay/temp/hierophant/blast(T, src, FALSE)
+	new /obj/effect/temp_visual/hierophant/blast(T, src, FALSE)
 	for(var/d in GLOB.diagonals)
 		INVOKE_ASYNC(src, .proc/blast_wall, T, d)
 
@@ -304,10 +304,10 @@ Difficulty: Hard
 	var/turf/T = get_turf(victim)
 	if(!T)
 		return
-	new /obj/effect/overlay/temp/hierophant/telegraph/cardinal(T, src)
+	new /obj/effect/temp_visual/hierophant/telegraph/cardinal(T, src)
 	playsound(T,'sound/effects/bin_close.ogg', 200, 1)
 	sleep(2)
-	new /obj/effect/overlay/temp/hierophant/blast(T, src, FALSE)
+	new /obj/effect/temp_visual/hierophant/blast(T, src, FALSE)
 	for(var/d in GLOB.cardinal)
 		INVOKE_ASYNC(src, .proc/blast_wall, T, d)
 
@@ -315,10 +315,10 @@ Difficulty: Hard
 	var/turf/T = get_turf(victim)
 	if(!T)
 		return
-	new /obj/effect/overlay/temp/hierophant/telegraph(T, src)
+	new /obj/effect/temp_visual/hierophant/telegraph(T, src)
 	playsound(T,'sound/effects/bin_close.ogg', 200, 1)
 	sleep(2)
-	new /obj/effect/overlay/temp/hierophant/blast(T, src, FALSE)
+	new /obj/effect/temp_visual/hierophant/blast(T, src, FALSE)
 	for(var/d in GLOB.alldirs)
 		INVOKE_ASYNC(src, .proc/blast_wall, T, d)
 
@@ -327,7 +327,7 @@ Difficulty: Hard
 	var/turf/previousturf = T
 	var/turf/J = get_step(previousturf, set_dir)
 	for(var/i in 1 to range)
-		new /obj/effect/overlay/temp/hierophant/blast(J, src, FALSE)
+		new /obj/effect/temp_visual/hierophant/blast(J, src, FALSE)
 		previousturf = J
 		J = get_step(previousturf, set_dir)
 
@@ -342,8 +342,8 @@ Difficulty: Hard
 		INVOKE_ASYNC(src, .proc/arena_squares, T, d)
 	for(var/t in RANGE_TURFS(11, T))
 		if(t && get_dist(t, T) == 11)
-			new /obj/effect/overlay/temp/hierophant/wall(t)
-			new /obj/effect/overlay/temp/hierophant/blast(t, src, FALSE)
+			new /obj/effect/temp_visual/hierophant/wall(t)
+			new /obj/effect/temp_visual/hierophant/blast(t, src, FALSE)
 	if(get_dist(src, T) >= 11) //hey you're out of range I need to get closer to you!
 		INVOKE_ASYNC(src, .proc/blink, T)
 
@@ -351,7 +351,7 @@ Difficulty: Hard
 	var/turf/previousturf = T
 	var/turf/J = get_step(previousturf, set_dir)
 	for(var/i in 1 to 10)
-		var/obj/effect/overlay/temp/hierophant/squares/HS = new /obj/effect/overlay/temp/hierophant/squares(J)
+		var/obj/effect/temp_visual/hierophant/squares/HS = new /obj/effect/temp_visual/hierophant/squares(J)
 		HS.dir = set_dir
 		previousturf = J
 		J = get_step(previousturf, set_dir)
@@ -362,19 +362,19 @@ Difficulty: Hard
 		return
 	var/turf/T = get_turf(victim)
 	var/turf/source = get_turf(src)
-	new /obj/effect/overlay/temp/hierophant/telegraph(T, src)
-	new /obj/effect/overlay/temp/hierophant/telegraph(source, src)
+	new /obj/effect/temp_visual/hierophant/telegraph(T, src)
+	new /obj/effect/temp_visual/hierophant/telegraph(source, src)
 	playsound(T,'sound/magic/Wand_Teleport.ogg', 200, 1)
 	playsound(source,'sound/machines/AirlockOpen.ogg', 200, 1)
 	blinking = TRUE
 	sleep(2) //short delay before we start...
-	new /obj/effect/overlay/temp/hierophant/telegraph/teleport(T, src)
-	new /obj/effect/overlay/temp/hierophant/telegraph/teleport(source, src)
+	new /obj/effect/temp_visual/hierophant/telegraph/teleport(T, src)
+	new /obj/effect/temp_visual/hierophant/telegraph/teleport(source, src)
 	for(var/t in RANGE_TURFS(1, T))
-		var/obj/effect/overlay/temp/hierophant/blast/B = new /obj/effect/overlay/temp/hierophant/blast(t, src, FALSE)
+		var/obj/effect/temp_visual/hierophant/blast/B = new /obj/effect/temp_visual/hierophant/blast(t, src, FALSE)
 		B.damage = 30
 	for(var/t in RANGE_TURFS(1, source))
-		var/obj/effect/overlay/temp/hierophant/blast/B = new /obj/effect/overlay/temp/hierophant/blast(t, src, FALSE)
+		var/obj/effect/temp_visual/hierophant/blast/B = new /obj/effect/temp_visual/hierophant/blast(t, src, FALSE)
 		B.damage = 30
 	animate(src, alpha = 0, time = 2, easing = EASE_OUT) //fade out
 	sleep(1)
@@ -396,11 +396,11 @@ Difficulty: Hard
 	var/turf/T = get_turf(victim)
 	if(!T)
 		return
-	new /obj/effect/overlay/temp/hierophant/telegraph(T, src)
+	new /obj/effect/temp_visual/hierophant/telegraph(T, src)
 	playsound(T,'sound/effects/bin_close.ogg', 200, 1)
 	sleep(2)
 	for(var/t in RANGE_TURFS(1, T))
-		new /obj/effect/overlay/temp/hierophant/blast(t, src, FALSE)
+		new /obj/effect/temp_visual/hierophant/blast(t, src, FALSE)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/burst(turf/original) //release a wave of blasts
 	playsound(original,'sound/machines/AirlockOpen.ogg', 200, 1)
@@ -413,7 +413,7 @@ Difficulty: Hard
 		if(dist > last_dist)
 			last_dist = dist
 			sleep(1 + min(burst_range - last_dist, 12) * 0.5) //gets faster as it gets further out
-		new /obj/effect/overlay/temp/hierophant/blast(T, src, FALSE)
+		new /obj/effect/temp_visual/hierophant/blast(T, src, FALSE)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/AltClickOn(atom/A) //player control handler(don't give this to a player holy fuck)
 	if(!istype(A) || get_dist(A, src) <= 2)
@@ -421,29 +421,29 @@ Difficulty: Hard
 	blink(A)
 
 //Hierophant overlays
-/obj/effect/overlay/temp/hierophant
+/obj/effect/temp_visual/hierophant
 	name = "vortex energy"
 	layer = BELOW_MOB_LAYER
 	var/mob/living/caster //who made this, anyway
 
-/obj/effect/overlay/temp/hierophant/Initialize(mapload, new_caster)
+/obj/effect/temp_visual/hierophant/Initialize(mapload, new_caster)
 	. = ..()
 	if(new_caster)
 		caster = new_caster
 
-/obj/effect/overlay/temp/hierophant/squares
+/obj/effect/temp_visual/hierophant/squares
 	icon_state = "hierophant_squares"
 	duration = 3
 	light_range = 1
 	randomdir = FALSE
 
-/obj/effect/overlay/temp/hierophant/squares/Initialize(mapload, new_caster)
+/obj/effect/temp_visual/hierophant/squares/Initialize(mapload, new_caster)
 	. = ..()
 	if(ismineralturf(loc))
 		var/turf/closed/mineral/M = loc
 		M.gets_drilled(caster)
 
-/obj/effect/overlay/temp/hierophant/wall //smoothing and pooling were not friends, but pooling is dead.
+/obj/effect/temp_visual/hierophant/wall //smoothing and pooling were not friends, but pooling is dead.
 	name = "vortex wall"
 	icon = 'icons/turf/walls/hierophant_wall_temp.dmi'
 	icon_state = "wall"
@@ -451,21 +451,21 @@ Difficulty: Hard
 	duration = 100
 	smooth = SMOOTH_TRUE
 
-/obj/effect/overlay/temp/hierophant/wall/Initialize(mapload, new_caster)
+/obj/effect/temp_visual/hierophant/wall/Initialize(mapload, new_caster)
 	. = ..()
 	queue_smooth_neighbors(src)
 	queue_smooth(src)
 
-/obj/effect/overlay/temp/hierophant/wall/Destroy()
+/obj/effect/temp_visual/hierophant/wall/Destroy()
 	queue_smooth_neighbors(src)
 	return ..()
 
-/obj/effect/overlay/temp/hierophant/wall/CanPass(atom/movable/mover, turf/target, height = 0)
+/obj/effect/temp_visual/hierophant/wall/CanPass(atom/movable/mover, turf/target, height = 0)
 	if(mover == caster)
 		return TRUE
 	return FALSE
 
-/obj/effect/overlay/temp/hierophant/chaser //a hierophant's chaser. follows target around, moving and producing a blast every speed deciseconds.
+/obj/effect/temp_visual/hierophant/chaser //a hierophant's chaser. follows target around, moving and producing a blast every speed deciseconds.
 	duration = 98
 	var/mob/living/target //what it's following
 	var/turf/targetturf //what turf the target is actually on
@@ -479,7 +479,7 @@ Difficulty: Hard
 	var/currently_seeking = FALSE
 	var/friendly_fire_check = FALSE //if blasts produced apply friendly fire
 
-/obj/effect/overlay/temp/hierophant/chaser/Initialize(mapload, new_caster, new_target, new_speed, is_friendly_fire)
+/obj/effect/temp_visual/hierophant/chaser/Initialize(mapload, new_caster, new_target, new_speed, is_friendly_fire)
 	. = ..()
 	target = new_target
 	friendly_fire_check = is_friendly_fire
@@ -487,14 +487,14 @@ Difficulty: Hard
 		speed = new_speed
 	addtimer(CALLBACK(src, .proc/seek_target), 1)
 
-/obj/effect/overlay/temp/hierophant/chaser/proc/get_target_dir()
+/obj/effect/temp_visual/hierophant/chaser/proc/get_target_dir()
 	. = get_cardinal_dir(src, targetturf)
 	if((. != previous_moving_dir && . == more_previouser_moving_dir) || . == 0) //we're alternating, recalculate
 		var/list/cardinal_copy = GLOB.cardinal.Copy()
 		cardinal_copy -= more_previouser_moving_dir
 		. = pick(cardinal_copy)
 
-/obj/effect/overlay/temp/hierophant/chaser/proc/seek_target()
+/obj/effect/temp_visual/hierophant/chaser/proc/seek_target()
 	if(!currently_seeking)
 		currently_seeking = TRUE
 		targetturf = get_turf(target)
@@ -522,31 +522,31 @@ Difficulty: Hard
 				sleep(speed)
 			targetturf = get_turf(target)
 
-/obj/effect/overlay/temp/hierophant/chaser/proc/make_blast()
-	new /obj/effect/overlay/temp/hierophant/blast(loc, caster, friendly_fire_check)
+/obj/effect/temp_visual/hierophant/chaser/proc/make_blast()
+	new /obj/effect/temp_visual/hierophant/blast(loc, caster, friendly_fire_check)
 
-/obj/effect/overlay/temp/hierophant/telegraph
+/obj/effect/temp_visual/hierophant/telegraph
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "hierophant_telegraph"
 	pixel_x = -32
 	pixel_y = -32
 	duration = 3
 
-/obj/effect/overlay/temp/hierophant/telegraph/diagonal
+/obj/effect/temp_visual/hierophant/telegraph/diagonal
 	icon_state = "hierophant_telegraph_diagonal"
 
-/obj/effect/overlay/temp/hierophant/telegraph/cardinal
+/obj/effect/temp_visual/hierophant/telegraph/cardinal
 	icon_state = "hierophant_telegraph_cardinal"
 
-/obj/effect/overlay/temp/hierophant/telegraph/teleport
+/obj/effect/temp_visual/hierophant/telegraph/teleport
 	icon_state = "hierophant_telegraph_teleport"
 	duration = 9
 
-/obj/effect/overlay/temp/hierophant/telegraph/edge
+/obj/effect/temp_visual/hierophant/telegraph/edge
 	icon_state = "hierophant_telegraph_edge"
 	duration = 40
 
-/obj/effect/overlay/temp/hierophant/blast
+/obj/effect/temp_visual/hierophant/blast
 	icon_state = "hierophant_blast"
 	name = "vortex blast"
 	light_range = 1
@@ -557,7 +557,7 @@ Difficulty: Hard
 	var/friendly_fire_check = FALSE
 	var/bursting = FALSE //if we're bursting and need to hit anyone crossing us
 
-/obj/effect/overlay/temp/hierophant/blast/Initialize(mapload, new_caster, friendly_fire)
+/obj/effect/temp_visual/hierophant/blast/Initialize(mapload, new_caster, friendly_fire)
 	. = ..()
 	friendly_fire_check = friendly_fire
 	if(new_caster)
@@ -567,7 +567,7 @@ Difficulty: Hard
 		M.gets_drilled(caster)
 	INVOKE_ASYNC(src, .proc/blast)
 
-/obj/effect/overlay/temp/hierophant/blast/proc/blast()
+/obj/effect/temp_visual/hierophant/blast/proc/blast()
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
@@ -578,12 +578,12 @@ Difficulty: Hard
 	sleep(1.3) //slightly forgiving; the burst animation is 1.5 deciseconds
 	bursting = FALSE //we no longer damage crossers
 
-/obj/effect/overlay/temp/hierophant/blast/Crossed(atom/movable/AM)
+/obj/effect/temp_visual/hierophant/blast/Crossed(atom/movable/AM)
 	..()
 	if(bursting)
 		do_damage(get_turf(src))
 
-/obj/effect/overlay/temp/hierophant/blast/proc/do_damage(turf/T)
+/obj/effect/temp_visual/hierophant/blast/proc/do_damage(turf/T)
 	for(var/mob/living/L in T.contents - hit_things) //find and damage mobs...
 		hit_things += L
 		if((friendly_fire_check && caster && caster.faction_check_mob(L)) || L.stat == DEAD)
@@ -630,7 +630,7 @@ Difficulty: Hard
 			INVOKE_ASYNC(H, /obj/item/weapon/hierophant_club.proc/prepare_icon_update)
 			if(do_after(user, 50, target = src))
 				playsound(src,'sound/magic/Blind.ogg', 200, 1, -4)
-				new /obj/effect/overlay/temp/hierophant/telegraph/teleport(get_turf(src), user)
+				new /obj/effect/temp_visual/hierophant/telegraph/teleport(get_turf(src), user)
 				to_chat(user, "<span class='hierophant_warning'>You collect [src], reattaching it to the club!</span>")
 				H.beacon = null
 				user.update_action_buttons_icon()

--- a/code/modules/mob/living/simple_animal/hostile/stickman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stickman.dm
@@ -52,7 +52,7 @@
 
 /mob/living/simple_animal/hostile/stickman/Initialize(mapload, var/wizard_summoned)
 	..()
-	new /obj/effect/overlay/temp/paper_scatter(src)
+	new /obj/effect/temp_visual/paper_scatter(src)
 	summoned_by_wizard = wizard_summoned
 
 /mob/living/simple_animal/hostile/stickman/death()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -249,7 +249,7 @@
 
 /mob/living/simple_animal/gib_animation()
 	if(icon_gib)
-		new /obj/effect/overlay/temp/gib_animation/animal(loc, icon_gib)
+		new /obj/effect/temp_visual/gib_animation/animal(loc, icon_gib)
 
 /mob/living/simple_animal/say_mod(input, message_mode)
 	if(speak_emote && speak_emote.len)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -292,14 +292,14 @@
 
 	if(!src || !isturf(src.loc) || !(A in view(src.loc)))
 		return 0
-	if(istype(A, /obj/effect/overlay/temp/point))
+	if(istype(A, /obj/effect/temp_visual/point))
 		return 0
 
 	var/tile = get_turf(A)
 	if (!tile)
 		return 0
 
-	new /obj/effect/overlay/temp/point(A,invisibility)
+	new /obj/effect/temp_visual/point(A,invisibility)
 
 	return 1
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -242,12 +242,12 @@
 				L.loc = locate(locx,locy,mobloc.z)
 				var/limit = 2//For only two trailing shadows.
 				for(var/turf/T in getline(mobloc, L.loc))
-					new /obj/effect/overlay/temp/dir_setting/ninja/shadow(T, L.dir)
+					new /obj/effect/temp_visual/dir_setting/ninja/shadow(T, L.dir)
 					limit--
 					if(limit<=0)
 						break
 			else
-				new /obj/effect/overlay/temp/dir_setting/ninja/shadow(mobloc, L.dir)
+				new /obj/effect/temp_visual/dir_setting/ninja/shadow(mobloc, L.dir)
 				L.loc = get_step(L, direct)
 			L.setDir(direct)
 		if(3) //Incorporeal move, but blocked by holy-watered tiles and salt piles.

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -36,7 +36,7 @@
 	cut_overlays()
 	invisibility = INVISIBILITY_MAXIMUM
 
-	new /obj/effect/overlay/temp/monkeyify(loc)
+	new /obj/effect/temp_visual/monkeyify(loc)
 	sleep(22)
 	var/mob/living/carbon/monkey/O = new /mob/living/carbon/monkey( loc )
 
@@ -186,7 +186,7 @@
 	icon = null
 	cut_overlays()
 	invisibility = INVISIBILITY_MAXIMUM
-	new /obj/effect/overlay/temp/monkeyify/humanify(loc)
+	new /obj/effect/temp_visual/monkeyify/humanify(loc)
 	sleep(22)
 	var/mob/living/carbon/human/O = new( loc )
 	for(var/obj/item/C in O.loc)

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -72,7 +72,7 @@ It is possible to destroy the net by the occupant or someone else.
 			M.dropItemToGround(W)
 
 		playsound(M.loc, 'sound/effects/sparks4.ogg', 50, 1)
-		new /obj/effect/overlay/temp/dir_setting/ninja/phase/out(get_turf(M), M.dir)
+		new /obj/effect/temp_visual/dir_setting/ninja/phase/out(get_turf(M), M.dir)
 
 		visible_message("[M] suddenly vanishes!")
 		M.forceMove(pick(GLOB.holdingfacility)) //Throw mob in to the holding facility.
@@ -86,7 +86,7 @@ It is possible to destroy the net by the occupant or someone else.
 		spark_system.start()
 		playsound(M.loc, 'sound/effects/phasein.ogg', 25, 1)
 		playsound(M.loc, 'sound/effects/sparks2.ogg', 50, 1)
-		new /obj/effect/overlay/temp/dir_setting/ninja/phase(get_turf(M), M.dir)
+		new /obj/effect/temp_visual/dir_setting/ninja/phase(get_turf(M), M.dir)
 		qdel(src)
 
 	else//And they are free.

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_teleporting.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_teleporting.dm
@@ -33,7 +33,7 @@ Contents:
 
 		if(destination && isturf(mobloc))//So we don't teleport out of containers
 			playsound(H.loc, "sparks", 50, 1)
-			new /obj/effect/overlay/temp/dir_setting/ninja/phase/out(get_turf(H), H.dir)
+			new /obj/effect/temp_visual/dir_setting/ninja/phase/out(get_turf(H), H.dir)
 
 			handle_teleport_grab(destination, H)
 			H.loc = destination
@@ -41,7 +41,7 @@ Contents:
 			spark_system.start()
 			playsound(H.loc, 'sound/effects/phasein.ogg', 25, 1)
 			playsound(H.loc, "sparks", 50, 1)
-			new /obj/effect/overlay/temp/dir_setting/ninja/phase(get_turf(H), H.dir)
+			new /obj/effect/temp_visual/dir_setting/ninja/phase(get_turf(H), H.dir)
 
 			destination.phase_damage_creatures(20,H)//Paralyse and damage mobs and mechas on the turf
 			s_coold = 1
@@ -62,7 +62,7 @@ Contents:
 		var/turf/mobloc = get_turf(H.loc)//To make sure that certain things work properly below.
 		if(!T.density && isturf(mobloc))
 			playsound(H.loc, "sparks", 50, 1)
-			new /obj/effect/overlay/temp/dir_setting/ninja/phase/out(get_turf(H), H.dir)
+			new /obj/effect/temp_visual/dir_setting/ninja/phase/out(get_turf(H), H.dir)
 
 			handle_teleport_grab(T, H)
 			H.forceMove(T)
@@ -70,7 +70,7 @@ Contents:
 			spark_system.start()
 			playsound(H.loc, 'sound/effects/phasein.ogg', 25, 1)
 			playsound(H.loc, "sparks", 50, 1)
-			new /obj/effect/overlay/temp/dir_setting/ninja/phase(get_turf(H), H.dir)
+			new /obj/effect/temp_visual/dir_setting/ninja/phase(get_turf(H), H.dir)
 
 			T.phase_damage_creatures(20,H)//Paralyse and damage mobs and mechas on the turf
 			s_coold = 1

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -16,7 +16,7 @@
 	var/randomspread = 0						//Randomspread for automatics
 	var/delay = 0								//Delay for energy weapons
 	var/click_cooldown_override = 0				//Override this to make your gun have a faster fire rate, in tenths of a second. 4 is the default gun cooldown.
-	var/firing_effect_type = /obj/effect/overlay/temp/dir_setting/firing_effect	//the visual effect appearing when the ammo is fired.
+	var/firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect	//the visual effect appearing when the ammo is fired.
 
 
 /obj/item/ammo_casing/New()

--- a/code/modules/projectiles/ammunition/caseless.dm
+++ b/code/modules/projectiles/ammunition/caseless.dm
@@ -45,7 +45,7 @@
  	icon_state = "s-casing-live"
  	projectile_type = /obj/item/projectile/beam
  	fire_sound = 'sound/weapons/Laser.ogg'
- 	firing_effect_type = /obj/effect/overlay/temp/dir_setting/firing_effect/energy
+ 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
 
 /obj/item/ammo_casing/caseless/laser/gatling
 	projectile_type = /obj/item/projectile/beam/weak

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -6,7 +6,7 @@
 	var/e_cost = 100 //The amount of energy a cell needs to expend to create this shot.
 	var/select_name = "energy"
 	fire_sound = 'sound/weapons/Laser.ogg'
-	firing_effect_type = /obj/effect/overlay/temp/dir_setting/firing_effect/energy
+	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
 
 /obj/item/ammo_casing/energy/chameleon
 	e_cost = 0

--- a/code/modules/projectiles/ammunition/special.dm
+++ b/code/modules/projectiles/ammunition/special.dm
@@ -2,7 +2,7 @@
 	name = "magic casing"
 	desc = "I didn't even know magic needed ammo..."
 	projectile_type = /obj/item/projectile/magic
-	firing_effect_type = /obj/effect/overlay/temp/dir_setting/firing_effect/magic
+	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/magic
 
 /obj/item/ammo_casing/magic/change
 	projectile_type = /obj/item/projectile/magic/change
@@ -70,4 +70,4 @@
 	select_name = "spraydown"
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	e_cost = 20
-	firing_effect_type = /obj/effect/overlay/temp/dir_setting/firing_effect
+	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -195,7 +195,7 @@
 	if(ismineralturf(target_turf))
 		var/turf/closed/mineral/M = target_turf
 		M.gets_drilled(firer)
-	var/obj/effect/overlay/temp/kinetic_blast/K = new /obj/effect/overlay/temp/kinetic_blast(target_turf)
+	var/obj/effect/temp_visual/kinetic_blast/K = new /obj/effect/temp_visual/kinetic_blast(target_turf)
 	K.color = color
 	for(var/type in hit_overlays)
 		new type(target_turf)
@@ -319,7 +319,7 @@
 /obj/item/borg/upgrade/modkit/aoe/modify_projectile(obj/item/projectile/kinetic/K)
 	K.name = "kinetic explosion"
 	if(!K.turf_aoe && !K.mob_aoe)
-		K.hit_overlays += /obj/effect/overlay/temp/explosion/fast
+		K.hit_overlays += /obj/effect/temp_visual/explosion/fast
 	K.mob_aoe += modifier
 
 /obj/item/borg/upgrade/modkit/aoe/turfs

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -113,7 +113,7 @@
 
 /obj/item/weapon/gun/medbeam/proc/on_beam_tick(var/mob/living/target)
 	if(target.health != target.maxHealth)
-		new /obj/effect/overlay/temp/heal(get_turf(target), "#80F5FF")
+		new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 	target.adjustBruteLoss(-4)
 	target.adjustFireLoss(-4)
 	return

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -90,9 +90,9 @@
 			if(starting)
 				splatter_dir = get_dir(starting, target_loca)
 			if(isalien(L))
-				new /obj/effect/overlay/temp/dir_setting/bloodsplatter/xenosplatter(target_loca, splatter_dir)
+				new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(target_loca, splatter_dir)
 			else
-				new /obj/effect/overlay/temp/dir_setting/bloodsplatter(target_loca, splatter_dir)
+				new /obj/effect/temp_visual/dir_setting/bloodsplatter(target_loca, splatter_dir)
 			if(prob(33))
 				L.add_splatter_floor(target_loca)
 		else if(impact_effect_type)
@@ -224,7 +224,7 @@
 				pixel_y_offset += 32
 				old_pixel_y += 32
 				new_y--
-				
+
 			pixel_x = old_pixel_x
 			pixel_y = old_pixel_y
 			step_towards(src, locate(new_x, new_y, z))
@@ -237,7 +237,7 @@
 				animate(src, pixel_x = pixel_x_offset, pixel_y = pixel_y_offset, time = max(1, (delay <= 3 ? delay - 1 : delay)), flags = ANIMATION_END_NOW)
 			old_pixel_x = pixel_x_offset
 			old_pixel_y = pixel_y_offset
-			
+
 			if(original && (original.layer>=2.75) || ismob(original))
 				if(loc == get_turf(original))
 					if(!(original in permutated))

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -9,7 +9,7 @@
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'
 	flag = "laser"
 	eyeblur = 2
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/red_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_color = LIGHT_COLOR_RED
 
 /obj/item/projectile/beam/laser
@@ -25,7 +25,7 @@
 		var/mob/living/carbon/M = target
 		M.IgniteMob()
 	else if(isturf(target))
-		impact_effect_type = /obj/effect/overlay/temp/impact_effect/red_laser/wall
+		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
 
 /obj/item/projectile/beam/weak
 	damage = 15
@@ -48,7 +48,7 @@
 	irradiate = 30
 	range = 15
 	forcedodge = 1
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/green_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 
 /obj/item/projectile/beam/disabler
@@ -59,14 +59,14 @@
 	flag = "energy"
 	hitsound = 'sound/weapons/tap.ogg'
 	eyeblur = 0
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/blue_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"
 	damage = 50
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/blue_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/beam/pulse/on_hit(atom/target, blocked = 0)
@@ -94,7 +94,7 @@
 	damage = 30
 	legacy = 1
 	animate_movement = SLIDE_STEPS
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/green_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 
 /obj/item/projectile/beam/emitter/singularity_pull()
@@ -108,7 +108,7 @@
 	damage_type = STAMINA
 	flag = "laser"
 	var/suit_types = list(/obj/item/clothing/suit/redtag, /obj/item/clothing/suit/bluetag)
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/blue_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/beam/lasertag/on_hit(atom/target, blocked = 0)
@@ -122,7 +122,7 @@
 /obj/item/projectile/beam/lasertag/redtag
 	icon_state = "laser"
 	suit_types = list(/obj/item/clothing/suit/bluetag)
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/red_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_color = LIGHT_COLOR_RED
 
 /obj/item/projectile/beam/lasertag/bluetag
@@ -134,17 +134,17 @@
 	icon_state = "purple_laser"
 	damage = 200
 	damage_type = BURN
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/purple_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	light_color = LIGHT_COLOR_PURPLE
 
 /obj/item/projectile/beam/instakill/blue
 	icon_state = "blue_laser"
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/blue_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/beam/instakill/red
 	icon_state = "red_laser"
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/red_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_color = LIGHT_COLOR_RED
 
 /obj/item/projectile/beam/instakill/on_hit(atom/target)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -6,7 +6,7 @@
 	nodamage = 0
 	flag = "bullet"
 	hitsound_wall = "ricochet"
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect
+	impact_effect_type = /obj/effect/temp_visual/impact_effect
 
 /obj/item/projectile/bullet/weakbullet //beanbag, heavy stamina damage
 	damage = 5

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -133,7 +133,7 @@
 	damage = 20
 	damage_type = CLONE
 	irradiate = 10
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/green_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 
 /obj/item/projectile/energy/dart //ninja throwing dart
 	name = "dart"
@@ -162,7 +162,7 @@
 /obj/item/projectile/energy/tesla
 	name = "tesla bolt"
 	icon_state = "tesla_projectile"
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/blue_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	var/chain
 
 /obj/item/projectile/energy/tesla/fire(setAngle)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -5,7 +5,7 @@
 	damage_type = BURN
 	nodamage = 1
 	flag = "energy"
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/ion
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
 
 
 /obj/item/projectile/ion/on_hit(atom/target, blocked = 0)
@@ -202,7 +202,7 @@
 	damage = 5
 	range = 3.5 //works as 4, but doubles to 7
 	dismemberment = 20
-	impact_effect_type = /obj/effect/overlay/temp/impact_effect/purple_laser
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 
 /obj/item/projectile/plasma/Initialize()
 	. = ..()
@@ -270,7 +270,7 @@
 		A.throw_at(throwtarget,power+1,1)
 		thrown_items[A] = A
 	for(var/turf/F in range(T,power))
-		new /obj/effect/overlay/temp/gravpush(F)
+		new /obj/effect/temp_visual/gravpush(F)
 
 /obj/item/projectile/gravityattract
 	name = "attraction bolt"
@@ -300,7 +300,7 @@
 		A.throw_at(T, power+1, 1)
 		thrown_items[A] = A
 	for(var/turf/F in range(T,power))
-		new /obj/effect/overlay/temp/gravpush(F)
+		new /obj/effect/temp_visual/gravpush(F)
 
 /obj/item/projectile/gravitychaos
 	name = "gravitational blast"
@@ -330,5 +330,5 @@
 		A.throw_at(get_edge_target_turf(A, pick(GLOB.cardinal)), power+1, 1)
 		thrown_items[A] = A
 	for(var/turf/Z in range(T,power))
-		new /obj/effect/overlay/temp/gravpush(Z)
+		new /obj/effect/temp_visual/gravpush(Z)
 

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -298,7 +298,7 @@
 	var/initial_volume = reac_volume
 	reac_volume = ..()
 	if(reac_volume >= 10) //if it's not a spore cloud, bad time incoming
-		var/obj/effect/overlay/temp/explosion/fast/E = new /obj/effect/overlay/temp/explosion/fast(get_turf(M))
+		var/obj/effect/temp_visual/explosion/fast/E = new /obj/effect/temp_visual/explosion/fast(get_turf(M))
 		E.alpha = 150
 		for(var/mob/living/L in orange(get_turf(M), 1))
 			if("blob" in L.faction) //no friendly fire

--- a/code/modules/shuttle/ripple.dm
+++ b/code/modules/shuttle/ripple.dm
@@ -1,4 +1,4 @@
-/obj/effect/overlay/temp/ripple
+/obj/effect/temp_visual/ripple
 	name = "hyperspace ripple"
 	desc = "Something is coming through hyperspace, you can see the \
 		visual disturbances. It's probably best not to be on top of these \
@@ -13,10 +13,10 @@
 
 	duration = 3 * SHUTTLE_RIPPLE_TIME
 
-/obj/effect/overlay/temp/ripple/Initialize(mapload, time_left)
+/obj/effect/temp_visual/ripple/Initialize(mapload, time_left)
 	. = ..()
 	animate(src, alpha=255, time=time_left)
 	addtimer(CALLBACK(src, .proc/stop_animation), 8, TIMER_CLIENT_TIME)
 
-/obj/effect/overlay/temp/ripple/proc/stop_animation()
+/obj/effect/temp_visual/ripple/proc/stop_animation()
 	icon_state = "medi_holo_no_anim"

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -404,7 +404,7 @@
 /obj/docking_port/mobile/proc/create_ripples(obj/docking_port/stationary/S1, animate_time)
 	var/list/turfs = ripple_area(S1)
 	for(var/t in turfs)
-		ripples += new /obj/effect/overlay/temp/ripple(t, animate_time)
+		ripples += new /obj/effect/temp_visual/ripple(t, animate_time)
 
 /obj/docking_port/mobile/proc/remove_ripples()
 	for(var/R in ripples)
@@ -764,6 +764,6 @@
 	if(T in block(T0,T1))
 		return TRUE
 	return FALSE
-	
+
 
 #undef DOCKING_PORT_HIGHLIGHT

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -128,8 +128,8 @@
 	action_icon_state = "phaseshift"
 	action_background_icon_state = "bg_demon"
 	jaunt_in_time = 12
-	jaunt_in_type = /obj/effect/overlay/temp/dir_setting/wraith
-	jaunt_out_type = /obj/effect/overlay/temp/dir_setting/wraith/out
+	jaunt_in_type = /obj/effect/temp_visual/dir_setting/wraith
+	jaunt_out_type = /obj/effect/temp_visual/dir_setting/wraith/out
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/jaunt_steam(mobloc)
 	return
@@ -256,7 +256,7 @@
 	S.add_atom_colour("#990000", FIXED_COLOUR_PRIORITY)
 	S.faction = list("cult")
 	playsound(get_turf(S), 'sound/effects/ghost.ogg', 100, 1)
-	new /obj/effect/overlay/temp/cult/sac(get_turf(S))
+	new /obj/effect/temp_visual/cult/sac(get_turf(S))
 
 /obj/effect/proc_holder/spell/targeted/dominate/can_target(mob/living/target)
 	if(!isanimal(target) || target.stat)
@@ -267,5 +267,5 @@
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/golem
 	charge_max = 800
-	jaunt_in_type = /obj/effect/overlay/temp/dir_setting/cult/phase
-	jaunt_out_type = /obj/effect/overlay/temp/dir_setting/cult/phase/out
+	jaunt_in_type = /obj/effect/temp_visual/dir_setting/cult/phase
+	jaunt_out_type = /obj/effect/temp_visual/dir_setting/cult/phase/out

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -13,8 +13,8 @@
 	nonabstract_req = 1
 	var/jaunt_duration = 50 //in deciseconds
 	var/jaunt_in_time = 5
-	var/jaunt_in_type = /obj/effect/overlay/temp/wizard
-	var/jaunt_out_type = /obj/effect/overlay/temp/wizard/out
+	var/jaunt_in_type = /obj/effect/temp_visual/wizard
+	var/jaunt_out_type = /obj/effect/temp_visual/wizard/out
 	action_icon_state = "jaunt"
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/cast(list/targets,mob/user = usr) //magnets, so mostly hardcoded

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -257,7 +257,7 @@
 	selection_type = "view"
 	sound = 'sound/magic/Repulse.ogg'
 	var/maxthrow = 5
-	var/sparkle_path = /obj/effect/overlay/temp/gravpush
+	var/sparkle_path = /obj/effect/temp_visual/gravpush
 
 	action_icon_state = "repulse"
 
@@ -300,7 +300,7 @@
 	range = 2
 	cooldown_min = 150
 	invocation_type = "none"
-	sparkle_path = /obj/effect/overlay/temp/dir_setting/tailsweep
+	sparkle_path = /obj/effect/temp_visual/dir_setting/tailsweep
 	action_icon_state = "tailsweep"
 	action_background_icon_state = "bg_alien"
 

--- a/code/modules/vehicles/speedbike.dm
+++ b/code/modules/vehicles/speedbike.dm
@@ -17,7 +17,7 @@
 
 /obj/vehicle/space/speedbike/Move(newloc,move_dir)
 	if(has_buckled_mobs())
-		new /obj/effect/overlay/temp/dir_setting/speedbike_trail(loc,move_dir)
+		new /obj/effect/temp_visual/dir_setting/speedbike_trail(loc,move_dir)
 	. = ..()
 
 /obj/vehicle/space/speedbike/red


### PR DESCRIPTION
calling these overlays is basically just lying, because they're not overlays.
as such, I'm renaming them, to go along with moving them into their own folder in a previous PR.