### PR TITLE
Removes swat/combat knifes crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -325,29 +325,6 @@
 					/obj/item/clothing/suit/armor/bulletproof)
 	crate_name = "bulletproof armor crate"
 
-/datum/supply_pack/security/armory/swat
-	name = "SWAT Crate"
-	cost = 6000
-	contains = list(/obj/item/clothing/head/helmet/swat/nanotrasen,
-					/obj/item/clothing/head/helmet/swat/nanotrasen,
-					/obj/item/clothing/suit/space/swat,
-					/obj/item/clothing/suit/space/swat,
-					/obj/item/clothing/mask/gas/sechailer/swat,
-					/obj/item/clothing/mask/gas/sechailer/swat,
-					/obj/item/weapon/storage/belt/military/assault,
-					/obj/item/weapon/storage/belt/military/assault,
-					/obj/item/clothing/gloves/combat,
-					/obj/item/clothing/gloves/combat)
-	crate_name = "swat crate"
-
-/datum/supply_pack/security/armory/combatknives
-	name = "Combat Knives Crate"
-	cost = 3000
-	contains = list(/obj/item/weapon/kitchen/knife/combat,
-					/obj/item/weapon/kitchen/knife/combat,
-					/obj/item/weapon/kitchen/knife/combat)
-	crate_name = "combat knife crate"
-
 /datum/supply_pack/security/armory/laserarmor
 	name = "Reflector Vest Crate"
 	cost = 2000


### PR DESCRIPTION




:cl: Improvedname
del: Removes swat crate/combat knive crate
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) BRINGS NOTHING TO THE GAME NEVER GETS ORDERED BECAUSE IN REALITY IS THRESH AND NOBODY WANTS IT BAWHOPPEN ONLY ADDED IT TO STATIFY HIS TACTICAL MEMES.
