### PR TITLE
Pseudo Feature Freeze

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -392,7 +392,7 @@ JOIN_WITH_MUTANT_RACE
 ## Uncommenting races will allow them to be choosen at roundstart while join_with_muntant_race is on. You'll need at least one.
 
 ## You probably want humans on your space station, but technically speaking you can turn them off without any ill effect
-ROUNDSTART_RACES human
+#ROUNDSTART_RACES human
 
 ## Races that are strictly worse than humans that could probably be turned on without balance concerns
 ROUNDSTART_RACES lizard


### PR DESCRIPTION
We have too many bugs and too many bikeshedding arguments about our latest conversion mode or redundant RD gun, it's time to try putting our energies elsewhere.

## Things that will be accepted during this freeze:

- Bug Fixes

- Refactors

- Improvements to civilian systems or gameplay or new features that you can use while not an antagonist without getting banned

## Things that won't be accepted:

- Balance changes (there can be incidental balance changes from otherwise acceptable PRs, but no "I buffed tasers" or "I nerfed eswords"). This includes changes/balancing under the guise of reverts/removals. If you feel strongly that we absolutely can not wait to change X feature because it is making the game unplayable PM me and if I agree I'll open a revert.

- New antagonist toys/types/etc

- New civilian stuff that can't realistically be used without being an antagonist or using it on an antagonist.


The freeze will last 1-2 months (We'll see how its going and how people are feeling in 30 days)


## Things that are exempt from this: 

- Xhuis redoing clock cult

- Robustin wrapping up his gang changes

- PRs opened before the freeze

## List of coding projects for the freeze (and you can skip the freeze if you finish one)

By which I mean you can make one or more balance or feature PRs if you finish something from this list, depending on how complex the project is

https://tgstation13.org/phpBB/viewtopic.php?f=5&t=11755