### PR TITLE
Attempts to add items to a storage container beyond its slots limit will obtain a failure message again.

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -405,10 +405,9 @@
 	if(iscyborg(user))
 		return	//Robots can't interact with storage items.
 
-	if(contents.len >= storage_slots) //don't use items on the backpack if they don't fit
-		return 1
-
 	if(!can_be_inserted(W, 0 , user))
+		if(contents.len >= storage_slots) //don't use items on the backpack if they don't fit
+			return 1
 		return 0
 
 	handle_item_insertion(W, 0 , user)


### PR DESCRIPTION
:cl:
fix: Attempts to add items to a storage container beyond its slots limit will now obtain a failure message again.
/:cl:

Fixes #27795