### PR TITLE
Borg module resets now require cutting instead of pulsing the reset wire

### DIFF
--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -50,6 +50,9 @@
 				R.show_laws()
 		if(WIRE_LOCKDOWN)
 			R.SetLockdown(!R.lockcharge) // Toggle
+		if(WIRE_RESET_MODULE)
+			if(R.has_module())
+				R.visible_message("[R]'s module servos twitch.", "Your module display flickers.")
 
 /datum/wires/robot/on_cut(wire, mend)
 	var/mob/living/silicon/robot/R = holder

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -50,9 +50,6 @@
 				R.show_laws()
 		if(WIRE_LOCKDOWN)
 			R.SetLockdown(!R.lockcharge) // Toggle
-		if(WIRE_RESET_MODULE)
-			if(R.has_module())
-				R.ResetModule()
 
 /datum/wires/robot/on_cut(wire, mend)
 	var/mob/living/silicon/robot/R = holder
@@ -74,3 +71,6 @@
 				R.visible_message("[R]'s camera lense focuses loudly.", "Your camera lense focuses loudly.")
 		if(WIRE_LOCKDOWN) // Simple lockdown.
 			R.SetLockdown(!mend)
+		if(WIRE_RESET_MODULE)
+			if(R.has_module() && !mend)
+				R.ResetModule()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -195,6 +195,10 @@
 	if(module.type != /obj/item/weapon/robot_module)
 		return
 
+	if(wires.is_cut(WIRE_RESET_MODULE))
+		to_chat(src,"<span class='userdanger'>ERROR: Module installer reply timeout. Please check internal connections.</span>")
+		return
+
 	var/list/modulelist = list("Standard" = /obj/item/weapon/robot_module/standard, \
 	"Engineering" = /obj/item/weapon/robot_module/engineering, \
 	"Medical" = /obj/item/weapon/robot_module/medical, \


### PR DESCRIPTION
:cl:
balance: The reset wire on borgs must now be cut to reset a borg's module instead of pulsed.
/:cl:

No more abusing voice analyzers for free resets. This keeps the wire mechanic, but makes choosing a module a more permanent thing.