### PR TITLE
Adds a policy notice to getting polymorphed

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -276,6 +276,7 @@
 	M.wabbajack_act(new_mob)
 
 	to_chat(new_mob, "<span class='warning'>Your form morphs into that of a [randomize].</span>")
+	to_chat(M, "<span class='danger'>Note that you are allowed to act as an antagonist while transformed, unless you wanted to be intentionally transformed.</span>")
 
 	qdel(M)
 	return new_mob

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -276,7 +276,7 @@
 	M.wabbajack_act(new_mob)
 
 	to_chat(new_mob, "<span class='warning'>Your form morphs into that of a [randomize].</span>")
-	to_chat(M, "<span class='danger'>Note that you are allowed to act as an antagonist while transformed, unless you wanted to be intentionally transformed.</span>")
+	to_chat(new_mob, "<span class='danger'>Note that you are allowed to act as an antagonist while transformed, unless you wanted to be intentionally transformed.</span>")
 
 	qdel(M)
 	return new_mob

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -276,7 +276,7 @@
 	M.wabbajack_act(new_mob)
 
 	to_chat(new_mob, "<span class='warning'>Your form morphs into that of a [randomize].</span>")
-	to_chat(new_mob, "<span class='danger'>Note that you are allowed to act as an antagonist while transformed, unless you wanted to be intentionally transformed.</span>")
+	to_chat(new_mob, "<span class='danger'>Note that you are allowed to act as an antagonist while transformed into a hostile mob, unless you volunteered for or seeked out transformation.</span>")
 
 	qdel(M)
 	return new_mob


### PR DESCRIPTION
Specifies our policy on whether or not you're an antagonist when you get polymorphed.

The message is `Note that you are allowed to act as an antagonist while transformed, unless you wanted to be intentionally transformed.` The span is `danger`. If either should be changed, let me know.