### PR TITLE
Brains extracted from infectious zombies keep their old species

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -72,6 +72,9 @@
 		if(!brainmob.stored_dna)
 			brainmob.stored_dna = new /datum/dna/stored(brainmob)
 		C.dna.copy_dna(brainmob.stored_dna)
+		var/obj/item/organ/zombie_infection/ZI = L.getorganslot("zombie_infection")
+		if(ZI)
+			brainmob.set_species(ZI.old_species)	//For if the brain is cloned
 	if(L.mind && L.mind.current)
 		L.mind.transfer_to(brainmob)
 	to_chat(brainmob, "<span class='notice'>You feel slightly disoriented. That's normal when you're just a brain.</span>")

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -70,8 +70,10 @@
 
 	var/stand_up = (owner.stat == DEAD) || (owner.stat == UNCONSCIOUS)
 
+	if(!owner.revive(full_heal = TRUE))
+		return
+
 	owner.grab_ghost()
-	owner.revive(full_heal = TRUE)
 	owner.visible_message("<span class='danger'>[owner] suddenly convulses, as [owner.p_they()][stand_up ? " stagger to [owner.p_their()] feet and" : ""] gain a ravenous hunger in [owner.p_their()] eyes!</span>", "<span class='alien'>You HUNGER!</span>")
 	playsound(owner.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)
 	owner.do_jitter_animation(living_transformation_time * 10)


### PR DESCRIPTION
Brains removed from infectious zombies keep their underlying species rather than having it be zombie. This only matters for head/brain cloning because inserting a brain into a mob doesn't transfer DNA.
Also keeps zombies from trying to revive when they can't be revived(typically due to not having a brain). No longer will they stagger to their feet and roar while continuing to be dead and horizontal.

Fixes #27350 