### PR TITLE
Rework chem dispensers to use battieries instead of var/energy.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -9,8 +9,9 @@
 	idle_power_usage = 40
 	interact_offline = 1
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	var/energy = 100
-	var/max_energy = 100
+	var/cell_type = /obj/item/weapon/stock_parts/cell/high
+	var/obj/item/weapon/stock_parts/cell/cell
+	var/powerefficiency = 0.01
 	var/amount = 30
 	var/recharged = 0
 	var/recharge_delay = 5
@@ -54,6 +55,7 @@
 
 /obj/machinery/chem_dispenser/Initialize()
 	. = ..()
+	cell = new cell_type
 	recharge()
 	dispensable_reagents = sortList(dispensable_reagents)
 
@@ -67,10 +69,8 @@
 
 /obj/machinery/chem_dispenser/proc/recharge()
 	if(stat & (BROKEN|NOPOWER)) return
-	var/addenergy = 1
-	var/oldenergy = energy
-	energy = min(energy + addenergy, max_energy)
-	if(energy != oldenergy)
+	var/usedpower = cell.give( 1 / powerefficiency) //Should always be a gain of one on the UI.
+	if(usedpower)
 		use_power(2500)
 
 /obj/machinery/chem_dispenser/emag_act(mob/user)
@@ -106,8 +106,8 @@
 /obj/machinery/chem_dispenser/ui_data()
 	var/data = list()
 	data["amount"] = amount
-	data["energy"] = energy
-	data["maxEnergy"] = max_energy
+	data["energy"] = cell.charge ? cell.charge * powerefficiency : "0" //To prevent NaN in the UI.
+	data["maxEnergy"] = cell.maxcharge * powerefficiency
 	data["isBeakerLoaded"] = beaker ? 1 : 0
 
 	var beakerContents[0]
@@ -149,10 +149,10 @@
 			if(beaker && dispensable_reagents.Find(reagent))
 				var/datum/reagents/R = beaker.reagents
 				var/free = R.maximum_volume - R.total_volume
-				var/actual = min(amount, energy * 10, free)
+				var/actual = min(amount, (cell.charge * powerefficiency)*10, free)
 
 				R.add_reagent(reagent, actual)
-				energy = max(energy - actual / 10, 0)
+				cell.use((actual / 10) / powerefficiency)
 				. = TRUE
 		if("remove")
 			var/amount = text2num(params["amount"])
@@ -184,20 +184,23 @@
 		beaker.loc = src
 		to_chat(user, "<span class='notice'>You add \the [B] to the machine.</span>")
 
-		beaker_overlay = beaker_overlay ||  mutable_appearance(icon, "disp_beaker") 
+		beaker_overlay = beaker_overlay ||  mutable_appearance(icon, "disp_beaker")
 		beaker_overlay.pixel_x = rand(-10, 5)//randomize beaker overlay position.
 		add_overlay(beaker_overlay)
 	else if(user.a_intent != INTENT_HARM && !istype(I, /obj/item/weapon/card/emag))
 		to_chat(user, "<span class='warning'>You can't load \the [I] into the machine!</span>")
+		return ..()
 	else
 		return ..()
+
+/obj/machinery/chem_dispenser/get_cell()
+	return cell
 
 /obj/machinery/chem_dispenser/constructable
 	name = "portable chem dispenser"
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "minidispenser"
-	energy = 10
-	max_energy = 10
+	powerefficiency = 0.001
 	amount = 5
 	recharge_delay = 30
 	dispensable_reagents = list()
@@ -263,16 +266,13 @@
 
 /obj/machinery/chem_dispenser/constructable/RefreshParts()
 	var/time = 0
-	var/temp_energy = 0
 	var/i
+	for(var/obj/item/weapon/stock_parts/cell/P in component_parts)
+		cell = P
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
-		temp_energy += M.rating
-	temp_energy--
-	max_energy = temp_energy * 5  //max energy = (bin1.rating + bin2.rating - 1) * 5, 5 on lowest 25 on highest
+		time += M.rating
 	for(var/obj/item/weapon/stock_parts/capacitor/C in component_parts)
 		time += C.rating
-	for(var/obj/item/weapon/stock_parts/cell/P in component_parts)
-		time += round(P.maxcharge, 10000) / 10000
 	recharge_delay /= time/2         //delay between recharges, double the usual time on lowest 50% less than usual on highest
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		for(i=1, i<=M.rating, i++)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -196,6 +196,26 @@
 /obj/machinery/chem_dispenser/get_cell()
 	return cell
 
+/obj/machinery/chem_dispenser/emp_act(severity)
+	var/list/datum/reagents/R = list()
+	var/total = min(rand(3,15), Floor(cell.charge*powerefficiency))
+	var/datum/reagents/Q = new(total*10)
+	var/datum/reagents/medium
+	if(prob(66))
+		medium.add_reagent_list(pick(list(list("potassium" = 15, "sugar" = 15, "phosphorus" = 15),list("fluorosurfactant" = 25, "water" = 25))))
+		R += medium
+	if(beaker && beaker.reagents)
+		R += beaker.reagents
+	for(var/i in 1 to total)
+		Q.add_reagent(pick(dispensable_reagents), 10)
+	R += Q
+	chem_splash(get_turf(src), 3, R)
+	if(beaker && beaker.reagents)
+		beaker.reagents.remove_all()
+	cell.use(total/powerefficiency)
+	visible_message("<span class='danger'> The [src] malfunctions, spraying chemicals everywhere!</span>")
+	..()
+
 /obj/machinery/chem_dispenser/constructable
 	name = "portable chem dispenser"
 	icon = 'icons/obj/chemical.dmi'

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -198,12 +198,8 @@
 
 /obj/machinery/chem_dispenser/emp_act(severity)
 	var/list/datum/reagents/R = list()
-	var/total = min(rand(3,15), Floor(cell.charge*powerefficiency))
+	var/total = min(rand(7,15), Floor(cell.charge*powerefficiency))
 	var/datum/reagents/Q = new(total*10)
-	var/datum/reagents/medium
-	if(prob(66))
-		medium.add_reagent_list(pick(list(list("potassium" = 15, "sugar" = 15, "phosphorus" = 15),list("fluorosurfactant" = 25, "water" = 25))))
-		R += medium
 	if(beaker && beaker.reagents)
 		R += beaker.reagents
 	for(var/i in 1 to total)
@@ -213,6 +209,7 @@
 	if(beaker && beaker.reagents)
 		beaker.reagents.remove_all()
 	cell.use(total/powerefficiency)
+	cell.emp_act()
 	visible_message("<span class='danger'> The [src] malfunctions, spraying chemicals everywhere!</span>")
 	..()
 


### PR DESCRIPTION
:cl:
tweak: Chem Dispensers now store their power in their batteries. 
tweak: Instead of being based on battery and capacitor ratings, recharge delay for portable chem dispensers is now based on their capacitor and matter bin ratings.
/:cl:

I've updated chem dispensers so that their energy is based on the power stored in their internal batteries. I've also added a coefficient, so that portable dispensers will continue to have a worse maximum energy than chemistry's. In that way, it's kind of a nerf, since a Bluespace battery would increase it's reagent energy from 10 to 40, which is a bit down from their previous 45. I've tried to maintain as much as possible for number balance. There also won't be changes to the UI. A full dispenser will still say 100, and 10u of reagent will still decrease it by 1.