### PR TITLE
Adds in a toy syndie minibomb to the arcade prize list

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -12,6 +12,7 @@
 		/obj/item/clothing/under/syndicate/tacticool			= 2,
 		/obj/item/toy/sword										= 2,
 		/obj/item/toy/gun										= 2,
+		/obj/item/toy/minibomb									= 2,
 		/obj/item/weapon/gun/ballistic/shotgun/toy/crossbow	= 2,
 		/obj/item/weapon/storage/box/fakesyndiesuit				= 2,
 		/obj/item/weapon/storage/crayons						= 2,

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -275,30 +275,33 @@
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "syndicate"
 	item_state = "flashbang"
-	var/isactive = FALSE
-	var/det_time = 50  //Definately not copypasta
+	var/active = FALSE
 	var/pranksound = 'sound/items/bikehorn.ogg'
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/toy/minibomb/attack_self(mob/user)
-	if(active)
-		return
-	else
+	if(!active)
 		playsound(user.loc, 'sound/weapons/armbomb.ogg', 60, 1) //Commence the panic
-		prime()
-		
-/obj/item/toy/minibomb/prime(src) //No copypasta here at all
-	active = TRUE
-	user << "<span class='warning'>You prime the [name]! [det_time/10] seconds!</span>"
-	icon_state = initial(icon_state) + "_active"
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		C.throw_mode_on()
-	spawn(det_time)
-		playsound(src.loc, pranksound, 50, 1) //what a prank so funny hahaha
-		active = FALSE
-		icon_state = inital(icon_state)
-	
+		active = TRUE
+		user << "<span class='warning'>You prime the [name]! 5 seconds!</span>"
+		icon_state = initial(icon_state) + "_active"
+		if(iscarbon(user))
+			var/mob/living/carbon/C = user
+			C.throw_mode_on()
+		spawn(50)
+			if(prob(25)) //Cool 25% chance for a neat effect
+				var/obj/item/weapon/grenade/chem_grenade/glitter/O = new /obj/item/weapon/grenade/chem_grenade/glitter/blue(get_turf(src))
+				var/explosionsound = pick('sound/effects/Explosion1.ogg','sound/effects/Explosion2.ogg','sound/effects/Explosion3.ogg')
+				playsound(src.loc, explosionsound, 50, 1) //EVERYONE PANIC AS THERE'S SUDDENLY SMOKE AND NOISES
+				O.det_time = 0 //Instant detonation
+				O.prime()
+				active = FALSE
+				icon_state = initial(icon_state)
+			else
+				playsound(src.loc, pranksound, 50, 1) //what a prank so funny hahaha
+				active = FALSE
+				icon_state = initial(icon_state)
+
 
 /*
  * Foam armblade

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -5,7 +5,7 @@
  *		Toy gun
  *		Toy crossbow
  *		Toy swords
- *      Toy minibomb
+ *		Toy minibomb
  *		Crayons
  *		Snap pops
  *		Mech prizes
@@ -277,11 +277,10 @@
 	item_state = "flashbang"
 	var/active = FALSE
 	var/pranksound = 'sound/items/bikehorn.ogg'
-	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/toy/minibomb/attack_self(mob/user)
 	if(!active)
-		playsound(user.loc, 'sound/weapons/armbomb.ogg', 60, 1) //Commence the panic
+		playsound(src, 'sound/weapons/armbomb.ogg', 60, 1) //Commence the panic
 		active = TRUE
 		user << "<span class='warning'>You prime the [name]! 5 seconds!</span>"
 		icon_state = initial(icon_state) + "_active"
@@ -292,7 +291,7 @@
 			if(prob(25)) //Cool 25% chance for a neat effect
 				var/obj/item/weapon/grenade/chem_grenade/glitter/O = new /obj/item/weapon/grenade/chem_grenade/glitter/blue(get_turf(src))
 				var/explosionsound = pick('sound/effects/Explosion1.ogg','sound/effects/Explosion2.ogg','sound/effects/Explosion3.ogg')
-				playsound(src.loc, explosionsound, 50, 1) //EVERYONE PANIC AS THERE'S SUDDENLY SMOKE AND NOISES
+				playsound(src, explosionsound, 50, 1) //EVERYONE PANIC AS THERE'S SUDDENLY SMOKE AND NOISES
 				O.det_time = 0 //Instant detonation
 				O.prime()
 				active = FALSE

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -5,6 +5,7 @@
  *		Toy gun
  *		Toy crossbow
  *		Toy swords
+ *      Toy minibomb
  *		Crayons
  *		Snap pops
  *		Mech prizes
@@ -264,6 +265,40 @@
 			to_chat(user, "<span class='warning'>It's already fabulous!</span>")
 	else
 		return ..()
+
+/*
+ * Toy Syndie Minibomb
+ */
+/obj/item/toy/minibomb
+	name = "syndicate minibomb"
+	desc = "A syndicate minibomb made out of some foam, don't question on why it looks exactly like it's counterpart."
+	icon = 'icons/obj/grenade.dmi'
+	icon_state = "syndicate"
+	item_state = "flashbang"
+	var/isactive = FALSE
+	var/det_time = 50  //Definately not copypasta
+	var/pranksound = 'sound/items/bikehorn.ogg'
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/toy/minibomb/attack_self(mob/user)
+	if(active)
+		return
+	else
+		playsound(user.loc, 'sound/weapons/armbomb.ogg', 60, 1) //Commence the panic
+		prime()
+		
+/obj/item/toy/minibomb/prime(src) //No copypasta here at all
+	active = TRUE
+	user << "<span class='warning'>You prime the [name]! [det_time/10] seconds!</span>"
+	icon_state = initial(icon_state) + "_active"
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		C.throw_mode_on()
+	spawn(det_time)
+		playsound(src.loc, pranksound, 50, 1) //what a prank so funny hahaha
+		active = FALSE
+		icon_state = inial(icon_state)
+	
 
 /*
  * Foam armblade

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -297,7 +297,7 @@
 	spawn(det_time)
 		playsound(src.loc, pranksound, 50, 1) //what a prank so funny hahaha
 		active = FALSE
-		icon_state = inial(icon_state)
+		icon_state = inital(icon_state)
 	
 
 /*


### PR DESCRIPTION
:cl: ma44
add: Nanotrasen has put in a toy that looks a lot like a syndie minibomb, lord knows why but apparently assistants love them. 
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 

Because throwing syndiebombs is a great way to go and trigger some people like some toys are suppose to do (inhands, sounds)

Now tested and compiling

https://i.gyazo.com/1f5c5afe1d014d5d6664e404fe1879e8.png

Effect of the glitter (don't know  why but alright)
should maybe make it qdel on glitter or make a weaker version just because its super duper flashy