### PR TITLE
Reduces default brig times to be consistent with suggested policy.

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -5,8 +5,8 @@
 #define MAX_TIMER 9000
 
 #define PRESET_SHORT 1200
-#define PRESET_MEDIUM 3000
-#define PRESET_LONG 6000
+#define PRESET_MEDIUM 1800
+#define PRESET_LONG 3000
 
 
 
@@ -212,7 +212,7 @@
 	if(..())
 		return
 	. = TRUE
-	
+
 	if(!allowed(usr))
 		to_chat(usr, "<span class='warning'>Access denied.</span>")
 		return FALSE


### PR DESCRIPTION
:cl: bandit
tweak: Default short/medium/long brig times are now, in order, 2, 3, and 5 minutes.
/:cl:

## IMPORTANT NOTE, READ BEFORE COMMENTING: 
I do not know whether this violates the freeze. I consider it a necessary improvement to a civilian system, but it could be argued that it is a balance change. As an admin, who has to deal with sec ahelps several times per round, and as someone who hates people fighting over easily fixable shit, I would urge people to view it as the former.

**tl;dr: The default security brig timers are longer than policy suggests security applies. I believe this is a significant factor in the uptick in sec complaints lately, and one that is very easy to fix.**

As you may know, there have been endless complaints about security overreach lately. At least once per round I get a complaint about someone getting a 10-minute sentence. I've played since 2013 and adminned for at least a year. As an admin, I *never* got those complaints in this volume until recently, and as a player, I rarely saw 10-minute sentences.  People have thrown out a lot of possible reasons why, but I think a large factor is something pretty simple: people just clicking the default sentence. 

A couple months ago -- I think when brig doors were given a TGUI interface -- there were options put into place to set a preset Short, Medium, and Long brig timer with one click. Previously, your option was to set times manually. Anyone who plays security knows how annoying and fiddly it is to manually set a time, so most people just use the default times. The game outright encourages them to do so.

Currently, those times are:
- 2 minutes for a short sentence.
- 5 minutes for a medium sentence.
- 10 minutes for a long sentence.

These times are... long. And they're not consistent with what has been advised in security policy. Space Law is not official, but it is a good general ballpark here, as it has existed for over four years and advises times that are radically lower: 3 minutes for "medium" crimes like assault, and 5 minutes for major crimes like murder. 10 minutes is considered an extreme sentence, one where you should seriously consider perma. 

The Space Law times are also more in keeping with round lengths these days, where 10 minutes is often up to a third of the round.

The new times, then, are consistent with those, which are again:
- 2 minutes for a short sentence.
- 3 minutes for a medium sentence.
- 5 minutes for a long sentence.

You can still set custom sentences, obviously, but you have to do that manually. Let me reiterate that, **no one is taking away your ability to give up to 10 minutes**.

This is an easy fix, and I believe this will significantly cut down on the amount of unreasonable brig times, cut down on adminhelps about those times, and cause everyone a lot less grief. 