### PR TITLE
Fix player mob direction while riding the janicart and other rideable things

### DIFF
--- a/code/datums/riding.dm
+++ b/code/datums/riding.dm
@@ -86,6 +86,7 @@
 		if(!Process_Spacemove(direction) || !isturf(ridden.loc))
 			return
 		step(ridden, direction)
+		user.dir = ridden.dir //Why this isnt checked somewhere else is byond me
 
 		handle_vehicle_layer()
 		handle_vehicle_offsets()


### PR DESCRIPTION

:cl: NIN
fix: Player now faces correctly when riding Janicart and other ride able things
/:cl:

Pretty quick fix, just forces the players mob to face in the same direction as the thing they are riding. This shouldn't break unless something exists that the player doesn't face forward while riding on.

