### PR TITLE
Makes Zombies 2 spooky

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -8,6 +8,7 @@
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/zombie
 	species_traits = list(NOBREATH,RESISTCOLD,RESISTPRESSURE,NOBLOOD,RADIMMUNE,NOZOMBIE,EASYDISMEMBER,EASYLIMBATTACHMENT)
 	mutant_organs = list(/obj/item/organ/tongue/zombie)
+	var/static/list/spooks = list('sound/hallucinations/growl1','sound/hallucinations/growl2','sound/hallucinations/growl3','sound/hallucinations/veryfar_noise','sound/hallucinations/wail')
 
 /datum/species/zombie/infectious
 	name = "Infectious Zombie"
@@ -25,6 +26,8 @@
 	. = ..()
 	C.a_intent = INTENT_HARM // THE SUFFERING MUST FLOW
 	C.heal_overall_damage(4,4)
+	prob(4)
+		playsound(C, pick(spooks), 50, TRUE, 10)
 	if(C.InCritical())
 		C.death()
 		// Zombies only move around when not in crit, they instantly

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -24,7 +24,7 @@
 /datum/species/zombie/infectious/spec_life(mob/living/carbon/C)
 	. = ..()
 	C.a_intent = INTENT_HARM // THE SUFFERING MUST FLOW
-	C.heal_overall_damage(5,5)
+	C.heal_overall_damage(4,4)
 	if(C.InCritical())
 		C.death()
 		// Zombies only move around when not in crit, they instantly

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -8,7 +8,7 @@
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/zombie
 	species_traits = list(NOBREATH,RESISTCOLD,RESISTPRESSURE,NOBLOOD,RADIMMUNE,NOZOMBIE,EASYDISMEMBER,EASYLIMBATTACHMENT)
 	mutant_organs = list(/obj/item/organ/tongue/zombie)
-	var/static/list/spooks = list('sound/hallucinations/growl1','sound/hallucinations/growl2','sound/hallucinations/growl3','sound/hallucinations/veryfar_noise','sound/hallucinations/wail')
+	var/static/list/spooks = list('sound/hallucinations/growl1.ogg','sound/hallucinations/growl2.ogg','sound/hallucinations/growl3.ogg','sound/hallucinations/veryfar_noise.ogg','sound/hallucinations/wail.ogg')
 
 /datum/species/zombie/infectious
 	name = "Infectious Zombie"
@@ -26,7 +26,7 @@
 	. = ..()
 	C.a_intent = INTENT_HARM // THE SUFFERING MUST FLOW
 	C.heal_overall_damage(4,4)
-	prob(4)
+	if(prob(4))
 		playsound(C, pick(spooks), 50, TRUE, 10)
 	if(C.InCritical())
 		C.death()

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -24,7 +24,7 @@
 /datum/species/zombie/infectious/spec_life(mob/living/carbon/C)
 	. = ..()
 	C.a_intent = INTENT_HARM // THE SUFFERING MUST FLOW
-	H.heal_overall_damage(5,5)
+	C.heal_overall_damage(5,5)
 	if(C.InCritical())
 		C.death()
 		// Zombies only move around when not in crit, they instantly

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -14,10 +14,12 @@
 	id = "memezombies"
 	limbs_id = "zombie"
 	mutanthands = /obj/item/zombie_hand
-	no_equip = list(slot_wear_mask, slot_head)
 	armor = 20 // 120 damage to KO a zombie, which kills it
 	speedmod = 2
 	mutanteyes = /obj/item/organ/eyes/night_vision/zombie
+
+/datum/species/zombie/infectious/spec_stun(mob/living/carbon/human/H,amount)
+	. = min(2, amount)
 
 /datum/species/zombie/infectious/spec_life(mob/living/carbon/C)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -24,6 +24,7 @@
 /datum/species/zombie/infectious/spec_life(mob/living/carbon/C)
 	. = ..()
 	C.a_intent = INTENT_HARM // THE SUFFERING MUST FLOW
+	H.heal_overall_damage(5,5)
 	if(C.InCritical())
 		C.death()
 		// Zombies only move around when not in crit, they instantly


### PR DESCRIPTION
Stun capped at 2 ticks (4s), zombifying no longer drops your mask/helmet, and zombies now heal 4 brute/4 burn per tick. 

Romerol purchases were down to 6 last month(of which I was probably 4 of them), I called it months ago. Fully stunnable zombies that move slowly are never going to be a serious threat unless everyone already died from other causes.

Edit: Yes zombies were so pathetic people would run to medbay and ask for surgery. Headmins have ruled that to be INVALID so please report your local shitty zombie to the nearest authorities.

:cl: Robustin
balance: Zombies now have a 4s cap on stun durations 
balance: Zombies now regenerate 4 brute/4 burn every 2 seconds.
balance: Zombies will no longer drop their mask/helmet upon turning, making them harder to identify
balance: Zombies will randomly moan/groan/wail which can be heard from far away, greatly enhancing their spookiness but preventing them from being too sneaky. 
:cl: