### PR TITLE
Flame thrower plasma tanks can be removed easily.

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -135,8 +135,17 @@
 
 
 /obj/item/weapon/flamethrower/attack_self(mob/user)
+	if(ptank)
+		user.put_in_hands(ptank)
+		ptank = null
+		to_chat(user, "<span class='notice'>You remove the plasma tank from [src]!</span>")
+
+/obj/item/weapon/flamethrower/AltClick(mob/user)
 	toggle_igniter(user)
 
+/obj/item/weapon/flamethrower/examine(mob/user)
+	..()
+	to_chat(user, "<span class='notice'>\The [src] is [(lit?"lit":"unlit")]. Alt-click to toggle.</span>")
 
 /obj/item/weapon/flamethrower/proc/toggle_igniter(mob/user)
 	if(!ptank)

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -138,7 +138,7 @@
 	toggle_igniter(user)
 
 /obj/item/weapon/flamethrower/AltClick(mob/user)
-	if(ptank)
+	if(ptank && isliving(user) && !user.incapacitated() && Adjacent)
 		user.put_in_hands(ptank)
 		ptank = null
 		to_chat(user, "<span class='notice'>You remove the plasma tank from [src]!</span>")

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -135,17 +135,18 @@
 
 
 /obj/item/weapon/flamethrower/attack_self(mob/user)
+	toggle_igniter(user)
+
+/obj/item/weapon/flamethrower/AltClick(mob/user)
 	if(ptank)
 		user.put_in_hands(ptank)
 		ptank = null
 		to_chat(user, "<span class='notice'>You remove the plasma tank from [src]!</span>")
 
-/obj/item/weapon/flamethrower/AltClick(mob/user)
-	toggle_igniter(user)
-
 /obj/item/weapon/flamethrower/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>\The [src] is [(lit?"lit":"unlit")]. Alt-click to toggle.</span>")
+	if(ptank)
+		to_chat(user, "<span class='notice'>\The [src] has \the [ptank] attached. Alt-click to remove it.</span>")
 
 /obj/item/weapon/flamethrower/proc/toggle_igniter(mob/user)
 	if(!ptank)

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -138,7 +138,7 @@
 	toggle_igniter(user)
 
 /obj/item/weapon/flamethrower/AltClick(mob/user)
-	if(ptank && isliving(user) && !user.incapacitated() && Adjacent)
+	if(ptank && isliving(user) && !user.incapacitated() && Adjacent(user))
 		user.put_in_hands(ptank)
 		ptank = null
 		to_chat(user, "<span class='notice'>You remove the plasma tank from [src]!</span>")


### PR DESCRIPTION
:cl:
tweak: Flame thrower plasma tanks can be removed with alt-click.
/:cl:

fixes #28385 