### PR TITLE
Puts the Viruses back in the viro fridge at the syndicate base.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -726,7 +726,7 @@
 	},
 /area/ruin/powered/syndicate_lava_base)
 "bM" = (
-/obj/machinery/smartfridge/chemistry/virology,
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/open/floor/plasteel/podhatch{
 	tag = "icon-podhatch (EAST)";
 	icon_state = "podhatch";


### PR DESCRIPTION
Refixes #27288 because #27518 undid my fix in #27289.