### PR TITLE
Increase plasmaman tank volume

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -140,7 +140,7 @@
 	item_state = "plasmaman_tank_belt"
 	slot_flags = SLOT_BELT
 	force = 5
-	volume = 3
+	volume = 6
 	w_class = WEIGHT_CLASS_SMALL //thanks i forgot this
 
 /obj/item/weapon/tank/internals/plasmaman/belt/full/New()


### PR DESCRIPTION
:cl: Nanotrasen Plasmaman Outreach Division
tweak: plasmaman tank volume has been increased from 3 to 6.
/:cl:

[why]: I thought it wouldn't be a problem, but only having 15-25 minutes worth of plasma is a bit too harsh, especially when the volume used to be 70
