### PR TITLE
[WIP] Changes how still exploding turfs are determined

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -192,13 +192,18 @@ GLOBAL_LIST_EMPTY(explosions)
 								Search.next_exploded_turf = null
 								NextTurf.previous_exploded_turf = null
 							Search.explosion_level = 0
+							#ifdef TESTING
+							Search.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#FF0000")
+							#endif
 							break
 				
 				//add it to the linked list
 				T.previous_exploded_turf = last_exploded
 				last_exploded.next_exploded_turf = T
 				last_exploded = T
-
+				#ifdef TESTING
+				T.add_atom_colour("#FF0000", TEMPORARY_COLOUR_PRIORITY)
+				#endif
 				//and explode
 				T.explosion_level = dist
 				T.ex_act(dist)
@@ -252,6 +257,9 @@ GLOBAL_LIST_EMPTY(explosions)
 	//unfuck the shit
 	while(last_exploded)
 		last_exploded.next_exploded_turf = null
+		#ifdef TESTING
+		last_exploded.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#FF0000")
+		#endif
 		var/temp = last_exploded.previous_exploded_turf
 		last_exploded.previous_exploded_turf = null
 		last_exploded = temp

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -198,8 +198,9 @@ GLOBAL_LIST_EMPTY(explosions)
 							break
 				
 				//add it to the linked list
-				T.previous_exploded_turf = last_exploded
-				last_exploded.next_exploded_turf = T
+				if(last_exploded)
+					T.previous_exploded_turf = last_exploded
+					last_exploded.next_exploded_turf = T
 				last_exploded = T
 				#ifdef TESTING
 				T.add_atom_colour("#FF0000", TEMPORARY_COLOUR_PRIORITY)

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -181,16 +181,18 @@ GLOBAL_LIST_EMPTY(explosions)
 			var/their_el = T.explosion_level	//let the bigger one have it
 			if(dist > their_el)
 
-				//search for the next turf in the ring and unexplode it
-				for(var/I in GLOB.cardinal)
-					var/turf/Search = get_step(T, I)
-					if(Search && Search.explosion_id == id && !Search.previous_exploded_turf)
-						var/turf/NextTurf = Search.next_exploded_turf
-						if(NextTurf)
-							Search.next_exploded_turf = null
-							NextTurf.previous_exploded_turf = null
-						Search.explosion_level = 0
-						break
+				//don't do this if we're too close to the epicenter
+				if(iteration > 7)
+					//search for the next turf in the ring and unexplode it
+					for(var/I in GLOB.cardinal)
+						var/turf/Search = get_step(T, I)
+						if(Search && Search.explosion_id == id && !Search.previous_exploded_turf)
+							var/turf/NextTurf = Search.next_exploded_turf
+							if(NextTurf)
+								Search.next_exploded_turf = null
+								NextTurf.previous_exploded_turf = null
+							Search.explosion_level = 0
+							break
 				
 				//add it to the linked list
 				T.previous_exploded_turf = last_exploded

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -135,7 +135,6 @@ GLOBAL_LIST_EMPTY(explosions)
 
 	EX_PREPROCESS_CHECK_TICK
 
-	var/list/exploded_this_tick = list()	//open turfs that need to be blocked off while we sleep
 	var/list/affected_turfs = GatherSpiralTurfs(max_range, epicenter)
 
 	var/reactionary = config.reactionary_explosions
@@ -149,11 +148,11 @@ GLOBAL_LIST_EMPTY(explosions)
 	var/iteration = 0
 	var/affTurfLen = affected_turfs.len
 	var/expBlockLen = cached_exp_block.len
+	var/turf/last_exploded
 	for(var/TI in affected_turfs)
 		var/turf/T = TI
 		++iteration
-		var/init_dist = cheap_hypotenuse(T.x, T.y, x0, y0)
-		var/dist = init_dist
+		var/dist = cheap_hypotenuse(T.x, T.y, x0, y0)
 
 		if(reactionary)
 			var/turf/Trajectory = T
@@ -179,10 +178,28 @@ GLOBAL_LIST_EMPTY(explosions)
 			new /obj/effect/hotspot(T) //Mostly for ambience!
 
 		if(dist > 0)
-			T.explosion_level = max(T.explosion_level, dist)	//let the bigger one have it
-			T.explosion_id = id
-			T.ex_act(dist)
-			exploded_this_tick += T
+			var/their_el = T.explosion_level	//let the bigger one have it
+			if(dist > their_el)
+
+				//search for the next turf in the ring and unexplode it
+				for(var/I in GLOB.cardinal)
+					var/turf/Search = get_step(T, I)
+					if(Search && Search.explosion_id == id && !Search.previous_exploded_turf)
+						var/turf/NextTurf = Search.next_exploded_turf
+						if(NextTurf)
+							Search.next_exploded_turf = null
+							NextTurf.previous_exploded_turf = null
+						Search.explosion_level = 0
+						break
+				
+				//add it to the linked list
+				T.previous_exploded_turf = last_exploded
+				last_exploded.next_exploded_turf = T
+				last_exploded = T
+
+				//and explode
+				T.explosion_level = dist
+				T.ex_act(dist)
 
 		//--- THROW ITEMS AROUND ---
 
@@ -230,18 +247,12 @@ GLOBAL_LIST_EMPTY(explosions)
 				affTurfLen = affected_turfs.len
 				expBlockLen = cached_exp_block.len
 
-			var/circumference = (PI * (init_dist + 4) * 2) //+4 to radius to prevent shit gaps
-			if(exploded_this_tick.len > circumference)	//only do this every revolution
-				for(var/Unexplode in exploded_this_tick)
-					var/turf/UnexplodeT = Unexplode
-					UnexplodeT.explosion_level = 0
-				exploded_this_tick.Cut()
-
 	//unfuck the shit
-	for(var/Unexplode in exploded_this_tick)
-		var/turf/UnexplodeT = Unexplode
-		UnexplodeT.explosion_level = 0
-	exploded_this_tick.Cut()
+	while(last_exploded)
+		last_exploded.next_exploded_turf = null
+		var/temp = last_exploded.previous_exploded_turf
+		last_exploded.previous_exploded_turf = null
+		last_exploded = temp
 
 	var/took = (REALTIMEOFDAY - started_at) / 10
 
@@ -249,7 +260,7 @@ GLOBAL_LIST_EMPTY(explosions)
 	if(GLOB.Debug2)
 		log_world("## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds.")
 
-	if(!stopped)	//if we aren't in a hurry
+	if(running)	//if we aren't in a hurry
 		//Machines which report explosions.
 		for(var/array in GLOB.doppler_arrays)
 			var/obj/machinery/doppler_array/A = array

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -17,8 +17,10 @@
 
 	var/list/image/blueprint_data //for the station blueprints, images of objects eg: pipes
 
-	var/explosion_level = 0	//for preventing explosion dodging
-	var/explosion_id = 0
+	var/turf/previous_exploded_turf
+	var/turf/next_exploded_turf
+	var/explosion_level = 0
+	var/explosion_id
 
 	var/list/decals
 	var/requires_activation	//add to air processing after initialize?

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -17,10 +17,10 @@
 
 	var/list/image/blueprint_data //for the station blueprints, images of objects eg: pipes
 
-	var/turf/previous_exploded_turf
+	var/turf/previous_exploded_turf	//explosion dodging stuff
 	var/turf/next_exploded_turf
 	var/explosion_level = 0
-	var/explosion_id
+	var/explosion_id = 0
 
 	var/list/decals
 	var/requires_activation	//add to air processing after initialize?


### PR DESCRIPTION
Whole radius thing wasn't working out. Now explosions have a doubly-linked list of turfs that form a ring along the outermost edge of a running explosion. Anything entering these turfs will be exploded. You still can't get hit by the same explosion twice.

Closes #27888 

TODO:

- [ ] - Add a snowflake check for the first 8 turfs because they are too close together