### PR TITLE
Fix choice for golems transferring between shells

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -149,8 +149,8 @@
 
 /obj/effect/mob_spawn/human/golem/attack_hand(mob/user)
 	if(isgolem(user) && can_transfer)
-		var/transfer = alert("Transfer your soul to [src]? (Warning, your old body will die!)",,"Yes","No")
-		if(!transfer)
+		var/transfer_choice = alert("Transfer your soul to [src]? (Warning, your old body will die!)",,"Yes","No")
+		if(transfer_choice != "Yes")
 			return
 		log_game("[user.ckey] golem-swapped into [src]")
 		user.visible_message("<span class='notice'>A faint light leaves [user], moving to [src] and animating it!</span>","<span class='notice'>You leave your old body behind, and transfer into [src]!</span>")


### PR DESCRIPTION
:cl:
fix: Golems touching a shell can now choose to stay in their own body.
/:cl:

Feature added in #26765, but used `alert()` incorrectly.

@duncathan 
http://www.byond.com/docs/ref/info.html#/proc/alert

Fixes #27374 