### PR TITLE
Buffs nitrous oxide

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -121,8 +121,8 @@
 /datum/chemical_reaction/nitrous_oxide
 	name = "Nitrous Oxide"
 	id = "nitrous_oxide"
-	results = list("nitrous_oxide" = 2, "water" = 4)
-	required_reagents = list("ammonia" = 3, "nitrogen" = 1, "oxygen" = 2)
+	results = list("nitrous_oxide" = 5)
+	required_reagents = list("ammonia" = 2, "nitrogen" = 1, "oxygen" = 2)
 	required_temp = 525
 
 ////////////////////////////////// Mutation Toxins ///////////////////////////////////


### PR DESCRIPTION
:cl: Swindly
balance: Nitrous oxide no longer produces water as a by-product, requires 2 parts ammonia instead of 3, and produces 5 parts when made instead of 2.
/:cl:

[why]:  (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Nitrous oxide is also bad because the by-product reacts with the ingredients as it is being produced which messes up production.