### PR TITLE
A silicon will always be able to speak Galactic Common

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -128,7 +128,7 @@
 
 /datum/language_holder/synthetic
 	languages = list(/datum/language/common)
-	shadow_languages = list(/datum/language/machine, /datum/language/draconic)
+	shadow_languages = list(/datum/language/common, /datum/language/machine, /datum/language/draconic)
 
 /datum/language_holder/universal/New()
 	..()


### PR DESCRIPTION
:cl: coiax
add: Galactic Common has been added to silicon's internal language
database, meaning even if a cyborg is created from someone who
previously did not know Galactic Common, they will be able to speak it
as a silicon.
/:cl:

An oversight on my part. Otherwise, when you borg xeno brains, they'll
only be able to speak xeno, Draconic and EAL, which is a little silly.
