### PR TITLE
[READY]Likely shit way of slowing down supermatter processing to match objects subsystems speed

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -126,7 +126,7 @@
 	
 	//Shitty way of slowing down processing!
 	var/process_tick = 0
-	var/process_modifier = 4
+	var/process_modifier = 4	//MUST BE POWER OF 2
 
 /obj/machinery/power/supermatter_shard/make_frozen_visual()
 	return
@@ -190,11 +190,9 @@
 		qdel(src)
 
 /obj/machinery/power/supermatter_shard/process_atmos()
-	if(process_tick >= process_modifier)
-		process_tick = 0
-	else
-		process_tick++
+	if(++process_tick & process_modifier - 1)
 		return
+	process_tick = 0
 	var/turf/T = loc
 
 	if(isnull(T))		// We have a null turf...something is wrong, stop processing this entity.

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -124,7 +124,6 @@
 	var/produces_gas = 1
 	var/obj/effect/countdown/supermatter/countdown
 	
-	//Shitty way of slowing down processing!
 	var/process_tick = 0
 	var/process_modifier = 4	//MUST BE POWER OF 2
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -123,6 +123,10 @@
 	var/takes_damage = 1
 	var/produces_gas = 1
 	var/obj/effect/countdown/supermatter/countdown
+	
+	//Shitty way of slowing down processing!
+	var/process_tick = 0
+	var/process_modifier = 4
 
 /obj/machinery/power/supermatter_shard/make_frozen_visual()
 	return
@@ -186,6 +190,11 @@
 		qdel(src)
 
 /obj/machinery/power/supermatter_shard/process_atmos()
+	if(process_tick >= process_modifier)
+		process_tick = 0
+	else
+		process_tick++
+		return
 	var/turf/T = loc
 
 	if(isnull(T))		// We have a null turf...something is wrong, stop processing this entity.


### PR DESCRIPTION
Retains the pros of being on air subsystem (Not delaminating from server lag), while retaining the old processing speed.
Air processes at wait = 5, objects processes at wait = 20
20/5 = 4, set process_modifier to 4 and it processes effectively as slowly as before (still based on atmos lag though.)
Fixes #27471 
:cl:
tweak: Nanotrasen has reported that stations will be getting more stable, but weaker supermatter shards...
/:cl: