### PR TITLE
Cultists must be human to run for Cult Master status

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -232,8 +232,8 @@
 /datum/status_effect/cult_master
 	id = "The Cult Master"
 	duration = -1
-	tick_interval = 100
 	alert_type = null
+	on_remove_on_mob_delete = TRUE
 	var/alive = TRUE
 
 /datum/status_effect/cult_master/proc/deathrattle()
@@ -242,9 +242,8 @@
 		if(isliving(B.current))
 			var/mob/living/M = B.current
 			M << 'sound/hallucinations/veryfar_noise.ogg'
-			to_chat(M, "<span class='cultlarge'>The Cult's Master, [owner], has fallen in the [A]!")
-			
-			
+			to_chat(M, "<span class='cultlarge'>The Cult's Master, [owner], has fallen in \the [A]!</span>")
+
 /datum/status_effect/cult_master/tick()
 	if(owner.stat != DEAD && !alive)
 		alive = TRUE

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -237,6 +237,8 @@
 	var/alive = TRUE
 
 /datum/status_effect/cult_master/proc/deathrattle()
+	if(!QDELETED(GLOB.cult_narsie))
+		return //if nar-sie is alive, don't even worry about it
 	var/area/A = get_area(owner)
 	for(var/datum/mind/B in SSticker.mode.cult)
 		if(isliving(B.current))

--- a/code/game/gamemodes/cult/cult_comms.dm
+++ b/code/game/gamemodes/cult/cult_comms.dm
@@ -81,17 +81,12 @@
 	popup.open()
 	return 1
 
-/mob/living/proc/cult_master()
-	set category = "Cultist"
-	set name = "Assert Leadership"
-	pollCultists(src)  // This proc handles the distribution of cult master actions
-
 /datum/action/innate/cult/mastervote
 	name = "Assert Leadership"
 	button_icon_state = "cultvote"
 
 /datum/action/innate/cult/mastervote/IsAvailable()
-	if(GLOB.cult_vote_called)
+	if(GLOB.cult_vote_called || !ishuman(owner))
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
:cl: Joan
rscdel: Cultists must be human to run for Cult Master status.
/:cl:

Fixes #28431
Fixes #27304
Fixes a bug where a cult master being deleted wouldn't notify the cult
The cult master alert now ticks much faster, and is thus very likely to immediately alert the cult when the master dies rather than up to 10 seconds later
Added a missing span
