### PR TITLE
Fixes a to_chat runtime, adds macro for sending images

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -1,3 +1,6 @@
+//wrapper macro for sending images that makes grepping easy
+#define SEND_IMAGE(target, image) target << image
+
 /proc/random_blood_type()
 	return pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")
 

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -625,7 +625,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	else if(src.dir == WEST)
 		del src.currentimage
 		src.currentimage = new /image(left,src)
-	to_chat(my_target, currentimage)
+	SEND_IMAGE(my_target, currentimage)
 
 
 /obj/effect/fake_attacker/proc/attack_loop()
@@ -669,7 +669,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	var/obj/effect/overlay/O = new/obj/effect/overlay(target.loc)
 	O.name = "blood"
 	var/image/I = image('icons/effects/blood.dmi',O,"floor[rand(1,7)]",O.dir,1)
-	to_chat(target, I)
+	SEND_IMAGE(target, I)
 	QDEL_IN(O, 300)
 
 
@@ -786,7 +786,6 @@ Gunshots/explosions/opening doors/less rare audio (done)
 			new /obj/effect/hallucination/items_other(src.loc,src)
 		if("sounds")
 			//Strange audio
-			//to_chat(src, "Strange Audio")
 			switch(rand(1,20))
 				if(1) playsound_local(null,'sound/machines/airlock.ogg', 15, 1)
 				if(2)


### PR DESCRIPTION
The macro makes it easier to grep for cases where an image or icon etc
is sent and reduces direct use of << which should make it easier to
convert later if required

NB: to_chat does work for these types but gives a stack trace as well,
so changing them to use the macro is better
