### PR TITLE
[DNM]Crate chain-pushing

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -1,3 +1,5 @@
+#define MAX_CRATE_BUMP_CHAIN 5 //amount of crates that can be pushed at once
+
 /obj/structure/closet/crate
 	name = "crate"
 	desc = "A rectangular steel crate."
@@ -14,17 +16,34 @@
 	climb_stun = 0 //climbing onto crates isn't hard, guys
 	delivery_icon = "deliverycrate"
 	var/obj/item/weapon/paper/manifest/manifest
+	var/bump_chain = 1
 
 /obj/structure/closet/crate/New()
 	..()
 	update_icon()
 
+/obj/structure/closet/crate/Bump(atom/A)
+	..()
+	if(!istype(A, /obj/structure/closet/crate))
+		bump_chain = 0 //hit an obstacle, previous crate must not try to move or it'll loop
+	else
+		var/obj/structure/closet/crate/C = A
+		if(C.anchored)
+			bump_chain = 0 //an anchored crate is an obstacle
+
 /obj/structure/closet/crate/Bumped(AM as mob|obj)
 	..()
 	if(istype(AM, /obj/structure/closet/crate) && !anchored)
+		var/obj/structure/closet/crate/previous_crate = AM
+		bump_chain = previous_crate.bump_chain + 1
+		if(bump_chain > MAX_CRATE_BUMP_CHAIN)
+			bump_chain = 1
+			return
 		var/d = get_dir(AM, src)
-		if(step(src, d))
-			step(AM, d)
+		step(src, d) //move next crate
+		if(bump_chain) //did it hit an obstacle?
+			step(AM, d) //move to follow
+	bump_chain = 1 //reset
 
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target, height=0)
 	if(!istype(mover, /obj/structure/closet))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -19,6 +19,13 @@
 	..()
 	update_icon()
 
+/obj/structure/closet/crate/Bumped(AM as mob|obj)
+	..()
+	if(istype(AM, /obj/structure/closet/crate) && !anchored)
+		var/d = get_dir(AM, src)
+		if(step(src, d))
+			step(AM, d)
+
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target, height=0)
 	if(!istype(mover, /obj/structure/closet))
 		var/obj/structure/closet/crate/locatedcrate = locate(/obj/structure/closet/crate) in get_turf(mover)


### PR DESCRIPTION
:cl: XDTM
add: You can now push multiple crates in front of you. This also applies to conveyor belts.
/:cl:

If you're pushing a crate and there's a crate in front of that crate, you'll push that crate as well. Pretty much QoL for cargo, so they don't have to push every single crate one by one to get them on/off the shuttle.
