### PR TITLE
Replaced mob spawner vars with outfits

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -274,7 +274,7 @@
 "aV" = (
 /obj/effect/mob_spawn/human/beach/alive{
 	flavour_text = "You're, like, totally a dudebro, bruh. Ch'yea. You came here, like, on spring break, hopin' to pick up some bangin' hot chicks, y'knaw?";
-	pocket2 = /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/dank;
+	l_pocket = /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/dank;
 	uniform = /obj/item/clothing/under/pants/youngfolksjeans
 	},
 /turf/open/floor/plating/beach/sand,
@@ -532,7 +532,7 @@
 	},
 /obj/effect/mob_spawn/human/beach/alive{
 	flavour_text = "You're a spunky lifeguard! It's up to you to make sure nobody drowns or gets eaten by sharks and stuff.";
-	has_id = 1;
+	id = /obj/item/weapon/card/id;
 	id_access = "Medical Doctor";
 	id_job = "Lifeguard";
 	mob_gender = "female"

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -475,7 +475,7 @@
 /area/ruin/derelictoutpost)
 "bq" = (
 /obj/effect/mob_spawn/human/corpse/nanotrasensoldier{
-	helmet = null;
+	head = null;
 	id_job = "Tradepost Officer";
 	name = "Tradeport Officer";
 	random = 1

--- a/_maps/RandomZLevels/beach.dmm
+++ b/_maps/RandomZLevels/beach.dmm
@@ -163,7 +163,7 @@
 /area/awaymission/beach)
 "aC" = (
 /obj/effect/mob_spawn/human/cook{
-	helmet = null;
+	head = null;
 	id_access = "Bartender";
 	id_job = "Bartender";
 	suit = /obj/item/clothing/suit/armor/vest;

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -187,7 +187,7 @@
 /turf/closed/mineral,
 /area/awaymission/wwmines)
 "aO" = (
-/obj/effect/mob_spawn/human/syndicatecommando,
+/obj/effect/mob_spawn/human/corpse/syndicatecommando,
 /turf/open/floor/plasteel/cult{
 	name = "engraved floor";
 	tag = "icon-cult"
@@ -929,7 +929,7 @@
 	},
 /area/awaymission/wwgov)
 "dh" = (
-/obj/effect/mob_spawn/human/syndicatecommando{
+/obj/effect/mob_spawn/human/corpse/syndicatecommando{
 	mob_name = "Syndicate Commando"
 	},
 /turf/open/floor/carpet,
@@ -2017,7 +2017,7 @@
 	},
 /area/awaymission/wwmines)
 "gy" = (
-/obj/effect/mob_spawn/human/syndicatecommando{
+/obj/effect/mob_spawn/human/corpse/syndicatecommando{
 	mob_name = "Syndicate Commando"
 	},
 /turf/open/floor/grass,

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -20,7 +20,8 @@
 	var/r_hand = null
 	var/l_hand = null
 	var/internals_slot = null //ID of slot containing a gas tank
-	var/list/backpack_contents = list() // In the list(path=count,otherpath=count) format
+	var/list/backpack_contents = null // In the list(path=count,otherpath=count) format
+	var/list/implants = null
 
 /datum/outfit/proc/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	//to be overriden for customization depending on client prefs,species etc
@@ -71,11 +72,11 @@
 			H.equip_to_slot_or_del(new l_pocket(H),slot_l_store)
 		if(r_pocket)
 			H.equip_to_slot_or_del(new r_pocket(H),slot_r_store)
-
-		for(var/path in backpack_contents)
-			var/number = backpack_contents[path]
-			for(var/i=0,i<number,i++)
-				H.equip_to_slot_or_del(new path(H),slot_in_backpack)
+		if(backpack_contents)
+			for(var/path in backpack_contents)
+				var/number = backpack_contents[path]
+				for(var/i=0,i<number,i++)
+					H.equip_to_slot_or_del(new path(H),slot_in_backpack)
 
 	if(!H.head && toggle_helmet && istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit))
 		var/obj/item/clothing/suit/space/hardsuit/HS = H.wear_suit
@@ -88,6 +89,10 @@
 		if(internals_slot)
 			H.internal = H.get_item_by_slot(internals_slot)
 			H.update_action_buttons_icon()
+		if(implants)
+			for(var/implant_type in implants)
+				var/obj/item/weapon/implant/I = new implant_type(H)
+				I.implant(H, null, silent=TRUE)
 
 	H.update_body()
 	return 1

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1061,6 +1061,7 @@
 	outfit = /datum/outfit/orionsecurity
 
 /datum/outfit/orionsecurity
+	name = "Orion Spaceport Security"
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/armor/vest
 	shoes = /obj/item/clothing/shoes/combat

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1056,17 +1056,20 @@
 
 /obj/effect/mob_spawn/human/corpse/orionsecurity
 	name = "Spaceport Security"
+	id_job = "Officer"
+	id_access_list = list(GLOB.access_syndicate)
+	outfit = /datum/outfit/orionsecurity
+
+/datum/outfit/orionsecurity
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/armor/vest
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
-	radio = /obj/item/device/radio/headset
+	ears = /obj/item/device/radio/headset
 	mask = /obj/item/clothing/mask/gas
-	helmet = /obj/item/clothing/head/helmet/swat
+	head = /obj/item/clothing/head/helmet/swat
 	back = /obj/item/weapon/storage/backpack
-	has_id = 1
-	id_job = "Officer"
-	id_access_list = list(GLOB.access_syndicate)
+	id = /obj/item/weapon/card/id
 
 /obj/item/weapon/orion_ship
 	name = "model settler ship"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -263,6 +263,7 @@
 	to lose this opportunity. Find a way to get out of this mess and back to where you rightfully belong - your [pick("house", "apartment", "spaceship", "station")]</b>."
 
 /datum/outfit/lavalandprisoner
+	name = "Lavaland Prisoner"
 	uniform = /obj/item/clothing/under/rank/prisoner
 	mask = /obj/item/clothing/mask/breath
 	shoes = /obj/item/clothing/shoes/sneakers/orange

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -29,6 +29,7 @@
 	return ..()
 
 //Ash walker eggs: Spawns in ash walker dens in lavaland. Ghosts become unbreathing lizards that worship the Necropolis and are advised to retrieve corpses to create more ash walkers.
+
 /obj/effect/mob_spawn/human/ash_walker
 	name = "ash walker egg"
 	desc = "A man-sized yellow egg, spawned from some unfathomable creature. A humanoid silhouette lurks within."
@@ -36,8 +37,7 @@
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "large_egg"
 	mob_species = /datum/species/lizard/ashwalker
-	helmet = /obj/item/clothing/head/helmet/gladiator
-	uniform = /obj/item/clothing/under/gladiator/ash_walker
+	outfit = /datum/outfit/ashwalker
 	roundstart = FALSE
 	death = FALSE
 	anchored = 0
@@ -58,11 +58,17 @@
 		H.underwear = "Nude"
 		H.update_body()
 
-/obj/effect/mob_spawn/human/ash_walker/New()
-	..()
+/obj/effect/mob_spawn/human/ash_walker/Initialize(mapload)
+	. = ..()
 	var/area/A = get_area(src)
 	if(A)
 		notify_ghosts("An ash walker egg is ready to hatch in \the [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE)
+
+/datum/outfit/ashwalker
+	name ="Ashwalker"
+	head = /obj/item/clothing/head/helmet/gladiator
+	uniform = /obj/item/clothing/under/gladiator/ash_walker
+
 
 //Timeless prisons: Spawns in Wish Granter prisons in lavaland. Ghosts become age-old users of the Wish Granter and are advised to seek repentance for their past.
 /obj/effect/mob_spawn/human/exile
@@ -186,38 +192,38 @@
 	conditions of your makeshift shelter, the hostile creatures, and the ash drakes swooping down from the cloudless skies, all you can wish for is the feel of soft grass between your toes and \
 	the fresh air of Earth. These thoughts are dispelled by yet another recollection of how you got here... "
 
-/obj/effect/mob_spawn/human/hermit/New()
+/obj/effect/mob_spawn/human/hermit/Initialize(mapload)
+	. = ..()
 	var/arrpee = rand(1,4)
 	switch(arrpee)
 		if(1)
 			flavour_text += "you were a [pick("arms dealer", "shipwright", "docking manager")]'s assistant on a small trading station several sectors from here. Raiders attacked, and there was \
 			only one pod left when you got to the escape bay. You took it and launched it alone, and the crowd of terrified faces crowding at the airlock door as your pod's engines burst to \
 			life and sent you to this hell are forever branded into your memory.</b>"
-			uniform = /obj/item/clothing/under/assistantformal
-			shoes = /obj/item/clothing/shoes/sneakers/black
-			back = /obj/item/weapon/storage/backpack
+			outfit.uniform = /obj/item/clothing/under/assistantformal
+			outfit.shoes = /obj/item/clothing/shoes/sneakers/black
+			outfit.back = /obj/item/weapon/storage/backpack
 		if(2)
 			flavour_text += "you're an exile from the Tiger Cooperative. Their technological fanaticism drove you to question the power and beliefs of the Exolitics, and they saw you as a \
 			heretic and subjected you to hours of horrible torture. You were hours away from execution when a high-ranking friend of yours in the Cooperative managed to secure you a pod, \
 			scrambled its destination's coordinates, and launched it. You awoke from stasis when you landed and have been surviving - barely - ever since.</b>"
-			uniform = /obj/item/clothing/under/rank/prisoner
-			shoes = /obj/item/clothing/shoes/sneakers/orange
-			back = /obj/item/weapon/storage/backpack
+			outfit.uniform = /obj/item/clothing/under/rank/prisoner
+			outfit.shoes = /obj/item/clothing/shoes/sneakers/orange
+			outfit.back = /obj/item/weapon/storage/backpack
 		if(3)
 			flavour_text += "you were a doctor on one of Nanotrasen's space stations, but you left behind that damn corporation's tyranny and everything it stood for. From a metaphorical hell \
 			to a literal one, you find yourself nonetheless missing the recycled air and warm floors of what you left behind... but you'd still rather be here than there.</b>"
-			uniform = /obj/item/clothing/under/rank/medical
-			suit = /obj/item/clothing/suit/toggle/labcoat
-			back = /obj/item/weapon/storage/backpack/medic
-			shoes = /obj/item/clothing/shoes/sneakers/black
+			outfit.uniform = /obj/item/clothing/under/rank/medical
+			outfit.suit = /obj/item/clothing/suit/toggle/labcoat
+			outfit.back = /obj/item/weapon/storage/backpack/medic
+			outfit.shoes = /obj/item/clothing/shoes/sneakers/black
 		if(4)
 			flavour_text += "you were always joked about by your friends for \"not playing with a full deck\", as they so <i>kindly</i> put it. It seems that they were right when you, on a tour \
 			at one of Nanotrasen's state-of-the-art research facilities, were in one of the escape pods alone and saw the red button. It was big and shiny, and it caught your eye. You pressed \
 			it, and after a terrifying and fast ride for days, you landed here. You've had time to wisen up since then, and you think that your old friends wouldn't be laughing now.</b>"
-			uniform = /obj/item/clothing/under/color/grey/glorf
-			shoes = /obj/item/clothing/shoes/sneakers/black
-			back = /obj/item/weapon/storage/backpack
-	..()
+			outfit.uniform = /obj/item/clothing/under/color/grey/glorf
+			outfit.shoes = /obj/item/clothing/shoes/sneakers/black
+			outfit.back = /obj/item/weapon/storage/backpack
 
 /obj/effect/mob_spawn/human/hermit/Destroy()
 	new/obj/structure/fluff/empty_cryostasis_sleeper(get_turf(src))
@@ -239,10 +245,7 @@
 	mob_name = "an escaped prisoner"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "sleeper_s"
-	uniform = /obj/item/clothing/under/rank/prisoner
-	mask = /obj/item/clothing/mask/breath
-	shoes = /obj/item/clothing/shoes/sneakers/orange
-	pocket1 = /obj/item/weapon/tank/internals/emergency_oxygen
+	outfit = /datum/outfit/lavalandprisoner
 	roundstart = FALSE
 	death = FALSE
 	flavour_text = "<font size=3><b>G</b></font><b>ood. It seems as though your ship crashed. You're a prisoner, sentenced to hard work in one of Nanotrasen's labor camps, but it seems as \
@@ -252,12 +255,19 @@
 	L.real_name = "NTP #LL-0[rand(111,999)]" //Nanotrasen Prisoner #Lavaland-(numbers)
 	L.name = L.real_name
 
-/obj/effect/mob_spawn/human/prisoner_transport/New()
+/obj/effect/mob_spawn/human/prisoner_transport/Initialize(mapload)
+	. = ..()
 	var/list/crimes = list("murder", "larceny", "embezzlement", "unionization", "dereliction of duty", "kidnapping", "gross incompetence", "grand theft", "collaboration with the Syndicate", \
 	"worship of a forbidden deity", "interspecies relations", "mutiny")
 	flavour_text += "[pick(crimes)]. but regardless of that, it seems like your crime doesn't matter now. You don't know where you are, but you know that it's out to kill you, and you're not going \
 	to lose this opportunity. Find a way to get out of this mess and back to where you rightfully belong - your [pick("house", "apartment", "spaceship", "station")]</b>."
-	..()
+
+/datum/outfit/lavalandprisoner
+	uniform = /obj/item/clothing/under/rank/prisoner
+	mask = /obj/item/clothing/mask/breath
+	shoes = /obj/item/clothing/shoes/sneakers/orange
+	r_pocket = /obj/item/weapon/tank/internals/emergency_oxygen
+
 
 /obj/effect/mob_spawn/human/prisoner_transport/Destroy()
 	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))
@@ -270,30 +280,38 @@
 	mob_name = "hotel staff member"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "sleeper_s"
-	uniform = /obj/item/clothing/under/assistantformal
-	shoes = /obj/item/clothing/shoes/laceup
-	pocket1 = /obj/item/device/radio/off
-	back = /obj/item/weapon/storage/backpack
 	objectives = "Cater to visiting guests with your fellow staff. Do not leave your assigned hotel and always remember: The customer is always right!"
-	implants = list(/obj/item/weapon/implant/mindshield)
 	death = FALSE
 	roundstart = FALSE
 	random = TRUE
+	outfit = /datum/outfit/hotelstaff
 	flavour_text = "You are a staff member of a top-of-the-line space hotel! Cater to guests and <font size=6><b>DON'T</b></font> leave the hotel, lest the manager fire you for\
 		dereliction of duty!"
+
+/datum/outfit/hotelstaff
+	name = "Hotel Staff"
+	uniform = /obj/item/clothing/under/assistantformal
+	shoes = /obj/item/clothing/shoes/laceup
+	r_pocket = /obj/item/device/radio/off
+	back = /obj/item/weapon/storage/backpack
+	implants = list(/obj/item/weapon/implant/mindshield)
 
 /obj/effect/mob_spawn/human/hotel_staff/security
 	name = "hotel security sleeper"
 	mob_name = "hotel security memeber"
-	uniform = /obj/item/clothing/under/rank/security/blueshirt
-	shoes = /obj/item/clothing/shoes/jackboots
-	suit = /obj/item/clothing/suit/armor/vest/blueshirt
-	helmet = /obj/item/clothing/head/helmet/blueshirt
-	back = /obj/item/weapon/storage/backpack/security
-	belt = /obj/item/weapon/storage/belt/security/full
+	outfit = /datum/outfit/hotelstaff/security
 	flavour_text = "You are a peacekeeper assigned to this hotel to protect the intrests of the company while keeping the peace between \
 		guests and the staff.Do <font size=6><b>NOT</b></font> leave the hotel, as that is grounds for contract termination."
 	objectives = "Do not leave your assigned hotel. Try and keep the peace between staff and guests, non-lethal force heavily advised if possible."
+
+/datum/outfit/hotelstaff/security
+	name = "Hotel Secuirty"
+	uniform = /obj/item/clothing/under/rank/security/blueshirt
+	shoes = /obj/item/clothing/shoes/jackboots
+	suit = /obj/item/clothing/suit/armor/vest/blueshirt
+	head = /obj/item/clothing/head/helmet/blueshirt
+	back = /obj/item/weapon/storage/backpack/security
+	belt = /obj/item/weapon/storage/belt/security/full
 
 /obj/effect/mob_spawn/human/hotel_staff/Destroy()
 	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))
@@ -305,22 +323,17 @@
 	mob_name = "Demonic friend"
 	icon = 'icons/obj/cardboard_cutout.dmi'
 	icon_state = "cutout_basic"
-	uniform = /obj/item/clothing/under/assistantformal
-	shoes = /obj/item/clothing/shoes/laceup
-	pocket1 = /obj/item/device/radio/off
-	back = /obj/item/weapon/storage/backpack
-	implants = list(/obj/item/weapon/implant/mindshield) //No revolutionaries, he's MY friend.
+	outfit = /datum/outfit/demonic_friend
 	death = FALSE
 	roundstart = FALSE
 	random = TRUE
-	has_id = TRUE
 	id_job = "SuperFriend"
 	id_access = "assistant"
 	var/obj/effect/proc_holder/spell/targeted/summon_friend/spell
 	var/datum/mind/owner
 
 /obj/effect/mob_spawn/human/demonic_friend/Initialize(mapload, datum/mind/owner_mind, obj/effect/proc_holder/spell/targeted/summon_friend/summoning_spell)
-	..()
+	. = ..()
 	owner = owner_mind
 	flavour_text = "You have been given a reprieve from your eternity of torment, to be [owner.name]'s friend for their short mortal coil.  Be aware that if you do not live up to [owner.name]'s expectations, they can send you back to hell with a single thought.  [owner.name]'s death will also return you to hell."
 	var/area/A = get_area(src)
@@ -347,3 +360,11 @@
 		to_chat(L, "<span class='userdanger'>Your owner is already dead!  You will soon perish.</span>")
 		addtimer(CALLBACK(L, /mob.proc/dust, 150)) //Give em a few seconds as a mercy.
 
+/datum/outfit/demonic_friend
+	name = "Demonic Friend"
+	uniform = /obj/item/clothing/under/assistantformal
+	shoes = /obj/item/clothing/shoes/laceup
+	r_pocket = /obj/item/device/radio/off
+	back = /obj/item/weapon/storage/backpack
+	implants = list(/obj/item/weapon/implant/mindshield) //No revolutionaries, he's MY friend.
+	id = /obj/item/weapon/card/id

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -38,7 +38,7 @@
 	create(ckey = user.ckey)
 
 /obj/effect/mob_spawn/Initialize(mapload)
-	..()
+	. = ..()
 	if(instant || (roundstart && (mapload || (SSticker && SSticker.current_state > GAME_STATE_SETTING_UP))))
 		create()
 	else
@@ -90,29 +90,19 @@
 	mob_type = /mob/living/carbon/human
 	//Human specific stuff.
 	var/mob_species = null		//Set to make them a mutant race such as lizard or skeleton. Uses the datum typepath instead of the ID.
-	var/outfit_type = null		//Will start with this if exists then apply specific slots. Job outfits are generated with IDs and disabled PDAs.
-	var/uniform = null			//Set this to an object path to have the slot filled with said object on the corpse.
-	var/r_hand = null
-	var/l_hand = null
-	var/suit = null
-	var/shoes = null
-	var/gloves = null
-	var/radio = null
-	var/glasses = null
-	var/mask = null
-	var/neck = null
-	var/helmet = null
-	var/belt = null
-	var/pocket1 = null
-	var/pocket2 = null
-	var/back = null
-	var/has_id = FALSE			//Set to TRUE if you want them to have an ID
+	var/datum/outfit/outfit = /datum/outfit	//If this is a path, it will be instanced in Initialize()
+	var/disable_pda = TRUE
+	//All of these only affect the ID that the outfit has placed in the ID slot
 	var/id_job = null			//Such as "Clown" or "Chef." This just determines what the ID reads as, not their access
 	var/id_access = null		//This is for access. See access.dm for which jobs give what access. Use "Captain" if you want it to be all access.
 	var/id_access_list = null	//Allows you to manually add access to an ID card.
-	var/id_icon = null			//For setting it to be a gold, silver, centcom etc ID
+
 	var/husk = null
-	var/list/implants = list()
+
+/obj/effect/mob_spawn/human/Initialize()
+	. = ..()
+	if(ispath(outfit))
+		outfit = new outfit()
 
 /obj/effect/mob_spawn/human/equip(mob/living/carbon/human/H)
 	if(mob_species)
@@ -120,48 +110,15 @@
 	if(husk)
 		H.Drain()
 
-	if(outfit_type)
-		H.equipOutfit(outfit_type)
-
-		// We don't want corpse PDAs to show up in the messenger list.
-		var/obj/item/device/pda/PDA = locate(/obj/item/device/pda) in H
-		if(PDA)
-			PDA.toff = TRUE
-
-	if(uniform)
-		H.equip_to_slot_or_del(new uniform(H), slot_w_uniform)
-	if(suit)
-		H.equip_to_slot_or_del(new suit(H), slot_wear_suit)
-	if(shoes)
-		H.equip_to_slot_or_del(new shoes(H), slot_shoes)
-	if(gloves)
-		H.equip_to_slot_or_del(new gloves(H), slot_gloves)
-	if(radio)
-		H.equip_to_slot_or_del(new radio(H), slot_ears)
-	if(glasses)
-		H.equip_to_slot_or_del(new glasses(H), slot_glasses)
-	if(mask)
-		H.equip_to_slot_or_del(new mask(H), slot_wear_mask)
-	if(neck)
-		H.equip_to_slot_or_del(new neck(H), slot_neck)
-	if(helmet)
-		H.equip_to_slot_or_del(new helmet(H), slot_head)
-	if(belt)
-		H.equip_to_slot_or_del(new belt(H), slot_belt)
-	if(pocket1)
-		H.equip_to_slot_or_del(new pocket1(H), slot_r_store)
-	if(pocket2)
-		H.equip_to_slot_or_del(new pocket2(H), slot_l_store)
-	if(back)
-		H.equip_to_slot_or_del(new back(H), slot_back)
-	if(l_hand)
-		H.put_in_hands_or_del(new l_hand(H))
-	if(r_hand)
-		H.put_in_hands_or_del(new r_hand(H))
-	if(has_id)
-		var/obj/item/weapon/card/id/W = new(H)
-		if(id_icon)
-			W.icon_state = id_icon
+	if(outfit)
+		H.equipOutfit(outfit)
+		if(disable_pda)
+			// We don't want corpse PDAs to show up in the messenger list.
+			var/obj/item/device/pda/PDA = locate(/obj/item/device/pda) in H
+			if(PDA)
+				PDA.toff = TRUE
+	var/obj/item/weapon/card/id/W = H.wear_id
+	if(W)
 		if(id_access)
 			for(var/jobtype in typesof(/datum/job))
 				var/datum/job/J = new jobtype
@@ -176,15 +133,6 @@
 			W.assignment = id_job
 		W.registered_name = H.real_name
 		W.update_label()
-		H.equip_to_slot_or_del(W, slot_wear_id)
-
-	for(var/I in implants)
-		var/obj/item/weapon/implant/X = new I
-		X.implant(H)
-
-	if(!H.head && istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit))
-		var/obj/item/clothing/suit/space/hardsuit/HS = H.wear_suit
-		HS.ToggleHelmet()
 
 //Instant version - use when spawning corpses during runtime
 /obj/effect/mob_spawn/human/corpse
@@ -248,52 +196,22 @@
 
 // I'll work on making a list of corpses people request for maps, or that I think will be commonly used. Syndicate operatives for example.
 
-/obj/effect/mob_spawn/human/syndicatesoldier
-	name = "Syndicate Operative"
-	uniform = /obj/item/clothing/under/syndicate
-	suit = /obj/item/clothing/suit/armor/vest
-	shoes = /obj/item/clothing/shoes/combat
-	gloves = /obj/item/clothing/gloves/combat
-	radio = /obj/item/device/radio/headset
-	mask = /obj/item/clothing/mask/gas
-	helmet = /obj/item/clothing/head/helmet/swat
-	back = /obj/item/weapon/storage/backpack
-	has_id = 1
-	id_job = "Operative"
-	id_access_list = list(GLOB.access_syndicate)
-
-/obj/effect/mob_spawn/human/syndicatecommando
-	name = "Syndicate Commando"
-	uniform = /obj/item/clothing/under/syndicate
-	suit = /obj/item/clothing/suit/space/hardsuit/syndi
-	shoes = /obj/item/clothing/shoes/combat
-	gloves = /obj/item/clothing/gloves/combat
-	radio = /obj/item/device/radio/headset
-	mask = /obj/item/clothing/mask/gas/syndicate
-	back = /obj/item/weapon/tank/jetpack/oxygen
-	pocket1 = /obj/item/weapon/tank/internals/emergency_oxygen
-	has_id = 1
-	id_job = "Operative"
-	id_access_list = list(GLOB.access_syndicate)
-
 ///////////Civilians//////////////////////
 
 /obj/effect/mob_spawn/human/cook
 	name = "Cook"
-	outfit_type = /datum/outfit/job/cook
+	outfit = /datum/outfit/job/cook
 
 
 /obj/effect/mob_spawn/human/doctor
 	name = "Doctor"
-	outfit_type = /datum/outfit/job/doctor
+	outfit = /datum/outfit/job/doctor
 
 
 /obj/effect/mob_spawn/human/doctor/alive
 	death = FALSE
 	roundstart = FALSE
 	random = TRUE
-	radio = null
-	back = null
 	name = "sleeper"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "sleeper"
@@ -309,49 +227,40 @@
 
 /obj/effect/mob_spawn/human/engineer
 	name = "Engineer"
-	outfit_type = /datum/outfit/job/engineer
-	gloves = /obj/item/clothing/gloves/color/yellow
+	outfit = /datum/outfit/job/engineer/gloved
 
 /obj/effect/mob_spawn/human/engineer/rig
-	outfit_type = /datum/outfit/job/engineer/rig
+	outfit = /datum/outfit/job/engineer/gloved/rig
 
 /obj/effect/mob_spawn/human/clown
 	name = "Clown"
-	outfit_type = /datum/outfit/job/clown
+	outfit = /datum/outfit/job/clown
 
 /obj/effect/mob_spawn/human/scientist
 	name = "Scientist"
-	outfit_type = /datum/outfit/job/scientist
+	outfit = /datum/outfit/job/scientist
 
 /obj/effect/mob_spawn/human/miner
 	name = "Shaft Miner"
-	outfit_type = /datum/outfit/job/miner/asteroid
+	outfit = /datum/outfit/job/miner/asteroid
 
 /obj/effect/mob_spawn/human/miner/rig
-	outfit_type = /datum/outfit/job/miner/equipped/asteroid
+	outfit = /datum/outfit/job/miner/equipped/asteroid
 
 /obj/effect/mob_spawn/human/miner/explorer
-	outfit_type = /datum/outfit/job/miner/equipped
+	outfit = /datum/outfit/job/miner/equipped
 
 
 /obj/effect/mob_spawn/human/plasmaman
 	mob_species = /datum/species/plasmaman
-	helmet = /obj/item/clothing/head/helmet/space/plasmaman
-	uniform = /obj/item/clothing/under/plasmaman
-	back = /obj/item/weapon/tank/internals/plasmaman/full
-	mask = /obj/item/clothing/mask/breath
+	outfit = /datum/outfit/plasmaman
 
 
 /obj/effect/mob_spawn/human/bartender
 	name = "Space Bartender"
-	uniform = /obj/item/clothing/under/rank/bartender
-	back = /obj/item/weapon/storage/backpack
-	shoes = /obj/item/clothing/shoes/sneakers/black
-	suit = /obj/item/clothing/suit/armor/vest
-	glasses = /obj/item/clothing/glasses/sunglasses/reagent
-	has_id = 1
 	id_job = "Bartender"
 	id_access_list = list(GLOB.access_bar)
+	outfit = /datum/outfit/spacebartender
 
 /obj/effect/mob_spawn/human/bartender/alive
 	death = FALSE
@@ -362,10 +271,18 @@
 	icon_state = "sleeper"
 	flavour_text = "You are a space bartender!"
 
+/datum/outfit/spacebartender
+	name = "Space Bartender"
+	uniform = /obj/item/clothing/under/rank/bartender
+	back = /obj/item/weapon/storage/backpack
+	shoes = /obj/item/clothing/shoes/sneakers/black
+	suit = /obj/item/clothing/suit/armor/vest
+	glasses = /obj/item/clothing/glasses/sunglasses/reagent
+	id = /obj/item/weapon/card/id
+
+
 /obj/effect/mob_spawn/human/beach
-	glasses = /obj/item/clothing/glasses/sunglasses
-	uniform = /obj/item/clothing/under/shorts/red
-	pocket1 = /obj/item/weapon/storage/wallet/random
+	outfit = /datum/outfit/beachbum
 
 /obj/effect/mob_spawn/human/beach/alive
 	death = FALSE
@@ -377,46 +294,68 @@
 	icon_state = "sleeper"
 	flavour_text = "You are a beach bum!"
 
+/datum/outfit/beachbum
+	name = "Beach Bum"
+	glasses = /obj/item/clothing/glasses/sunglasses
+	uniform = /obj/item/clothing/under/shorts/red
+	r_pocket = /obj/item/weapon/storage/wallet/random
+
+
 /////////////////Officers+Nanotrasen Security//////////////////////
 
 /obj/effect/mob_spawn/human/bridgeofficer
 	name = "Bridge Officer"
-	radio = /obj/item/device/radio/headset/heads/hop
+	id_job = "Bridge Officer"
+	id_access_list = list(GLOB.access_cent_captain)
+	outfit = /datum/outfit/nanotrasenbridgeofficercorpse
+
+/datum/outfit/nanotrasenbridgeofficercorpse
+	name = "Bridge Officer Corpse"
+	ears = /obj/item/device/radio/headset/heads/hop
 	uniform = /obj/item/clothing/under/rank/centcom_officer
 	suit = /obj/item/clothing/suit/armor/bulletproof
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	glasses = /obj/item/clothing/glasses/sunglasses
-	has_id = 1
-	id_job = "Bridge Officer"
-	id_access_list = list(GLOB.access_cent_captain)
+	id = /obj/item/weapon/card/id
+
 
 /obj/effect/mob_spawn/human/commander
 	name = "Commander"
-	uniform = /obj/item/clothing/under/rank/centcom_commander
-	suit = /obj/item/clothing/suit/armor/bulletproof
-	radio = /obj/item/device/radio/headset/heads/captain
-	glasses = /obj/item/clothing/glasses/eyepatch
-	mask = /obj/item/clothing/mask/cigarette/cigar/cohiba
-	helmet = /obj/item/clothing/head/centhat
-	gloves = /obj/item/clothing/gloves/combat
-	shoes = /obj/item/clothing/shoes/combat/swat
-	pocket1 = /obj/item/weapon/lighter
-	has_id = 1
 	id_job = "Commander"
 	id_access_list = list(GLOB.access_cent_captain)
+	outfit = /datum/outfit/nanotrasencommandercorpse
+
+/datum/outfit/nanotrasencommandercorpse
+	name = "Nanotrasen Private Security Commander"
+	uniform = /obj/item/clothing/under/rank/centcom_commander
+	suit = /obj/item/clothing/suit/armor/bulletproof
+	ears = /obj/item/device/radio/headset/heads/captain
+	glasses = /obj/item/clothing/glasses/eyepatch
+	mask = /obj/item/clothing/mask/cigarette/cigar/cohiba
+	head = /obj/item/clothing/head/centhat
+	gloves = /obj/item/clothing/gloves/combat
+	shoes = /obj/item/clothing/shoes/combat/swat
+	r_pocket = /obj/item/weapon/lighter
+	id = /obj/item/weapon/card/id
+
 
 /obj/effect/mob_spawn/human/nanotrasensoldier
 	name = "Nanotrasen Private Security Officer"
+	id_job = "Private Security Force"
+	id_access_list = list(GLOB.access_cent_specops)
+	outfit = /datum/outfit/nanotrasensoldiercorpse
+
+/datum/outfit/nanotrasensoldiercorpse
+	name = "NT Private Security Officer Corpse"
 	uniform = /obj/item/clothing/under/rank/security
 	suit = /obj/item/clothing/suit/armor/vest
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
-	helmet = /obj/item/clothing/head/helmet/swat/nanotrasen
+	head = /obj/item/clothing/head/helmet/swat/nanotrasen
 	back = /obj/item/weapon/storage/backpack/security
-	has_id = 1
-	id_job = "Private Security Force"
-	id_access_list = list(GLOB.access_cent_specops)
+	id = /obj/item/weapon/card/id
+
 
 /obj/effect/mob_spawn/human/commander/alive
 	death = FALSE
@@ -426,6 +365,7 @@
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "sleeper"
 	flavour_text = "You are a Nanotrasen Commander!"
+
 
 /////////////////Spooky Undead//////////////////////
 
@@ -459,8 +399,13 @@
 	name = "abductor"
 	mob_name = "alien"
 	mob_species = /datum/species/abductor
+	outfit = /datum/outfit/abductorcorpse
+
+/datum/outfit/abductorcorpse
+	name = "Abductor Corpse"
 	uniform = /obj/item/clothing/under/color/grey
 	shoes = /obj/item/clothing/shoes/combat
+
 
 //For ghost bar.
 /obj/effect/mob_spawn/human/alive/space_bar_patron
@@ -469,11 +414,7 @@
 	random = TRUE
 	permanent = TRUE
 	uses = -1
-	uniform = /obj/item/clothing/under/rank/bartender
-	back = /obj/item/weapon/storage/backpack
-	shoes = /obj/item/clothing/shoes/sneakers/black
-	suit = /obj/item/clothing/suit/armor/vest
-	glasses = /obj/item/clothing/glasses/sunglasses/reagent
+	outfit = /datum/outfit/spacebartender
 
 /obj/effect/mob_spawn/human/alive/space_bar_patron/attack_hand(mob/user)
 	var/despawn = alert("Return to cryosleep? (Warning, Your mob will be deleted!)",,"Yes","No")
@@ -481,3 +422,11 @@
 		return
 	user.visible_message("<span class='notice'>[user.name] climbs back into cryosleep...</span>")
 	qdel(user)
+
+/datum/outfit/cryobartender
+	name = "Cryogenic Bartender"
+	uniform = /obj/item/clothing/under/rank/bartender
+	back = /obj/item/weapon/storage/backpack
+	shoes = /obj/item/clothing/shoes/sneakers/black
+	suit = /obj/item/clothing/suit/armor/vest
+	glasses = /obj/item/clothing/glasses/sunglasses/reagent

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -98,11 +98,31 @@
 	var/id_access_list = null	//Allows you to manually add access to an ID card.
 
 	var/husk = null
+	//these vars are for lazy mappers to override parts of the outfit
+	//these cannot be null by default, or mappers cannot set them to null if they want nothing in that slot
+	var/uniform = -1
+	var/r_hand = -1
+	var/l_hand = -1
+	var/suit = -1
+	var/shoes = -1
+	var/gloves = -1
+	var/ears = -1
+	var/glasses = -1
+	var/mask = -1
+	var/head = -1
+	var/belt = -1
+	var/r_pocket = -1
+	var/l_pocket = -1
+	var/back = -1
+	var/id = -1
 
 /obj/effect/mob_spawn/human/Initialize()
 	. = ..()
 	if(ispath(outfit))
 		outfit = new outfit()
+	if(!outfit)
+		outfit = new /datum/outfit
+
 
 /obj/effect/mob_spawn/human/equip(mob/living/carbon/human/H)
 	if(mob_species)
@@ -111,6 +131,11 @@
 		H.Drain()
 
 	if(outfit)
+		var/static/list/slots = list("uniform", "r_hand", "l_hand", "suit", "shoes", "gloves", "ears", "glasses", "mask", "head", "belt", "r_pocket", "l_pocket", "back", "id")
+		for(var/slot in slots)
+			var/T = vars[slot]
+			if(!isnum(T))
+				outfit.vars[slot] = T
 		H.equipOutfit(outfit)
 		if(disable_pda)
 			// We don't want corpse PDAs to show up in the messenger list.

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -186,12 +186,11 @@
 
 /obj/effect/mob_spawn/human/syndicatesoldier/coldres
 	name = "Syndicate Snow Operative"
-	uniform = /obj/item/clothing/under/syndicate/coldres
-	shoes = /obj/item/clothing/shoes/combat/coldres
-	radio = /obj/item/device/radio/headset/syndicate/alt
-	pocket1 = /obj/item/weapon/gun/ballistic/automatic/pistol
-	pocket2 = /obj/item/weapon/card/id/syndicate
-	has_id = 0
+	outfit = /datum/outfit/snowsyndie/corpse
+
+/datum/outfit/snowsyndie/corpse
+	name = "Syndicate Snow Operative Corpse"
+	implants = null
 
 /obj/effect/mob_spawn/human/syndicatesoldier/coldres/alive
 	name = "sleeper"
@@ -200,10 +199,19 @@
 	icon_state = "sleeper"
 	roundstart = FALSE
 	death = FALSE
-	implants = list(/obj/item/weapon/implant/exile)
 	faction = "syndicate"
+	outfit = /datum/outfit/snowsyndie
 	flavour_text = {"You are a syndicate operative recently awoken from cyrostatis in an underground outpost. Monitor Nanotrasen communications and record infomation. All intruders should be
 	disposed of swirfly to assure no gathered infomation is stolen or lost. Try not to wander too far from the outpost as the caves can be a deadly place even for a trained operative such as yourself."}
+
+/datum/outfit/snowsyndie
+	name = "Syndicate Snow Operative"
+	uniform = /obj/item/clothing/under/syndicate/coldres
+	shoes = /obj/item/clothing/shoes/combat/coldres
+	ears = /obj/item/device/radio/headset/syndicate/alt
+	r_pocket = /obj/item/weapon/gun/ballistic/automatic/pistol
+	l_pocket = /obj/item/weapon/card/id/syndicate
+	implants = list(/obj/item/weapon/implant/exile)
 
 /obj/effect/mob_spawn/human/syndicatesoldier/coldres/alive/female
 	mob_gender = FEMALE

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -98,13 +98,16 @@ Station Engineer
 	pda_slot = slot_l_store
 	backpack_contents = list(/obj/item/device/modular_computer/tablet/preset/advanced=1)
 
-/datum/outfit/job/engineer/rig
+/datum/outfit/job/engineer/gloved
+	name = "Station Engineer (Gloves)"
+	gloves = /obj/item/clothing/gloves/color/yellow
+
+/datum/outfit/job/engineer/gloved/rig
 	name = "Station Engineer (Hardsuit)"
 
 	mask = /obj/item/clothing/mask/breath
 	suit = /obj/item/clothing/suit/space/hardsuit/engine
 	suit_store = /obj/item/weapon/tank/internals/oxygen
-	gloves = /obj/item/clothing/gloves/color/yellow
 	head = null
 	internals_slot = slot_s_store
 

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -132,8 +132,6 @@
 	back = /obj/item/weapon/storage/backpack
 	shoes = /obj/item/clothing/shoes/sneakers/black
 
-	var/list/implants = null
-
 	var/backpack = /obj/item/weapon/storage/backpack
 	var/satchel  = /obj/item/weapon/storage/backpack/satchel
 	var/dufflebag = /obj/item/weapon/storage/backpack/dufflebag
@@ -158,7 +156,7 @@
 		else
 			back = backpack //Department backpack
 
-	if(box)
+	if(backpack_contents && box)
 		backpack_contents.Insert(1, box) // Box always takes a first slot in backpack
 		backpack_contents[box] = 1
 
@@ -183,8 +181,3 @@
 		PDA.owner = H.real_name
 		PDA.ownjob = J.title
 		PDA.update_label()
-
-	if(implants)
-		for(var/implant_type in implants)
-			var/obj/item/weapon/implant/I = new implant_type(H)
-			I.implant(H, null, silent=TRUE)

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -10,45 +10,58 @@
 
 /obj/effect/mob_spawn/human/corpse/syndicatesoldier
 	name = "Syndicate Operative"
+	id_job = "Operative"
+	id_access_list = list(GLOB.access_syndicate)
+	outfit = /datum/outfit/syndicatesoldiercorpse
+
+/datum/outfit/syndicatesoldiercorpse
+	name = "Syndicate Operative Corpse"
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/armor/vest
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
-	radio = /obj/item/device/radio/headset
+	ears = /obj/item/device/radio/headset
 	mask = /obj/item/clothing/mask/gas
-	helmet = /obj/item/clothing/head/helmet/swat
+	head = /obj/item/clothing/head/helmet/swat
 	back = /obj/item/weapon/storage/backpack
-	has_id = 1
-	id_job = "Operative"
-	id_access_list = list(GLOB.access_syndicate)
+	id = /obj/item/weapon/card/id
+
 
 /obj/effect/mob_spawn/human/corpse/syndicatecommando
 	name = "Syndicate Commando"
+	id_job = "Operative"
+	id_access_list = list(GLOB.access_syndicate)
+	outfit = /datum/outfit/syndicatecommandocorpse
+
+/datum/outfit/syndicatecommandocorpse
+	name = "Syndicate Commando Corpse"
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/space/hardsuit/syndi
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
-	radio = /obj/item/device/radio/headset
+	ears = /obj/item/device/radio/headset
 	mask = /obj/item/clothing/mask/gas/syndicate
 	back = /obj/item/weapon/tank/jetpack/oxygen
-	pocket1 = /obj/item/weapon/tank/internals/emergency_oxygen
-	has_id = 1
-	id_job = "Operative"
-	id_access_list = list(GLOB.access_syndicate)
+	r_pocket = /obj/item/weapon/tank/internals/emergency_oxygen
+	id = /obj/item/weapon/card/id
+
 
 /obj/effect/mob_spawn/human/corpse/syndicatestormtrooper
 	name = "Syndicate Stormtrooper"
+	id_job = "Operative"
+	id_access_list = list(GLOB.access_syndicate)
+	outfit = /datum/outfit/syndicatestormtroopercorpse
+
+/datum/outfit/syndicatestormtroopercorpse
+	name = "Syndicate Stormtrooper Corpse"
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/space/hardsuit/syndi/elite
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
-	radio = /obj/item/device/radio/headset
+	ears = /obj/item/device/radio/headset
 	mask = /obj/item/clothing/mask/gas/syndicate
 	back = /obj/item/weapon/tank/jetpack/oxygen/harness
-	has_id = 1
-	id_job = "Operative"
-	id_access_list = list(GLOB.access_syndicate)
-
+	id = /obj/item/weapon/card/id
 
 
 /obj/effect/mob_spawn/human/clown/corpse
@@ -58,62 +71,97 @@
 
 /obj/effect/mob_spawn/human/corpse/pirate
 	name = "Pirate"
+	outfit = /datum/outfit/piratecorpse
+
+/datum/outfit/piratecorpse
+	name = "Pirate Corpse"
 	uniform = /obj/item/clothing/under/pirate
 	shoes = /obj/item/clothing/shoes/jackboots
 	glasses = /obj/item/clothing/glasses/eyepatch
-	helmet = /obj/item/clothing/head/bandana
-
+	head = /obj/item/clothing/head/bandana
 
 
 /obj/effect/mob_spawn/human/corpse/pirate/ranged
 	name = "Pirate Gunner"
+	outfit = /datum/outfit/piratecorpse/ranged
+
+/datum/outfit/piratecorpse/ranged
+	name = "Pirate Gunner Corpse"
 	suit = /obj/item/clothing/suit/pirate
-	helmet = /obj/item/clothing/head/pirate
+	head = /obj/item/clothing/head/pirate
+
 
 /obj/effect/mob_spawn/human/corpse/russian
 	name = "Russian"
+	outfit = /datum/outfit/russiancorpse
+
+/datum/outfit/russiancorpse
+	name = "Russian Corpse"
 	uniform = /obj/item/clothing/under/soviet
 	shoes = /obj/item/clothing/shoes/jackboots
-	helmet = /obj/item/clothing/head/bearpelt
+	head = /obj/item/clothing/head/bearpelt
+
 
 /obj/effect/mob_spawn/human/corpse/russian/ranged
-	helmet = /obj/item/clothing/head/ushanka
+	outfit = /datum/outfit/russiancorpse/ranged
+
+/datum/outfit/russiancorpse/ranged
+	name = "Ranged Russian Corpse"
+	head = /obj/item/clothing/head/ushanka
 
 /obj/effect/mob_spawn/human/corpse/russian/ranged/trooper
+	outfit = /datum/outfit/russiancorpse/ranged/trooper
+
+/datum/outfit/russiancorpse/ranged/trooper
+	name = "Ranged Russian Trooper Corpse"
 	uniform = /obj/item/clothing/under/syndicate/camo
 	suit = /obj/item/clothing/suit/armor/bulletproof
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
-	radio = /obj/item/device/radio/headset
+	ears = /obj/item/device/radio/headset
 	mask = /obj/item/clothing/mask/balaclava
-	helmet = /obj/item/clothing/head/helmet/alt
+	head = /obj/item/clothing/head/helmet/alt
+
 
 /obj/effect/mob_spawn/human/corpse/russian/ranged/officer
 	name = "Russian Officer"
+	outfit = /datum/outfit/russiancorpse/officer
+
+/datum/outfit/russiancorpse/officer
+	name = "Russian Officer Corpse"
 	uniform = /obj/item/clothing/under/rank/security/navyblue/russian
 	suit = /obj/item/clothing/suit/security/officer/russian
 	shoes = /obj/item/clothing/shoes/laceup
-	radio = /obj/item/device/radio/headset
-	helmet = /obj/item/clothing/head/ushanka
+	ears = /obj/item/device/radio/headset
+	head = /obj/item/clothing/head/ushanka
+
 
 /obj/effect/mob_spawn/human/corpse/wizard
-	name = "Space Wizard"
+	name = "Space Wizard Corpse"
+	outfit = /datum/outfit/wizardcorpse
+
+/datum/outfit/wizardcorpse
+	name = "Space Wizard Corpse"
 	uniform = /obj/item/clothing/under/color/lightpurple
 	suit = /obj/item/clothing/suit/wizrobe
 	shoes = /obj/item/clothing/shoes/sandal/magic
-	helmet = /obj/item/clothing/head/wizard
+	head = /obj/item/clothing/head/wizard
 
 
 /obj/effect/mob_spawn/human/corpse/nanotrasensoldier
 	name = "Nanotrasen Private Security Officer"
+	id_job = "Private Security Force"
+	id_access = "Security Officer"
+	outfit = /datum/outfit/nanotrasensoldiercorpse2
+
+/datum/outfit/nanotrasensoldiercorpse2
+	name = "NT Private Security Officer Corpse"
 	uniform = /obj/item/clothing/under/rank/security
 	suit = /obj/item/clothing/suit/armor/vest
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
-	radio = /obj/item/device/radio/headset
+	ears = /obj/item/device/radio/headset
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
-	helmet = /obj/item/clothing/head/helmet/swat/nanotrasen
+	head = /obj/item/clothing/head/helmet/swat/nanotrasen
 	back = /obj/item/weapon/storage/backpack/security
-	has_id = 1
-	id_job = "Private Security Force"
-	id_access = "Security Officer"
+	id = /obj/item/weapon/card/id

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -126,29 +126,39 @@
 	shell_type = /obj/effect/mob_spawn/human/golem/servant
 
 ///Syndicate Listening Post
+
 /obj/effect/mob_spawn/human/lavaland_syndicate
-	r_hand = /obj/item/weapon/gun/ballistic/automatic/sniper_rifle
 	name = "Syndicate Bioweapon Scientist"
-	uniform = /obj/item/clothing/under/syndicate
-	suit = /obj/item/clothing/suit/toggle/labcoat
-	shoes = /obj/item/clothing/shoes/combat
-	gloves = /obj/item/clothing/gloves/combat
-	radio = /obj/item/device/radio/headset/syndicate/alt
-	back = /obj/item/weapon/storage/backpack
-	pocket1 = /obj/item/weapon/gun/ballistic/automatic/pistol
 	roundstart = FALSE
 	death = FALSE
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "sleeper"
-	has_id = 1
 	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Continue your research as best you can, and try to keep a low profile. Do not abandon the base without good cause.</b> The base is rigged with explosives should the worst happen, do not let the base fall into enemy hands!</b>"
 	id_access_list = list(GLOB.access_syndicate)
 	faction = list("syndicate")
+	outfit = /datum/outfit/lavaland_syndicate
+
+/datum/outfit/lavaland_syndicate
+	name = "Lavaland Syndicate Agent"
+	r_hand = /obj/item/weapon/gun/ballistic/automatic/sniper_rifle
+	uniform = /obj/item/clothing/under/syndicate
+	suit = /obj/item/clothing/suit/toggle/labcoat
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/combat
+	ears = /obj/item/device/radio/headset/syndicate/alt
+	back = /obj/item/weapon/storage/backpack
+	r_pocket = /obj/item/weapon/gun/ballistic/automatic/pistol
+	id = /obj/item/weapon/card/id
+
 
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms
 	name = "Syndicate Comms Agent"
+	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. Do not abandon the base without good cause.</b> Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!</b>"
+	outfit = /datum/outfit/lavaland_syndicate/comms
+
+/datum/outfit/lavaland_syndicate/comms
+	name = "Lavaland Syndicate Comms Agent"
 	r_hand = /obj/item/weapon/melee/energy/sword/saber
 	mask = /obj/item/clothing/mask/chameleon
 	suit = /obj/item/clothing/suit/armor/vest
-	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. Do not abandon the base without good cause.</b> Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!</b>"
-	pocket2 = /obj/item/weapon/card/id/syndicate/anyone
+	l_pocket = /obj/item/weapon/card/id/syndicate/anyone


### PR DESCRIPTION
It always annoyed me that mob spawners had a bunch of vars that were essentially the same as outfits.

[why]: Much of the code in mob spawners and outfits was exactly the same. This also adds all the ghost role outfits to the Select Equipment menu, if for some reason admins want to use that.