### PR TITLE
Fixes having more movespeed when xenos hug themselves

### DIFF
--- a/code/modules/mob/living/carbon/alien/status_procs.dm
+++ b/code/modules/mob/living/carbon/alien/status_procs.dm
@@ -17,4 +17,4 @@
 /mob/living/carbon/alien/AdjustStunned(amount, updating = 1, ignore_canstun = 0)
 	. = ..()
 	if(!.)
-		move_delay_add = min(move_delay_add + round(amount / 2), 10)
+		move_delay_add = min(max(0, move_delay_add + round(amount / 2)), 10)

--- a/code/modules/mob/living/carbon/alien/status_procs.dm
+++ b/code/modules/mob/living/carbon/alien/status_procs.dm
@@ -17,4 +17,4 @@
 /mob/living/carbon/alien/AdjustStunned(amount, updating = 1, ignore_canstun = 0)
 	. = ..()
 	if(!.)
-		move_delay_add = min(max(0, move_delay_add + round(amount / 2)), 10)
+		move_delay_add = Clamp(move_delay_add + round(amount/2), 0, 10)


### PR DESCRIPTION
Fixes #27364

The `move_delay_add` already decays, but it doesn't account for negatives, which I believe is intended?