### PR TITLE
[WIP] Makes overload respect override immunity and broken +  potentially adding to the blacklist

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -288,7 +288,11 @@
 
 	if(!canUseTopic())
 		return
-
+	
+	if(!M.can_be_overridden())
+		to_chat(src, "Can't overload this device.")
+		return
+	
 	if (istype(M, /obj/machinery))
 		for(var/datum/AI_Module/small/overload_machine/overload in current_modules)
 			if(overload.uses > 0)

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -293,6 +293,10 @@
 		to_chat(src, "Can't overload this device.")
 		return
 	
+	if(stat & BROKEN)
+		to_chat(src, "Target unresponsive: Critical Damage.")
+		return	
+
 	if (istype(M, /obj/machinery))
 		for(var/datum/AI_Module/small/overload_machine/overload in current_modules)
 			if(overload.uses > 0)
@@ -326,6 +330,10 @@
 	if (istype(M, /obj/machinery))
 		if(!M.can_be_overridden())
 			to_chat(src, "Can't override this device.")
+			return
+		if(stat & BROKEN)
+			to_chat(src, "Target unresponsive: Critical Damage.")
+			return
 		for(var/datum/AI_Module/small/override_machine/override in current_modules)
 			if(override.uses > 0)
 				override.uses --

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -23,7 +23,7 @@ Pipelines + Other Objects -> Pipe network
 	var/can_unwrench = 0
 	var/initialize_directions = 0
 	var/pipe_color
-	can_be_overridden = 0
+	var/can_be_overridden = 0
 	
 	var/global/list/iconsetids = list()
 	var/global/list/pipeimages = list()
@@ -331,3 +331,9 @@ Pipelines + Other Objects -> Pipe network
 	else
 		// atmosinit() calls update_icon(), so we don't need to call it
 		update_icon()
+		
+/obj/machinery/atmospherics/can_be_overridden()
+	if(can_be_overridden)
+		return 1
+	else
+		return 0

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -23,7 +23,8 @@ Pipelines + Other Objects -> Pipe network
 	var/can_unwrench = 0
 	var/initialize_directions = 0
 	var/pipe_color
-
+	can_be_overridden = 0
+	
 	var/global/list/iconsetids = list()
 	var/global/list/pipeimages = list()
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -13,6 +13,7 @@ Passive gate is similar to the regular pump except:
 	desc = "A one-way air valve that does not require power."
 
 	can_unwrench = 1
+	can_be_overridden = 0
 
 	var/on = 0
 	var/target_pressure = ONE_ATMOSPHERE

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -6,8 +6,9 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	icon_state = "mvalve_map"
 	name = "manual valve"
 	desc = "A pipe valve"
-
+	
 	can_unwrench = 1
+	can_be_overridden = 0
 
 	var/frequency = 0
 	var/id = null
@@ -60,6 +61,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	desc = "A digitally controlled valve."
 	icon_state = "dvalve_map"
 	valve_type = "d"
+	can_be_overridden = 1
 
 /obj/machinery/atmospherics/components/binary/valve/digital/attack_ai(mob/user)
 	return src.attack_hand(user)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -6,6 +6,7 @@ On top of that, now people can add component-speciic procs/vars if they want!
 /obj/machinery/atmospherics/components
 	var/welded = 0 //Used on pumps and scrubbers
 	var/showpipe = 0
+	can_be_overridden = 1
 
 	var/list/datum/pipeline/parents
 	var/list/datum/gas_mixture/airs

--- a/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
@@ -6,6 +6,7 @@
 	desc = "Exchanges heat between two input gases. Setup for fast heat transfer"
 
 	can_unwrench = 1
+	can_be_overridden = 0
 
 	var/obj/machinery/atmospherics/components/unary/heat_exchanger/partner = null
 	var/update_cycle

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -7,6 +7,7 @@
 	var/obj/machinery/portable_atmospherics/connected_device
 	use_power = 0
 	level = 0
+	can_be_overridden = 0
 
 /obj/machinery/atmospherics/components/unary/portables_connector/New()
 	..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
@@ -9,6 +9,7 @@
 	var/volume = 10000 //in liters, 1 meters by 1 meters by 2 meters
 	density = 1
 	var/gas_type = 0
+	can_be_overridden = 0
 
 /obj/machinery/atmospherics/components/unary/tank/New()
 	..()


### PR DESCRIPTION
:cl:
balance: Machine overload now has a blacklist shared with override. Both can no longer act on broken machines.
fix: The override blacklisting now actually works.
/:cl:

Currently machine overload and machine override can target every type of obj/machine bar one: the cover of the portable turret. Overload can even target that. Now this might sound like working as intended but a long list of things are machines, including rather ubiquitous pipes and holo-pads. This pr will act as a list of things it shouldn't be able to blow up by community suggestion. I'm almost certainly going to add transit tubing and most of the atmos/disposals equipment but I want some feedback on what else should go in as well as HEALTHY DEBATE about whether each suggestion is freeze friendly.


Things that logically should not explode + community input:

- [x] anything with status BROKEN

- [x ] atmos pipes and manual equipment

- [ ] disposals pipes

- [ ] transit tubing

for your consideration
 
1. Every kind of atmos machine (vents pumps, filters, etc.)
2. Disposals machinery (the kind that goes on the terminals)
3. Suggestions
