### PR TITLE
ID card mapping aid

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -87,7 +87,7 @@
 
 
 
-/obj/item/weapon/card/id/Initalize(mapload)
+/obj/item/weapon/card/id/Initialize(mapload)
 	. = ..()
 	if(mapload)
 		access = text2access(access_txt)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -83,6 +83,14 @@
 	var/list/access = list()
 	var/registered_name = null // The name registered_name on the card
 	var/assignment = null
+	var/access_txt // mapping aid
+
+
+
+/obj/item/weapon/card/id/Initalize(mapload)
+	. = ..()
+	if(mapload)
+		access = text2access(access_txt)
 
 /obj/item/weapon/card/id/attack_self(mob/user)
 	user.visible_message("<span class='notice'>[user] shows you: \icon[src] [src.name].</span>", \

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -136,26 +136,23 @@ GLOBAL_VAR_CONST(access_away_generic4, 208)
 /obj/item/proc/GetID()
 	return null
 
+/obj/proc/text2access(access_text)
+	. = list()
+	if(!access_text)
+		return
+	var/list/split = splittext(access_text,";")
+	for(var/x in split)
+		var/n = text2num(x)
+		if(n)
+			. += n
+
 //Call this before using req_access or req_one_access directly
 /obj/proc/gen_access()
 	//These generations have been moved out of /obj/New() because they were slowing down the creation of objects that never even used the access system.
-	if(!src.req_access)
-		src.req_access = list()
-		if(src.req_access_txt)
-			var/list/req_access_str = splittext(req_access_txt,";")
-			for(var/x in req_access_str)
-				var/n = text2num(x)
-				if(n)
-					req_access += n
-
-	if(!src.req_one_access)
-		src.req_one_access = list()
-		if(src.req_one_access_txt)
-			var/list/req_one_access_str = splittext(req_one_access_txt,";")
-			for(var/x in req_one_access_str)
-				var/n = text2num(x)
-				if(n)
-					req_one_access += n
+	for(var/a in text2access(req_access_txt))
+		req_access += a
+	for(var/b in text2access(req_one_access_txt))
+		req_one_access += b
 
 /obj/proc/check_access(obj/item/I)
 	gen_access()


### PR DESCRIPTION
Allows placing id cards with custom accesses on the map without making a subtype.

@WJohn 