### PR TITLE
Vending machines are more dangerous when throwing items

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -931,7 +931,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 /obj/machinery/vending/security/pre_throw(obj/item/I)
 	if(istype(I, /obj/item/weapon/grenade))
 		var/obj/item/weapon/grenade/G = I
-		G.prime()
+		G.preprime()
 	else if(istype(I, /obj/item/device/flashlight))
 		var/obj/item/device/flashlight/F = I
 		F.on = TRUE

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -48,6 +48,7 @@
 	var/icon_deny				//Icon_state when vending!
 	var/seconds_electrified = 0	//Shock customers like an airlock.
 	var/shoot_inventory = 0		//Fire items at customers! We're broken!
+	var/shoot_inventory_chance = 2
 	var/shut_up = 0				//Stop spouting those godawful pitches!
 	var/extended_inventory = 0	//can we access the hidden inventory?
 	var/scan_id = 1
@@ -561,7 +562,7 @@
 		speak(slogan)
 		last_slogan = world.time
 
-	if(shoot_inventory && prob(2))
+	if(shoot_inventory && prob(shoot_inventory_chance))
 		throw_item()
 
 
@@ -592,7 +593,7 @@
 	if(!target)
 		return 0
 
-	for(var/datum/data/vending_product/R in product_records)
+	for(var/datum/data/vending_product/R in shuffle(product_records))
 		if(R.amount <= 0) //Try to use a record that actually has something to dump.
 			continue
 		var/dump_path = R.product_path
@@ -605,9 +606,14 @@
 	if(!throw_item)
 		return 0
 
+	pre_throw(throw_item)
+
 	throw_item.throw_at(target, 16, 3)
 	visible_message("<span class='danger'>[src] launches [throw_item] at [target]!</span>")
 	return 1
+
+/obj/machinery/vending/proc/pre_throw(obj/item/I)
+	return
 
 
 /obj/machinery/vending/proc/shock(mob/user, prb)
@@ -615,9 +621,7 @@
 		return FALSE
 	if(!prob(prb))
 		return FALSE
-	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-	s.set_up(5, 1, src)
-	s.start()
+	do_sparks(5, TRUE, src)
 	var/tmp/check_range = TRUE
 	if(electrocute_mob(user, get_area(src), src, 0.7, check_range))
 		return TRUE
@@ -864,6 +868,11 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	/obj/item/weapon/storage/fancy/cigarettes/cigars = 1, /obj/item/weapon/storage/fancy/cigarettes/cigars/havana = 1, /obj/item/weapon/storage/fancy/cigarettes/cigars/cohiba = 1)
 	refill_canister = /obj/item/weapon/vending_refill/cigarette
 
+/obj/machinery/vending/cigarette/pre_throw(obj/item/I)
+	if(istype(I, /obj/item/weapon/lighter))
+		var/obj/item/weapon/lighter/L = I
+		L.set_lit(TRUE)
+
 /obj/machinery/vending/medical
 	name = "\improper NanoMed Plus"
 	desc = "Medical drug dispenser."
@@ -918,6 +927,15 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	premium = list(/obj/item/weapon/coin/antagtoken = 1)
 	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 50)
 	resistance_flags = FIRE_PROOF
+
+/obj/machinery/vending/security/pre_throw(obj/item/I)
+	if(istype(I, /obj/item/weapon/grenade))
+		var/obj/item/weapon/grenade/G = I
+		G.prime()
+	else if(istype(I, /obj/item/device/flashlight))
+		var/obj/item/device/flashlight/F = I
+		F.on = TRUE
+		F.update_brightness()
 
 /obj/machinery/vending/hydronutrients
 	name = "\improper NutriMax"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -528,6 +528,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/throw_impact(atom/A)
 	if(A && !QDELETED(A))
+		if(is_hot() && isliving(A))
+			var/mob/living/L = A
+			L.IgniteMob()
 		var/itempush = 1
 		if(w_class < 4)
 			itempush = 0 //too light to push anything

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -472,8 +472,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	var/lit = 0
+	var/fancy = TRUE
 	heat = 1500
 	resistance_flags = FIRE_PROOF
+	light_color = LIGHT_COLOR_FIRE
 
 /obj/item/weapon/lighter/update_icon()
 	if(lit)
@@ -484,37 +486,28 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/weapon/lighter/ignition_effect(atom/A, mob/user)
 	. = "<span class='rose'>With a single flick of their wrist, [user] smoothly lights [A] with [src]. Damn [user.p_theyre()] cool.</span>"
 
-/obj/item/weapon/lighter/greyscale
-	name = "cheap lighter"
-	desc = "A cheap-as-free lighter."
-	icon_state = "lighter"
-
-/obj/item/weapon/lighter/greyscale/Initialize()
-	. = ..()
-	add_atom_colour(color2hex(randomColor(1)), FIXED_COLOUR_PRIORITY)
-	update_icon()
-
-/obj/item/weapon/lighter/greyscale/update_icon()
-	cut_overlays()
-	var/mutable_appearance/base_overlay = mutable_appearance(icon,"[initial(icon_state)]_base")
-	base_overlay.appearance_flags = RESET_COLOR //the edging doesn't change color
+/obj/item/weapon/lighter/proc/set_lit(new_lit)
+	lit = new_lit
 	if(lit)
-		base_overlay.icon_state = "[initial(icon_state)]_on"
-	add_overlay(base_overlay)
-
-/obj/item/weapon/lighter/greyscale/ignition_effect(atom/A, mob/user)
-	. = "<span class='notice'>After some fiddling, [user] manages to light [A] with [src].</span>"
+		force = 5
+		damtype = "fire"
+		hitsound = 'sound/items/welder.ogg'
+		attack_verb = list("burnt", "singed")
+		set_light(1)
+		START_PROCESSING(SSobj, src)
+	else
+		hitsound = "swing_hit"
+		force = 0
+		attack_verb = null //human_defense.dm takes care of it
+		set_light(0)
+		STOP_PROCESSING(SSobj, src)
+	update_icon()
 
 /obj/item/weapon/lighter/attack_self(mob/living/user)
 	if(user.is_holding(src))
 		if(!lit)
-			lit = 1
-			update_icon()
-			force = 5
-			damtype = "fire"
-			hitsound = 'sound/items/welder.ogg'
-			attack_verb = list("burnt", "singed")
-			if(!istype(src, /obj/item/weapon/lighter/greyscale))
+			set_lit(TRUE)
+			if(fancy)
 				user.visible_message("Without even breaking stride, [user] flips open and lights [src] in one smooth movement.", "<span class='notice'>Without even breaking stride, you flip open and lights [src] in one smooth movement.</span>")
 			else
 				var/prot = FALSE
@@ -534,20 +527,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 					user.apply_damage(5, BURN, hitzone)
 					user.visible_message("<span class='warning'>After a few attempts, [user] manages to light [src] - however, [user.p_they()] burn their finger in the process.</span>", "<span class='warning'>You burn yourself while lighting the lighter!</span>")
 
-			set_light(1)
-			START_PROCESSING(SSobj, src)
 		else
-			lit = 0
-			update_icon()
-			hitsound = "swing_hit"
-			force = 0
-			attack_verb = null //human_defense.dm takes care of it
-			if(!istype(src, /obj/item/weapon/lighter/greyscale))
+			set_lit(FALSE)
+			if(fancy)
 				user.visible_message("You hear a quiet click, as [user] shuts off [src] without even looking at what [user.p_theyre()] doing. Wow.", "<span class='notice'>You quietly shut off [src] without even looking at what you're doing. Wow.</span>")
 			else
 				user.visible_message("[user] quietly shuts off [src].", "<span class='notice'>You quietly shut off [src].")
-			set_light(0)
-			STOP_PROCESSING(SSobj, src)
 	else
 		. = ..()
 
@@ -562,7 +547,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(M == user)
 			cig.attackby(src, user)
 		else
-			if(!istype(src, /obj/item/weapon/lighter/greyscale))
+			if(fancy)
 				cig.light("<span class='rose'>[user] whips the [name] out and holds it for [M]. [user.p_their(TRUE)] arm is as steady as the unflickering flame they light \the [cig] with.</span>")
 			else
 				cig.light("<span class='notice'>[user] holds the [name] out for [M], and lights the [cig.name].</span>")
@@ -574,6 +559,30 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/weapon/lighter/is_hot()
 	return lit * heat
+
+
+/obj/item/weapon/lighter/greyscale
+	name = "cheap lighter"
+	desc = "A cheap-as-free lighter."
+	icon_state = "lighter"
+	fancy = FALSE
+
+/obj/item/weapon/lighter/greyscale/Initialize()
+	. = ..()
+	add_atom_colour(color2hex(randomColor(1)), FIXED_COLOUR_PRIORITY)
+	update_icon()
+
+/obj/item/weapon/lighter/greyscale/update_icon()
+	cut_overlays()
+	var/mutable_appearance/base_overlay = mutable_appearance(icon,"[initial(icon_state)]_base")
+	base_overlay.appearance_flags = RESET_COLOR //the edging doesn't change color
+	if(lit)
+		base_overlay.icon_state = "[initial(icon_state)]_on"
+	add_overlay(base_overlay)
+
+/obj/item/weapon/lighter/greyscale/ignition_effect(atom/A, mob/user)
+	. = "<span class='notice'>After some fiddling, [user] manages to light [A] with [src].</span>"
+
 
 ///////////
 //ROLLING//

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -48,23 +48,26 @@
 /obj/item/weapon/grenade/attack_self(mob/user)
 	if(!active)
 		if(clown_check(user))
-			to_chat(user, "<span class='warning'>You prime the [name]! [det_time/10] seconds!</span>")
-			playsound(user.loc, 'sound/weapons/armbomb.ogg', 60, 1)
-			active = 1
-			icon_state = initial(icon_state) + "_active"
-			add_fingerprint(user)
-			var/turf/bombturf = get_turf(src)
-			var/area/A = get_area(bombturf)
-			var/message = "[ADMIN_LOOKUPFLW(user)]) has primed a [name] for detonation at [ADMIN_COORDJMP(bombturf)]"
-			GLOB.bombers += message
-			message_admins(message)
-			log_game("[key_name(usr)] has primed a [name] for detonation at [A.name] [COORD(bombturf)].")
 			if(iscarbon(user))
 				var/mob/living/carbon/C = user
 				C.throw_mode_on()
-			spawn(det_time)
-				prime()
 
+/obj/item/weapon/grenade/proc/preprime(mob/user)
+	if(user)
+		to_chat(user, "<span class='warning'>You prime the [name]! [det_time/10] seconds!</span>")
+	playsound(loc, 'sound/weapons/armbomb.ogg', 60, 1)
+	active = TRUE
+	icon_state = initial(icon_state) + "_active"
+	add_fingerprint(user)
+	var/turf/bombturf = get_turf(src)
+	var/area/A = get_area(bombturf)
+	if(user)
+		var/message = "[ADMIN_LOOKUPFLW(user)]) has primed a [name] for detonation at [ADMIN_COORDJMP(bombturf)]"
+		GLOB.bombers += message
+		message_admins(message)
+		log_game("[key_name(usr)] has primed a [name] for detonation at [A.name] [COORD(bombturf)].")
+
+	addtimer(CALLBACK(src, .proc/prime), det_time)
 
 /obj/item/weapon/grenade/proc/prime()
 

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -48,6 +48,7 @@
 /obj/item/weapon/grenade/attack_self(mob/user)
 	if(!active)
 		if(clown_check(user))
+			preprime(user)
 			if(iscarbon(user))
 				var/mob/living/carbon/C = user
 				C.throw_mode_on()


### PR DESCRIPTION
:cl: coiax
add: Various vending machines, when shooting their inventory at nearby
people, will "demonstrate their products features". This means that if a
cigarette vending machine throws a lighter at you, it will be on.
Vending machines also choose random products when throwing, rather than
the first available one.
/:cl:

- Lighter light is now flame coloured, and have been minorly refactored
- Secvendors prime flashbangs, and turn on their flashights when
throwing them at people.
- Cigarette vendors light their lighters
- The selection process shuffles the item list before iterating, so it
won't just throw the first thing
- Grenades now use addtimer
- A thrown item now ignites mobs if it is hot.

- [x] Flashbangs explode immediately, and should instead be actually primed
- [x] Lighters thrown at people do not set them on fire