### PR TITLE
Auto Rifle Armour Piercing Increase

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -28,8 +28,8 @@
 	damage = 10
 
 /obj/item/projectile/bullet/armourpiercing
-	damage = 17
-	armour_penetration = 10
+	damage = 15
+	armour_penetration = 40
 
 /obj/item/projectile/bullet/pellet
 	name = "pellet"
@@ -244,7 +244,7 @@
 	name = "\improper DNA injector"
 	icon_state = "syringeproj"
 	var/obj/item/weapon/dnainjector/injector
-	
+
 /obj/item/projectile/bullet/dnainjector/on_hit(atom/target, blocked = 0)
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target


### PR DESCRIPTION
The current Auto Rifle AP bullets are worthless, dealing 17 damage with 10 ap. Against, say, a Nuke Op or someone with similar bullet defence each bullet deals 10.2 damage. That's a 0.2 damage increase over standard bullets. 

This PR buffs the AP value of WT550 AP bullets to 40, however it nerfs the damage to only 15 damage per bullet. Against Ops, again for example, the bullet will now deal 13.5 damage.

:cl: Steelpoint
tweak: Changes to production of Nanotrasen Auto Rifle armour piercing bullets have now made AP bullets better able to penetrate armour, but at the cost of the amount of possible damage the bullet can do to soft targets.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
