### PR TITLE
Aux Base Fixes

### DIFF
--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -2,7 +2,8 @@
 
 #define BAD_ZLEVEL	1
 #define BAD_AREA	2
-#define ZONE_SET	3
+#define BAD_COORDS	3
+#define ZONE_SET	4
 
 /area/shuttle/auxillary_base
 	name = "Auxillary Base"
@@ -149,6 +150,9 @@ interface with the mining shuttle at the landing site if a mobile beacon is also
 		if(T.z != ZLEVEL_MINING)
 			return BAD_ZLEVEL
 		var/colony_radius = max(base_dock.width, base_dock.height)*0.5
+		if(T.x - colony_radius < 1 || T.x + colony_radius >= world.maxx || T.y - colony_radius < 1 || T.y + colony_radius >= world.maxx)
+			return BAD_COORDS //Avoid dropping the base too close to map boundaries, as it results in parts of it being left in space
+
 		var/list/area_counter = get_areas_in_range(colony_radius, T)
 		if(area_counter.len > 1) //Avoid smashing ruins unless you are inside a really big one
 			return BAD_AREA
@@ -193,8 +197,8 @@ interface with the mining shuttle at the landing site if a mobile beacon is also
 	to_chat(user, "<span class='notice'>You begin setting the landing zone parameters...</span>")
 	setting = TRUE
 	if(!do_after(user, 50, target = user)) //You get a few seconds to cancel if you do not want to drop there.
-		setting = FALSE
 		return
+	setting = FALSE
 
 	var/turf/T = get_turf(user)
 	var/obj/machinery/computer/auxillary_base/AB
@@ -212,6 +216,8 @@ interface with the mining shuttle at the landing site if a mobile beacon is also
 			to_chat(user, "<span class='warning'>This uplink can only be used in a designed mining zone.</span>")
 		if(BAD_AREA)
 			to_chat(user, "<span class='warning'>Unable to acquire a targeting lock. Find an area clear of stuctures or entirely within one.</span>")
+		if(BAD_COORDS)
+			to_chat(user, "<span class='warning'>Location is too close to the edge of the station's scanning range. Move several paces away and try again.</span>")
 		if(ZONE_SET)
 			qdel(src)
 
@@ -347,4 +353,5 @@ obj/docking_port/stationary/public_mining_dock/onShuttleMove()
 
 #undef BAD_ZLEVEL
 #undef BAD_AREA
+#undef BAD_COORDS
 #undef ZONE_SET

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -197,6 +197,7 @@ interface with the mining shuttle at the landing site if a mobile beacon is also
 	to_chat(user, "<span class='notice'>You begin setting the landing zone parameters...</span>")
 	setting = TRUE
 	if(!do_after(user, 50, target = user)) //You get a few seconds to cancel if you do not want to drop there.
+		setting = FALSE
 		return
 	setting = FALSE
 


### PR DESCRIPTION
:cl: Gun Hog
fix: The Auxiliary Base can no longer land outside the lavaland map's boundaries.
/:cl:
https://github.com/tgstation/tgstation/issues/25022
Also fixes the Aux Base's remote becoming inaccessible if it fails a turf check.