### PR TITLE
Improves Curator display cases

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -148,6 +148,8 @@ SUBSYSTEM_DEF(persistence)
 		T.trophy_message = chosen_trophy["message"]
 		T.placer_key = chosen_trophy["placer_key"]
 		T.update_icon()
+		T.showpiece.name = "replica [chosen_trophy["name"]]"
+		T.showpiece.desc = "A cheap plastic approximation of \a [chosen_trophy["name"]]."
 
 
 /datum/controller/subsystem/persistence/proc/CollectData()
@@ -197,3 +199,6 @@ SUBSYSTEM_DEF(persistence)
 		data["message"] = T.trophy_message
 		data["placer_key"] = T.placer_key
 		saved_trophies += list(data)
+
+		data["name"] = T.showpiece.name
+

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -147,10 +147,12 @@ SUBSYSTEM_DEF(persistence)
 		T.showpiece = new /obj/item/showpiece_dummy(T, path)
 		T.trophy_message = chosen_trophy["message"]
 		T.placer_key = chosen_trophy["placer_key"]
-		T.update_icon()
-		T.showpiece.name = "replica [chosen_trophy["name"]]"
-		T.showpiece.desc = "A cheap plastic approximation of \a [chosen_trophy["name"]]."
 
+		if(chosen_trophy["name"])
+			T.showpiece.name = "replica [chosen_trophy["name"]]"
+			T.showpiece.desc = "A cheap plastic approximation of \a [chosen_trophy["name"]]."
+
+		T.update_icon()
 
 /datum/controller/subsystem/persistence/proc/CollectData()
 	CollectChiselMessages()
@@ -198,7 +200,8 @@ SUBSYSTEM_DEF(persistence)
 		data["path"] = T.showpiece.type
 		data["message"] = T.trophy_message
 		data["placer_key"] = T.placer_key
-		saved_trophies += list(data)
 
 		data["name"] = T.showpiece.name
+
+		saved_trophies += list(data)
 

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -256,6 +256,7 @@
 	var/trophy_message = ""
 	var/placer_key = ""
 	var/added_roundstart = TRUE
+	var/scanned_for_replication = FALSE
 
 	alert = TRUE
 	integrity_failure = 0
@@ -319,7 +320,13 @@
 			else
 				to_chat(user, "You are too far to set the plaque's text.")
 
-		SSpersistence.SaveTrophy(src)
+		if(scanned_for_replication == FALSE)
+			var/scan = alert(user, "Scan this item for replication in future shifts? You can only do this once.", "Scan for replication?", "No", "Yes")
+			if(scan == "Yes")
+				visible_message("[src]'s sensor array whirs as it scans the [W] for future replication.")
+				scanned_for_replication = TRUE
+				SSpersistence.SaveTrophy(src)
+
 		return TRUE
 
 	else
@@ -332,13 +339,21 @@
 	desc = "The key to the curator's display cases."
 
 /obj/item/showpiece_dummy
-	name = "cheap plastic replica"
+	name = "replica"
+	desc = "A cheap plastic approximation."
 
 /obj/item/showpiece_dummy/Initialize(mapload, path)
 	. = ..()
 	var/obj/item/I = path
+
 	icon = initial(I.icon)
 	icon_state = initial(I.icon_state)
 	item_state = initial(I.item_state)
 	lefthand_file = initial(I.lefthand_file)
 	righthand_file = initial(I.righthand_file)
+
+	if(name == initial(name))
+		name = "replica [initial(I.name)]"
+
+	if(desc == initial(desc))
+		desc = "A cheap plastic approximation of [initial(I.name)]."

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -256,11 +256,9 @@
 	var/trophy_message = ""
 	var/placer_key = ""
 	var/added_roundstart = TRUE
-	var/is_locked = TRUE
 
 	alert = TRUE
 	integrity_failure = 0
-	openable = FALSE
 
 /obj/structure/displaycase/trophy/Initialize()
 	. = ..()
@@ -280,39 +278,29 @@
 
 	if(!user.Adjacent(src)) //no TK museology
 		return
-	if(user.a_intent == INTENT_HARM)
+
+	if(istype(user.get_active_held_item(),/obj/item/key/displaycase))
+		to_chat(user,  "<span class='notice'>You [open ? "close":"open"] \the [src]</span>")
+		toggle_lock(user)
+		return
+
+	if(user.a_intent == INTENT_HARM || !open)
 		return ..()
 
-	if(user.is_holding_item_of_type(/obj/item/key/displaycase))
-		if(added_roundstart)
-			is_locked = !is_locked
-			to_chat(user, "You [!is_locked ? "un" : ""]lock the case.")
-		else
-			to_chat(user, "<span class='danger'>The lock is stuck shut!</span>")
-		return
-
-	if(is_locked)
-		to_chat(user, "<span class='danger'>The case is shut tight with an old fashioned physical lock. Maybe you should ask the curator for the key?</span>")
-		return
-
-	if(!added_roundstart)
-		to_chat(user, "You've already put something new in this case.")
-		return
-
 	if(is_type_in_typecache(W, GLOB.blacklisted_cargo_types))
-		to_chat(user, "<span class='danger'>The case rejects the [W].</span>")
+		to_chat(user, "<span class='danger'>The case rejects \the [W].</span>")
 		return
 
 	for(var/a in W.GetAllContents())
 		if(is_type_in_typecache(a, GLOB.blacklisted_cargo_types))
-			to_chat(user, "<span class='danger'>The case rejects the [W].</span>")
+			to_chat(user, "<span class='danger'>The case rejects \the [W].</span>")
 			return
 
 	if(user.transferItemToLoc(W, src))
 
 		if(showpiece)
-			to_chat(user, "You press a button, and [showpiece] descends into the floor of the case.")
-			QDEL_NULL(showpiece)
+			to_chat(user, "The case already has something in it.")
+			return
 
 		to_chat(user, "You insert [W] into the case.")
 		showpiece = W
@@ -335,29 +323,22 @@
 		return TRUE
 
 	else
-		to_chat(user, "<span class='warning'>\The [W] is stuck to your hand, you can't put it in the [src.name]!</span>")
+		to_chat(user, "<span class='warning'>\The [W] is stuck to your hand, you can't put it in \the [src.name]!</span>")
 
 	return
-
-/obj/structure/displaycase/trophy/dump()
-	if (showpiece)
-		if(added_roundstart)
-			visible_message("<span class='danger'>The [showpiece] crumbles to dust!</span>")
-			new /obj/effect/decal/cleanable/ash(loc)
-			QDEL_NULL(showpiece)
-		else
-			..()
 
 /obj/item/key/displaycase
 	name = "display case key"
 	desc = "The key to the curator's display cases."
 
 /obj/item/showpiece_dummy
-	name = "Cheap replica"
+	name = "cheap plastic replica"
 
 /obj/item/showpiece_dummy/Initialize(mapload, path)
 	. = ..()
 	var/obj/item/I = path
-	name = initial(I.name)
 	icon = initial(I.icon)
 	icon_state = initial(I.icon_state)
+	item_state = initial(I.item_state)
+	lefthand_file = initial(I.lefthand_file)
+	righthand_file = initial(I.righthand_file)


### PR DESCRIPTION
:cl: cacogen
add: Items saved in Curator display cases can now be removed (roundstart items are still non-functional replicas though)
tweak: You can now open Curator display cases with the key to get items out of them
tweak: Curator display cases no longer eat items they're clicked with, they have to be open and empty to put things in them
:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)
I rolled Curator for the first time today and I was a little disappointed by the display cases. The way they worked wasn't very intuitive, and they had a habit of eating items and then had to be destroyed to get them back.

I really like the item persistence thing, but I wanted to actually be able to get the items out and play with them and I didn't like having to delete them to display something of my own.

This change makes it so that the non-functional replicas saved in the cases can be taken out. They have inhand sprites now so it actually looks like you're carrying the item and their specific names are now preserved from the previous round so that unique items such as IDs and PDAs keep their names.

Bear in mind these are just /obj/items with the sprite of the object that was saved, so they have no functionality whatsoever.

Other stuff this pull does:

* You can add and remove displayed items from cases as much as you want
* The key now has to be in your active hand to open and close the case, so you don't accidentally toggle the lock when trying to display something
* Using an object on the case while it's closed results in you attacking the case with it instead of trying to display it
* Fixed some of the pronouns in user messages so they look better
* Sets the name and description of replicas to indicate that they're replicas of the item and not the item itself

Known issues:

* ~~Existing saved trophies didn't have their names saved, so this may cause a runtime at roundstart when spawning them (not sure though, if someone could confirm this then I'll add a check for name before reading from it)~~ added a check just in case
* ~~Each time a trophy is added to a case, it's saved. This means the pool of saved trophies can be spammed with garbage. I'd like to make it so when a trophy is removed from a case it's removed from the pool, but I'm not sure how to do that.~~ can only save a trophy once per case per round again
* Overlays aren't preserved (e.g. gun charge meters and reagents in beakers). I don't think this can be fixed without a ton of work or just giving them the item itself (which could be possible if you assigned a cost to each item spawned, but would take a ton of work because you'd then also have to create a system that decides which variables to save based on object type).
* Unique inhands (e.g. gun sprites with visible charge meters) don't show up at all. I might fix this later on because otherwise it kind of defeats the purpose of having gun replicas for example.