### PR TITLE
Removes goonchat ping display

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -33,11 +33,11 @@ SUBSYSTEM_DEF(server_maint)
 					to_chat(C, "<span class='danger'>You have been inactive for more than [config.afk_period / 600] minutes and have been disconnected.</span>")
 					qdel(C)
 		
-			if(C)
-				if(ping_chats)
-					var/datum/chatOutput/chat = C.chatOutput
-					if(chat.loaded)
-						chat.Pang()
+		if(C)
+			if(ping_chats)
+				var/datum/chatOutput/chat = C.chatOutput
+				if(chat.loaded)
+					chat.Pang()
 
 			if (!(world.time - C.connection_time < PING_BUFFER_TIME || C.inactivity >= (wait-1)))
 				winset(C, null, "command=.update_ping+[world.time+world.tick_lag*world.tick_usage/100]")

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -20,7 +20,7 @@ SUBSYSTEM_DEF(server_maint)
 	
 	var/list/currentrun = src.currentrun
 	var/round_started = SSticker.HasRoundStarted()
-	var/ping_chats = !(times_fired % 5)
+	var/ping_chats = !(times_fired % 5) || last_fire <= (world.time - 30)
 
 	for(var/I in currentrun)
 		var/client/C = I
@@ -33,11 +33,11 @@ SUBSYSTEM_DEF(server_maint)
 					to_chat(C, "<span class='danger'>You have been inactive for more than [config.afk_period / 600] minutes and have been disconnected.</span>")
 					qdel(C)
 		
-		if(C)
-			if(ping_chats)
-				var/datum/chatOutput/chat = C.chatOutput
-				if(chat.loaded)
-					chat.Pang()
+			if(C)
+				if(ping_chats)
+					var/datum/chatOutput/chat = C.chatOutput
+					if(chat.loaded)
+						chat.Pang()
 
 			if (!(world.time - C.connection_time < PING_BUFFER_TIME || C.inactivity >= (wait-1)))
 				winset(C, null, "command=.update_ping+[world.time+world.tick_lag*world.tick_usage/100]")

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -20,6 +20,7 @@ SUBSYSTEM_DEF(server_maint)
 	
 	var/list/currentrun = src.currentrun
 	var/round_started = SSticker.HasRoundStarted()
+	var/ping_chats = !(times_fired % 5)
 
 	for(var/I in currentrun)
 		var/client/C = I
@@ -31,9 +32,15 @@ SUBSYSTEM_DEF(server_maint)
 					log_access("AFK: [key_name(C)]")
 					to_chat(C, "<span class='danger'>You have been inactive for more than [config.afk_period / 600] minutes and have been disconnected.</span>")
 					qdel(C)
+		
+		if(C)
+			if(ping_chats)
+				var/datum/chatOutput/chat = C.chatOutput
+				if(chat.loaded)
+					chat.Pang()
 
-		if (!(!C || world.time - C.connection_time < PING_BUFFER_TIME || C.inactivity >= (wait-1)))
-			winset(C, null, "command=.update_ping+[world.time+world.tick_lag*world.tick_usage/100]")
+			if (!(world.time - C.connection_time < PING_BUFFER_TIME || C.inactivity >= (wait-1)))
+				winset(C, null, "command=.update_ping+[world.time+world.tick_lag*world.tick_usage/100]")
 
 		if (MC_TICK_CHECK) //one day, when ss13 has 1000 people per server, you guys are gonna be glad I added this tick check
 			return

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -97,8 +97,6 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	messageQueue = null
 	sendClientData()
 
-	pingLoop()
-
 /datum/chatOutput/proc/Pang()
 	ehjax_send(data = "softPang") // SoftPang isn't handled anywhere but it'll always reset the opts.lastPang.
 

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -99,12 +99,8 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 
 	pingLoop()
 
-/datum/chatOutput/proc/pingLoop()
-	set waitfor = FALSE
-
-	while (owner)
-		ehjax_send(data = owner.is_afk(29) ? "softPang" : "pang") // SoftPang isn't handled anywhere but it'll always reset the opts.lastPang.
-		sleep(30)
+/datum/chatOutput/proc/Pang()
+	ehjax_send(data = "softPang") // SoftPang isn't handled anywhere but it'll always reset the opts.lastPang.
 
 /datum/chatOutput/proc/ehjax_send(client/C = owner, window = "browseroutput", data)
 	if(islist(data))

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -73,9 +73,6 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 		if("debug")
 			data = debug(arglist(params))
 
-		if("ping")
-			data = ping(arglist(params))
-
 		if("analyzeClientData")
 			data = analyzeClientData(arglist(params))
 

--- a/code/modules/goonchat/browserassets/html/browserOutput.html
+++ b/code/modules/goonchat/browserassets/html/browserOutput.html
@@ -23,16 +23,11 @@
 
 	</div>
 	<div id="userBar" style="display: none;">
-		<div id="ping">
-			<i class="icon-circle" id="pingDot"></i>
-			<span class="ms" id="pingMs">--ms</span>
-		</div>
 		<div id="options">
 			<a href="#" class="toggle" id="toggleOptions" title="Options"><i class="icon-cog"></i></a>
 			<div class="sub" id="subOptions">
 				<a href="#" class="decreaseFont" id="decreaseFont"><span>Decrease font size</span> <i class="icon-font">-</i></a>
 				<a href="#" class="increaseFont" id="increaseFont"><span>Increase font size</span> <i class="icon-font">+</i></a>
-				<a href="#" class="togglePing" id="togglePing"><span>Toggle ping display</span> <i class="icon-circle"></i></a>
 				<a href="#" class="highlightTerm" id="highlightTerm"><span>Highlight string</span> <i class="icon-tag"></i></a>
 				<a href="#" class="saveLog" id="saveLog"><span>Save chat log</span> <i class="icon-save"></i></a>
 				<a href="#" class="clearMessages" id="clearMessages"><span>Clear all messages</span> <i class="icon-eraser"></i></a>

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -41,13 +41,10 @@ var opts = {
 	'highlightTerms': [],
 	'highlightLimit': 5,
 	'highlightColor': '#FFFF00', //The color of the highlighted message
-	'pingDisabled': false, //Has the user disabled the ping counter
 
-	//Ping display
+	//Connectivity
 	'lastPang': 0, //Timestamp of the last response from the server.
 	'pangLimit': 35000,
-	'pingTime': 0, //Timestamp of when ping sent
-	'pongTime': 0, //Timestamp of when ping received
 	'noResponse': false, //Tracks the state of the previous ping request
 	'noResponseCount': 0, //How many failed pings?
 
@@ -369,23 +366,6 @@ function ehjaxCallback(data) {
 	opts.lastPang = Date.now();
 	if (data == 'softPang') {
 		return;
-	} else if (data == 'pang') {
-		opts.pingCounter = 0; //reset
-		opts.pingTime = Date.now();
-		runByond('?_src_=chat&proc=ping');
-
-	} else if (data == 'pong') {
-		if (opts.pingDisabled) {return;}
-		opts.pongTime = Date.now();
-		var pingDuration = Math.ceil((opts.pongTime - opts.pingTime) / 2);
-		$('#pingMs').text(pingDuration+'ms');
-		pingDuration = Math.min(pingDuration, 255);
-		var red = pingDuration;
-		var green = 255 - pingDuration;
-		var blue = 0;
-		var hex = rgbToHex(red, green, blue);
-		$('#pingDot').css('color', '#'+hex);
-
 	} else if (data == 'roundrestart') {
 		opts.restarting = true;
 		internalOutput('<div class="connectionClosed internal restarting">The connection has been closed because the server is restarting. Please wait while you automatically reconnect.</div>', 'internal');
@@ -492,7 +472,6 @@ $(function() {
 	******************************************/
 	var savedConfig = {
 		'sfontSize': getCookie('fontsize'),
-		'spingDisabled': getCookie('pingdisabled'),
 		'shighlightTerms': getCookie('highlightterms'),
 		'shighlightColor': getCookie('highlightcolor'),
 	};
@@ -500,13 +479,6 @@ $(function() {
 	if (savedConfig.sfontSize) {
 		$messages.css('font-size', savedConfig.sfontSize);
 		internalOutput('<span class="internal boldnshit">Loaded font size setting of: '+savedConfig.sfontSize+'</span>', 'internal');
-	}
-	if (savedConfig.spingDisabled) {
-		if (savedConfig.spingDisabled == 'true') {
-			opts.pingDisabled = true;
-			$('#ping').hide();
-		}
-		internalOutput('<span class="internal boldnshit">Loaded ping display of: '+(opts.pingDisabled ? 'hidden' : 'visible')+'</span>', 'internal');
 	}
 	if (savedConfig.shighlightTerms) {
 		var savedTerms = $.parseJSON(savedConfig.shighlightTerms);
@@ -762,17 +734,6 @@ $(function() {
 		$messages.css({'font-size': fontSize});
 		setCookie('fontsize', fontSize, 365);
 		internalOutput('<span class="internal boldnshit">Font size set to '+fontSize+'</span>', 'internal');
-	});
-
-	$('#togglePing').click(function(e) {
-		if (opts.pingDisabled) {
-			$('#ping').slideDown('fast');
-			opts.pingDisabled = false;
-		} else {
-			$('#ping').slideUp('fast');
-			opts.pingDisabled = true;
-		}
-		setCookie('pingdisabled', (opts.pingDisabled ? 'true' : 'false'), 365);
 	});
 
 	$('#saveLog').click(function(e) {

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -44,7 +44,7 @@ var opts = {
 
 	//Connectivity
 	'lastPang': 0, //Timestamp of the last response from the server.
-	'pangLimit': 35000,
+	'pangLimit': 40000,
 	'noResponse': false, //Tracks the state of the previous ping request
 	'noResponseCount': 0, //How many failed pings?
 
@@ -456,7 +456,7 @@ $(function() {
 				if (!opts.noResponse) { //Only actually append a message if the previous ping didn't also fail (to prevent spam)
 					opts.noResponse = true;
 					opts.noResponseCount++;
-					internalOutput('<div class="connectionClosed internal" data-count="'+opts.noResponseCount+'">You are either AFK, experiencing lag or the connection has closed.</div>', 'internal');
+					internalOutput('<div class="connectionClosed internal" data-count="'+opts.noResponseCount+'">You are either experiencing lag or the connection has closed.</div>', 'internal');
 				}
 		} else if (opts.noResponse) { //Previous ping attempt failed ohno
 				$('.connectionClosed[data-count="'+opts.noResponseCount+'"]:not(.restored)').addClass('restored').text('Your connection has been restored (probably)!');


### PR DESCRIPTION
We don't need to waste server resources running two ping trackers. Also reworks the connectivity checker loop to use the controller instead of sleeps