### PR TITLE
Prevents cyborgs from extruding materials

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -269,13 +269,15 @@
 		return
 	if(!in_range(src, user))
 		return
+	if(is_cyborg)
+		return
 	else
 		if(zero_amount())
 			return
 		//get amount from user
 		var/min = 0
 		var/max = src.get_amount()
-		var/stackmaterial = round(input(user,"How many sheets do you wish to take out of this stack? (Maximum  [max]") as num)
+		var/stackmaterial = round(input(user,"How many sheets do you wish to take out of this stack? (Maximum  [max])") as num)
 		if(stackmaterial == null || stackmaterial <= min || stackmaterial >= src.get_amount())
 			return
 		else


### PR DESCRIPTION
:cl: QualityVan
del: Cyborgs can no longer alt-click their material stacks to split them
/:cl:

When a cyborg splits a stack of its materials via alt-click, what you get is two stacks of cyborg materials. That's bad. This prevents that. You can still harvest metal/glass/rods/cable by building stuff and then tearing it down but like
why go through the effort

Fixes #28131 