### PR TITLE
Fixes pre-round-start logs

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -18,7 +18,7 @@
 
 	SetupExternalRSC()
 
-	GLOB.config_error_log = file("data/logs/config_error.log") //temporary file used to record errors with loading config, moved to log directory once logging is set bl
+	GLOB.config_error_log = GLOB.world_href_log = GLOB.world_runtime_log = GLOB.world_attack_log = GLOB.world_game_log = file("data/logs/config_error.log") //temporary file used to record errors with loading config, moved to log directory once logging is set bl
 
 	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
 


### PR DESCRIPTION
Make it so all logs point to the temp log at world start so we can see other errors.