### PR TITLE
[s] The arrivals shuttle is out of bounds for the nuke disk when it leaves

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -590,7 +590,12 @@
 /atom/movable/proc/in_bounds()
 	. = FALSE
 	var/turf/currentturf = get_turf(src)
-	if(currentturf && (currentturf.z == ZLEVEL_CENTCOM || currentturf.z == ZLEVEL_STATION))
+	var/area/currentarea = get_area(src)
+	if(!currentturf)
+		. = FALSE
+	else if(istype(currentarea, /area/shuttle/arrival) && currentturf.z == ZLEVEL_CENTCOM)
+		. = FALSE
+	else if(currentturf && (currentturf.z == ZLEVEL_CENTCOM || currentturf.z == ZLEVEL_STATION))
 		. = TRUE
 
 


### PR DESCRIPTION
:cl: coiax
balance: When the arrivals shuttle leaves the station, if the nuke disk
is present, it will relocate.
/:cl:

Fixes #27399.
Closes #27582.

This does it in a better way than grounding the arrivals shuttle.