### PR TITLE
Nerfs Tasers

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -76,7 +76,7 @@
 	projectile_type = /obj/item/projectile/energy/electrode
 	select_name = "stun"
 	fire_sound = 'sound/weapons/taser.ogg'
-	e_cost = 200
+	e_cost = 300
 
 /obj/item/ammo_casing/energy/electrode/spec
 	e_cost = 100


### PR DESCRIPTION
:cl: Tacolizard Forver: Greytide Resistance
balance: Taser shot cost has been raised from 200 to 300. This lowers your amount of shots per charge from 5 to 3.
/:cl:

[why]: I know I'm gonna get shit for this, but I strongly feel like this is needed. The amount of stuns in this game is appalling. Stuns are basically a 1-shot kill, and ruin combat.

**Honestly I believe this could be nerfed down to 1 shot per charge, but I think that would be too controversial.**
