### PR TITLE
[FUN REMOVAL] Mobs that are flying no longer crash into glass tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -195,7 +195,7 @@
 		check_break(M)
 
 /obj/structure/table/glass/proc/check_break(mob/living/M)
-	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL)
+	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !M.movement_type & FLYING)
 		table_shatter(M)
 
 /obj/structure/table/glass/proc/table_shatter(mob/M)


### PR DESCRIPTION
Fixes #26461 
# CLOSE THE ISSUE AND I CLOSE THE PR!!