### PR TITLE
Revert "Makes cyborg module change logging not awful"

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -23,7 +23,7 @@
 	var/clean_on_move = FALSE
 
 	var/did_feedback = FALSE
-	var/uses_feedback = TRUE
+	var/feedback_key
 
 	var/hat_offset = -3
 
@@ -225,11 +225,8 @@
 	R.notify_ai(NEW_MODULE)
 	if(R.hud_used)
 		R.hud_used.update_robot_modules_display()
-	if(uses_feedback)
-		if(!did_feedback)
-			SSblackbox.add_details("cyborg_first_module", name)
-		else
-			SSblackbox.add_details("cyborg_module_change", name)
+	if(feedback_key && !did_feedback)
+		SSblackbox.inc(feedback_key, 1)
 
 /obj/item/weapon/robot_module/standard
 	name = "Standard"
@@ -255,6 +252,7 @@
 		/obj/item/clockwork/ratvarian_spear/cyborg,
 		/obj/item/clockwork/replica_fabricator/cyborg)
 	moduleselect_icon = "standard"
+	feedback_key = "cyborg_standard"
 	hat_offset = -3
 
 /obj/item/weapon/robot_module/medical
@@ -285,6 +283,7 @@
 		/obj/item/clockwork/ratvarian_spear/cyborg)
 	cyborg_base_icon = "medical"
 	moduleselect_icon = "medical"
+	feedback_key = "cyborg_medical"
 	can_be_pushed = FALSE
 	hat_offset = 3
 
@@ -318,6 +317,7 @@
 		/obj/item/clockwork/replica_fabricator/cyborg)
 	cyborg_base_icon = "engineer"
 	moduleselect_icon = "engineer"
+	feedback_key = "cyborg_engineering"
 	magpulsing = TRUE
 	hat_offset = INFINITY // No hats
 
@@ -334,6 +334,7 @@
 		/obj/item/clockwork/ratvarian_spear/cyborg)
 	cyborg_base_icon = "sec"
 	moduleselect_icon = "security"
+	feedback_key = "cyborg_security"
 	can_be_pushed = FALSE
 	hat_offset = 3
 
@@ -370,6 +371,7 @@
 		/obj/item/clockwork/ratvarian_spear/cyborg)
 	cyborg_base_icon = "peace"
 	moduleselect_icon = "standard"
+	feedback_key = "cyborg_peacekeeper"
 	can_be_pushed = FALSE
 	hat_offset = -2
 
@@ -397,6 +399,7 @@
 		/obj/item/clockwork/replica_fabricator/cyborg)
 	cyborg_base_icon = "janitor"
 	moduleselect_icon = "janitor"
+	feedback_key = "cyborg_janitor"
 	hat_offset = -5
 	clean_on_move = TRUE
 
@@ -447,6 +450,7 @@
 		/obj/item/borg/sight/xray/truesight_lens)
 	moduleselect_icon = "service"
 	special_light_key = "service"
+	feedback_key = "cyborg_service"
 	hat_offset = 0
 
 /obj/item/weapon/robot_module/butler/respawn_consumable(mob/living/silicon/robot/R, coeff = 1)
@@ -499,6 +503,7 @@
 		/obj/item/borg/sight/xray/truesight_lens)
 	cyborg_base_icon = "miner"
 	moduleselect_icon = "miner"
+	feedback_key = "cyborg_miner"
 	hat_offset = 0
 
 /obj/item/weapon/robot_module/syndicate
@@ -517,7 +522,6 @@
 		/obj/item/clockwork/ratvarian_spear/cyborg)
 	cyborg_base_icon = "synd_sec"
 	moduleselect_icon = "malf"
-	uses_feedback = FALSE
 	can_be_pushed = FALSE
 	hat_offset = 3
 
@@ -545,7 +549,6 @@
 		/obj/item/clockwork/ratvarian_spear/cyborg)
 	cyborg_base_icon = "synd_medical"
 	moduleselect_icon = "malf"
-	uses_feedback = FALSE
 	can_be_pushed = FALSE
 	hat_offset = 3
 


### PR DESCRIPTION
Reverts tgstation/tgstation#28406

@ChangelingRain 

This revert pr is purely out of spite that the original pr didn't explain what the fuck it did in any level of detail


Edit, after it's been explained to me, I'm still in for the revert.

In the old system, I can get data on a range of dates about cyborgs and modules directly in sql, and even directly export it to a chart, in this new system, I would have to make a 3rd party program to parse the data. And all for what seems to be no benefit.