### PR TITLE
Removes loot from Syndicate and Spaceport simple mobs.

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1050,25 +1050,8 @@
 	name = "Spaceport Security"
 	desc = "The Premier security forces for all spaceports found along the Orion Trail."
 	faction = list("orion")
-	loot = list(/obj/effect/gibspawner/human)
-
-/obj/effect/mob_spawn/human/corpse/orionsecurity
-	name = "Spaceport Security"
-	id_job = "Officer"
-	id_access_list = list(GLOB.access_syndicate)
-	outfit = /datum/outfit/orionsecurity
-
-/datum/outfit/orionsecurity
-	name = "Orion Spaceport Security"
-	uniform = /obj/item/clothing/under/syndicate
-	suit = /obj/item/clothing/suit/armor/vest
-	shoes = /obj/item/clothing/shoes/combat
-	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/device/radio/headset
-	mask = /obj/item/clothing/mask/gas
-	head = /obj/item/clothing/head/helmet/swat
-	back = /obj/item/weapon/storage/backpack
-	id = /obj/item/weapon/card/id
+	loot = list()
+	del_on_death = true
 
 /obj/item/weapon/orion_ship
 	name = "model settler ship"

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1050,9 +1050,7 @@
 	name = "Spaceport Security"
 	desc = "The Premier security forces for all spaceports found along the Orion Trail."
 	faction = list("orion")
-	loot = list(/obj/effect/mob_spawn/human/corpse/orionsecurity,
-				/obj/item/weapon/gun/ballistic/automatic/c20r/unrestricted,
-				/obj/item/weapon/shield/energy)
+	loot = list(/obj/effect/gibspawner/human)
 
 /obj/effect/mob_spawn/human/corpse/orionsecurity
 	name = "Spaceport Security"

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1051,7 +1051,7 @@
 	desc = "The Premier security forces for all spaceports found along the Orion Trail."
 	faction = list("orion")
 	loot = list()
-	del_on_death = true
+	del_on_death = TRUE
 
 /obj/item/weapon/orion_ship
 	name = "model settler ship"

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -84,9 +84,7 @@
 	name = "Syndicate Stormtrooper"
 	maxHealth = 340
 	health = 340
-	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatestormtrooper,
-				/obj/item/weapon/melee/energy/sword/saber/red,
-				/obj/item/weapon/shield/energy)
+	loot = list(/obj/effect/gibspawner/human)
 
 ///////////////Guns////////////
 
@@ -121,9 +119,7 @@
 	health = 200
 	projectilesound = 'sound/weapons/Gunshot.ogg'
 	casingtype = /obj/item/ammo_casing/shotgun/buckshot
-	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatestormtrooper,
-				/obj/item/weapon/gun/ballistic/automatic/shotgun/bulldog/unrestricted,
-				/obj/item/weapon/shield/energy)
+	loot = list(/obj/effect/gibspawner/human)
 
 ///////////////Misc////////////
 


### PR DESCRIPTION
:cl:
del: Removed loot drops from Syndicate Simple mobs.
/:cl:

[why]: # _Xenobiologists_ Orion Trial emaggers spawning them and abusing sentience/non-aggression potion to get Energy shields and C20rs every round. Literally away mission era 2.0.