### PR TITLE
[Delta] Adds freon tank to engineering secure storage

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -63624,6 +63624,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/freon,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqt" = (


### PR DESCRIPTION
There's no freon tank onboard the station to save the engine in times of crisis.