### PR TITLE
Prevents wizard from gaining infinite skeletons with a 3-use Necrostone

### DIFF
--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -175,6 +175,7 @@
 			continue
 		var/mob/living/carbon/human/H = X
 		if(H.stat == DEAD)
+			dust(H)
 			spooky_scaries.Remove(X)
 			continue
 	listclearnulls(spooky_scaries)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -175,7 +175,7 @@
 			continue
 		var/mob/living/carbon/human/H = X
 		if(H.stat == DEAD)
-			dust(H)
+			H.dust(TRUE)
 			spooky_scaries.Remove(X)
 			continue
 	listclearnulls(spooky_scaries)


### PR DESCRIPTION
Turns out you can use a staff/wand of healing to make a new skeleton and then revive the old one.

Not anymore!