### PR TITLE
Renamed Volt Void to Volt Blaster and removed it consuming and scaling with power

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -159,7 +159,7 @@
 		successful = TRUE
 		ranged_ability_user.visible_message("<span class='warning'>[ranged_ability_user] fires a ray of energy at [target]!</span>", "<span class='nzcrentr'>You fire a volt ray at [target].</span>")
 		playsound(ranged_ability_user, 'sound/effects/light_flicker.ogg', 50, 1)
-		var/turf/T = get_turf(target)
+		T = get_turf(target)
 		new/obj/effect/temp_visual/ratvar/volt_hit(T, ranged_ability_user)
 		add_logs(ranged_ability_user, T, "fired a volt ray")
 		remove_ranged_ability()

--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -159,21 +159,7 @@
 		successful = TRUE
 		ranged_ability_user.visible_message("<span class='warning'>[ranged_ability_user] fires a ray of energy at [target]!</span>", "<span class='nzcrentr'>You fire a volt ray at [target].</span>")
 		playsound(ranged_ability_user, 'sound/effects/light_flicker.ogg', 50, 1)
-		var/turf/targetturf = get_turf(target)
-		var/obj/structure/destructible/clockwork/powered/volt_checker/VC = new/obj/structure/destructible/clockwork/powered/volt_checker(get_turf(ranged_ability_user))
-		var/multiplier = 1
-		var/usable_power = min(Floor(VC.total_accessable_power() * 0.2, MIN_CLOCKCULT_POWER), 1000)
-		if(VC.try_use_power(usable_power))
-			multiplier += (usable_power * 0.001) //should be a multiplier of 2 at maximum power usage
-		if(iscyborg(ranged_ability_user))
-			var/mob/living/silicon/robot/C = ranged_ability_user
-			if(C.cell)
-				var/prev_power = usable_power //we don't want to increase the multiplier past 2
-				usable_power = min(Floor(C.cell.charge * 0.2, MIN_CLOCKCULT_POWER), 1000) - prev_power
-				if(usable_power > 0 && C.cell.use(usable_power))
-					multiplier += (usable_power * 0.001)
-		qdel(VC)
-		new/obj/effect/temp_visual/ratvar/volt_hit/true(targetturf, ranged_ability_user, multiplier)
+		new/obj/effect/temp_visual/ratvar/volt_hit(get_turf(target), ranged_ability_user)
 		add_logs(ranged_ability_user, targetturf, "fired a volt ray")
 		remove_ranged_ability()
 

--- a/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/slab_abilities.dm
@@ -159,8 +159,9 @@
 		successful = TRUE
 		ranged_ability_user.visible_message("<span class='warning'>[ranged_ability_user] fires a ray of energy at [target]!</span>", "<span class='nzcrentr'>You fire a volt ray at [target].</span>")
 		playsound(ranged_ability_user, 'sound/effects/light_flicker.ogg', 50, 1)
-		new/obj/effect/temp_visual/ratvar/volt_hit(get_turf(target), ranged_ability_user)
-		add_logs(ranged_ability_user, targetturf, "fired a volt ray")
+		var/turf/T = get_turf(target)
+		new/obj/effect/temp_visual/ratvar/volt_hit(T, ranged_ability_user)
+		add_logs(ranged_ability_user, T, "fired a volt ray")
 		remove_ranged_ability()
 
 	return TRUE

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
@@ -59,11 +59,11 @@
 
 /obj/item/clockwork/slab/cyborg/security //four scriptures, plus a spear
 	quickbound = list(/datum/clockwork_scripture/channeled/belligerent, /datum/clockwork_scripture/ranged_ability/judicial_marker, /datum/clockwork_scripture/channeled/taunting_tirade, \
-	/datum/clockwork_scripture/channeled/volt_void/cyborg)
+	/datum/clockwork_scripture/channeled/volt_blaster)
 
 /obj/item/clockwork/slab/cyborg/peacekeeper //four scriptures, plus a spear
 	quickbound = list(/datum/clockwork_scripture/channeled/belligerent, /datum/clockwork_scripture/ranged_ability/judicial_marker, /datum/clockwork_scripture/channeled/taunting_tirade, \
-	/datum/clockwork_scripture/channeled/volt_void/cyborg)
+	/datum/clockwork_scripture/channeled/volt_blaster)
 
 /obj/item/clockwork/slab/cyborg/janitor //five scriptures, plus a fabricator
 	quickbound = list(/datum/clockwork_scripture/create_object/replicant, /datum/clockwork_scripture/create_object/sigil_of_transgression, \
@@ -74,7 +74,7 @@
 	/datum/clockwork_scripture/spatial_gateway, /datum/clockwork_scripture/fellowship_armory, /datum/clockwork_scripture/create_object/clockwork_obelisk)
 
 /obj/item/clockwork/slab/cyborg/miner //three scriptures, plus a spear and xray vision
-	quickbound = list(/datum/clockwork_scripture/ranged_ability/linked_vanguard, /datum/clockwork_scripture/spatial_gateway, /datum/clockwork_scripture/channeled/volt_void/cyborg)
+	quickbound = list(/datum/clockwork_scripture/ranged_ability/linked_vanguard, /datum/clockwork_scripture/spatial_gateway, /datum/clockwork_scripture/channeled/volt_blaster)
 
 /obj/item/clockwork/slab/cyborg/access_display(mob/living/user)
 	if(!GLOB.ratvar_awakens)

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_cyborg.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_cyborg.dm
@@ -44,9 +44,3 @@
 	<b>Left-click a target to place a Judicial Marker!\n\
 	Click your slab to cancel.</b></span>"
 	timeout_time = 50
-
-//Volt Void, but with a different quickbind desc
-/datum/clockwork_scripture/channeled/volt_void/cyborg
-	quickbind_desc = "Allows you to fire energy rays at target locations using your own power. Failing to fire causes backlash.<br><b>Maximum 4 chants.</b>"
-	tier = SCRIPTURE_PERIPHERAL
-	quickbind = FALSE

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_scripts.dm
@@ -347,27 +347,27 @@
 	return slab.procure_gateway(invoker, duration, portal_uses)
 
 
-//Volt Void: Channeled for up to five times over ten seconds to fire up to five rays of energy at target locations.
-/datum/clockwork_scripture/channeled/volt_void
+//Volt Blaster: Channeled for up to five times over ten seconds to fire up to five rays of energy at target locations.
+/datum/clockwork_scripture/channeled/volt_blaster
 	descname = "Channeled, Targeted Energy Blasts"
-	name = "Volt Void" //Alternative name: "On all levels but physical, I am a power sink"
-	desc = "Allows you to fire energy rays at target locations; more power consumed causes more damage. Channeled every fifth of a second for a maximum of ten seconds."
+	name = "Volt Blaster"
+	desc = "Allows you to fire five energy rays at target locations. Channeled every fourth of a second for a maximum of ten seconds."
 	channel_time = 30
 	invocations = list("Amperage...", "...grant me your power!")
 	chant_invocations = list("Use charge to kill!", "Slay with power!", "Hunt with energy!")
-	chant_amount = 4
-	chant_interval = 5
+	chant_amount = 5
+	chant_interval = 4
 	consumed_components = list(GEIS_CAPACITOR = 1, HIEROPHANT_ANSIBLE = 2)
 	usage_tip = "Though it requires you to stand still, this scripture can do massive damage."
 	tier = SCRIPTURE_SCRIPT
 	primary_component = HIEROPHANT_ANSIBLE
 	sort_priority = 10
 	quickbind = TRUE
-	quickbind_desc = "Allows you to fire energy rays at target locations. Failing to fire causes backlash.<br><b>Maximum 4 chants.</b>"
+	quickbind_desc = "Allows you to fire energy rays at target locations.<br><b>Maximum 5 chants.</b>"
 	var/static/list/nzcrentr_insults = list("You're not very good at aiming.", "You hunt badly.", "What a waste of energy.", "Almost funny to watch.",
 	"Boss says </span><span class='heavy_brass'>\"Click something, you idiot!\"</span><span class='nzcrentr'>.", "Stop wasting components if you can't aim.")
 
-/datum/clockwork_scripture/channeled/volt_void/chant_effects(chant_number)
+/datum/clockwork_scripture/channeled/volt_blaster/chant_effects(chant_number)
 	slab.busy = null
 	var/datum/clockwork_scripture/ranged_ability/volt_ray/ray = new
 	ray.slab = slab
@@ -375,24 +375,6 @@
 	var/turf/T = get_turf(invoker)
 	if(!ray.run_scripture() && slab && invoker)
 		if(can_recite() && T == get_turf(invoker))
-			if(!GLOB.ratvar_awakens)
-				var/obj/structure/destructible/clockwork/powered/volt_checker/VC = new/obj/structure/destructible/clockwork/powered/volt_checker(get_turf(invoker))
-				var/multiplier = 0.5
-				var/usable_power = min(Floor(VC.total_accessable_power() * 0.2, MIN_CLOCKCULT_POWER), 1000)
-				if(VC.try_use_power(usable_power))
-					multiplier += (usable_power * 0.0005) //at maximum power, should be 1 multiplier
-				qdel(VC)
-				if(iscyborg(invoker))
-					var/mob/living/silicon/robot/C = invoker
-					if(C.cell)
-						var/prev_power = usable_power //we don't want to increase the multiplier past 1
-						usable_power = min(Floor(C.cell.charge * 0.2, MIN_CLOCKCULT_POWER), 1000) - prev_power
-						if(usable_power > 0 && C.cell.use(usable_power))
-							multiplier += (usable_power * 0.0005)
-				var/obj/effect/temp_visual/ratvar/volt_hit/VH = new /obj/effect/temp_visual/ratvar/volt_hit(get_turf(invoker), null, multiplier)
-				invoker.visible_message("<span class='warning'>[invoker] is struck by [invoker.p_their()] own [VH.name]!</span>", "<span class='userdanger'>You're struck by your own [VH.name]!</span>")
-				invoker.adjustFireLoss(VH.damage) //you have to fail all five blasts to die to this
-				playsound(invoker, 'sound/machines/defib_zap.ogg', VH.damage, 1, -1)
 			to_chat(invoker, "<span class='nzcrentr'>\"[text2ratvar(pick(nzcrentr_insults))]\"</span>")
 		else
 			return FALSE
@@ -410,6 +392,3 @@
 	ranged_message = "<span class='nzcrentr_small'><i>You charge the clockwork slab with shocking might.</i>\n\
 	<b>Left-click a target to fire, quickly!</b></span>"
 	timeout_time = 20
-
-/obj/structure/destructible/clockwork/powered/volt_checker
-	invisibility = INVISIBILITY_ABSTRACT

--- a/code/game/objects/effects/temporary_visuals/clockcult.dm
+++ b/code/game/objects/effects/temporary_visuals/clockcult.dm
@@ -81,21 +81,15 @@
 /obj/effect/temp_visual/ratvar/volt_hit
 	name = "volt blast"
 	layer = ABOVE_MOB_LAYER
-	duration = 5
+	duration = 8
 	icon_state = "volt_hit"
 	light_range = 1.5
 	light_power = 2
 	light_color = LIGHT_COLOR_ORANGE
 	var/mob/user
-	var/damage = 20
+	var/damage = 25
 
-/obj/effect/temp_visual/ratvar/volt_hit/Initialize(mapload, caster, multiplier)
-	if(multiplier)
-		damage *= multiplier
-	duration = max(round(damage * 0.2), 1)
-	. = ..()
-
-/obj/effect/temp_visual/ratvar/volt_hit/true/Initialize(mapload, caster, multiplier)
+/obj/effect/temp_visual/ratvar/volt_hit/Initialize(mapload, caster)
 	. = ..()
 	user = caster
 	if(user)


### PR DESCRIPTION
:cl: Joan
spellcheck: Renamed Volt Void to Volt Blaster.
tweak: Volt Blaster does not consume power when firing and does not cause backlash if you don't fire.
balance: Volt Blaster does 25 damage, from 20-40 depending on power, and has 5 shots, from 4, over its duration.
/:cl:

Obscure as shit. This thing did 20 damage, but consumed up to 1000 power to get up to double damage, meaning you could fire 4 shots of 40 damage if sufficiently supplied. This was absolutely unclear.

It also hurt you if you failed to fire it, which fucking sucked if you weren't aware of it, which you basically never would be, since that was only mentioned on the quickbind desc.