### PR TITLE
Corpses left behind when killing legion have semi-randomized equipment.

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -115,6 +115,9 @@
 	var/l_pocket = -1
 	var/back = -1
 	var/id = -1
+	var/neck = -1
+	var/backpack_contents = -1
+	var/suit_store
 
 /obj/effect/mob_spawn/human/Initialize()
 	if(ispath(outfit))
@@ -130,7 +133,7 @@
 		H.Drain()
 
 	if(outfit)
-		var/static/list/slots = list("uniform", "r_hand", "l_hand", "suit", "shoes", "gloves", "ears", "glasses", "mask", "head", "belt", "r_pocket", "l_pocket", "back", "id")
+		var/static/list/slots = list("uniform", "r_hand", "l_hand", "suit", "shoes", "gloves", "ears", "glasses", "mask", "head", "belt", "r_pocket", "l_pocket", "back", "id", "neck", "backpack_contents", "suit_store")
 		for(var/slot in slots)
 			var/T = vars[slot]
 			if(!isnum(T))

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -135,6 +135,8 @@
 		H.set_species(mob_species)
 	if(husk)
 		H.Drain()
+	else //Because for some reason I can't track down, things are getting turned into husks even if husk = false. It's in some damage proc somewhere.
+		H.cure_husk()
 	H.underwear = "Nude"
 	H.undershirt = "Nude"
 	H.socks = "Nude"

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -18,6 +18,8 @@
 	var/uses = 1			//how many times can we spawn from it. set to -1 for infinite.
 	var/brute_damage = 0
 	var/oxy_damage = 0
+	var/burn_damage = 0
+	var/mob_color //Change the mob's color
 	density = 1
 	anchored = 1
 	var/banType = "lavaland"
@@ -68,6 +70,8 @@
 
 	M.adjustOxyLoss(oxy_damage)
 	M.adjustBruteLoss(brute_damage)
+	M.adjustFireLoss(burn_damage)
+	M.color = mob_color
 	equip(M)
 
 	if(ckey)
@@ -131,7 +135,9 @@
 		H.set_species(mob_species)
 	if(husk)
 		H.Drain()
-
+	H.underwear = "Nude"
+	H.undershirt = "Nude"
+	H.socks = "Nude"
 	if(outfit)
 		var/static/list/slots = list("uniform", "r_hand", "l_hand", "suit", "shoes", "gloves", "ears", "glasses", "mask", "head", "belt", "r_pocket", "l_pocket", "back", "id", "neck", "backpack_contents", "suit_store")
 		for(var/slot in slots)

--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -6,17 +6,20 @@
 /mob/living/carbon/human/Weaken(amount, updating = 1, ignore_canstun = 0)
 	amount = dna.species.spec_stun(src,amount)
 	return ..()
-	
+
 /mob/living/carbon/human/Paralyse(amount, updating = 1, ignore_canstun = 0)
 	amount = dna.species.spec_stun(src,amount)
 	return ..()
-	
+
 /mob/living/carbon/human/cure_husk()
 	. = ..()
 	if(.)
 		update_hair()
 
 /mob/living/carbon/human/become_husk()
+	if(istype(dna.species, /datum/species/skeleton)) //skeletons shouldn't be husks.
+		cure_husk()
+		return
 	. = ..()
 	if(.)
 		update_hair()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -107,6 +107,7 @@
 	stat_attack = UNCONSCIOUS
 	robust_searching = 1
 	var/mob/living/carbon/human/stored_mob
+	var/fromtendril = FALSE
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/death(gibbed)
 	visible_message("<span class='warning'>The skulls on [src] wail in anger as they flee from their dying host!</span>")
@@ -115,6 +116,8 @@
 		if(stored_mob)
 			stored_mob.forceMove(get_turf(src))
 			stored_mob = null
+		else if(fromtendril)
+			new /obj/effect/mob_spawn/human/corpse/damaged(T)
 		else
 			new /obj/effect/mob_spawn/human/corpse/damaged/legioninfested(T)
 	..(gibbed)
@@ -219,7 +222,7 @@
 	//Legion infested mobs
 
 /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize()
-	var/type = pickweight(list("Miner" = 70, "Ashwalker" = 12, "Golem" = 12, "Shadow" = 2, "YeOlde" = 2, "Operative" = 2))
+	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 11, "Golem" = 11,"Clown" = 11, pick(list("Shadow", "YeOlde","Operative")) = 1)
 	switch(type)
 		if("Miner")
 			mob_species = pickweight(list(/datum/species/human = 70, /datum/species/lizard = 26, /datum/species/fly = 2, /datum/species/plasmaman = 2))
@@ -235,10 +238,12 @@
 			mask = /obj/item/clothing/mask/gas/explorer
 			if(prob(20))
 				suit = pickweight(list(/obj/item/clothing/suit/hooded/explorer = 18, /obj/item/clothing/suit/hooded/cloak/goliath = 2))
-			if (belt == -1 && prob(4))
-				belt = pickweight(list(/obj/item/weapon/storage/belt/mining = 2, /obj/item/weapon/storage/belt/mining = 2))
-			if(prob(10))
-				r_pocket = pickweight(list(/obj/item/stack/spacecash/c1000 = 7,/obj/item/weapon/reagent_containers/hypospray/medipen/survival = 2, /obj/item/borg/upgrade/modkit/damage = 1 ))
+			if (mob_species != /datum/species/plasmaman && prob(4))
+				belt = pickweight(list(/obj/item/weapon/storage/belt/mining = 2, /obj/item/weapon/storage/belt/mining/alt = 2))
+			else if (mob_species != /datum/species/plasmaman)
+				belt = /obj/item/weapon/tank/internals/emergency_oxygen/engi
+			if(prob(30))
+				r_pocket = pickweight(list(/obj/item/stack/marker_beacon = 20, /obj/item/stack/spacecash/c1000 = 7,/obj/item/weapon/reagent_containers/hypospray/medipen/survival = 2, /obj/item/borg/upgrade/modkit/damage = 1 ))
 			if(prob(10))
 				l_pocket = pickweight(list(/obj/item/stack/spacecash/c1000 = 7,/obj/item/weapon/reagent_containers/hypospray/medipen/survival = 2, /obj/item/borg/upgrade/modkit/cooldown = 1 ))
 		if("Ashwalker")
@@ -251,26 +256,46 @@
 				suit = /obj/item/clothing/suit/armor/bone
 				gloves = /obj/item/clothing/gloves/bracer
 			if(prob(5))
-				back = pickweight(list(/datum/crafting_recipe/bonespear = 3,/obj/item/weapon/twohanded/fireaxe/boneaxe = 2))
+				back = pickweight(list(/obj/item/weapon/twohanded/bonespear = 3,/obj/item/weapon/twohanded/fireaxe/boneaxe = 2))
 			if(prob(10))
 				belt = /obj/item/weapon/storage/belt/mining/primitive
 			if(prob(30))
 				r_pocket = /obj/item/weapon/kitchen/knife/combat/bone
 			if(prob(30))
 				l_pocket = /obj/item/weapon/kitchen/knife/combat/bone
+		if("Clown")
+			name = pick(GLOB.clown_names)
+			outfit = /datum/outfit/job/clown
+			outfit.backpack_contents = list()
+			if(prob(40))
+				outfit.backpack_contents += pick(list(/obj/item/weapon/stamp/clown = 1, /obj/item/weapon/reagent_containers/spray/waterflower = 1,/obj/item/weapon/reagent_containers/food/snacks/grown/banana = 1, /obj/item/device/megaphone/clown = 1,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_laughter = 1,/obj/item/weapon/pneumatic_cannon/pie = 1))
+			if(prob(30))
+				outfit.backpack_contents += list(/obj/item/stack/sheet/mineral/bananium = pickweight(list( 1 = 3, 2 = 2, 3 = 1)))
+			if(prob(10))
+				l_pocket = /obj/item/weapon/bikehorn/golden
+			if(prob(10))
+				r_pocket = /obj/item/weapon/implanter/sad_trombone
 		if("Golem")
 			mob_species = /datum/species/golem/random
-			if(prob(20))
-				glasses = pickweight(list(/obj/item/clothing/glasses/meson = 5, /obj/item/clothing/glasses/night = 4, /obj/item/clothing/glasses/hud/health/night = 1))
-			if(prob(20))
-				belt = pickweight(list(/obj/item/weapon/storage/belt/mining/vendor = 1,/obj/item/weapon/storage/belt/utility/full = 1))
+			if(prob(10))
+				glasses = pick(list(/obj/item/clothing/glasses/meson, /obj/item/clothing/glasses/hud/health,/obj/item/clothing/glasses/hud/diagnostic, /obj/item/clothing/glasses/science, /obj/item/clothing/glasses/welding))
+			if(prob(10))
+				belt = pick(list(/obj/item/weapon/storage/belt/mining/vendor,/obj/item/weapon/storage/belt/utility/full))
+			if(prob(50))
+				r_pocket = /obj/item/weapon/bedsheet/rd/royal_cape
+			if(prob(10))
+				l_pocket = pick(list(/obj/item/weapon/crowbar/power, /obj/item/weapon/wrench/power, /obj/item/weapon/weldingtool/experimental))
 		if("YeOlde")
 			mob_gender = FEMALE
 			uniform = /obj/item/clothing/under/maid
+			gloves = /obj/item/clothing/gloves/color/white
+			shoes = /obj/item/clothing/shoes/laceup
 			head = /obj/item/clothing/head/helmet/knight
 			suit = /obj/item/clothing/suit/armor/riot/knight
 			back = /obj/item/weapon/shield/riot/buckler
 			belt = /obj/item/weapon/nullrod/claymore
+			r_pocket = /obj/item/weapon/tank/internals/emergency_oxygen
+			mask = /obj/item/clothing/mask/breath
 		if("Operative")
 			id_job = "Operative"
 			id_access_list = list(GLOB.access_syndicate)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -221,6 +221,7 @@
 //Tendril-spawned Legion remains, the charred skeletons of those whose bodies sank into laval or fell into chasms.
 /obj/effect/mob_spawn/human/corpse/charredskeleton
 	name = "charred skeletal remains"
+	burn_damage = 1000
 	mob_name = "ashen skeleton"
 	mob_gender = NEUTER
 	husk = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -222,7 +222,7 @@
 	//Legion infested mobs
 
 /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize()
-	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 11, "Golem" = 11,"Clown" = 11, pick(list("Shadow", "YeOlde","Operative")) = 1))
+	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 10, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist")) = 4))
 	switch(type)
 		if("Miner")
 			mob_species = pickweight(list(/datum/species/human = 70, /datum/species/lizard = 26, /datum/species/fly = 2, /datum/species/plasmaman = 2))
@@ -240,6 +240,8 @@
 				suit = pickweight(list(/obj/item/clothing/suit/hooded/explorer = 18, /obj/item/clothing/suit/hooded/cloak/goliath = 2))
 			if (mob_species != /datum/species/plasmaman && prob(4))
 				belt = pickweight(list(/obj/item/weapon/storage/belt/mining = 2, /obj/item/weapon/storage/belt/mining/alt = 2))
+			else if(prob(10))
+				belt = pickweight(list(/obj/item/weapon/pickaxe = 8, /obj/item/weapon/pickaxe/mini = 4, /obj/item/weapon/pickaxe/silver = 2, /obj/item/weapon/pickaxe/diamond = 1))
 			else if (mob_species != /datum/species/plasmaman)
 				belt = /obj/item/weapon/tank/internals/emergency_oxygen/engi
 			if(prob(30))
@@ -266,23 +268,24 @@
 		if("Clown")
 			name = pick(GLOB.clown_names)
 			outfit = /datum/outfit/job/clown
-			outfit.backpack_contents = list()
+			belt = null
+			backpack_contents = list()
 			if(prob(70))
-				outfit.backpack_contents += pick(list(/obj/item/weapon/stamp/clown = 1, /obj/item/weapon/reagent_containers/spray/waterflower = 1,/obj/item/weapon/reagent_containers/food/snacks/grown/banana = 1, /obj/item/device/megaphone/clown = 1,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_laughter = 1,/obj/item/weapon/pneumatic_cannon/pie = 1))
+				backpack_contents += pick(list(/obj/item/weapon/stamp/clown = 1, /obj/item/weapon/reagent_containers/spray/waterflower = 1,/obj/item/weapon/reagent_containers/food/snacks/grown/banana = 1, /obj/item/device/megaphone/clown = 1,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_laughter = 1,/obj/item/weapon/pneumatic_cannon/pie = 1))
 			if(prob(30))
-				outfit.backpack_contents += list(/obj/item/stack/sheet/mineral/bananium = pickweight(list( 1 = 3, 2 = 2, 3 = 1)))
+				backpack_contents += list(/obj/item/stack/sheet/mineral/bananium = pickweight(list( 1 = 3, 2 = 2, 3 = 1)))
 			if(prob(10))
-				l_pocket = /obj/item/weapon/bikehorn/golden
+				l_pocket = pickweight(list(/obj/item/weapon/bikehorn/golden = 3, /obj/item/weapon/bikehorn/airhorn= 1 ))
 			if(prob(10))
 				r_pocket = /obj/item/weapon/implanter/sad_trombone
 		if("Golem")
-			mob_species = /datum/species/golem/random
-			if(prob(10))
-				glasses = pick(list(/obj/item/clothing/glasses/meson, /obj/item/clothing/glasses/hud/health,/obj/item/clothing/glasses/hud/diagnostic, /obj/item/clothing/glasses/science, /obj/item/clothing/glasses/welding))
+			mob_species = pick(list(/datum/species/golem/adamantine, /datum/species/golem/plasma, /datum/species/golem/diamond, /datum/species/golem/gold, /datum/species/golem/silver, /datum/species/golem/plasteel, /datum/species/golem/titanium, /datum/species/golem/plastitanium))
+			if(prob(30))
+				glasses = pickweight(list(/obj/item/clothing/glasses/meson = 2, /obj/item/clothing/glasses/hud/health = 2,/obj/item/clothing/glasses/hud/diagnostic =2, /obj/item/clothing/glasses/science = 2, /obj/item/clothing/glasses/welding = 2, /obj/item/clothing/glasses/night = 1))
 			if(prob(10))
 				belt = pick(list(/obj/item/weapon/storage/belt/mining/vendor,/obj/item/weapon/storage/belt/utility/full))
 			if(prob(50))
-				outfit.neck = /obj/item/weapon/bedsheet/rd/royal_cape
+				neck = /obj/item/weapon/bedsheet/rd/royal_cape
 			if(prob(10))
 				l_pocket = pick(list(/obj/item/weapon/crowbar/power, /obj/item/weapon/wrench/power, /obj/item/weapon/weldingtool/experimental))
 		if("YeOlde")
@@ -303,13 +306,22 @@
 		if("Shadow")
 			mob_species = /datum/species/shadow
 			r_pocket = /obj/item/weapon/reagent_containers/pill/shadowtoxin
-			outfit.neck = /obj/item/clothing/tie/medal/nobel_science
+			neck = /obj/item/clothing/tie/medal/nobel_science
 			uniform = /obj/item/clothing/under/color/black
 			shoes = /obj/item/clothing/shoes/sneakers/black
 			suit = /obj/item/clothing/suit/toggle/labcoat
 			glasses = /obj/item/clothing/glasses/sunglasses/blindfold
 			back = /obj/item/weapon/tank/internals/oxygen
 			mask = /obj/item/clothing/mask/breath
+		if("Cultist")
+			uniform = /obj/item/clothing/under/roman
+			suit = /obj/item/clothing/suit/cultrobes
+			head = /obj/item/clothing/head/culthood
+			suit_store = /obj/item/weapon/tome
+			r_pocket = /obj/item/weapon/restraints/legcuffs/bola/cult
+			l_pocket = /obj/item/weapon/melee/cultblade/dagger
+			glasses =  /obj/item/clothing/glasses/night/cultblind
+			backpack_contents = list(/obj/item/weapon/reagent_containers/food/drinks/bottle/unholywater = 1, /obj/item/device/cult_shift = 1, /obj/item/device/flashlight/flare/culttorch = 1, /obj/item/stack/sheet/runed_metal = 15)
 	. = ..()
 
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -263,14 +263,12 @@
 			if(prob(20))
 				glasses = pickweight(list(/obj/item/clothing/glasses/meson = 5, /obj/item/clothing/glasses/night = 4, /obj/item/clothing/glasses/hud/health/night = 1))
 			if(prob(20))
-				belt = pickweight(/obj/item/weapon/storage/belt/mining/vendor = 1,/obj/item/weapon/storage/belt/utility/full = 1))
+				belt = pickweight(list(/obj/item/weapon/storage/belt/mining/vendor = 1,/obj/item/weapon/storage/belt/utility/full = 1))
 		if("YeOlde")
 			mob_gender = FEMALE
 			uniform = /obj/item/clothing/under/maid
 			head = /obj/item/clothing/head/helmet/knight
 			suit = /obj/item/clothing/suit/armor/riot/knight
-			gloves = /obj/item/clothing/gloves/plate
-			shoes = /obj/item/clothing/shoes/plate
 			back = /obj/item/weapon/shield/riot/buckler
 			belt = /obj/item/weapon/nullrod/claymore
 		if("Operative")

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -219,26 +219,27 @@
 	//Legion infested mobs
 
 /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize()
-	var/type = pickweight(list("Miner" = 70, "Ashwalker" = 10, "Golem" = 10, "Shadow" = 5, "YeOlde" = 3, "Operative" = 2))
+	var/type = pickweight(list("Miner" = 70, "Ashwalker" = 12, "Golem" = 12, "Shadow" = 2, "YeOlde" = 2, "Operative" = 2))
 	switch(type)
 		if("Miner")
 			mob_species = pickweight(list(/datum/species/human = 70, /datum/species/lizard = 26, /datum/species/fly = 2, /datum/species/plasmaman = 2))
-			if(!istype(mob_species, /datum/species/plasmaman))
+			if(mob_species == /datum/species/plasmaman)
 				uniform = /obj/item/clothing/under/plasmaman
 				head = /obj/item/clothing/head/helmet/space/plasmaman
 				belt = /obj/item/weapon/tank/internals/plasmaman/belt
 			else
 				uniform = /obj/item/clothing/under/rank/miner/lavaland
-			if(!istype(mob_species, /datum/species/lizard))
+			if(mob_species != /datum/species/lizard)
 				shoes = /obj/item/clothing/shoes/workboots/mining
 			gloves = /obj/item/clothing/gloves/color/black
 			mask = /obj/item/clothing/mask/gas/explorer
-			suit = pickweight(list(null =  80, /obj/item/clothing/suit/hooded/explorer = 18, /obj/item/clothing/suit/hooded/cloak/goliath = 2))
-			if (belt == -1)
-				belt = pickweight(list(null = 96, /obj/item/weapon/storage/belt/mining = 2, /obj/item/weapon/storage/belt/mining = 2))
+			if(prob(20))
+				suit = pickweight(list(/obj/item/clothing/suit/hooded/explorer = 18, /obj/item/clothing/suit/hooded/cloak/goliath = 2))
+			if (belt == -1 && prob(4))
+				belt = pickweight(list(/obj/item/weapon/storage/belt/mining = 2, /obj/item/weapon/storage/belt/mining = 2))
 			if(prob(10))
 				r_pocket = pickweight(list(/obj/item/stack/spacecash/c1000 = 7,/obj/item/weapon/reagent_containers/hypospray/medipen/survival = 2, /obj/item/borg/upgrade/modkit/damage = 1 ))
-			else if(prob(10))
+			if(prob(10))
 				l_pocket = pickweight(list(/obj/item/stack/spacecash/c1000 = 7,/obj/item/weapon/reagent_containers/hypospray/medipen/survival = 2, /obj/item/borg/upgrade/modkit/cooldown = 1 ))
 		if("Ashwalker")
 			mob_species = /datum/species/lizard/ashwalker
@@ -251,7 +252,7 @@
 				gloves = /obj/item/clothing/gloves/bracer
 			if(prob(5))
 				back = pickweight(list(/datum/crafting_recipe/bonespear = 3,/obj/item/weapon/twohanded/fireaxe/boneaxe = 2))
-			if(prob(14))
+			if(prob(10))
 				belt = /obj/item/weapon/storage/belt/mining/primitive
 			if(prob(30))
 				r_pocket = /obj/item/weapon/kitchen/knife/combat/bone
@@ -259,8 +260,10 @@
 				l_pocket = /obj/item/weapon/kitchen/knife/combat/bone
 		if("Golem")
 			mob_species = /datum/species/golem/random
-			glasses = pickweight(list(/obj/item/clothing/glasses/meson = 5, /obj/item/clothing/glasses/night = 4, /obj/item/clothing/glasses/hud/health/night = 1))
-			belt = pickweight(list(null = 8, /obj/item/weapon/storage/belt/mining/vendor = 1,/obj/item/weapon/storage/belt/utility/full = 1))
+			if(prob(20))
+				glasses = pickweight(list(/obj/item/clothing/glasses/meson = 5, /obj/item/clothing/glasses/night = 4, /obj/item/clothing/glasses/hud/health/night = 1))
+			if(prob(20))
+				belt = pickweight(/obj/item/weapon/storage/belt/mining/vendor = 1,/obj/item/weapon/storage/belt/utility/full = 1))
 		if("YeOlde")
 			mob_gender = FEMALE
 			uniform = /obj/item/clothing/under/maid

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -116,7 +116,7 @@
 			stored_mob.forceMove(get_turf(src))
 			stored_mob = null
 		else
-			new /obj/effect/mob_spawn/human/corpse/damaged(T)
+			new /obj/effect/mob_spawn/human/corpse/damaged/legioninfested(T)
 	..(gibbed)
 
 //Legion skull
@@ -202,7 +202,7 @@
 	layer = MOB_LAYER
 	del_on_death = TRUE
 	sentience_type = SENTIENCE_BOSS
-	loot = list(/obj/item/organ/regenerative_core/legion = 3, /obj/effect/mob_spawn/human/corpse/damaged = 5)
+	loot = list(/obj/item/organ/regenerative_core/legion = 3, /obj/effect/mob_spawn/human/corpse/damaged/legioninfested = 5)
 	move_to_delay = 14
 	vision_range = 5
 	aggro_vision_range = 9
@@ -214,3 +214,78 @@
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+
+
+	//Legion infested mobs
+
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize()
+	var/type = pickweight(list("Miner" = 70, "Ashwalker" = 10, "Golem" = 10, "Shadow" = 5, "YeOlde" = 3, "Operative" = 2))
+	switch(type)
+		if("Miner")
+			mob_species = pickweight(list(/datum/species/human = 70, /datum/species/lizard = 26, /datum/species/fly = 2, /datum/species/plasmaman = 2))
+			if(!istype(mob_species, /datum/species/plasmaman))
+				uniform = /obj/item/clothing/under/plasmaman
+				head = /obj/item/clothing/head/helmet/space/plasmaman
+				belt = /obj/item/weapon/tank/internals/plasmaman/belt
+			else
+				uniform = /obj/item/clothing/under/rank/miner/lavaland
+			if(!istype(mob_species, /datum/species/lizard))
+				shoes = /obj/item/clothing/shoes/workboots/mining
+			gloves = /obj/item/clothing/gloves/color/black
+			mask = /obj/item/clothing/mask/gas/explorer
+			suit = pickweight(list(null =  80, /obj/item/clothing/suit/hooded/explorer = 18, /obj/item/clothing/suit/hooded/cloak/goliath = 2))
+			if (belt == -1)
+				belt = pickweight(list(null = 96, /obj/item/weapon/storage/belt/mining = 2, /obj/item/weapon/storage/belt/mining = 2))
+			if(prob(10))
+				r_pocket = pickweight(list(/obj/item/stack/spacecash/c1000 = 7,/obj/item/weapon/reagent_containers/hypospray/medipen/survival = 2, /obj/item/borg/upgrade/modkit/damage = 1 ))
+			else if(prob(10))
+				l_pocket = pickweight(list(/obj/item/stack/spacecash/c1000 = 7,/obj/item/weapon/reagent_containers/hypospray/medipen/survival = 2, /obj/item/borg/upgrade/modkit/cooldown = 1 ))
+		if("Ashwalker")
+			mob_species = /datum/species/lizard/ashwalker
+			uniform = /obj/item/clothing/under/gladiator/ash_walker
+			if(prob(95))
+				head = /obj/item/clothing/head/helmet/gladiator
+			else
+				head = /obj/item/clothing/head/helmet/skull
+				suit = /obj/item/clothing/suit/armor/bone
+				gloves = /obj/item/clothing/gloves/bracer
+			if(prob(5))
+				back = pickweight(list(/datum/crafting_recipe/bonespear = 3,/obj/item/weapon/twohanded/fireaxe/boneaxe = 2))
+			if(prob(14))
+				belt = /obj/item/weapon/storage/belt/mining/primitive
+			if(prob(30))
+				r_pocket = /obj/item/weapon/kitchen/knife/combat/bone
+			if(prob(30))
+				l_pocket = /obj/item/weapon/kitchen/knife/combat/bone
+		if("Golem")
+			mob_species = /datum/species/golem/random
+			glasses = pickweight(list(/obj/item/clothing/glasses/meson = 5, /obj/item/clothing/glasses/night = 4, /obj/item/clothing/glasses/hud/health/night = 1))
+			belt = pickweight(list(null = 8, /obj/item/weapon/storage/belt/mining/vendor = 1,/obj/item/weapon/storage/belt/utility/full = 1))
+		if("YeOlde")
+			mob_gender = FEMALE
+			uniform = /obj/item/clothing/under/maid
+			head = /obj/item/clothing/head/helmet/knight
+			suit = /obj/item/clothing/suit/armor/riot/knight
+			gloves = /obj/item/clothing/gloves/plate
+			shoes = /obj/item/clothing/shoes/plate
+			back = /obj/item/weapon/shield/riot/buckler
+			belt = /obj/item/weapon/nullrod/claymore
+		if("Operative")
+			id_job = "Operative"
+			id_access_list = list(GLOB.access_syndicate)
+			outfit = /datum/outfit/syndicatecommandocorpse
+		if("Shadow")
+			mob_species = /datum/species/shadow
+			r_pocket = /obj/item/weapon/reagent_containers/pill/shadowtoxin
+			l_pocket = /obj/item/clothing/tie/medal/nobel_science
+			uniform = /obj/item/clothing/under/color/black
+			shoes = /obj/item/clothing/shoes/sneakers/black
+			suit = /obj/item/clothing/suit/toggle/labcoat
+			glasses = /obj/item/clothing/glasses/sunglasses/blindfold
+			back = /obj/item/weapon/tank/internals/oxygen
+			mask = /obj/item/clothing/mask/breath
+	. = ..()
+
+
+
+

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -241,18 +241,18 @@
 				belt = /obj/item/weapon/tank/internals/plasmaman/belt
 			else
 				uniform = /obj/item/clothing/under/rank/miner/lavaland
+				if (prob(4))
+					belt = pickweight(list(/obj/item/weapon/storage/belt/mining = 2, /obj/item/weapon/storage/belt/mining/alt = 2))
+				else if(prob(10))
+					belt = pickweight(list(/obj/item/weapon/pickaxe = 8, /obj/item/weapon/pickaxe/mini = 4, /obj/item/weapon/pickaxe/silver = 2, /obj/item/weapon/pickaxe/diamond = 1))
+				else
+					belt = /obj/item/weapon/tank/internals/emergency_oxygen/engi
 			if(mob_species != /datum/species/lizard)
 				shoes = /obj/item/clothing/shoes/workboots/mining
 			gloves = /obj/item/clothing/gloves/color/black
 			mask = /obj/item/clothing/mask/gas/explorer
 			if(prob(20))
 				suit = pickweight(list(/obj/item/clothing/suit/hooded/explorer = 18, /obj/item/clothing/suit/hooded/cloak/goliath = 2))
-			if (mob_species != /datum/species/plasmaman && prob(4))
-				belt = pickweight(list(/obj/item/weapon/storage/belt/mining = 2, /obj/item/weapon/storage/belt/mining/alt = 2))
-			else if(prob(10))
-				belt = pickweight(list(/obj/item/weapon/pickaxe = 8, /obj/item/weapon/pickaxe/mini = 4, /obj/item/weapon/pickaxe/silver = 2, /obj/item/weapon/pickaxe/diamond = 1))
-			else if (mob_species != /datum/species/plasmaman)
-				belt = /obj/item/weapon/tank/internals/emergency_oxygen/engi
 			if(prob(30))
 				r_pocket = pickweight(list(/obj/item/stack/marker_beacon = 20, /obj/item/stack/spacecash/c1000 = 7,/obj/item/weapon/reagent_containers/hypospray/medipen/survival = 2, /obj/item/borg/upgrade/modkit/damage = 1 ))
 			if(prob(10))

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -117,7 +117,7 @@
 			stored_mob.forceMove(get_turf(src))
 			stored_mob = null
 		else if(fromtendril)
-			new /obj/effect/mob_spawn/human/corpse/damaged(T)
+			new /obj/effect/mob_spawn/human/corpse/charredskeleton(T)
 		else
 			new /obj/effect/mob_spawn/human/corpse/damaged/legioninfested(T)
 	..(gibbed)
@@ -218,8 +218,16 @@
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 
+//Tendril-spawned Legion remains, the charred skeletons of those whose bodies sank into laval or fell into chasms.
+/obj/effect/mob_spawn/human/corpse/charredskeleton
+	name = "charred skeletal remains"
+	mob_name = "ashen skeleton"
+	mob_gender = NEUTER
+	husk = FALSE
+	mob_species = /datum/species/skeleton
+	mob_color = "#454545"
 
-	//Legion infested mobs
+//Legion infested mobs
 
 /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize()
 	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 10, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist")) = 4))

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -222,7 +222,7 @@
 	//Legion infested mobs
 
 /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize()
-	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 11, "Golem" = 11,"Clown" = 11, pick(list("Shadow", "YeOlde","Operative")) = 1)
+	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 11, "Golem" = 11,"Clown" = 11, pick(list("Shadow", "YeOlde","Operative")) = 1))
 	switch(type)
 		if("Miner")
 			mob_species = pickweight(list(/datum/species/human = 70, /datum/species/lizard = 26, /datum/species/fly = 2, /datum/species/plasmaman = 2))
@@ -267,7 +267,7 @@
 			name = pick(GLOB.clown_names)
 			outfit = /datum/outfit/job/clown
 			outfit.backpack_contents = list()
-			if(prob(40))
+			if(prob(70))
 				outfit.backpack_contents += pick(list(/obj/item/weapon/stamp/clown = 1, /obj/item/weapon/reagent_containers/spray/waterflower = 1,/obj/item/weapon/reagent_containers/food/snacks/grown/banana = 1, /obj/item/device/megaphone/clown = 1,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_laughter = 1,/obj/item/weapon/pneumatic_cannon/pie = 1))
 			if(prob(30))
 				outfit.backpack_contents += list(/obj/item/stack/sheet/mineral/bananium = pickweight(list( 1 = 3, 2 = 2, 3 = 1)))
@@ -282,7 +282,7 @@
 			if(prob(10))
 				belt = pick(list(/obj/item/weapon/storage/belt/mining/vendor,/obj/item/weapon/storage/belt/utility/full))
 			if(prob(50))
-				r_pocket = /obj/item/weapon/bedsheet/rd/royal_cape
+				outfit.neck = /obj/item/weapon/bedsheet/rd/royal_cape
 			if(prob(10))
 				l_pocket = pick(list(/obj/item/weapon/crowbar/power, /obj/item/weapon/wrench/power, /obj/item/weapon/weldingtool/experimental))
 		if("YeOlde")
@@ -303,7 +303,7 @@
 		if("Shadow")
 			mob_species = /datum/species/shadow
 			r_pocket = /obj/item/weapon/reagent_containers/pill/shadowtoxin
-			l_pocket = /obj/item/clothing/tie/medal/nobel_science
+			outfit.neck = /obj/item/clothing/tie/medal/nobel_science
 			uniform = /obj/item/clothing/under/color/black
 			shoes = /obj/item/clothing/shoes/sneakers/black
 			suit = /obj/item/clothing/suit/toggle/labcoat

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/necropolis_tendril.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/necropolis_tendril.dm
@@ -31,7 +31,7 @@
 	mob_type = /mob/living/simple_animal/hostile/asteroid/goliath/beast
 
 /mob/living/simple_animal/hostile/spawner/lavaland/legion
-	mob_type = /mob/living/simple_animal/hostile/asteroid/hivelord/legion
+	mob_type = /mob/living/simple_animal/hostile/asteroid/hivelord/legion{fromtendril = 1}
 
 /mob/living/simple_animal/hostile/spawner/lavaland/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -208,6 +208,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "modkit"
 	origin_tech = "programming=2;materials=2;magnets=4"
+	w_class = WEIGHT_CLASS_SMALL
 	require_module = 1
 	module_type = /obj/item/weapon/robot_module/miner
 	var/denied_type = null

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -142,3 +142,10 @@
 	icon_state = "pill18"
 	list_reagents = list("insulin" = 50)
 	roundstart = 1
+
+/obj/item/weapon/reagent_containers/pill/shadowtoxin
+	name = "black pill"
+	desc = "I wouldn't eat this if I were you."
+	icon_state = "pill9"
+	color = "#454545"
+	list_reagents = list("shadowmutationtoxin" = 1)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -8,6 +8,7 @@
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
 Optimumtact = Host
+Expletive = Game Master
 kingofkosmos = Game Master
 MrStonedOne = Game Master
 microscopics = Game Master

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -8,7 +8,7 @@
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
 Optimumtact = Host
-Expletive = Game Master
+Expletives = Game Master
 kingofkosmos = Game Master
 MrStonedOne = Game Master
 microscopics = Game Master


### PR DESCRIPTION
:cl: Nanotrasen Mining Alert
add: Nanotrasen's mining operations have created far more corpses than an entire galaxy of cooks could hope to deal with. To solve this, we decided to just dump them all from orbit onto the barren lava planet. Unfortunately, the creatures called "Legion" have infested a great number of them, and you can now commonly find the bodies of former Nanotrasen employees left behind. Additionally, there are reports of natives, other settlers, and even stranger things found among the corpses.
/:cl:

I've tried to make any useful equipment only created rarely. Around 1-2% is what I aimed for. The vast majority of corpses will be shaft miners with nothing useful, ash walkers with only their default armor and helmet, and naked golems. Since the wish granter dungeon was removed, the syndicate hardsuit was no longer obtainable on lavaland, but with this PR it is. Similarly, with the wish granter gone, there was also no way for a miner to become a shadow without science's help.

Shaft miner corpses can have  marker beacons, and rarely have explorer's webbing, survival medipens, space cash, goliath cloaks, or very rarely a kinetic accelerator modkit.

Ashwalker corpses can semi-commonly have bone daggers, and much more rarely have tribal equipment like bone armor, sinew belts, or bone spears, or axes.

Golem corpses might have mesons or a collection of huds or welding gogles. They can also rarely have a full toolbelt or an explorer's webbing + capsule. They'll commonly have a cape of the liberator, and they'll rarely have a random advanced tool. Either a power tool or an experimental welder.

Clown corpses have the clown costume, with a high chance of a normal clown item. They can also rarely have up to 3 sheets of bananium, a golden bike horn, or sad trombone implanter in their pockets. This is blatant clowncreep and you should not stand for it.

Then the four 'special' corpses: A dead operative, primarily for the hardsuit. A dead medieval knight, with armor, a  holy claymore, and buckler,a dead shadow scientist with a pill containing 1u of shadow mutation toxin,  and finally, a cultist in old cult robes who is carrying a lot of items that would only be useful to cultists of nar'sie.

Lastly, none of these corpses will be left behind by legion that get spawned by necropolis tendrils.  Those will instead leave behind "ashen skeletons", which are naked dead skeletons with their color set to #454545. 