### PR TITLE
[Box] Removes extra unattached vent from Xenobiology Lab

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -48285,10 +48285,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;


### PR DESCRIPTION
:cl: Penguaro
fix: [Box] Removes extra/unattached vent from Xeno Lab
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
It looks like it is an accident and can be confusing when you access the air alarm and see it listed.

The vent is located under a table by one of the slime pens. For the picture, I removed the table and the control for the barricade.
![xenomap](https://cloud.githubusercontent.com/assets/9791590/26703357/dc12990e-46ee-11e7-82e2-277d6971e472.jpg)
