### PR TITLE
Adds a length check to medal commendations on post round report

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -579,7 +579,7 @@ SUBSYSTEM_DEF(ticker)
 
 	CHECK_TICK
 	//medals, placed far down so that people can actually see the commendations.
-	if(GLOB.commendations)
+	if(GLOB.commendations.len)
 		to_chat(world, "<b><font size=3>Medal Commendations:</font></b>")
 		for (var/com in GLOB.commendations)
 			to_chat(world, com)


### PR DESCRIPTION
This was triggering everytime, even when there is no commendation.