### PR TITLE
Flamethrower fixes

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -14,14 +14,16 @@
 	origin_tech = "combat=1;plasmatech=2;engineering=2"
 	resistance_flags = FIRE_PROOF
 	var/status = 0
-	var/throw_amount = 100
 	var/lit = 0	//on or off
 	var/operating = 0//cooldown
 	var/obj/item/weapon/weldingtool/weldtool = null
 	var/obj/item/device/assembly/igniter/igniter = null
 	var/obj/item/weapon/tank/internals/plasma/ptank = null
 	var/warned_admins = 0 //for the message_admins() when lit
-
+	//variables for prebuilt flamethrowers
+	var/create_full = FALSE
+	var/create_with_tank = FALSE
+	var/igniter_type = /obj/item/device/assembly/igniter 
 
 /obj/item/weapon/flamethrower/Destroy()
 	if(weldtool)
@@ -32,9 +34,8 @@
 		qdel(ptank)
 	return ..()
 
-
 /obj/item/weapon/flamethrower/process()
-	if(!lit)
+	if(!lit || !igniter)
 		STOP_PROCESSING(SSobj, src)
 		return null
 	var/turf/location = loc
@@ -43,8 +44,7 @@
 		if(M.is_holding(src))
 			location = M.loc
 	if(isturf(location)) //start a fire if possible
-		location.hotspot_expose(700, 2)
-	return
+		igniter.flamethrower_process(location)
 
 
 /obj/item/weapon/flamethrower/update_icon()
@@ -58,6 +58,9 @@
 		item_state = "flamethrower_1"
 	else
 		item_state = "flamethrower_0"
+	if(ismob(loc))
+		var/mob/M = loc
+		M.update_inv_hands()
 	return
 
 /obj/item/weapon/flamethrower/afterattack(atom/target, mob/user, flag)
@@ -82,13 +85,13 @@
 	if(istype(W, /obj/item/weapon/wrench) && !status)//Taking this apart
 		var/turf/T = get_turf(src)
 		if(weldtool)
-			weldtool.loc = T
+			weldtool.forceMove(T)
 			weldtool = null
 		if(igniter)
-			igniter.loc = T
+			igniter.forceMove(T)
 			igniter = null
 		if(ptank)
-			ptank.loc = T
+			ptank.forceMove(T)
 			ptank = null
 		new /obj/item/stack/rods(T)
 		qdel(src)
@@ -114,7 +117,10 @@
 
 	else if(istype(W,/obj/item/weapon/tank/internals/plasma))
 		if(ptank)
-			to_chat(user, "<span class='notice'>There is already a plasma tank loaded in [src]!</span>")
+			if(user.transferItemToLoc(W,src))
+				ptank.forceMove(get_turf(src))
+				ptank = W
+				to_chat(user, "<span class='notice'>You swap the plasma tank in [src]!</span>")
 			return
 		if(!user.transferItemToLoc(W, src))
 			return
@@ -129,53 +135,26 @@
 
 
 /obj/item/weapon/flamethrower/attack_self(mob/user)
-	if(user.stat || user.restrained() || user.lying)
-		return
-	user.set_machine(src)
+	toggle_igniter(user)
+
+
+/obj/item/weapon/flamethrower/proc/toggle_igniter(mob/user)
 	if(!ptank)
 		to_chat(user, "<span class='notice'>Attach a plasma tank first!</span>")
 		return
-	var/dat = text("<TT><B>Flamethrower (<A HREF='?src=\ref[src];light=1'>[lit ? "<font color='red'>Lit</font>" : "Unlit"]</a>)</B><BR>\n Tank Pressure: [ptank.air_contents.return_pressure()]<BR>\nAmount to throw: <A HREF='?src=\ref[src];amount=-100'>-</A> <A HREF='?src=\ref[src];amount=-10'>-</A> <A HREF='?src=\ref[src];amount=-1'>-</A> [throw_amount] <A HREF='?src=\ref[src];amount=1'>+</A> <A HREF='?src=\ref[src];amount=10'>+</A> <A HREF='?src=\ref[src];amount=100'>+</A><BR>\n<A HREF='?src=\ref[src];remove=1'>Remove plasmatank</A> - <A HREF='?src=\ref[src];close=1'>Close</A></TT>")
-	user << browse(dat, "window=flamethrower;size=600x300")
-	onclose(user, "flamethrower")
-	return
-
-
-/obj/item/weapon/flamethrower/Topic(href,href_list[])
-	if(href_list["close"])
-		usr.unset_machine()
-		usr << browse(null, "window=flamethrower")
+	if(!status)
+		to_chat(user, "<span class='notice'>Secure the igniter first!</span>")
 		return
-	if(usr.stat || usr.restrained() || usr.lying)
-		return
-	usr.set_machine(src)
-	if(href_list["light"])
-		if(!ptank)
-			return
-		if(!status)
-			return
-		lit = !lit
-		if(lit)
-			START_PROCESSING(SSobj, src)
-			if(!warned_admins)
-				message_admins("[ADMIN_LOOKUPFLW(usr)] has lit a flamethrower.")
-				warned_admins = 1
-	if(href_list["amount"])
-		throw_amount = throw_amount + text2num(href_list["amount"])
-		throw_amount = max(50, min(5000, throw_amount))
-	if(href_list["remove"])
-		if(!ptank)
-			return
-		usr.put_in_hands(ptank)
-		ptank = null
-		lit = 0
-		usr.unset_machine()
-		usr << browse(null, "window=flamethrower")
-	for(var/mob/M in viewers(1, loc))
-		if((M.client && M.machine == src))
-			attack_self(M)
+	to_chat(user, "<span class='notice'>You ignite [src]!</span>")
+	lit = !lit
+	if(lit)
+		START_PROCESSING(SSobj, src)
+		if(!warned_admins)
+			message_admins("[ADMIN_LOOKUPFLW(user)] has lit a flamethrower.")
+			warned_admins = 1
+	else
+		STOP_PROCESSING(SSobj,src)
 	update_icon()
-	return
 
 /obj/item/weapon/flamethrower/CheckParts(list/parts_list)
 	..()
@@ -195,19 +174,22 @@
 	for(var/turf/T in turflist)
 		if(T == previousturf)
 			continue	//so we don't burn the tile we be standin on
-		if(!T.atmos_adjacent_turfs || !T.atmos_adjacent_turfs[previousturf])
+		var/list/turfs_sharing_with_prev = previousturf.GetAtmosAdjacentTurfs(alldir=1)
+		if(!(T in turfs_sharing_with_prev))
 			break
-		ignite_turf(T)
+		if(igniter)
+			igniter.ignite_turf(src,T)
+		else
+			default_ignite(T)
 		sleep(1)
 		previousturf = T
 	operating = 0
 	for(var/mob/M in viewers(1, loc))
 		if((M.client && M.machine == src))
 			attack_self(M)
-	return
 
 
-/obj/item/weapon/flamethrower/proc/ignite_turf(turf/target, release_amount = 0.05)
+/obj/item/weapon/flamethrower/proc/default_ignite(turf/target, release_amount = 0.05)
 	//TODO: DEFERRED Consider checking to make sure tank pressure is high enough before doing this...
 	//Transfer 5% of current tank air contents to turf
 	var/datum/gas_mixture/air_transfer = ptank.air_contents.remove_ratio(release_amount)
@@ -218,30 +200,42 @@
 	target.hotspot_expose((ptank.air_contents.temperature*2) + 380,500)
 	//location.hotspot_expose(1000,500,1)
 	SSair.add_to_active(target, 0)
-	return
 
 
-/obj/item/weapon/flamethrower/full/New(var/loc)
-	..()
-	if(!weldtool)
-		weldtool = new /obj/item/weapon/weldingtool(src)
-	weldtool.status = 0
-	if(!igniter)
-		igniter = new /obj/item/device/assembly/igniter(src)
-	igniter.secured = 0
-	status = 1
-	update_icon()
+/obj/item/weapon/flamethrower/Initialize(mapload)
+	. = ..()
+	if(create_full)
+		if(!weldtool)
+			weldtool = new /obj/item/weapon/weldingtool(src)
+		weldtool.status = 0
+		if(!igniter)
+			igniter = new igniter_type(src)
+		igniter.secured = 0
+		status = 1
+		if(create_with_tank)
+			ptank = new /obj/item/weapon/tank/internals/plasma/full(src)
+		update_icon()
 
-/obj/item/weapon/flamethrower/full/tank/New(var/loc)
-	..()
-	ptank = new /obj/item/weapon/tank/internals/plasma/full(src)
-	update_icon()
+/obj/item/weapon/flamethrower/full/tank
+	create_full = TRUE
 
+/obj/item/weapon/flamethrower/full/tank
+	create_with_tank = TRUE
 
 /obj/item/weapon/flamethrower/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
 	if(ptank && damage && attack_type == PROJECTILE_ATTACK && prob(15))
 		owner.visible_message("<span class='danger'>[attack_text] hits the fueltank on [owner]'s [src], rupturing it! What a shot!</span>")
 		var/target_turf = get_turf(owner)
-		ignite_turf(target_turf, 100)
+		igniter.ignite_turf(src,target_turf, release_amount = 100)
 		qdel(ptank)
 		return 1 //It hit the flamethrower, not them
+
+
+/obj/item/device/assembly/igniter/proc/flamethrower_process(turf/open/location)
+	location.hotspot_expose(700,2)
+
+/obj/item/device/assembly/igniter/cold/flamethrower_process(turf/open/location)
+	return
+
+/obj/item/device/assembly/igniter/proc/ignite_turf(obj/item/weapon/flamethrower/F,turf/open/location,release_amount = 0.05)
+	F.default_ignite(location,release_amount)


### PR DESCRIPTION
Fixes & interface simplification from #27813 

- Fixes clicking on diagonals
- Fixes inhand visual updates.
- Removes interface, you now just use inhand to toggle the flamethrower. (Release pressure was just a placebo for a long time so that can be added later if need be.)
- Allows fast switching plasma tanks when there's one in already.