### PR TITLE
Paper planes will be the same color as the paper used to create them.

### DIFF
--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -20,6 +20,7 @@
 	if(newPaper)
 		internalPaper = newPaper
 		flags = newPaper.flags
+		color = newPaper.color
 		newPaper.forceMove(src)
 	else
 		internalPaper = new /obj/item/weapon/paper(src)


### PR DESCRIPTION
:cl:
tweak: Paper planes are now the same color as the paper used to make them.
/:cl:

Is this really a tweak or should it be a feature or a fix? It's a one line change.