### PR TITLE
Fix #28176 : You can EMP Proof a camera with a sheet of plasma

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -159,9 +159,10 @@
 
 		else if(istype(W, /obj/item/stack/sheet/mineral/plasma))
 			if(!isEmpProof())
+				var/obj/item/stack/sheet/mineral/plasma/P = W
 				upgradeEmpProof()
 				to_chat(user, "[msg]")
-				qdel(W)
+				P.use(1)
 			else
 				to_chat(user, "[msg2]")
 			return


### PR DESCRIPTION
Fixes #28176 