### PR TITLE
Makes dismembered heads and brains respect NOCLONE

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -72,6 +72,8 @@
 		if(!brainmob.stored_dna)
 			brainmob.stored_dna = new /datum/dna/stored(brainmob)
 		C.dna.copy_dna(brainmob.stored_dna)
+		if(L.disabilities & NOCLONE)
+			brainmob.disabilities |= NOCLONE	//This is so you can't just decapitate a husked guy and clone them without needing to get a new body
 		var/obj/item/organ/zombie_infection/ZI = L.getorganslot("zombie_infection")
 		if(ZI)
 			brainmob.set_species(ZI.old_species)	//For if the brain is cloned


### PR DESCRIPTION
Basically, if you want to clone someone with the NOCLONE disability, you now have to put them in a new body again.

Borging ignores the noclone disability, and being put in a new body will remove it, as the player is transferred out of the brainmob

:cl:
fix: Cloning dismembered heads and brains now respects husking and other clone preventing disabilities.
/:cl: