### PR TITLE
Reworks the mining resonator

### DIFF
--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -203,7 +203,7 @@
 			user.changeNext_move(CLICK_CD_MELEE)
 		return
 	if(LAZYLEN(fields) < fieldlimit)
-		var/obj/effect/temp_visual/resonance/RE = new(T, user, src)
+		new /obj/effect/temp_visual/resonance(T, user, src)
 		if(!ismineralturf(T))
 			user.changeNext_move(CLICK_CD_MELEE)
 

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -210,7 +210,8 @@
 			user.changeNext_move(CLICK_CD_RANGE)
 
 /obj/item/weapon/resonator/pre_attackby(atom/target, mob/living/user, params)
-	CreateResonance(target, user)
+	if(!istype(target, /obj/item/weapon/storage) && isturf(target.loc))
+		CreateResonance(target, user)
 	return TRUE
 
 /obj/effect/temp_visual/resonance

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -169,102 +169,136 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "resonator"
 	item_state = "resonator"
-	desc = "A handheld device that creates small fields of energy that resonate until they detonate, crushing rock. It can also be activated without a target to create a field at the user's location, to act as a delayed time trap. It's more effective in a vacuum."
+	desc = "A handheld device that creates small fields of energy that resonate until they detonate, crushing rock. It's more effective in a vacuum."
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 15
 	throwforce = 10
-	var/burst_time = 30
-	var/fieldlimit = 4
+	var/fieldlimit = 3
 	var/list/fields = list()
-	var/quick_burst_mod = 0.8
+	var/quick_burst_mod = 3
 	origin_tech = "magnets=3;engineering=3"
+
+/obj/item/weapon/resonator/examine(mob/user)
+	..()
+	to_chat(user, "<span class='notice'>Striking a resonance field that was recently crossed will immediately detonate it and do <b>[100*quick_burst_mod]%</b> damage.</span>")
 
 /obj/item/weapon/resonator/upgraded
 	name = "upgraded resonator"
-	desc = "An upgraded version of the resonator that can produce more fields at once, as well as having no damage penalty for bursting a resonance field early."
+	desc = "An upgraded version of the resonator that can produce more fields at once."
 	icon_state = "resonator_u"
 	item_state = "resonator_u"
 	origin_tech = "materials=4;powerstorage=3;engineering=3;magnets=3"
-	fieldlimit = 6
-	quick_burst_mod = 1
+	fieldlimit = 5
+	quick_burst_mod = 4
 
-/obj/item/weapon/resonator/proc/CreateResonance(target, creator)
+/obj/item/weapon/resonator/proc/CreateResonance(target, mob/user)
 	var/turf/T = get_turf(target)
-	var/obj/effect/resonance/R = locate(/obj/effect/resonance) in T
+	var/obj/effect/temp_visual/resonance/R = locate(/obj/effect/temp_visual/resonance) in T
 	if(R)
-		R.resonance_damage *= quick_burst_mod
-		R.burst()
+		if(R.was_crossed && !R.is_bursting)
+			R.damage_multiplier = quick_burst_mod
+			deltimer(R.timerid)
+			INVOKE_ASYNC(R, /obj/effect/temp_visual/resonance.proc/burst)
+			user.changeNext_move(CLICK_CD_MELEE)
 		return
-	if(fields.len < fieldlimit)
+	if(LAZYLEN(fields) < fieldlimit)
 		playsound(src,'sound/weapons/resonator_fire.ogg',50,1)
-		var/obj/effect/resonance/RE = new(T, creator, burst_time, src)
-		fields += RE
+		var/obj/effect/temp_visual/resonance/RE = new(T, user, src)
+		if(ismineralturf(T))
+			INVOKE_ASYNC(RE, /obj/effect/temp_visual/resonance.proc/crossed_burst)
+		else
+			user.changeNext_move(CLICK_CD_MELEE)
 
-/obj/item/weapon/resonator/attack_self(mob/user)
-	if(burst_time == 50)
-		burst_time = 30
-		to_chat(user, "<span class='info'>You set the resonator's fields to detonate after 3 seconds.</span>")
-	else
-		burst_time = 50
-		to_chat(user, "<span class='info'>You set the resonator's fields to detonate after 5 seconds.</span>")
+/obj/item/weapon/resonator/pre_attackby(atom/target, mob/living/user, params)
+	CreateResonance(target, user)
+	return TRUE
 
-/obj/item/weapon/resonator/afterattack(atom/target, mob/user, proximity_flag)
-	if(proximity_flag)
-		if(!check_allowed_items(target, 1))
-			return
-		user.changeNext_move(CLICK_CD_MELEE)
-		CreateResonance(target, user)
-
-/obj/effect/resonance
+/obj/effect/temp_visual/resonance
 	name = "resonance field"
 	desc = "A resonating field that significantly damages anything inside of it when the field eventually ruptures. More damaging in low pressure environments."
-	icon = 'icons/effects/effects.dmi'
 	icon_state = "shield1"
 	layer = ABOVE_ALL_MOB_LAYER
-	anchored = TRUE
-	mouse_opacity = 0
-	var/resonance_damage = 20
+	duration = 50
+	var/resonance_damage = 5
+	var/damage_multiplier = 1
 	var/creator
 	var/obj/item/weapon/resonator/res
+	var/was_crossed = FALSE
+	var/is_bursting = FALSE
 
-/obj/effect/resonance/New(loc, set_creator, timetoburst, set_resonator)
-	..()
+/obj/effect/temp_visual/resonance/Initialize(mapload, set_creator, set_resonator)
+	. = ..()
 	creator = set_creator
 	res = set_resonator
-	check_pressure()
-	addtimer(CALLBACK(src, .proc/burst), timetoburst)
+	if(res)
+		res.fields += src
+	transform = matrix()*0.75
+	deltimer(timerid)
+	timerid = addtimer(CALLBACK(src, .proc/burst), duration, TIMER_STOPPABLE)
+	for(var/mob/living/L in T)
+		INVOKE_ASYNC(src, .proc/crossed_burst)
+		break
 
-/obj/effect/resonance/Destroy()
+/obj/effect/temp_visual/resonance/Destroy()
 	if(res)
 		res.fields -= src
+		res = null
+	creator = null
 	. = ..()
 
-/obj/effect/resonance/proc/check_pressure()
-	var/turf/proj_turf = get_turf(src)
+/obj/effect/temp_visual/resonance/proc/check_pressure(turf/proj_turf)
+	if(!proj_turf)
+		proj_turf = get_turf(src)
 	if(!istype(proj_turf))
 		return
 	var/datum/gas_mixture/environment = proj_turf.return_air()
 	var/pressure = environment.return_pressure()
+	resonance_damage = initial(resonance_damage)
 	if(pressure < 50)
 		name = "strong [initial(name)]"
-		resonance_damage = 60
+		resonance_damage *= 4
 	else
 		name = initial(name)
-		resonance_damage = initial(resonance_damage)
+	resonance_damage *= damage_multiplier
 
-/obj/effect/resonance/proc/burst()
-	check_pressure()
+/obj/effect/temp_visual/resonance/Crossed(atom/movable/AM)
+	..()
+	if(isliving(AM) && !was_crossed && !is_bursting)
+		crossed_burst()
+
+/obj/effect/temp_visual/resonance/proc/crossed_burst()
+	was_crossed = TRUE
+	animate(src, transform = matrix()*1.5, time = 15)
+	deltimer(timerid)
+	timerid = addtimer(CALLBACK(src, .proc/burst), 15, TIMER_STOPPABLE)
+
+/obj/effect/temp_visual/resonance/proc/burst()
+	is_bursting = TRUE
+	animate(src, transform = matrix()*2, time = 2, flags = ANIMATION_END_NOW)
 	var/turf/T = get_turf(src)
-	playsound(src,'sound/weapons/resonator_blast.ogg',50,1)
+	sleep(2)
+	new /obj/effect/temp_visual/resonance_crush(T)
 	if(ismineralturf(T))
 		var/turf/closed/mineral/M = T
 		M.gets_drilled(creator)
+	check_pressure(T)
+	playsound(T,'sound/weapons/resonator_blast.ogg',50,1)
 	for(var/mob/living/L in T)
 		if(creator)
 			add_logs(creator, L, "used a resonator field on", "resonator")
 		to_chat(L, "<span class='userdanger'>[src] ruptured with you in it!</span>")
 		L.apply_damage(resonance_damage, BRUTE)
 	qdel(src)
+
+/obj/effect/temp_visual/resonance_crush
+	icon_state = "shield1"
+	layer = ABOVE_ALL_MOB_LAYER
+	duration = 4
+
+/obj/effect/temp_visual/resonance_crush/Initialize()
+	. = ..()
+	transform = matrix()*1.5
+	animate(src, transform = matrix()*0.1, alpha = 50, time = 4)
 
 /**********************Facehugger toy**********************/
 

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -206,6 +206,8 @@
 		new /obj/effect/temp_visual/resonance(T, user, src)
 		if(!ismineralturf(T))
 			user.changeNext_move(CLICK_CD_MELEE)
+		else
+			user.changeNext_move(CLICK_CD_RANGE)
 
 /obj/item/weapon/resonator/pre_attackby(atom/target, mob/living/user, params)
 	CreateResonance(target, user)
@@ -235,10 +237,10 @@
 	deltimer(timerid)
 	timerid = addtimer(CALLBACK(src, .proc/burst), duration, TIMER_STOPPABLE)
 	for(var/mob/living/L in loc) //mob here, expand!
-		INVOKE_ASYNC(src, .proc/crossed_burst)
+		INVOKE_ASYNC(src, .proc/crossed_burst, 10)
 		return
 	if(ismineralturf(loc)) //mineral turf, expand!
-		INVOKE_ASYNC(src, .proc/crossed_burst)
+		INVOKE_ASYNC(src, .proc/crossed_burst, 25)
 
 /obj/effect/temp_visual/resonance/Destroy()
 	if(res)
@@ -265,13 +267,13 @@
 /obj/effect/temp_visual/resonance/Crossed(atom/movable/AM)
 	..()
 	if(isliving(AM) && !was_crossed && !is_bursting)
-		crossed_burst()
+		crossed_burst(10)
 
-/obj/effect/temp_visual/resonance/proc/crossed_burst()
+/obj/effect/temp_visual/resonance/proc/crossed_burst(delay_til_burst = 15)
 	was_crossed = TRUE
-	animate(src, transform = matrix()*1.5, time = 15)
+	animate(src, transform = matrix()*1.5, time = delay_til_burst)
 	deltimer(timerid)
-	timerid = addtimer(CALLBACK(src, .proc/burst), 15, TIMER_STOPPABLE)
+	timerid = addtimer(CALLBACK(src, .proc/burst), delay_til_burst, TIMER_STOPPABLE)
 
 /obj/effect/temp_visual/resonance/proc/burst()
 	is_bursting = TRUE

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -240,7 +240,7 @@
 		INVOKE_ASYNC(src, .proc/crossed_burst, 10)
 		return
 	if(ismineralturf(loc)) //mineral turf, expand!
-		INVOKE_ASYNC(src, .proc/crossed_burst, 25)
+		INVOKE_ASYNC(src, .proc/crossed_burst, 20)
 
 /obj/effect/temp_visual/resonance/Destroy()
 	if(res)
@@ -277,7 +277,7 @@
 
 /obj/effect/temp_visual/resonance/proc/burst()
 	is_bursting = TRUE
-	animate(src, transform = matrix()*2, time = 2, flags = ANIMATION_END_NOW)
+	animate(src, transform = matrix()*1.5, time = 2, flags = ANIMATION_END_NOW)
 	var/turf/T = get_turf(src)
 	sleep(2)
 	new /obj/effect/temp_visual/resonance_crush(T)

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -176,6 +176,8 @@
 	var/fieldlimit = 3
 	var/list/fields = list()
 	var/quick_burst_mod = 3
+	var/mob_burst_speed = 1
+	var/turf_burst_speed = 2
 	origin_tech = "magnets=3;engineering=3"
 
 /obj/item/weapon/resonator/examine(mob/user)
@@ -209,8 +211,8 @@
 		else
 			user.changeNext_move(CLICK_CD_RANGE)
 
-/obj/item/weapon/resonator/pre_attackby(atom/target, mob/living/user, params)
-	if(!istype(target, /obj/item/weapon/storage) && isturf(target.loc))
+/obj/item/weapon/resonator/pre_attackby(atom/target, mob/user, params)
+	if(check_allowed_items(target, 1))
 		CreateResonance(target, user)
 	return TRUE
 
@@ -222,6 +224,8 @@
 	duration = 50
 	var/resonance_damage = 5
 	var/damage_multiplier = 1
+	var/mob_burst_speed = 1
+	var/turf_burst_speed = 2
 	var/creator
 	var/obj/item/weapon/resonator/res
 	var/was_crossed = FALSE
@@ -233,15 +237,17 @@
 	res = set_resonator
 	if(res)
 		res.fields += src
+		mob_burst_speed = res.mob_burst_speed
+		turf_burst_speed = res.turf_burst_speed
 	playsound(src,'sound/weapons/resonator_fire.ogg',50,1)
 	transform = matrix()*0.75
 	deltimer(timerid)
 	timerid = addtimer(CALLBACK(src, .proc/burst), duration, TIMER_STOPPABLE)
 	for(var/mob/living/L in loc) //mob here, expand!
-		INVOKE_ASYNC(src, .proc/crossed_burst, 10)
+		INVOKE_ASYNC(src, .proc/crossed_burst, mob_burst_speed)
 		return
 	if(ismineralturf(loc)) //mineral turf, expand!
-		INVOKE_ASYNC(src, .proc/crossed_burst, 20)
+		INVOKE_ASYNC(src, .proc/crossed_burst, turf_burst_speed)
 
 /obj/effect/temp_visual/resonance/Destroy()
 	if(res)
@@ -268,7 +274,7 @@
 /obj/effect/temp_visual/resonance/Crossed(atom/movable/AM)
 	..()
 	if(isliving(AM) && !was_crossed && !is_bursting)
-		crossed_burst(10)
+		crossed_burst(mob_burst_speed)
 
 /obj/effect/temp_visual/resonance/proc/crossed_burst(delay_til_burst = 15)
 	was_crossed = TRUE

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -180,7 +180,8 @@
 
 /obj/item/weapon/resonator/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>Striking a resonance field that was recently crossed will immediately detonate it and do <b>[100*quick_burst_mod]%</b> damage.</span>")
+	to_chat(user, "<span class='notice'>Resonance fields will expand quickly if crossed or when created on a mob or rock wall.</span>")
+	to_chat(user, "<span class='notice'>Striking an expanding resonance field will immediately detonate it and do <b>[100*quick_burst_mod]%</b> damage.</span>")
 
 /obj/item/weapon/resonator/upgraded
 	name = "upgraded resonator"
@@ -202,11 +203,8 @@
 			user.changeNext_move(CLICK_CD_MELEE)
 		return
 	if(LAZYLEN(fields) < fieldlimit)
-		playsound(src,'sound/weapons/resonator_fire.ogg',50,1)
 		var/obj/effect/temp_visual/resonance/RE = new(T, user, src)
-		if(ismineralturf(T))
-			INVOKE_ASYNC(RE, /obj/effect/temp_visual/resonance.proc/crossed_burst)
-		else
+		if(!ismineralturf(T))
 			user.changeNext_move(CLICK_CD_MELEE)
 
 /obj/item/weapon/resonator/pre_attackby(atom/target, mob/living/user, params)
@@ -232,12 +230,15 @@
 	res = set_resonator
 	if(res)
 		res.fields += src
+	playsound(src,'sound/weapons/resonator_fire.ogg',50,1)
 	transform = matrix()*0.75
 	deltimer(timerid)
 	timerid = addtimer(CALLBACK(src, .proc/burst), duration, TIMER_STOPPABLE)
-	for(var/mob/living/L in T)
+	for(var/mob/living/L in loc) //mob here, expand!
 		INVOKE_ASYNC(src, .proc/crossed_burst)
-		break
+		return
+	if(ismineralturf(loc)) //mineral turf, expand!
+		INVOKE_ASYNC(src, .proc/crossed_burst)
 
 /obj/effect/temp_visual/resonance/Destroy()
 	if(res)


### PR DESCRIPTION
:cl: Joan
balance: Reworked the mining resonator: Resonator fields disappear after 5 seconds and will burst 1 second after being crossed or being placed on a mob.
rscadd: Resonator fields do increased damage and immediately burst if struck in the 1 second after being crossed or placed on a mob.
tweak: Resonator fields have animations showing when to strike: if the field is slowly expanding, hit it to cause it to burst for bonus damage. 
/:cl:

This thing sucks, but this should suck less and be more interactive.

For a simple explanation of how it works now:
You can place a field as a weak trap which does 20 damage if it bursts without being struck, or as a setup to go in and strike when a field is triggered and begins to expand, which does 60/80(normal/upgraded resonator) damage plus the resonator's 15.
