### PR TITLE
ore coin crossed runtime fix

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -36,7 +36,7 @@
 				if(istype(thing, /obj/item/weapon/storage/bag/ore))
 					OB = thing
 					break
-		else if(issilicon(AM))
+		else if(iscyborg(AM))
 			var/mob/living/silicon/robot/R = AM
 			for(var/thing in R.module_active)
 				if(istype(thing, /obj/item/weapon/storage/bag/ore))


### PR DESCRIPTION
Make sure it checks for the proper type and not the parent type as AI's
can actually move around the map

Fixes a runtime