### PR TITLE
[READY FOR ~REVIEW~]Makes morphs only able to change into /objs or /mobs

### DIFF
--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -35,10 +35,10 @@
 	var/morphed = 0
 	var/atom/movable/form = null
 	var/morph_time = 0
-	var/static/list/blacklist_typecache = typecacheof(list( \
-	/obj/screen, \
-	/obj/singularity, \
-	/mob/living/simple_animal/hostile/morph, \
+	var/static/list/blacklist_typecache = typecacheof(list(
+	/obj/screen,
+	/obj/singularity,
+	/mob/living/simple_animal/hostile/morph,
 	/obj/effect))
 	
 	var/playstyle_string = "<b><font size=3 color='red'>You are a morph,</font> an abomination of science created primarily with changeling cells. \

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -73,7 +73,7 @@
 		return FALSE
 	else if(istype(A,/mob/living/simple_animal/hostile/morph))
 		return FALSE
-	else if(istype(A, /obj) || istype(A, /mob))
+	else if(isobj(A)) || istype(ismob(A))
 		return TRUE
 	else
 		return FALSE

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -35,8 +35,8 @@
 	var/morphed = 0
 	var/atom/movable/form = null
 	var/morph_time = 0
-	var/list/blacklist_typecache
-
+	var/static/list/blacklist_typecache = typecacheof(list(/obj/screen, /obj/singularity, /mob/living/simple_animal/hostile/morph, /obj/effect))
+	
 	var/playstyle_string = "<b><font size=3 color='red'>You are a morph,</font> an abomination of science created primarily with changeling cells. \
 							You may take the form of anything nearby by shift-clicking it. This process will alert any nearby \
 							observers, and can only be performed once every five seconds. While morphed, you move faster, but do \
@@ -67,16 +67,8 @@
 		return //we hide medical hud while morphed
 	..()
 
-/mob/living/simple_animal/hostile/morph/Initialize()
-	. = ..()
-	blacklist_typecache = list()
-	blacklist_typecache |= typecacheof(list(/obj/screen))
-	blacklist_typecache |= typecacheof(list(/obj/singularity))
-	blacklist_typecache |= typecacheof(list(/mob/living/simple_animal/hostile/morph))
-	blacklist_typecache |= typecacheof(list(/obj/effect))
-
 /mob/living/simple_animal/hostile/morph/proc/allowed(atom/movable/A) // make it into property/proc ? not sure if worth it
-	return !is_type_in_typecache(A.type, blacklist_typecache)
+	return !is_type_in_typecache(A, blacklist_typecache)
 
 /mob/living/simple_animal/hostile/morph/proc/eat(atom/movable/A)
 	if(A && A.loc != src)

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -35,6 +35,7 @@
 	var/morphed = 0
 	var/atom/movable/form = null
 	var/morph_time = 0
+	var/list/blacklist_typecache
 
 	var/playstyle_string = "<b><font size=3 color='red'>You are a morph,</font> an abomination of science created primarily with changeling cells. \
 							You may take the form of anything nearby by shift-clicking it. This process will alert any nearby \
@@ -66,17 +67,15 @@
 		return //we hide medical hud while morphed
 	..()
 
+/mob/living/simple_animal/hostile/morph/Initialize()
+	. = ..()
+	blacklist_typecache |= typecacheof(list(/obj/screen))
+	blacklist_typecache |= typecacheof(list(/obj/singularity))
+	blacklist_typecache |= typecacheof(list(mob/living/simple_animal/hostile/morph))
+	blacklist_typecache |= typecacheof(list(/obj/effect))
+
 /mob/living/simple_animal/hostile/morph/proc/allowed(atom/movable/A) // make it into property/proc ? not sure if worth it
-	if(istype(A,/obj/screen))
-		return FALSE
-	else if(istype(A,/obj/singularity))
-		return FALSE
-	else if(istype(A,/mob/living/simple_animal/hostile/morph))
-		return FALSE
-	else if(isobj(A) || ismob(A))
-		return TRUE
-	else
-		return FALSE
+	return !is_type_in_typecache(A.type, blacklist_typecache)
 
 /mob/living/simple_animal/hostile/morph/proc/eat(atom/movable/A)
 	if(A && A.loc != src)

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -73,7 +73,7 @@
 		return FALSE
 	else if(istype(A,/mob/living/simple_animal/hostile/morph))
 		return FALSE
-	else if(isobj(A)) || istype(ismob(A))
+	else if(isobj(A) || ismob(A))
 		return TRUE
 	else
 		return FALSE
@@ -103,6 +103,7 @@
 	visible_message("<span class='warning'>[src] suddenly twists and changes shape, becoming a copy of [target]!</span>", \
 					"<span class='notice'>You twist your body and assume the form of [target].</span>")
 	appearance = target.appearance
+	copy_overlays(target)
 	alpha = max(alpha, 150)	//fucking chameleons
 	transform = initial(transform)
 	pixel_y = initial(pixel_y)

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -69,9 +69,10 @@
 
 /mob/living/simple_animal/hostile/morph/Initialize()
 	. = ..()
+	blacklist_typecache = list()
 	blacklist_typecache |= typecacheof(list(/obj/screen))
 	blacklist_typecache |= typecacheof(list(/obj/singularity))
-	blacklist_typecache |= typecacheof(list(mob/living/simple_animal/hostile/morph))
+	blacklist_typecache |= typecacheof(list(/mob/living/simple_animal/hostile/morph))
 	blacklist_typecache |= typecacheof(list(/obj/effect))
 
 /mob/living/simple_animal/hostile/morph/proc/allowed(atom/movable/A) // make it into property/proc ? not sure if worth it

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -68,12 +68,15 @@
 
 /mob/living/simple_animal/hostile/morph/proc/allowed(atom/movable/A) // make it into property/proc ? not sure if worth it
 	if(istype(A,/obj/screen))
-		return 0
-	if(istype(A,/obj/singularity))
-		return 0
-	if(istype(A,/mob/living/simple_animal/hostile/morph))
-		return 0
-	return 1
+		return FALSE
+	else if(istype(A,/obj/singularity))
+		return FALSE
+	else if(istype(A,/mob/living/simple_animal/hostile/morph))
+		return FALSE
+	else if(istype(A, /obj) || istype(A, /mob))
+		return TRUE
+	else
+		return FALSE
 
 /mob/living/simple_animal/hostile/morph/proc/eat(atom/movable/A)
 	if(A && A.loc != src)

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -35,7 +35,11 @@
 	var/morphed = 0
 	var/atom/movable/form = null
 	var/morph_time = 0
-	var/static/list/blacklist_typecache = typecacheof(list(/obj/screen, /obj/singularity, /mob/living/simple_animal/hostile/morph, /obj/effect))
+	var/static/list/blacklist_typecache = typecacheof(list( \
+	/obj/screen, \
+	/obj/singularity, \
+	/mob/living/simple_animal/hostile/morph, \
+	/obj/effect))
 	
 	var/playstyle_string = "<b><font size=3 color='red'>You are a morph,</font> an abomination of science created primarily with changeling cells. \
 							You may take the form of anything nearby by shift-clicking it. This process will alert any nearby \


### PR DESCRIPTION
I can't see a case where we would want morphs to change into an /atom/movable that isn't an /obj, a /turf, a /datum (lmao), or an /area.
fixes https://github.com/tgstation/tgstation/issues/27509
Fixes #27511