### PR TITLE
Marine First Aid Kit

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ueg_crash1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ueg_crash1.dmm
@@ -16,7 +16,7 @@
 "ap" = (/turf/open/floor/plasteel/black,/area/ruin/powered)
 "aq" = (/obj/effect/decal/cleanable/vomit,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
 "ar" = (/obj/machinery/portable_atmospherics/canister/oxygen{maximum_pressure = 1019.25},/turf/open/floor/plasteel/black,/area/ruin/powered)
-"as" = (/turf/open/floor/plating,/area/ruin/powered)
+"as" = (/obj/item/weapon/storage/firstaid/regular,/turf/open/floor/plating,/area/ruin/powered)
 "at" = (/obj/item/ammo_box/magazine/carbine,/turf/open/floor/plating{tag = "icon-platingdmg3"; icon_state = "platingdmg3"},/area/ruin/powered)
 "au" = (/obj/effect/decal/cleanable/blood,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
 "av" = (/obj/item/clothing/mask/breath,/turf/open/floor/plasteel/black,/area/ruin/powered)
@@ -27,7 +27,7 @@
 "aA" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/open/floor/plasteel/black,/area/ruin/powered)
 "aB" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/open/floor/plasteel/black,/area/ruin/powered)
 "aC" = (/obj/item/clothing/glasses/meson,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"aD" = (/obj/structure/rack,/obj/item/weapon/storage/firstaid/tactical,/obj/item/device/flashlight/seclite{desc = "A robust flashlight used by the military."; name = "combat flashlight"},/obj/item/weapon/kitchen/knife/combat/survival{name = "military knife"},/obj/item/weapon/survivalcapsule,/obj/item/ammo_box/magazine/carbine,/obj/item/ammo_box/magazine/carbine,/obj/item/weapon/gun/ballistic/automatic/carbine,/turf/open/floor/plating,/area/ruin/powered)
+"aD" = (/obj/structure/rack,/obj/item/device/flashlight/seclite{desc = "A robust flashlight used by the military."; name = "combat flashlight"},/obj/item/weapon/kitchen/knife/combat/survival{name = "military knife"},/obj/item/weapon/survivalcapsule,/obj/item/ammo_box/magazine/carbine,/obj/item/ammo_box/magazine/carbine,/obj/item/weapon/gun/ballistic/automatic/carbine,/turf/open/floor/plating,/area/ruin/powered)
 "aE" = (/obj/machinery/suit_storage_unit/ueg{name = "Marine Armour Storage Unit"},/obj/machinery/light,/turf/open/floor/plating,/area/ruin/powered)
 "aF" = (/turf/open/floor/plating{tag = "icon-platingdmg3"; icon_state = "platingdmg3"},/area/lavaland/surface/outdoors)
 "aG" = (/obj/machinery/door/airlock/hatch{name = "Armoury"; req_access_txt = "205"},/turf/open/floor/plasteel/black,/area/ruin/powered)
@@ -37,33 +37,34 @@
 "aK" = (/turf/open/floor/plasteel/vault{dir = 5},/area/lavaland/surface/outdoors)
 "aL" = (/turf/open/floor/plating{tag = "icon-platingdmg2"; icon_state = "platingdmg2"},/area/lavaland/surface/outdoors)
 "aM" = (/obj/structure/sign/poster/official/help_others,/turf/closed/wall/mineral/plastitanium{desc = "An wall of plasma and titanium."},/area/ruin/powered)
-"aN" = (/obj/effect/decal/cleanable/vomit,/turf/open/floor/plating,/area/ruin/powered)
-"aO" = (/turf/open/floor/plating{tag = "icon-platingdmg3"; icon_state = "platingdmg3"},/area/ruin/powered)
-"aP" = (/turf/open/floor/plating{tag = "icon-platingdmg1"; icon_state = "platingdmg1"},/area/lavaland/surface/outdoors)
-"aQ" = (/obj/effect/decal/cleanable/blood/old,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"aR" = (/obj/structure/closet,/obj/item/toy/prize/honk,/turf/open/floor/plasteel/vault{dir = 5},/area/lavaland/surface/outdoors)
-"aS" = (/obj/structure/sign/poster/contraband/clown,/turf/closed/wall/mineral/plastitanium{desc = "An wall of plasma and titanium."},/area/lavaland/surface/outdoors)
-"aT" = (/turf/open/floor/plating{tag = "icon-platingdmg2"; icon_state = "platingdmg2"},/area/ruin/powered)
-"aU" = (/obj/structure/sign/poster/official/walk,/turf/closed/wall/mineral/plastitanium{desc = "An wall of plasma and titanium."},/area/ruin/powered)
-"aV" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"aW" = (/obj/effect/decal/cleanable/oil,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"aX" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"aY" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"aZ" = (/obj/machinery/door/airlock/hatch{name = "Personal Quarters D"; req_access_txt = "205"},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"ba" = (/obj/structure/sign/poster/official/enlist{desc = "Enlist in the marine corps today!"},/turf/closed/wall/mineral/plastitanium{desc = "An wall of plasma and titanium."},/area/ruin/powered)
-"bb" = (/obj/effect/decal/cleanable/robot_debris,/turf/open/floor/plasteel/black,/area/ruin/powered)
-"bc" = (/obj/effect/decal/cleanable/blood,/obj/structure/closet,/obj/item/weapon/storage/box/donkpockets,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"bd" = (/turf/open/floor/plasteel/vault{dir = 5},/turf/open/floor/plating{tag = "icon-platingdmg2"; icon_state = "platingdmg2"},/area/ruin/powered)
-"be" = (/obj/structure/closet,/obj/item/clothing/shoes/combat,/obj/item/clothing/under/syndicate/camo,/obj/item/weapon/storage/box/donkpockets,/obj/item/clothing/gloves/combat,/obj/item/weapon/storage/backpack/explorer{name = "marine bag"},/obj/item/weapon/card/id/marine,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"bf" = (/obj/structure/dresser,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"bg" = (/obj/effect/decal/cleanable/blood/gibs/body,/turf/open/floor/plating{tag = "icon-platingdmg3"; icon_state = "platingdmg3"},/area/ruin/powered)
-"bh" = (/obj/effect/decal/cleanable/blood/gibs,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"bi" = (/obj/structure/girder,/turf/open/floor/plating{tag = "icon-platingdmg3"; icon_state = "platingdmg3"},/area/ruin/powered)
-"bj" = (/obj/structure/sign/poster/contraband/space_cola,/turf/closed/wall/mineral/plastitanium{desc = "An wall of plasma and titanium."},/area/ruin/powered)
-"bk" = (/obj/structure/table_frame,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"bl" = (/obj/effect/mob_spawn/human/marine,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"bm" = (/obj/machinery/light,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
-"bn" = (/obj/structure/table,/obj/effect/holodeck_effect/cards,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"aN" = (/turf/open/floor/plating,/area/ruin/powered)
+"aO" = (/obj/effect/decal/cleanable/vomit,/turf/open/floor/plating,/area/ruin/powered)
+"aP" = (/turf/open/floor/plating{tag = "icon-platingdmg3"; icon_state = "platingdmg3"},/area/ruin/powered)
+"aQ" = (/turf/open/floor/plating{tag = "icon-platingdmg1"; icon_state = "platingdmg1"},/area/lavaland/surface/outdoors)
+"aR" = (/obj/effect/decal/cleanable/blood/old,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"aS" = (/obj/structure/closet,/obj/item/toy/prize/honk,/turf/open/floor/plasteel/vault{dir = 5},/area/lavaland/surface/outdoors)
+"aT" = (/obj/structure/sign/poster/contraband/clown,/turf/closed/wall/mineral/plastitanium{desc = "An wall of plasma and titanium."},/area/lavaland/surface/outdoors)
+"aU" = (/turf/open/floor/plating{tag = "icon-platingdmg2"; icon_state = "platingdmg2"},/area/ruin/powered)
+"aV" = (/obj/structure/sign/poster/official/walk,/turf/closed/wall/mineral/plastitanium{desc = "An wall of plasma and titanium."},/area/ruin/powered)
+"aW" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"aX" = (/obj/effect/decal/cleanable/oil,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"aY" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"aZ" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"ba" = (/obj/machinery/door/airlock/hatch{name = "Personal Quarters D"; req_access_txt = "205"},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"bb" = (/obj/structure/sign/poster/official/enlist{desc = "Enlist in the marine corps today!"},/turf/closed/wall/mineral/plastitanium{desc = "An wall of plasma and titanium."},/area/ruin/powered)
+"bc" = (/obj/effect/decal/cleanable/robot_debris,/turf/open/floor/plasteel/black,/area/ruin/powered)
+"bd" = (/obj/effect/decal/cleanable/blood,/obj/structure/closet,/obj/item/weapon/storage/box/donkpockets,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"be" = (/turf/open/floor/plasteel/vault{dir = 5},/turf/open/floor/plating{tag = "icon-platingdmg2"; icon_state = "platingdmg2"},/area/ruin/powered)
+"bf" = (/obj/structure/closet,/obj/item/clothing/shoes/combat,/obj/item/clothing/under/syndicate/camo,/obj/item/weapon/storage/box/donkpockets,/obj/item/clothing/gloves/combat,/obj/item/weapon/storage/backpack/explorer{name = "marine bag"},/obj/item/weapon/card/id/marine,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"bg" = (/obj/structure/dresser,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"bh" = (/obj/effect/decal/cleanable/blood/gibs/body,/turf/open/floor/plating{tag = "icon-platingdmg3"; icon_state = "platingdmg3"},/area/ruin/powered)
+"bi" = (/obj/effect/decal/cleanable/blood/gibs,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"bj" = (/obj/structure/girder,/turf/open/floor/plating{tag = "icon-platingdmg3"; icon_state = "platingdmg3"},/area/ruin/powered)
+"bk" = (/obj/structure/sign/poster/contraband/space_cola,/turf/closed/wall/mineral/plastitanium{desc = "An wall of plasma and titanium."},/area/ruin/powered)
+"bl" = (/obj/structure/table_frame,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"bm" = (/obj/effect/mob_spawn/human/marine,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"bn" = (/obj/machinery/light,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
+"bo" = (/obj/structure/table,/obj/effect/holodeck_effect/cards,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered)
 
 (1,1,1) = {"
 aaaaaaaaabaaaaaaaaaaaaaaabaaaaaaaaaaababacacaaaaaaaaaaaa
@@ -83,20 +84,20 @@ acacabafafafafafaiaAayaBaiayayaiahahaiafafabafafafababaa
 acacafafafafafaeaiaCapayaiaDaEaiaFaeafafafafafafafafaaaa
 acacafafafafadadaiaGazaGaiaiaiaiaiadadafafafafafafafafaa
 abacafafafafaeaeaiayapayaiaHaIaJaiaKaLafafafafafafafafaa
-ababafafafafafaeaiaAayaBaMasaNaOaiaeaFaPafafafafafafafaa
-ababafafafafafaeaiayapaQaiauaHaOaiaRaeaeaSabafafafafaaaa
-acabafafafafaFadaiapayapaiaiaiaTaUaiaiahaiabafafafafafaa
-acabafafafaeaeaLahayapayapasaHaOapaVapayazababafafafaaaa
-acabafafafaFaPaFahapaWapayapayasayapayapazababafafafafaa
-acabafafafafaeaeaiaXapaYaiaiaiahaiaiaiaZaiababafafafafaa
-acabafafafafafafbabbayapaibcbdayaibebfayaiabafafafafafaa
-acabafafafafafafaiahahahaiaHbgbhbiayayaybjabafafafafafaa
-acacafafafafafafafaeaPaeaiaJaubkaiblbmbnaiabafafafafafaa
+ababafafafafafaeaiaAayaBaMaNaOaPaiaeaFaQafafafafafafafaa
+ababafafafafafaeaiayapaRaiauaHaPaiaSaeaeaTabafafafafaaaa
+acabafafafafaFadaiapayapaiaiaiaUaVaiaiahaiabafafafafafaa
+acabafafafaeaeaLahayapayapaNaHaPapaWapayazababafafafaaaa
+acabafafafaFaQaFahapaXapayapayaNayapayapazababafafafafaa
+acabafafafafaeaeaiaYapaZaiaiaiahaiaiaibaaiababafafafafaa
+acabafafafafafafbbbcayapaibdbeayaibfbgayaiabafafafafafaa
+acabafafafafafafaiahahahaiaHbhbibjayayaybkabafafafafafaa
+acacafafafafafafafaeaQaeaiaJaublaibmbnboaiabafafafafafaa
 aaafafafafafafafafaeaeafaiaiaiaiaiaiaiaiaiabafafafafafaa
 aaafafafafafafafafafafafafafafafafaeaeadababafafafafafaa
 aaafafafafafabababafafafafafafafafafafadafafafafafafafaa
 aaafafafafafababababababafafafafafafafafafafafafafafafaa
 aaafafabababaeabadabababababababafafafafafafafafafafafaa
-aaafafafababaPabaLadabababaaaaaaaaaaaaaaaaafafafafafafaa
+aaafafafababaQabaLadabababaaaaaaaaaaaaaaaaafafafafafafaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}


### PR DESCRIPTION
Removes the combat medkit the Marine has access to and replaces it with a standard First Aid Kit.

The main issue with the combat medkit was that I did not realise that the Combat Injector used admin level of healing chems, this made the medkit way too effective.

The FAK should be more than sufficient for the Marine.

:cl: Steelpoint
tweak: Iron Hawk Marine's Combat Medkit was replaced with a standard First Aid Kit.
/:cl:
