### PR TITLE
fixes projectile dampener projectors not draining robot cell

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -565,6 +565,7 @@
 		restore_projectile(P)
 
 /obj/item/borg/projectile_dampen/process()
+	host = loc
 	process_recharge()
 	process_usage()
 	update_location()


### PR DESCRIPTION
i'm sorry ok 
just a note here, one of the downsides of the projectile field is it's QUITE intensive on cyborg cells, and it'll actually drain it whenever it needs to recharge until it's fully charged unless the cyborg is at like 5% power (750 for 15k cells!)
i'm still looking to balance this stuff more, but when the two fix prs are merged and they start being successfully used I'll have actual data..