### PR TITLE
[Fix] Gangsters sniper rifle now starts with the correct (weaker) ammo

### DIFF
--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -238,7 +238,7 @@
 	name = "Black Market .50cal Sniper Rifle"
 	id = "sniper"
 	cost = 40
-	item_path = /obj/item/weapon/gun/ballistic/automatic/sniper_rifle
+	item_path = /obj/item/weapon/gun/ballistic/automatic/sniper_rifle/gang
 
 /datum/gang_item/weapon/ammo/sniper_ammo
 	name = "Smuggled .50cal Sniper Rounds"


### PR DESCRIPTION
I added a gang sniper rifle so that the pre-loaded ammo wouldn't use the more powerful normal rounds but I forgot to add that to the item list.