### PR TITLE
Adds a new toy to arcade prizes.  A rumbling toy toolbox meant to mimic hisgrace

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -44,7 +44,7 @@
 		/obj/item/weapon/grenade/chem_grenade/glitter/blue		= 1,
 		/obj/item/weapon/grenade/chem_grenade/glitter/white		= 1,
 		/obj/item/toy/eightball									= 2,
-		/obj/item/toy/windupToolbox/							= 2)
+		/obj/item/toy/windupToolbox								= 2)
 
 	light_color = LIGHT_COLOR_GREEN
 

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -43,7 +43,8 @@
 		/obj/item/weapon/grenade/chem_grenade/glitter/pink		= 1,
 		/obj/item/weapon/grenade/chem_grenade/glitter/blue		= 1,
 		/obj/item/weapon/grenade/chem_grenade/glitter/white		= 1,
-		/obj/item/toy/eightball									= 2)
+		/obj/item/toy/eightball									= 2,
+		/obj/item/toy/windupToolbox/							= 2)
 
 	light_color = LIGHT_COLOR_GREEN
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -286,6 +286,7 @@
 	item_state = "artistic_toolbox"
 	var/active = FALSE
 	icon = 'icons/obj/weapons.dmi'
+	attack_verb = list("robusted")
 
 /obj/item/toy/windupToolbox/attack_self(mob/user)
 	if(!active)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -279,6 +279,27 @@
 	resistance_flags = FLAMMABLE
 
 
+/obj/item/toy/windupToolbox
+	name = "windup toolbox"
+	desc = "A replica toolbox that rumbles when you turn the key"
+	icon_state = "his_grace"
+	item_state = "artistic_toolbox"
+	var/active = FALSE
+	icon = 'icons/obj/weapons.dmi'
+
+/obj/item/toy/windupToolbox/attack_self(mob/user)
+	if(!active)
+		icon_state = "his_grace_awakened"
+		to_chat(user, "<span class='warning'>You wind up [src], it begins to rumble.</span>")
+		active = TRUE
+		addtimer(CALLBACK(src, .proc/stopRumble), 600)
+	else
+		to_chat(user, "[src] is already active.")
+
+/obj/item/toy/windupToolbox/proc/stopRumble()
+	icon_state = initial(icon_state)
+	active = FALSE
+
 /*
  * Subtype of Double-Bladed Energy Swords
  */


### PR DESCRIPTION
:cl: Lordpidey
add: Toy toolboxes with realistic rumbling action have been added to arcade prizes.
/:cl:

Why:  This adds a new toy to the arcade prizes, meant to mimic his grace.  It adds uncertainty to the round when someone sees a shaking toolbox.
