### PR TITLE
Since you can properly scrub Freon now, it doesn't destroy itself.

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -76,7 +76,6 @@
 /datum/gas_reaction/freon/react(datum/gas_mixture/air, turf/open/location)
 	. = NO_REACTION
 	if(location && location.freon_gas_act())
-		air.gases["freon"][MOLES] -= MOLES_PLASMA_VISIBLE
 		. = REACTING
 
 //water vapor: puts out fires?


### PR DESCRIPTION
# This was added because I couldn't compile tgui. Therefore, it gets to go away now since scrubbers were fixed.