### PR TITLE
You can no longer get acid from nettles, deathnettles and kudzu removed from mutating weeds

### DIFF
--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -10,8 +10,6 @@
 	yield = 4
 	growthstages = 5
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/plant_type/weed_hardy)
-	mutatelist = list(/obj/item/seeds/nettle/death)
-	reagents_add = list("sacid" = 0.5)
 
 /obj/item/seeds/nettle/death
 	name = "pack of death-nettle seeds"

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -419,7 +419,7 @@
 		if(myseed)
 			qdel(myseed)
 			myseed = null
-		var/newWeed = pick(/obj/item/seeds/liberty, /obj/item/seeds/angel, /obj/item/seeds/nettle/death, /obj/item/seeds/kudzu)
+		var/newWeed = pick(/obj/item/seeds/liberty, /obj/item/seeds/angel)
 		myseed = new newWeed
 		dead = 0
 		hardmutate()


### PR DESCRIPTION
[Changelogs]: 

:cl: ma44
del: Nettles no longer provide acid
del: Kudzu and death nettles can no longer spawn by mutating weeds
/:cl:

[why]: # 

https://i.gyazo.com/01d139b7262c51819c3063fd7060314b.png

Server says it's bad

(inb4 no compile)
