### PR TITLE
Gives Void Torch its icon back

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -375,8 +375,8 @@
 	desc = "Used by veteran cultists to instantly transport items to their needful bretheren."
 	w_class = WEIGHT_CLASS_SMALL
 	brightness_on = 1
-	icon_state = "torch-on"
-	item_state = "torch-on"
+	icon_state = "torch"
+	item_state = "torch"
 	color = "#ff0000"
 	on_damage = 15
 	slot_flags = null


### PR DESCRIPTION
Some icon refactor broke this icon, I'll probably change this item soon anyway but its long overdue to actually be visible. 