### PR TITLE
Fix NOPOWER being set incorrectly for holopads

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -73,7 +73,7 @@ Possible to do for anyone motivated enough:
 	if (powered())
 		stat &= ~NOPOWER
 	else
-		stat |= ~NOPOWER
+		stat |= NOPOWER
 		if(outgoing_call)
 			outgoing_call.ConnectionFailure(src)
 


### PR DESCRIPTION
Instead of setting NOPOWER it was setting all stat flags but NOPOWER,
this had a similar effect in that the holopad would stop working, but
would lead to it not working when power was restored either, as it was
now seen as fully broken

Fixes #27833 