### PR TITLE
Turret bases will properly layer under turret covers

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -87,7 +87,9 @@
 	if(has_cover)
 		cover = new /obj/machinery/porta_turret_cover(loc)
 		cover.parent_turret = src
-		underlays += image('icons/obj/turrets.dmi',icon_state = "basedark")
+		var/mutable_appearance/base = mutable_appearance('icons/obj/turrets.dmi', "basedark")
+		base.layer = NOT_HIGH_OBJ_LAYER
+		underlays += base
 	if(!has_cover)
 		INVOKE_ASYNC(src, .proc/popUp)
 


### PR DESCRIPTION
Instead of the base going over the cover when the turret pops up.