### PR TITLE
Removes orion trail guard loot drops

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1050,27 +1050,8 @@
 	name = "Spaceport Security"
 	desc = "The Premier security forces for all spaceports found along the Orion Trail."
 	faction = list("orion")
-	loot = list(/obj/effect/mob_spawn/human/corpse/orionsecurity,
-				/obj/item/weapon/gun/ballistic/automatic/c20r/unrestricted,
-				/obj/item/weapon/shield/energy)
+	loot = list(/obj/effect/gibspawner/human)
 
-/obj/effect/mob_spawn/human/corpse/orionsecurity
-	name = "Spaceport Security"
-	id_job = "Officer"
-	id_access_list = list(GLOB.access_syndicate)
-	outfit = /datum/outfit/orionsecurity
-
-/datum/outfit/orionsecurity
-	name = "Orion Spaceport Security"
-	uniform = /obj/item/clothing/under/syndicate
-	suit = /obj/item/clothing/suit/armor/vest
-	shoes = /obj/item/clothing/shoes/combat
-	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/device/radio/headset
-	mask = /obj/item/clothing/mask/gas
-	head = /obj/item/clothing/head/helmet/swat
-	back = /obj/item/weapon/storage/backpack
-	id = /obj/item/weapon/card/id
 
 /obj/item/weapon/orion_ship
 	name = "model settler ship"


### PR DESCRIPTION
Remember how we removed away missions because it was a lootfest of syndie gear?

:cl:
balance: The orion trail port authority have equipped their officers with microbombs.
/:cl: