### PR TITLE
Adds a new guideline about gameplay and roleplay to the codebase.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -311,6 +311,8 @@ There is no strict process when it comes to merging pull requests, pull requests
 
 * Please explain why you are submitting the pull request, and how you think your change will be beneficial to the game. Failure to do so will be grounds for rejecting the PR.
 
+* Space Station 13 is often referred to as an RPG, similar to other table-top die rolling games focused on roleplay. Something important to remember is that despite the fact that die rolling table top games have lots of complex lore, they still have to focus on the gameplay ahead of that, lest they run into balancing issues from putting the lore ahead of the gameplay. Please try to justify your changes via the actual gameplay impacts(if it has any), instead of arguing about the lore.
+
 ## Banned content
 Do not add any of the following in a Pull Request or risk getting the PR closed:
 * National Socialist Party of Germany content, National Socialist Party of Germany related content, or National Socialist Party of Germany references


### PR DESCRIPTION
Even games like Final Fantasy with years upon years of lore have to draw the line at some point.

As a case study, let's look at Doom or Death spells in Final Fantasy.

The descriptions for them often imply you can kill literally anything with these spells, but this is not the case, despite the lore stating it.

Imagine how easy those games would be if you could just cast Death or Doom on every boss. The lore says you should be able to. Some of the bosses are just guys with extra ranks in the military or something, not all of them are super dimensional beings and gods and stuff. But you still can't cast death or doom on them.