### PR TITLE
If you're lucky enough to get multiple lifesteal crystal modkits you can actually make use of them

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/energy/kinetic_accelerator
 	name = "proto-kinetic accelerator"
-	desc = "A self recharging, ranged mining tool that does increased damage in low pressure. Capable of holding up to six slots worth of mod kits."
+	desc = "A self recharging, ranged mining tool that does increased damage in low pressure."
 	icon_state = "kineticgun"
 	item_state = "kineticgun"
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic)
@@ -334,28 +334,6 @@
 	..()
 	modifier = initial(modifier) //get our modifiers back
 	turf_aoe = initial(turf_aoe)
-	if(stats_stolen) //if we had our stats stolen, find the stealer and take them from it
-		for(var/obj/item/borg/upgrade/modkit/aoe/AOE in KA.modkits)
-			if(AOE.stats_stolen)
-				continue
-			AOE.modifier -= modifier
-			AOE.turf_aoe -= turf_aoe
-	else //otherwise, reset the stolen stats and have it recalculate
-		var/obj/item/borg/upgrade/modkit/aoe/new_stealer
-		for(var/obj/item/borg/upgrade/modkit/aoe/AOE in KA.modkits)
-			if(!new_stealer)
-				new_stealer = AOE //just make the first one a stealer
-			AOE.modifier = initial(AOE.modifier)
-			AOE.turf_aoe = initial(AOE.turf_aoe)
-			AOE.stats_stolen = FALSE
-		if(new_stealer) //if there's no stealer, then there's no other aoe modkits
-			for(var/obj/item/borg/upgrade/modkit/aoe/AOE in KA.modkits)
-				if(AOE != new_stealer)
-					new_stealer.modifier += AOE.modifier
-					AOE.modifier = 0
-					new_stealer.turf_aoe += AOE.turf_aoe
-					AOE.turf_aoe = FALSE
-					AOE.stats_stolen = TRUE
 	stats_stolen = FALSE
 
 /obj/item/borg/upgrade/modkit/aoe/modify_projectile(obj/item/projectile/kinetic/K)
@@ -418,7 +396,6 @@
 	name = "lifesteal crystal"
 	desc = "Causes kinetic accelerator shots to slightly heal the firer on striking a living target."
 	icon_state = "modkit_crystal"
-	denied_type = /obj/item/borg/upgrade/modkit/lifesteal
 	modifier = 2.5 //Not a very effective method of healing.
 	cost = 20
 	var/static/list/damage_heal_order = list(BRUTE, BURN, OXY)


### PR DESCRIPTION
Frankly I'd be very surprised if a single miner got more than one, but if they do, they can actually take advantage of it for MAD HEALS.

Also removed some code that is entirely pointless when you can't remove a single modkit from the KA, only all of them at once.