### PR TITLE
fix .html files being invalid types

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -23,11 +23,11 @@
 		if(copytext(path,-1,0) != "/")		//didn't choose a directory, no need to iterate again
 			break
 	var/extensions
-	for(i in valid_extensions)
+	for(var/i in valid_extensions)
 		if(extensions)
 			extensions += "|"
 		extensions += valid_extensions[i]
-	var/regex/valid_ext = new("\.([extensions])$", "i")
+	var/regex/valid_ext = new("\\.([extensions])$", "i")
 	if( !fexists(path) || !(valid_ext.Find(path)) )
 		to_chat(src, "<font color='red'>Error: browse_files(): File not found/Invalid file([path]).</font>")
 		return

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -3,7 +3,7 @@
 	for(var/file in args)
 		src << browse_rsc(file)
 
-/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm", ".html"))
+/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list("txt","log","htm", "html"))
 	var/path = root
 
 	for(var/i=0, i<max_iterations, i++)

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -3,7 +3,7 @@
 	for(var/file in args)
 		src << browse_rsc(file)
 
-/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm", "html")) //no . on html is a scummy hack to maintain compatibility with existing logs without complicating the proc with some regex
+/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm", ".html")) //no . on html is a scummy hack to maintain compatibility with existing logs without complicating the proc with some regex
 	var/path = root
 
 	for(var/i=0, i<max_iterations, i++)
@@ -22,9 +22,13 @@
 
 		if(copytext(path,-1,0) != "/")		//didn't choose a directory, no need to iterate again
 			break
-
-	var/extension = copytext(path,-4,0)
-	if( !fexists(path) || !(extension in valid_extensions) )
+	var/extensions
+	for(i in valid_extensions)
+		if(extensions)
+			extensions += "|"
+		extensions += valid_extensions[i]
+	var/regex/valid_ext = new("\.([extensions])$", "i")
+	if( !fexists(path) || !(valid_ext.Find(path)) )
 		to_chat(src, "<font color='red'>Error: browse_files(): File not found/Invalid file([path]).</font>")
 		return
 

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -3,7 +3,7 @@
 	for(var/file in args)
 		src << browse_rsc(file)
 
-/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm", ".html")) //no . on html is a scummy hack to maintain compatibility with existing logs without complicating the proc with some regex
+/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm", ".html"))
 	var/path = root
 
 	for(var/i=0, i<max_iterations, i++)

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -3,7 +3,7 @@
 	for(var/file in args)
 		src << browse_rsc(file)
 
-/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm", ".html"))
+/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm", "html")) //no . on html is a scummy hack to maintain compatibility with existing logs without complicating the proc with some regex
 	var/path = root
 
 	for(var/i=0, i<max_iterations, i++)


### PR DESCRIPTION
So this was broken for a fortnight.

`browse_files()` checks for the last 4 characters in the file path, changing the extension would break compatibility with existing logs and in my opinion using regex isn't worth it here (but totally possible to do if wanted), so this is a hack to work around that.