### PR TITLE
Ripleys will collect all ore in front of them when they move with a clamp and stored ore box

### DIFF
--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -64,12 +64,9 @@
 
 
 /obj/item/mecha_parts/mecha_equipment/drill/proc/move_ores()
-	if(locate(/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp) in chassis.equipment)
-		var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in chassis:cargo
-		if(ore_box)
-			for(var/obj/item/weapon/ore/ore in range(1, chassis))
-				if(get_dir(chassis,ore)&chassis.dir)
-					ore.Move(ore_box)
+	if(locate(/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp) in chassis.equipment && istype(chassis, /obj/mecha/working/ripley))
+		var/obj/mecha/working/ripley/R = chassis //we could assume that it's a ripley because it has a clamp, but that's ~unsafe~ and ~bad practice~
+		R.collect_ore()
 
 /obj/item/mecha_parts/mecha_equipment/drill/can_attach(obj/mecha/M as obj)
 	if(..())

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -19,12 +19,17 @@
 
 /obj/mecha/working/ripley/Move()
 	. = ..()
-	if(. && (locate(/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp) in equipment))
+	if(.)
+		collect_ore()
+	update_pressure()
+
+/obj/mecha/working/ripley/proc/collect_ore()
+	if(locate(/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp) in equipment)
 		var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in cargo
 		if(ore_box)
-			for(var/obj/item/weapon/ore/ore in get_turf(src))
-				ore.Move(ore_box)
-	update_pressure()
+			for(var/obj/item/weapon/ore/ore in range(1, src))
+				if(ore.Adjacent(src) && (get_dir(src, ore) & dir)) //we can reach it and it's in front of us? grab it!
+					ore.forceMove(ore_box)
 
 /obj/mecha/working/ripley/Destroy()
 	for(var/i=1, i <= hides, i++)

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -28,7 +28,7 @@
 		var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in cargo
 		if(ore_box)
 			for(var/obj/item/weapon/ore/ore in range(1, src))
-				if(ore.Adjacent(src) && (get_dir(src, ore) & dir)) //we can reach it and it's in front of us? grab it!
+				if(ore.Adjacent(src) && ((get_dir(src, ore) & dir) || ore.loc == loc)) //we can reach it and it's in front of us? grab it!
 					ore.forceMove(ore_box)
 
 /obj/mecha/working/ripley/Destroy()


### PR DESCRIPTION
:cl: Joan
tweak: Ripleys will collect all ore in front of them when they move with a clamp and stored ore box.
/:cl:

Instead of just the ore on the tile they move to. This is the same as ore collection when using a drill, which collects all ore in front of you.