### PR TITLE
Buffs chemical grenades

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -103,7 +103,7 @@
 			to_chat(user, "<span class='warning'>You need one length of coil to wire the assembly!</span>")
 			return
 
-	else if(stage == READY && istype(I, /obj/item/weapon/wirecutters))
+	else if(stage == READY && istype(I, /obj/item/weapon/wirecutters) && !active)
 		stage_change(WIRED)
 		to_chat(user, "<span class='notice'>You unlock the [initial(name)] assembly.</span>")
 


### PR DESCRIPTION
:cl: Swindly
balance: Chemical grenades are no longer permanently disabled after being unlocked by wirecutters after being primed.
/:cl:

[why]:  (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Disabling grenades so that they don't function even after being fully deconstructed and rebuilt without any indication of non-functionality is bad.