### PR TITLE
Fixes using hotkey mode to avoid forcesay

### DIFF
--- a/code/modules/client/verbs/sethotkeys.dm
+++ b/code/modules/client/verbs/sethotkeys.dm
@@ -8,8 +8,6 @@
 	var/hotkey_macro = "hotkeys"
 	var/current_setting
 
-	var/list/default_macros = list("default", "robot-default")
-
 	if(from_pref)
 		current_setting = (prefs.hotkeys ? hotkey_macro : hotkey_default)
 	else
@@ -19,7 +17,22 @@
 		hotkey_macro = mob.macro_hotkeys
 		hotkey_default = mob.macro_default
 
-	if(current_setting in default_macros)
+	if(!in_hotkey_mode(current_setting))
 		winset(src, null, "mainwindow.macro=[hotkey_default] input.focus=true input.background-color=#d3b5b5")
 	else
 		winset(src, null, "mainwindow.macro=[hotkey_macro] mapwindow.map.focus=true input.background-color=#e0e0e0")
+
+/client/proc/in_hotkey_mode(current_setting)
+	var/static/list/default_macros = list("default", "robot-default")
+	if(!current_setting)
+		current_setting = winget(src, "mainwindow", "macro")
+	return !(current_setting in default_macros)
+
+/client/proc/ResetHotkeyInputFocus(clear_input)
+	var/cmd
+	if(clear_input)
+		cmd = "input.text=[null]"
+	if(in_hotkey_mode())
+		cmd = "[cmd ? "[cmd] " : ""] mapwindow.map.focus=true"
+	if(cmd)
+		winset(src, null, cmd)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -128,4 +128,4 @@
 						temp += pick(append)
 
 					say(temp)
-				winset(client, "input", "text=[null]")
+				client.ResetHotkeyInputFocus(TRUE)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -1,12 +1,22 @@
 //Speech verbs.
 /mob/verb/say_verb(message as text)
 	set name = "Say"
-	set category = "IC"
+	set hidden = TRUE
+	var/static/list/client_default_macros = list("default", "robot-default")
+
+	if(client)
+		client.ResetHotkeyInputFocus(FALSE)
+
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 	usr.say(message)
 
+/mob/verb/say_hotkey_verb()
+	set name = ".say_hotkey"
+	set hidden = TRUE
+	//even in hotkey mode, we need this to make them forcesay
+	winset(usr, null, "input.focus=true input.text=\"Say \\\"\"")
 
 /mob/verb/whisper_verb(message as text)
 	set name = "Whisper"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -403,7 +403,7 @@ macro "hotkeys"
 		is-disabled = false
 	elem 
 		name = "T"
-		command = "say"
+		command = ".say_hotkey"
 		is-disabled = false
 	elem "w_key"
 		name = "W+REP"
@@ -879,7 +879,7 @@ macro "robot-hotkeys"
 		is-disabled = false
 	elem 
 		name = "T"
-		command = "say"
+		command = ".say_hotkey"
 		is-disabled = false
 	elem "w_key"
 		name = "W+REP"


### PR DESCRIPTION
Fixes #8999

:cl:
tweak: The hotkey say dialog has been removed, it now uses the command bar
fix: Say in hotkey mode will no longer prevent attacks from forcesaying what wa-ACK!!
/:cl:
