### PR TITLE
Mesons no longer remove light

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -37,7 +37,7 @@
 	origin_tech = "magnets=1;engineering=2"
 	darkness_view = 2
 	vision_flags = SEE_TURFS
-	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+	lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
 	glass_colour_type = /datum/client_colour/glass_colour/lightgreen
 
 /obj/item/clothing/glasses/meson/night


### PR DESCRIPTION
:cl: Joan
rscdel: Mesons no longer remove light
/:cl:

https://github.com/tgstation/tgstation/pull/27409#issuecomment-302892254
I don't know, @KorPhaeron, is it?

Spoiler: I fully expect the answer to be no, because...
# This PR effectively removes turf vision, and that's almost certainly worse than #27409's solution, which is to just remove turf vision on mining.