### PR TITLE
Bonfires light up in lavaland atmos

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -170,7 +170,7 @@
 		var/turf/open/O = loc
 		if(O.air)
 			var/G = O.air.gases
-			if(G["o2"][MOLES] > 16)
+			if(G["o2"][MOLES] > 13)
 				return 1
 	return 0
 


### PR DESCRIPTION
:cl: RandomMarine
tweak: Bonfires now work on lavaland!
/:cl:

On rare occasions someone tries to start a bonfire on lavaland but they end up disappointed.
Now they won't.