### PR TITLE
Fixes poweroutage event blowing up SM

### DIFF
--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -9,7 +9,7 @@
 		S.update_icon()
 		S.power_change()
 
-	var/list/skipped_areas = list(/area/engine/engineering, /area/ai_monitored/turret_protected/ai)
+	var/list/skipped_areas = list(/area/engine/engineering, /area/engine/supermatter, /area/engine/atmospherics_engine, /area/ai_monitored/turret_protected/ai)
 
 	for(var/area/A in world)
 		if( !A.requires_power || A.always_unpowered )


### PR DESCRIPTION
fixes #27732

Engineering was already blacklisted to prevent this with Lord Singuloth. SM engine has new paths and was never added, ect ect.