### PR TITLE
Removes deadly snowballs

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1034,7 +1034,6 @@
 	desc = "A compact ball of snow. Good for throwing at people."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "snowball"
-	throwforce = 12 //pelt your enemies to death with lumps of snow
 
 /obj/item/toy/snowball/afterattack(atom/target as mob|obj|turf|area, mob/user)
 	user.drop_item()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1040,8 +1040,10 @@
 	src.throw_at(target, throw_range, throw_speed)
 
 /obj/item/toy/snowball/throw_impact(atom/hit_atom)
-	if(!..())
+	if((ishuman(hit_atom)))
+		var/mob/living/carbon/M = hit_atom
 		playsound(src, 'sound/effects/pop.ogg', 20, 1)
+		M.apply_damage(15, STAMINA)
 		qdel(src)
 
 /*


### PR DESCRIPTION

:cl: Cebutris
del: Removes the damage from snowballs
/:cl:

[why]: Because snowballs, as balls of snow, obtainable from the Winter Wonderland holodeck, should not do more damage than a harmbaton. Growing up in Canada, I myself have been pelted with more than ten snowballs in a row without requiring immediate medical attention, and those were REAL snowballs, not holographic ones that have no buisness doing any damage at all