### PR TITLE
Refactors how diagonal smoothing underlays work

### DIFF
--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -167,23 +167,14 @@
 				underlay_appearance.icon = fixed_underlay["icon"]
 				underlay_appearance.icon_state = fixed_underlay["icon_state"]
 		else
-			var/turf/T = get_step(src, turn(adjacencies, 180))
-			if(T && (T.density || T.smooth))
+			var/turned_adjacency = turn(adjacencies, 180)
+			var/turf/T = get_step(src, turned_adjacency)
+			if(!T.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
 				T = get_step(src, turn(adjacencies, 135))
-				if(T && (T.density || T.smooth))
+				if(!T.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
 					T = get_step(src, turn(adjacencies, 225))
-
-			if(isspaceturf(T) && !istype(T, /turf/open/space/transit))
-				underlay_appearance.icon = 'icons/turf/space.dmi'
-				underlay_appearance.icon_state = SPACE_ICON_STATE
-				underlay_appearance.plane = PLANE_SPACE
-			else if(T && !T.density && !T.smooth)
-				underlay_appearance.icon = T.icon
-				underlay_appearance.icon_state = T.icon_state
-			else if(baseturf && !initial(baseturf.density) && !initial(baseturf.smooth))
-				underlay_appearance.icon = initial(baseturf.icon)
-				underlay_appearance.icon_state = initial(baseturf.icon_state)
-			else
+			//if all else fails, ask our own turf
+			if(!T.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency) && !get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
 				underlay_appearance.icon = DEFAULT_UNDERLAY_ICON
 				underlay_appearance.icon_state = DEFAULT_UNDERLAY_ICON_STATE
 		underlays = U

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -5,6 +5,9 @@
 	density = 1
 	blocks_air = 1
 
+/turf/closed/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	return FALSE
+
 /turf/closed/indestructible
 	name = "wall"
 	icon = 'icons/turf/walls.dmi'
@@ -110,6 +113,11 @@
 	icon_state = "necro"
 	explosion_block = 50
 	baseturf = /turf/closed/indestructible/necropolis
+
+/turf/closed/indestructible/necropolis/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = 'icons/turf/floors.dmi'
+	underlay_appearance.icon_state = "necro1"
+	return TRUE
 
 /turf/closed/indestructible/riveted/hierophant
 	name = "wall"

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -45,6 +45,9 @@
 
 /turf/open/indestructible/hierophant/two
 
+/turf/open/indestructible/hierophant/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	return FALSE
+
 /turf/open/indestructible/paper
 	name = "notebook floor"
 	desc = "A floor made of invulnerable notebook paper."

--- a/code/game/turfs/simulated/chasm.dm
+++ b/code/game/turfs/simulated/chasm.dm
@@ -22,6 +22,10 @@
 	if(!drop_stuff())
 		STOP_PROCESSING(SSobj, src)
 
+/turf/open/chasm/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = 'icons/turf/floors.dmi'
+	underlay_appearance.icon_state = "basalt"
+	return TRUE
 
 /turf/open/chasm/attackby(obj/item/C, mob/user, params, area/area_restriction)
 	..()
@@ -170,6 +174,11 @@
 	icon = 'icons/turf/floors/junglechasm.dmi'
 	planetary_atmos = TRUE
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+
+/turf/open/chasm/jungle/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = 'icons/turf/floors.dmi'
+	underlay_appearance.icon_state = "dirt"
+	return TRUE
 
 /turf/open/chasm/straight_down/jungle
 	icon = 'icons/turf/floors/junglechasm.dmi'

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -140,7 +140,7 @@
 	floor_tile = /obj/item/stack/tile/carpet
 	broken_states = list("damaged")
 	smooth = SMOOTH_TRUE
-	canSmoothWith = list(/turf/open/floor/carpet, /turf/open/chasm)
+	canSmoothWith = list(/turf/open/floor/carpet)
 	flags = NONE
 
 /turf/open/floor/carpet/Initialize()
@@ -175,14 +175,21 @@
 	burnt = 1
 	update_icon()
 
+/turf/open/floor/carpet/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	return FALSE
 
 
-turf/open/floor/fakepit
+/turf/open/floor/fakepit
 	desc = "A clever illusion designed to look like a bottomless pit."
 	smooth = SMOOTH_TRUE | SMOOTH_BORDER | SMOOTH_MORE
-	canSmoothWith = list(/turf/open/floor/fakepit, /turf/open/chasm)
+	canSmoothWith = list(/turf/open/floor/fakepit)
 	icon = 'icons/turf/floors/Chasms.dmi'
 	icon_state = "smooth"
+
+/turf/open/floor/fakepit/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = 'icons/turf/floors.dmi'
+	underlay_appearance.icon_state = "basalt"
+	return TRUE
 
 /turf/open/floor/fakespace
 	icon = 'icons/turf/space.dmi'
@@ -193,4 +200,10 @@ turf/open/floor/fakepit
 
 /turf/open/floor/fakespace/Initialize()
 	..()
-	icon_state = "[rand(0,25)]"
+	icon_state = SPACE_ICON_STATE
+
+/turf/open/floor/fakespace/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = 'icons/turf/space.dmi'
+	underlay_appearance.icon_state = SPACE_ICON_STATE
+	underlay_appearance.plane = PLANE_SPACE
+	return TRUE

--- a/code/game/turfs/simulated/floor/plating/lava.dm
+++ b/code/game/turfs/simulated/floor/plating/lava.dm
@@ -38,6 +38,11 @@
 /turf/open/floor/plating/lava/make_plating()
 	return
 
+/turf/open/floor/plating/lava/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = 'icons/turf/floors.dmi'
+	underlay_appearance.icon_state = "basalt"
+	return TRUE
+
 /turf/open/floor/plating/lava/GetHeatCapacity()
 	. = 700000
 

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -26,7 +26,7 @@
 
 /turf/closed/mineral/Initialize()
 	if (!canSmoothWith)
-		canSmoothWith = list(/turf/closed)
+		canSmoothWith = list(/turf/closed/mineral, /turf/closed/indestructible)
 	pixel_y = -4
 	pixel_x = -4
 	icon = smooth_icon
@@ -41,6 +41,13 @@
 /turf/closed/mineral/shuttleRotate(rotation)
 	setDir(angle2dir(rotation+dir2angle(dir)))
 	queue_smooth(src)
+
+/turf/closed/mineral/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	if(turf_type)
+		underlay_appearance.icon = initial(turf_type.icon)
+		underlay_appearance.icon_state = initial(turf_type.icon_state)
+		return TRUE
+	return ..()
 
 
 /turf/closed/mineral/attackby(obj/item/weapon/pickaxe/P, mob/user, params)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -160,6 +160,12 @@
 /turf/open/space/acid_act(acidpwr, acid_volume)
 	return 0
 
+/turf/open/space/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = 'icons/turf/space.dmi'
+	underlay_appearance.icon_state = SPACE_ICON_STATE
+	underlay_appearance.plane = PLANE_SPACE
+	return TRUE
+
 
 /turf/open/space/rcd_vals(mob/user, obj/item/weapon/construction/rcd/the_rcd)
 	if(!CanBuildHere())

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -4,6 +4,11 @@
 	baseturf = /turf/open/space/transit
 	flags = NOJAUNT //This line goes out to every wizard that ever managed to escape the den. I'm sorry.
 
+/turf/open/space/transit/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	. = ..()
+	underlay_appearance.icon_state = "speedspace_ns_[get_transit_state(asking_turf)]"
+	underlay_appearance.transform = turn(matrix(), get_transit_angle(asking_turf))
+
 /turf/open/space/transit/south
 	dir = SOUTH
 
@@ -69,25 +74,32 @@
 		throw_atom(AM)
 
 /turf/open/space/transit/proc/update_icon()
-	var/p = 9
-	var/angle = 0
-	var/state = 1
-	switch(dir)
-		if(NORTH)
-			angle = 180
-			state = ((-p*x+y) % 15) + 1
-			if(state < 1)
-				state += 15
-		if(EAST)
-			angle = 90
-			state = ((x+p*y) % 15) + 1
-		if(WEST)
-			angle = -90
-			state = ((x-p*y) % 15) + 1
-			if(state < 1)
-				state += 15
-		else
-			state =	((p*x+y) % 15) + 1
+	icon_state = "speedspace_ns_[get_transit_state(src)]"
+	transform = turn(matrix(), get_transit_angle(src))
 
-	icon_state = "speedspace_ns_[state]"
-	transform = turn(matrix(), angle)
+/proc/get_transit_state(turf/T)
+	var/p = 9
+	. = 1
+	switch(T.dir)
+		if(NORTH)
+			. = ((-p*T.x+T.y) % 15) + 1
+			if(. < 1)
+				. += 15
+		if(EAST)
+			. = ((T.x+p*T.y) % 15) + 1
+		if(WEST)
+			. = ((T.x-p*T.y) % 15) + 1
+			if(. < 1)
+				. += 15
+		else
+			. = ((p*T.x+T.y) % 15) + 1
+
+/proc/get_transit_angle(turf/T)
+	. = 0
+	switch(T.dir)
+		if(NORTH)
+			. = 180
+		if(EAST)
+			. = 90
+		if(WEST)
+			. = -90

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -394,6 +394,12 @@
 		if(ismob(A) || .)
 			A.ratvar_act()
 
+/turf/proc/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = icon
+	underlay_appearance.icon_state = icon_state
+	underlay_appearance.dir = adjacency_dir
+	return TRUE
+
 /turf/proc/add_blueprints(atom/movable/AM)
 	var/image/I = new
 	I.appearance = AM.appearance

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -217,6 +217,7 @@
 /area/survivalpod
 	name = "\improper Emergency Shelter"
 	icon_state = "away"
+	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	requires_power = 0
 	has_gravity = 1
 
@@ -394,7 +395,9 @@
 	icon = 'icons/obj/lavaland/donkvendor.dmi'
 	icon_on = "donkvendor"
 	icon_off = "donkvendor"
-	luminosity = 8
+	light_range = 5
+	light_power = 1.2
+	light_color = "#DDFFD3"
 	max_n_of_items = 10
 	pixel_y = -4
 	flags = NODECONSTRUCT


### PR DESCRIPTION
Fixes a bug where diagonal shuttle turfs didn't have the right icon
![](http://puu.sh/w0eiN/e750dfbf82.png)

Tweaked rock to no longer smooth with most turfs
![](http://puu.sh/w0etd/983bdc3708.png)
![](http://puu.sh/w0eCN/86904fca79.png)
Fixes #27437
Survival capsules now properly use and have lighting
![](http://puu.sh/w0exs/73f0f3c35a.png)