### PR TITLE
Make goonchat use unverified asset sending

### DIFF
--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -280,7 +280,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	)
 
 /datum/asset/simple/goonchat
-	verify = TRUE
+	verify = FALSE
 	assets = list(
 		"jquery.min.js"            = 'code/modules/html_interface/js/jquery.min.js',
 		"json2.min.js"             = 'code/modules/goonchat/browserassets/js/json2.min.js',


### PR DESCRIPTION
Verified asset sending is only needed for use with `output()` (goonchat loading uses `browse()`) and doing verified sending too soon after a client connects causes bugs.

@Cyberboss @lzimann 
