### PR TITLE
Mechs now take the correct amount of charge from inserted cells

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -37,7 +37,6 @@
 	var/list/facing_modifiers = list(FRONT_ARMOUR = 1.5, SIDE_ARMOUR = 1, BACK_ARMOUR = 0.5)
 	var/obj/item/weapon/stock_parts/cell/cell
 	var/state = 0
-	var/cell_power_remaining = 1 // 0 - no power, 1 - 100% power in cell. Starts as 1 so putting any cell into empty mech doesn't deplete charge from it
 	var/list/log = new
 	var/last_message = 0
 	var/add_req_access = 1

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -213,7 +213,6 @@
 			clearInternalDamage(MECHA_INT_TEMP_CONTROL)
 			to_chat(user, "<span class='notice'>You repair the damaged temperature controller.</span>")
 		else if(state==3 && cell)
-			cell_power_remaining = max(0.1, cell.charge/cell.maxcharge) //10% charge or whatever is remaining in the current cell
 			cell.forceMove(loc)
 			cell = null
 			state = 4
@@ -232,7 +231,6 @@
 				var/obj/item/weapon/stock_parts/cell/C = W
 				to_chat(user, "<span class='notice'>You install the powercell.</span>")
 				C.forceMove(src)
-				C.use(max(0, C.charge - C.maxcharge*cell_power_remaining)) //Set inserted cell's power to saved percentage if that's higher
 				cell = C
 				log_message("Powercell installed")
 			else


### PR DESCRIPTION
[Changelogs]: GLACoding

fix: Mechs take the correct amount of charge from new cells

[why]: Before inserting a fully charged cell into a depleted mech would deplete the cell and still leave the mech at 0% power. This fixes that and removes Cell_power_remaining as it had no use.
