### PR TITLE
Removes some medals from the captain's lockbox

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -109,11 +109,11 @@
 
 /obj/item/weapon/storage/lockbox/medal/PopulateContents()
 	new /obj/item/clothing/accessory/medal/silver/valor(src)
+	new /obj/item/clothing/accessory/medal/silver/valor(src)
 	new /obj/item/clothing/accessory/medal/bronze_heart(src)
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/accessory/medal/conduct(src)
 	new /obj/item/clothing/accessory/medal/gold/captain(src)
 	new /obj/item/clothing/accessory/medal/silver/security(src)
-	new /obj/item/clothing/accessory/medal/plasma(src)
 	new /obj/item/clothing/accessory/medal/plasma/nobel_science(src)
-	new /obj/item/clothing/accessory/medal/gold/heroism(src)
+	new /obj/item/clothing/accessory/medal/plasma/nobel_science(src)


### PR DESCRIPTION
:cl: NanoTrasen Janitorial Department
del: It seems one of our cleaning crews misplaced some medals...
/:cl:

The medal of heroism's desc states that it is awarded by centcomm, not the captain.
The plasma medal has a pretty bland desc that doesn't include any info on how or why it's awarded.
Duplicate medals have been added to compensate for the removal
