### PR TITLE
Fix cable coil dupe and APC icon oddity

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -99,8 +99,8 @@
 /obj/machinery/power/apc/connect_to_network()
 	//Override because the APC does not directly connect to the network; it goes through a terminal.
 	//The terminal is what the power computer looks for anyway.
-	if(!terminal)
-		make_terminal()
+	//if(!terminal)
+	//	make_terminal() //unnecessary
 	if(terminal)
 		terminal.connect_to_network()
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -632,6 +632,8 @@
 			charging = 0
 			src.update_icon()
 		return
+	if(stat & MAINT && opened == 0) //no board; no interface
+		return
 	..()
 
 /obj/machinery/power/apc/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, \

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -221,7 +221,7 @@
 		return
 
 	if(update & 1) // Updating the icon state
-		if(update_state & UPSTATE_ALLGOOD)
+		if(update_state & UPSTATE_ALLGOOD || update_state & UPSTATE_MAINT)
 			icon_state = "apc0"
 		else if(update_state & (UPSTATE_OPENED1|UPSTATE_OPENED2))
 			var/basestate = "apc[ cell ? "2" : "1" ]"

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -221,7 +221,7 @@
 		return
 
 	if(update & 1) // Updating the icon state
-		if(update_state & UPSTATE_ALLGOOD || update_state & UPSTATE_MAINT)
+		if(update_state & UPSTATE_ALLGOOD)
 			icon_state = "apc0"
 		else if(update_state & (UPSTATE_OPENED1|UPSTATE_OPENED2))
 			var/basestate = "apc[ cell ? "2" : "1" ]"
@@ -241,6 +241,8 @@
 			icon_state = "apcemag"
 		else if(update_state & UPSTATE_WIREEXP)
 			icon_state = "apcewires"
+		else if(update_state & UPSTATE_MAINT)
+			icon_state = "apc0"
 
 	if(!(update_state & UPSTATE_ALLGOOD))
 		cut_overlays()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -99,8 +99,6 @@
 /obj/machinery/power/apc/connect_to_network()
 	//Override because the APC does not directly connect to the network; it goes through a terminal.
 	//The terminal is what the power computer looks for anyway.
-	//if(!terminal)
-	//	make_terminal() //unnecessary
 	if(terminal)
 		terminal.connect_to_network()
 
@@ -450,7 +448,7 @@
 				update_icon()
 		else if(emagged)
 			to_chat(user, "<span class='warning'>The interface is broken!</span>")
-		else if(stat & MAINT && opened == 0)
+		else if((stat & MAINT) && !opened)
 			..() //its an empty closed frame... theres no wires to expose!
 		else
 			panel_open = !panel_open
@@ -634,7 +632,7 @@
 			charging = 0
 			src.update_icon()
 		return
-	if(stat & MAINT && opened == 0) //no board; no interface
+	if((stat & MAINT) && !opened) //no board; no interface
 		return
 	..()
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -448,6 +448,8 @@
 				update_icon()
 		else if(emagged)
 			to_chat(user, "<span class='warning'>The interface is broken!</span>")
+		else if(stat & MAINT && opened == 0)
+			..() //its an empty closed frame... theres no wires to expose!
 		else
 			panel_open = !panel_open
 			to_chat(user, "The wires have been [panel_open ? "exposed" : "unexposed"]")


### PR DESCRIPTION
:cl: p440
fix: Fixed duping cable coils with magic APC terminals
fix: Fixed invalid icon state for empty APCs
/:cl:

_the fine details_
first part fixes this:
![no terminal](https://cloud.githubusercontent.com/assets/4196609/26658454/16091c44-461f-11e7-8780-eed07421c991.jpg) + wirecutters => ![magic terminal](https://cloud.githubusercontent.com/assets/4196609/26658472/2c129d1c-461f-11e7-9578-273c6f34f05b.jpg)
go up cut the terminal, place a new cable on the floor and repeat for infinite cable coil

when cutting the cable it would call `connect_to_network()` on things attached to the node to confirm the connected powernet before disconnecting from it and deleting itself
the problem is (in apc.dm)
`if(!terminal)
		make_terminal()`
would just happily make the terminal when this happened and from what i can see this call is never actually necessary since now the terminals get made when someone constructs them or during Initialize()
(correct me if i'm wrong)

second part fixes this:
if you remove the electronics from an APC you can still close the door with a crowbar and then interact with the interface, including opening up the wires panel and hacking the wires, despite there being no electronics nor wiring to hack. on top of this the icon doesn't update until you open the wires panel, and then it doesn't update until you open the cell door. 
for clarity:
how the icon behaves currently 
![1](https://cloud.githubusercontent.com/assets/4196609/26658637/43ede274-4620-11e7-8e26-7ce2851e0ede.jpg) crowbar > ![1](https://cloud.githubusercontent.com/assets/4196609/26658637/43ede274-4620-11e7-8e26-7ce2851e0ede.jpg) screwdriver > ![2](https://cloud.githubusercontent.com/assets/4196609/26658659/6d536a3a-4620-11e7-9340-9a85ecdb58fe.png) screwdriver > ![2](https://cloud.githubusercontent.com/assets/4196609/26658659/6d536a3a-4620-11e7-9340-9a85ecdb58fe.png) crowbar > ![1](https://cloud.githubusercontent.com/assets/4196609/26658637/43ede274-4620-11e7-8e26-7ce2851e0ede.jpg)

the changes
![1](https://cloud.githubusercontent.com/assets/4196609/26658637/43ede274-4620-11e7-8e26-7ce2851e0ede.jpg) crowbar > ![3](https://cloud.githubusercontent.com/assets/4196609/26658715/d685b814-4620-11e7-96c6-4f52d3e8e24e.png)

screwdrivering at this point would just bash it with the screwdriver, as it would do with any other invalid tool. and since there's no electronics, using it with an empty hand just does nothing. using the crowbar just opens it up again.


i discovered this while trying to replicate #24240 (i had no success)



