### PR TITLE
Re-removes "the station" from drone law 3

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -55,7 +55,7 @@
 	var/laws = \
 	"1. You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone.\n"+\
 	"2. You may not harm any being, regardless of intent or circumstance.\n"+\
-	"3. Your goals are to build, maintain, repair, improve, and power the station to the best of your abilities, You must never actively work against these goals."
+	"3. Your goals are to build, maintain, repair, improve, and provide power to the best of your abilities, You must never actively work against these goals."
 	var/light_on = 0
 	var/heavy_emp_damage = 25 //Amount of damage sustained if hit by a heavy EMP pulse
 	var/alarms = list("Atmosphere" = list(), "Fire" = list(), "Power" = list())


### PR DESCRIPTION
:cl: RandomMarine
tweak: Drone laws no longer restrict drones to the station.
/:cl:

Why: The main reason I'm making this is that #21665 was made and merged under a false pretense. As evident in https://github.com/tgstation/tgstation/commit/6b5676998eb564553cdd349711e35ac465f29c2a , the change to the law was intentional.

I also don't really see any good reason why drones should be restricted to the station.