### PR TITLE
Adds F.R.A.M.E. cartridge

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -228,7 +228,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += "<a href='byond://?src=\ref[src];choice=21'><img src=pda_mail.png> Messages</a><br>"
 
 				if (istype(cartridge, /obj/item/weapon/cartridge/virus))
-					var/obj/item/weapon/cartridge/virus/viral_cart
+					var/obj/item/weapon/cartridge/virus/viral_cart = cartridge
 					dat += "<b>[viral_cart.charges] viral files left.</b><HR>"
 
 				dat += "<h4><img src=pda_menu.png> Detected PDAs</h4>"
@@ -417,16 +417,15 @@ GLOBAL_LIST_EMPTY(PDAs)
 				tnote = null
 			if("Ringtone")
 				var/t = input(U, "Please enter new ringtone", name, ttone) as text
-				if(in_range(src, U) && loc == U)
-					if(t)
-						if(hidden_uplink && (trim(lowertext(t)) == trim(lowertext(lock_code))))
-							hidden_uplink.interact(U)
-							to_chat(U, "The PDA softly beeps.")
-							U << browse(null, "window=pda")
-							src.mode = 0
-						else
-							t = copytext(sanitize(t), 1, 20)
-							ttone = t
+				if(in_range(src, U) && loc == U && t)
+					if(hidden_uplink && (trim(lowertext(t)) == trim(lowertext(lock_code))))
+						hidden_uplink.interact(U)
+						to_chat(U, "The PDA softly beeps.")
+						U << browse(null, "window=pda")
+						src.mode = 0
+					else
+						t = copytext(sanitize(t), 1, 20)
+						ttone = t
 				else
 					U << browse(null, "window=pda")
 					return

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -241,7 +241,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 							continue
 						dat += "<li><a href='byond://?src=\ref[src];choice=Message;target=\ref[P]'>[P]</a>"
 						if(cartridge)
-							dat += cartridge.message_special()
+							dat += cartridge.message_special(P)
 						dat += "</li>"
 						count++
 				dat += "</ul>"

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -227,9 +227,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += "<a href='byond://?src=\ref[src];choice=Ringtone'><img src=pda_bell.png> Set Ringtone</a> | "
 				dat += "<a href='byond://?src=\ref[src];choice=21'><img src=pda_mail.png> Messages</a><br>"
 
-				if (istype(cartridge, /obj/item/weapon/cartridge/virus))
-					var/obj/item/weapon/cartridge/virus/viral_cart = cartridge
-					dat += "<b>[viral_cart.charges] viral files left.</b><HR>"
+				if(cartridge)
+					dat += cartridge.message_header()
 
 				dat += "<h4><img src=pda_menu.png> Detected PDAs</h4>"
 
@@ -241,8 +240,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 						if (P == src)
 							continue
 						dat += "<li><a href='byond://?src=\ref[src];choice=Message;target=\ref[P]'>[P]</a>"
-						if (istype(cartridge, /obj/item/weapon/cartridge/virus))
-							dat += " (<a href='byond://?src=\ref[src];choice=virus;target=\ref[P]'>*Send Virus*</a>)"
+						if(cartridge)
+							dat += cartridge.message_special()
 						dat += "</li>"
 						count++
 				dat += "</ul>"
@@ -436,11 +435,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if("MessageAll")
 				src.send_to_all(U)
 
-			if("virus")
-				if(istype(cartridge, /obj/item/weapon/cartridge/virus))//Cartridge checks are kind of unnecessary since everything is done through switch.
-					var/obj/item/weapon/cartridge/virus/V = cartridge
-					var/obj/item/device/pda/P = locate(href_list["target"])//Leaving it alone in case it may do something useful, I guess.
-					V.send_virus(P,U)
+			if("special")
+				if(cartridge)
+					cartridge.special(U, href_list)
 				else
 					U << browse(null, "window=pda")
 					return
@@ -943,4 +940,3 @@ GLOBAL_LIST_EMPTY(PDAs)
 	for(var/obj/item/device/pda/P in GLOB.PDAs)
 		if(!P.owner || P.toff || P.hidden) continue
 		. += P
-	return .

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -227,12 +227,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += "<a href='byond://?src=\ref[src];choice=Ringtone'><img src=pda_bell.png> Set Ringtone</a> | "
 				dat += "<a href='byond://?src=\ref[src];choice=21'><img src=pda_mail.png> Messages</a><br>"
 
-				if (istype(cartridge, /obj/item/weapon/cartridge/syndicate))
-					dat += "<b>[cartridge:shock_charges] detonation charges left.</b><HR>"
-				if (istype(cartridge, /obj/item/weapon/cartridge/clown))
-					dat += "<b>[cartridge:honk_charges] viral files left.</b><HR>"
-				if (istype(cartridge, /obj/item/weapon/cartridge/mime))
-					dat += "<b>[cartridge:mime_charges] viral files left.</b><HR>"
+				if (istype(cartridge, /obj/item/weapon/cartridge/virus))
+					var/obj/item/weapon/cartridge/virus/viral_cart
+					dat += "<b>[viral_cart.charges] viral files left.</b><HR>"
 
 				dat += "<h4><img src=pda_menu.png> Detected PDAs</h4>"
 
@@ -244,12 +241,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 						if (P == src)
 							continue
 						dat += "<li><a href='byond://?src=\ref[src];choice=Message;target=\ref[P]'>[P]</a>"
-						if (istype(cartridge, /obj/item/weapon/cartridge/syndicate) && P.detonate)
-							dat += " (<a href='byond://?src=\ref[src];choice=Detonate;target=\ref[P]'><img src=pda_boom.png>*Detonate*</a>)"
-						if (istype(cartridge, /obj/item/weapon/cartridge/clown))
-							dat += " (<a href='byond://?src=\ref[src];choice=Send Honk;target=\ref[P]'><img src=pda_honk.png>*Send Virus*</a>)"
-						if (istype(cartridge, /obj/item/weapon/cartridge/mime))
-							dat += " (<a href='byond://?src=\ref[src];choice=Send Silence;target=\ref[P]'>*Send Virus*</a>)"
+						if (istype(cartridge, /obj/item/weapon/cartridge/virus))
+							dat += " (<a href='byond://?src=\ref[src];choice=virus;target=\ref[P]'>*Send Virus*</a>)"
 						dat += "</li>"
 						count++
 				dat += "</ul>"
@@ -444,30 +437,11 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if("MessageAll")
 				src.send_to_all(U)
 
-			if("Send Honk")//Honk virus
-				if(istype(cartridge, /obj/item/weapon/cartridge/clown))//Cartridge checks are kind of unnecessary since everything is done through switch.
+			if("virus")
+				if(istype(cartridge, /obj/item/weapon/cartridge/virus))//Cartridge checks are kind of unnecessary since everything is done through switch.
+					var/obj/item/weapon/cartridge/virus/V = cartridge
 					var/obj/item/device/pda/P = locate(href_list["target"])//Leaving it alone in case it may do something useful, I guess.
-					if(!isnull(P))
-						if (!P.toff && cartridge:honk_charges > 0)
-							cartridge:honk_charges--
-							U.show_message("<span class='notice'>Virus sent!</span>", 1)
-							P.honkamt = (rand(15,20))
-					else
-						to_chat(U, "PDA not found.")
-				else
-					U << browse(null, "window=pda")
-					return
-			if("Send Silence")//Silent virus
-				if(istype(cartridge, /obj/item/weapon/cartridge/mime))
-					var/obj/item/device/pda/P = locate(href_list["target"])
-					if(!isnull(P))
-						if (!P.toff && cartridge:mime_charges > 0)
-							cartridge:mime_charges--
-							U.show_message("<span class='notice'>Virus sent!</span>", 1)
-							P.silent = 1
-							P.ttone = "silence"
-					else
-						to_chat(U, "PDA not found.")
+					V.send_virus(P,U)
 				else
 					U << browse(null, "window=pda")
 					return
@@ -482,38 +456,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 								M.open()
 							else
 								M.close()
-
-
-			if("Detonate")//Detonate PDA
-				if(istype(cartridge, /obj/item/weapon/cartridge/syndicate))
-					var/obj/item/device/pda/P = locate(href_list["target"])
-					if(!isnull(P))
-						if (!P.toff && cartridge:shock_charges > 0)
-							cartridge:shock_charges--
-
-							var/difficulty = 0
-
-							if(P.cartridge)
-								difficulty += P.cartridge.access_medical
-								difficulty += P.cartridge.access_security
-								difficulty += P.cartridge.access_engine
-								difficulty += P.cartridge.access_clown
-								difficulty += P.cartridge.access_janitor
-								difficulty += P.cartridge.access_manifest * 2
-							else
-								difficulty += 2
-
-							if(prob(difficulty * 15) || (P.hidden_uplink))
-								U.show_message("<span class='danger'>An error flashes on your [src].</span>", 1)
-							else
-								U.show_message("<span class='notice'>Success!</span>", 1)
-								P.explode()
-					else
-						to_chat(U, "PDA not found.")
-				else
-					U.unset_machine()
-					U << browse(null, "window=pda")
-					return
 
 //pAI FUNCTIONS===================================
 			if("pai")
@@ -896,7 +838,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	if(T)
 		T.hotspot_expose(700,125)
-		if(istype(cartridge, /obj/item/weapon/cartridge/syndicate))
+		if(istype(cartridge, /obj/item/weapon/cartridge/virus/syndicate))
 			explosion(T, -1, 1, 3, 4)
 		else
 			explosion(T, -1, -1, 2, 3)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -435,7 +435,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if("MessageAll")
 				src.send_to_all(U)
 
-			if("special")
+			if("cart")
 				if(cartridge)
 					cartridge.special(U, href_list)
 				else

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -1,7 +1,7 @@
 //Clown PDA is slippery.
 /obj/item/device/pda/clown
 	name = "clown PDA"
-	default_cartridge = /obj/item/weapon/cartridge/clown
+	default_cartridge = /obj/item/weapon/cartridge/virus/clown
 	icon_state = "pda-clown"
 	desc = "A portable microcomputer by Thinktronic Systems, LTD. The surface is coated with polytetrafluoroethylene and banana drippings."
 	ttone = "honk"
@@ -11,10 +11,10 @@
 		var/mob/living/carbon/M = AM
 		if(M.slip(0, 6, src, NO_SLIP_WHEN_WALKING))
 			if (ishuman(M) && (M.real_name != src.owner))
-				if (istype(src.cartridge, /obj/item/weapon/cartridge/clown))
-					var/obj/item/weapon/cartridge/clown/cart = src.cartridge
-					if(cart.honk_charges < 5)
-						cart.honk_charges++
+				if (istype(src.cartridge, /obj/item/weapon/cartridge/virus/clown))
+					var/obj/item/weapon/cartridge/virus/cart = src.cartridge
+					if(cart.charges < 5)
+						cart.charges++
 
 
 // Special AI/pAI PDAs that cannot explode.
@@ -79,7 +79,7 @@
 
 /obj/item/device/pda/mime
 	name = "mime PDA"
-	default_cartridge = /obj/item/weapon/cartridge/mime
+	default_cartridge = /obj/item/weapon/cartridge/virus/mime
 	icon_state = "pda-mime"
 	silent = 1
 	ttone = "silence"
@@ -134,7 +134,7 @@
 	icon_state = "pda-miner"
 
 /obj/item/device/pda/syndicate
-	default_cartridge = /obj/item/weapon/cartridge/syndicate
+	default_cartridge = /obj/item/weapon/cartridge/virus/syndicate
 	icon_state = "pda-syndi"
 	name = "military PDA"
 	owner = "John Doe"

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -772,7 +772,7 @@ Code:
 	return ""
 
 //If the cartridge adds something to each potetial messaging target
-/obj/item/weapon/cartridge/proc/message_special()
+/obj/item/weapon/cartridge/proc/message_special(obj/item/device/pda/target)
 	return ""
 
 //This is called for special abilities of cartridges

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -766,3 +766,14 @@ Code:
 			return
 
 	return menu
+
+//If the cartridge adds a special line to the top of the messaging app
+/obj/item/weapon/cartridge/proc/message_header()
+	return ""
+
+//If the cartridge adds something to each potetial messaging target
+/obj/item/weapon/cartridge/proc/message_special()
+	return ""
+
+//This is called for special abilities of cartridges
+/obj/item/weapon/cartridge/proc/special(mov/living/user, list/params)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -96,18 +96,6 @@
 	access_security = 1
 	spam_enabled = 1
 
-/obj/item/weapon/cartridge/clown
-	name = "\improper Honkworks 5.0 cartridge"
-	icon_state = "cart-clown"
-	access_clown = 1
-	var/honk_charges = 5
-
-/obj/item/weapon/cartridge/mime
-	name = "\improper Gestur-O 1000 cartridge"
-	icon_state = "cart-mi"
-	access_mime = 1
-	var/mime_charges = 5
-
 /obj/item/weapon/cartridge/curator
 	name = "\improper Lib-Tweet cartridge"
 	icon_state = "cart-s"
@@ -231,13 +219,6 @@
 /obj/item/weapon/cartridge/captain/New()
 	..()
 	radio = new /obj/item/radio/integrated/signal(src)
-
-/obj/item/weapon/cartridge/syndicate
-	name = "\improper Detomatix cartridge"
-	icon_state = "cart"
-	access_remote_door = 1
-	remote_door_id = "smindicate" //Make sure this matches the syndicate shuttle's shield/door id!!	//don't ask about the name, testing.
-	var/shock_charges = 4
 
 /obj/item/weapon/cartridge/proc/unlock()
 	if (!istype(loc, /obj/item/device/pda))

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -73,6 +73,7 @@ obj/item/weapon/cartridge/virus/proc/send_virus(obj/item/device/pda/target, mob/
 /obj/item/weapon/cartridge/virus/frame
 	name = "\improper F.R.A.M.E. cartridge"
 	icon_state = "cart"
+	var/telecrystals = 0
 
 /obj/item/weapon/cartridge/virus/frame/send_virus(obj/item/device/pda/target, mob/living/U)
 	if(charges <= 0)
@@ -86,10 +87,10 @@ obj/item/weapon/cartridge/virus/proc/send_virus(obj/item/device/pda/target, mob/
 			var/obj/item/device/uplink/uplink = new(target)
 			target.hidden_uplink = uplink
 			target.lock_code = lock_code
-			target.hidden_uplink.telecrystals = 0
 		else
-			target.hidden_uplink.hidden_crystals = target.hidden_uplink.telecrystals //Temporarially hide the PDA's crystals, so you can't force open other PDAs.
-			target.hidden_uplink.telecrystals = 0
+			target.hidden_uplink.hidden_crystals = target.hidden_uplink.telecrystals //Temporarially hide the PDA's crystals, so you can't steal telecrystals.
+		target.hidden_uplink.telecrystals = telecrystals
+		telecrystals = 0
 		target.hidden_uplink.active = TRUE
 	else
 		to_chat(U, "PDA not found.")

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -1,6 +1,5 @@
 /obj/item/weapon/cartridge/virus
 	name = "Generic Virus PDA cart"
-	desc = "If you see this, let a coder know that there is a generic PDA virus cart."
 	var/charges = 5
 
 obj/item/weapon/cartridge/virus/proc/send_virus(obj/item/device/pda/target, mob/living/U)
@@ -68,5 +67,29 @@ obj/item/weapon/cartridge/virus/proc/send_virus(obj/item/device/pda/target, mob/
 		to_chat(U, "<span class='notice'>Virus Sent!</span>")
 		target.silent = 1
 		target.ttone = "silence"
+	else
+		to_chat(U, "PDA not found.")
+
+/obj/item/weapon/cartridge/virus/frame
+	name = "\improper F.R.A.M.E. cartridge"
+	icon_state = "cart"
+
+/obj/item/weapon/cartridge/virus/frame/send_virus(obj/item/device/pda/target, mob/living/U)
+	if(charges <= 0)
+		to_chat(U, "<span class='notice'>Out of charges.</span>")
+		return
+	if(!isnull(target) && !target.toff)
+		charges--
+		var/lock_code = "[rand(100,999)] [pick("Alpha","Bravo","Charlie","Delta","Echo","Foxtrot","Golf","Hotel","India","Juliet","Kilo","Lima","Mike","November","Oscar","Papa","Quebec","Romeo","Sierra","Tango","Uniform","Victor","Whiskey","X-ray","Yankee","Zulu")]"
+		to_chat(U, "<span class='notice'>Virus Sent!  The unlock code to the target is: [lock_code]</span>")
+		if(!target.hidden_uplink)
+			var/obj/item/device/uplink/uplink = new(target)
+			target.hidden_uplink = uplink
+			target.lock_code = lock_code
+			target.hidden_uplink.telecrystals = 0
+		else
+			target.hidden_uplink.hidden_crystals = target.hidden_uplink.telecrystals //Temporarially hide the PDA's crystals, so you can't force open other PDAs.
+			target.hidden_uplink.telecrystals = 0
+		target.hidden_uplink.active = TRUE
 	else
 		to_chat(U, "PDA not found.")

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -6,10 +6,12 @@
 	return
 
 /obj/item/weapon/cartridge/virus/message_header()
-	return "<b>[viral_cart.charges] viral files left.</b><HR>"
+	return "<b>[charges] viral files left.</b><HR>"
 	
-/obj/item/weapon/cartridge/virus/message_header()
-	return " (<a href='byond://?src=\ref[src];choice=cart;special=virus;target=\ref[P]'>*Send Virus*</a>)"
+/obj/item/weapon/cartridge/virus/message_special(var/obj/item/device/pda/target)
+	if (!istype(loc, /obj/item/device/pda))
+		return ""  //Sanity check, this shouldn't be possible.
+	return " (<a href='byond://?src=\ref[loc];choice=cart;special=virus;target=\ref[target]'>*Send Virus*</a>)"
 
 /obj/item/weapon/cartridge/virus/special(mob/living/user, list/params)
 	var/obj/item/device/pda/P = locate(params["target"])//Leaving it alone in case it may do something useful, I guess.

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -8,7 +8,7 @@
 /obj/item/weapon/cartridge/virus/message_header()
 	return "<b>[charges] viral files left.</b><HR>"
 	
-/obj/item/weapon/cartridge/virus/message_special(var/obj/item/device/pda/target)
+/obj/item/weapon/cartridge/virus/message_special(obj/item/device/pda/target)
 	if (!istype(loc, /obj/item/device/pda))
 		return ""  //Sanity check, this shouldn't be possible.
 	return " (<a href='byond://?src=\ref[loc];choice=cart;special=virus;target=\ref[target]'>*Send Virus*</a>)"

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -2,39 +2,18 @@
 	name = "Generic Virus PDA cart"
 	var/charges = 5
 
-obj/item/weapon/cartridge/virus/proc/send_virus(obj/item/device/pda/target, mob/living/U)
+/obj/item/weapon/cartridge/virus/proc/send_virus(obj/item/device/pda/target, mob/living/U)
 	return
 
-/obj/item/weapon/cartridge/virus/syndicate
-	name = "\improper Detomatix cartridge"
-	icon_state = "cart"
-	access_remote_door = 1
-	remote_door_id = "smindicate" //Make sure this matches the syndicate shuttle's shield/door id!!	//don't ask about the name, testing.
-	charges = 4
+/obj/item/weapon/cartridge/virus/message_header()
+	return "<b>[viral_cart.charges] viral files left.</b><HR>"
+	
+/obj/item/weapon/cartridge/virus/message_header()
+	return " (<a href='byond://?src=\ref[src];choice=cart;special=virus;target=\ref[P]'>*Send Virus*</a>)"
 
-/obj/item/weapon/cartridge/virus/syndicate/send_virus(obj/item/device/pda/target, mob/living/U)
-	if(charges <= 0)
-		to_chat(U, "<span class='notice'>Out of charges.</span>")
-		return
-	if(!isnull(target) && !target.toff)
-		charges--
-		var/difficulty = 0
-		if(target.cartridge)
-			difficulty += target.cartridge.access_medical
-			difficulty += target.cartridge.access_security
-			difficulty += target.cartridge.access_engine
-			difficulty += target.cartridge.access_clown
-			difficulty += target.cartridge.access_janitor
-			difficulty += target.cartridge.access_manifest * 2
-		else
-			difficulty += 2
-		if(prob(difficulty * 15) || (target.hidden_uplink))
-			U.show_message("<span class='danger'>An error flashes on your [src].</span>", 1)
-		else
-			U.show_message("<span class='notice'>Success!</span>", 1)
-			target.explode()
-	else
-		to_chat(U, "PDA not found.")
+/obj/item/weapon/cartridge/virus/special(mob/living/user, list/params)
+	var/obj/item/device/pda/P = locate(params["target"])//Leaving it alone in case it may do something useful, I guess.
+	send_virus(P,user)
 
 /obj/item/weapon/cartridge/virus/clown
 	name = "\improper Honkworks 5.0 cartridge"
@@ -67,6 +46,37 @@ obj/item/weapon/cartridge/virus/proc/send_virus(obj/item/device/pda/target, mob/
 		to_chat(U, "<span class='notice'>Virus Sent!</span>")
 		target.silent = 1
 		target.ttone = "silence"
+	else
+		to_chat(U, "PDA not found.")
+
+/obj/item/weapon/cartridge/virus/syndicate
+	name = "\improper Detomatix cartridge"
+	icon_state = "cart"
+	access_remote_door = 1
+	remote_door_id = "smindicate" //Make sure this matches the syndicate shuttle's shield/door id!!	//don't ask about the name, testing.
+	charges = 4
+
+/obj/item/weapon/cartridge/virus/syndicate/send_virus(obj/item/device/pda/target, mob/living/U)
+	if(charges <= 0)
+		to_chat(U, "<span class='notice'>Out of charges.</span>")
+		return
+	if(!isnull(target) && !target.toff)
+		charges--
+		var/difficulty = 0
+		if(target.cartridge)
+			difficulty += target.cartridge.access_medical
+			difficulty += target.cartridge.access_security
+			difficulty += target.cartridge.access_engine
+			difficulty += target.cartridge.access_clown
+			difficulty += target.cartridge.access_janitor
+			difficulty += target.cartridge.access_manifest * 2
+		else
+			difficulty += 2
+		if(prob(difficulty * 15) || (target.hidden_uplink))
+			U.show_message("<span class='danger'>An error flashes on your [src].</span>", 1)
+		else
+			U.show_message("<span class='notice'>Success!</span>", 1)
+			target.explode()
 	else
 		to_chat(U, "PDA not found.")
 

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -100,7 +100,7 @@
 			target.hidden_uplink = uplink
 			target.lock_code = lock_code
 		else
-			target.hidden_uplink.hidden_crystals = target.hidden_uplink.telecrystals //Temporarially hide the PDA's crystals, so you can't steal telecrystals.
+			target.hidden_uplink.hidden_crystals += target.hidden_uplink.telecrystals //Temporarially hide the PDA's crystals, so you can't steal telecrystals.
 		target.hidden_uplink.telecrystals = telecrystals
 		telecrystals = 0
 		target.hidden_uplink.active = TRUE

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -1,0 +1,72 @@
+/obj/item/weapon/cartridge/virus
+	name = "Generic Virus PDA cart"
+	desc = "If you see this, let a coder know that there is a generic PDA virus cart."
+	var/charges = 5
+
+obj/item/weapon/cartridge/virus/proc/send_virus(obj/item/device/pda/target, mob/living/U)
+	return
+
+/obj/item/weapon/cartridge/virus/syndicate
+	name = "\improper Detomatix cartridge"
+	icon_state = "cart"
+	access_remote_door = 1
+	remote_door_id = "smindicate" //Make sure this matches the syndicate shuttle's shield/door id!!	//don't ask about the name, testing.
+	charges = 4
+
+/obj/item/weapon/cartridge/virus/syndicate/send_virus(obj/item/device/pda/target, mob/living/U)
+	if(charges <= 0)
+		to_chat(U, "<span class='notice'>Out of charges.</span>")
+		return
+	if(!isnull(target) && !target.toff)
+		charges--
+		var/difficulty = 0
+		if(target.cartridge)
+			difficulty += target.cartridge.access_medical
+			difficulty += target.cartridge.access_security
+			difficulty += target.cartridge.access_engine
+			difficulty += target.cartridge.access_clown
+			difficulty += target.cartridge.access_janitor
+			difficulty += target.cartridge.access_manifest * 2
+		else
+			difficulty += 2
+		if(prob(difficulty * 15) || (target.hidden_uplink))
+			U.show_message("<span class='danger'>An error flashes on your [src].</span>", 1)
+		else
+			U.show_message("<span class='notice'>Success!</span>", 1)
+			target.explode()
+	else
+		to_chat(U, "PDA not found.")
+
+/obj/item/weapon/cartridge/virus/clown
+	name = "\improper Honkworks 5.0 cartridge"
+	icon_state = "cart-clown"
+	desc = "A data cartridge for portable microcomputers. It smells vaguely of banannas"
+	access_clown = 1
+
+/obj/item/weapon/cartridge/virus/clown/send_virus(obj/item/device/pda/target, mob/living/U)
+	if(charges <= 0)
+		to_chat(U, "<span class='notice'>Out of charges.</span>")
+		return
+	if(!isnull(target) && !target.toff)
+		charges--
+		to_chat(U, "<span class='notice'>Virus Sent!</span>")
+		target.honkamt = (rand(15,20))
+	else
+		to_chat(U, "PDA not found.")
+
+/obj/item/weapon/cartridge/virus/mime
+	name = "\improper Gestur-O 1000 cartridge"
+	icon_state = "cart-mi"
+	access_mime = 1
+
+/obj/item/weapon/cartridge/virus/mime/send_virus(obj/item/device/pda/target, mob/living/U)
+	if(charges <= 0)
+		to_chat(U, "<span class='notice'>Out of charges.</span>")
+		return
+	if(!isnull(target) && !target.toff)
+		charges--
+		to_chat(U, "<span class='notice'>Virus Sent!</span>")
+		target.silent = 1
+		target.ttone = "silence"
+	else
+		to_chat(U, "PDA not found.")

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -20,11 +20,18 @@
 /obj/item/stack/telecrystal/afterattack(obj/item/I, mob/user, proximity)
 	if(!proximity)
 		return
-	if(istype(I, /obj/item))
-		if(I.hidden_uplink && I.hidden_uplink.active) //No metagaming by using this on every PDA around just to see if it gets used up.
-			I.hidden_uplink.telecrystals += amount
-			use(amount)
-			to_chat(user, "<span class='notice'>You slot [src] into the [I] and charge its internal uplink.</span>")
+	if(istype(I, /obj/item) && I.hidden_uplink && I.hidden_uplink.active) //No metagaming by using this on every PDA around just to see if it gets used up.
+		I.hidden_uplink.telecrystals += amount
+		use(amount)
+		to_chat(user, "<span class='notice'>You slot [src] into the [I] and charge its internal uplink.</span>")
+	else if(istype(I, /obj/item/weapon/cartridge/virus/frame))
+		var/obj/item/weapon/cartridge/virus/frame/cart = I
+		if(!cart.charges)
+			to_chat(user, "<span class='notice'>The [cart] is out of charges, it's refusing to accept the [src]</span>")
+			return
+		cart.telecrystals += amount
+		use(amount)
+		to_chat(user, "<span class='notice'>You slot [src] into the [cart].  The next time it's used, it will also give telecrystals</span>")
 
 /obj/item/stack/telecrystal/five
 	amount = 5

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -87,7 +87,7 @@
 			new /obj/item/device/doorCharge(src)
 			new /obj/item/device/camera_bug(src)
 			new /obj/item/device/sbeacondrop/powersink(src)
-			new /obj/item/weapon/cartridge/syndicate(src)
+			new /obj/item/weapon/cartridge/virus/syndicate(src)
 			new /obj/item/weapon/storage/toolbox/syndicate(src) //To actually get to those places
 			new /obj/item/pizzabox/bomb
 

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -530,7 +530,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	var/static/list/non_fakeattack_weapons = list(/obj/item/weapon/gun/ballistic, /obj/item/ammo_box/a357,\
 	/obj/item/weapon/gun/energy/kinetic_accelerator/crossbow, /obj/item/weapon/melee/energy/sword/saber,\
 	/obj/item/weapon/storage/box/syndicate, /obj/item/weapon/storage/box/emps,\
-	/obj/item/weapon/cartridge/syndicate, /obj/item/clothing/under/chameleon,\
+	/obj/item/weapon/cartridge/virus/syndicate, /obj/item/clothing/under/chameleon,\
 	/obj/item/clothing/shoes/chameleon, /obj/item/weapon/card/id/syndicate,\
 	/obj/item/clothing/mask/chameleon, /obj/item/clothing/glasses/thermal,\
 	/obj/item/device/chameleon, /obj/item/weapon/card/emag,	/obj/item/weapon/grenade/plastic/x4,\

--- a/code/modules/uplink/uplink.dm
+++ b/code/modules/uplink/uplink.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST_EMPTY(uplinks)
 	var/spent_telecrystals = 0
 	var/purchase_log = ""
 	var/list/uplink_items
+	var/hidden_crystals = 0
 
 /obj/item/device/uplink/Initialize()
 	. = ..()
@@ -57,7 +58,8 @@ GLOBAL_LIST_EMPTY(uplinks)
 
 /obj/item/device/uplink/interact(mob/user)
 	active = TRUE
-	ui_interact(user)
+	if(user)
+		ui_interact(user)
 
 /obj/item/device/uplink/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, \
 									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.inventory_state)
@@ -119,6 +121,8 @@ GLOBAL_LIST_EMPTY(uplinks)
 				. = TRUE
 		if("lock")
 			active = FALSE
+			telecrystals += hidden_crystals
+			hidden_crystals = 0
 			SStgui.close_uis(src)
 		if("select")
 			selected_cat = params["category"]

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -744,7 +744,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	exclude_modes = list(/datum/game_mode/nuclear)
 	player_minimum = 20
 
-/datum/uplink_item/stealthy_weapons/frame
+/datum/uplink_item/stealthy_tools/frame
 	name = "F.R.A.M.E. PDA Cartridge"
 	desc = "When inserted into a personal digital assistant, this cartridge gives you five PDA viruses which \
 			when used cause the targeted PDA to become a new uplink with zero TCs, and immediately become unlocked.  \

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -686,7 +686,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 			detonate PDAs of crewmembers who have their message feature enabled. \
 			The concussive effect from the explosion will knock the recipient out for a short period, and deafen \
 			them for longer. Beware, it has a chance to detonate your PDA."
-	item = /obj/item/weapon/cartridge/syndicate
+	item = /obj/item/weapon/cartridge/virus/syndicate
 	cost = 6
 
 /datum/uplink_item/stealthy_weapons/suppressor

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -744,6 +744,15 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	exclude_modes = list(/datum/game_mode/nuclear)
 	player_minimum = 20
 
+/datum/uplink_item/stealthy_weapons/frame
+	name = "F.R.A.M.E. PDA Cartridge"
+	desc = "When inserted into a personal digital assistant, this cartridge gives you five PDA viruses which \
+			when used cause the targeted PDA to become a new uplink with zero TCs, and immediately become unlocked.  \
+			You will recieve the unlock code upon activating the virus, and the new uplink may be charged with \
+			telecrystals normally."
+	item = /obj/item/weapon/cartridge/virus/frame
+	cost = 4
+
 /datum/uplink_item/stealthy_tools/syndigaloshes/nuke
 	name = "Stealthy No-Slip Chameleon Shoes"
 	desc = "These shoes will allow the wearer to run on wet floors and slippery objects without falling down. \

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -753,6 +753,7 @@
 #include "code\game\objects\items\devices\PDA\PDA.dm"
 #include "code\game\objects\items\devices\PDA\PDA_types.dm"
 #include "code\game\objects\items\devices\PDA\radio.dm"
+#include "code\game\objects\items\devices\PDA\virus_cart.dm"
 #include "code\game\objects\items\devices\radio\beacon.dm"
 #include "code\game\objects\items\devices\radio\electropack.dm"
 #include "code\game\objects\items\devices\radio\encryptionkey.dm"


### PR DESCRIPTION
:cl: lordpidey
add: Added F.R.A.M.E. cartridge to uplinks.  This PDA cartridge contains 5 viruses, which when used will unlock the target's PDA into a syndicate uplink, in addition, you will receive the code needed to unlock the uplink again, if you so desire.
add: If you use telecrystals on a F.R.A.M.E. cartridge, the next time it is used, it will also give those crystals to the target uplink.
/:cl:

Two things in this PR.

One: I refactored virus based PDA uplinks, they're more consistent now.

Two: I added the F.R.A.M.E. cartridge, it works similarly to the existing virus cartirdges.  It has five charges, and upon using a charge, it will unlock the target's PDA with zero TC.  You will also receive the code needed to unlock the PDA.

If it's used on an already traitorous PDA, it will still unlock, but with zero TC.  Though re-locking and unlocking normally will bring the normal TC count back. (So you can't use it to steal TC from other traitors).  If this happens, the code you receive for unlocking it will not work.

You may also apply TC directly to the cartridge, and the next time it is used, it will not only unlock the PDA, but also give the crystals to the target PDA.

If you use TC on it AND target an already traitorous PDA, it will only show the crystals you put in, but if locked and unlocked, it will simply add the new crystals to the old crystals.


Why:  I think this will allow a great deal of stealth espionage to the game, as it allows stealth transferring of crystals, deputizing sub traitors, and framing people as a traitor.  The possibilities are endless.