### PR TITLE
Makes black carpet less expensive

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -346,7 +346,7 @@
 
 /datum/crafting_recipe/blackcarpet
 	name = "Black Carpet"
-	reqs = list(/obj/item/stack/tile/carpet = 50, /obj/item/toy/crayon/black = 1)
+	reqs = list(/obj/item/stack/tile/carpet = 10, /obj/item/toy/crayon/black = 1)
 	result = /obj/item/stack/tile/carpet/black
 	category = CAT_MISC
 


### PR DESCRIPTION
:cl: Goodstuff
tweak: Black carpet now only costs 10 carpet to make one tile instead of 50 for one tile
/:cl:

50 regular carpet for one black carpet tile seemed like way too much so I reduced it to 10 for one.