### PR TITLE
A fix, a feature, and a lot of much needed description love

### DIFF
--- a/code/game/machinery/embedded_controller/access_controller.dm
+++ b/code/game/machinery/embedded_controller/access_controller.dm
@@ -41,6 +41,7 @@
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "access_button_standby"
 	name = "access button"
+	desc = "A button used for the explicit purpose of opening an airlock."
 	var/idDoor
 	var/obj/machinery/door/airlock/door
 	var/obj/machinery/doorButtons/airlock_controller/controller
@@ -105,6 +106,7 @@
 /obj/machinery/doorButtons/airlock_controller
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "access_control_standby"
+	desc = "A small console that can cycle opening between two airlocks."
 	name = "access console"
 	var/obj/machinery/door/airlock/interiorAirlock
 	var/obj/machinery/door/airlock/exteriorAirlock

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -3,6 +3,7 @@
 // can also operate on non-loc area through "otherarea" var
 /obj/machinery/light_switch
 	name = "light switch"
+	desc = "Make dark."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light1"
 	anchored = 1

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -96,6 +96,7 @@ Class Procs:
 /obj/machinery
 	name = "machinery"
 	icon = 'icons/obj/stationobjs.dmi'
+	desc = "Some kind of machine."
 	verb_say = "beeps"
 	verb_yell = "blares"
 	pressure_resistance = 15

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -2,6 +2,7 @@
 	name = "pipe dispenser"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "pipe_d"
+	desc = "Dispenses countless types of pipes. Very useful if you need pipes."
 	density = 1
 	anchored = 1
 	var/wait = 0
@@ -107,6 +108,7 @@
 	name = "disposal pipe dispenser"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "pipe_d"
+	desc = "Dispenses pipes that will ultimately be used to move trash around."
 	density = 1
 	anchored = 1
 
@@ -181,6 +183,7 @@ Nah
 	name = "transit tube dispenser"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "pipe_d"
+	desc = "Dispenses pipes that will move humans and/or trash around."
 	density = 1
 	anchored = 1
 

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -8,6 +8,7 @@
 	name = "turret"
 	icon = 'icons/obj/turrets.dmi'
 	icon_state = "turretCover"
+	desc = "A covered turret that shoots at its enemies."
 	anchored = 1
 	layer = OBJ_LAYER
 	invisibility = INVISIBILITY_OBSERVER	//the turret is invisible if it's inside its cover
@@ -548,6 +549,8 @@
 	installation = /obj/item/weapon/gun/energy/laser
 
 /obj/machinery/porta_turret/syndicate
+	name = "mechanical turret"
+	desc = "A ballistic machine gun auto-turret."
 	installation = null
 	always_up = 1
 	use_power = 0

--- a/code/game/machinery/telecomms/computers/logbrowser.dm
+++ b/code/game/machinery/telecomms/computers/logbrowser.dm
@@ -3,6 +3,7 @@
 /obj/machinery/computer/telecomms/server
 	name = "telecommunications server monitoring console"
 	icon_screen = "comm_logs"
+	desc = "Has full access to all details and record of the telecommunications network it's monitoring."
 
 	var/screen = 0				// the screen number:
 	var/list/servers = list()	// the servers located by the computer

--- a/code/game/machinery/telecomms/computers/telemonitor.dm
+++ b/code/game/machinery/telecomms/computers/telemonitor.dm
@@ -8,6 +8,7 @@
 /obj/machinery/computer/telecomms/monitor
 	name = "telecommunications monitoring console"
 	icon_screen = "comm_monitor"
+	desc = "Monitors the details of the telecommunications network it's synced with."
 
 	var/screen = 0				// the screen number:
 	var/list/machinelist = list()	// the machines located by the computer

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -4,6 +4,7 @@
 	suffix = "\[3\]"
 	icon_state = "walkietalkie"
 	item_state = "walkietalkie"
+	desc = "A basic handheld radio that communicates with local telecommunication networks."
 	dog_fashion = /datum/dog_fashion/back
 	var/on = 1 // 0 for off
 	var/last_transmission

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -41,7 +41,7 @@
 
 /obj/item/target/syndicate
 	icon_state = "target_s"
-	desc = "A shooting target that looks like a syndicate scum."
+	desc = "A shooting target that looks like syndicate scum."
 	hp = 2600
 
 /obj/item/target/alien

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -140,6 +140,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("coffin", /obj/structure/closet/coffin, 5, time = 15, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("book case", /obj/structure/bookcase, 4, time = 15, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("drying rack", /obj/machinery/smartfridge/drying_rack, 10, time = 15, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("dresser", /obj/structure/dresser, 10, time = 15, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("dog bed", /obj/structure/bed/dogbed, 10, time = 10, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("picture frame", /obj/item/wallframe/picture, 1, time = 10),\
 	new/datum/stack_recipe("display case chassis", /obj/structure/displaycase_chassis, 5, one_per_turf = 1, on_floor = 1), \

--- a/code/game/objects/items/weapons/signs.dm
+++ b/code/game/objects/items/weapons/signs.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/picket_sign
 	icon_state = "picket"
 	name = "blank picket sign"
-	desc = "It's blank"
+	desc = "It's blank."
 	force = 5
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bashed","smacked")

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -289,7 +289,9 @@
 	icon_state = "grenadebeltnew"
 	item_state = "security"
 	max_w_class = WEIGHT_CLASS_BULKY
+	display_contents_with_number = 1
 	storage_slots = 30
+	max_combined_w_class = 60 //needs to be this high
 	can_hold = list(
 		/obj/item/weapon/grenade,
 		/obj/item/weapon/screwdriver,

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -17,6 +17,7 @@
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "donutbox6"
 	name = "donut box"
+	desc = "Mmm. Donuts."
 	resistance_flags = FLAMMABLE
 	var/icon_type = "donut"
 	var/spawn_type = null

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -177,7 +177,7 @@
 	icon_opened = "safe0"
 	icon_locking = "safeb"
 	icon_sparking = "safespark"
-	desc = "Great for securing things against the masses."
+	desc = "Excellent for securing things away from grubby hands."
 	force = 8
 	w_class = WEIGHT_CLASS_GIGANTIC
 	max_w_class = 8

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -177,6 +177,7 @@
 	icon_opened = "safe0"
 	icon_locking = "safeb"
 	icon_sparking = "safespark"
+	desc = "Great for securing things against the masses."
 	force = 8
 	w_class = WEIGHT_CLASS_GIGANTIC
 	max_w_class = 8

--- a/code/game/objects/items/weapons/vending_items.dm
+++ b/code/game/objects/items/weapons/vending_items.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/vending_restock.dmi'
 	icon_state = "refill_snack"
 	item_state = "restock_unit"
+	desc = "A vending machine restock cart,"
 	flags = CONDUCT
 	force = 7
 	throwforce = 10

--- a/code/game/objects/items/weapons/vending_items.dm
+++ b/code/game/objects/items/weapons/vending_items.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/vending_restock.dmi'
 	icon_state = "refill_snack"
 	item_state = "restock_unit"
-	desc = "A vending machine restock cart,"
+	desc = "A vending machine restock cart."
 	flags = CONDUCT
 	force = 7
 	throwforce = 10

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -4,6 +4,7 @@
 	name = "\improper AI core"
 	icon = 'icons/mob/AI.dmi'
 	icon_state = "0"
+	desc = "The framework for an artificial intelligence core."
 	obj_integrity = 500
 	max_integrity = 500
 	var/state = 0

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -2,6 +2,7 @@
 	name = "airlock assembly"
 	icon = 'icons/obj/doors/airlocks/station/public.dmi'
 	icon_state = "construction"
+	desc = "The mechanical framework for an airlock."
 	var/overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 	anchored = 0
 	density = 1

--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -14,7 +14,7 @@
 			to_chat(user, "<span class='notice'>You successfully [anchored ? "unwrench" : "wrench"] [src].</span>")
 			anchored = !anchored
 
-/obj/vehicle/deconstruct(disassembled = TRUE)
+/obj/structure/dresser/deconstruct(disassembled = TRUE)
 	new /obj/item/stack/sheet/mineral/wood (loc, 10)
 	qdel(src)
 

--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -6,6 +6,18 @@
 	density = 1
 	anchored = 1
 
+/obj/structure/dresser/attackby(obj/item/P, mob/user, params)
+	if(istype(P, /obj/item/weapon/wrench))
+		to_chat(user, "<span class='notice'>You begin to [anchored ? "unwrench" : "wrench"] [src].</span>")
+		playsound(loc, P.usesound, 50, 1)
+		if(do_after(user, 20, target = src))
+			to_chat(user, "<span class='notice'>You successfully [anchored ? "unwrench" : "wrench"] [src].</span>")
+			anchored = !anchored
+
+/obj/vehicle/deconstruct(disassembled = TRUE)
+	new /obj/item/stack/sheet/mineral/wood (loc, 10)
+	qdel(src)
+
 /obj/structure/dresser/attack_hand(mob/user)
 	if(!Adjacent(user))//no tele-grooming
 		return

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -7,6 +7,7 @@
 //trees
 /obj/structure/flora/tree
 	name = "tree"
+	desc = "A large tree."
 	density = 1
 	pixel_x = -16
 	layer = FLY_LAYER
@@ -41,6 +42,7 @@
 
 /obj/structure/flora/tree/pine
 	name = "pine tree"
+	desc = "A large pine tree."
 	icon = 'icons/obj/flora/pinetrees.dmi'
 	icon_state = "pine_1"
 
@@ -50,6 +52,7 @@
 
 /obj/structure/flora/tree/pine/xmas
 	name = "xmas tree"
+	desc = "A wondrous Christmas tree."
 	icon_state = "pine_c"
 
 /obj/structure/flora/tree/pine/xmas/Initialize()
@@ -58,10 +61,12 @@
 
 /obj/structure/flora/tree/dead
 	icon = 'icons/obj/flora/deadtrees.dmi'
+	desc = "A dead tree. How it died, you know not."
 	icon_state = "tree_1"
 
 /obj/structure/flora/tree/palm
 	icon = 'icons/misc/beach2.dmi'
+	desc = "A tree straight from the tropics."
 	icon_state = "palm1"
 
 /obj/structure/flora/tree/palm/Initialize()
@@ -123,6 +128,7 @@
 //bushes
 /obj/structure/flora/bush
 	name = "bush"
+	desc = "Some kind of shrub or something."
 	icon = 'icons/obj/flora/snowflora.dmi'
 	icon_state = "snowbush1"
 	anchored = 1
@@ -135,6 +141,7 @@
 
 /obj/structure/flora/ausbushes
 	name = "bush"
+	desc = "Some kind of plant."
 	icon = 'icons/obj/flora/ausflora.dmi'
 	icon_state = "firstbush_1"
 
@@ -250,6 +257,7 @@
 
 /obj/item/weapon/twohanded/required/kirbyplants
 	name = "potted plant"
+	desc = "A little bit of nature contained in a pot."
 	icon = 'icons/obj/flora/plants.dmi'
 	icon_state = "plant-01"
 	layer = ABOVE_MOB_LAYER
@@ -352,6 +360,7 @@
 
 /obj/structure/flora/junglebush
 	name = "bush"
+	desc = "A wild plant that is found in jungles."
 	icon = 'icons/obj/flora/jungleflora.dmi'
 	icon_state = "busha"
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -2,6 +2,7 @@
 	name = "girder"
 	icon_state = "girder"
 	anchored = 1
+	desc = "A large structural assembly made out of metal; Requires a layer of metal before it can be considered a wall."
 	density = 1
 	layer = BELOW_OBJ_LAYER
 	var/state = GIRDER_NORMAL

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -3,6 +3,7 @@
 // normal transit tubes
 /obj/structure/c_transit_tube
 	name = "unattached transit tube"
+	desc = "A transit tube for moving things around."
 	icon = 'icons/obj/atmospherics/pipes/transit_tube.dmi'
 	icon_state = "straight"
 	density = 0
@@ -152,6 +153,7 @@
 //see station.dm for the logic
 /obj/structure/c_transit_tube_pod
 	name = "unattached transit tube pod"
+	desc = "The lynchpin of the transit system."
 	icon = 'icons/obj/atmospherics/pipes/transit_tube.dmi'
 	icon_state = "pod"
 	anchored = 0

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -12,7 +12,8 @@
 /obj/structure/windoor_assembly
 	icon = 'icons/obj/doors/windoor.dmi'
 
-	name = "windoor Assembly"
+	name = "windoor assembly"
+	desc = "A small glass and wire assembly for windoors."
 	icon_state = "l_windoor_assembly01"
 	anchored = 0
 	density = 0

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -6,39 +6,44 @@
 
 /obj/structure/shuttle/engine
 	name = "engine"
+	desc = "A bluespace engine used to make shuttles move forwards."
 	density = 1
 	anchored = 1
 
 /obj/structure/shuttle/engine/heater
-	name = "heater"
+	name = "engine heater"
+	desc = "Directs energy into compressed particles in order to power engines."
 	icon_state = "heater"
 
 /obj/structure/shuttle/engine/platform
-	name = "platform"
+	name = "engine platform"
+	desc = "A platform for engine components, or something."
 	icon_state = "platform"
 
 /obj/structure/shuttle/engine/propulsion
-	name = "propulsion"
+	name = "propulsion engine"
+	desc = "A standard reliable bluespace engine used by many forms of shuttles."
 	icon_state = "propulsion"
 	opacity = 1
 
 /obj/structure/shuttle/engine/propulsion/burst
-	name = "burst"
+	name = "burst engine"
+	desc = "An engine that releases a large bluespace burst to propel it forwards."
 
 /obj/structure/shuttle/engine/propulsion/burst/left
-	name = "left"
 	icon_state = "burst_l"
 
 /obj/structure/shuttle/engine/propulsion/burst/right
-	name = "right"
 	icon_state = "burst_r"
 
 /obj/structure/shuttle/engine/router
-	name = "router"
+	name = "engine router"
+	desc = "Redirects around energized particles in engine structures."
 	icon_state = "router"
 
 /obj/structure/shuttle/engine/large
 	name = "engine"
+	desc = "A very large bluespace engine used to propel very large ships forwards."
 	opacity = 1
 	icon = 'icons/obj/2x2.dmi'
 	icon_state = "large_engine"
@@ -48,6 +53,7 @@
 
 obj/structure/shuttle/engine/huge
 	name = "engine"
+	desc = "An extremely large bluespace engine used to propel extremely large ships forwards."
 	opacity = 1
 	icon = 'icons/obj/3x3.dmi'
 	icon_state = "huge_engine"

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -5,7 +5,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 /obj/machinery/atmospherics/components/binary/valve
 	icon_state = "mvalve_map"
 	name = "manual valve"
-	desc = "A pipe valve"
+	desc = "A pipe valve."
 
 	can_unwrench = 1
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -1,6 +1,7 @@
 /obj/machinery/atmospherics/components/trinary/filter
 	name = "gas filter"
 	icon_state = "filter_off"
+	desc = "Very useful for filtering gasses."
 	density = 0
 	can_unwrench = 1
 	var/on = 0
@@ -12,12 +13,12 @@
 /obj/machinery/atmospherics/components/trinary/filter/flipped
 	icon_state = "filter_off_f"
 	flipped = 1
-	
+
 // These two filter types have critical_machine flagged to on and thus causes the area they are in to be exempt from the Grid Check event.
-	
+
 /obj/machinery/atmospherics/components/trinary/filter/critical
 	critical_machine = TRUE
-	
+
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical
 	critical_machine = TRUE
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -1,6 +1,7 @@
 /obj/machinery/atmospherics/components/trinary/mixer
 	icon_state = "mixer_off"
 	density = 0
+	desc = "Very useful for mixing gasses."
 
 	name = "gas mixer"
 	can_unwrench = 1

--- a/code/modules/atmospherics/machinery/other/zvent.dm
+++ b/code/modules/atmospherics/machinery/other/zvent.dm
@@ -1,8 +1,8 @@
 /obj/machinery/zvent
 	name = "interfloor air transfer system"
-
 	icon = 'icons/obj/atmospherics/components/unary_devices.dmi'
 	icon_state = "vent_map"
+	desc = "This may be needed some day."
 	density = 0
 	anchored=1
 

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -4,13 +4,10 @@
 /obj/machinery/atmospherics/pipe/manifold
 	icon = 'icons/obj/atmospherics/pipes/manifold.dmi'
 	icon_state = "manifold"
-
 	name = "pipe manifold"
 	desc = "A manifold composed of regular pipes"
-
 	dir = SOUTH
 	initialize_directions = EAST|NORTH|WEST
-
 	device_type = TRINARY
 
 /obj/machinery/atmospherics/pipe/manifold/SetInitDirections()

--- a/code/modules/atmospherics/machinery/pipes/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold4w.dm
@@ -4,12 +4,9 @@
 /obj/machinery/atmospherics/pipe/manifold4w
 	icon = 'icons/obj/atmospherics/pipes/manifold.dmi'
 	icon_state = "manifold4w"
-
 	name = "4-way pipe manifold"
 	desc = "A manifold composed of regular pipes"
-
 	initialize_directions = NORTH|SOUTH|EAST|WEST
-
 	device_type = QUATERNARY
 
 /obj/machinery/atmospherics/pipe/manifold4w/SetInitDirections()

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -1,13 +1,10 @@
 /obj/machinery/atmospherics/pipe
 	var/datum/gas_mixture/air_temporary //used when reconstructing a pipeline that broke
 	var/volume = 0
-
 	level = 1
-
 	use_power = 0
 	can_unwrench = 1
 	var/datum/pipeline/parent = null
-
 	//Buckling
 	can_buckle = 1
 	buckle_requires_restraints = 1

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -280,5 +280,5 @@
 
 /obj/item/clothing/head/crown/fancy
 	name = "magnificent crown"
-	desc = "A crown worn by only the highest emperors of the land."
+	desc = "A crown worn by only the highest emperors of the <s>land</s> space."
 	icon_state = "fancycrown"

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -14,6 +14,7 @@
 	name = "bookcase"
 	icon = 'icons/obj/library.dmi'
 	icon_state = "bookempty"
+	desc = "A great place for storing knowledge."
 	anchored = 0
 	density = 1
 	opacity = 0
@@ -166,6 +167,7 @@
 	name = "book"
 	icon = 'icons/obj/library.dmi'
 	icon_state ="book"
+	desc = "Crack it open, inhale the musk of its pages, and learn something new."
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL		 //upped to three because books are, y'know, pretty big. (and you could hide them inside eachother recursively forever)
@@ -289,6 +291,7 @@
 	name = "barcode scanner"
 	icon = 'icons/obj/library.dmi'
 	icon_state ="scanner"
+	desc = "A great tool if you want to scan a barcode."
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_TINY

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -19,6 +19,7 @@
 	icon_state = "oldcomp"
 	icon_screen = "library"
 	icon_keyboard = null
+	desc = "Ordered books MUST be returned on time."
 	circuit = /obj/item/weapon/circuitboard/computer/libraryconsole
 	var/screenstate = 0
 	var/title
@@ -161,6 +162,7 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 // It's December 25th, 2014, and this is STILL here, and it's STILL relevant. Kill me
 /obj/machinery/computer/libraryconsole/bookmanagement
 	name = "book inventory management console"
+	desc = "Librarian's command station."
 	var/arcanecheckout = 0
 	screenstate = 0 // 0 - Main Menu, 1 - Inventory, 2 - Checked Out, 3 - Check Out a Book
 	verb_say = "beeps"
@@ -554,6 +556,7 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 	name = "book binder"
 	icon = 'icons/obj/library.dmi'
 	icon_state = "binder"
+	desc = "Only useful for binding paper products."
 	anchored = 1
 	density = 1
 	var/busy = 0

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -4,6 +4,7 @@
 	name = "stacking machine console"
 	icon = 'icons/obj/machines/mining_machines.dmi'
 	icon_state = "console"
+	desc = "Controls a stacking machine. In theory."
 	density = 0
 	anchored = 1
 	var/obj/machinery/mineral/stacking_machine/machine = null
@@ -60,6 +61,7 @@
 	name = "stacking machine"
 	icon = 'icons/obj/machines/mining_machines.dmi'
 	icon_state = "stacker"
+	desc = "A machine that automatically stacks acquired materials. Controlled by a nearby console."
 	density = 1
 	anchored = 1
 	var/obj/machinery/mineral/stacking_unit_console/CONSOLE

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -134,6 +134,7 @@ GLOBAL_LIST_INIT(message_servers, list())
 	icon_state = "blackbox"
 	name = "Blackbox Recorder"
 	density = 1
+	desc = "A machine that attempts to learn everything there is in the universe."
 	anchored = 1
 	use_power = 1
 	idle_power_usage = 10

--- a/code/modules/shuttle/ferry.dm
+++ b/code/modules/shuttle/ferry.dm
@@ -1,5 +1,6 @@
 /obj/machinery/computer/shuttle/ferry
 	name = "transport ferry console"
+	desc = "A console that controls a transport ferry."
 	circuit = /obj/item/weapon/circuitboard/computer/ferry
 	shuttleId = "ferry"
 	possible_destinations = "ferry_home;ferry_away"

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -2,6 +2,7 @@
 
 /obj/machinery/computer/shuttle/syndicate
 	name = "syndicate shuttle terminal"
+	desc = "A terminal that controls the syndicate shuttle."
 	circuit = /obj/item/weapon/circuitboard/computer/syndicate_shuttle
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
@@ -13,6 +14,7 @@
 
 /obj/machinery/computer/shuttle/syndicate/recall
 	name = "syndicate shuttle recall terminal"
+	desc = "Use this if your friends leave you behind."
 	possible_destinations = "syndicate_away"
 
 
@@ -41,6 +43,7 @@
 
 /obj/machinery/computer/shuttle/syndicate/drop_pod
 	name = "syndicate assault pod control"
+	desc = "Controls the drop pod's launch."
 	icon = 'icons/obj/terminals.dmi'
 	icon_state = "dorm_available"
 	light_color = LIGHT_COLOR_BLUE


### PR DESCRIPTION

:cl:
add: Dressers are now construct-able with wood and can be unanchored and moved with a wrench.
fix: Grenade belts UI now doesn't cover half the screen.
add: Added countless new descriptions to things missing them.
/:cl:

Self explanatory PR.
