### PR TITLE
sortMerge fix

### DIFF
--- a/code/__HELPERS/sorts/__main.dm
+++ b/code/__HELPERS/sorts/__main.dm
@@ -626,14 +626,13 @@ GLOBAL_DATUM_INIT(sortInstance, /datum/sortInstance, new())
 		var/val2 = fetchElement(L,cursor2)
 
 		while(1)
-			if(call(cmp)(val1,val2) < 0)
+			if(call(cmp)(val1,val2) <= 0)
 				if(++cursor1 >= end1)
 					break
 				val1 = fetchElement(L,cursor1)
 			else
 				moveElement(L,cursor2,cursor1)
 
-				++cursor2
 				if(++cursor2 >= end2)
 					break
 				++end1


### PR DESCRIPTION
Fixes for sortMerge()
Resolves an issue where the RHS run's cursor was skipping elements.
Also resolves an issue with the comparisons not resulting in a stable sort.