### PR TITLE
HOTFIX: Cult now gets a functioning summon objective

### DIFF
--- a/code/datums/antagonists/datum_cult.dm
+++ b/code/datums/antagonists/datum_cult.dm
@@ -37,14 +37,12 @@
 		message_admins("Cult Sacrifice: Could not find unconvertable or convertable target. WELP!")
 		GLOB.sac_complete = TRUE
 	SSticker.mode.cult_objectives += "sacrifice"
-	if(GLOB.summon_spots.len)
-		SSticker.mode.cult_objectives += "eldergod"
-	else
+	if(!GLOB.summon_spots.len)
 		while(GLOB.summon_spots.len < SUMMON_POSSIBILITIES)
-			var/area/summon = pick(GLOB.sortedAreas)
+			var/area/summon = pick(GLOB.sortedAreas - GLOB.summon_spots)
 			if(summon && (summon.z == ZLEVEL_STATION) && summon.valid_territory)
-				GLOB.summon_spots |= summon
-		SSticker.mode.cult_objectives += "eldergod"
+				GLOB.summon_spots += summon
+	SSticker.mode.cult_objectives += "eldergod"
 
 /datum/antagonist/cult/proc/cult_memorization(datum/mind/cult_mind)
 	var/mob/living/current = cult_mind.current

--- a/code/datums/antagonists/datum_cult.dm
+++ b/code/datums/antagonists/datum_cult.dm
@@ -56,6 +56,7 @@
 					explanation = "Sacrifice [GLOB.sac_mind], the [GLOB.sac_mind.assigned_role] via invoking a Sacrifice rune with them on it and three acolytes around it."
 				else
 					explanation = "The veil has already been weakened here, proceed to the final objective."
+					GLOB.sac_complete = TRUE
 			if("eldergod")
 				explanation = "Summon Nar-Sie by invoking the rune 'Summon Nar-Sie'. <b>The summoning can only be accomplished in [english_list(GLOB.summon_spots)] - where the veil is weak enough for the ritual to begin.</b>"
 		if(!silent)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -101,14 +101,12 @@
 				GLOB.sac_image = reshape
 		else
 			message_admins("Cult Sacrifice: Could not find unconvertable or convertable target. WELP!")
-	if(GLOB.summon_spots.len)
-		cult_objectives += "eldergod"
-	else
+	if(!GLOB.summon_spots.len)
 		while(GLOB.summon_spots.len < SUMMON_POSSIBILITIES)
-			var/area/summon = pick(GLOB.sortedAreas)
-			if(summon && (summon.z == ZLEVEL_STATION) && summon.valid_territory)
-				GLOB.summon_spots |= summon
-		cult_objectives += "eldergod"
+			var/area/summon = pick(GLOB.sortedAreas - GLOB.summon_spots)
+			if((summon.z == ZLEVEL_STATION) && summon.valid_territory)
+				GLOB.summon_spots += summon
+	cult_objectives += "eldergod"
 
 	for(var/datum/mind/cult_mind in cultists_to_cult)
 		equip_cultist(cult_mind.current)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -53,7 +53,6 @@
 
 /datum/game_mode/cult/pre_setup()
 	cult_objectives += "sacrifice"
-	cult_objectives += "eldergod"
 
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs
@@ -102,6 +101,15 @@
 				GLOB.sac_image = reshape
 		else
 			message_admins("Cult Sacrifice: Could not find unconvertable or convertable target. WELP!")
+	if(GLOB.summon_spots.len)
+		cult_objectives += "eldergod"
+	else
+		while(GLOB.summon_spots.len < SUMMON_POSSIBILITIES)
+			var/area/summon = pick(GLOB.sortedAreas)
+			if(summon && (summon.z == ZLEVEL_STATION) && summon.valid_territory)
+				GLOB.summon_spots |= summon
+		cult_objectives += "eldergod"
+
 	for(var/datum/mind/cult_mind in cultists_to_cult)
 		equip_cultist(cult_mind.current)
 		update_cult_icons_added(cult_mind)
@@ -239,11 +247,11 @@
 						SSblackbox.add_details("cult_objective","cult_sacrifice|FAIL")
 				if("eldergod")
 					if(!eldergod)
-						explanation = "Summon Nar-Sie. <span class='greenannounce'>Success!</span>"
+						explanation = "Summon Nar-Sie. The summoning can only be accomplished in [english_list(GLOB.summon_spots)].<span class='greenannounce'>Success!</span>"
 						SSblackbox.add_details("cult_objective","cult_narsie|SUCCESS")
 						SSticker.news_report = CULT_SUMMON
 					else
-						explanation = "Summon Nar-Sie. <span class='boldannounce'>Fail.</span>"
+						explanation = "Summon Nar-Sie. The summoning can only be accomplished in [english_list(GLOB.summon_spots)]<span class='boldannounce'>Fail.</span>"
 						SSblackbox.add_details("cult_objective","cult_narsie|FAIL")
 						SSticker.news_report = CULT_FAILURE
 


### PR DESCRIPTION
The summon objective is only distributed properly through datum cultists, roundstart cultists get meme'd because the objective is created before the summoning locations are determined.

This includes details about the summon locations in the post-round ticker.

Speedmerge plz thx. I caught this one before its screwed up a round and post-roundstart cultists should get a proper list but I'd like to nip this one in the bud.