### PR TITLE
Tinkerer's Daemons are no longer totally disabled if you drop below the servant requirement

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -7,7 +7,7 @@
 
 GLOBAL_VAR_INIT(clockwork_construction_value, 0) //The total value of all structures built by the clockwork cult
 GLOBAL_VAR_INIT(clockwork_caches, 0) //How many clockwork caches exist in the world (not each individual)
-GLOBAL_VAR_INIT(clockwork_daemons, 0) //How many daemons exist in the world
+GLOBAL_LIST_EMPTY(active_daemons) //A list of all active tinkerer's daemons
 GLOBAL_LIST_EMPTY(all_clockwork_objects) //All clockwork items, structures, and effects in existence
 GLOBAL_LIST_EMPTY(all_clockwork_mobs) //All clockwork SERVANTS (not creatures) in existence
 GLOBAL_LIST_INIT(clockwork_component_cache, list(BELLIGERENT_EYE = 0, VANGUARD_COGWHEEL = 0, GEIS_CAPACITOR = 0, REPLICANT_ALLOY = 0, HIEROPHANT_ANSIBLE = 0)) //The pool of components that caches draw from

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -468,10 +468,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 			textlist = list("<b>[servants]</b> Servant, who [validservants ? "counts":"does not count"] towards scripture.<br>")
 		textlist += "<b>[GLOB.clockwork_caches ? "[GLOB.clockwork_caches]</b> Tinkerer's Caches.":"No Tinkerer's Caches, construct one!</b>"]<br>\
 		<b>[GLOB.clockwork_construction_value]</b> Construction Value.<br>"
-		if(GLOB.clockwork_daemons)
-			textlist += "<b>[GLOB.clockwork_daemons]</b> Tinkerer's Daemons: <b>[servants * 0.2 < GLOB.clockwork_daemons ? "DISABLED":"ACTIVE"]</b><br>"
-		else
-			textlist += "No Tinkerer's Daemons.<br>"
+		textlist += "<b>[Floor(servants * 0.2)]</b> Tinkerer's Daemons can be active at once. <b>[LAZYLEN(GLOB.active_daemons)]</b> are active.<br>"
 		for(var/obj/structure/destructible/clockwork/massive/celestial_gateway/G in GLOB.all_clockwork_objects)
 			var/area/gate_area = get_area(G)
 			textlist += "Ark Location: <b>[uppertext(gate_area.map_name)]</b><br>"

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -240,7 +240,7 @@
 /datum/clockwork_scripture/create_object/tinkerers_daemon
 	descname = "Powered Structure, Component Generator"
 	name = "Tinkerer's Daemon"
-	desc = "Creates a tinkerer's daemon which can rapidly collect components. It will only function if it has sufficient power, is outnumbered by Servants by a ratio of 5:1, \
+	desc = "Creates a tinkerer's daemon which can rapidly collect components. It will only function if it has sufficient power, active daemons are outnumbered by Servants by a ratio of 5:1, \
 	and there is at least one existing cache."
 	invocations = list("May this generator...", "...collect Engine parts that yet hold greatness!")
 	channel_time = 80
@@ -256,19 +256,6 @@
 	sort_priority = 9
 	quickbind = TRUE
 	quickbind_desc = "Creates a Tinkerer's Daemon, which can rapidly collect components for power."
-
-/datum/clockwork_scripture/create_object/tinkerers_daemon/check_special_requirements()
-	var/servants = 0
-	for(var/mob/living/L in GLOB.living_mob_list)
-		if(is_servant_of_ratvar(L))
-			servants++
-	if(servants * 0.2 < GLOB.clockwork_daemons)
-		to_chat(invoker, "<span class='nezbere'>\"Daemons are already disabled, making more of them would be a waste.\"</span>")
-		return FALSE
-	if(servants * 0.2 < GLOB.clockwork_daemons+1)
-		to_chat(invoker, "<span class='nezbere'>\"This daemon would be useless, friend.\"</span>")
-		return FALSE
-	return ..()
 
 
 //Clockwork Obelisk: Creates a powerful obelisk that can be used to broadcast messages or open a gateway to any servant or clockwork obelisk at a power cost.


### PR DESCRIPTION
:cl: Joan
balance: Tinkerer's Daemons are no longer totally disabled if you drop below the servant requirement.
balance: Instead, Tinkerer's Daemons will disable until the number of active daemons is equal to or less than one-fifth of the living Servants.
tweak: Tinkerer's Daemons produce components very slightly slower.
/:cl:

This means you can have 3 daemons at 10 people and have 2 of them active at a time; previously, all of them would be disabled at once.
Daemons are still entirely disabled below 5 servants, though.