### PR TITLE
Dog beds can now be renamed after new owners

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -161,7 +161,7 @@
 	anchored = 0
 	buildstacktype = /obj/item/stack/sheet/mineral/wood
 	buildstackamount = 10
-	var/owner = ""
+	var/mob/living/owner = null
 
 /obj/structure/bed/dogbed/proc/update_owner(mob/living/M)
 	owner = M

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -161,6 +161,16 @@
 	anchored = 0
 	buildstacktype = /obj/item/stack/sheet/mineral/wood
 	buildstackamount = 10
+	var/owner = ""
+
+/obj/structure/bed/dogbed/proc/update_owner(mob/living/M)
+	owner = M
+	name = "[M]'s bed"
+	desc = "[M]'s bed! Looks comfy."
+
+/obj/structure/bed/dogbed/buckle_mob(mob/living/M, force, check_loc)
+	. = ..()
+	update_owner(M)
 
 
 /obj/structure/bed/alien

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -172,7 +172,6 @@
 	. = ..()
 	update_owner(M)
 
-
 /obj/structure/bed/alien
 	name = "resting contraption"
 	desc = "This looks similar to contraptions from earth. Could aliens be stealing our technology?"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -276,11 +276,6 @@
 		var/datum/dog_fashion/DF = new inventory_back.dog_fashion(src)
 		DF.apply(src)
 
-	//if(name != real_name)
-	//	var/dogarea = getarea(src)
-	//		for(obj/structure/dogbed/D in dogarea)
-	//			dogbed.name = "[src]'s bed"
-
 //IAN! SQUEEEEEEEEE~
 /mob/living/simple_animal/pet/dog/corgi/Ian
 	name = "Ian"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -43,6 +43,13 @@
 	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab/pug = 3)
 	gold_core_spawnable = 2
 
+/mob/living/simple_animal/pet/dog/Initialize()
+	var/dog_area = get_area(src)
+	for(var/obj/structure/bed/dogbed/D in dog_area)
+		if(!D.owner)
+			D.update_owner(src)
+			break
+
 /mob/living/simple_animal/pet/dog/corgi/Initialize()
 	..()
 	regenerate_icons()
@@ -268,6 +275,11 @@
 	if(inventory_back && inventory_back.dog_fashion)
 		var/datum/dog_fashion/DF = new inventory_back.dog_fashion(src)
 		DF.apply(src)
+
+	//if(name != real_name)
+	//	var/dogarea = getarea(src)
+	//		for(obj/structure/dogbed/D in dogarea)
+	//			dogbed.name = "[src]'s bed"
 
 //IAN! SQUEEEEEEEEE~
 /mob/living/simple_animal/pet/dog/corgi/Ian


### PR DESCRIPTION
:cl: cacogen
add: You can now rename dog beds by buckling a new owner to them
add: Dogs that spawn in an area with a vacant bed will take possession of and rename the bed
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 

I noticed during HoP rounds that when you rename Ian with the collar in your locker the name on his bed stays the same. 

This pull makes it so by buckling the renamed dog to the bed you can rename the bed after it (e.g. "Lieutenant Ian's bed"). It updates the description as well.

The renaming works for any living mob, so if you buckle a human to it (such as one that killed Ian) the bed will be renamed after your new pet.

This also automatically renames a vacant bed when a dog spawns in the same area as it.

I have no idea if this code is any good so I'd appreciate feedback.