### PR TITLE
Adds an alternative method to creating black carpet

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -116,7 +116,7 @@
 	if (istype(O, /obj/item/toy/crayon/black))
 		use(1)
 		new/obj/item/stack/tile/carpet/black(user.loc)
-		..()
+	..()
 
 /obj/item/stack/tile/fakespace
 	name = "astral carpet"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -112,8 +112,15 @@
 	icon_state = "tile-carpet-black"
 	turf_type = /turf/open/floor/carpet/black
 
-/obj/item/stack/tile/carpet/black/fifty
-	amount = 50
+/obj/item/stack/tile/carpet/attackby(obj/item/O, mob/user, params)
+	if (istype(O, /obj/item/toy/crayon/black))
+		amount -= 1
+		new/obj/item/stack/tile/carpet/black(user.loc)
+		if(amount == 0)
+			del src
+		else
+	else
+		return ..()
 
 /obj/item/stack/tile/fakespace
 	name = "astral carpet"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -114,13 +114,9 @@
 
 /obj/item/stack/tile/carpet/attackby(obj/item/O, mob/user, params)
 	if (istype(O, /obj/item/toy/crayon/black))
-		amount -= 1
+		use(1)
 		new/obj/item/stack/tile/carpet/black(user.loc)
-		if(amount == 0)
-			del src
-		else
-	else
-		return ..()
+		..()
 
 /obj/item/stack/tile/fakespace
 	name = "astral carpet"

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -379,12 +379,6 @@
 	result = /obj/item/toy/sword
 	category = CAT_MISC
 
-/datum/crafting_recipe/blackcarpet
-	name = "Black Carpet"
-	reqs = list(/obj/item/stack/tile/carpet = 50, /obj/item/toy/crayon/black = 1)
-	result = /obj/item/stack/tile/carpet/black/fifty
-	category = CAT_MISC
-
 /datum/crafting_recipe/showercurtain
 	name = "Shower Curtains"
 	reqs = 	list(/obj/item/stack/sheet/cloth = 2, /obj/item/stack/sheet/plastic = 2, /obj/item/stack/rods = 1)


### PR DESCRIPTION
:cl: Goodstuff
Add: Black carpet is can now be made by hitting a crayon against regular carpet
tweak: The black carpet recipe in the crafting menu gives less black carpet
/:cl:

Now you can make a few extra tiles of black carpet without needing to go and steal the library floor for just 3 extra black carpet tiles.
