### PR TITLE
Makes RCD ammo use consistent + small speed tweaks

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -125,8 +125,8 @@ obj/item/weapon/construction
 	var/canRturf = 0
 	var/ranged = FALSE
 	var/airlock_type = /obj/machinery/door/airlock
+	var/airlock_glass = FALSE // So the floor's rcd_act knows how much ammo to use
 	var/window_type = /obj/structure/window/fulltile
-
 	var/advanced_airlock_setting = 1 //Set to 1 if you want more paintjobs available
 	var/list/conf_access = null
 	var/use_one_access = 0 //If the airlock should require ALL or only ONE of the listed accesses.
@@ -266,8 +266,10 @@ obj/item/weapon/construction
 						airlock_type = /obj/machinery/door/airlock/external
 					if("High Security")
 						airlock_type = /obj/machinery/door/airlock/highsecurity
+				airlock_glass = FALSE
 			else
 				airlock_type = /obj/machinery/door/airlock
+				airlock_glass = FALSE
 
 		if("Glass")
 			if(advanced_airlock_setting == 1)
@@ -289,10 +291,13 @@ obj/item/weapon/construction
 						airlock_type = /obj/machinery/door/airlock/glass_research
 					if("Mining")
 						airlock_type = /obj/machinery/door/airlock/glass_mining
+				airlock_glass = TRUE
 			else
 				airlock_type = /obj/machinery/door/airlock/glass
+				airlock_glass = TRUE
 		else
 			airlock_type = /obj/machinery/door/airlock
+			airlock_glass = FALSE
 
 
 /obj/item/weapon/construction/rcd/proc/rcd_create(atom/A, mob/user)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -23,7 +23,9 @@
 		if(RCD_DECONSTRUCT)
 			return list("mode" = RCD_DECONSTRUCT, "delay" = 20, "cost" = 5)
 		if(RCD_WINDOWGRILLE)
-			return list("mode" = RCD_WINDOWGRILLE, "delay" = 40, "cost" = 10)
+			if(the_rcd.window_type == /obj/structure/window/reinforced/fulltile)
+				return list("mode" = RCD_WINDOWGRILLE, "delay" = 40, "cost" = 12)
+			else return list("mode" = RCD_WINDOWGRILLE, "delay" = 20, "cost" = 8)
 	return FALSE
 
 /obj/structure/grille/rcd_act(mob/user, var/obj/item/weapon/construction/rcd/the_rcd, passed_mode)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -206,11 +206,13 @@
 		if(RCD_FLOORWALL)
 			return list("mode" = RCD_FLOORWALL, "delay" = 20, "cost" = 16)
 		if(RCD_AIRLOCK)
-			return list("mode" = RCD_AIRLOCK, "delay" = 50, "cost" = 16)
+			if(the_rcd.airlock_glass)
+				return list("mode" = RCD_AIRLOCK, "delay" = 50, "cost" = 20)
+			else return list("mode" = RCD_AIRLOCK, "delay" = 50, "cost" = 16)
 		if(RCD_DECONSTRUCT)
 			return list("mode" = RCD_DECONSTRUCT, "delay" = 50, "cost" = 33)
 		if(RCD_WINDOWGRILLE)
-			return list("mode" = RCD_WINDOWGRILLE, "delay" = 40, "cost" = 4)
+			return list("mode" = RCD_WINDOWGRILLE, "delay" = 10, "cost" = 4)
 	return FALSE
 
 /turf/open/floor/rcd_act(mob/user, obj/item/weapon/construction/rcd/the_rcd, passed_mode)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -173,7 +173,10 @@
 
 	switch(the_rcd.mode)
 		if(RCD_FLOORWALL)
-			return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 2)
+			var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
+			if(L)
+				return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 1)
+			else return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 3)
 	return FALSE
 
 /turf/open/space/rcd_act(mob/user, obj/item/weapon/construction/rcd/the_rcd, passed_mode)


### PR DESCRIPTION
:cl: RandomMarine
tweak: RCDs now always use matter consistent with the material needed when building.
tweak: Floors now cost 3 or 1 matter to build, based on if a lattice exists on the tile.
tweak: Reinforced windows cost 12 matter. Normal windows cost 8 matter. (Both up/down from 10)
tweak: Glass airlocks cost 20 matter.
tweak: RCDs are faster at building grilles and plain glass windows.
/:cl:

Why: Consistency. It's currently a waste to build a glass window or a floor over a lattice, for example. While reinforced windows and glass airlocks are built for less than their normal cost.

Also, RCDs are currently slower at building grilles than by hand (And also take longer to build than a solid wall, whyyyy?), so this changes that too.
This also makes glass windows build in the same time it takes to place on a grille, with the bonus of being already screwed in place (Because it's -rapid-).

I feel this is more an improvement for engineers than a big balance matter.