### PR TITLE
Fixes #27979 : Bulldog shotguns update properly when their magazine is removed.

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -270,8 +270,8 @@
 	update_icon()
 
 /obj/item/weapon/gun/ballistic/automatic/shotgun/bulldog/update_icon()
+	cut_overlays()
 	if(magazine)
-		cut_overlays()
 		add_overlay("[magazine.icon_state]")
 	icon_state = "bulldog[chambered ? "" : "-e"]"
 


### PR DESCRIPTION
:cl:
fix: Bulldog Shotguns should update their sprite properly when you remove the magazine.
/:cl:

Fixes #27979 