### PR TITLE
Lavaland - Alternative - Ruins are fullbright again

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -13,7 +13,7 @@
 "ad" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ae" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -21,44 +21,44 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "af" = (
 /obj/structure/table,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ag" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ah" = (
 /obj/machinery/power/smes,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ai" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aj" = (
 /turf/closed/wall/mineral/sandstone{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ak" = (
 /obj/structure/toilet,
 /obj/effect/decal/sandeffect,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "al" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -66,7 +66,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "am" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -75,13 +75,13 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "an" = (
 /obj/item/device/flashlight/lantern,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ao" = (
 /obj/structure/sink{
 	dir = 4;
@@ -96,79 +96,79 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ap" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aq" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ar" = (
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "as" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "at" = (
 /obj/item/weapon/tank/internals/oxygen,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "au" = (
 /obj/effect/decal/sandeffect,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "av" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aw" = (
 /obj/machinery/door/airlock/sandstone,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ax" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/sandstone{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ay" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/sandeffect,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "az" = (
 /obj/item/clothing/neck/necklace/dope,
 /obj/item/weapon/reagent_containers/spray/spraytan,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aA" = (
 /obj/effect/decal/sandeffect,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aB" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand;
 	tag = "icon-asteroidwarning (NORTH)"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aC" = (
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aD" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/drinkingglasses,
@@ -176,101 +176,101 @@
 /obj/item/weapon/reagent_containers/food/drinks/shaker,
 /obj/item/weapon/storage/box/beakers,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aE" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aF" = (
 /obj/machinery/vending/boozeomat{
 	emagged = 1;
 	req_access_txt = "0"
 	},
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aG" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/barman_recipes,
 /obj/item/weapon/reagent_containers/glass/rag,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aH" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aI" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aJ" = (
 /obj/structure/closet/crate/bin,
 /obj/item/weapon/tank/internals/emergency_oxygen,
 /obj/item/trash/candy,
 /obj/item/toy/talking/owl,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand;
 	tag = "icon-asteroidwarning (NORTH)"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aK" = (
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aL" = (
 /obj/effect/mob_spawn/human/bartender/alive{
 	name = "beach bum sleeper"
 	},
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aM" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aN" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aO" = (
 /obj/structure/stacklifter,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aP" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aQ" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aR" = (
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/tequila,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aS" = (
 /obj/machinery/processor,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aT" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aU" = (
 /obj/effect/overlay/palmtree_l,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aV" = (
 /obj/effect/mob_spawn/human/beach/alive{
 	flavour_text = "You're, like, totally a dudebro, bruh. Ch'yea. You came here, like, on spring break, hopin' to pick up some bangin' hot chicks, y'knaw?";
@@ -278,31 +278,31 @@
 	uniform = /obj/item/clothing/under/pants/youngfolksjeans
 	},
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aW" = (
 /obj/structure/chair/stool,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand;
 	tag = "icon-asteroidwarning (NORTH)"
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aX" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aY" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "aZ" = (
 /obj/effect/overlay/coconut,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "ba" = (
 /obj/machinery/light{
 	dir = 4;
@@ -316,24 +316,24 @@
 "bb" = (
 /obj/structure/weightlifter,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bc" = (
 /obj/machinery/door/airlock/sandstone,
 /obj/effect/decal/sandeffect,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bd" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	req_access = null
 	},
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "be" = (
 /obj/vehicle/scooter/skateboard{
 	dir = 4
 	},
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bf" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -347,10 +347,10 @@
 "bg" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall/mineral/sandstone,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bh" = (
 /turf/closed/wall/mineral/sandstone,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bi" = (
 /turf/open/floor/plating/beach/sand{
 	density = 1;
@@ -365,14 +365,14 @@
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bk" = (
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/food/snacks/pastatomato,
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bl" = (
 /obj/structure/chair/wood/normal{
 	icon_state = "wooden_chair";
@@ -381,7 +381,7 @@
 /turf/open/floor/plasteel/asteroid{
 	baseturf = /turf/open/floor/plating/beach/sand
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bm" = (
 /mob/living/simple_animal/crab,
 /turf/open/floor/plating/beach/sand{
@@ -456,7 +456,7 @@
 "bx" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "by" = (
 /obj/machinery/door/airlock/sandstone,
 /obj/effect/decal/sandeffect,
@@ -467,7 +467,7 @@
 "bz" = (
 /mob/living/simple_animal/crab,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bA" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -480,7 +480,7 @@
 /obj/item/weapon/storage/firstaid,
 /obj/item/weapon/storage/firstaid/brute,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bB" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -492,7 +492,7 @@
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bC" = (
 /obj/structure/table/wood,
 /obj/item/weapon/tank/internals/oxygen,
@@ -512,11 +512,11 @@
 "bE" = (
 /obj/item/weapon/reagent_containers/spray/spraytan,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bF" = (
 /obj/item/toy/beach_ball,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bG" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -524,7 +524,7 @@
 /obj/structure/window/reinforced,
 /obj/item/device/megaphone,
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bH" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -538,7 +538,7 @@
 	mob_gender = "female"
 	},
 /turf/open/floor/wood,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bI" = (
 /obj/structure/dresser,
 /turf/open/floor/pod/dark{
@@ -548,11 +548,11 @@
 "bJ" = (
 /obj/structure/chair,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bK" = (
 /obj/item/weapon/storage/backpack/dufflebag,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bL" = (
 /obj/effect/decal/sandeffect{
 	density = 1
@@ -562,43 +562,78 @@
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	density = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bM" = (
 /turf/open/floor/plasteel/stairs/old,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bN" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bO" = (
 /obj/item/device/camera,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bP" = (
 /obj/item/weapon/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bQ" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/beach/coastline_t,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bR" = (
 /turf/open/floor/plating/beach/coastline_t,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bS" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/beach/coastline_t,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bT" = (
 /turf/open/floor/plating/beach/coastline_b,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bU" = (
 /turf/open/floor/plating/beach/water,
-/area/ruin/powered)
+/area/ruin/powered/beach)
 "bV" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/floor/plating/beach/water,
-/area/ruin/powered)
+/area/ruin/powered/beach)
+"bW" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"bX" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"bY" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"bZ" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"ca" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"cb" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
+"cc" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/beach)
 
 (1,1,1) = {"
 aa
@@ -859,9 +894,9 @@ aa
 (9,1,1) = {"
 aa
 ab
-ab
-ab
-ab
+bW
+bY
+ca
 aA
 aA
 aA
@@ -893,7 +928,7 @@ aa
 ac
 ae
 as
-ab
+cb
 aB
 aK
 aK
@@ -1275,9 +1310,9 @@ aa
 (22,1,1) = {"
 aa
 ab
-ab
-ab
-ab
+bX
+bZ
+cc
 aA
 aA
 aA

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -83,7 +83,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "an" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -93,7 +93,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ao" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -103,7 +103,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ap" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -113,7 +113,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aq" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -122,7 +122,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ar" = (
 /obj/structure/disposalpipe/segment{
 	invisibility = 101
@@ -131,7 +131,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "as" = (
 /obj/effect/mob_spawn/human/corpse/damaged,
 /obj/effect/decal/cleanable/blood/old,
@@ -142,7 +142,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "at" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -153,7 +153,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "au" = (
 /obj/structure/disposalpipe/segment{
 	invisibility = 101
@@ -161,7 +161,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "av" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -172,7 +172,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aw" = (
 /obj/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -181,7 +181,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ax" = (
 /obj/effect/decal/cleanable/pie_smudge,
 /obj/structure/disposalpipe/segment{
@@ -191,7 +191,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ay" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -203,7 +203,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "az" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -214,7 +214,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -224,7 +224,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -235,20 +235,20 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aC" = (
 /turf/open/indestructible{
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible{
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aE" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -257,7 +257,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -268,7 +268,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -279,7 +279,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -291,7 +291,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -303,7 +303,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -313,7 +313,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -324,7 +324,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -333,7 +333,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -344,13 +344,13 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aN" = (
 /obj/structure/disposalpipe/segment{
 	invisibility = 101
 	},
 /turf/open/floor/plating,
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aO" = (
 /obj/item/weapon/bikehorn,
 /obj/structure/disposalpipe/segment{
@@ -361,7 +361,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -370,7 +370,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aQ" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
@@ -383,7 +383,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/plating,
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -393,7 +393,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -403,14 +403,14 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -422,7 +422,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aW" = (
 /obj/item/weapon/bikehorn,
 /obj/effect/decal/cleanable/dirt,
@@ -433,7 +433,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aX" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -444,7 +444,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aY" = (
 /obj/item/weapon/bikehorn,
 /obj/structure/disposalpipe/segment{
@@ -454,7 +454,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "aZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -463,14 +463,14 @@
 /turf/open/indestructible{
 	icon_state = "darkredfull"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ba" = (
 /obj/effect/decal/cleanable/pie_smudge,
 /turf/open/indestructible{
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -479,7 +479,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -491,7 +491,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -505,7 +505,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "be" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -516,7 +516,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -528,7 +528,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -538,7 +538,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -548,7 +548,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -558,7 +558,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -567,7 +567,7 @@
 /turf/open/indestructible{
 	icon_state = "light_on"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bk" = (
 /obj/structure/disposalpipe/segment{
 	invisibility = 101
@@ -575,12 +575,12 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bl" = (
 /turf/open/indestructible{
 	icon_state = "light_on"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -590,7 +590,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -600,7 +600,7 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bo" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -610,18 +610,18 @@
 /area/ruin/powered)
 "bp" = (
 /turf/closed/mineral/clown,
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bq" = (
 /obj/item/weapon/pickaxe,
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "br" = (
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -631,7 +631,7 @@
 /turf/open/indestructible{
 	icon_state = "darkredfull"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -641,7 +641,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bu" = (
 /obj/item/weapon/bikehorn,
 /obj/structure/disposalpipe/segment{
@@ -653,7 +653,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bv" = (
 /obj/machinery/light{
 	dir = 8
@@ -669,14 +669,14 @@
 	icon_state = "darkredfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "by" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/indestructible{
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bz" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -685,13 +685,13 @@
 /turf/open/indestructible{
 	icon_state = "white"
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bA" = (
 /turf/open/indestructible{
 	icon_state = "darkredfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bB" = (
 /turf/open/indestructible/sound{
 	icon_state = "bananium";
@@ -699,7 +699,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bC" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -711,7 +711,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bD" = (
 /obj/structure/mecha_wreckage/honker,
 /obj/structure/disposalpipe/segment{
@@ -721,7 +721,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bE" = (
 /obj/effect/decal/cleanable/oil,
 /obj/structure/disposalpipe/segment{
@@ -732,7 +732,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bF" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -743,7 +743,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bG" = (
 /obj/item/weapon/grown/bananapeel{
 	color = "#2F3000";
@@ -759,7 +759,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bI" = (
 /obj/effect/mob_spawn/human/corpse/damaged,
 /obj/effect/decal/cleanable/blood/old,
@@ -767,7 +767,7 @@
 	icon_state = "darkyellowfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -777,7 +777,7 @@
 	icon_state = "darkredfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -788,19 +788,19 @@
 	icon_state = "darkredfull";
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bL" = (
 /obj/item/weapon/reagent_containers/food/drinks/trophy/gold_cup,
 /obj/structure/table/glass,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bM" = (
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bN" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -809,7 +809,7 @@
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bO" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/indestructible/sound{
@@ -818,27 +818,27 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bP" = (
 /obj/structure/statue/bananium/clown,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bQ" = (
 /obj/structure/table/glass,
 /obj/item/weapon/grown/bananapeel/bluespace,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bR" = (
 /obj/structure/table/glass,
 /obj/item/clothing/shoes/clown_shoes/banana_shoes,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bS" = (
 /obj/item/weapon/coin/clown,
 /obj/item/weapon/coin/clown,
@@ -847,27 +847,27 @@
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bT" = (
 /obj/item/slime_extract/rainbow,
 /obj/structure/table/glass,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bU" = (
 /obj/item/weapon/bikehorn/airhorn,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bV" = (
 /obj/structure/table/glass,
 /obj/item/weapon/gun/magic/staff/honk,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bW" = (
 /obj/item/weapon/bikehorn,
 /turf/open/indestructible/sound{
@@ -876,7 +876,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -891,7 +891,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "bZ" = (
 /obj/machinery/door/airlock/clown,
 /turf/open/indestructible/sound{
@@ -900,7 +900,7 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "ca" = (
 /obj/item/weapon/bikehorn,
 /obj/effect/decal/cleanable/dirt,
@@ -910,13 +910,411 @@
 	sound = 'sound/effects/clownstep1.ogg';
 	wet = 5
 	},
-/area/ruin/powered)
+/area/ruin/powered/clownplanet)
 "cb" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered)
+"cc" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cd" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ce" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cf" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cg" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ch" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ci" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cj" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ck" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cl" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cm" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cn" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"co" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cp" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cq" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cr" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cs" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ct" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cu" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cv" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cw" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cx" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cy" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cz" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cA" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cB" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cC" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cD" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cE" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cF" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cG" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cH" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cI" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cJ" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cK" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cL" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cM" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cN" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cO" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cP" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cQ" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cR" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cS" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cT" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cU" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cV" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cW" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cX" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cY" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"cZ" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"da" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"db" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dc" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dd" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"de" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"df" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dg" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dh" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"di" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dj" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dk" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dl" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dm" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dn" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"do" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dp" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dq" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dr" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"ds" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dt" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"du" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dv" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dw" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dx" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dy" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
+"dz" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered/clownplanet)
 
 (1,1,1) = {"
 aa
@@ -1095,7 +1493,7 @@ aa
 ah
 ak
 ak
-ah
+cq
 aF
 at
 ar
@@ -1137,7 +1535,7 @@ ar
 aJ
 aL
 aL
-ah
+cE
 bx
 bA
 bB
@@ -1172,14 +1570,14 @@ aL
 bb
 bb
 bp
-ah
+cG
 bA
 bA
 bB
-ah
-ah
+dd
+dg
 bH
-ah
+do
 bB
 bB
 bB
@@ -1207,8 +1605,8 @@ bb
 bb
 bq
 bp
-ah
-ah
+cM
+cS
 bA
 bB
 bB
@@ -1245,7 +1643,7 @@ bA
 bA
 bA
 bB
-ah
+dh
 bB
 bB
 bH
@@ -1264,7 +1662,7 @@ ae
 ah
 ak
 ao
-al
+ch
 ar
 aH
 az
@@ -1275,12 +1673,12 @@ bg
 bj
 bl
 bp
-ah
+cN
 bA
 bA
 bB
 bB
-ah
+dk
 bB
 bB
 bB
@@ -1308,16 +1706,16 @@ aL
 bb
 bb
 br
-ah
-ah
+cH
+cO
 bA
 bB
 bB
-ah
-ah
+di
+dl
 bB
 bB
-ah
+dx
 bB
 bH
 ak
@@ -1331,7 +1729,7 @@ ab
 ad
 ah
 ak
-ah
+cc
 at
 ar
 aB
@@ -1342,14 +1740,14 @@ aB
 aL
 aL
 bs
-al
+cI
 aJ
-ah
-ah
-ah
+cT
+cW
+de
 bP
 bS
-ah
+dp
 bB
 bB
 bH
@@ -1378,13 +1776,13 @@ aA
 aV
 ay
 az
-ah
-ah
+cU
+cX
 bL
 bM
 bM
 bM
-ah
+ds
 bB
 bH
 bH
@@ -1402,10 +1800,10 @@ al
 al
 au
 ar
-al
+cs
 ar
 aT
-al
+cw
 ax
 ar
 aH
@@ -1413,13 +1811,13 @@ aD
 aA
 aM
 aG
-ah
+cY
 bM
 bQ
 bT
 bM
-ah
-ah
+dt
+dy
 bH
 bB
 bB
@@ -1447,7 +1845,7 @@ bt
 aM
 aG
 aV
-al
+cZ
 bN
 bM
 bU
@@ -1456,7 +1854,7 @@ bZ
 bB
 bH
 bB
-ah
+dz
 ak
 bX
 ak
@@ -1481,12 +1879,12 @@ bu
 by
 bC
 aD
-ah
+da
 bM
 bR
 bV
 bM
-ah
+du
 bB
 bB
 bB
@@ -1502,7 +1900,7 @@ ac
 ah
 ah
 ak
-ah
+ci
 az
 az
 az
@@ -1515,12 +1913,12 @@ aG
 ba
 aL
 bI
-ah
+db
 bL
 bM
 bM
 bM
-ah
+dv
 bB
 bB
 bB
@@ -1536,24 +1934,24 @@ ad
 ah
 ak
 ak
-ah
+cj
 az
 az
 aO
 aA
 aA
 aL
-ah
-ah
+cx
+cA
 aZ
-ah
+cJ
 bD
-ah
+cV
 bB
-ah
+df
 bP
 bS
-ah
+dq
 bB
 bB
 bH
@@ -1569,8 +1967,8 @@ aa
 ad
 ah
 ak
-ah
-ah
+cd
+ck
 aA
 aA
 aA
@@ -1580,13 +1978,13 @@ aL
 bh
 bk
 bn
-ah
+cK
 bE
 aJ
 bB
 bB
-ah
-ah
+dj
+dm
 bY
 bB
 bB
@@ -1603,8 +2001,8 @@ aa
 ae
 ah
 ak
-ah
-ah
+ce
+cl
 aA
 aK
 aL
@@ -1615,12 +2013,12 @@ bb
 bl
 bl
 bp
-ah
+cP
 bJ
 bA
 bB
 bB
-ah
+dn
 bB
 bH
 bB
@@ -1649,9 +2047,9 @@ bb
 bl
 bl
 bz
-al
+cQ
 bK
-ah
+dc
 bB
 bB
 bH
@@ -1671,8 +2069,8 @@ aa
 aa
 ah
 ak
-ah
-ah
+cf
+cm
 aC
 aA
 aA
@@ -1683,7 +2081,7 @@ bi
 bm
 br
 bp
-ah
+cR
 bA
 bA
 bB
@@ -1705,8 +2103,8 @@ aa
 aa
 ah
 ak
-ah
-ah
+cg
+cn
 aD
 aA
 aL
@@ -1716,7 +2114,7 @@ aL
 bh
 bn
 bp
-ah
+cL
 bA
 bA
 bB
@@ -1724,7 +2122,7 @@ bB
 bB
 bB
 bB
-ah
+dw
 bB
 bB
 ak
@@ -1740,7 +2138,7 @@ aa
 ah
 ak
 ak
-ah
+co
 aE
 aA
 aA
@@ -1748,8 +2146,8 @@ aA
 aM
 aB
 aL
-ah
-ah
+cB
+cF
 bA
 bA
 bB
@@ -1774,15 +2172,15 @@ aa
 ah
 ah
 ak
-ah
-ah
+cp
+cr
 aM
 aB
 aM
 ar
 ar
 aS
-ah
+cC
 ak
 ah
 bF
@@ -1791,7 +2189,7 @@ bB
 ah
 bB
 bB
-ah
+dr
 bB
 bB
 ak
@@ -1810,13 +2208,13 @@ ah
 ah
 ak
 ak
-ah
-aQ
-ah
+ct
+cu
+cv
 ba
 aC
-aQ
-ah
+cy
+cD
 ak
 ah
 ah
@@ -1849,7 +2247,7 @@ ak
 aU
 aU
 aU
-ah
+cz
 ak
 ah
 ah

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -22,38 +22,38 @@
 /turf/closed/wall/mineral/titanium/nodiagonal{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "af" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ag" = (
 /turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ah" = (
 /obj/structure/toilet,
 /turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ai" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aj" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ak" = (
 /obj/structure/table/wood,
 /obj/item/device/taperecorder,
@@ -61,20 +61,20 @@
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "al" = (
 /obj/structure/table/wood,
 /obj/item/toy/carpplushie,
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "am" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "an" = (
 /obj/machinery/sleeper{
 	icon_state = "sleeper-open";
@@ -83,12 +83,12 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ao" = (
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ap" = (
 /obj/structure/table,
 /obj/item/weapon/circular_saw,
@@ -98,7 +98,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aq" = (
 /obj/structure/table,
 /obj/item/weapon/cautery{
@@ -108,7 +108,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ar" = (
 /obj/structure/table,
 /obj/item/weapon/surgical_drapes,
@@ -116,12 +116,12 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "as" = (
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "at" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -129,7 +129,7 @@
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "au" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -137,7 +137,7 @@
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "av" = (
 /obj/item/weapon/reagent_containers/glass/rag,
 /obj/item/weapon/reagent_containers/spray/cleaner,
@@ -145,13 +145,13 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aw" = (
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ax" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/weapon/storage/bag/trash,
@@ -177,7 +177,7 @@
 /turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "az" = (
 /obj/structure/noticeboard{
 	dir = 1;
@@ -190,25 +190,25 @@
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aA" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aB" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aC" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aD" = (
 /obj/structure/table,
 /obj/item/weapon/retractor,
@@ -216,7 +216,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aE" = (
 /turf/closed/wall/mineral/titanium/nodiagonal{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -229,13 +229,13 @@
 /turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aG" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/titanium/nodiagonal{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aH" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/titanium/nodiagonal{
@@ -255,20 +255,20 @@
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aL" = (
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aM" = (
 /obj/effect/mob_spawn/human/doctor/alive/lavaland,
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aN" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/blood/random,
@@ -279,38 +279,38 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aO" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aP" = (
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 0
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aQ" = (
 /turf/open/floor/plasteel/blue/corner{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aR" = (
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 4
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aS" = (
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aT" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/cobweb,
@@ -324,18 +324,18 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aU" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aV" = (
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aW" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 28
@@ -343,25 +343,25 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aX" = (
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aY" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "aZ" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ba" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/glass/beaker,
@@ -369,21 +369,21 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bb" = (
 /obj/structure/table/reinforced,
 /obj/item/device/laser_pointer,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bc" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bd" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/gloves,
@@ -394,14 +394,14 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "be" = (
 /obj/effect/decal/cleanable/oil,
 /obj/item/weapon/storage/toolbox/mechanical,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bf" = (
 /obj/structure/table,
 /obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
@@ -409,39 +409,39 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bg" = (
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bh" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/brute,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bi" = (
 /obj/item/toy/cattoy,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bj" = (
 /obj/structure/table/glass,
 /obj/item/weapon/lazarus_injector,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bk" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bl" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/snacks/cookie{
@@ -466,7 +466,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bm" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -475,13 +475,13 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bn" = (
 /obj/structure/bed/dogbed,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bo" = (
 /obj/item/weapon/reagent_containers/glass/bowl,
 /obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
@@ -489,7 +489,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bp" = (
 /obj/structure/closet/crate/bin,
 /obj/item/trash/pistachios,
@@ -499,32 +499,32 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bq" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "br" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bs" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/phone,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bt" = (
 /obj/item/weapon/twohanded/required/kirbyplants,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bu" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -533,7 +533,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 4
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bv" = (
 /obj/effect/mob_spawn/mouse{
 	dir = 4;
@@ -543,13 +543,13 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bx" = (
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room";
@@ -558,7 +558,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "by" = (
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
@@ -566,14 +566,14 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bz" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/regular,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bA" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin,
@@ -581,14 +581,14 @@
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bB" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/hug,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bC" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -596,7 +596,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bD" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/glass/bottle/cyanide{
@@ -607,20 +607,20 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bE" = (
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bF" = (
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 10
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bG" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -629,7 +629,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 6
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bH" = (
 /obj/structure/table,
 /obj/item/weapon/tank/internals/oxygen,
@@ -638,7 +638,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 8
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bI" = (
 /obj/structure/sign/bluecross_2{
 	name = "animal hospital"
@@ -646,7 +646,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bJ" = (
 /obj/machinery/door/airlock/glass_large{
 	name = "Ian's Pet Care"
@@ -655,7 +655,7 @@
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bK" = (
 /obj/item/weapon/reagent_containers/glass/bowl,
 /obj/item/weapon/reagent_containers/food/snacks/grown/wheat,
@@ -665,7 +665,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bL" = (
 /obj/vehicle/scooter/skateboard{
 	dir = 4
@@ -691,7 +691,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bO" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass{
@@ -707,7 +707,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bQ" = (
 /obj/structure/table/glass,
 /obj/item/clothing/neck/petcollar,
@@ -715,7 +715,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bR" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -728,7 +728,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 10
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bS" = (
 /obj/structure/closet,
 /obj/item/weapon/defibrillator/loaded,
@@ -738,7 +738,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 6
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bT" = (
 /obj/item/weapon/pickaxe,
 /obj/effect/decal/cleanable/blood/old,
@@ -757,7 +757,7 @@
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "bX" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -806,7 +806,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cd" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/latex,
@@ -815,7 +815,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ce" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -824,13 +824,13 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cf" = (
 /obj/structure/closet/l3closet,
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cg" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Break Room"
@@ -838,7 +838,7 @@
 /turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ch" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Emergency Care"
@@ -846,7 +846,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ci" = (
 /obj/machinery/door/unpowered/shuttle{
 	desc = "There's a note wedged in the seam saying something about directing pizza here.";
@@ -856,7 +856,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cj" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Morgue"
@@ -864,7 +864,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "ck" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Medical Supplies"
@@ -872,7 +872,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cl" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Safety Supplies"
@@ -880,7 +880,7 @@
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 "cm" = (
 /obj/machinery/door/unpowered/shuttle{
 	name = "Tool Storage"
@@ -888,7 +888,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
-/area/ruin/powered)
+/area/ruin/powered/animal_hospital)
 
 (1,1,1) = {"
 aa

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "ac" = (
 /obj/item/stack/medical/ointment,
 /obj/structure/table,
@@ -290,89 +290,89 @@
 /obj/item/clothing/shoes/winterboots,
 /obj/item/clothing/gloves/fingerless,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aT" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aU" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aV" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aW" = (
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aX" = (
 /turf/open/floor/pod/light,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aY" = (
 /obj/structure/chair/stool,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "aZ" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/fans/tiny,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "ba" = (
 /obj/machinery/door/airlock/silver,
 /obj/structure/fans/tiny,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bb" = (
 /obj/machinery/door/airlock/silver,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bc" = (
 /obj/structure/table,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bd" = (
 /obj/structure/table,
 /obj/item/weapon/pen,
 /obj/item/weapon/paper_bin,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "be" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bf" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bg" = (
 /obj/item/weapon/twohanded/required/chainsaw,
 /obj/structure/closet,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bh" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bi" = (
 /obj/machinery/computer/monitor,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bj" = (
 /obj/item/weapon/storage/toolbox/mechanical,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bk" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bl" = (
 /turf/open/floor/wood{
 	baseturf = /turf/open/floor/plating/lava/smooth;
@@ -382,22 +382,22 @@
 /area/ruin/powered/snow_biodome)
 "bm" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bn" = (
 /obj/item/clothing/mask/balaclava,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bo" = (
 /obj/structure/table,
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_carp,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bp" = (
 /obj/structure/table,
 /obj/item/weapon/pen,
 /obj/item/weapon/paper,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "bq" = (
 /obj/machinery/light/built{
 	dir = 1
@@ -406,12 +406,25 @@
 	baseturf = /turf/open/floor/plating/asteroid/basalt;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
 "br" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/glass_large,
 /turf/open/floor/pod/dark,
-/area/ruin/powered/snow_biodome)
+/area/ruin/powered)
+"bs" = (
+/obj/machinery/door/airlock/glass_large,
+/obj/structure/fans/tiny,
+/turf/open/floor/pod/dark,
+/area/ruin/powered)
+"bt" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/pod/dark,
+/area/ruin/powered)
+"bu" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/pod/dark,
+/area/ruin/powered)
 
 (1,1,1) = {"
 aa
@@ -887,7 +900,7 @@ ao
 ak
 ak
 ak
-aO
+bs
 aX
 aX
 br
@@ -919,10 +932,10 @@ ao
 ao
 ak
 ak
-aP
+bt
 aX
 aX
-aP
+bu
 bm
 "}
 (17,1,1) = {"

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
@@ -15,36 +15,36 @@
 /area/ruin/powered)
 "e" = (
 /turf/open/floor/plating/lava/smooth,
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "f" = (
 /obj/item/weapon/reagent_containers/syringe/gluttony,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "g" = (
 /obj/effect/gluttony,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "h" = (
 /obj/item/weapon/veilrender/vealrender,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "i" = (
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "j" = (
 /obj/item/trash/plate,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "k" = (
 /obj/machinery/door/airlock/uranium,
 /obj/structure/fans/tiny/invisible,
@@ -57,37 +57,37 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "m" = (
 /obj/item/trash/raisins,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "n" = (
 /obj/item/trash/pistachios,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "o" = (
 /obj/item/trash/popcorn,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "p" = (
 /obj/item/trash/semki,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 "q" = (
 /obj/item/trash/syndi_cakes,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/gluttony)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
@@ -20,14 +20,14 @@
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "f" = (
 /obj/structure/cursed_slot_machine,
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "g" = (
 /obj/structure/table/wood/poker,
 /obj/item/weapon/coin/mythril,
@@ -35,7 +35,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "h" = (
 /obj/structure/table/wood/poker,
 /obj/item/weapon/coin/diamond,
@@ -43,13 +43,13 @@
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "i" = (
 /turf/open/floor/carpet{
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "j" = (
 /obj/structure/table/wood/poker,
 /obj/item/weapon/coin/adamantine,
@@ -57,7 +57,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth;
 	icon_state = "carpetsymbol"
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "k" = (
 /obj/machinery/computer/arcade/battle{
 	emagged = 1
@@ -65,38 +65,38 @@
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "l" = (
 /obj/item/weapon/coin/gold,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "m" = (
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "n" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c1000,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "o" = (
 /obj/item/weapon/storage/bag/money,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "p" = (
 /obj/structure/table/wood/poker,
 /obj/item/weapon/ore/gold,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "q" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c20,
@@ -104,7 +104,7 @@
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "r" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c500,
@@ -113,20 +113,20 @@
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "s" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c200,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/greed)
 "t" = (
 /obj/machinery/door/airlock/gold,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/engine/cult{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/obj/structure/fans/tiny/invisible,
 /area/ruin/powered)
 
 (1,1,1) = {"

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -20,7 +20,7 @@
 /turf/open/floor/mineral/silver{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/pride)
 "f" = (
 /obj/structure/mirror{
 	pixel_x = 32
@@ -28,12 +28,12 @@
 /turf/open/floor/mineral/silver{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/pride)
 "g" = (
 /turf/open/floor/mineral/silver{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/pride)
 "h" = (
 /obj/structure/mirror/magic/pride,
 /turf/closed/wall/mineral/diamond{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -19,31 +19,31 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "e" = (
 /obj/structure/table/wood,
 /obj/item/weapon/storage/box/disks_plantgene,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "f" = (
 /obj/machinery/plantgenes/seedvault,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "g" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "h" = (
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "i" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/structure/beebox,
@@ -57,7 +57,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "j" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion";
@@ -71,13 +71,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "l" = (
 /obj/machinery/door/airlock,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "m" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion";
@@ -90,7 +90,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "o" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/weapon/cultivator,
@@ -108,13 +108,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "p" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "q" = (
 /obj/item/weapon/hatchet,
 /obj/item/weapon/storage/bag/plants,
@@ -123,7 +123,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "r" = (
 /obj/structure/table/wood,
 /obj/item/weapon/storage/bag/plants,
@@ -133,7 +133,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "s" = (
 /obj/structure/table/wood,
 /obj/item/weapon/gun/energy/floragun,
@@ -144,13 +144,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "t" = (
 /obj/effect/mob_spawn/human/seed_vault,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "u" = (
 /obj/structure/sink{
 	icon_state = "sink";
@@ -161,19 +161,19 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "v" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "w" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "x" = (
 /obj/machinery/reagentgrinder{
 	pixel_y = 5
@@ -186,7 +186,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "y" = (
 /obj/structure/sink{
 	dir = 4;
@@ -197,13 +197,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "z" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "A" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/fans/tiny,
@@ -217,31 +217,31 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "C" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "D" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "E" = (
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "F" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "G" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/clothing/under/rank/hydroponics,
@@ -251,13 +251,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "H" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "I" = (
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/glass/bucket,
@@ -267,14 +267,14 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "J" = (
 /obj/item/weapon/storage/toolbox/syndicate,
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth
 	},
-/area/ruin/powered)
+/area/ruin/powered/seedvault)
 "K" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1459,6 +1459,380 @@
 	},
 /turf/open/floor/plating/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"dv" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dw" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dx" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dy" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dz" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dA" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dB" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dC" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dD" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dE" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dF" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dG" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dH" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dI" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dJ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dK" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dL" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dM" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dN" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dO" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dP" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dQ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dR" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dS" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dT" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dU" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dV" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dW" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dX" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dY" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"dZ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ea" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eb" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ec" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ed" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ee" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ef" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eg" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eh" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ei" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ej" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ek" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"el" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"em" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"en" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eo" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ep" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eq" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"er" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"es" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"et" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eu" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ev" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ew" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ex" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ey" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ez" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eA" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eB" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eC" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eD" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eE" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eF" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eG" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eH" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eI" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eJ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eK" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eL" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eM" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eN" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eO" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eP" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eQ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eR" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eS" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eT" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eU" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eV" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eW" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eX" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eY" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"eZ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fa" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fb" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fc" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fd" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fe" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ff" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fg" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fh" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fi" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fj" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fk" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fl" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fm" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fn" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fo" = (
+/obj/item/weapon/bombcore/large/underwall,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fp" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fq" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fr" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fs" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"ft" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fu" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fv" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fw" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fx" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fy" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fz" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fA" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fB" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Syndicate Recon Outpost";
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered)
+"fC" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Syndicate Recon Outpost";
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered)
+"fD" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fE" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fF" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fG" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fH" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"fI" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
 
 (1,1,1) = {"
 aa
@@ -1764,15 +2138,15 @@ ac
 ab
 ab
 ac
-ad
-ad
-ad
-ad
-ad
-ad
-ae
-ad
-ad
+eF
+eI
+eK
+eM
+eO
+eQ
+eS
+eY
+fg
 ac
 ab
 ab
@@ -1790,21 +2164,21 @@ ab
 ab
 ab
 ac
-ad
-ad
-ad
-ad
-ad
-ae
-ad
-ad
-ad
-ad
-ad
-ad
-ae
-ad
-ad
+dU
+ea
+ec
+eg
+ei
+ek
+eo
+eq
+es
+eu
+ew
+ey
+eB
+eD
+eG
 cG
 cG
 cG
@@ -1812,7 +2186,7 @@ cW
 cG
 cG
 cG
-ad
+fh
 ac
 ab
 ab
@@ -1830,7 +2204,7 @@ ab
 ab
 ab
 ab
-ad
+dV
 aq
 aq
 aq
@@ -1852,7 +2226,7 @@ cG
 cG
 cG
 cG
-ad
+fi
 ab
 ab
 ab
@@ -1870,7 +2244,7 @@ ac
 ab
 ab
 ab
-ad
+dW
 aq
 aQ
 aO
@@ -1892,7 +2266,7 @@ cG
 cG
 cG
 cG
-ad
+fj
 ab
 ab
 ab
@@ -1910,7 +2284,7 @@ ab
 ab
 ac
 ac
-ad
+dX
 aq
 aq
 aq
@@ -1932,7 +2306,7 @@ cG
 cG
 cG
 cG
-ad
+fk
 ab
 ab
 ab
@@ -1947,10 +2321,10 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ad
+dJ
+dQ
+dS
+dY
 ad
 ad
 ad
@@ -1972,7 +2346,7 @@ cG
 cG
 cG
 cG
-ad
+fl
 ac
 ab
 ab
@@ -1987,7 +2361,7 @@ ab
 ab
 ab
 ab
-ad
+dK
 ao
 aw
 aA
@@ -2012,7 +2386,7 @@ cG
 cG
 cG
 cG
-ad
+fm
 ac
 ab
 ab
@@ -2027,7 +2401,7 @@ ab
 ab
 ab
 ab
-ad
+dL
 ap
 aq
 ap
@@ -2052,7 +2426,7 @@ cG
 de
 cG
 cG
-ad
+fn
 ac
 ac
 ab
@@ -2067,7 +2441,7 @@ ab
 ab
 ab
 ac
-ad
+dM
 aq
 ap
 aq
@@ -2092,9 +2466,9 @@ cD
 ad
 dj
 ad
-ae
-ad
-ad
+fo
+fs
+fw
 ab
 ab
 ab
@@ -2107,7 +2481,7 @@ ab
 ab
 ab
 ac
-ad
+dN
 ar
 ax
 aB
@@ -2134,7 +2508,7 @@ aq
 cU
 bu
 dt
-ad
+fx
 ab
 ab
 ab
@@ -2146,8 +2520,8 @@ ab
 ab
 ab
 ab
-ad
-ad
+dv
+dO
 ad
 ad
 ad
@@ -2174,7 +2548,7 @@ aq
 aq
 dp
 aO
-ad
+fy
 ab
 ab
 ab
@@ -2186,7 +2560,7 @@ ab
 ab
 ab
 ab
-ad
+dw
 af
 as
 as
@@ -2214,7 +2588,7 @@ dk
 aS
 bu
 dt
-ad
+fz
 ab
 ab
 ab
@@ -2226,7 +2600,7 @@ ab
 ab
 ab
 ab
-ad
+dx
 ag
 as
 as
@@ -2254,7 +2628,7 @@ ad
 ad
 ad
 ad
-ad
+fA
 du
 ab
 ab
@@ -2266,7 +2640,7 @@ ab
 ab
 ab
 ab
-ad
+dy
 ah
 as
 as
@@ -2294,7 +2668,7 @@ cv
 dn
 dq
 aO
-dn
+fB
 ab
 ab
 ab
@@ -2306,7 +2680,7 @@ ab
 ab
 ab
 ab
-ae
+dz
 ad
 as
 as
@@ -2334,7 +2708,7 @@ cA
 dn
 dr
 aO
-dn
+fC
 ab
 ab
 ab
@@ -2346,7 +2720,7 @@ ab
 ab
 ab
 ab
-ad
+dA
 ai
 as
 as
@@ -2370,11 +2744,11 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
+eT
+eZ
+fp
+ft
+fD
 du
 ab
 ab
@@ -2386,7 +2760,7 @@ ab
 ab
 ab
 ab
-ad
+dB
 aj
 as
 as
@@ -2410,7 +2784,7 @@ aq
 cU
 cZ
 dh
-ae
+eU
 ac
 ac
 ac
@@ -2426,7 +2800,7 @@ ab
 ab
 ab
 ab
-ad
+dC
 ad
 ad
 ad
@@ -2450,7 +2824,7 @@ ap
 ap
 ap
 aq
-ad
+eV
 ac
 ac
 ab
@@ -2466,7 +2840,7 @@ ab
 ab
 ab
 ab
-ad
+dD
 ak
 at
 ay
@@ -2490,11 +2864,11 @@ cM
 cV
 da
 aq
-ad
-ad
-ad
-ad
-ad
+eW
+fa
+fq
+fu
+fE
 ab
 ab
 ab
@@ -2506,7 +2880,7 @@ ab
 ab
 ab
 ab
-ad
+dE
 al
 au
 au
@@ -2534,7 +2908,7 @@ ad
 aq
 do
 aq
-ad
+fF
 ab
 ab
 ab
@@ -2546,7 +2920,7 @@ ab
 ab
 ab
 ab
-ad
+dF
 ad
 ad
 ae
@@ -2574,7 +2948,7 @@ dl
 do
 ds
 do
-ad
+fG
 ab
 ab
 ab
@@ -2586,7 +2960,7 @@ ab
 ab
 ab
 ab
-ad
+dG
 am
 au
 au
@@ -2614,7 +2988,7 @@ ad
 aq
 do
 aq
-ad
+fH
 ab
 ab
 ab
@@ -2626,7 +3000,7 @@ ab
 ab
 ab
 ab
-ad
+dH
 an
 av
 az
@@ -2651,10 +3025,10 @@ ad
 cF
 ad
 ad
-ad
-ad
-ad
-ad
+fb
+fr
+fv
+fI
 ab
 ab
 ab
@@ -2666,13 +3040,13 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+dI
+dP
+dR
+dT
+dZ
+eb
+ed
 aW
 ad
 ad
@@ -2691,7 +3065,7 @@ ad
 dc
 di
 di
-ad
+fc
 ab
 ab
 ab
@@ -2712,7 +3086,7 @@ ac
 ac
 ab
 ac
-ad
+ee
 aX
 bf
 ad
@@ -2731,7 +3105,7 @@ ad
 dd
 di
 dm
-ad
+fd
 ab
 ab
 ab
@@ -2752,10 +3126,10 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ad
+ef
+eh
+ej
+el
 bw
 bI
 ap
@@ -2771,7 +3145,7 @@ ad
 dc
 di
 di
-ad
+fe
 ac
 ab
 ab
@@ -2795,23 +3169,23 @@ ac
 ab
 ab
 ac
-ad
+em
 by
 bx
 ap
 bx
 ce
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+ez
+eC
+eE
+eH
+eJ
+eL
+eN
+eP
+eR
+eX
+ff
 ac
 ab
 ab
@@ -2835,13 +3209,13 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+en
+ep
+er
+et
+ev
+ex
+eA
 ab
 ab
 ab

--- a/code/game/area/areas/ruins.dm
+++ b/code/game/area/areas/ruins.dm
@@ -21,20 +21,58 @@
 
 
 //Areas
+
+/area/ruin/powered/beach
+	icon_state = "dk_yellow"
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+
+/area/ruin/powered/clownplanet
+	icon_state = "dk_yellow"
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+
+/area/ruin/powered/animal_hospital
+	icon_state = "dk_yellow"
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+
+/area/ruin/powered/snow_biodome
+	icon_state = "dk_yellow"
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+
+/area/ruin/powered/gluttony
+	icon_state = "dk_yellow"
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+
+/area/ruin/powered/golem_ship
+	name = "Free Golem Ship"
+	icon_state = "dk_yellow"
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+
+/area/ruin/powered/greed
+	icon_state = "dk_yellow"
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+	
 /area/ruin/unpowered/hierophant
 	name = "Hierophant's Arena"
+	icon_state = "dk_yellow"
+
+/area/ruin/powered/pride
+	icon_state = "dk_yellow"
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+
+/area/ruin/powered/seedvault
+	icon_state = "dk_yellow"
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+
+/area/ruin/powered/syndicate_lava_base
+	name = "Secret Base"
+	icon_state = "dk_yellow"
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+
 
 /area/ruin/unpowered/no_grav/way_home
 	name = "\improper Salvation"
 	icon_state = "away"
 
-/area/ruin/powered/snow_biodome
-
-/area/ruin/powered/golem_ship
-	name = "Free Golem Ship"
-
-/area/ruin/powered/syndicate_lava_base
-	name = "Secret Base"
 
 // Ruins of "onehalf" ship
 
@@ -54,8 +92,6 @@
 	name = "Bridge"
 	icon_state = "bridge"
 
-
-
 /area/ruin/powered/dinner_for_two
 	name = "Dinner for Two"
 
@@ -65,6 +101,10 @@
 /area/ruin/powered/aesthetic
 	name = "Aesthetic"
 	ambientsounds = list('sound/ambience/ambivapor1.ogg')
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+
+
+
 
 
 //Ruin of Hotel

--- a/code/game/area/areas/ruins.dm
+++ b/code/game/area/areas/ruins.dm
@@ -104,9 +104,6 @@
 	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
 
 
-
-
-
 //Ruin of Hotel
 
 /area/ruin/hotel


### PR DESCRIPTION
Restores fullbright to the interior area of powered ruins. The exteriors are now properly unlit so you can't see them while walking around.

The alternative to this is to add lights to each ruin, which I did in #27844 . The choice of which is a better method of fixing is up to you.

Golem ship's issue with the engines being fullbright mentioned in #24777 isn't fixed in this one since mapmerge is spitting out buffer overflow errors on it when I try to fix it.