### PR TITLE
Makes injuries more gruesome

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -45,26 +45,50 @@
 	var/temp = getBruteLoss()
 	if(temp)
 		if (temp < 30)
-			msg += "[t_He] [t_has] minor bruising.\n"
+			if(prob(50)
+				msg += "[t_He] [t_has] small bruises.\n"
+			else
+				msg += "[t_He] [t_has] minor bruising.\n"
 		else
-			msg += "<B>[t_He] [t_has] severe bruising!</B>\n"
+			if(prob(33))
+				msg += "<B>[t_He] [t_is] bloodied!</B>\n"
+			else if(prob(33))
+				msg += "<B>[t_his] body is mangled!</B>\n"
+			else
+				msg += "<B>[t_his] body is battered and bruised!</B>\n"
 
 	temp = getFireLoss()
 	if(temp)
 		if (temp < 30)
-			msg += "[t_He] [t_has] minor burns.\n"
+			if(prob(50))
+				msg += "[t_his] skin is bright red.\n"
+			else
+				msg += "[t_his] skin is covered in small burns.\n"
 		else
-			msg += "<B>[t_He] [t_has] severe burns!</B>\n"
+			if(prob(33))
+				msg += "<B>[t_his] skin is covered in large blisters!</B>\n"
+			else if(prob(33))
+				msg += "<B>[t_his] skin is charred and blistering!</B>\n"
+			else
+				msg += "<B>[t_his] skin is blackened and burned!</B>\n"
 
 	temp = getCloneLoss()
 	if(temp)
 		if(getCloneLoss() < 30)
-			msg += "[t_He] [t_is] slightly deformed.\n"
+			if(prob(50))
+				msg += "[t_He] [t_is] covered in minor deformities.\n"
+			else
+				msg += "[t_his] body is deformed.\n"
 		else
-			msg += "<b>[t_He] [t_is] severely deformed.</b>\n"
+			if(prob(33))
+				msg += "<B>[t_his] skin is covered in large, unnatural genetic deformities!</B>\n"
+			else if(prob(33))
+				msg += "<B>[t_his] body is covered in lumps and warts!</B>\n"
+			else
+				msg += "<B>[t_his] body and limbs are severely deformed in several areas!</B>\n"
 
 	if(getBrainLoss() > 60)
-		msg += "[t_He] seems to be clumsy and unable to think.\n"
+		msg += "[t_He] has a blank, dumb look on his face.\n"
 
 	if(fire_stacks > 0)
 		msg += "[t_He] [t_is] covered in something flammable.\n"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -45,7 +45,7 @@
 	var/temp = getBruteLoss()
 	if(temp)
 		if (temp < 30)
-			if(prob(50)
+			if(prob(50))
 				msg += "[t_He] [t_has] small bruises.\n"
 			else
 				msg += "[t_He] [t_has] minor bruising.\n"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -50,7 +50,7 @@
 			else
 				msg += "[t_He] [t_has] minor bruising.\n"
 		else
-			if(prob(50))
+			if(prob(33))
 				msg += "<B>[t_He] [t_is] bloodied!</B>\n"
 			else if(prob(50))
 				msg += "<B>[t_his] body is mangled!</B>\n"
@@ -65,7 +65,7 @@
 			else
 				msg += "[t_his] skin is covered in small burns.\n"
 		else
-			if(prob(50))
+			if(prob(33))
 				msg += "<B>[t_his] skin is covered in large blisters!</B>\n"
 			else if(prob(50))
 				msg += "<B>[t_his] skin is charred and blistering!</B>\n"
@@ -80,7 +80,7 @@
 			else
 				msg += "[t_his] body is deformed.\n"
 		else
-			if(prob(50))
+			if(prob(33))
 				msg += "<B>[t_his] skin is covered in large, unnatural genetic deformities!</B>\n"
 			else if(prob(50))
 				msg += "<B>[t_his] body is covered in lumps and warts!</B>\n"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -50,9 +50,9 @@
 			else
 				msg += "[t_He] [t_has] minor bruising.\n"
 		else
-			if(prob(33))
+			if(prob(50))
 				msg += "<B>[t_He] [t_is] bloodied!</B>\n"
-			else if(prob(33))
+			else if(prob(50))
 				msg += "<B>[t_his] body is mangled!</B>\n"
 			else
 				msg += "<B>[t_his] body is battered and bruised!</B>\n"
@@ -65,9 +65,9 @@
 			else
 				msg += "[t_his] skin is covered in small burns.\n"
 		else
-			if(prob(33))
+			if(prob(50))
 				msg += "<B>[t_his] skin is covered in large blisters!</B>\n"
-			else if(prob(33))
+			else if(prob(50))
 				msg += "<B>[t_his] skin is charred and blistering!</B>\n"
 			else
 				msg += "<B>[t_his] skin is blackened and burned!</B>\n"
@@ -80,9 +80,9 @@
 			else
 				msg += "[t_his] body is deformed.\n"
 		else
-			if(prob(33))
+			if(prob(50))
 				msg += "<B>[t_his] skin is covered in large, unnatural genetic deformities!</B>\n"
-			else if(prob(33))
+			else if(prob(50))
 				msg += "<B>[t_his] body is covered in lumps and warts!</B>\n"
 			else
 				msg += "<B>[t_his] body and limbs are severely deformed in several areas!</B>\n"


### PR DESCRIPTION
:cl: Tacolizard Forever: mangled and bruised!
add: Examining people will now reveal much more specific and gruesome details about their injuries.
/:cl:

[why]: I've been playing DF a lot and really enjoyed looking at the detailed injury information on my dwarves. I have changed our injury messages to describe more visible damage, and less 'he has severe burns' which is just bland and boring.

~~I may get around to giving people 'scars' after they are healed and mabye add different injury info depending on whether someone was beaten with a blunt object or cut with something sharp.~~

Github Desktop (i don't know why i use it oh god) has borked everything again so I'm going to delete my fork and start over if/when this gets merged then make any changes.