### PR TITLE
Plastic explosives can no longer be detonated by EMPs

### DIFF
--- a/code/game/objects/items/weapons/grenades/plastic.dm
+++ b/code/game/objects/items/weapons/grenades/plastic.dm
@@ -18,6 +18,10 @@
 	plastic_overlay = mutable_appearance(icon, "[item_state]2")
 	..()
 
+/obj/item/weapon/grenade/plastic/Initialize(mapload)
+	. = ..()
+	SET_SECONDARY_FLAG(src, NO_EMP_WIRES)
+
 /obj/item/weapon/grenade/plastic/Destroy()
 	qdel(nadeassembly)
 	nadeassembly = null


### PR DESCRIPTION
:cl: coiax
balance: Plastic explosives can no longer be detonated by EMPs.
/:cl:

> OOC: TheWulfe: Why does an Ion Rifle INSTANTLY kill anyone who
> carries the most common and basic item, the C4?