### PR TITLE
!!!Projectile spread tweaks!!! <-- Yes, this is a huge balance change for dualwielding!

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -231,7 +231,7 @@
 				if(randomspread)
 					sprd = round((rand() - 0.5) * (randomized_gun_spread + randomized_bonus_spread))
 				else //Smart spread
-					sprd = round((((rand_spr/burst_size) * (i/burst_size)) - (0.5 + (rand_spr * 0.25))) * (randomized_gun_spread + randomized_bonus_spread))
+					sprd = round((((rand_spr/burst_size) * i) - (0.5 + (rand_spr * 0.25))) * (randomized_gun_spread + randomized_bonus_spread))
 
 				if(!chambered.fire_casing(target, user, params, ,suppressed, zone_override, sprd))
 					shoot_with_empty_chamber(user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -214,6 +214,7 @@
 
 	var/sprd = 0
 	var/randomized_gun_spread = 0
+	var/rand_spr = rand()
 	if(spread)
 		randomized_gun_spread =	rand(0,spread)
 	var/randomized_bonus_spread = rand(0, bonus_spread)
@@ -230,7 +231,7 @@
 				if(randomspread)
 					sprd = round((rand() - 0.5) * (randomized_gun_spread + randomized_bonus_spread))
 				else //Smart spread
-					sprd = round((i / burst_size - 0.5) * (randomized_gun_spread + randomized_bonus_spread))
+					sprd = round((((rand_spr/burst_size) * (i/burst_size)) - (0.5 + (rand_spr * 0.25))) * (randomized_gun_spread + randomized_bonus_spread))
 
 				if(!chambered.fire_casing(target, user, params, ,suppressed, zone_override, sprd))
 					shoot_with_empty_chamber(user)
@@ -249,7 +250,7 @@
 		firing_burst = 0
 	else
 		if(chambered)
-			sprd = round((pick(1,-1)) * (randomized_gun_spread + randomized_bonus_spread))
+			sprd = round((rand() - 0.5) * (randomized_gun_spread + randomized_bonus_spread))
 			if(!chambered.fire_casing(target, user, params, , suppressed, zone_override, sprd))
 				shoot_with_empty_chamber(user)
 				return


### PR DESCRIPTION
Makes burst fire and non-burst fire weapons have the same amount of spread, rather than burst fire being more inaccurate.

Balance change being:

# ACCOMPLISHES THIS BY BUFFING NON BURST FIRE WEAPONS INSTEAD OF NERFING BURST FIRE WEAPONS!!

I can also do the opposite, so maintainers, please tell me which.

Also, tweaks how non random-spread weapons are calculated. The randomspread var is unused far as I know, but just in case. The var being 0 will cause spread to ALWAYS favor the right almost completely ignoring the left. This will more or less normalize it to be more or less equal between left/right.

Fixes #26510