### PR TITLE
Hardcodes the legacy nudge port

### DIFF
--- a/tools/minibot/config.py
+++ b/tools/minibot/config.py
@@ -1,7 +1,6 @@
 # Configuration for the minibot.py bot starts here
 server = "irc.rizon.net"
 port = 6667
-nudge_port = 45678
 
 channels = ["#asdfgbus", "#botbus"]
 defaultchannel = "#asdfgbus"

--- a/tools/minibot/minibot.py
+++ b/tools/minibot/minibot.py
@@ -73,7 +73,7 @@ def setup_irc_socket():
 
 def setup_nudge_socket():
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	s.bind(("", nudge_port))  # localhost:nudge_port
+	s.bind(("", 45678))  # localhost:nudge_port
 	s.listen(5)
 	logger.info("Nudge socket up and listening")
 	return s

--- a/tools/minibot/nudge.py
+++ b/tools/minibot/nudge.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from config import *
 import sys
 import pickle
 import socket
@@ -17,7 +16,7 @@ def pack():
 
 def nudge(data):
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	s.connect(("localhost", nudge_port))
+	s.connect(("localhost", 45678))
 	s.send(data)
 	s.close()
 


### PR DESCRIPTION
This is causing issues for new installs of TGS2 since they only link nudge.py and not config.py.

This along with https://github.com/tgstation/tgstation-server-tools/pull/32 fixes https://github.com/tgstation/tgstation-server-tools/issues/31

@LetterJay