### PR TITLE
Gives all hats a default icon/item state so they work with chameleon gear.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -271,6 +271,8 @@ BLIND     // can't see anything
 /obj/item/clothing/head
 	name = "head"
 	icon = 'icons/obj/clothing/hats.dmi'
+	icon_state = "top_hat"
+	item_state = "that"
 	body_parts_covered = HEAD
 	slot_flags = SLOT_HEAD
 	var/blockTracking = 0 //For AI tracking


### PR DESCRIPTION
Why not, this can't be abused and it wont' lead to anything bad as they'll be overridden by defined head clothing.