### PR TITLE
Add Glass Panes to Box Armoury Weapon Racks

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -1147,6 +1147,10 @@
 /obj/effect/turf_decal/bot{
 	dir = 2
 	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
 /turf/open/floor/plasteel{
 	dir = 2
 	},
@@ -1343,6 +1347,13 @@
 /obj/effect/turf_decal/bot{
 	dir = 2
 	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel{
 	dir = 2
 	},
@@ -1360,6 +1371,13 @@
 	},
 /obj/effect/turf_decal/bot{
 	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel{
 	dir = 2
@@ -54402,6 +54420,10 @@
 	},
 /obj/effect/turf_decal/bot{
 	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
 /turf/open/floor/plasteel{
 	dir = 2
@@ -114113,11 +114135,11 @@ btp
 cbv
 ccq
 bns
-cjD
-cjD
-cjD
-cjD
-cnj
+aof
+aof
+aof
+aof
+amw
 aaa
 aaa
 aaa
@@ -114370,13 +114392,13 @@ ckS
 bky
 ccq
 cds
-cjD
+aof
 ckt
 cly
 cmw
-cnj
-cnj
-cnj
+amw
+amw
+amw
 aaa
 aaa
 aaf
@@ -114884,13 +114906,13 @@ cbg
 bTr
 cct
 cdu
-cjG
+aqx
 cku
 clz
 cmx
-cnj
-cnj
-cnj
+amw
+amw
+amw
 aaa
 aaa
 aaf
@@ -115141,11 +115163,11 @@ bky
 bky
 bky
 bky
-cjD
-cjD
-cjD
-cjD
-cnj
+aof
+aof
+aof
+aof
+amw
 aaa
 aaa
 aaa


### PR DESCRIPTION
Seeing either a meteor or a antagonist be in the process of deconstructing a wall, and then seeing every single gun in the armoury fly out into their lap before they've even finished deconning the wall, is not only annoying but makes raiding the armoury even more trivial when all the work is done for you via the guns just falling into your backpack.

This PR adds a set of glass panes around the north side of the centre weapon racks.

![panes](https://cloud.githubusercontent.com/assets/6595389/26351085/8866681a-3fe8-11e7-9222-a4ab3e0ce324.png)

:cl: Steelpoint
add: Boxstation armoury weapon racks now have glass panes to help prevent the weapons easily flying out of a breached hull.
/:cl:
