### PR TITLE
Server_maint now clears nulls from client list

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -16,6 +16,7 @@ SUBSYSTEM_DEF(server_maint)
 
 /datum/controller/subsystem/server_maint/fire(resumed = FALSE)
 	if(!resumed)
+		listclearnulls(GLOB.clients)
 		src.currentrun = GLOB.clients.Copy()
 	
 	var/list/currentrun = src.currentrun


### PR DESCRIPTION
BYOND is stupid and doesn't always call client/Del