### PR TITLE
Datum antag refactor

### DIFF
--- a/code/datums/antagonists/antag_datum.dm
+++ b/code/datums/antagonists/antag_datum.dm
@@ -22,11 +22,15 @@
 
 /datum/antagonist/proc/can_be_owned(datum/mind/new_owner)
 	. = TRUE
-	if(owner.has_antag_datum(type))
+	if(!new_owner)
+		new_owner = owner
+	if(new_owner.has_antag_datum(type))
 		return FALSE
-	for(var/i in owner.antag_datums)
+	for(var/i in new_owner.antag_datums)
 		var/datum/antagonist/A = i
 		if(is_type_in_typecache(src, A.typecache_datum_blacklist))
+			return FALSE
+		if(is_type_in_typecache(A, typecache_datum_blacklist))
 			return FALSE
 
 /datum/antagonist/proc/on_body_transfer(mob/living/old_body, mob/living/new_body)
@@ -61,3 +65,9 @@
 
 /datum/antagonist/proc/farewell()
 	return
+
+/datum/antagonist/proc/create_antagonist_group(var/list/datum/mind/targets) //overridden where creating a group is different, e.g double agents (internal affairs) 
+	for(var/M in targets)
+		var/datum/mind/target = M
+		target.add_antag_datum(type)
+	

--- a/code/datums/antagonists/datum_traitor.dm
+++ b/code/datums/antagonists/datum_traitor.dm
@@ -1,3 +1,4 @@
+#define TRAITORS_REQUIRED_FOR_EXCHANGE 8
 /datum/antagonist/traitor
 	name = "Traitor"
 	var/should_specialise = TRUE //do we split into AI and human
@@ -9,6 +10,39 @@
 	var/give_objectives = TRUE
 	var/should_give_codewords = TRUE
 	var/list/objectives_given = list()
+
+/datum/antagonist/traitor/create_antagonist_group(var/list/datum/mind/targets)
+	.=..(targets)
+	if(length(targets)>=TRAITORS_REQUIRED_FOR_EXCHANGE)
+		shuffle_inplace(targets)
+
+		var/datum/mind/M1
+		var/datum/mind/M2
+		for(var/T in targets)
+			var/datum/mind/M = T
+			if(ishuman(M.current))
+				M1 = M
+				break
+		if(!M1)
+			return .
+		for(var/T in targets)
+			var/datum/mind/M = T
+			if(M == M1)
+				continue
+			if(ishuman(M.current))
+				M2 = M
+				break
+		if(!M2)
+			return .
+		var/datum/antagonist/traitor/human/A1 = M1.has_antag_datum(type)
+		if(!A1)
+			return .
+		var/datum/antagonist/traitor/human/A2 = M2.has_antag_datum(type)
+		if(!A2)
+			return .
+		A2.add_exchange("red", M2)
+		A1.add_exchange("blue", M1)
+		
 
 /datum/antagonist/traitor/proc/transfer_important_variables(datum/antagonist/traitor/other)
 	other.silent = silent
@@ -41,13 +75,13 @@
 	if(istype(new_body,/mob/living/silicon/ai)==istype(old_body,/mob/living/silicon/ai))
 		..()
 	else
-		silent = TRUE
 		owner.add_antag_datum(base_datum_custom)
 		for(var/datum/antagonist/traitor/new_datum in owner.antag_datums)
 			if(new_datum == src)
 				continue
 			transfer_important_variables(new_datum)
 			break
+		silent = TRUE
 		on_removal()
 		
 		
@@ -62,10 +96,15 @@
 	should_give_codewords = FALSE
 
 /datum/antagonist/traitor/proc/specialise()
-	silent = TRUE
 	if(owner.current&&istype(owner.current,/mob/living/silicon/ai))
-		owner.add_antag_datum(ai_datum)
-	else owner.add_antag_datum(human_datum)
+		var/datum/antagonist/traitor/A = new ai_datum
+		transfer_important_variables(A)
+		owner.add_preexisting_antag_datum(A)
+	else 
+		var/datum/antagonist/traitor/A = new human_datum
+		transfer_important_variables(A)
+		owner.add_preexisting_antag_datum(A)
+	silent = TRUE
 	on_removal()
 	
 /datum/antagonist/traitor/on_gain()
@@ -127,14 +166,6 @@
 	var/is_hijacker = prob(10)
 	var/martyr_chance = prob(20)
 	var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
-	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 8) 	//Set up an exchange if there are enough traitors
-		if(!SSticker.mode.exchange_red)
-			SSticker.mode.exchange_red = owner
-		else
-			SSticker.mode.exchange_blue = owner
-			assign_exchange_role(SSticker.mode.exchange_red)
-			assign_exchange_role(SSticker.mode.exchange_blue)
-		objective_count += 1					//Exchange counts towards number of objectives
 	for(var/i = objective_count, i < config.traitor_objectives_amount, i++)
 		forge_single_objective()
 
@@ -284,29 +315,26 @@
 /datum/antagonist/traitor/human/equip(var/silent = FALSE)
 	owner.equip_traitor(employer, silent)
 
-/datum/antagonist/traitor/human/proc/assign_exchange_role()
-	//set faction
-	var/faction = "red"
-	if(owner == SSticker.mode.exchange_blue)
-		faction = "blue"
-
+/datum/antagonist/traitor/human/proc/add_exchange(var/faction, var/datum/mind/target)
 	//Assign objectives
 	var/datum/objective/steal/exchange/exchange_objective = new
-	exchange_objective.set_faction(faction,((faction == "red") ? SSticker.mode.exchange_blue : SSticker.mode.exchange_red))
+	exchange_objective.set_faction(faction,target)
 	exchange_objective.owner = owner
 	add_objective(exchange_objective)
+	owner.announce_last_objective()
 
 	if(prob(20))
 		var/datum/objective/steal/exchange/backstab/backstab_objective = new
 		backstab_objective.set_faction(faction)
 		backstab_objective.owner = owner
 		add_objective(backstab_objective)
+		owner.announce_last_objective()
 
 	//Spawn and equip documents
 	var/mob/living/carbon/human/mob = owner.current
 
 	var/obj/item/weapon/folder/syndicate/folder
-	if(owner == SSticker.mode.exchange_red)
+	if(faction == "red")
 		folder = new/obj/item/weapon/folder/syndicate/red(mob.loc)
 	else
 		folder = new/obj/item/weapon/folder/syndicate/blue(mob.loc)
@@ -323,3 +351,4 @@
 		where = "In your [equipped_slot]"
 	to_chat(mob, "<BR><BR><span class='info'>[where] is a folder containing <b>secret documents</b> that another Syndicate group wants. We have set up a meeting with one of their agents on station to make an exchange. Exercise extreme caution as they cannot be trusted and may be hostile.</span><BR>")
 
+#undef TRAITORS_REQUIRED_FOR_EXCHANGE

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -128,16 +128,20 @@
 	memory = null
 
 // Datum antag mind procs
-/datum/mind/proc/add_antag_datum(datum_type)
-	if(!datum_type)
-		return
-	var/datum/antagonist/A = new datum_type(src)
+/datum/mind/proc/add_preexisting_antag_datum(var/datum/antagonist/A)
+	A.owner = src
 	if(!A.can_be_owned(src))
 		qdel(A)
 		return
 	LAZYADD(antag_datums, A)
 	A.on_gain()
 	return A
+	
+/datum/mind/proc/add_antag_datum(datum_type)
+	if(!datum_type)
+		return
+	var/datum/antagonist/A = new datum_type()
+	add_preexisting_antag_datum(A)
 
 /datum/mind/proc/remove_antag_datum(datum_type)
 	if(!datum_type)
@@ -1419,12 +1423,19 @@
 
 	edit_memory()
 
+/datum/mind/proc/announce_objective(var/obj_count)
+	var/datum/objective/O = objectives[obj_count]
+	var/exp_text = O.explanation_text
+	to_chat(current, "<B>Objective #[obj_count]</B>: [exp_text]")
+
+/datum/mind/proc/announce_last_objective()
+	announce_objective(length(objectives))
+
 /datum/mind/proc/announce_objectives()
 	var/obj_count = 1
 	to_chat(current, "<span class='notice'>Your current objectives:</span>")
 	for(var/objective in objectives)
-		var/datum/objective/O = objective
-		to_chat(current, "<B>Objective #[obj_count]</B>: [O.explanation_text]")
+		announce_objective(obj_count)
 		obj_count++
 
 /datum/mind/proc/find_syndicate_uplink()

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -1,5 +1,4 @@
 /datum/game_mode
-	var/list/target_list = list()
 	var/list/late_joining_list = list()
 
 /datum/game_mode/traitor/internal_affairs
@@ -21,40 +20,14 @@
 
 
 
-/datum/game_mode/traitor/internal_affairs/post_setup()
-	var/i = 0
-	for(var/datum/mind/traitor in pre_traitors)
-		i++
-		if(i + 1 > pre_traitors.len)
-			i = 0
-		target_list[traitor] = pre_traitors[i+1]	
-	..()
-
-
 /datum/game_mode/traitor/internal_affairs/add_latejoin_traitor(datum/mind/character)
 
 	check_potential_agents()
 
 	// As soon as we get 3 or 4 extra latejoin traitors, make them traitors and kill each other.
 	if(late_joining_list.len >= rand(3, 4))
-		// True randomness
-		shuffle_inplace(late_joining_list)
-		// Reset the target_list, it'll be used again in force_traitor_objectives
-		target_list = list()
-
-		// Basically setting the target_list for who is killing who
-		var/i = 0
-		for(var/datum/mind/traitor in late_joining_list)
-			i++
-			if(i + 1 > late_joining_list.len)
-				i = 0
-			target_list[traitor] = late_joining_list[i + 1]
-			traitor.special_role = traitor_name
-
-		// Now, give them their targets
-		for(var/datum/mind/traitor in target_list)
-			..(traitor)
-
+		var/datum/antagonist/A = new antag_datum
+		A.create_antagonist_group(late_joining_list)
 		late_joining_list = list()
 	else
 		late_joining_list += character

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -25,7 +25,7 @@
 	var/list/datum/mind/pre_traitors = list()
 	var/traitors_possible = 4 //hard limit on traitors if scaling is turned off
 	var/num_modifier = 0 // Used for gamemodes, that are a child of traitor, that need more than the usual.
-	var/antag_datum = ANTAG_DATUM_TRAITOR //what type of antag to create
+	var/datum/antagonist/antag_datum = ANTAG_DATUM_TRAITOR //what type of antag to create
 
 
 /datum/game_mode/traitor/pre_setup()
@@ -60,9 +60,8 @@
 
 
 /datum/game_mode/traitor/post_setup()
-	for(var/datum/mind/traitor in pre_traitors)
-		spawn(rand(10,100))
-			traitor.add_antag_datum(antag_datum)
+	var/datum/antagonist/A = new antag_datum
+	A.create_antagonist_group(pre_traitors)
 	if(!exchange_blue)
 		exchange_blue = -1 //Block latejoiners from getting exchange objectives
 	modePlayer += traitors
@@ -162,3 +161,4 @@
 	var/datum/atom_hud/antag/traitorhud = GLOB.huds[ANTAG_HUD_TRAITOR]
 	traitorhud.leave_hud(traitor_mind.current)
 	set_antag_hud(traitor_mind.current, null)
+

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -38,8 +38,7 @@
 	if(config.protect_assistant_from_antagonist)
 		temp.restricted_jobs += "Assistant"
 
-	var/list/mob/living/carbon/human/candidates = list()
-	var/mob/living/carbon/human/H = null
+	var/list/datum/mind/candidates = list()
 
 	for(var/mob/living/carbon/human/applicant in GLOB.player_list)
 		if(ROLE_TRAITOR in applicant.client.prefs.be_special)
@@ -49,19 +48,16 @@
 						if(!jobban_isbanned(applicant, ROLE_TRAITOR) && !jobban_isbanned(applicant, "Syndicate"))
 							if(temp.age_check(applicant.client))
 								if(!(applicant.job in temp.restricted_jobs))
-									candidates += applicant
+									candidates += applicant.mind
 
 	if(candidates.len)
 		var/numTraitors = min(candidates.len, 3)
-
-		for(var/i = 0, i<numTraitors, i++)
-			H = pick(candidates)
-			H.mind.make_Traitor()
-			candidates.Remove(H)
-
+		shuffle_inplace(candidates)
+		var/list/datum/mind/final_cut = candidates.Copy(1,numTraitors + 1)
+		var/datum/antagonist/traitor/T = new
+		T.create_antagonist_group(final_cut)
+		
 		return 1
-
-
 	return 0
 
 


### PR DESCRIPTION
This adds the ability to create a datum-based antag as a group, currently used for IAA and the document exchange objective. This allows for less dependence on gamemode code, which brings us closer to DATUM HEAVEN.