### PR TITLE
Adds AI follow links to PDA messages and holopad speech

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -632,7 +632,14 @@ GLOBAL_LIST_EMPTY(PDAs)
 		L = get(src, /mob/living/silicon)
 
 	if(L && L.stat != UNCONSCIOUS)
-		to_chat(L, "\icon[src] <b>Message from [source.owner] ([source.ownjob]), </b>\"[msg.message]\"[msg.get_photo_ref()] (<a href='byond://?src=\ref[src];choice=Message;skiprefresh=1;target=\ref[source]'>Reply</a>)")
+
+		var/hrefstart
+		var/hrefend
+		if (isAI(L))
+			hrefstart = "<a href='?src=\ref[L];track=[html_encode(source.owner)]'>"
+			hrefend = "</a>"
+
+		to_chat(L, "\icon[src.icon] <b>Message from [hrefstart][source.owner] ([source.ownjob])[hrefend], </b>\"[msg.message]\"[msg.get_photo_ref()] (<a href='byond://?src=\ref[src];choice=Message;skiprefresh=1;target=\ref[source]'>Reply</a>)")
 
 	update_icon()
 	add_overlay(icon_alert)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -832,8 +832,20 @@
 
 /mob/living/silicon/ai/proc/relay_speech(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
 	raw_message = lang_treat(speaker, message_language, raw_message, spans, message_mode)
-	var/name_used = speaker.GetVoice()
-	var/rendered = "<i><span class='game say'>Relayed Speech: <span class='name'>[name_used]</span> <span class='message'>[raw_message]</span></span></i>"
+	var/start = "Relayed Speech: "
+	var/namepart = "[speaker.GetVoice()][speaker.get_alt_name()]"
+	var/hrefpart = "<a href='?src=\ref[src];track=[html_encode(namepart)]'>"
+	var/jobpart
+
+	if (iscarbon(speaker))
+		var/mob/living/carbon/S = speaker
+		if(S.job)
+			jobpart = "[S.job]"
+	else
+		jobpart = "Unknown"
+
+	var/rendered = "<i><span class='game say'>[start]<span class='name'>[hrefpart][namepart] ([jobpart])</a> </span><span class='message'>[raw_message]</span></span></i>"
+
 	show_message(rendered, 2)
 
 /mob/living/silicon/ai/fully_replace_character_name(oldname,newname)


### PR DESCRIPTION
:cl: cacogen
add: Adds AI follow links to holopad speech and PDA messages. Note that PDA messages point to the owner of the PDA and not the PDA's actual location.
bugfix: Fixes PDA icon not showing up beside received messages for AIs
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
I've wanted these for years. It's annoying having someone PDA message you asking for a door only to have to find them in the tracking list because you can't just click their name to follow them.

Similarly it'd be nice to be able to jump back to people you've spoken to via holopad after panning away to do something for them.

Not sure about the code, took ages for me to figure out how to do this (and how to test it with only one person). 

Incidentally, sending messages to yourself as an AI using the message monitor console doesn't result in the message being printed to the chat window for some reason. I couldn't figure out how to fix it. If you're a human you get the message just fine.

Also if you're a mime and you send a message to yourself using the message monitor console you get no alert at all (your PDA is completely silent) yet you do when you receive messages from other PDAs. Wish I knew what caused this.