### PR TITLE
Plasmaman Plasma Tanks are just as large as normal emergency tanks

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -140,6 +140,7 @@
 	item_state = "plasmaman_tank_belt"
 	slot_flags = SLOT_BELT
 	force = 5
+	volume = 3
 
 /obj/item/weapon/tank/internals/plasmaman/belt/full/New()
 	..()

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -141,6 +141,7 @@
 	slot_flags = SLOT_BELT
 	force = 5
 	volume = 3
+	w_class = WEIGHT_CLASS_SMALL //thanks i forgot this
 
 /obj/item/weapon/tank/internals/plasmaman/belt/full/New()
 	..()


### PR DESCRIPTION
:cl: Tacolizard Forever: Plasmaman Powercreep
tweak: Plasmaman tanks are the same size as emergency oxygen tanks.
/:cl:

Previously they only fit on the belt, making it really irritating to play any job that uses a belt. Now they are just as large as normal emergency tanks.

to people who claim the belt restriction was 'balance' i have a few counterarguments.

1. This was considered an issue in #13001 by ChangelingRain
2. The restriction can be circumvented by putting the belt in your pack and dragging it. If the 'balance' is so easy to get around, is it really balance?
3. I doubt the belt restriction was intended. It seems like it was just an accident, especially considering the sprite looks similar to a normal emergency tank.
4. Referencing 2, purposefully making the interface clunky as part of balance is bad game design.
5. Nobody who wouldn't play plasmaman is going to do so simply because they can use a belt. Plasmamen have plenty of disadvantages that are both intended and more severe.
6. It doesn't even make any fucking sense. Why should a tank with the same capacity and sprite size as an emergency tank be magically unable to be placed anywhere except the belt?

I really can't believe I have to defend this PR kek

fixes #13001
