### PR TITLE
UPDATE: Removes airlock charge from uplink

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -731,9 +731,9 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 			The next person to use that airlock will trigger an explosion, knocking them down and destroying \
 			the airlock maintenance panel."
 	item = /obj/item/device/doorCharge
-	cost = 2
-	surplus = 10
-	exclude_modes = list(/datum/game_mode/nuclear)
+	cost = 4
+	surplus = 0
+	include_modes = list(/datum/game_mode/nuclear)
 
 // Stealth Items
 /datum/uplink_item/stealthy_tools

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -725,16 +725,6 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	item = /obj/item/weapon/grenade/clusterbuster/soap
 	cost = 6
 
-/datum/uplink_item/stealthy_weapons/door_charge
-	name = "Explosive Airlock Charge"
-	desc = "A small, easily concealable device. It can be applied to an open airlock panel, booby-trapping it. \
-			The next person to use that airlock will trigger an explosion, knocking them down and destroying \
-			the airlock maintenance panel."
-	item = /obj/item/device/doorCharge
-	cost = 4
-	surplus = 0
-	include_modes = list(/datum/game_mode/nuclear)
-
 // Stealth Items
 /datum/uplink_item/stealthy_tools
 	category = "Stealth and Camouflage Items"


### PR DESCRIPTION
I shake my head looking back at the Goof PR that buffed this stupid piece of shit item. Some prophets among us somehow saw this coming:

Kor: "invisible instant kill would probably be unpleasant though"

Joan: "Oh boy an instant kill for everyone near the door if they don't get medical help that sounds fun"

**Yes this item is broken, yes nobody buys it because its crushingly unfun for anyone involved.** What traitor wants to sit around and stare at a fucking door, someone walks up, dies, and there's 0 interaction whatsoever. You could make this stupid piece of shit instantly gib the first person to see the fucking door and it would still go unbought because its just a shitty item. Just because its purchased infrequently due to its terribly unfun nature doesn't mean we should tolerate its shittiness. If someone wants to make a non-instant-kill version for traitor be my guest but LEL20FIRESTACKS + KO + EXPLOSION is just fucking stupid. TWENTY FIRE STACKS WHAT THE FUCK. 

This is an official ided PR.

:cl: OMR
del: Removed airlock charge from Syndicate Uplink
:cl: