### PR TITLE
Lavaland - Ruins now have lights

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -13,7 +13,7 @@
 "ad" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ae" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -21,44 +21,47 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "af" = (
 /obj/structure/table,
 /obj/item/clothing/mask/gas,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ag" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ah" = (
 /obj/machinery/power/smes,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ai" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aj" = (
 /turf/closed/wall/mineral/sandstone{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ak" = (
 /obj/structure/toilet,
 /obj/effect/decal/sandeffect,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "al" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -66,7 +69,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "am" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -75,13 +78,16 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "an" = (
 /obj/item/device/flashlight/lantern,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ao" = (
 /obj/structure/sink{
 	dir = 4;
@@ -96,181 +102,187 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ap" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aq" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ar" = (
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "as" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "at" = (
 /obj/item/weapon/tank/internals/oxygen,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "au" = (
 /obj/effect/decal/sandeffect,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "av" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aw" = (
 /obj/machinery/door/airlock/sandstone,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ax" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/sandstone{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ay" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/sandeffect,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "az" = (
 /obj/item/clothing/neck/necklace/dope,
 /obj/item/weapon/reagent_containers/spray/spraytan,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aA" = (
 /obj/effect/decal/sandeffect,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aB" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand;
 	tag = "icon-asteroidwarning (NORTH)"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aC" = (
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aD" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/drinkingglasses,
 /obj/item/weapon/storage/box/drinkingglasses,
 /obj/item/weapon/reagent_containers/food/drinks/shaker,
 /obj/item/weapon/storage/box/beakers,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aE" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aF" = (
 /obj/machinery/vending/boozeomat{
 	emagged = 1;
 	req_access_txt = "0"
 	},
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aG" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/barman_recipes,
 /obj/item/weapon/reagent_containers/glass/rag,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aH" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aI" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aJ" = (
 /obj/structure/closet/crate/bin,
 /obj/item/weapon/tank/internals/emergency_oxygen,
 /obj/item/trash/candy,
 /obj/item/toy/talking/owl,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand;
 	tag = "icon-asteroidwarning (NORTH)"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aK" = (
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aL" = (
 /obj/effect/mob_spawn/human/bartender/alive{
 	name = "beach bum sleeper"
 	},
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aM" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aN" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aO" = (
 /obj/structure/stacklifter,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aP" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aQ" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aR" = (
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/tequila,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aS" = (
 /obj/machinery/processor,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aT" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aU" = (
 /obj/effect/overlay/palmtree_l,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aV" = (
 /obj/effect/mob_spawn/human/beach/alive{
 	flavour_text = "You're, like, totally a dudebro, bruh. Ch'yea. You came here, like, on spring break, hopin' to pick up some bangin' hot chicks, y'knaw?";
@@ -278,31 +290,31 @@
 	uniform = /obj/item/clothing/under/pants/youngfolksjeans
 	},
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aW" = (
 /obj/structure/chair/stool,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand;
 	tag = "icon-asteroidwarning (NORTH)"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aX" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aY" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aZ" = (
 /obj/effect/overlay/coconut,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ba" = (
 /obj/machinery/light{
 	dir = 4;
@@ -316,24 +328,24 @@
 "bb" = (
 /obj/structure/weightlifter,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bc" = (
 /obj/machinery/door/airlock/sandstone,
 /obj/effect/decal/sandeffect,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bd" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	req_access = null
 	},
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "be" = (
 /obj/vehicle/scooter/skateboard{
 	dir = 4
 	},
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bf" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -347,10 +359,10 @@
 "bg" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall/mineral/sandstone,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bh" = (
 /turf/closed/wall/mineral/sandstone,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bi" = (
 /turf/open/floor/plating/beach/sand{
 	density = 1;
@@ -365,14 +377,14 @@
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bk" = (
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/food/snacks/pastatomato,
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bl" = (
 /obj/structure/chair/wood/normal{
 	icon_state = "wooden_chair";
@@ -381,7 +393,7 @@
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bm" = (
 /mob/living/simple_animal/crab,
 /turf/open/floor/plating/beach/sand{
@@ -456,7 +468,7 @@
 "bx" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "by" = (
 /obj/machinery/door/airlock/sandstone,
 /obj/effect/decal/sandeffect,
@@ -467,7 +479,7 @@
 "bz" = (
 /mob/living/simple_animal/crab,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bA" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -480,7 +492,7 @@
 /obj/item/weapon/storage/firstaid,
 /obj/item/weapon/storage/firstaid/brute,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bB" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -492,7 +504,7 @@
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bC" = (
 /obj/structure/table/wood,
 /obj/item/weapon/tank/internals/oxygen,
@@ -512,11 +524,11 @@
 "bE" = (
 /obj/item/weapon/reagent_containers/spray/spraytan,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bF" = (
 /obj/item/toy/beach_ball,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bG" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -524,7 +536,7 @@
 /obj/structure/window/reinforced,
 /obj/item/device/megaphone,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bH" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -538,7 +550,7 @@
 	mob_gender = "female"
 	},
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bI" = (
 /obj/structure/dresser,
 /turf/open/floor/pod/dark{
@@ -548,11 +560,11 @@
 "bJ" = (
 /obj/structure/chair,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bK" = (
 /obj/item/weapon/storage/backpack/dufflebag,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bL" = (
 /obj/effect/decal/sandeffect{
 	density = 1
@@ -562,43 +574,227 @@
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	density = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bM" = (
 /turf/open/floor/plasteel/stairs/old,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bN" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bO" = (
 /obj/item/device/camera,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bP" = (
 /obj/item/weapon/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bQ" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/beach/coastline_t,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bR" = (
 /turf/open/floor/plating/beach/coastline_t,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bS" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/beach/coastline_t,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bT" = (
 /turf/open/floor/plating/beach/coastline_b,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bU" = (
 /turf/open/floor/plating/beach/water,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bV" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/floor/plating/beach/water,
+/area/ruin/powered/beach)
+"bW" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"bX" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"bY" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"bZ" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"ca" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"cb" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"cc" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"cd" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/closed/wall/mineral/sandstone{
+	baseturf = /turf/open/floor/plating/beach/sand
+	},
+/area/ruin/powered/beach)
+"ce" = (
+/obj/effect/decal/sandeffect,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered/beach)
+"cf" = (
+/obj/effect/decal/sandeffect,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered/beach)
+"cg" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered/beach)
+"ch" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered/beach)
+"ci" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered/beach)
+"cj" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/asteroid{
+	baseturf = /turf/open/floor/plating/beach/sand;
+	tag = "icon-asteroidwarning (NORTH)"
+	},
+/area/ruin/powered/beach)
+"ck" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/asteroid{
+	baseturf = /turf/open/floor/plating/beach/sand;
+	tag = "icon-asteroidwarning (NORTH)"
+	},
+/area/ruin/powered/beach)
+"cl" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered/beach)
+"cm" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
 /area/ruin/powered)
+"cn" = (
+/obj/effect/decal/sandeffect,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"co" = (
+/obj/effect/decal/sandeffect,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"cp" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"cq" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered/beach)
+"cr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered/beach)
+"cs" = (
+/obj/effect/overlay/palmtree_l,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered/beach)
+"ct" = (
+/obj/machinery/light,
+/turf/open/floor/plating/beach/water,
+/area/ruin/powered/beach)
+"cu" = (
+/obj/machinery/light,
+/turf/open/floor/plating/beach/water,
+/area/ruin/powered/beach)
+"cv" = (
+/obj/machinery/light,
+/turf/open/floor/plating/beach/water,
+/area/ruin/powered/beach)
+"cw" = (
+/obj/machinery/light,
+/turf/open/floor/plating/beach/water,
+/area/ruin/powered/beach)
+"cx" = (
+/obj/machinery/light,
+/turf/open/floor/plating/beach/water,
+/area/ruin/powered/beach)
+"cy" = (
+/obj/machinery/light,
+/turf/open/floor/plating/beach/water,
+/area/ruin/powered/beach)
 
 (1,1,1) = {"
 aa
@@ -646,11 +842,11 @@ ab
 ab
 ab
 bn
-br
+cm
 bu
 bv
 bu
-bs
+co
 bC
 ab
 ab
@@ -673,7 +869,7 @@ ab
 ab
 ab
 ap
-ar
+cg
 ar
 ar
 ab
@@ -721,7 +917,7 @@ ap
 bR
 bT
 bU
-bU
+ct
 ab
 ab
 aa
@@ -740,7 +936,7 @@ aO
 ar
 bb
 ar
-ar
+ci
 ar
 ar
 aA
@@ -748,7 +944,7 @@ aA
 aA
 ar
 ar
-ar
+cr
 bN
 bR
 bT
@@ -819,7 +1015,7 @@ bT
 bU
 bU
 bU
-bU
+cv
 ab
 ab
 aa
@@ -859,10 +1055,10 @@ aa
 (9,1,1) = {"
 aa
 ab
-ab
-ab
-ab
-aA
+bW
+bW
+bW
+ce
 aA
 aA
 aA
@@ -893,7 +1089,7 @@ aa
 ac
 ae
 as
-ab
+bW
 aB
 aK
 aK
@@ -980,7 +1176,7 @@ bU
 bU
 bU
 bU
-bU
+cx
 ab
 aa
 "}
@@ -1051,7 +1247,7 @@ aa
 (15,1,1) = {"
 aa
 ac
-aj
+cd
 aj
 aj
 aF
@@ -1092,7 +1288,7 @@ aj
 aj
 bc
 aj
-aB
+cj
 aK
 aA
 ar
@@ -1172,7 +1368,7 @@ bU
 bU
 bU
 bU
-bU
+cy
 ab
 aa
 "}
@@ -1188,14 +1384,14 @@ aj
 aj
 aj
 aj
-aB
+ck
 aK
 aA
 ar
 ar
 ar
 ar
-ar
+cq
 ar
 ar
 bR
@@ -1275,10 +1471,10 @@ aa
 (22,1,1) = {"
 aa
 ab
-ab
-ab
-ab
-aA
+bW
+bW
+bW
+cf
 aA
 aA
 aA
@@ -1363,7 +1559,7 @@ bT
 bU
 bU
 bU
-bU
+cw
 ab
 ab
 aa
@@ -1412,7 +1608,7 @@ aq
 ar
 be
 ar
-ar
+cl
 ar
 ar
 aA
@@ -1420,7 +1616,7 @@ aA
 aA
 ar
 ar
-aU
+cs
 ar
 bR
 bT
@@ -1457,7 +1653,7 @@ ap
 bR
 bT
 bU
-bU
+cu
 ab
 ab
 aa
@@ -1473,7 +1669,7 @@ ab
 ab
 ab
 ap
-ar
+ch
 ap
 ar
 ab
@@ -1510,11 +1706,11 @@ ab
 ab
 ab
 bo
-bs
+cn
 bu
 bu
 bv
-br
+cp
 bC
 ab
 ab

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -83,7 +83,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "an" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -93,7 +93,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ao" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -103,7 +103,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ap" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -113,7 +113,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aq" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -122,7 +122,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ar" = (
 /obj/structure/disposalpipe/segment{
 	invisibility = 101
@@ -131,7 +131,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "as" = (
 /obj/effect/mob_spawn/human/corpse/damaged,
 /obj/effect/decal/cleanable/blood/old,
@@ -142,7 +142,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "at" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -153,7 +153,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "au" = (
 /obj/structure/disposalpipe/segment{
 	invisibility = 101
@@ -161,7 +161,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "av" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -172,7 +172,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aw" = (
 /obj/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -181,7 +181,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ax" = (
 /obj/effect/decal/cleanable/pie_smudge,
 /obj/structure/disposalpipe/segment{
@@ -191,7 +191,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ay" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -203,7 +203,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "az" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -214,7 +214,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -224,7 +224,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -235,20 +235,20 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aC" = (
 /turf/open/indestructible{
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible{
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aE" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -257,7 +257,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -268,7 +268,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -279,7 +279,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -291,7 +291,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -303,7 +303,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -313,7 +313,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -324,7 +324,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -333,7 +333,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -344,13 +344,13 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aN" = (
 /obj/structure/disposalpipe/segment{
 	invisibility = 101
 	},
 /turf/open/floor/plating,
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aO" = (
 /obj/item/weapon/bikehorn,
 /obj/structure/disposalpipe/segment{
@@ -361,7 +361,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -370,7 +370,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aQ" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
@@ -383,7 +383,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/plating,
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -393,7 +393,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -403,14 +403,14 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -422,7 +422,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aW" = (
 /obj/item/weapon/bikehorn,
 /obj/effect/decal/cleanable/dirt,
@@ -433,7 +433,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aX" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -444,7 +444,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aY" = (
 /obj/item/weapon/bikehorn,
 /obj/structure/disposalpipe/segment{
@@ -454,7 +454,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -463,14 +463,14 @@
 /turf/open/indestructible{
 	icon_state = "darkredfull"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ba" = (
 /obj/effect/decal/cleanable/pie_smudge,
 /turf/open/indestructible{
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -479,7 +479,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -491,7 +491,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -505,7 +505,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "be" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -516,7 +516,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -528,7 +528,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -538,7 +538,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -548,7 +548,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -558,7 +558,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -567,20 +567,24 @@
 /turf/open/indestructible{
 	icon_state = "light_on"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bk" = (
 /obj/structure/disposalpipe/segment{
 	invisibility = 101
 	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bl" = (
 /turf/open/indestructible{
 	icon_state = "light_on"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -590,7 +594,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -600,7 +604,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bo" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -610,18 +614,18 @@
 /area/ruin/powered)
 "bp" = (
 /turf/closed/mineral/clown,
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bq" = (
 /obj/item/weapon/pickaxe,
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "br" = (
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -631,7 +635,7 @@
 /turf/open/indestructible{
 	icon_state = "darkredfull"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -641,7 +645,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bu" = (
 /obj/item/weapon/bikehorn,
 /obj/structure/disposalpipe/segment{
@@ -653,7 +657,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bv" = (
 /obj/machinery/light{
 	dir = 8
@@ -669,14 +673,14 @@
 	icon_state = "darkredfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "by" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/indestructible{
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bz" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -685,13 +689,13 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bA" = (
 /turf/open/indestructible{
 	icon_state = "darkredfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bB" = (
 /turf/open/indestructible/sound{
 	icon_state = "bananium";
@@ -699,7 +703,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bC" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -711,7 +715,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bD" = (
 /obj/structure/mecha_wreckage/honker,
 /obj/structure/disposalpipe/segment{
@@ -721,7 +725,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bE" = (
 /obj/effect/decal/cleanable/oil,
 /obj/structure/disposalpipe/segment{
@@ -732,7 +736,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bF" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -743,7 +747,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bG" = (
 /obj/item/weapon/grown/bananapeel{
 	color = "#2F3000";
@@ -759,7 +763,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bI" = (
 /obj/effect/mob_spawn/human/corpse/damaged,
 /obj/effect/decal/cleanable/blood/old,
@@ -767,7 +771,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -777,7 +781,7 @@
 	icon_state = "darkredfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -788,19 +792,19 @@
 	icon_state = "darkredfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bL" = (
 /obj/item/weapon/reagent_containers/food/drinks/trophy/gold_cup,
 /obj/structure/table/glass,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bM" = (
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bN" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -809,7 +813,7 @@
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bO" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/indestructible/sound{
@@ -818,56 +822,59 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bP" = (
 /obj/structure/statue/bananium/clown,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bQ" = (
 /obj/structure/table/glass,
 /obj/item/weapon/grown/bananapeel/bluespace,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bR" = (
 /obj/structure/table/glass,
 /obj/item/clothing/shoes/clown_shoes/banana_shoes,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bS" = (
 /obj/item/weapon/coin/clown,
 /obj/item/weapon/coin/clown,
 /obj/item/weapon/coin/clown,
 /obj/item/weapon/coin/clown,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bT" = (
 /obj/item/slime_extract/rainbow,
 /obj/structure/table/glass,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bU" = (
 /obj/item/weapon/bikehorn/airhorn,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bV" = (
 /obj/structure/table/glass,
 /obj/item/weapon/gun/magic/staff/honk,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bW" = (
 /obj/item/weapon/bikehorn,
 /turf/open/indestructible/sound{
@@ -876,7 +883,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -891,7 +898,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bZ" = (
 /obj/machinery/door/airlock/clown,
 /turf/open/indestructible/sound{
@@ -900,7 +907,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ca" = (
 /obj/item/weapon/bikehorn,
 /obj/effect/decal/cleanable/dirt,
@@ -910,13 +917,588 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "cb" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered)
+"cc" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cd" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ce" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cf" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cg" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ch" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ci" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cj" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ck" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cl" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cm" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cn" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"co" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cp" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cq" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cr" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cs" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ct" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cu" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cv" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cw" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cx" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cy" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cz" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cA" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cB" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cC" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cD" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cE" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cF" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cG" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cH" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cI" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cJ" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cK" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cL" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cM" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cN" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cO" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cP" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cQ" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cR" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cS" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cT" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cU" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cV" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cW" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cX" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cY" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cZ" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"da" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"db" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dc" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dd" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"de" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"df" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dg" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dh" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"di" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dj" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dk" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dl" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dm" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dn" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"do" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dp" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dq" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dr" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ds" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dt" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"du" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dv" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dw" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dx" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dy" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dz" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dA" = (
+/obj/machinery/light/small,
+/turf/open/floor/noslip{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"dB" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible{
+	icon_state = "darkyellowfull";
+	wet = 5
+	},
+/area/ruin/powered/clownplanet)
+"dC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible{
+	icon_state = "darkyellowfull";
+	wet = 5
+	},
+/area/ruin/powered/clownplanet)
+"dD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c";
+	invisibility = 101
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible{
+	icon_state = "darkyellowfull";
+	wet = 5
+	},
+/area/ruin/powered/clownplanet)
+"dE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c";
+	invisibility = 101
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible{
+	icon_state = "darkyellowfull";
+	wet = 5
+	},
+/area/ruin/powered/clownplanet)
+"dF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/indestructible{
+	icon_state = "white"
+	},
+/area/ruin/powered/clownplanet)
+"dG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible{
+	icon_state = "white"
+	},
+/area/ruin/powered/clownplanet)
+"dH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c";
+	invisibility = 101
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible{
+	icon_state = "white"
+	},
+/area/ruin/powered/clownplanet)
+"dI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible{
+	icon_state = "darkredfull";
+	wet = 5
+	},
+/area/ruin/powered/clownplanet)
+"dJ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible{
+	icon_state = "darkredfull";
+	wet = 5
+	},
+/area/ruin/powered/clownplanet)
+"dK" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/carpet{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dL" = (
+/obj/item/weapon/coin/clown,
+/obj/item/weapon/coin/clown,
+/obj/item/weapon/coin/clown,
+/obj/item/weapon/coin/clown,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/sound{
+	icon_state = "bananium";
+	name = "bananium floor";
+	sound = 'sound/effects/clownstep1.ogg';
+	wet = 5
+	},
+/area/ruin/powered/clownplanet)
+"dN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/sound{
+	icon_state = "bananium";
+	name = "bananium floor";
+	sound = 'sound/effects/clownstep1.ogg';
+	wet = 5
+	},
+/area/ruin/powered/clownplanet)
+"dO" = (
+/obj/machinery/light,
+/turf/open/indestructible/sound{
+	icon_state = "bananium";
+	name = "bananium floor";
+	sound = 'sound/effects/clownstep1.ogg';
+	wet = 5
+	},
+/area/ruin/powered/clownplanet)
+"dP" = (
+/obj/machinery/light,
+/turf/open/indestructible/sound{
+	icon_state = "bananium";
+	name = "bananium floor";
+	sound = 'sound/effects/clownstep1.ogg';
+	wet = 5
+	},
+/area/ruin/powered/clownplanet)
 
 (1,1,1) = {"
 aa
@@ -1065,7 +1647,7 @@ ak
 am
 aN
 aS
-aV
+dE
 aH
 bf
 aJ
@@ -1095,7 +1677,7 @@ aa
 ah
 ak
 ak
-ah
+cc
 aF
 at
 ar
@@ -1137,7 +1719,7 @@ ar
 aJ
 aL
 aL
-ah
+cc
 bx
 bA
 bB
@@ -1170,16 +1752,16 @@ aL
 aX
 aL
 bb
-bb
+dF
 bp
-ah
-bA
+cc
+dI
 bA
 bB
-ah
-ah
+cc
+cc
 bH
-ah
+cc
 bB
 bB
 bB
@@ -1207,8 +1789,8 @@ bb
 bb
 bq
 bp
-ah
-ah
+cc
+cc
 bA
 bB
 bB
@@ -1217,7 +1799,7 @@ bB
 bB
 ca
 bH
-bB
+dO
 ah
 ak
 ak
@@ -1245,7 +1827,7 @@ bA
 bA
 bA
 bB
-ah
+cc
 bB
 bB
 bH
@@ -1264,8 +1846,8 @@ ae
 ah
 ak
 ao
-al
-ar
+ch
+dB
 aH
 az
 az
@@ -1275,12 +1857,12 @@ bg
 bj
 bl
 bp
-ah
+cc
 bA
 bA
 bB
 bB
-ah
+cc
 bB
 bB
 bB
@@ -1306,18 +1888,18 @@ an
 aB
 aL
 bb
-bb
+dG
 br
-ah
-ah
+cc
+cc
 bA
 bB
 bB
-ah
-ah
+cc
+cc
 bB
 bB
-ah
+cc
 bB
 bH
 ak
@@ -1331,7 +1913,7 @@ ab
 ad
 ah
 ak
-ah
+cc
 at
 ar
 aB
@@ -1342,15 +1924,15 @@ aB
 aL
 aL
 bs
-al
+ch
 aJ
-ah
-ah
-ah
+cc
+cc
+cc
 bP
 bS
-ah
-bB
+cc
+dM
 bB
 bH
 ca
@@ -1378,13 +1960,13 @@ aA
 aV
 ay
 az
-ah
-ah
+cc
+cc
 bL
 bM
 bM
 bM
-ah
+cc
 bB
 bH
 bH
@@ -1402,10 +1984,10 @@ al
 al
 au
 ar
-al
+ch
 ar
 aT
-al
+ch
 ax
 ar
 aH
@@ -1413,13 +1995,13 @@ aD
 aA
 aM
 aG
-ah
-bM
+cc
+dK
 bQ
 bT
 bM
-ah
-ah
+cc
+cc
 bH
 bB
 bB
@@ -1431,7 +2013,7 @@ ah
 (16,1,1) = {"
 ac
 ag
-ac
+dA
 ah
 ak
 ao
@@ -1447,7 +2029,7 @@ bt
 aM
 aG
 aV
-al
+ch
 bN
 bM
 bU
@@ -1456,7 +2038,7 @@ bZ
 bB
 bH
 bB
-ah
+cc
 ak
 bX
 ak
@@ -1481,12 +2063,12 @@ bu
 by
 bC
 aD
-ah
+cc
 bM
 bR
 bV
 bM
-ah
+cc
 bB
 bB
 bB
@@ -1502,7 +2084,7 @@ ac
 ah
 ah
 ak
-ah
+cc
 az
 az
 az
@@ -1515,12 +2097,12 @@ aG
 ba
 aL
 bI
-ah
+cc
 bL
 bM
 bM
 bM
-ah
+cc
 bB
 bB
 bB
@@ -1536,25 +2118,25 @@ ad
 ah
 ak
 ak
-ah
+cc
 az
 az
 aO
 aA
 aA
 aL
-ah
-ah
+cc
+cc
 aZ
-ah
+cc
 bD
-ah
+cc
 bB
-ah
+cc
 bP
-bS
-ah
-bB
+dL
+cc
+dN
 bB
 bH
 bH
@@ -1569,8 +2151,8 @@ aa
 ad
 ah
 ak
-ah
-ah
+cc
+cc
 aA
 aA
 aA
@@ -1580,13 +2162,13 @@ aL
 bh
 bk
 bn
-ah
+cc
 bE
 aJ
 bB
 bB
-ah
-ah
+cc
+cc
 bY
 bB
 bB
@@ -1603,9 +2185,9 @@ aa
 ae
 ah
 ak
-ah
-ah
-aA
+cc
+cc
+dC
 aK
 aL
 az
@@ -1615,12 +2197,12 @@ bb
 bl
 bl
 bp
-ah
+cc
 bJ
 bA
 bB
 bB
-ah
+cc
 bB
 bH
 bB
@@ -1649,9 +2231,9 @@ bb
 bl
 bl
 bz
-al
+ch
 bK
-ah
+cc
 bB
 bB
 bH
@@ -1659,7 +2241,7 @@ bH
 bH
 bB
 bW
-bB
+dP
 ah
 bX
 ak
@@ -1671,8 +2253,8 @@ aa
 aa
 ah
 ak
-ah
-ah
+cc
+cc
 aC
 aA
 aA
@@ -1683,7 +2265,7 @@ bi
 bm
 br
 bp
-ah
+cc
 bA
 bA
 bB
@@ -1705,8 +2287,8 @@ aa
 aa
 ah
 ak
-ah
-ah
+cc
+cc
 aD
 aA
 aL
@@ -1714,17 +2296,17 @@ aA
 aL
 aL
 bh
-bn
+dH
 bp
-ah
+cc
+dJ
 bA
-bA
 bB
 bB
 bB
 bB
 bB
-ah
+cc
 bB
 bB
 ak
@@ -1740,7 +2322,7 @@ aa
 ah
 ak
 ak
-ah
+cc
 aE
 aA
 aA
@@ -1748,8 +2330,8 @@ aA
 aM
 aB
 aL
-ah
-ah
+cc
+cc
 bA
 bA
 bB
@@ -1774,15 +2356,15 @@ aa
 ah
 ah
 ak
-ah
-ah
+cc
+cc
 aM
 aB
-aM
+dD
 ar
 ar
 aS
-ah
+cc
 ak
 ah
 bF
@@ -1791,7 +2373,7 @@ bB
 ah
 bB
 bB
-ah
+cc
 bB
 bB
 ak
@@ -1810,13 +2392,13 @@ ah
 ah
 ak
 ak
-ah
-aQ
-ah
+cc
+cu
+cc
 ba
 aC
-aQ
-ah
+cu
+cc
 ak
 ah
 ah
@@ -1849,7 +2431,7 @@ ak
 aU
 aU
 aU
-ah
+cc
 ak
 ah
 ah

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -22,38 +22,38 @@
 /turf/closed/wall/mineral/titanium/nodiagonal{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "af" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ag" = (
 /turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ah" = (
 /obj/structure/toilet,
 /turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ai" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aj" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ak" = (
 /obj/structure/table/wood,
 /obj/item/device/taperecorder,
@@ -61,34 +61,37 @@
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "al" = (
 /obj/structure/table/wood,
 /obj/item/toy/carpplushie,
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "am" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "an" = (
 /obj/machinery/sleeper{
 	icon_state = "sleeper-open";
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ao" = (
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ap" = (
 /obj/structure/table,
 /obj/item/weapon/circular_saw,
@@ -98,7 +101,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aq" = (
 /obj/structure/table,
 /obj/item/weapon/cautery{
@@ -108,7 +111,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ar" = (
 /obj/structure/table,
 /obj/item/weapon/surgical_drapes,
@@ -116,12 +119,12 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "as" = (
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "at" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -129,7 +132,7 @@
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "au" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -137,7 +140,7 @@
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "av" = (
 /obj/item/weapon/reagent_containers/glass/rag,
 /obj/item/weapon/reagent_containers/spray/cleaner,
@@ -145,13 +148,16 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aw" = (
 /obj/structure/bed/roller,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ax" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/weapon/storage/bag/trash,
@@ -177,7 +183,7 @@
 /turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "az" = (
 /obj/structure/noticeboard{
 	dir = 1;
@@ -190,25 +196,25 @@
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aA" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aB" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aC" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aD" = (
 /obj/structure/table,
 /obj/item/weapon/retractor,
@@ -216,7 +222,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aE" = (
 /turf/closed/wall/mineral/titanium/nodiagonal{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -229,13 +235,13 @@
 /turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aG" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/titanium/nodiagonal{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aH" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/titanium/nodiagonal{
@@ -255,62 +261,65 @@
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aL" = (
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aM" = (
 /obj/effect/mob_spawn/human/doctor/alive/lavaland,
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aN" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/blood/random,
 /obj/item/weapon/reagent_containers/blood/random,
 /obj/item/weapon/reagent_containers/blood/random,
 /obj/item/weapon/reagent_containers/blood/random,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aO" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aP" = (
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 0
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aQ" = (
 /turf/open/floor/plasteel/blue/corner{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aR" = (
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 4
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aS" = (
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aT" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/cobweb,
@@ -321,21 +330,24 @@
 	},
 /obj/item/ammo_casing/shotgun/buckshot,
 /obj/item/weapon/storage/box/bodybags,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aU" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aV" = (
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aW" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 28
@@ -343,25 +355,25 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aX" = (
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aY" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aZ" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ba" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/glass/beaker,
@@ -369,21 +381,24 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bb" = (
 /obj/structure/table/reinforced,
 /obj/item/device/laser_pointer,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bc" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bd" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/gloves,
@@ -391,17 +406,20 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "be" = (
 /obj/effect/decal/cleanable/oil,
 /obj/item/weapon/storage/toolbox/mechanical,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bf" = (
 /obj/structure/table,
 /obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
@@ -409,39 +427,39 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bg" = (
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bh" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/brute,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bi" = (
 /obj/item/toy/cattoy,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bj" = (
 /obj/structure/table/glass,
 /obj/item/weapon/lazarus_injector,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bk" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bl" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/snacks/cookie{
@@ -462,11 +480,14 @@
 /obj/item/weapon/reagent_containers/food/snacks/cookie{
 	name = "doggie biscuit"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bm" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -475,13 +496,16 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bn" = (
 /obj/structure/bed/dogbed,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bo" = (
 /obj/item/weapon/reagent_containers/glass/bowl,
 /obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
@@ -489,7 +513,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bp" = (
 /obj/structure/closet/crate/bin,
 /obj/item/trash/pistachios,
@@ -499,32 +523,32 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bq" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "br" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bs" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/phone,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bt" = (
 /obj/item/weapon/twohanded/required/kirbyplants,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bu" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -533,7 +557,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 4
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bv" = (
 /obj/effect/mob_spawn/mouse{
 	dir = 4;
@@ -543,13 +567,13 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bx" = (
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room";
@@ -558,7 +582,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "by" = (
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
@@ -566,14 +590,14 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bz" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/regular,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bA" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin,
@@ -581,14 +605,14 @@
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bB" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/hug,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bC" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -596,7 +620,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bD" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/glass/bottle/cyanide{
@@ -607,20 +631,20 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bE" = (
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bF" = (
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 10
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bG" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -629,7 +653,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 6
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bH" = (
 /obj/structure/table,
 /obj/item/weapon/tank/internals/oxygen,
@@ -638,7 +662,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bI" = (
 /obj/structure/sign/bluecross_2{
 	name = "animal hospital"
@@ -646,7 +670,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bJ" = (
 /obj/machinery/door/airlock/glass_large{
 	name = "Ian's Pet Care"
@@ -655,7 +679,7 @@
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bK" = (
 /obj/item/weapon/reagent_containers/glass/bowl,
 /obj/item/weapon/reagent_containers/food/snacks/grown/wheat,
@@ -665,7 +689,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bL" = (
 /obj/vehicle/scooter/skateboard{
 	dir = 4
@@ -691,7 +715,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bO" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass{
@@ -707,7 +731,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bQ" = (
 /obj/structure/table/glass,
 /obj/item/clothing/neck/petcollar,
@@ -715,7 +739,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bR" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -728,7 +752,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 10
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bS" = (
 /obj/structure/closet,
 /obj/item/weapon/defibrillator/loaded,
@@ -738,7 +762,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 6
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bT" = (
 /obj/item/weapon/pickaxe,
 /obj/effect/decal/cleanable/blood/old,
@@ -757,7 +781,7 @@
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bX" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -806,7 +830,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cd" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/latex,
@@ -815,7 +839,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ce" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -824,13 +848,13 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cf" = (
 /obj/structure/closet/l3closet,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cg" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Break Room"
@@ -838,7 +862,7 @@
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ch" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Emergency Care"
@@ -846,7 +870,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ci" = (
 /obj/machinery/door/unpowered/shuttle{
 	desc = "There's a note wedged in the seam saying something about directing pizza here.";
@@ -856,7 +880,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cj" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Morgue"
@@ -864,7 +888,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ck" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Medical Supplies"
@@ -872,7 +896,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cl" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Safety Supplies"
@@ -880,7 +904,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cm" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Tool Storage"
@@ -888,7 +912,157 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
+"cn" = (
+/obj/machinery/light,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/lavaland/surface/outdoors)
+"co" = (
+/obj/machinery/light,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/lavaland/surface/outdoors)
+"cp" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"cq" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered/animal_hospital)
+"cr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cmo{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered/animal_hospital)
+"cs" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cmo{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered/animal_hospital)
+"ct" = (
+/obj/effect/mob_spawn/human/doctor/alive/lavaland,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/blue/side{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1
+	},
+/area/ruin/powered/animal_hospital)
+"cu" = (
+/obj/effect/mob_spawn/human/doctor/alive/lavaland,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/blue/side{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1
+	},
+/area/ruin/powered/animal_hospital)
+"cv" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/blue/side{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1
+	},
+/area/ruin/powered/animal_hospital)
+"cw" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/blue/side{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 0
+	},
+/area/ruin/powered/animal_hospital)
+"cx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/lavaland/surface/outdoors)
+"cy" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/blue/side{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 4
+	},
+/area/ruin/powered/animal_hospital)
+"cz" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/blue/side{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1
+	},
+/area/ruin/powered/animal_hospital)
+"cA" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/blue/side{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 4
+	},
+/area/ruin/powered/animal_hospital)
+"cB" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/blue/side{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 4
+	},
+/area/ruin/powered/animal_hospital)
+"cC" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/lavaland/surface/outdoors)
+"cD" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/lavaland/surface/outdoors)
+"cE" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 aa
@@ -963,7 +1137,7 @@ ab
 aJ
 ab
 ab
-ac
+cx
 ab
 aa
 aa
@@ -987,7 +1161,7 @@ aa
 aa
 aa
 ab
-ab
+cp
 ax
 ac
 aJ
@@ -1047,7 +1221,7 @@ aa
 ab
 ae
 ag
-ag
+cq
 ay
 ae
 aK
@@ -1062,7 +1236,7 @@ bp
 by
 bF
 ae
-ac
+cC
 ac
 ab
 ab
@@ -1087,7 +1261,7 @@ ae
 ae
 ae
 ae
-aL
+cz
 bq
 bz
 aP
@@ -1104,14 +1278,14 @@ ac
 aa
 ab
 ab
-ac
+cn
 ae
 ae
 ae
 ae
 aG
 aL
-aP
+cw
 ae
 aV
 ba
@@ -1137,7 +1311,7 @@ ac
 ac
 ae
 ai
-as
+cr
 as
 cg
 aK
@@ -1170,7 +1344,7 @@ aj
 at
 as
 ae
-aM
+ct
 aK
 ck
 ao
@@ -1230,7 +1404,7 @@ al
 au
 as
 ae
-aM
+cu
 aK
 cl
 ao
@@ -1242,7 +1416,7 @@ aK
 aK
 aP
 ae
-bM
+cD
 ac
 ac
 ab
@@ -1257,7 +1431,7 @@ ac
 ac
 ae
 am
-as
+cs
 as
 cg
 aK
@@ -1320,7 +1494,7 @@ cd
 an
 aA
 ae
-aL
+cv
 aP
 ae
 ae
@@ -1335,7 +1509,7 @@ bn
 bN
 bP
 ae
-ab
+cE
 ab
 aa
 aa
@@ -1374,7 +1548,7 @@ aa
 aa
 ab
 ab
-ac
+co
 ae
 ap
 ao
@@ -1443,15 +1617,15 @@ ae
 aO
 aR
 aR
+cy
 aR
 aR
 aR
+cA
 aR
 aR
 aR
-aR
-aR
-aR
+cB
 aR
 bS
 ae

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "ac" = (
 /obj/item/stack/medical/ointment,
 /obj/structure/table,
@@ -19,6 +19,9 @@
 /obj/structure/table,
 /obj/item/stack/medical/gauze,
 /obj/item/stack/medical/gauze,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -36,6 +39,9 @@
 /area/ruin/powered/snow_biodome)
 "ag" = (
 /obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -54,6 +60,9 @@
 /area/ruin/powered/snow_biodome)
 "aj" = (
 /obj/structure/sink,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -290,89 +299,92 @@
 /obj/item/clothing/shoes/winterboots,
 /obj/item/clothing/gloves/fingerless,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aT" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aU" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aV" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aW" = (
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aX" = (
 /turf/open/floor/pod/light,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aY" = (
 /obj/structure/chair/stool,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aZ" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/fans/tiny,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "ba" = (
 /obj/machinery/door/airlock/silver,
 /obj/structure/fans/tiny,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bb" = (
 /obj/machinery/door/airlock/silver,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bc" = (
 /obj/structure/table,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bd" = (
 /obj/structure/table,
 /obj/item/weapon/pen,
 /obj/item/weapon/paper_bin,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "be" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bf" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bg" = (
 /obj/item/weapon/twohanded/required/chainsaw,
 /obj/structure/closet,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bh" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bi" = (
 /obj/machinery/computer/monitor,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bj" = (
 /obj/item/weapon/storage/toolbox/mechanical,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bk" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bl" = (
 /turf/open/floor/wood{
 	baseturf = /turf/open/floor/plating/lava/smooth;
@@ -382,22 +394,22 @@
 /area/ruin/powered/snow_biodome)
 "bm" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bn" = (
 /obj/item/clothing/mask/balaclava,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bo" = (
 /obj/structure/table,
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_carp,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bp" = (
 /obj/structure/table,
 /obj/item/weapon/pen,
 /obj/item/weapon/paper,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bq" = (
 /obj/machinery/light/built{
 	dir = 1
@@ -406,12 +418,202 @@
 	baseturf = /turf/open/floor/plating/asteroid/basalt;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "br" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/glass_large,
 /turf/open/floor/pod/dark,
+/area/ruin/powered)
+"bs" = (
+/obj/machinery/door/airlock/glass_large,
+/obj/structure/fans/tiny,
+/turf/open/floor/pod/dark,
+/area/ruin/powered)
+"bt" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/pod/dark,
+/area/ruin/powered)
+"bu" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/pod/dark,
+/area/ruin/powered)
+"bv" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ice{
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
 /area/ruin/powered/snow_biodome)
+"bw" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	name = "floor"
+	},
+/area/ruin/powered/snow_biodome)
+"bx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	name = "floor"
+	},
+/area/ruin/powered/snow_biodome)
+"by" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bz" = (
+/obj/machinery/light,
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	name = "floor"
+	},
+/area/ruin/powered/snow_biodome)
+"bA" = (
+/obj/machinery/light,
+/turf/open/floor/wood{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	name = "floor"
+	},
+/area/ruin/powered/snow_biodome)
+"bB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bC" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bE" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bG" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/powered)
+"bH" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/powered)
+"bI" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/powered)
+"bJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bL" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bM" = (
+/obj/machinery/light,
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bN" = (
+/obj/machinery/light,
+/turf/open/floor/plating/ice{
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bO" = (
+/obj/machinery/light,
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bP" = (
+/obj/machinery/light,
+/turf/open/floor/plating/asteroid/snow{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
+"bQ" = (
+/obj/machinery/light/small,
+/turf/open/floor/pod/dark,
+/area/ruin/powered)
+"bR" = (
+/obj/machinery/light/small,
+/turf/open/floor/pod/dark,
+/area/ruin/powered)
 
 (1,1,1) = {"
 aa
@@ -458,10 +660,10 @@ ab
 ab
 ab
 aS
-aW
+bG
 aW
 aX
-aW
+bI
 aW
 bh
 ab
@@ -486,7 +688,7 @@ ab
 ab
 ab
 ak
-ak
+by
 ak
 ab
 aS
@@ -552,7 +754,7 @@ ak
 aI
 ak
 ak
-ak
+bC
 az
 ak
 aB
@@ -560,7 +762,7 @@ ak
 ak
 ak
 aI
-ak
+bJ
 ak
 ak
 ak
@@ -577,7 +779,7 @@ aa
 aa
 aa
 ab
-ao
+bv
 ao
 ao
 ao
@@ -631,7 +833,7 @@ ak
 ak
 ak
 ak
-ak
+bO
 ab
 ab
 bm
@@ -744,7 +946,7 @@ aq
 aq
 aK
 aq
-ak
+bD
 ao
 ao
 ao
@@ -770,7 +972,7 @@ ab
 ad
 af
 ar
-at
+bw
 at
 aD
 at
@@ -790,7 +992,7 @@ ak
 ak
 ak
 az
-ak
+bM
 ab
 aS
 aS
@@ -806,7 +1008,7 @@ au
 au
 aq
 at
-at
+bz
 aq
 ak
 ak
@@ -825,7 +1027,7 @@ ak
 aI
 ab
 bn
-aW
+bQ
 ab
 bm
 "}
@@ -887,7 +1089,7 @@ ao
 ak
 ak
 ak
-aO
+bs
 aX
 aX
 br
@@ -919,10 +1121,10 @@ ao
 ao
 ak
 ak
-aP
+bt
 aX
 aX
-aP
+bt
 bm
 "}
 (17,1,1) = {"
@@ -966,7 +1168,7 @@ av
 at
 aG
 at
-at
+bA
 aq
 aR
 ak
@@ -985,7 +1187,7 @@ ao
 ao
 ab
 aW
-aW
+bR
 ab
 bm
 "}
@@ -995,7 +1197,7 @@ ai
 af
 aq
 av
-at
+bx
 aH
 at
 aN
@@ -1014,7 +1216,7 @@ ak
 ak
 ak
 ao
-ao
+bN
 ab
 bo
 bp
@@ -1032,7 +1234,7 @@ aq
 aq
 aq
 aq
-ak
+bE
 ak
 ak
 ak
@@ -1175,7 +1377,7 @@ ak
 aI
 aI
 ak
-ak
+bP
 ab
 ab
 bm
@@ -1224,7 +1426,7 @@ az
 ak
 ak
 ak
-ak
+bF
 ak
 ak
 ak
@@ -1232,7 +1434,7 @@ ak
 ak
 az
 ak
-ak
+bK
 ak
 ak
 az
@@ -1286,7 +1488,7 @@ ab
 ab
 ab
 ak
-ak
+bB
 ak
 ab
 aU
@@ -1298,7 +1500,7 @@ bf
 bj
 ab
 ak
-ak
+bL
 ak
 ab
 ab
@@ -1322,7 +1524,7 @@ ab
 ab
 ab
 aV
-aW
+bH
 aY
 bc
 be

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
@@ -15,36 +15,36 @@
 /area/ruin/powered)
 "e" = (
 /turf/open/floor/plating/lava/smooth,
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "f" = (
 /obj/item/weapon/reagent_containers/syringe/gluttony,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "g" = (
 /obj/effect/gluttony,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "h" = (
 /obj/item/weapon/veilrender/vealrender,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "i" = (
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "j" = (
 /obj/item/trash/plate,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "k" = (
 /obj/machinery/door/airlock/uranium,
 /obj/structure/fans/tiny/invisible,
@@ -57,37 +57,113 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "m" = (
 /obj/item/trash/raisins,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "n" = (
 /obj/item/trash/pistachios,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "o" = (
 /obj/item/trash/popcorn,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "p" = (
 /obj/item/trash/semki,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "q" = (
 /obj/item/trash/syndi_cakes,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
+"r" = (
+/obj/effect/gluttony,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/gluttony)
+"s" = (
+/obj/effect/gluttony,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/gluttony)
+"t" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/gluttony)
+"u" = (
+/obj/effect/gluttony,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/gluttony)
+"v" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/gluttony)
+"w" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/gluttony)
+"x" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/gluttony)
+"y" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/gluttony)
+"z" = (
+/obj/item/trash/plate,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/gluttony)
+"A" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/gluttony)
 
 (1,1,1) = {"
 a
@@ -211,7 +287,7 @@ c
 d
 i
 i
-i
+v
 d
 c
 b
@@ -253,7 +329,7 @@ c
 c
 c
 d
-i
+t
 i
 m
 d
@@ -277,7 +353,7 @@ d
 d
 g
 m
-i
+w
 d
 d
 d
@@ -294,7 +370,7 @@ c
 d
 e
 d
-g
+r
 g
 g
 g
@@ -302,7 +378,7 @@ g
 i
 p
 i
-j
+z
 l
 i
 d
@@ -338,7 +414,7 @@ c
 d
 e
 d
-g
+s
 g
 g
 g
@@ -346,7 +422,7 @@ i
 g
 i
 l
-i
+A
 i
 q
 d
@@ -365,7 +441,7 @@ d
 d
 g
 i
-i
+x
 d
 d
 d
@@ -385,7 +461,7 @@ c
 c
 c
 d
-g
+u
 i
 i
 d
@@ -431,7 +507,7 @@ c
 d
 j
 i
-i
+y
 d
 c
 b

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -122,6 +122,9 @@
 	name = "shrine of the liberator";
 	pixel_x = 0
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium/purple{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -215,6 +218,7 @@
 /obj/item/weapon/storage/firstaid/fire,
 /obj/structure/table/wood,
 /obj/item/weapon/storage/firstaid/fire,
+/obj/machinery/light,
 /turf/open/floor/mineral/titanium/purple{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
@@ -259,6 +263,122 @@
 /obj/machinery/door/airlock/titanium,
 /obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium/purple{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"I" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"J" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"K" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"L" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/purple{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"M" = (
+/obj/effect/mob_spawn/human/golem/adamantine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/purple{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"N" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/purple{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"O" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/purple{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"P" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/purple{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"Q" = (
+/obj/machinery/light/small,
+/turf/open/floor/mineral/titanium/purple{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"R" = (
+/obj/machinery/light/small,
+/turf/open/floor/mineral/titanium/purple{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"S" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/purple{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"T" = (
+/obj/machinery/light/small,
+/turf/open/floor/mineral/titanium/purple{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"U" = (
+/obj/effect/mob_spawn/human/golem/adamantine,
+/obj/machinery/light/small,
+/turf/open/floor/mineral/titanium/purple{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"V" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"W" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/golem_ship)
+"X" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
 /area/ruin/powered/golem_ship)
@@ -358,7 +478,7 @@ a
 a
 a
 b
-l
+L
 l
 j
 l
@@ -384,10 +504,10 @@ l
 l
 b
 l
-l
+Q
 G
 l
-l
+T
 b
 b
 b
@@ -427,7 +547,7 @@ j
 l
 l
 b
-l
+P
 l
 G
 l
@@ -444,18 +564,18 @@ a
 a
 b
 c
-f
+I
 b
-m
+M
 o
 b
 l
 l
 G
 o
-m
+U
 b
-f
+V
 F
 b
 a
@@ -510,18 +630,18 @@ a
 a
 b
 c
-f
+J
 b
 l
 l
+O
 l
 l
-l
-l
+S
 l
 z
 b
-f
+W
 F
 b
 a
@@ -598,9 +718,9 @@ a
 a
 b
 e
-f
+K
 b
-l
+N
 l
 l
 l
@@ -609,7 +729,7 @@ v
 l
 B
 b
-f
+X
 f
 b
 a
@@ -670,7 +790,7 @@ h
 h
 b
 t
-l
+R
 b
 h
 h

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
@@ -16,26 +16,32 @@
 "e" = (
 /obj/structure/table/wood/poker,
 /obj/item/weapon/gun/ballistic/revolver/russian/soul,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "f" = (
 /obj/structure/cursed_slot_machine,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "g" = (
 /obj/structure/table/wood/poker,
 /obj/item/weapon/coin/mythril,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "h" = (
 /obj/structure/table/wood/poker,
 /obj/item/weapon/coin/diamond,
@@ -43,13 +49,13 @@
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "i" = (
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "j" = (
 /obj/structure/table/wood/poker,
 /obj/item/weapon/coin/adamantine,
@@ -57,7 +63,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "k" = (
 /obj/machinery/computer/arcade/battle{
 	emagged = 1
@@ -65,46 +71,50 @@
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "l" = (
 /obj/item/weapon/coin/gold,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "m" = (
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "n" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c1000,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "o" = (
 /obj/item/weapon/storage/bag/money,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "p" = (
 /obj/structure/table/wood/poker,
 /obj/item/weapon/ore/gold,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "q" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c20,
 /obj/item/stack/spacecash/c50,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "r" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c500,
@@ -113,21 +123,47 @@
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "s" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c200,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "t" = (
 /obj/machinery/door/airlock/gold,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/obj/structure/fans/tiny/invisible,
 /area/ruin/powered)
+"u" = (
+/obj/structure/table/wood/poker,
+/obj/item/stack/spacecash/c500,
+/obj/item/stack/spacecash/c100,
+/obj/item/stack/spacecash/c1000,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/engine/cult{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/greed)
+"v" = (
+/obj/item/weapon/coin/gold,
+/obj/machinery/light/small,
+/turf/open/floor/engine/cult{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/greed)
+"w" = (
+/obj/item/weapon/storage/bag/money,
+/obj/machinery/light/small,
+/turf/open/floor/engine/cult{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/greed)
 
 (1,1,1) = {"
 a
@@ -320,7 +356,7 @@ m
 m
 l
 m
-l
+v
 d
 d
 a
@@ -364,7 +400,7 @@ m
 l
 m
 l
-o
+w
 d
 d
 a
@@ -404,7 +440,7 @@ c
 d
 d
 p
-r
+u
 r
 d
 c

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -20,7 +20,7 @@
 /turf/open/floor/mineral/silver{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/pride)
 "f" = (
 /obj/structure/mirror{
 	pixel_x = 32
@@ -28,12 +28,12 @@
 /turf/open/floor/mineral/silver{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/pride)
 "g" = (
 /turf/open/floor/mineral/silver{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/pride)
 "h" = (
 /obj/structure/mirror/magic/pride,
 /turf/closed/wall/mineral/diamond{
@@ -47,6 +47,109 @@
 	blocks_air = 1
 	},
 /area/ruin/powered)
+"j" = (
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/pride)
+"k" = (
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/pride)
+"l" = (
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/mineral/silver{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/pride)
+"m" = (
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/mineral/silver{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/pride)
+"n" = (
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/mineral/silver{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/pride)
+"o" = (
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/mineral/silver{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/pride)
+"p" = (
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/mineral/silver{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/pride)
+"q" = (
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/mineral/silver{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/pride)
+"r" = (
+/obj/machinery/light/small,
+/turf/open/floor/mineral/silver{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/pride)
+"s" = (
+/obj/machinery/light/small,
+/turf/open/floor/mineral/silver{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/pride)
 
 (1,1,1) = {"
 a
@@ -120,16 +223,16 @@ c
 d
 d
 d
+j
 e
 e
+l
 e
 e
+n
 e
 e
-e
-e
-e
-e
+p
 e
 e
 d
@@ -153,7 +256,7 @@ g
 g
 g
 g
-g
+r
 d
 a
 a
@@ -197,7 +300,7 @@ g
 g
 g
 g
-g
+s
 d
 c
 a
@@ -208,16 +311,16 @@ c
 d
 d
 d
+k
 f
 f
+m
 f
 f
+o
 f
 f
-f
-f
-f
-f
+q
 f
 f
 d

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -19,31 +19,31 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "e" = (
 /obj/structure/table/wood,
 /obj/item/weapon/storage/box/disks_plantgene,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "f" = (
 /obj/machinery/plantgenes/seedvault,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "g" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "h" = (
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "i" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/structure/beebox,
@@ -57,7 +57,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "j" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion";
@@ -71,13 +71,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "l" = (
 /obj/machinery/door/airlock,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "m" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion";
@@ -90,7 +90,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "o" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/weapon/cultivator,
@@ -108,13 +108,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "p" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "q" = (
 /obj/item/weapon/hatchet,
 /obj/item/weapon/storage/bag/plants,
@@ -123,7 +123,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "r" = (
 /obj/structure/table/wood,
 /obj/item/weapon/storage/bag/plants,
@@ -133,7 +133,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "s" = (
 /obj/structure/table/wood,
 /obj/item/weapon/gun/energy/floragun,
@@ -144,13 +144,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "t" = (
 /obj/effect/mob_spawn/human/seed_vault,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "u" = (
 /obj/structure/sink{
 	icon_state = "sink";
@@ -161,19 +161,19 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "v" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "w" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "x" = (
 /obj/machinery/reagentgrinder{
 	pixel_y = 5
@@ -186,7 +186,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "y" = (
 /obj/structure/sink{
 	dir = 4;
@@ -197,13 +197,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "z" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "A" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/fans/tiny,
@@ -217,31 +217,31 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "C" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "D" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "E" = (
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "F" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "G" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/clothing/under/rank/hydroponics,
@@ -251,13 +251,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "H" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "I" = (
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/glass/bucket,
@@ -267,14 +267,14 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "J" = (
 /obj/item/weapon/storage/toolbox/syndicate,
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "K" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -292,6 +292,102 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"N" = (
+/obj/structure/table/wood,
+/obj/item/weapon/storage/box/disks_plantgene,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
+"O" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
+"P" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
+"Q" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
+"R" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
+"S" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
+"T" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
+"U" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
+"V" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
+"W" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
+"X" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
+"Y" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/turf/open/floor/plasteel/freezer{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/seedvault)
 
 (1,1,1) = {"
 a
@@ -346,10 +442,10 @@ a
 a
 c
 c
+T
 h
 h
-h
-h
+U
 c
 c
 a
@@ -389,12 +485,12 @@ c
 k
 c
 n
-h
+R
 u
 h
 h
 u
-h
+V
 u
 c
 a
@@ -429,17 +525,17 @@ a
 a
 a
 c
-e
+N
 h
 c
-p
+P
 h
 p
 h
 h
 p
 h
-p
+X
 c
 a
 a
@@ -539,17 +635,17 @@ a
 b
 a
 c
-h
+O
 h
 c
-p
+Q
 h
 h
 h
 h
 h
 h
-p
+Y
 c
 a
 a
@@ -587,12 +683,12 @@ c
 i
 c
 s
-h
+S
 y
 h
 h
 y
-h
+W
 J
 c
 a

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -34,6 +34,9 @@
 	req_access = null;
 	req_access_txt = "150"
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel/podhatch,
 /area/ruin/powered/syndicate_lava_base)
 "ah" = (
@@ -52,6 +55,9 @@
 	name = "skeletal minibar"
 	},
 /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/ruin/powered/syndicate_lava_base)
 "aj" = (
@@ -152,6 +158,9 @@
 /obj/item/stack/packageWrap,
 /obj/item/weapon/hand_labeler,
 /obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/podhatch{
 	dir = 8
 	},
@@ -165,6 +174,10 @@
 /obj/item/ammo_box/magazine/sniper_rounds,
 /obj/item/ammo_box/magazine/sniper_rounds,
 /obj/item/ammo_box/magazine/sniper_rounds,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/powered/syndicate_lava_base)
 "az" = (
@@ -179,6 +192,9 @@
 /obj/item/ammo_box/magazine/sniper_rounds,
 /obj/item/ammo_box/magazine/sniper_rounds,
 /obj/item/ammo_box/magazine/sniper_rounds,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/powered/syndicate_lava_base)
 "aA" = (
@@ -338,6 +354,9 @@
 /obj/item/weapon/tank/internals/emergency_oxygen/engi,
 /obj/item/device/flashlight/seclite,
 /obj/item/clothing/mask/gas,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/podhatch{
 	tag = "icon-podhatch (EAST)";
 	icon_state = "podhatch";
@@ -421,6 +440,7 @@
 	icon_state = "plant-21";
 	layer = 4.1
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/black,
 /area/ruin/powered/syndicate_lava_base)
 "be" = (
@@ -431,6 +451,9 @@
 /obj/structure/toilet{
 	tag = "icon-toilet00 (WEST)";
 	icon_state = "toilet00";
+	dir = 8
+	},
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -501,6 +524,9 @@
 /obj/item/device/assembly/signaler,
 /obj/item/device/assembly/voice,
 /obj/item/device/assembly/voice,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -519,11 +545,17 @@
 	},
 /area/ruin/powered/syndicate_lava_base)
 "bn" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/podhatch{
 	dir = 9
 	},
 /area/ruin/powered/syndicate_lava_base)
 "bo" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/podhatch{
 	dir = 5
 	},
@@ -566,6 +598,9 @@
 	pixel_y = 3
 	},
 /obj/item/weapon/storage/box/syringes,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/podhatch,
 /area/ruin/powered/syndicate_lava_base)
 "bt" = (
@@ -584,6 +619,9 @@
 /turf/open/floor/plating,
 /area/ruin/powered/syndicate_lava_base)
 "bv" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -737,6 +775,9 @@
 /obj/machinery/vending/toyliberationstation{
 	req_access_txt = "150"
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -874,6 +915,7 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
+/obj/machinery/light,
 /turf/open/floor/plasteel/podhatch{
 	tag = "icon-podhatch (NORTH)";
 	icon_state = "podhatch";
@@ -1117,6 +1159,9 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -1215,6 +1260,9 @@
 /obj/item/weapon/retractor,
 /obj/item/weapon/hemostat,
 /obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -1282,6 +1330,9 @@
 /area/ruin/powered/syndicate_lava_base)
 "cZ" = (
 /obj/structure/filingcabinet/security,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -1342,6 +1393,9 @@
 	amount = 50
 	},
 /obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -1429,6 +1483,10 @@
 /obj/structure/sign/vacuum{
 	pixel_x = -32
 	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -1459,6 +1517,597 @@
 	},
 /turf/open/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"dv" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dw" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dx" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dy" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dz" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dA" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dB" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dC" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dD" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dE" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dF" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dG" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dH" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dI" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dJ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dK" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dL" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dM" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dN" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dO" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dP" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dQ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dR" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dS" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dT" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dU" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dV" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dW" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dX" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dY" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dZ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ea" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eb" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ec" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ed" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ee" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ef" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eg" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eh" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ei" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ej" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ek" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"el" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"em" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"en" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eo" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ep" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eq" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"er" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"es" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"et" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eu" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ev" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ew" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ex" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ey" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ez" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eA" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eB" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eC" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eD" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eE" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eF" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eG" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eH" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eI" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eJ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eK" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eL" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eM" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eN" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eO" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eP" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eQ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eR" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eS" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eT" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eU" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eV" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eW" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eX" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eY" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eZ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fa" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fb" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fc" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fd" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fe" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ff" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fg" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fh" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fi" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fj" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fk" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fl" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fm" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fn" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fo" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fp" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fq" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fr" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fs" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ft" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fu" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fv" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fw" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fx" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fy" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fz" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fA" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fB" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Syndicate Recon Outpost";
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered)
+"fC" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Syndicate Recon Outpost";
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered)
+"fD" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fE" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fF" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fG" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fH" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fI" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/syndicate_lava_base)
+"fK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/syndicate_lava_base)
+"fL" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fM" = (
+/obj/item/weapon/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fN" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fO" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fQ" = (
+/obj/structure/bed/roller,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/ruin/powered/syndicate_lava_base)
+"fS" = (
+/obj/machinery/iv_drip,
+/obj/item/weapon/reagent_containers/blood/random,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fT" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/podhatch{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fV" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fW" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fX" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fY" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/ruin/powered/syndicate_lava_base)
+"fZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"ga" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/podhatch,
+/area/ruin/powered/syndicate_lava_base)
+"gb" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/podhatch,
+/area/ruin/powered/syndicate_lava_base)
+"gc" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/podhatch{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"gd" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"ge" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/powered/syndicate_lava_base)
+"gf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"gg" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/podhatch{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"gh" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"gi" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/ruin/powered/syndicate_lava_base)
+"gj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/powered/syndicate_lava_base)
+"gk" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/circuit/red,
+/area/ruin/powered/syndicate_lava_base)
+"gl" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/circuit/red,
+/area/ruin/powered/syndicate_lava_base)
 
 (1,1,1) = {"
 aa
@@ -1764,15 +2413,15 @@ ac
 ab
 ab
 ac
-ad
-ad
-ad
-ad
-ad
-ad
-ae
-ad
-ad
+dv
+dv
+dv
+dv
+dv
+dv
+dz
+dv
+dv
 ac
 ab
 ab
@@ -1790,29 +2439,29 @@ ab
 ab
 ab
 ac
-ad
-ad
-ad
-ad
-ad
-ae
-ad
-ad
-ad
-ad
-ad
-ad
-ae
-ad
-ad
+dv
+dv
+dv
+dv
+dv
+dz
+dv
+dv
+dv
+dv
+dv
+dv
+dz
+dv
+dv
 cG
-cG
+ge
 cG
 cW
 cG
+gj
 cG
-cG
-ad
+dv
 ac
 ab
 ab
@@ -1830,12 +2479,12 @@ ab
 ab
 ab
 ab
-ad
+dv
 aq
 aq
 aq
 aY
-aq
+fP
 aY
 bz
 bJ
@@ -1852,7 +2501,7 @@ cG
 cG
 cG
 cG
-ad
+dv
 ab
 ab
 ab
@@ -1870,7 +2519,7 @@ ac
 ab
 ab
 ab
-ad
+dv
 aq
 aQ
 aO
@@ -1892,7 +2541,7 @@ cG
 cG
 cG
 cG
-ad
+dv
 ab
 ab
 ab
@@ -1910,9 +2559,9 @@ ab
 ab
 ac
 ac
-ad
+dv
 aq
-aq
+fL
 aq
 aZ
 aq
@@ -1932,7 +2581,7 @@ cG
 cG
 cG
 cG
-ad
+dv
 ab
 ab
 ab
@@ -1947,10 +2596,10 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ad
+dv
+dv
+dv
+dv
 ad
 ad
 ad
@@ -1972,7 +2621,7 @@ cG
 cG
 cG
 cG
-ad
+dv
 ac
 ab
 ab
@@ -1987,7 +2636,7 @@ ab
 ab
 ab
 ab
-ad
+dv
 ao
 aw
 aA
@@ -1999,7 +2648,7 @@ ad
 bh
 bB
 aS
-bO
+fS
 bO
 cf
 cm
@@ -2012,7 +2661,7 @@ cG
 cG
 cG
 cG
-ad
+dv
 ac
 ab
 ab
@@ -2027,7 +2676,7 @@ ab
 ab
 ab
 ab
-ad
+dv
 ap
 aq
 ap
@@ -2052,7 +2701,7 @@ cG
 de
 cG
 cG
-ad
+dv
 ac
 ac
 ab
@@ -2067,7 +2716,7 @@ ab
 ab
 ab
 ac
-ad
+dv
 aq
 ap
 aq
@@ -2092,9 +2741,9 @@ cD
 ad
 dj
 ad
-ae
-ad
-ad
+dz
+dv
+dv
 ab
 ab
 ab
@@ -2107,7 +2756,7 @@ ab
 ab
 ab
 ac
-ad
+dv
 ar
 ax
 aB
@@ -2122,8 +2771,8 @@ aq
 bP
 bX
 ad
-cn
-cw
+fX
+ga
 ae
 aS
 cL
@@ -2134,7 +2783,7 @@ aq
 cU
 bu
 dt
-ad
+dv
 ab
 ab
 ab
@@ -2146,8 +2795,8 @@ ab
 ab
 ab
 ab
-ad
-ad
+dv
+dv
 ad
 ad
 ad
@@ -2174,7 +2823,7 @@ aq
 aq
 dp
 aO
-ad
+dv
 ab
 ab
 ab
@@ -2186,10 +2835,10 @@ ab
 ab
 ab
 ab
-ad
+dv
 af
 as
-as
+fJ
 aC
 aK
 aq
@@ -2206,7 +2855,7 @@ cn
 cw
 cf
 aq
-aq
+gf
 cT
 cY
 dg
@@ -2214,7 +2863,7 @@ dk
 aS
 bu
 dt
-ad
+dv
 ab
 ab
 ab
@@ -2226,7 +2875,7 @@ ab
 ab
 ab
 ab
-ad
+dv
 ag
 as
 as
@@ -2254,7 +2903,7 @@ ad
 ad
 ad
 ad
-ad
+dv
 du
 ab
 ab
@@ -2266,7 +2915,7 @@ ab
 ab
 ab
 ab
-ad
+dv
 ah
 as
 as
@@ -2280,21 +2929,21 @@ bn
 aY
 aY
 aY
-aY
+fT
 aY
 co
 cy
 aY
+gc
 aY
 aY
-aY
-aY
+gg
 aY
 cv
 dn
 dq
 aO
-dn
+fB
 ab
 ab
 ab
@@ -2306,7 +2955,7 @@ ab
 ab
 ab
 ab
-ae
+dz
 ad
 as
 as
@@ -2320,21 +2969,21 @@ bo
 aZ
 aZ
 aZ
-aZ
+fU
 aZ
 cp
 cz
 aZ
+gd
 aZ
 aZ
-aZ
-aZ
+gh
 aZ
 cA
 dn
 dr
 aO
-dn
+fB
 ab
 ab
 ab
@@ -2346,7 +2995,7 @@ ab
 ab
 ab
 ab
-ad
+dv
 ai
 as
 as
@@ -2354,7 +3003,7 @@ aG
 ap
 aq
 ap
-bb
+fM
 ad
 ad
 bu
@@ -2370,11 +3019,11 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
+dv
+dv
+dv
+dv
+dv
 du
 ab
 ab
@@ -2386,10 +3035,10 @@ ab
 ab
 ab
 ab
-ad
+dv
 aj
 as
-as
+fK
 aH
 aq
 ap
@@ -2410,7 +3059,7 @@ aq
 cU
 cZ
 dh
-ae
+dz
 ac
 ac
 ac
@@ -2426,7 +3075,7 @@ ab
 ab
 ab
 ab
-ad
+dv
 ad
 ad
 ad
@@ -2450,7 +3099,7 @@ ap
 ap
 ap
 aq
-ad
+dv
 ac
 ac
 ab
@@ -2466,7 +3115,7 @@ ab
 ab
 ab
 ab
-ad
+dv
 ak
 at
 ay
@@ -2482,19 +3131,19 @@ ap
 aq
 bP
 ad
-cn
-cw
+fY
+gb
 cf
 aq
 cM
 cV
 da
 aq
-ad
-ad
-ad
-ad
-ad
+dv
+dv
+dv
+dv
+dv
 ab
 ab
 ab
@@ -2506,7 +3155,7 @@ ab
 ab
 ab
 ab
-ad
+dv
 al
 au
 au
@@ -2514,7 +3163,7 @@ au
 aO
 aT
 aq
-aq
+fN
 ad
 bs
 aq
@@ -2532,9 +3181,9 @@ db
 aq
 ad
 aq
-do
+gk
 aq
-ad
+dv
 ab
 ab
 ab
@@ -2546,7 +3195,7 @@ ab
 ab
 ab
 ab
-ad
+dv
 ad
 ad
 ae
@@ -2574,7 +3223,7 @@ dl
 do
 ds
 do
-ad
+dv
 ab
 ab
 ab
@@ -2586,7 +3235,7 @@ ab
 ab
 ab
 ab
-ad
+dv
 am
 au
 au
@@ -2594,7 +3243,7 @@ au
 aO
 aT
 aq
-aq
+fO
 ae
 bu
 bu
@@ -2612,9 +3261,9 @@ aO
 bK
 ad
 aq
-do
+gl
 aq
-ad
+dv
 ab
 ab
 ab
@@ -2626,7 +3275,7 @@ ab
 ab
 ab
 ab
-ad
+dv
 an
 av
 az
@@ -2640,7 +3289,7 @@ bv
 bI
 ap
 bI
-aO
+fV
 ad
 cr
 cB
@@ -2651,10 +3300,10 @@ ad
 cF
 ad
 ad
-ad
-ad
-ad
-ad
+dv
+dv
+dv
+dv
 ab
 ab
 ab
@@ -2666,13 +3315,13 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+dv
+dv
+dv
+dv
+dv
+dv
+dv
 aW
 ad
 ad
@@ -2691,7 +3340,7 @@ ad
 dc
 di
 di
-ad
+dv
 ab
 ab
 ab
@@ -2712,7 +3361,7 @@ ac
 ac
 ab
 ac
-ad
+dv
 aX
 bf
 ad
@@ -2722,7 +3371,7 @@ ap
 bx
 bx
 ad
-aq
+fZ
 aq
 aq
 aq
@@ -2731,7 +3380,7 @@ ad
 dd
 di
 dm
-ad
+dv
 ab
 ab
 ab
@@ -2752,15 +3401,15 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ad
-bw
+dv
+dv
+dv
+dv
+fQ
 bI
 ap
 bU
-aO
+fW
 ad
 ct
 cC
@@ -2769,9 +3418,9 @@ cK
 cS
 ad
 dc
+gi
 di
-di
-ad
+dv
 ac
 ab
 ab
@@ -2795,23 +3444,23 @@ ac
 ab
 ab
 ac
-ad
+dv
 by
 bx
-ap
+fR
 bx
 ce
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+dv
+dv
+dv
+dv
+dv
+dv
+dv
+dv
+dv
+dv
+dv
 ac
 ab
 ab
@@ -2835,13 +3484,13 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+dv
+dv
+dv
+dv
+dv
+dv
+dv
 ab
 ab
 ab

--- a/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
+++ b/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
@@ -37,6 +37,9 @@
 /area/ruin/powered/aesthetic)
 "j" = (
 /obj/structure/chair/stool,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel/vaporwave,
 /area/ruin/powered/aesthetic)
 "k" = (
@@ -153,10 +156,10 @@
 	},
 /area/ruin/unpowered/no_grav)
 "G" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plating/astplate{
 	initial_gas_mix = "TEMP=2.7"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line,
 /area/ruin/unpowered/no_grav)
 "H" = (
 /obj/effect/overlay/palmtree_l,
@@ -195,6 +198,39 @@
 "N" = (
 /obj/effect/decal/sandeffect,
 /turf/open/floor/plasteel/airless/asteroid,
+/area/ruin/unpowered/no_grav)
+"O" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/ruin/powered/aesthetic)
+"P" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/vaporwave,
+/area/ruin/powered/aesthetic)
+"Q" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/vaporwave,
+/area/ruin/powered/aesthetic)
+"R" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/astplate{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered/no_grav)
+"S" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/astplate{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/ruin/unpowered/no_grav)
 
 (1,1,1) = {"
@@ -294,7 +330,7 @@ h
 u
 y
 f
-B
+R
 d
 d
 a
@@ -326,7 +362,7 @@ j
 k
 k
 v
-k
+P
 f
 C
 I
@@ -390,11 +426,11 @@ a
 d
 c
 g
-n
+O
 n
 k
 w
-k
+Q
 g
 F
 I
@@ -430,7 +466,7 @@ p
 u
 y
 g
-B
+S
 d
 d
 a

--- a/code/game/area/areas/ruins.dm
+++ b/code/game/area/areas/ruins.dm
@@ -82,6 +82,8 @@
 	name = "Bridge"
 	icon_state = "bridge"
 
+
+
 /area/ruin/powered/dinner_for_two
 	name = "Dinner for Two"
 

--- a/code/game/area/areas/ruins.dm
+++ b/code/game/area/areas/ruins.dm
@@ -93,9 +93,6 @@
 	ambientsounds = list('sound/ambience/ambivapor1.ogg')
 
 
-
-
-
 //Ruin of Hotel
 
 /area/ruin/hotel

--- a/code/game/area/areas/ruins.dm
+++ b/code/game/area/areas/ruins.dm
@@ -21,20 +21,48 @@
 
 
 //Areas
+
+/area/ruin/powered/beach
+	icon_state = "dk_yellow"
+
+/area/ruin/powered/clownplanet
+	icon_state = "dk_yellow"
+
+/area/ruin/powered/animal_hospital
+	icon_state = "dk_yellow"
+
+/area/ruin/powered/snow_biodome
+	icon_state = "dk_yellow"
+
+/area/ruin/powered/gluttony
+	icon_state = "dk_yellow"
+
+/area/ruin/powered/golem_ship
+	name = "Free Golem Ship"
+	icon_state = "dk_yellow"
+
+/area/ruin/powered/greed
+	icon_state = "dk_yellow"
+	
 /area/ruin/unpowered/hierophant
 	name = "Hierophant's Arena"
+	icon_state = "dk_yellow"
+
+/area/ruin/powered/pride
+	icon_state = "dk_yellow"
+
+/area/ruin/powered/seedvault
+	icon_state = "dk_yellow"
+
+/area/ruin/powered/syndicate_lava_base
+	name = "Secret Base"
+	icon_state = "dk_yellow"
+
 
 /area/ruin/unpowered/no_grav/way_home
 	name = "\improper Salvation"
 	icon_state = "away"
 
-/area/ruin/powered/snow_biodome
-
-/area/ruin/powered/golem_ship
-	name = "Free Golem Ship"
-
-/area/ruin/powered/syndicate_lava_base
-	name = "Secret Base"
 
 // Ruins of "onehalf" ship
 
@@ -54,8 +82,6 @@
 	name = "Bridge"
 	icon_state = "bridge"
 
-
-
 /area/ruin/powered/dinner_for_two
 	name = "Dinner for Two"
 
@@ -65,6 +91,9 @@
 /area/ruin/powered/aesthetic
 	name = "Aesthetic"
 	ambientsounds = list('sound/ambience/ambivapor1.ogg')
+
+
+
 
 
 //Ruin of Hotel


### PR DESCRIPTION
Adds lights to the now pitch-black powered ruins.

Alternative to my other pull #27845, which makes them all fullbright again (though the below issue isn't fixed in that one.)

-DOES- fix Golem ship's issue with the engines being fulbright mentioned in #24777.

Closes #27829