### PR TITLE
Adds the Human Language

### DIFF
--- a/code/modules/language/human.dm
+++ b/code/modules/language/human.dm
@@ -7,7 +7,8 @@
 	key = "v"
 	space_chance = 10
 	syllables = list("hamburger", "cheeseburger", "freedom", "USA", "commie", "fuck",
-					"shit", "motherfucker", "asshole", "god", "otaku", "weeaboo",
+					"shit", "motherfucker", "asshole", "god", "gun", "won", "both", "wars", "MAGA",
+					"otaku", "weeaboo",
 					"waifu", "neko", "kawaii", "uguu", "-kun", "-san")
 	default_priority = 80
 	icon_state = "human"

--- a/code/modules/language/human.dm
+++ b/code/modules/language/human.dm
@@ -1,0 +1,13 @@
+/datum/language/human
+	name = "Human"
+	desc = "The native language of Humans, hailing from Japanifornia."
+	speech_verb = "says"
+	ask_verb = "asks"
+	exclaim_verb = "exclaims"
+	key = "v"
+	space_chance = 10
+	syllables = list("hamburger", "cheeseburger", "freedom", "USA", "commie", "fuck",
+					"shit", "motherfucker", "asshole", "god", "otaku", "weeaboo",
+					"waifu", "neko", "kawaii", "uguu", "-kun", "-san")
+	default_priority = 80
+	icon_state = "human"

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -9,6 +9,9 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 
 
+/datum/species/human/after_equip_job(datum/job/J, mob/living/carbon/human/H)
+	H.grant_language(/datum/language/human)
+
 /datum/species/human/qualifies_for_rank(rank, list/features)
 	return TRUE	//Pure humans are always allowed in all roles.
 

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -37,7 +37,7 @@
 
 /obj/item/organ/tongue/can_speak_in_language(datum/language/dt)
 	if(istype(src, /obj/item/organ/tongue/lizard) && istype(dt, /datum/language/human))
-		return false
+		return FALSE
 	. = is_type_in_typecache(dt, languages_possible)
 
 /obj/item/organ/tongue/lizard

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -15,7 +15,8 @@
 		/datum/language/common,
 		/datum/language/draconic,
 		/datum/language/monkey,
-		/datum/language/ratvar
+		/datum/language/ratvar,
+		/datum/language/human
 	))
 
 /obj/item/organ/tongue/get_spans()
@@ -35,6 +36,8 @@
 		M.dna.species.say_mod = initial(M.dna.species.say_mod)
 
 /obj/item/organ/tongue/can_speak_in_language(datum/language/dt)
+	if(istype(src, /obj/item/organ/tongue/lizard) && istype(dt, /datum/language/human))
+		return false
 	. = is_type_in_typecache(dt, languages_possible)
 
 /obj/item/organ/tongue/lizard

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1379,6 +1379,7 @@
 #include "code\modules\language\common.dm"
 #include "code\modules\language\draconic.dm"
 #include "code\modules\language\drone.dm"
+#include "code\modules\language\human.dm"
 #include "code\modules\language\language.dm"
 #include "code\modules\language\language_menu.dm"
 #include "code\modules\language\machine.dm"


### PR DESCRIPTION
The language is added as part of the job equipping code, changing your
species to Human via xenobio will not magically teach you the language.
Normal human tongues are capable of speaking Human.
pAIs with translator and Librarians are capable of speaking and
understanding Human

This is to increase diversity and roleplay in SS13.