### PR TITLE
Emagging a cloner drops bits, cloners don't keep extra flesh

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -358,8 +358,12 @@
 /obj/machinery/clonepod/proc/go_out()
 	countdown.stop()
 	var/mob/living/mob_occupant = occupant
+	var/turf/T = get_turf(src)
 
 	if(mess) //Clean that mess and dump those gibs!
+		for(var/obj/fl in unattached_flesh)
+			fl.forceMove(T)
+		unattached_flesh.Cut()
 		mess = FALSE
 		new /obj/effect/gibspawner/generic(loc)
 		audible_message("<span class='italics'>You hear a splat.</span>")
@@ -375,10 +379,12 @@
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
 		mob_occupant.flash_act()
 
-	var/turf/T = get_turf(src)
 	occupant.forceMove(T)
 	icon_state = "pod_0"
 	mob_occupant.domutcheck(1) //Waiting until they're out before possible monkeyizing. The 1 argument forces powers to manifest.
+	for(var/fl in unattached_flesh)
+		qdel(fl)
+	unattached_flesh.Cut()
 
 	occupant = null
 
@@ -389,8 +395,7 @@
 		SPEAK("Critical error! Please contact a Thinktronic Systems \
 			technician, as your warranty may be affected.")
 		mess = TRUE
-		for(var/obj/item/O in unattached_flesh)
-			qdel(O)
+		maim_clone(mob_occupant)	//Remove every bit that's grown back so far to drop later, also destroys bits that haven't grown yet
 		icon_state = "pod_g"
 		if(mob_occupant.mind != clonemind)
 			clonemind.transfer_to(mob_occupant)
@@ -450,9 +455,10 @@
 	var/static/list/zones = list("r_arm", "l_arm", "r_leg", "l_leg")
 	for(var/zone in zones)
 		var/obj/item/bodypart/BP = H.get_bodypart(zone)
-		BP.drop_limb()
-		BP.forceMove(src)
-		unattached_flesh += BP
+		if(BP)
+			BP.drop_limb()
+			BP.forceMove(src)
+			unattached_flesh += BP
 
 	for(var/o in H.internal_organs)
 		var/obj/item/organ/organ = o


### PR DESCRIPTION
:cl: QualityVan
tweak: Cloning pods which are interrupted by a emagging will now produce a slightly lumpier smoothie
fix: Cloning pods that have stopped cloning early can no longer be broken open to extract leftover parts
/:cl:

Makes it so cloning pods don't leave any unattached organs/limbs in them when the occupant is removed.
Also makes it so any organs/limbs that have been reattached('grown') are re-removed when a cloning pod is emagged and then dropped to the floor whenever it's opened(any bits that haven't been reattached at time of emagging will be destroyed). Won't drop brains, heads, or torsos.

i'm writing the changelog right now coiax shut up