### PR TITLE
Annoyed admirals recalling shuttles

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1416,3 +1416,24 @@ GLOBAL_PROTECT(valid_HTTPSGet)
 		mob_occupant = brain.brainmob
 
 	return mob_occupant
+
+/proc/msglog_admins(text)
+	message_admins(text)
+	log_admin(text)
+
+/proc/trigger_centcom_recall()
+	if(SSshuttle.emergency.mode != SHUTTLE_CALL)
+		return
+
+	var/time = rand(600, 1200)
+	var/message = pick(GLOB.annoyed_admiral_messages)
+
+	message = input("Enter message from the on-call admiral to be put in the recall report.", "Annoyed Admiral Message", message) as text|null
+
+	if(!message)
+		return
+
+	message_admins("[key_name_admin(usr)] triggered a Centcom recall in [time/10] seconds, with the annoyed admiral message of: [message]")
+	log_game("[key_name(usr)] triggered a Centcom recall in [time/10] seconds, with the annoyed admiral message of: [message]")
+
+	addtimer(CALLBACK(SSshuttle, /datum/controller/subsystem/shuttle/.proc/centcom_recall, SSshuttle.emergency.timer, message), time)

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -161,3 +161,5 @@ GLOBAL_LIST_INIT(numbers_as_words, list("One", "Two", "Three", "Four",
 	return L
 
 GLOBAL_LIST_INIT(station_numerals, greek_letters + phonetic_alphabet + numbers_as_words + generate_number_strings())
+
+GLOBAL_LIST_INIT(annoyed_admiral_messages, list("Do you know how expensive these stations are?","Stop wasting my time.","I was sleeping, thanks a lot.","Stand and fight you cowards!","You knew the risks coming in.","Stop being paranoid.","Whatever's broken just build a new one.","No.", "<i>null</i>","<i>Error: No comment given.</i>", "It's a good day to die!"))

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -215,7 +215,32 @@ SUBSYSTEM_DEF(shuttle)
 			emergency.request(null, signal_origin, html_decode(emergency_reason), 0)
 
 	log_game("[key_name(user)] has called the shuttle.")
-	message_admins("[key_name_admin(user)] has called the shuttle.")
+	message_admins("[key_name_admin(user)] has called the shuttle. (<A HREF='?_src_=holder;trigger_centcom_recall=1'>TRIGGER CENTCOM RECALL</A>)")
+
+/datum/controller/subsystem/shuttle/proc/centcom_recall(old_timer, annoyed_admiral_message)
+	if(emergency.mode != SHUTTLE_CALL || emergency.timer != old_timer)
+		return
+
+	emergency.cancel(/area/centcom)
+	msglog_admins("Shuttle has been recalled from Centcom.")
+
+	addtimer(CALLBACK(src, .proc/centcom_recall2, annoyed_admiral_message), 50)
+
+/datum/controller/subsystem/shuttle/proc/centcom_recall2(annoyed_admiral_message)
+	if(!annoyed_admiral_message)
+		annoyed_admiral_message = pick(GLOB.annoyed_admiral_messages)
+	var/intercepttext = "<FONT size = 3><b>NanoTrasen Update</b>: Request For Shuttle.</FONT><HR>\
+						To whom it may concern:<BR><BR>\
+						We have taken note of the situation upon [station_name()] and have come to the \
+						conclusion that it does not warrant the abandonment of the station.<BR>\
+						If you do not agree with our opinion we suggest that you open a direct \
+						line with us and explain the nature of your crisis.<BR><BR>\
+						<i>This message has been automatically generated based upon readings from long \
+						range diagnostic tools. To assure the quality of your request every finalized report \
+						is reviewed by an on-call rear admiral.<BR>\
+						<b>Rear Admiral's Notes:</b> \
+						[annoyed_admiral_message]"
+	print_command_report(intercepttext, announce=TRUE)
 
 // Called when an emergency shuttle mobile docking port is
 // destroyed, which will only happen with admin intervention
@@ -514,4 +539,4 @@ SUBSYSTEM_DEF(shuttle)
 	for(var/obj/docking_port/mobile/M in mobile)
 		if(M.is_in_shuttle_bounds(A))
 			return TRUE
-		
+

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -281,6 +281,11 @@
 		minor_announce("The emergency shuttle will reach its destination in [round(SSshuttle.emergency.timeLeft(600))] minutes.")
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] edited the Emergency Shuttle's timeleft to [timer] seconds.</span>")
 		href_list["secrets"] = "check_antagonist"
+	else if(href_list["trigger_centcom_recall"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		trigger_centcom_recall()
 
 	else if(href_list["toggle_continuous"])
 		if(!check_rights(R_ADMIN))


### PR DESCRIPTION
:cl: coiax
add: When a shuttle is called, sometimes an on-call admiral, using
available information to them, will recall the shuttle from Centcom.
/:cl:

This is in essence, a simple IC way for admins to recall the shuttle
if they feel that the shuttle should not come. It's up to them entirely,
the system does not trigger otherwise. They also get to set a cranky
message that is automatically fed back to the crew.

It would be nice if admins used their own judgement if the crew is
evacuating for no real reason, and might send an ERT at the same time to
keep the round going? Who knows, I'm just providing the tools.