### PR TITLE
Fixes various bugs with photos and photo copying.

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -171,7 +171,7 @@
 					var/icon/small_img = icon(temp_img) //Icon() is needed or else temp_img will be rescaled too >.>
 					var/icon/ic = icon('icons/obj/items.dmi',"photo")
 					small_img.Scale(8, 8)
-					ic.Blend(small_img,ICON_OVERLAY, 10, 13)
+					ic.Blend(small_img,ICON_OVERLAY, 13, 13)
 					p.icon = ic
 					toner -= 5
 					busy = 1

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -533,7 +533,6 @@
 	cut_overlays()
 	if(displayed)
 		add_overlay(getFlatIcon(displayed))
-		add_overlay("frame-overlay")
 
 /obj/item/wallframe/picture/after_attach(obj/O)
 	..()
@@ -591,13 +590,12 @@
 
 /obj/structure/sign/picture_frame/attack_hand(mob/user)
 	if(framed)
-		framed.show()
+		framed.show(user)
 
 /obj/structure/sign/picture_frame/update_icon()
 	cut_overlays()
 	if(framed)
 		add_overlay(getFlatIcon(framed))
-		add_overlay("frame-overlay")
 
 /obj/structure/sign/picture_frame/deconstruct(disassembled = TRUE)
 	if(!(flags & NODECONSTRUCT))


### PR DESCRIPTION
* Fixes a bug where photo overlays would not show up on a picture frame when adding the photo. The nails or whatever overlay would sometimes override the actual photo but inconsistently.
* Fixes a bug where clicking a mounted picture frame would not display the photo to the user.
* Fixes a bug where photocopying your ass would offset the overlay to the left. Fixes https://github.com/tgstation/tgstation/issues/26469.