### PR TITLE
Makes shades/constructs able to speak galcommon again

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -89,7 +89,6 @@
 
 /datum/language_holder/construct
 	languages = list(/datum/language/common, /datum/language/narsie)
-	only_speaks_language = /datum/language/narsie
 
 /datum/language_holder/drone
 	languages = list(/datum/language/common, /datum/language/drone, /datum/language/machine)


### PR DESCRIPTION
:cl: Kor
fix: The chaplains possessed blade, shades, and constructs, can once again speak galactic common.
/:cl:

Shades are not a cult only entity (chaplains, miners, wizards all come into contact with them) so it doesn't make sense to restrict them to speaking a cult only language.