### PR TITLE
Flashdarks can't be used for examining eyes/mouth.

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -57,7 +57,7 @@
 			to_chat(user, "<span class='warning'>[M] doesn't have a head!</span>")
 			return
 
-		if(flashlight_power && flashlight_power < 1)
+		if(flashlight_power < 1)
 			to_chat(user, "<span class='warning'>\The [src] isn't bright enough to see anything!</span> ")
 			return
 		

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -57,6 +57,10 @@
 			to_chat(user, "<span class='warning'>[M] doesn't have a head!</span>")
 			return
 
+		if(flashlight_power && flashlight_power < 1)
+			to_chat(user, "<span class='warning'>\The [src] isn't bright enough to see anything!</span> ")
+			return
+		
 		switch(user.zone_selected)
 			if("eyes")
 				if((M.head && M.head.flags_cover & HEADCOVERSEYES) || (M.wear_mask && M.wear_mask.flags_cover & MASKCOVERSEYES) || (M.glasses && M.glasses.flags_cover & GLASSESCOVERSEYES))


### PR DESCRIPTION
Fixes #28333

:cl: optional name here
fix: Flashdarks can no longer be used to examine head based organs.
/:cl:
