### PR TITLE
Remember to test your PRs, kids! - Rebalances matter cartridge cost redux

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -401,7 +401,6 @@ obj/item/weapon/construction
 	icon_state = "rcd"
 	item_state = "rcdammo"
 	origin_tech = "materials=3"
-	w_class = WEIGHT_CLASS_TINY
 	materials = list(MAT_METAL=12000, MAT_GLASS=8000)
 	var/ammoamt = 40
 

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -401,6 +401,7 @@ obj/item/weapon/construction
 	icon_state = "rcd"
 	item_state = "rcdammo"
 	origin_tech = "materials=3"
+	w_class = WEIGHT_CLASS_TINY
 	materials = list(MAT_METAL=12000, MAT_GLASS=8000)
 	var/ammoamt = 40
 

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -108,9 +108,9 @@
 	export_types = list(/obj/item/weapon/construction/rcd)
 
 /datum/export/rcd_ammo
-	cost = 15 // 1.5 metal, 1 glass -> 12.5 credits, +2.5 credits
+	cost = 60 // 6 metal, 4 glass -> 50 credits, +10 credits
 	unit_name = "compressed matter cardridge"
-	export_types = list(/datum/design/rcd_ammo)
+	export_types = list(/obj/item/weapon/rcd_ammo)
 
 /datum/export/rpd
 	cost = 350 // 37.5 metal, 18.75 glass -> 281.25 credits, + some

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -235,7 +235,7 @@
 	name = "Compressed Matter Cartridge"
 	id = "rcd_ammo"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 3000, MAT_GLASS=2000)
+	materials = list(MAT_METAL = 12000, MAT_GLASS=8000)
 	build_path = /obj/item/weapon/rcd_ammo
 	category = list("initial","Construction")
 


### PR DESCRIPTION
:cl: RandomMarine
tweak: Compressed matter cartridge production costs now reflect their material worth at basic efficiency.
fix: Compressed matter cartridges can now be exported.
/:cl:

I kind of expect this to be closed on account of the freeze. But this is a redux of a pre-freeze change #22687 that actually accomplishes what that PR attempted to do.

And fixes RCD ammo export because JUST TRY EXPORTING A DATUM

fixes #15473 for real