### PR TITLE
Adds another unique KA mod to necropolis chests

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -49,3 +49,5 @@
 #define STATUS_EFFECT_SIGILMARK /datum/status_effect/sigil_mark
 
 #define STATUS_EFFECT_CRUSHERDAMAGETRACKING /datum/status_effect/crusher_damage //tracks total kinetic crusher damage on a target
+
+#define STATUS_EFFECT_SYPHONMARK /datum/status_effect/syphon_mark //tracks kills for the KA death syphon module

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -16,3 +16,29 @@
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = null
 	var/total_damage = 0
+
+/datum/status_effect/syphon_mark
+	id = "syphon_mark"
+	duration = 50
+	status_type = STATUS_EFFECT_MULTIPLE
+	alert_type = null
+	on_remove_on_mob_delete = TRUE
+	var/obj/item/borg/upgrade/modkit/bounty/reward_target
+
+/datum/status_effect/syphon_mark/on_apply()
+	if(owner.stat == DEAD)
+		return FALSE
+	return ..()
+
+/datum/status_effect/syphon_mark/proc/get_kill()
+	if(reward_target)
+		reward_target.get_kill(owner)
+
+/datum/status_effect/syphon_mark/tick()
+	if(owner.stat == DEAD)
+		get_kill()
+		qdel(src)
+
+/datum/status_effect/cult_master/on_remove()
+	get_kill()
+	. = ..()

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -39,6 +39,6 @@
 		get_kill()
 		qdel(src)
 
-/datum/status_effect/cult_master/on_remove()
+/datum/status_effect/syphon_mark/on_remove()
 	get_kill()
 	. = ..()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -11,7 +11,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,27)
+	var/loot = rand(1,28)
 	switch(loot)
 		if(1)
 			new /obj/item/device/shared_storage/red(src)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -69,6 +69,8 @@
 		if(27)
 			new /obj/item/borg/upgrade/modkit/lifesteal(src)
 			new /obj/item/weapon/bedsheet/cult(src)
+		if(28)
+			new /obj/item/borg/upgrade/modkit/bounty(src)
 
 
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -79,3 +79,6 @@
 	crusher_loot = /obj/item/crusher_trophy/watcher_wing
 	loot = list()
 	butcher_results = list(/obj/item/weapon/ore/diamond = 2, /obj/item/stack/sheet/sinew = 2, /obj/item/stack/sheet/bone = 1)
+
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril
+	fromtendril = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -91,6 +91,9 @@
 	stat_attack = UNCONSCIOUS
 	robust_searching = 1
 
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/tendril
+	fromtendril = TRUE
+
 //tentacles
 /obj/effect/goliath_tentacle
 	name = "Goliath tentacle"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -111,7 +111,6 @@
 	stat_attack = UNCONSCIOUS
 	robust_searching = 1
 	var/mob/living/carbon/human/stored_mob
-	var/fromtendril = FALSE
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/death(gibbed)
 	visible_message("<span class='warning'>The skulls on [src] wail in anger as they flee from their dying host!</span>")
@@ -125,6 +124,9 @@
 		else
 			new /obj/effect/mob_spawn/human/corpse/damaged/legioninfested(T)
 	..(gibbed)
+
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril
+	fromtendril = TRUE
 
 //Legion skull
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -16,6 +16,7 @@
 	var/crusher_loot
 	var/throw_message = "bounces off of"
 	var/icon_aggro = null // for swapping to when we get aggressive
+	var/fromtendril = FALSE
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	mob_size = MOB_SIZE_LARGE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/necropolis_tendril.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/necropolis_tendril.dm
@@ -17,7 +17,7 @@
 	maxHealth = 250
 	max_mobs = 3
 	spawn_time = 300 //30 seconds default
-	mob_type = /mob/living/simple_animal/hostile/asteroid/basilisk/watcher
+	mob_type = /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril
 	spawn_text = "emerges from"
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
@@ -28,10 +28,10 @@
 	var/obj/effect/light_emitter/tendril/emitted_light
 
 /mob/living/simple_animal/hostile/spawner/lavaland/goliath
-	mob_type = /mob/living/simple_animal/hostile/asteroid/goliath/beast
+	mob_type = /mob/living/simple_animal/hostile/asteroid/goliath/beast/tendril
 
 /mob/living/simple_animal/hostile/spawner/lavaland/legion
-	mob_type = /mob/living/simple_animal/hostile/asteroid/hivelord/legion{fromtendril = 1}
+	mob_type = /mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril
 
 /mob/living/simple_animal/hostile/spawner/lavaland/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -479,7 +479,7 @@
 	if(ismegafauna(L)) //megafauna reward
 		bonus_mod = 4
 	if(!bounties_reaped[L.type])
-		bounties_reaped[L.type] = modifier * bonus_mod
+		bounties_reaped[L.type] = min(modifier * bonus_mod, maximum_bounty)
 	else
 		bounties_reaped[L.type] = min(bounties_reaped[L.type] + (modifier * bonus_mod), maximum_bounty)
 

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -163,6 +163,7 @@
 	range = 3
 	log_override = TRUE
 
+	var/pressure_decrease_active = FALSE
 	var/pressure_decrease = 0.25
 	var/obj/item/weapon/gun/energy/kinetic_accelerator/kinetic_gun
 
@@ -179,6 +180,7 @@
 	if(pressure > 50)
 		name = "weakened [name]"
 		damage = damage * pressure_decrease
+		pressure_decrease_active = TRUE
 	. = ..()
 
 /obj/item/projectile/kinetic/on_range()
@@ -194,7 +196,10 @@
 	if(!target_turf)
 		target_turf = get_turf(src)
 	if(kinetic_gun) //hopefully whoever shot this was not very, very unfortunate.
-		for(var/obj/item/borg/upgrade/modkit/M in kinetic_gun.get_modkits())
+		var/list/mods = kinetic_gun.get_modkits()
+		for(var/obj/item/borg/upgrade/modkit/M in mods)
+			M.projectile_strike_predamage(src, target_turf, target, kinetic_gun)
+		for(var/obj/item/borg/upgrade/modkit/M in mods)
 			M.projectile_strike(src, target_turf, target, kinetic_gun)
 	if(ismineralturf(target_turf))
 		var/turf/closed/mineral/M = target_turf
@@ -265,6 +270,9 @@
 
 /obj/item/borg/upgrade/modkit/proc/modify_projectile(obj/item/projectile/kinetic/K)
 
+//use this one for effects you want to trigger before mods that do damage
+/obj/item/borg/upgrade/modkit/proc/projectile_strike_predamage(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/weapon/gun/energy/kinetic_accelerator/KA)
+//and this one for things that don't need to trigger before other damage-dealing mods
 /obj/item/borg/upgrade/modkit/proc/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/weapon/gun/energy/kinetic_accelerator/KA)
 
 //Range
@@ -394,7 +402,7 @@
 	modifier = -14 //Makes the cooldown 3 seconds(with no cooldown mods) if you miss. Don't miss.
 	cost = 50
 
-/obj/item/borg/upgrade/modkit/cooldown/repeater/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/weapon/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/cooldown/repeater/projectile_strike_predamage(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/weapon/gun/energy/kinetic_accelerator/KA)
 	var/valid_repeat = FALSE
 	if(isliving(target))
 		var/mob/living/L = target
@@ -404,7 +412,7 @@
 		valid_repeat = TRUE
 	if(valid_repeat)
 		KA.overheat = FALSE
-	KA.attempt_reload(KA.overheat_time * 0.25) //If you hit, the cooldown drops to 0.75 seconds.
+		KA.attempt_reload(KA.overheat_time * 0.25) //If you hit, the cooldown drops to 0.75 seconds.
 
 /obj/item/borg/upgrade/modkit/lifesteal
 	name = "lifesteal crystal"
@@ -415,7 +423,7 @@
 	cost = 20
 	var/static/list/damage_heal_order = list(BRUTE, BURN, OXY)
 
-/obj/item/borg/upgrade/modkit/lifesteal/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/weapon/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/lifesteal/projectile_strike_predamage(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/weapon/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target) && isliving(K.firer))
 		var/mob/living/L = target
 		if(L.stat == DEAD)
@@ -438,6 +446,42 @@
 			R.burst()
 			return
 		new /obj/effect/temp_visual/resonance(target_turf, K.firer, null, 30)
+
+/obj/item/borg/upgrade/modkit/bounty
+	name = "death syphon"
+	desc = "Killing or assisting in killing a creature permenantly increases your damage against that type of creature."
+	denied_type = /obj/item/borg/upgrade/modkit/bounty
+	modifier = 1.25
+	cost = 30
+	var/maximum_bounty = 25
+	var/list/bounties_reaped = list()
+
+/obj/item/borg/upgrade/modkit/bounty/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/weapon/gun/energy/kinetic_accelerator/KA)
+	if(isliving(target))
+		var/mob/living/L = target
+		var/list/existing_marks = L.has_status_effect_list(STATUS_EFFECT_SYPHONMARK)
+		for(var/i in existing_marks)
+			var/datum/status_effect/syphon_mark/SM = i
+			if(SM.reward_target == src) //we want to allow multiple people with bounty modkits to use them, but we need to replace our own marks so we don't multi-reward
+				SM.reward_target = null
+				qdel(SM)
+		var/datum/status_effect/syphon_mark/SM = L.apply_status_effect(STATUS_EFFECT_SYPHONMARK)
+		SM.reward_target = src
+		if(bounties_reaped[L.type])
+			var/kill_modifier = 1
+			if(K.pressure_decrease_active)
+				kill_modifier *= K.pressure_decrease
+			var/armor = L.run_armor_check(K.def_zone, K.flag, "", "", K.armour_penetration)
+			L.apply_damage(bounties_reaped[L.type]*kill_modifier, K.damage_type, K.def_zone, armor)
+
+/obj/item/borg/upgrade/modkit/bounty/proc/get_kill(mob/living/L)
+	var/bonus_mod = 1
+	if(ismegafauna(L)) //megafauna reward
+		bonus_mod = 4
+	if(!bounties_reaped[L.type])
+		bounties_reaped[L.type] = modifier * bonus_mod
+	else
+		bounties_reaped[L.type] = min(bounties_reaped[L.type] + (modifier * bonus_mod), maximum_bounty)
 
 //Indoors
 /obj/item/borg/upgrade/modkit/indoors


### PR DESCRIPTION
:cl: Joan
rscadd: Added a new unique Kinetic Accelerator module to necropolis chests.
/:cl:

Death Syphon, which grants 1.25 additional damage against creature types you kill or assist in killing. The bonus damage awarded is quadrupled for megafauna, but is capped at 25 additional damage no matter what the creature's type is.

This effect DOES work on humans, but is affected by pressure penalties.
