### PR TITLE
Cleans up basemap.dm

### DIFF
--- a/_maps/basemap.dm
+++ b/_maps/basemap.dm
@@ -1,13 +1,10 @@
-#ifndef ALL_MAPS
-
 #include "map_files\generic\Centcomm.dmm"
 #include "map_files\generic\SpaceStation.dmm"
 #include "map_files\generic\Space.dmm"
 #include "map_files\generic\SpaceDock.dmm"
 #include "map_files\Mining\Lavaland.dmm"
 
-#else
-
+#ifdef ALL_MAPS
 #include "map_files\debug\runtimestation.dmm"
 #include "map_files\Deltastation\DeltaStation2.dmm"
 #include "map_files\MetaStation\MetaStation.dmm"
@@ -15,13 +12,6 @@
 #include "map_files\PubbyStation\PubbyStation.dmm"
 #include "map_files\TgStation\tgstation.2.1.3.dmm"
 #include "map_files\Cerestation\cerestation.dmm"
-
-#include "map_files\generic\Centcomm.dmm"
-#include "map_files\generic\SpaceStation.dmm"
-#include "map_files\generic\Space.dmm"
-#include "map_files\generic\SpaceDock.dmm"
-
-#include "map_files\Mining\Lavaland.dmm"
 
 #ifdef TRAVISBUILDING
 #include "templates.dm"


### PR DESCRIPTION
Order of the maps when compiling with all of them doesn't really matter, so the copypasta is not really needed here. 