### PR TITLE
Fixes an incorrect line in beam rifle vars

### DIFF
--- a/code/modules/projectiles/guns/beam_rifle.dm
+++ b/code/modules/projectiles/guns/beam_rifle.dm
@@ -32,7 +32,7 @@
 	canMouseDown = TRUE
 	pin = null
 	var/aiming = FALSE
-	var/aiming_time = 10
+	var/aiming_time = 7
 	var/aiming_time_fire_threshold = 2
 	var/aiming_time_left = 7
 	var/aiming_time_increase_user_movement = 3


### PR DESCRIPTION
Woops, forgot to set this one to the same as aiming_time_left.