### PR TITLE
Changes default scaling mode to Point Sampling

### DIFF
--- a/interface/menu.dm
+++ b/interface/menu.dm
@@ -101,7 +101,7 @@ GLOBAL_LIST_EMPTY(menulist)
 /datum/verbs/menu/Icon/Scaling
 	checkbox = CHECKBOX_GROUP
 	name = "Scaling Mode"
-	default = /datum/verbs/menu/Icon/Scaling/verb/NN
+	default = /datum/verbs/menu/Icon/Scaling/verb/PS
 
 /datum/verbs/menu/Icon/Scaling/verb/NN()
 	set name = "@.winset \"mapwindow.map.zoom-mode=distort\""


### PR DESCRIPTION
:cl: Tacolizard
tweak: Point Sampling is now the default scaling mode
/:cl:

Most people who play this game do so using the stretch-to-fit option, because most people don't happen to have a monitor at a resolution to make a perfect scaling option fit properly. When using stretch-to-fit and Nearest Neighbor, the game looks strange, to say the least. Setting the scaling mode to point sampling is perfect because people who play at perfect scaling modes won't notice a difference, and everyone else will enjoy better looking scaling.