### PR TITLE
Plasma cutters will mine further but will go less distance in open air

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -203,7 +203,7 @@
 	range = 4
 	dismemberment = 20
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
-	var/mine_range = 4 //mines this many additional tiles
+	var/mine_range = 3 //mines this many additional tiles
 
 /obj/item/projectile/plasma/Initialize()
 	. = ..()

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -235,8 +235,8 @@
 
 /obj/item/projectile/plasma/adv/mech
 	damage = 10
-	range = 6
-	mine_range = 6
+	range = 9
+	mine_range = 3
 
 /obj/item/projectile/plasma/turret
 	//Between normal and advanced for damage, made a beam so not the turret does not destroy glass

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -200,9 +200,10 @@
 	icon_state = "plasmacutter"
 	damage_type = BRUTE
 	damage = 5
-	range = 3.5 //works as 4, but doubles to 7
+	range = 4
 	dismemberment = 20
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
+	var/mine_range = 4 //mines this many additional tiles
 
 /obj/item/projectile/plasma/Initialize()
 	. = ..()
@@ -215,24 +216,27 @@
 		if(pressure < 60)
 			name = "full strength [name]"
 			damage *= 4
-			range *= 2
 
 /obj/item/projectile/plasma/on_hit(atom/target)
 	. = ..()
 	if(ismineralturf(target))
 		var/turf/closed/mineral/M = target
 		M.gets_drilled(firer)
-		Range()
+		if(mine_range)
+			mine_range--
+			range++
 		if(range > 0)
 			return -1
 
 /obj/item/projectile/plasma/adv
 	damage = 7
 	range = 5
+	mine_range = 5
 
 /obj/item/projectile/plasma/adv/mech
 	damage = 10
 	range = 6
+	mine_range = 6
 
 /obj/item/projectile/plasma/turret
 	//Between normal and advanced for damage, made a beam so not the turret does not destroy glass


### PR DESCRIPTION
:cl: Joan
balance: Swapped how far plasma cutter blasts go when going through rock and in open air. This means blasts through air will go 4/5 tiles, but will mine 7/10 tiles, for normal/advanced plasma cutters, respectively.
/:cl:

Effectively, they're shorter-ranged and less safe for fighting monsters, but way, way better for strip mining the entire hell world.