### PR TITLE
Adds a single D4 to Lavaland mining base

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -627,6 +627,7 @@
 /area/mine/production)
 "bD" = (
 /obj/structure/closet/crate,
+/obj/item/weapon/dice/d4,
 /turf/open/floor/plasteel/brown{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
 	dir = 1


### PR DESCRIPTION
:cl: optional name here
add: 1D4 into Lavaland Mining base crate.
/:cl:

[why]: # 
What could POSSIBLY go wrong?
>Roll it with your buddies to decide who gets the loot!
>Roll for KA, Plasma cutter, Crusher, or Reso!
>Play D4 games whilst the ash storm rages on!
>So many great, wacky and wonderful things to do!
>Use it as a caltrop against native shoeless wildlife.

A useful defense against native wildlife.