### PR TITLE
INDESTRUCTIBLE objects are no longer affected by explosions

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -48,6 +48,8 @@
 	take_damage(tforce, BRUTE, "melee", 1, get_dir(src, AM))
 
 /obj/ex_act(severity, target)
+	if(resistance_flags & INDESTRUCTIBLE)
+		return
 	..() //contents explosion
 	if(target == src)
 		qdel(src)


### PR DESCRIPTION
Fixes #27608 

:cl:
fix: Indestructible objects can no longer be destroyed by bombs
/:cl: