### PR TITLE
Removes tech requirement from flashes

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -763,7 +763,6 @@
 	name = "Flash"
 	desc = "When a problem arises, SCIENCE is the solution."
 	id = "sflash"
-	req_tech = list("magnets" = 3, "combat" = 2)
 	build_type = MECHFAB
 	materials = list(MAT_METAL = 750, MAT_GLASS = 750)
 	construction_time = 100


### PR DESCRIPTION
:cl: Tacolizard
del: Flashes no longer have a tech requirement
/:cl:

why would flashes, a key part of borg making, be locked behind combat tech levels? Or tech levels at all? There's literally no other way to get flashes other than ordering from cargo, so if RnD never gets combat levels, robotics gets to sit around for the round after making a single borg.
