### PR TITLE
Workaround for byond bug causing clients to flood the server with repeated asset cache arrival messages

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -40,7 +40,7 @@
 			return
 		else if (job in completed_asset_jobs) //byond bug ID:2256651
 			to_chat(src, "<span class='danger'>An error has been detected in how your client is receiving resources. Attempting to correct.... (If you keep seeing these messages you might want to close byond and reconnect)</span>")
-			client << browse("...", "window=asset_cache_browser")
+			src << browse("...", "window=asset_cache_browser")
 
 	if (!holder && config.minutetopiclimit)
 		var/minute = round(world.time, 600)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -38,6 +38,9 @@
 		if (job && job <= last_asset_job && !(job in completed_asset_jobs))
 			completed_asset_jobs += job
 			return
+		else if (job in completed_asset_jobs) //byond bug ID:2256651
+			to_chat(src, "<span class='danger'>An error has been detected in how your client is receiving resources. Attempting to correct.... (If you keep seeing these messages you might want to close byond and reconnect)</span>")
+			client << browse("...", "window=asset_cache_browser")
 
 	if (!holder && config.minutetopiclimit)
 		var/minute = round(world.time, 600)


### PR DESCRIPTION
http://www.byond.com/forum/?post=2256651



:cl:
experiment: Added some code to detect the byond bug causing clients to send phantom actions shortly after connection. It will attempt to fix or work around the issue.
/:cl: