### PR TITLE
Autosurgeons/autoimplanters are used by attacking yourself, not using in hand.

### DIFF
--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -34,15 +34,16 @@
 	else if(!storedorgan)
 		to_chat(user, "<span class='notice'>[src] currently has no implant stored.</span>")
 		return
-	storedorgan.Insert(user)//insert stored organ into the user
-	user.visible_message("<span class='notice'>[user] holds [src] against [t_himself] and presses a button. A short mechanical noise emanates from the autoimplanter.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
-	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
-	storedorgan = null
-	name = initial(name)
-	if(uses != INFINITE)
-		uses--
-	if(!uses)
-		desc = "[initial(desc)] Looks like it's been used up."
+	if(do_after(user, 20, target = user))
+		storedorgan.Insert(user)//insert stored organ into the user
+		user.visible_message("<span class='notice'>[user] holds [src] close and presses a button. A short mechanical noise emanates from the autoimplanter.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
+		playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
+		storedorgan = null
+		name = initial(name)
+		if(uses != INFINITE)
+			uses--
+		if(!uses)
+			desc = "[initial(desc)] Looks like it's been used up."
 
 /obj/item/device/autosurgeon/attackby(obj/item/I, mob/user, params)
 	if(istype(I, organ_type))

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -2,7 +2,7 @@
 
 /obj/item/device/autosurgeon
 	name = "autosurgeon"
-	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. It has a slot to insert implants/organs and a screwdriver slot for removing accidentally added items."
+	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. It has a slot to insert implants/organs and a screwdriver slot for removing accidentally added items. Can only be used on oneself."
 	icon_state = "autoimplanter"
 	item_state = "walkietalkie"//left as this so as to intentionally not have inhands
 	w_class = WEIGHT_CLASS_SMALL
@@ -21,7 +21,13 @@
 	I.forceMove(src)
 	name = "[initial(name)] ([storedorgan.name])"
 
-/obj/item/device/autosurgeon/attack_self(mob/user)//when the object it used...
+/obj/item/device/autosurgeon/afterattack(obj/target, mob/user , proximity)//when the object it used..
+	if(!proximity)
+		return
+	if(!ishuman(target))
+		return
+	if(target != user) // no drive-by autoimplanting
+		return.
 	if(!uses)
 		to_chat(user, "<span class='warning'>[src] has already been used. The tools are dull and won't reactivate.</span>")
 		return
@@ -29,7 +35,7 @@
 		to_chat(user, "<span class='notice'>[src] currently has no implant stored.</span>")
 		return
 	storedorgan.Insert(user)//insert stored organ into the user
-	user.visible_message("<span class='notice'>[user] presses a button on [src], and you hear a short mechanical noise.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
+	user.visible_message("<span class='notice'>[user] holds [src] against [t_himself] and presses a button. A short mechanical noise emanates from the autoimplanter.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
 	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
 	storedorgan = null
 	name = initial(name)


### PR DESCRIPTION
:cl: bandit
tweak: Auto-implanters are now used by attacking yourself. There is a short cooldown.
/:cl:

Because using it in hand is a very unintuitive mechanic, inconsistent with almost every other device of this type. Also added a short cooldown.

I want to suppress the hit animation because it looks bad, but don't know how