### PR TITLE
Standardizes shunting to arrivals shuttle

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -506,13 +506,30 @@
 		return
 
 	//First we spawn a dude.
-	var/mob/living/carbon/human/new_character = new(pick(GLOB.latejoin))//The mob being spawned.
+	var/mob/living/carbon/human/new_character = new(get_latejoin_turf())//The mob being spawned.
 
 	G_found.client.prefs.copy_to(new_character)
 	new_character.dna.update_dna_identity()
 	new_character.key = G_found.key
 
 	return new_character
+
+/proc/get_latejoin_turf()
+	var/turf/D
+	if(GLOB.latejoin.len)
+		D = get_turf(pick(GLOB.latejoin))
+	if(!D)
+		for(var/turf/T in get_area_turfs(/area/shuttle/arrival))
+			if(!T.density)
+				var/clear = 1
+				for(var/obj/O in T)
+					if(O.density)
+						clear = 0
+						break
+				if(clear)
+					D = T
+					continue
+	return D
 
 /proc/send_to_playing_players(thing) //sends a whatever to all playing players; use instead of to_chat(world, where needed)
 	for(var/M in GLOB.player_list)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -520,15 +520,9 @@
 		D = get_turf(pick(GLOB.latejoin))
 	if(!D)
 		for(var/turf/T in get_area_turfs(/area/shuttle/arrival))
-			if(!T.density)
-				var/clear = 1
-				for(var/obj/O in T)
-					if(O.density)
-						clear = 0
-						break
-				if(clear)
-					D = T
-					continue
+			if(!is_blocked_turf(T))
+				D = T
+				break
 	return D
 
 /proc/send_to_playing_players(thing) //sends a whatever to all playing players; use instead of to_chat(world, where needed)

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_EMPTY(generic_event_spawns)			//list of all spawns for events
 
 GLOBAL_LIST_EMPTY(wizardstart)
 GLOBAL_LIST_EMPTY(newplayer_start)
-GLOBAL_LIST_EMPTY(latejoin)
+GLOBAL_LIST_EMPTY(latejoin)	//contains a list of chairs since the shuttle moves. use get_latejoin_turf() in game.dm for choosing a location
 GLOBAL_LIST_EMPTY(prisonwarp)	//prisoners go to these
 GLOBAL_LIST_EMPTY(holdingfacility)	//captured people go here
 GLOBAL_LIST_EMPTY(xeno_spawn)//Aliens spawn at these.

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -395,6 +395,8 @@ SUBSYSTEM_DEF(job)
 						continue
 		if(istype(S, /obj/effect/landmark) && isturf(S.loc))
 			H.loc = S.loc
+		else if(isturf(S))
+			H.forceMove(S)
 
 	if(H.mind)
 		H.mind.assigned_role = rank

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -380,7 +380,7 @@ SUBSYSTEM_DEF(job)
 			break
 		if(!S) //if there isn't a spawnpoint send them to latejoin, if there's no latejoin go yell at your mapper
 			log_world("Couldn't find a round start spawn point for [rank]")
-			S = get_turf(pick(GLOB.latejoin))
+			S = get_latejoin_turf()
 		if(!S) //final attempt, lets find some area in the arrivals shuttle to spawn them in to.
 			log_world("Couldn't find a round start latejoin spawn point.")
 			for(var/turf/T in get_area_turfs(/area/shuttle/arrival))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1448,7 +1448,7 @@
 		special_role = "Wizard"
 		assigned_role = "Wizard"
 		if(!GLOB.wizardstart.len)
-			current.loc = pick(GLOB.latejoin)
+			current.loc = get_latejoin_turf()
 			to_chat(current, "HOT INSERTION, GO GO GO")
 		else
 			current.loc = pick(GLOB.wizardstart)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1448,7 +1448,7 @@
 		special_role = "Wizard"
 		assigned_role = "Wizard"
 		if(!GLOB.wizardstart.len)
-			current.loc = get_latejoin_turf()
+			current.forceMove(get_latejoin_turf())
 			to_chat(current, "HOT INSERTION, GO GO GO")
 		else
 			current.loc = pick(GLOB.wizardstart)

--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -219,7 +219,7 @@
 		H.uncuff()
 		return
 	//Area not chosen / It's not safe area - teleport to arrivals
-	H.forceMove(pick(GLOB.latejoin))
+	H.forceMove(get_latejoin_turf())
 	H.uncuff()
 	return
 

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -142,7 +142,7 @@
 		return
 
 	//First we spawn a dude.
-	var/mob/living/carbon/human/new_character = new(pick(GLOB.latejoin))//The mob being spawned.
+	var/mob/living/carbon/human/new_character = new(get_latejoin_turf())//The mob being spawned.
 
 	G_found.client.prefs.copy_to(new_character)
 	new_character.dna.update_dna_identity()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -595,7 +595,7 @@
 	set category = "Admin"
 	set name = "Unprison"
 	if (M.z == ZLEVEL_CENTCOM)
-		M.loc = get_latejoin_turf()
+		M.forceMove(get_latejoin_turf())
 		message_admins("[key_name_admin(usr)] has unprisoned [key_name_admin(M)]")
 		log_admin("[key_name(usr)] has unprisoned [key_name(M)]")
 	else

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -434,7 +434,7 @@
 			if("Hard Restart (No Delay, No Feeback Reason)")
 				world.Reboot()
 			if("Hardest Restart (No actions, just reboot)")
-				world.Reboot(fast_track = TRUE)		
+				world.Reboot(fast_track = TRUE)
 			if("Service Restart (Force restart DD)")
 				GLOB.reboot_mode = REBOOT_MODE_HARD
 				world.ServiceReboot()
@@ -595,7 +595,7 @@
 	set category = "Admin"
 	set name = "Unprison"
 	if (M.z == ZLEVEL_CENTCOM)
-		M.loc = pick(GLOB.latejoin)
+		M.loc = get_latejoin_turf()
 		message_admins("[key_name_admin(usr)] has unprisoned [key_name_admin(M)]")
 		log_admin("[key_name(usr)] has unprisoned [key_name(M)]")
 	else

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -226,7 +226,7 @@
 		return 0
 
 	var/alien_caste = input(usr, "Please choose which caste to spawn.","Pick a caste",null) as null|anything in list("Queen","Praetorian","Hunter","Sentinel","Drone","Larva")
-	var/obj/effect/landmark/spawn_here = GLOB.xeno_spawn.len ? pick(GLOB.xeno_spawn) : pick(GLOB.latejoin)
+	var/obj/effect/landmark/spawn_here = GLOB.xeno_spawn.len ? pick(GLOB.xeno_spawn) : get_latejoin_turf()
 	var/mob/living/carbon/alien/new_xeno
 	switch(alien_caste)
 		if("Queen")
@@ -284,7 +284,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 				if(GLOB.xeno_spawn.len)
 					T = pick(GLOB.xeno_spawn)
 				else
-					T = pick(GLOB.latejoin)
+					T = get_latejoin_turf()
 
 				var/mob/living/carbon/alien/new_xeno
 				switch(G_found.mind.special_role)//If they have a mind, we can determine which caste they were.
@@ -314,7 +314,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		//check if they were a monkey
 		else if(findtext(G_found.real_name,"monkey"))
 			if(alert("This character appears to have been a monkey. Would you like to respawn them as such?",,"Yes","No")=="Yes")
-				var/mob/living/carbon/monkey/new_monkey = new(pick(GLOB.latejoin))
+				var/mob/living/carbon/monkey/new_monkey = new(get_latejoin_turf())
 				G_found.mind.transfer_to(new_monkey)	//be careful when doing stuff like this! I've already checked the mind isn't in use
 				new_monkey.key = G_found.key
 				to_chat(new_monkey, "You have been fully respawned. Enjoy the game.")
@@ -325,7 +325,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 
 	//Ok, it's not a xeno or a monkey. So, spawn a human.
-	var/mob/living/carbon/human/new_character = new(pick(GLOB.latejoin))//The mob being spawned.
+	var/mob/living/carbon/human/new_character = new(get_latejoin_turf())//The mob being spawned.
 
 	var/datum/data/record/record_found			//Referenced to later to either randomize or not randomize the character.
 	if(G_found.mind && !G_found.mind.active)	//mind isn't currently in use by someone/something

--- a/code/modules/events/devil.dm
+++ b/code/modules/events/devil.dm
@@ -14,10 +14,7 @@
 
 /datum/round_event/ghost_role/devil/spawn_role()
 	//selecting a spawn_loc
-	var/list/spawn_locs = GLOB.latejoin
-	var/spawn_loc = pick(spawn_locs)
-	if(!spawn_loc)
-		return MAP_ERROR
+	var/spawn_loc = get_latejoin_turf()
 
 	//selecting a candidate player
 	var/list/candidates = get_candidates("devil", null, ROLE_DEVIL)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -322,7 +322,7 @@
 	if(isliving(equip))	//Borgs get borged in the equip, so we need to make sure we handle the new mob.
 		character = equip
 
-	character.loc = get_latejoin_turf()
+	character.forceMove(get_latejoin_turf())
 	character.update_parallax_teleport()
 
 	var/atom/movable/chair = locate(/obj/structure/chair) in character.loc

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -322,22 +322,7 @@
 	if(isliving(equip))	//Borgs get borged in the equip, so we need to make sure we handle the new mob.
 		character = equip
 
-	var/D
-	if(GLOB.latejoin.len)
-		D = get_turf(pick(GLOB.latejoin))
-	if(!D)
-		for(var/turf/T in get_area_turfs(/area/shuttle/arrival))
-			if(!T.density)
-				var/clear = 1
-				for(var/obj/O in T)
-					if(O.density)
-						clear = 0
-						break
-				if(clear)
-					D = T
-					continue
-
-	character.loc = D
+	character.loc = get_latejoin_turf()
 	character.update_parallax_teleport()
 
 	var/atom/movable/chair = locate(/obj/structure/chair) in character.loc


### PR DESCRIPTION
:cl: QualityVan
fix: Stopped people getting stuck inside chairs on the arrivals shuttle
/:cl:

So GLOB.latejoin contains a list of chairs. A lot of stuff that shunts there, mostly secondary in case trying to shunt somewhere else fails, treated it as a list of turfs. This fixes that and prevents it from breaking if someone destroys all the chairs on the arrivals shuttle. Adds a get_latejoin_turf() proc that returns a suitable turf on the arrivals shuttle.

Fixes #27957 