### PR TITLE
Nevermind this doesn't fix the core problem of projectiles slamming into walls and still moving even when it should of stopped...

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -27,6 +27,8 @@
 	var/Angle = 0
 	var/spread = 0			//amount (in degrees) of projectile spread
 	var/legacy = 0			//legacy projectile system
+	var/pixel_x_adj = 0		//One time adjustments to pixel projectiles...
+	var/pixel_y_adj = 0
 	animate_movement = 0	//Use SLIDE_STEPS in conjunction with legacy
 
 	var/damage = 10
@@ -150,8 +152,14 @@
 
 	prehit(A)
 	var/permutation = A.bullet_act(src, def_zone) // searches for return value, could be deleted after run so check A isn't null
-	if(permutation == -1 || forcedodge)// the bullet passes through a dense object!
+	if(permutation == -1 || forcedodge)// the bullet passes through a dense object
+		var/turf/ct = get_turf(src)
+		var/_x = target_turf.x - ct.x
+		var/_y = target_turf.y - ct.y
 		loc = target_turf
+		
+		pixel_x_adj = _x * world.icon_size
+		pixel_y_adj = _y * world.icon_size
 		if(A)
 			permutated.Add(A)
 		return 0
@@ -205,6 +213,13 @@
 			var/Pixel_y=round((cos(Angle)+16*cos(Angle)*2), 1)
 			var/pixel_x_offset = old_pixel_x + Pixel_x
 			var/pixel_y_offset = old_pixel_y + Pixel_y
+			if(pixel_x_adj)
+				pixel_x_offset += pixel_x_adj
+				pixel_x_adj = 0
+			if(pixel_y_adj)
+				pixel_y_offset += pixel_y_adj
+				pixel_y_adj = 0
+	
 			var/new_x = x
 			var/new_y = y
 
@@ -224,7 +239,7 @@
 				pixel_y_offset += 32
 				old_pixel_y += 32
 				new_y--
-
+			
 			pixel_x = old_pixel_x
 			pixel_y = old_pixel_y
 			step_towards(src, locate(new_x, new_y, z))


### PR DESCRIPTION
Forcedodging will now also adjust the projectile's current pixel_x and pixel_y to adjust for the projectile being forcefully moved to that tile instead of following the regular pixel projectile movement paths.
Fixes #27620 
Honestly projectiles would be better if they were incorporeal but checked for hits on every tile they passed because we wouldn't have problems of projectiles bouncing off walls (No one notices this because projectiles are slow and properly delete on impact but in my hitscan beam rifle PRs when doing tracers I've noticed projectiles literally bouncing off a side of a wall and hitting something next to it.)