### PR TITLE
Vapes are tiny

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -622,6 +622,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon = 'icons/obj/clothing/masks.dmi'
 	icon_state = null
 	item_state = null
+	w_class = WEIGHT_CLASS_TINY
 	var/chem_volume = 100
 	var/vapetime = 0 //this so it won't puff out clouds every tick
 	var/screw = 0 // kinky


### PR DESCRIPTION
:cl:
tweak: E-Cigarettes can now fit in your pocket.
/:cl:

It's kind of weird that they couldn't fit in your pocket to begin with. Now they're the same size as other smoking items.