### PR TITLE
 Remove roundstart teleport beacon from golem ship

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -133,7 +133,6 @@
 	},
 /area/ruin/powered/golem_ship)
 "s" = (
-/obj/machinery/bluespace_beacon,
 /turf/open/floor/mineral/titanium/purple{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},


### PR DESCRIPTION
I'm not really clear why there was a teleport beacon on the golem ship but it doesn't belong.