### PR TITLE
Scale rot 2017.

### DIFF
--- a/code/datums/diseases/scalerot.dm
+++ b/code/datums/diseases/scalerot.dm
@@ -10,63 +10,86 @@
 	cure_chance = 10//scalerot, generally speaking, is not easy to cure, and requires lengthy decontamination procedures, and vitamin megadoses are pseudoscience.
 	desc = "A lethal bacteria that affects only scale based skin surfaces. Rots away scales. Commonly carried by various races, and naturally occurs on scaled races experiencing poor hygiene, moist skin, or excess humidty or moisture."
 	severity = DANGEROUS
-	longevity = 400
+	longevity = 650
 
 /datum/disease/scalerot/stage_act()
 	..()
 	if(affected_mob.dna.species.id == "lizard"||affected_mob.dna.species.id == "fly") //Non-scaled species are not affected by the virus and merely carry it.
 		switch(stage)
 			if(1)
-				if(affected_mob.dna.species.id == "lizard")
-					affected_mob << "<span class='notice'>[pick("Your scales feels awfully itchy", "Your tail hurts")]</span>"
-				if(affected_mob.dna.species.id == "fly")
-					affected_mob << "<span class='notice'>[pick("Your chitin feels awfully soft", "Your proboscis hurts")]</span>"
+				if(prob(40))
+					if(affected_mob.dna.species.id == "lizard")
+						to_chat(affected_mob << "<span class='notice'>[pick("Your scales feels awfully itchy", "Your tail hurts")]</span>")
+					if(affected_mob.dna.species.id == "fly")
+						to_chat(affected_mob << "<span class='notice'>[pick("Your chitin feels awfully soft", "Your proboscis hurts")]</span>")
 			if(2)
-				if(affected_mob.dna.species.id == "lizard")
-					affected_mob << "<span class='warning'>[pick("You claw at your scales", "Your claws feel strange")]</span>"
-				if(affected_mob.dna.species.id == "fly")
-					affected_mob << "<span class='warning'>[pick("Your chitin feels sticky", "Your chitin leaks glucose")]</span>"
+				if(prob(10))
+					if(affected_mob.dna.species.id == "lizard")
+						to_chat(affected_mob << "<span class='warning'>[pick("You claw at your scales", "Your claws feel strange")]</span>")
+					if(affected_mob.dna.species.id == "fly")
+						to_chat(affected_mob << "<span class='warning'>[pick("Your chitin feels sticky", "Your chitin leaks glucose")]</span>")
 				if(prob(10))
 					affected_mob.adjustStaminaLoss(15)
 			if(3)
-				if(affected_mob.dna.species.id == "lizard")
-					affected_mob.say("hs?")
-					affected_mob << "<span class='danger'>You painfully let out a hiss.</span>"
-				if(affected_mob.dna.species.id == "fly")
-					affected_mob.say("buz?")
-					affected_mob << "<span class='danger'>You make a pathetic attempt to buzz, painfully.</span>"
-				affected_mob.adjustBruteLoss(1)
+				if(prob(10))
+					if(affected_mob.dna.species.id == "lizard")
+						to_chat(affected_mob.say("hs?"))
+						to_chat(affected_mob << "<span class='danger'>You painfully let out a hiss.</span>")
+					if(affected_mob.dna.species.id == "fly")
+						to_chat(affected_mob.say("buz?"))
+						to_chat(affected_mob << "<span class='danger'>You make a pathetic attempt to buzz, painfully.</span>")
+				if(prob(70))
+					affected_mob.adjustBruteLoss(2)
 				if(prob(10))
 					affected_mob.adjustStaminaLoss(20)
 			if(4)
-				if(affected_mob.dna.species.id == "lizard")
-					affected_mob << "<span class='danger'>Your scales rot away and reveal flesh</span>"
-				if(affected_mob.dna.species.id == "fly")
-					affected_mob << "<span class='danger'>Your chitin starts to leatherize and begins to crack</span>"
-				affected_mob.adjustBruteLoss(2)
+				if(prob(10))
+					if(affected_mob.dna.species.id == "lizard")
+						affected_mob << "<span class='danger'>Your scales rot away and reveal sores</span>"
+					if(affected_mob.dna.species.id == "fly")
+						to_chat(affected_mob << "<span class='danger'>Your chitin starts to leatherize and begins to crack</span>")
+				if(prob(70))
+					affected_mob.adjustBruteLoss(3)
 				if(prob(10))
 					affected_mob.adjustStaminaLoss(25)
 			if(5)
-				affected_mob.adjustBruteLoss(3)
+				reduce_health()
+				remove_tail()
 				if(prob(10))
-					affected_mob.adjustStaminaLoss(20)
+					affected_mob.adjustStaminaLoss(25)
 				if(prob(5))
 					affected_mob.Weaken(2)
-				if(affected_mob.dna.species.id == "lizard")
-					affected_mob << "<span class='danger'>You tear at your scales and rip off some scales!</span>"
-				if(affected_mob.dna.species.id == "fly")
-					affected_mob << "<span class='danger'>You loosen some chitin and slough off some chitin!</span>"
-				if(prob(15))
-					if("tail_lizard"||"waggingtail_lizard" in affected_mob.dna.species.mutant_bodyparts)
-						affected_mob.dna.species.mutant_bodyparts -= "tail_lizard"
-						new /obj/item/severedtail(get_turf(affected_mob))
-						affected_mob.visible_message("[affected_mob]'s tail rots off and flops to the ground.</span>")
-						affected_mob.update_body()
-						affected_mob.adjustBruteLoss(25)
-						affected_mob.adjustStaminaLoss(100)
-						affected_mob.bleed(35)
-		if(affected_mob.reagents.get_reagent_amount(("ethanol") > 15)||("sterilizine">1))
-			cure()
+				if(prob(5))
+					affected_mob.adjustBruteLoss(3)
+		if(affected_mob.reagents.get_reagent_amount(("ethanol") > 15)||("sterilizine" > 1 ))
+			proper_cure()
 	else
 		stage = 1
 	return
+
+/datum/disease/scalerot/proc/reduce_health()
+	if(affected_mob.getCloneLoss() < 25)
+		affected_mob.setCloneLoss(25)
+		if(affected_mob.dna.species.id == "lizard")
+			to_chat(affected_mob << "<span class='danger'>You tear some scales!</span>")
+		if(affected_mob.dna.species.id == "fly")
+			to_chat(affected_mob << "<span class='danger'>Some chitin sloughs off!</span>")
+
+/datum/disease/scalerot/proc/remove_tail()
+	if("tail_lizard"||"waggingtail_lizard" in affected_mob.dna.species.mutant_bodyparts)
+		affected_mob.dna.species.mutant_bodyparts -= "tail_lizard"
+		new /obj/item/severedtail(get_turf(affected_mob))
+		to_chat(affected_mob.visible_message("[affected_mob]'s tail rots off and flops to the ground.</span>")) //rekt
+		affected_mob.update_body()
+		affected_mob.adjustBruteLoss(25)
+		affected_mob.Weaken(5)
+		affected_mob.bleed(35)
+
+/datum/disease/scalerot/proc/proper_cure()
+	if(5)
+		affected_mob.adjustCloneLoss(-25)
+		if(affected_mob.dna.species.id == "lizard")
+			to_chat(affected_mob << "<span class='notice'>Your scales are cleansed of the rot.</span>")
+		if(affected_mob.dna.species.id == "fly")
+			to_chat(affected_mob << "<span class='notice'>Your chitin feels healthier after the anti-biotic cleansing.</span>")
+	cure()

--- a/code/datums/diseases/scalerot.dm
+++ b/code/datums/diseases/scalerot.dm
@@ -65,7 +65,7 @@
 						affected_mob.adjustBruteLoss(25)
 						affected_mob.adjustStaminaLoss(100)
 						affected_mob.bleed(35)
-		if(affected_mob.reagents.get_reagent_amount(("ethanol") > 15)||("sterilizine"<1))
+		if(affected_mob.reagents.get_reagent_amount(("ethanol") > 15)||("sterilizine">1))
 			cure()
 	else
 		stage = 1

--- a/code/datums/diseases/scalerot.dm
+++ b/code/datums/diseases/scalerot.dm
@@ -3,13 +3,14 @@
 	max_stages = 5
 	spread_text = "On contact"
 	spread_flags = CONTACT_GENERAL
-	cure_text = "Alcohol based anti-septics."
-	cures = list("ethanol", "sterilizine")
+	cure_text = "Alcohol based anti-septics or vitamin superdoses."
+	cures = list("vitamin")
 	agent = "Reptilian Necrotizing Dermatitis"
 	viable_mobtypes = list(/mob/living/carbon/human)
-	cure_chance = 5//scalerot, generally speaking, is not easy to cure, and requires lengthy decontamination procedures.
+	cure_chance = 10//scalerot, generally speaking, is not easy to cure, and requires lengthy decontamination procedures, and vitamin megadoses are pseudoscience.
 	desc = "A lethal bacteria that affects only scale based skin surfaces. Rots away scales. Commonly carried by various races, and naturally occurs on scaled races experiencing poor hygiene, moist skin, or excess humidty or moisture."
 	severity = DANGEROUS
+	longevity = 400
 
 /datum/disease/scalerot/stage_act()
 	..()
@@ -25,7 +26,8 @@
 					affected_mob << "<span class='warning'>[pick("You claw at your scales", "Your claws feel strange")]</span>"
 				if(affected_mob.dna.species.id == "fly")
 					affected_mob << "<span class='warning'>[pick("Your chitin feels sticky", "Your chitin leaks glucose")]</span>"
-				affected_mob.adjustStaminaLoss(35)
+				if(prob(10))
+					affected_mob.adjustStaminaLoss(15)
 			if(3)
 				if(affected_mob.dna.species.id == "lizard")
 					affected_mob.say("hs?")
@@ -33,17 +35,23 @@
 				if(affected_mob.dna.species.id == "fly")
 					affected_mob.say("buz?")
 					affected_mob << "<span class='danger'>You make a pathetic attempt to buzz, painfully.</span>"
-				affected_mob.adjustBruteLoss(5)
+				affected_mob.adjustBruteLoss(1)
+				if(prob(10))
+					affected_mob.adjustStaminaLoss(20)
 			if(4)
 				if(affected_mob.dna.species.id == "lizard")
 					affected_mob << "<span class='danger'>Your scales rot away and reveal flesh</span>"
 				if(affected_mob.dna.species.id == "fly")
 					affected_mob << "<span class='danger'>Your chitin starts to leatherize and begins to crack</span>"
-				affected_mob.adjustCloneLoss(5)
-				affected_mob.adjustBruteLoss(10)
+				affected_mob.adjustBruteLoss(2)
+				if(prob(10))
+					affected_mob.adjustStaminaLoss(25)
 			if(5)
-				affected_mob.adjustCloneLoss(10)
-				affected_mob.adjustBruteLoss(15)
+				affected_mob.adjustBruteLoss(3)
+				if(prob(10))
+					affected_mob.adjustStaminaLoss(20)
+				if(prob(5))
+					affected_mob.Weaken(2)
 				if(affected_mob.dna.species.id == "lizard")
 					affected_mob << "<span class='danger'>You tear at your scales and rip off some scales!</span>"
 				if(affected_mob.dna.species.id == "fly")
@@ -57,6 +65,8 @@
 						affected_mob.adjustBruteLoss(25)
 						affected_mob.adjustStaminaLoss(100)
 						affected_mob.bleed(35)
+		if(affected_mob.reagents.get_reagent_amount(("ethanol") > 15)||("sterilizine"<1))
+			cure()
 	else
 		stage = 1
 	return

--- a/code/datums/diseases/scalerot.dm
+++ b/code/datums/diseases/scalerot.dm
@@ -1,0 +1,62 @@
+/datum/disease/scalerot
+	name = "Scale rot"
+	max_stages = 5
+	spread_text = "On contact"
+	spread_flags = CONTACT_GENERAL
+	cure_text = "Alcohol based anti-septics."
+	cures = list("ethanol", "sterilizine")
+	agent = "Reptilian Necrotizing Dermatitis"
+	viable_mobtypes = list(/mob/living/carbon/human)
+	cure_chance = 5//scalerot, generally speaking, is not easy to cure, and requires lengthy decontamination procedures.
+	desc = "A lethal bacteria that affects only scale based skin surfaces. Rots away scales. Commonly carried by various races, and naturally occurs on scaled races experiencing poor hygiene, moist skin, or excess humidty or moisture."
+	severity = DANGEROUS
+
+/datum/disease/scalerot/stage_act()
+	..()
+	if(affected_mob.dna.species.id == "lizard"||affected_mob.dna.species.id == "fly") //Non-scaled species are not affected by the virus and merely carry it.
+		switch(stage)
+			if(1)
+				if(affected_mob.dna.species.id == "lizard")
+					affected_mob << "<span class='notice'>[pick("Your scales feels awfully itchy", "Your tail hurts")]</span>"
+				if(affected_mob.dna.species.id == "fly")
+					affected_mob << "<span class='notice'>[pick("Your chitin feels awfully soft", "Your proboscis hurts")]</span>"
+			if(2)
+				if(affected_mob.dna.species.id == "lizard")
+					affected_mob << "<span class='warning'>[pick("You claw at your scales", "Your claws feel strange")]</span>"
+				if(affected_mob.dna.species.id == "fly")
+					affected_mob << "<span class='warning'>[pick("Your chitin feels sticky", "Your chitin leaks glucose")]</span>"
+				affected_mob.adjustStaminaLoss(35)
+			if(3)
+				if(affected_mob.dna.species.id == "lizard")
+					affected_mob.say("hs?")
+					affected_mob << "<span class='danger'>You painfully let out a hiss.</span>"
+				if(affected_mob.dna.species.id == "fly")
+					affected_mob.say("buz?")
+					affected_mob << "<span class='danger'>You make a pathetic attempt to buzz, painfully.</span>"
+				affected_mob.adjustBruteLoss(5)
+			if(4)
+				if(affected_mob.dna.species.id == "lizard")
+					affected_mob << "<span class='danger'>Your scales rot away and reveal flesh</span>"
+				if(affected_mob.dna.species.id == "fly")
+					affected_mob << "<span class='danger'>Your chitin starts to leatherize and begins to crack</span>"
+				affected_mob.adjustCloneLoss(5)
+				affected_mob.adjustBruteLoss(10)
+			if(5)
+				affected_mob.adjustCloneLoss(10)
+				affected_mob.adjustBruteLoss(15)
+				if(affected_mob.dna.species.id == "lizard")
+					affected_mob << "<span class='danger'>You tear at your scales and rip off some scales!</span>"
+				if(affected_mob.dna.species.id == "fly")
+					affected_mob << "<span class='danger'>You loosen some chitin and slough off some chitin!</span>"
+				if(prob(15))
+					if("tail_lizard"||"waggingtail_lizard" in affected_mob.dna.species.mutant_bodyparts)
+						affected_mob.dna.species.mutant_bodyparts -= "tail_lizard"
+						new /obj/item/severedtail(get_turf(affected_mob))
+						affected_mob.visible_message("[affected_mob]'s tail rots off and flops to the ground.</span>")
+						affected_mob.update_body()
+						affected_mob.adjustBruteLoss(25)
+						affected_mob.adjustStaminaLoss(100)
+						affected_mob.bleed(35)
+	else
+		stage = 1
+	return

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -887,3 +887,21 @@
 /obj/item/weapon/storage/box/fountainpens/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/pen/fountain(src)
+
+/obj/item/weapon/storage/box/scalerot/pen
+	name = "Scale rot injectors"
+	desc = "Contains a virulent bioweapon in a sealed injector, and several pens containing the cure."
+
+/obj/item/weapon/storage/box/scalerot/pen/PopulateContents()
+	new /obj/item/weapon/reagent_containers/hypospray/medipen/scalerot(src)
+	for(var/i in 1 to 6)
+		new /obj/item/weapon/reagent_containers/hypospray/medipen/scalerot_cure(src)
+
+/obj/item/weapon/storage/box/scalerot/bottle
+	name = "Scale rot bacterium sample"
+	desc = "Contains a virulent bioweapon in a synthblood medium, and several pens containing the cure."
+
+/obj/item/weapon/storage/box/scalerot/bottle/PopulateContents()
+	new /obj/item/weapon/reagent_containers/glass/bottle/scalerot(src)
+	for(var/i in 1 to 6)
+		new /obj/item/weapon/reagent_containers/hypospray/medipen/scalerot_cure(src)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -55,8 +55,8 @@
 		new /datum/data/mining_equipment("Drone Ranged Upgrade",/obj/item/device/mine_bot_ugprade/cooldown,								600),
 		new /datum/data/mining_equipment("Drone AI Upgrade",	/obj/item/slimepotion/sentience/mining,									1000),
 		new /datum/data/mining_equipment("Jump Boots",			/obj/item/clothing/shoes/bhop,											2500),
-		new /datum/data/mining_equipment("Anti-Walker injector",	/obj/item/weapon/reagent_containers/hypospray/medipen/scalerot,		2000),
-		new /datum/data/mining_equipment("Anti-Walker disease",	/obj/item/weapon/reagent_containers/glass/bottle/scalerot,				1000),
+		new /datum/data/mining_equipment("Anti-Ash Walker injector",	/obj/item/weapon/storage/box/scalerot/pen,						2000),
+		new /datum/data/mining_equipment("Anti-Ash Walker disease",	/obj/item/weapon/storage/box/scalerot/bottle,						1000),
 		)
 
 /datum/data/mining_equipment

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -55,6 +55,8 @@
 		new /datum/data/mining_equipment("Drone Ranged Upgrade",/obj/item/device/mine_bot_ugprade/cooldown,								600),
 		new /datum/data/mining_equipment("Drone AI Upgrade",	/obj/item/slimepotion/sentience/mining,									1000),
 		new /datum/data/mining_equipment("Jump Boots",			/obj/item/clothing/shoes/bhop,											2500),
+		new /datum/data/mining_equipment("Anti-Walker injector",	/obj/item/weapon/reagent_containers/hypospray/medipen/scalerot,		2000),
+		new /datum/data/mining_equipment("Anti-Walker disease",	/obj/item/weapon/reagent_containers/glass/bottle/scalerot,				1000),
 		)
 
 /datum/data/mining_equipment

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -348,3 +348,10 @@
 	desc = "A small bottle containing Bio Virus Antidote Kit."
 	icon_state = "bottle5"
 	list_reagents = list("atropine" = 5, "epinephrine" = 5, "salbutamol" = 10, "spaceacillin" = 10)
+
+/obj/item/weapon/reagent_containers/glass/bottle/scalerot
+	name = "Scale rot culture bottle"
+	desc = "A small bottle. Contains Reptilian Necrotizing Dermatitis culture in synthblood medium. WARNING: KEEP AWAY FROM REPTILIAN LIFE-FORMS."
+	icon_state = "bottle3"
+	amount_per_transfer_from_this = 5
+	spawned_disease = /datum/disease/scalerot

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -153,3 +153,11 @@
 	volume = 15
 	amount_per_transfer_from_this = 15
 	list_reagents = list("scale_rot_baceria" = 15)
+
+/obj/item/weapon/reagent_containers/hypospray/medipen/scalerot_cure
+	name = "Scale rot anti-biotic autoinjector"
+	desc = "For effective, singular, and isolated inocoulation and curing of scale rot infections. Just stab and squeeze!"
+	icon_state = "stimpen"
+	volume = 30
+	amount_per_transfer_from_this = 30
+	list_reagents = list("ethanol" = 15, "sterilizine" = 15)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -146,3 +146,10 @@
 	volume = 1
 	amount_per_transfer_from_this = 1
 	list_reagents = list("unstablemutationtoxin" = 1)
+
+/obj/item/weapon/reagent_containers/hypospray/medipen/scalerot
+	name = "Scale rot autoinjector"
+	desc = "For effective, systematic, and widespread genocide of scaled races. Just stab and squeeze!"
+	volume = 15
+	amount_per_transfer_from_this = 15
+	list_reagents = list("scale_rot_baceria" = 15)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -261,6 +261,7 @@
 #include "code\datums\diseases\pierrot_throat.dm"
 #include "code\datums\diseases\retrovirus.dm"
 #include "code\datums\diseases\rhumba_beat.dm"
+#include "code\datums\diseases\scalerot.dm"
 #include "code\datums\diseases\transformation.dm"
 #include "code\datums\diseases\tuberculosis.dm"
 #include "code\datums\diseases\wizarditis.dm"


### PR DESCRIPTION
:cl: 
add: Scale rot.
add: Scale rot to Mining vendors.
add: Scale rot to disease outbreak event.
add: Scale rot medipens.
add: Scale rot reagents.
add: Scale rot to cargo ordering.
add: Scale rot cure/vaccine autoinjectors.
/:cl:

[why]: 
A wacky, improved, new way of fighting Ash Walkers for miners!
Add two more warcrimes to the list by using Biological weapons and creating a genocide!
Creates paranoia for Ash Walkers and a new objective - secure a source of alcohol.
Creates paranoia for lizard and flyperson playing people!
Gives a Virologist a run for his money too!

**COMMIT NUMBER TWO**
**Due to calls for amnesty and out of mmy sheer pity and humanitarianism for coderbus.**

**Scalerot is weaker.**
**Cures itself over a long, long period of time.**
**Is curable by alcohol and vitamins.**
**Can be ordered from Cargo.**
**Comes with vaccines/cures to resolve accidental infections.**

**Virus no longer deals constant damage. Instead uses a random roll to decide if it is going to deal damage or not.**
**Virus now "permanently" reduces the max health of Lizards via (cloneloss).**
**Station cures restore the cloneloss, vitamin cures do not.**