### PR TITLE
Refactor + Rebalance of species armor

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -29,6 +29,8 @@
 			var/obj/item/clothing/C = bp
 			if(C.body_parts_covered & def_zone.body_part)
 				protection += C.armor[d_type]
+	if(dna && dna.species)
+		protection += dna.species.armor[d_type]
 	return protection
 
 ///checkeyeprot()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -38,7 +38,7 @@
 	var/list/mutant_bodyparts = list() 	// Parts of the body that are diferent enough from the standard human model that they cause clipping with some equipment
 	var/list/mutant_organs = list()		//Internal organs that are unique to this race.
 	var/speedmod = 0	// this affects the race's speed. positive numbers make it move slower, negative numbers make it move faster
-	var/armor = 0		// overall defense for the race... or less defense, if it's negative.
+	var/list/armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0) //species innate armor
 	var/brutemod = 1	// multiplier for brute damage
 	var/burnmod = 1		// multiplier for burn damage
 	var/coldmod = 1		// multiplier for cold damage
@@ -1256,7 +1256,7 @@
 	return TRUE
 
 /datum/species/proc/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H)
-	var/hit_percent = (100-(blocked+armor))/100
+	var/hit_percent = (100-(blocked))/100
 	if(!damage || hit_percent <= 0)
 		return 0
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -38,7 +38,7 @@
 	var/list/mutant_bodyparts = list() 	// Parts of the body that are diferent enough from the standard human model that they cause clipping with some equipment
 	var/list/mutant_organs = list()		//Internal organs that are unique to this race.
 	var/speedmod = 0	// this affects the race's speed. positive numbers make it move slower, negative numbers make it move faster
-	var/list/armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0) //species innate armor
+	var/list/armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0) //species innate armor
 	var/brutemod = 1	// multiplier for brute damage
 	var/burnmod = 1		// multiplier for burn damage
 	var/coldmod = 1		// multiplier for cold damage
@@ -795,6 +795,9 @@
 		H.reagents.del_reagent(chem.id)
 		return 1
 	return 0
+
+/datum/species/proc/delete_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
+	return
 
 /datum/species/proc/handle_speech(message, mob/living/carbon/human/H)
 	return message

--- a/code/modules/mob/living/carbon/human/species_types/abductors.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abductors.dm
@@ -4,7 +4,7 @@
 	say_mod = "gibbers"
 	sexes = 0
 	species_traits = list(NOBLOOD,NOBREATH,VIRUSIMMUNE,NOGUNS,NOHUNGER)
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 20, bomb = 0, bio = 50, rad = 50, fire = 0, acid = 0) //bizarre alien biology
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 20, "bomb" = 0, "bio" = 50, "rad" = 50, "fire" = 0, "acid" = 0) //bizarre alien biology
 	mutanttongue = /obj/item/organ/tongue/abductor
 	var/scientist = 0 // vars to not pollute spieces list with castes
 	var/team = 1

--- a/code/modules/mob/living/carbon/human/species_types/abductors.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abductors.dm
@@ -4,6 +4,7 @@
 	say_mod = "gibbers"
 	sexes = 0
 	species_traits = list(NOBLOOD,NOBREATH,VIRUSIMMUNE,NOGUNS,NOHUNGER)
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 20, bomb = 0, bio = 50, rad = 50, fire = 0, acid = 0) //bizarre alien biology
 	mutanttongue = /obj/item/organ/tongue/abductor
 	var/scientist = 0 // vars to not pollute spieces list with castes
 	var/team = 1

--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -4,7 +4,7 @@
 	say_mod = "states"
 	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOFIRE,NOBLOOD,VIRUSIMMUNE,RADIMMUNE,PIERCEIMMUNE,NOHUNGER,EASYLIMBATTACHMENT)
 	meat = null
-	armor = list(melee = 10, bullet = 10, laser = 0, energy = -10, bomb = 30, bio = 100, rad = 100, fire = 100, acid = 0)
+	armor = list("melee" = 10, "bullet" = 10, "laser" = 0, "energy" = -10, "bomb" = 30, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
 	damage_overlay_type = "synth"
 	mutanttongue = /obj/item/organ/tongue/robot
 	limbs_id = "synth"

--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -2,8 +2,9 @@
 	name = "Android"
 	id = "android"
 	say_mod = "states"
-	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOFIRE,NOBLOOD,VIRUSIMMUNE,PIERCEIMMUNE,NOHUNGER,EASYLIMBATTACHMENT)
+	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOFIRE,NOBLOOD,VIRUSIMMUNE,RADIMMUNE,PIERCEIMMUNE,NOHUNGER,EASYLIMBATTACHMENT)
 	meat = null
+	armor = list(melee = 10, bullet = 10, laser = 0, energy = -10, bomb = 30, bio = 100, rad = 100, fire = 100, acid = 0)
 	damage_overlay_type = "synth"
 	mutanttongue = /obj/item/organ/tongue/robot
 	limbs_id = "synth"

--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -4,7 +4,7 @@
 	say_mod = "states"
 	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOFIRE,NOBLOOD,VIRUSIMMUNE,RADIMMUNE,PIERCEIMMUNE,NOHUNGER,EASYLIMBATTACHMENT)
 	meat = null
-	armor = list("melee" = 10, "bullet" = 10, "laser" = 0, "energy" = -10, "bomb" = 30, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = -20, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
 	damage_overlay_type = "synth"
 	mutanttongue = /obj/item/organ/tongue/robot
 	limbs_id = "synth"

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -4,6 +4,7 @@
 	say_mod = "buzzes"
 	mutanttongue = /obj/item/organ/tongue/fly
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/fly
+	armor = list(melee = -10, bullet = -10, laser = 0, energy = 0, bomb = 0, bio = 20, rad = 20, fire = 0, acid = 0)
 
 /datum/species/fly/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.id == "pestkiller")

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -4,16 +4,13 @@
 	say_mod = "buzzes"
 	mutanttongue = /obj/item/organ/tongue/fly
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/fly
-	armor = list(melee = -10, bullet = -10, laser = 0, energy = 0, bomb = 0, bio = 20, rad = 20, fire = 0, acid = 0)
+	armor = list("melee" = -10, "bullet" = -10, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 20, "rad" = 20, "fire" = 0, "acid" = 0)
 
 /datum/species/fly/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.id == "pestkiller")
 		H.adjustToxLoss(3)
 		H.reagents.remove_reagent(chem.id, REAGENTS_METABOLISM)
 		return 1
-
-
-/datum/species/fly/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(istype(chem,/datum/reagent/consumable))
 		var/datum/reagent/consumable/nutri_check = chem
 		if(nutri_check.nutriment_factor > 0)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -5,7 +5,7 @@
 	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOFIRE,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NODISMEMBER,MUTCOLORS,NO_UNDERWEAR)
 	mutant_organs = list(/obj/item/organ/adamantine_resonator)
 	speedmod = 2
-	armor = list(melee = 60, bullet = 60, laser = 35, energy = 0, bomb = 60, bio = 100, rad = 100, fire = 100, acid = 0)
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 35, "energy" = 0, "bomb" = 60, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
 	siemens_coeff = 0
 	punchdamagelow = 5
 	punchdamagehigh = 14
@@ -87,7 +87,7 @@
 	name = "Diamond Golem"
 	id = "diamond golem"
 	fixed_mut_color = "0ff"
-	armor = list(melee = 80, bullet = 80, laser = 60, energy = 0, bomb = 80, bio = 100, rad = 100, fire = 100, acid = 0)
+	armor = list("melee" = 80, "bullet" = 80, "laser" = 60, "energy" = 0, "bomb" = 80, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
 	meat = /obj/item/weapon/ore/diamond
 	info_text = "As a <span class='danger'>Diamond Golem</span>, you are far more resistant than the average golem."
 	prefix = "Diamond"
@@ -99,7 +99,7 @@
 	id = "gold golem"
 	fixed_mut_color = "cc0"
 	speedmod = 1
-	armor = list(melee = 45, bullet = 45, laser = 45, energy = 0, bomb = 40, bio = 100, rad = 100, fire = 100, acid = 0)
+	armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 0, "bomb" = 40, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
 	meat = /obj/item/weapon/ore/gold
 	info_text = "As a <span class='danger'>Gold Golem</span>, you are faster but less resistant than the average golem."
 	prefix = "Golden"
@@ -197,7 +197,7 @@
 	meat = /obj/item/stack/sheet/mineral/wood
 	//Can burn and take damage from heat
 	species_traits = list(NOBREATH,RESISTCOLD,RESISTPRESSURE,NOGUNS,NOBLOOD,PIERCEIMMUNE,NODISMEMBER,MUTCOLORS,NO_UNDERWEAR)
-	armor = list(melee = 40, bullet = 40, laser = 20, energy = 0, bomb = 30, bio = 0, rad = 0, fire = -20, acid = 0)
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 20, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = -20, "acid" = 0)
 	burnmod = 1.25
 	heatmod = 1.5
 	info_text = "As a <span class='danger'>Wooden Golem</span>, you have plant-like traits: you take damage from extreme temperatures, can be set on fire, and have lower armor than a normal golem. You regenerate when in the light and wither in the darkness."
@@ -270,7 +270,7 @@
 	id = "sand golem"
 	fixed_mut_color = "ffdc8f"
 	meat = /obj/item/weapon/ore/glass //this is sand
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = -100, bio = 100, rad = 100, fire = 0, acid = 0)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = -100, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
 	burnmod = 3 //melts easily
 	brutemod = 0.25
 	info_text = "As a <span class='danger'>Sand Golem</span>, you are immune to physical bullets and take very little brute damage, but are extremely vulnerable to burn damage. You will also turn to sand when dying, preventing any form of recovery."
@@ -300,7 +300,7 @@
 	id = "glass golem"
 	fixed_mut_color = "5a96b4aa" //transparent body
 	meat = /obj/item/weapon/shard
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = -100, bio = 100, rad = 100, fire = 100, acid = 100)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = -100, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
 	brutemod = 3 //very fragile
 	burnmod = 0.25
 	info_text = "As a <span class='danger'>Glass Golem</span>, you reflect lasers and energy weapons, and are very resistant to burn damage, but you are extremely vulnerable to brute damage. On death, you'll shatter beyond any hope of recovery."
@@ -556,7 +556,7 @@
 	sexes = FALSE
 	info_text = "As a <span class='danger'>Cloth Golem</span>, you are able to reform yourself after death, provided your remains aren't burned or destroyed. You are, of course, very flammable."
 	species_traits = list(NOBREATH,RESISTCOLD,RESISTPRESSURE,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NODISMEMBER,NO_UNDERWEAR) //no mutcolors, and can burn
-	armor = list(melee = 10, bullet = 40, laser = 10, energy = 0, bomb = 50, bio = 100, rad = 100, fire = -50, acid = 0)
+	armor = list("melee" = 10, "bullet" = 40, "laser" = 10, "energy" = 0, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = -50, "acid" = 0)
 	burnmod = 2 // don't get burned
 	speedmod = 1 // not as heavy as stone
 	punchdamagelow = 4
@@ -592,7 +592,7 @@
 	desc = "It emits a strange aura, as if there was still life within it..."
 	obj_integrity = 50
 	max_integrity = 50
-	armor = list(melee = 90, bullet = 90, laser = 25, energy = 80, bomb = 50, bio = 100, fire = -50, acid = -50)
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 25, "energy" = 80, "bomb" = 50, "bio" = 100, "fire" = -50, "acid" = -50)
 	icon = 'icons/obj/items.dmi'
 	icon_state = "pile_bandages"
 	resistance_flags = FLAMMABLE

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -5,7 +5,7 @@
 	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOFIRE,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NODISMEMBER,MUTCOLORS,NO_UNDERWEAR)
 	mutant_organs = list(/obj/item/organ/adamantine_resonator)
 	speedmod = 2
-	armor = list("melee" = 60, "bullet" = 60, "laser" = 35, "energy" = 0, "bomb" = 60, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 45, "energy" = 0, "bomb" = 60, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
 	siemens_coeff = 0
 	punchdamagelow = 5
 	punchdamagehigh = 14
@@ -270,7 +270,7 @@
 	id = "sand golem"
 	fixed_mut_color = "ffdc8f"
 	meat = /obj/item/weapon/ore/glass //this is sand
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = -100, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
 	burnmod = 3 //melts easily
 	brutemod = 0.25
 	info_text = "As a <span class='danger'>Sand Golem</span>, you are immune to physical bullets and take very little brute damage, but are extremely vulnerable to burn damage. You will also turn to sand when dying, preventing any form of recovery."
@@ -300,7 +300,7 @@
 	id = "glass golem"
 	fixed_mut_color = "5a96b4aa" //transparent body
 	meat = /obj/item/weapon/shard
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = -100, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
 	brutemod = 3 //very fragile
 	burnmod = 0.25
 	info_text = "As a <span class='danger'>Glass Golem</span>, you reflect lasers and energy weapons, and are very resistant to burn damage, but you are extremely vulnerable to brute damage. On death, you'll shatter beyond any hope of recovery."

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -5,7 +5,7 @@
 	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOFIRE,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NODISMEMBER,MUTCOLORS,NO_UNDERWEAR)
 	mutant_organs = list(/obj/item/organ/adamantine_resonator)
 	speedmod = 2
-	armor = 55
+	armor = list(melee = 60, bullet = 60, laser = 35, energy = 0, bomb = 60, bio = 100, rad = 100, fire = 100, acid = 0)
 	siemens_coeff = 0
 	punchdamagelow = 5
 	punchdamagehigh = 14
@@ -87,9 +87,9 @@
 	name = "Diamond Golem"
 	id = "diamond golem"
 	fixed_mut_color = "0ff"
-	armor = 70 //up from 55
+	armor = list(melee = 80, bullet = 80, laser = 60, energy = 0, bomb = 80, bio = 100, rad = 100, fire = 100, acid = 0)
 	meat = /obj/item/weapon/ore/diamond
-	info_text = "As a <span class='danger'>Diamond Golem</span>, you are more resistant than the average golem."
+	info_text = "As a <span class='danger'>Diamond Golem</span>, you are far more resistant than the average golem."
 	prefix = "Diamond"
 	special_names = list("Back")
 
@@ -99,7 +99,7 @@
 	id = "gold golem"
 	fixed_mut_color = "cc0"
 	speedmod = 1
-	armor = 25 //down from 55
+	armor = list(melee = 45, bullet = 45, laser = 45, energy = 0, bomb = 40, bio = 100, rad = 100, fire = 100, acid = 0)
 	meat = /obj/item/weapon/ore/gold
 	info_text = "As a <span class='danger'>Gold Golem</span>, you are faster but less resistant than the average golem."
 	prefix = "Golden"
@@ -196,8 +196,8 @@
 	fixed_mut_color = "49311c"
 	meat = /obj/item/stack/sheet/mineral/wood
 	//Can burn and take damage from heat
-	species_traits = list(NOBREATH,RESISTCOLD,RESISTPRESSURE,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NODISMEMBER,MUTCOLORS,NO_UNDERWEAR)
-	armor = 30
+	species_traits = list(NOBREATH,RESISTCOLD,RESISTPRESSURE,NOGUNS,NOBLOOD,PIERCEIMMUNE,NODISMEMBER,MUTCOLORS,NO_UNDERWEAR)
+	armor = list(melee = 40, bullet = 40, laser = 20, energy = 0, bomb = 30, bio = 0, rad = 0, fire = -20, acid = 0)
 	burnmod = 1.25
 	heatmod = 1.5
 	info_text = "As a <span class='danger'>Wooden Golem</span>, you have plant-like traits: you take damage from extreme temperatures, can be set on fire, and have lower armor than a normal golem. You regenerate when in the light and wither in the darkness."
@@ -270,9 +270,8 @@
 	id = "sand golem"
 	fixed_mut_color = "ffdc8f"
 	meat = /obj/item/weapon/ore/glass //this is sand
-	armor = 0
+	armor = list(melee = 80, bullet = 0, laser = 0, energy = 0, bomb = -100, bio = 100, rad = 100, fire = 0, acid = 0)
 	burnmod = 3 //melts easily
-	brutemod = 0.25
 	info_text = "As a <span class='danger'>Sand Golem</span>, you are immune to physical bullets and take very little brute damage, but are extremely vulnerable to burn damage. You will also turn to sand when dying, preventing any form of recovery."
 	attack_sound = 'sound/effects/shovel_dig.ogg'
 	prefix = "Sand"
@@ -300,7 +299,7 @@
 	id = "glass golem"
 	fixed_mut_color = "5a96b4aa" //transparent body
 	meat = /obj/item/weapon/shard
-	armor = 0
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = -100, bio = 100, rad = 100, fire = 100, acid = 100)
 	brutemod = 3 //very fragile
 	burnmod = 0.25
 	info_text = "As a <span class='danger'>Glass Golem</span>, you reflect lasers and energy weapons, and are very resistant to burn damage, but you are extremely vulnerable to brute damage. On death, you'll shatter beyond any hope of recovery."
@@ -556,7 +555,7 @@
 	sexes = FALSE
 	info_text = "As a <span class='danger'>Cloth Golem</span>, you are able to reform yourself after death, provided your remains aren't burned or destroyed. You are, of course, very flammable."
 	species_traits = list(NOBREATH,RESISTCOLD,RESISTPRESSURE,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NODISMEMBER,NO_UNDERWEAR) //no mutcolors, and can burn
-	armor = 15 //feels no pain, but not too resistant
+	armor = list(melee = 10, bullet = 40, laser = 10, energy = 0, bomb = 50, bio = 100, rad = 100, fire = -50, acid = 0)
 	burnmod = 2 // don't get burned
 	speedmod = 1 // not as heavy as stone
 	punchdamagelow = 4

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -270,8 +270,9 @@
 	id = "sand golem"
 	fixed_mut_color = "ffdc8f"
 	meat = /obj/item/weapon/ore/glass //this is sand
-	armor = list(melee = 80, bullet = 0, laser = 0, energy = 0, bomb = -100, bio = 100, rad = 100, fire = 0, acid = 0)
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = -100, bio = 100, rad = 100, fire = 0, acid = 0)
 	burnmod = 3 //melts easily
+	brutemod = 0.25
 	info_text = "As a <span class='danger'>Sand Golem</span>, you are immune to physical bullets and take very little brute damage, but are extremely vulnerable to burn damage. You will also turn to sand when dying, preventing any form of recovery."
 	attack_sound = 'sound/effects/shovel_dig.ogg'
 	prefix = "Sand"

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -8,7 +8,7 @@
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/slime
 	exotic_blood = "slimejelly"
 	damage_overlay_type = ""
-	armor = list(melee = 0, bullet = 0, laser = 30, energy = 20, bomb = 40, bio = 0, rad = 0, fire = 0, acid = 0) //jelly absorbs shockwaves and electric shocks
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 30, "energy" = 20, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0) //jelly absorbs shockwaves and electric shocks
 	var/datum/action/innate/regenerate_limbs/regenerate_limbs
 
 /datum/species/jelly/on_species_loss(mob/living/carbon/C)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -4,10 +4,11 @@
 	id = "jelly"
 	default_color = "00FF90"
 	say_mod = "chirps"
-	species_traits = list(MUTCOLORS,EYECOLOR,NOBLOOD,VIRUSIMMUNE,TOXINLOVER)
+	species_traits = list(MUTCOLORS,EYECOLOR,NOBLOOD,VIRUSIMMUNE,TOXINLOVER,EASYDISMEMBER)
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/slime
 	exotic_blood = "slimejelly"
 	damage_overlay_type = ""
+	armor = list(melee = 0, bullet = 0, laser = 30, energy = 20, bomb = 40, bio = 0, rad = 0, fire = 0, acid = 0) //jelly absorbs shockwaves and electric shocks
 	var/datum/action/innate/regenerate_limbs/regenerate_limbs
 
 /datum/species/jelly/on_species_loss(mob/living/carbon/C)
@@ -99,7 +100,7 @@
 	name = "Slimeperson"
 	id = "slime"
 	default_color = "00FFFF"
-	species_traits = list(MUTCOLORS,EYECOLOR,HAIR,FACEHAIR,NOBLOOD,VIRUSIMMUNE, TOXINLOVER)
+	species_traits = list(MUTCOLORS,EYECOLOR,HAIR,FACEHAIR,NOBLOOD,VIRUSIMMUNE,TOXINLOVER,EASYDISMEMBER)
 	say_mod = "says"
 	hair_color = "mutcolor"
 	hair_alpha = 150

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -5,7 +5,7 @@
 	say_mod = "rattles"
 	blacklisted = 1
 	sexes = 0
-	armor = list("melee" = -40, "bullet" = -40, "laser" = -20, "energy" = 10, "bomb" = -40, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
+	armor = list("melee" = -30, "bullet" = -30, "laser" = -15, "energy" = 10, "bomb" = -30, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton
 	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NOHUNGER,EASYDISMEMBER,EASYLIMBATTACHMENT)
 	mutant_organs = list(/obj/item/organ/tongue/bone)

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -5,7 +5,7 @@
 	say_mod = "rattles"
 	blacklisted = 1
 	sexes = 0
-	armor = list(melee = -40, bullet = -40, laser = -20, energy = 10, bomb = -40, bio = 100, rad = 100, fire = 100, acid = 0)
+	armor = list("melee" = -40, "bullet" = -40, "laser" = -20, "energy" = 10, "bomb" = -40, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton
 	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NOHUNGER,EASYDISMEMBER,EASYLIMBATTACHMENT)
 	mutant_organs = list(/obj/item/organ/tongue/bone)
@@ -20,9 +20,11 @@
 			return 2
 	return 0
 
-/datum/species/skeleton/spec_life(mob/living/carbon/human/H)
+/datum/species/skeleton/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
+	if(chem.id == "milk") //strong bones and calcium
+		armor = list("melee" = 10, "bullet" = 10, "laser" = 0, "energy" = 10, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)
 	..()
-	if(H.has_reagent("milk")) //strong bones and calcium
-		armor = list(melee = 10, bullet = 10, laser = 0, energy = 10, bomb = 0, bio = 100, rad = 100, fire = 100, acid = 0)
-	else
-		armor = initial(armor)
+
+/datum/species/skeleton/delete_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
+	if(chem.id == "milk")
+		armor = list("melee" = -40, "bullet" = -40, "laser" = -20, "energy" = 10, "bomb" = -40, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 0)

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -19,3 +19,10 @@
 			"<span class='userdanger'>The [P.name] passes between [H]'s bones, missing [H.p_them()]!</span>")
 			return 2
 	return 0
+
+/datum/species/skeleton/spec_life(mob/living/carbon/human/H)
+	..()
+	if(H.has_reagent("milk")) //strong bones and calcium
+		armor = list(melee = 10, bullet = 10, laser = 0, energy = 10, bomb = 0, bio = 100, rad = 100, fire = 100, acid = 0)
+	else
+		armor = initial(armor)

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -5,7 +5,17 @@
 	say_mod = "rattles"
 	blacklisted = 1
 	sexes = 0
+	armor = list(melee = -40, bullet = -40, laser = -20, energy = 10, bomb = -40, bio = 100, rad = 100, fire = 100, acid = 0)
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton
 	species_traits = list(NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE,NOHUNGER,EASYDISMEMBER,EASYLIMBATTACHMENT)
 	mutant_organs = list(/obj/item/organ/tongue/bone)
 	damage_overlay_type = ""//let's not show bloody wounds or burns over bones.
+
+/datum/species/skeleton/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+	if(!(P.original == H && P.firer == H))
+		if(prob(25) && (P.flag == "bullet" || P.flag == "laser"))
+			playsound(H, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
+			H.visible_message("<span class='danger'>The [P.name] passes between [H]'s bones, missing [H.p_them()]!</span>", \
+			"<span class='userdanger'>The [P.name] passes between [H]'s bones, missing [H.p_them()]!</span>")
+			return 2
+	return 0

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -441,6 +441,10 @@
 			if(my_atom && isliving(my_atom))
 				var/mob/living/M = my_atom
 				R.on_mob_delete(M)
+				if(ishuman(M))
+					var/mob/living/carbon/human/H = M
+					if(H.dna && H.dna.species)
+						H.dna.species.delete_chemicals(R, H)
 			qdel(R)
 			reagent_list -= R
 			update_total()


### PR DESCRIPTION
:cl: XDTM
balance: Species armor has been rebalanced:
balance: Abductors are slightly more resistant to energy weapons and biological weapons.
balance: Androids are now radiation immune, and are slightly more resistant to melee, bullet and bomb damage, but are more affected by energy weapons.
balance: Flypeople take slightly more bullet and melee damage, but are more resistant to biological weapons.
balance: Golems no longer have a 55% reduction to all damage. They're now slightly more resistant to bullet, melee and bomb damage but much less resistant (but still resistant) to laser damage. Diamond, gold and wood golems have the same pattern, with higher, and lower values respectively.
balance: Sand and Glass golems are very weak against bomb damage.
balance: Slime and jelly people are now resistant to lasers, energy, and bomb damage, but are much easier to dismember. (No bones, after all)
balance: Skeletons now take increased damage from lasers and much increased damage from melee, bullets and bombs. However, there is a chance that bullets may pass through them harmlessly.
balance: Skeletons have instead increased armor if they have milk in their system.
/:cl:

All values are not final, i'll undo any controversial balance changes.
