### PR TITLE
Nerfs plasma cost

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -43,7 +43,7 @@
 
 // Plasma. The oil of 26 century. The reason why you are here.
 /datum/export/material/plasma
-	cost = 500
+	cost = 300
 	k_elasticity = 0
 	material_id = MAT_PLASMA
 	message = "cm3 of plasma"
@@ -74,7 +74,7 @@
 
 // Plastitanium.
 /datum/export/material/plastitanium
-	cost = 750
+	cost = 550
 	material_id = MAT_TITANIUM // code can only check for one material_id; plastitanium is half plasma, half titanium, so ((250 x 250) + (250 x 500)) / 250
 	message = "cm3 of plastitanium"
 


### PR DESCRIPTION
:cl: optional name here
balance: The cost of plasma has been reduced from 500 to 300, but retain their immunity to saturation
/:cl:

Plasma exports has been deemed too powerful which is a part of the reason why https://github.com/tgstation/tgstation/pull/27099 was made. To balance things while still maintaining lore, plasma still retain their immunity to saturation and have had their cost nerfed instead.

For the mathematics, [here](https://www.wolframalpha.com/input/?i=y%3D500*e%5E((-1%2F30)*x),+y%3D+300,+y%3D500+from+0+to+200) is the marginal cost function and [here](https://www.wolframalpha.com/input/?i=y%3D500*(30+-+30*e%5E(-x%2F30)),+y%3D300*x,y%3D500*x+from+0+to+200) is the cumulative cost function (how many points cargo gets in total for exporting x amount).

Green is how it is currently, blue is @Iamgoofball's [proposal](https://github.com/tgstation/tgstation/pull/27598) to have plasma saturate normally, purple is my PR to reduce plasma cost instead of incorporating saturation.