### PR TITLE
Fixes jetpacks working indoors/in areas with gravity

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -207,9 +207,3 @@
 		var/obj/item/clothing/suit/space/hardsuit/C = wear_suit
 		J = C.jetpack
 	return J
-
-/mob/has_gravity(turf/T)
-	var/obj/item/weapon/tank/jetpack/J = get_jetpack()
-	if(J && J.on)
-		return FALSE
-	return ..()


### PR DESCRIPTION
1. @Cyberboss these were your changes that caused it, were they on purpose? I'm assuming not because people shouldn't be hyperspeed indoors with jetpacks that aren't even using any good amount of gas due to being indoors. 
2. I ded pls nerf, @Robustin robusted me with jetpack abuse so I'm taking it off the table boys :^)

fixes #26482

:cl:
bugfix: Nanotrasen decided to remove the integrated jet engines from jetpacks. They can no longer be used successfully indoors.
/:cl: