### PR TITLE
Refactors PDA cartridge permissions

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1414,3 +1414,8 @@ GLOBAL_PROTECT(valid_HTTPSGet)
 		mob_occupant = brain.brainmob
 
 	return mob_occupant
+
+/proc/BitCount(bitfield)
+	var/temp = bitfield - ((bitfield>>1)&46811) - ((bitfield>>2)&37449);
+	temp = ((temp + (temp>>3))&29127) % 63;
+	return temp;

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1418,6 +1418,6 @@ GLOBAL_PROTECT(valid_HTTPSGet)
 //counts the number of bits in Byond's 16-bit width field
 //in constant time and memory!
 /proc/BitCount(bitfield)
-	var/temp = bitfield - ((bitfield>>1)&46811) - ((bitfield>>2)&37449); //0133333 and 0111111 respectively
-	temp = ((temp + (temp>>3))&29127) % 63;	//070707
-	return temp;
+	var/temp = bitfield - ((bitfield>>1)&46811) - ((bitfield>>2)&37449) //0133333 and 0111111 respectively
+	temp = ((temp + (temp>>3))&29127) % 63	//070707
+	return temp

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1415,7 +1415,9 @@ GLOBAL_PROTECT(valid_HTTPSGet)
 
 	return mob_occupant
 
+//counts the number of bits in Byond's 16-bit width field
+//in constant time and memory!
 /proc/BitCount(bitfield)
-	var/temp = bitfield - ((bitfield>>1)&46811) - ((bitfield>>2)&37449);
-	temp = ((temp + (temp>>3))&29127) % 63;
+	var/temp = bitfield - ((bitfield>>1)&46811) - ((bitfield>>2)&37449); //0133333 and 0111111 respectively
+	temp = ((temp + (temp>>3))&29127) % 63;	//070707
 	return temp;

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/notehtml = ""
 	var/notescanned = 0 // True if what is in the notekeeper was from a paper.
 	var/cart = "" //A place to stick cartridge menu information
-	var/detonatable = 1 // Can the PDA be blown up?
+	var/detonatable = TRUE // Can the PDA be blown up?
 	var/hidden = 0 // Is the PDA hidden from the PDA list?
 	var/emped = 0
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -153,31 +153,31 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += "<li><a href='byond://?src=\ref[src];choice=2'><img src=pda_mail.png> Messenger</a></li>"
 
 				if (cartridge)
-					if (cartridge.access_clown)
+					if (cartridge.access&CART_CLOWN)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Honk'><img src=pda_honk.png> Honk Synthesizer</a></li>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=Trombone'><img src=pda_honk.png> Sad Trombone</a></li>"
-					if (cartridge.access_manifest)
+					if (cartridge.access&CART_MANIFEST)
 						dat += "<li><a href='byond://?src=\ref[src];choice=41'><img src=pda_notes.png> View Crew Manifest</a></li>"
-					if(cartridge.access_status_display)
+					if(cartridge.access&CART_STATUS_DISPLAY)
 						dat += "<li><a href='byond://?src=\ref[src];choice=42'><img src=pda_status.png> Set Status Display</a></li>"
 					dat += "</ul>"
-					if (cartridge.access_engine)
+					if (cartridge.access&CART_ENGINE)
 						dat += "<h4>Engineering Functions</h4>"
 						dat += "<ul>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=43'><img src=pda_power.png> Power Monitor</a></li>"
 						dat += "</ul>"
-					if (cartridge.access_medical)
+					if (cartridge.access&CART_MEDICAL)
 						dat += "<h4>Medical Functions</h4>"
 						dat += "<ul>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=44'><img src=pda_medical.png> Medical Records</a></li>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=Medical Scan'><img src=pda_scanner.png> [scanmode == 1 ? "Disable" : "Enable"] Medical Scanner</a></li>"
 						dat += "</ul>"
-					if (cartridge.access_security)
+					if (cartridge.access&CART_SECURITY)
 						dat += "<h4>Security Functions</h4>"
 						dat += "<ul>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=45'><img src=pda_cuffs.png> Security Records</A></li>"
 						dat += "</ul>"
-					if(cartridge.access_quartermaster)
+					if(cartridge.access&CART_QUARTERMASTER)
 						dat += "<h4>Quartermaster Functions:</h4>"
 						dat += "<ul>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=47'><img src=pda_crate.png> Supply Records</A></li>"
@@ -189,21 +189,21 @@ GLOBAL_LIST_EMPTY(PDAs)
 				if (cartridge)
 					if(cartridge.bot_access_flags)
 						dat += "<li><a href='byond://?src=\ref[src];choice=54'><img src=pda_medbot.png> Bots Access</a></li>"
-					if (cartridge.access_janitor)
+					if (cartridge.access&CART_JANITOR)
 						dat += "<li><a href='byond://?src=\ref[src];choice=49'><img src=pda_bucket.png> Custodial Locator</a></li>"
 					if (istype(cartridge.radio, /obj/item/radio/integrated/signal))
 						dat += "<li><a href='byond://?src=\ref[src];choice=40'><img src=pda_signaler.png> Signaler System</a></li>"
-					if (cartridge.access_newscaster)
+					if (cartridge.access&CART_NEWSCASTER)
 						dat += "<li><a href='byond://?src=\ref[src];choice=53'><img src=pda_notes.png> Newscaster Access </a></li>"
-					if (cartridge.access_reagent_scanner)
+					if (cartridge.access&CART_REAGENT_SCANNER)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Reagent Scan'><img src=pda_reagent.png> [scanmode == 3 ? "Disable" : "Enable"] Reagent Scanner</a></li>"
-					if (cartridge.access_engine)
+					if (cartridge.access&CART_ENGINE)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Halogen Counter'><img src=pda_reagent.png> [scanmode == 4 ? "Disable" : "Enable"] Halogen Counter</a></li>"
-					if (cartridge.access_atmos)
+					if (cartridge.access&CART_ATMOS)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Gas Scan'><img src=pda_reagent.png> [scanmode == 5 ? "Disable" : "Enable"] Gas Scanner</a></li>"
-					if (cartridge.access_remote_door)
+					if (cartridge.access&CART_REMOTE_DOOR)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Toggle Door'><img src=pda_rdoor.png> Toggle Remote Door</a></li>"
-					if (cartridge.access_dronephone)
+					if (cartridge.access&CART_DRONEPHONE)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Drone Phone'><img src=pda_dronephone.png> Drone Phone</a></li>"
 				dat += "<li><a href='byond://?src=\ref[src];choice=3'><img src=pda_atmos.png> Atmospheric Scan</a></li>"
 				dat += "<li><a href='byond://?src=\ref[src];choice=Light'><img src=pda_flashlight.png> [fon ? "Disable" : "Enable"] Flashlight</a></li>"
@@ -362,17 +362,17 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if("Medical Scan")
 				if(scanmode == 1)
 					scanmode = 0
-				else if((!isnull(cartridge)) && (cartridge.access_medical))
+				else if((!isnull(cartridge)) && (cartridge.access&CART_MEDICAL))
 					scanmode = 1
 			if("Reagent Scan")
 				if(scanmode == 3)
 					scanmode = 0
-				else if((!isnull(cartridge)) && (cartridge.access_reagent_scanner))
+				else if((!isnull(cartridge)) && (cartridge.access&CART_REAGENT_SCANNER))
 					scanmode = 3
 			if("Halogen Counter")
 				if(scanmode == 4)
 					scanmode = 0
-				else if((!isnull(cartridge)) && (cartridge.access_engine))
+				else if((!isnull(cartridge)) && (cartridge.access&CART_ENGINE))
 					scanmode = 4
 			if("Honk")
 				if ( !(last_noise && world.time < last_noise + 20) )
@@ -385,7 +385,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if("Gas Scan")
 				if(scanmode == 5)
 					scanmode = 0
-				else if((!isnull(cartridge)) && (cartridge.access_atmos))
+				else if((!isnull(cartridge)) && (cartridge.access&CART_ATMOS))
 					scanmode = 5
 			if("Drone Phone")
 				var/area/A = get_area(U)
@@ -448,7 +448,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 //SYNDICATE FUNCTIONS===================================
 
 			if("Toggle Door")
-				if(cartridge && cartridge.access_remote_door)
+				if(cartridge && cartridge.access&CART_REMOTE_DOOR)
 					for(var/obj/machinery/door/poddoor/M in GLOB.machines)
 						if(M.id == cartridge.remote_door_id)
 							if(M.density)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -153,31 +153,31 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += "<li><a href='byond://?src=\ref[src];choice=2'><img src=pda_mail.png> Messenger</a></li>"
 
 				if (cartridge)
-					if (cartridge.access&CART_CLOWN)
+					if (cartridge.access & CART_CLOWN)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Honk'><img src=pda_honk.png> Honk Synthesizer</a></li>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=Trombone'><img src=pda_honk.png> Sad Trombone</a></li>"
-					if (cartridge.access&CART_MANIFEST)
+					if (cartridge.access & CART_MANIFEST)
 						dat += "<li><a href='byond://?src=\ref[src];choice=41'><img src=pda_notes.png> View Crew Manifest</a></li>"
-					if(cartridge.access&CART_STATUS_DISPLAY)
+					if(cartridge.access & CART_STATUS_DISPLAY)
 						dat += "<li><a href='byond://?src=\ref[src];choice=42'><img src=pda_status.png> Set Status Display</a></li>"
 					dat += "</ul>"
-					if (cartridge.access&CART_ENGINE)
+					if (cartridge.access & CART_ENGINE)
 						dat += "<h4>Engineering Functions</h4>"
 						dat += "<ul>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=43'><img src=pda_power.png> Power Monitor</a></li>"
 						dat += "</ul>"
-					if (cartridge.access&CART_MEDICAL)
+					if (cartridge.access & CART_MEDICAL)
 						dat += "<h4>Medical Functions</h4>"
 						dat += "<ul>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=44'><img src=pda_medical.png> Medical Records</a></li>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=Medical Scan'><img src=pda_scanner.png> [scanmode == 1 ? "Disable" : "Enable"] Medical Scanner</a></li>"
 						dat += "</ul>"
-					if (cartridge.access&CART_SECURITY)
+					if (cartridge.access & CART_SECURITY)
 						dat += "<h4>Security Functions</h4>"
 						dat += "<ul>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=45'><img src=pda_cuffs.png> Security Records</A></li>"
 						dat += "</ul>"
-					if(cartridge.access&CART_QUARTERMASTER)
+					if(cartridge.access & CART_QUARTERMASTER)
 						dat += "<h4>Quartermaster Functions:</h4>"
 						dat += "<ul>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=47'><img src=pda_crate.png> Supply Records</A></li>"
@@ -189,21 +189,21 @@ GLOBAL_LIST_EMPTY(PDAs)
 				if (cartridge)
 					if(cartridge.bot_access_flags)
 						dat += "<li><a href='byond://?src=\ref[src];choice=54'><img src=pda_medbot.png> Bots Access</a></li>"
-					if (cartridge.access&CART_JANITOR)
+					if (cartridge.access & CART_JANITOR)
 						dat += "<li><a href='byond://?src=\ref[src];choice=49'><img src=pda_bucket.png> Custodial Locator</a></li>"
 					if (istype(cartridge.radio, /obj/item/radio/integrated/signal))
 						dat += "<li><a href='byond://?src=\ref[src];choice=40'><img src=pda_signaler.png> Signaler System</a></li>"
-					if (cartridge.access&CART_NEWSCASTER)
+					if (cartridge.access & CART_NEWSCASTER)
 						dat += "<li><a href='byond://?src=\ref[src];choice=53'><img src=pda_notes.png> Newscaster Access </a></li>"
-					if (cartridge.access&CART_REAGENT_SCANNER)
+					if (cartridge.access & CART_REAGENT_SCANNER)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Reagent Scan'><img src=pda_reagent.png> [scanmode == 3 ? "Disable" : "Enable"] Reagent Scanner</a></li>"
-					if (cartridge.access&CART_ENGINE)
+					if (cartridge.access & CART_ENGINE)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Halogen Counter'><img src=pda_reagent.png> [scanmode == 4 ? "Disable" : "Enable"] Halogen Counter</a></li>"
-					if (cartridge.access&CART_ATMOS)
+					if (cartridge.access & CART_ATMOS)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Gas Scan'><img src=pda_reagent.png> [scanmode == 5 ? "Disable" : "Enable"] Gas Scanner</a></li>"
-					if (cartridge.access&CART_REMOTE_DOOR)
+					if (cartridge.access & CART_REMOTE_DOOR)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Toggle Door'><img src=pda_rdoor.png> Toggle Remote Door</a></li>"
-					if (cartridge.access&CART_DRONEPHONE)
+					if (cartridge.access & CART_DRONEPHONE)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Drone Phone'><img src=pda_dronephone.png> Drone Phone</a></li>"
 				dat += "<li><a href='byond://?src=\ref[src];choice=3'><img src=pda_atmos.png> Atmospheric Scan</a></li>"
 				dat += "<li><a href='byond://?src=\ref[src];choice=Light'><img src=pda_flashlight.png> [fon ? "Disable" : "Enable"] Flashlight</a></li>"
@@ -362,17 +362,17 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if("Medical Scan")
 				if(scanmode == 1)
 					scanmode = 0
-				else if((!isnull(cartridge)) && (cartridge.access&CART_MEDICAL))
+				else if((!isnull(cartridge)) && (cartridge.access & CART_MEDICAL))
 					scanmode = 1
 			if("Reagent Scan")
 				if(scanmode == 3)
 					scanmode = 0
-				else if((!isnull(cartridge)) && (cartridge.access&CART_REAGENT_SCANNER))
+				else if((!isnull(cartridge)) && (cartridge.access & CART_REAGENT_SCANNER))
 					scanmode = 3
 			if("Halogen Counter")
 				if(scanmode == 4)
 					scanmode = 0
-				else if((!isnull(cartridge)) && (cartridge.access&CART_ENGINE))
+				else if((!isnull(cartridge)) && (cartridge.access & CART_ENGINE))
 					scanmode = 4
 			if("Honk")
 				if ( !(last_noise && world.time < last_noise + 20) )
@@ -385,7 +385,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if("Gas Scan")
 				if(scanmode == 5)
 					scanmode = 0
-				else if((!isnull(cartridge)) && (cartridge.access&CART_ATMOS))
+				else if((!isnull(cartridge)) && (cartridge.access & CART_ATMOS))
 					scanmode = 5
 			if("Drone Phone")
 				var/area/A = get_area(U)
@@ -448,7 +448,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 //SYNDICATE FUNCTIONS===================================
 
 			if("Toggle Door")
-				if(cartridge && cartridge.access&CART_REMOTE_DOOR)
+				if(cartridge && cartridge.access & CART_REMOTE_DOOR)
 					for(var/obj/machinery/door/poddoor/M in GLOB.machines)
 						if(M.id == cartridge.remote_door_id)
 							if(M.density)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/notehtml = ""
 	var/notescanned = 0 // True if what is in the notekeeper was from a paper.
 	var/cart = "" //A place to stick cartridge menu information
-	var/detonate = 1 // Can the PDA be blown up?
+	var/detonatable = 1 // Can the PDA be blown up?
 	var/hidden = 0 // Is the PDA hidden from the PDA list?
 	var/emped = 0
 
@@ -826,7 +826,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 
 /obj/item/device/pda/proc/explode() //This needs tuning.
-	if(!detonate) return
+	if(!detonatable) return
 	var/turf/T = get_turf(src)
 
 	if (ismob(loc))

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -23,7 +23,7 @@
 	icon_state = "NONE"
 	ttone = "data"
 	fon = 0
-	detonate = 0
+	detonatable = 0
 
 /obj/item/device/pda/ai/attack_self(mob/user)
 	if ((honkamt > 0) && (prob(60)))//For clown virus.
@@ -121,7 +121,7 @@
 	default_cartridge = /obj/item/weapon/cartridge/captain
 	inserted_item = /obj/item/weapon/pen/fountain/captain
 	icon_state = "pda-captain"
-	detonate = 0
+	detonatable = 0
 
 /obj/item/device/pda/cargo
 	name = "cargo technician PDA"

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -23,7 +23,7 @@
 	icon_state = "NONE"
 	ttone = "data"
 	fon = 0
-	detonatable = 0
+	detonatable = FALSE
 
 /obj/item/device/pda/ai/attack_self(mob/user)
 	if ((honkamt > 0) && (prob(60)))//For clown virus.
@@ -121,7 +121,7 @@
 	default_cartridge = /obj/item/weapon/cartridge/captain
 	inserted_item = /obj/item/weapon/pen/fountain/captain
 	icon_state = "pda-captain"
-	detonatable = 0
+	detonatable = FALSE
 
 /obj/item/device/pda/cargo
 	name = "cargo technician PDA"

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -30,7 +30,7 @@
 //	var/access_flora = 0
 	var/remote_door_id = ""
 
-	var/bot_access_flags = 0 //Bit flags. Selection: SEC_BOT|MULE_BOT|FLOOR_BOT|CLEAN_BOT|MED_BOT
+	var/bot_access_flags = 0 //Bit flags. Selection: SEC_BOT | MULE_BOT | FLOOR_BOT | CLEAN_BOT | MED_BOT
 	var/spam_enabled = 0 //Enables "Send to All" Option
 
 	var/mode = null
@@ -51,13 +51,13 @@
 /obj/item/weapon/cartridge/engineering
 	name = "\improper Power-ON cartridge"
 	icon_state = "cart-e"
-	access = CART_ENGINE|CART_DRONEPHONE
+	access = CART_ENGINE | CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT
 
 /obj/item/weapon/cartridge/atmos
 	name = "\improper BreatheDeep cartridge"
 	icon_state = "cart-a"
-	access = CART_ATMOS|CART_DRONEPHONE
+	access = CART_ATMOS | CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT
 
 /obj/item/weapon/cartridge/medical
@@ -81,14 +81,14 @@
 /obj/item/weapon/cartridge/detective
 	name = "\improper D.E.T.E.C.T. cartridge"
 	icon_state = "cart-s"
-	access = CART_SECURITY|CART_MEDICAL|CART_MANIFEST
+	access = CART_SECURITY | CART_MEDICAL | CART_MANIFEST
 	bot_access_flags = SEC_BOT
 
 /obj/item/weapon/cartridge/janitor
 	name = "\improper CustodiPRO cartridge"
 	desc = "The ultimate in clean-room design."
 	icon_state = "cart-j"
-	access = CART_JANITOR|CART_DRONEPHONE
+	access = CART_JANITOR | CART_DRONEPHONE
 	bot_access_flags = CLEAN_BOT
 
 /obj/item/weapon/cartridge/lawyer
@@ -112,7 +112,7 @@
 /obj/item/weapon/cartridge/roboticist
 	name = "\improper B.O.O.P. Remote Control cartridge"
 	desc = "Packed with heavy duty triple-bot interlink!"
-	bot_access_flags = FLOOR_BOT|CLEAN_BOT|MED_BOT
+	bot_access_flags = FLOOR_BOT | CLEAN_BOT | MED_BOT
 	access = CART_DRONEPHONE
 
 /obj/item/weapon/cartridge/signal
@@ -123,7 +123,7 @@
 	name = "\improper Signal Ace 2 cartridge"
 	desc = "Complete with integrated radio signaler!"
 	icon_state = "cart-tox"
-	access = CART_REAGENT_SCANNER|CART_ATMOS
+	access = CART_REAGENT_SCANNER | CART_ATMOS
 
 /obj/item/weapon/cartridge/signal/New()
 	..()
@@ -141,38 +141,38 @@
 /obj/item/weapon/cartridge/head
 	name = "\improper Easy-Record DELUXE cartridge"
 	icon_state = "cart-h"
-	access = CART_MANIFEST|CART_STATUS_DISPLAY
+	access = CART_MANIFEST | CART_STATUS_DISPLAY
 
 /obj/item/weapon/cartridge/hop
 	name = "\improper HumanResources9001 cartridge"
 	icon_state = "cart-h"
-	access = CART_MANIFEST|CART_STATUS_DISPLAY|CART_JANITOR|CART_SECURITY|CART_NEWSCASTER|CART_QUARTERMASTER|CART_DRONEPHONE
-	bot_access_flags = MULE_BOT|CLEAN_BOT
+	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_JANITOR | CART_SECURITY | CART_NEWSCASTER | CART_QUARTERMASTER | CART_DRONEPHONE
+	bot_access_flags = MULE_BOT | CLEAN_BOT
 
 /obj/item/weapon/cartridge/hos
 	name = "\improper R.O.B.U.S.T. DELUXE cartridge"
 	icon_state = "cart-hos"
-	access = CART_MANIFEST|CART_STATUS_DISPLAY|CART_SECURITY
+	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_SECURITY
 	bot_access_flags = SEC_BOT
 
 
 /obj/item/weapon/cartridge/ce
 	name = "\improper Power-On DELUXE cartridge"
 	icon_state = "cart-ce"
-	access = CART_MANIFEST|CART_STATUS_DISPLAY|CART_ENGINE|CART_ATMOS|CART_DRONEPHONE
+	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_ENGINE | CART_ATMOS | CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT
 
 /obj/item/weapon/cartridge/cmo
 	name = "\improper Med-U DELUXE cartridge"
 	icon_state = "cart-cmo"
-	access = CART_MANIFEST|CART_STATUS_DISPLAY|CART_REAGENT_SCANNER|CART_MEDICAL
+	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_REAGENT_SCANNER | CART_MEDICAL
 	bot_access_flags = MED_BOT
 
 /obj/item/weapon/cartridge/rd
 	name = "\improper Signal Ace DELUXE cartridge"
 	icon_state = "cart-rd"
-	access = CART_MANIFEST|CART_STATUS_DISPLAY|CART_REAGENT_SCANNER|CART_ATMOS|CART_DRONEPHONE
-	bot_access_flags = FLOOR_BOT|CLEAN_BOT|MED_BOT
+	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_REAGENT_SCANNER | CART_ATMOS | CART_DRONEPHONE
+	bot_access_flags = FLOOR_BOT | CLEAN_BOT | MED_BOT
 
 /obj/item/weapon/cartridge/rd/New()
 	..()
@@ -182,8 +182,8 @@
 	name = "\improper Value-PAK cartridge"
 	desc = "Now with 350% more value!" //Give the Captain...EVERYTHING! (Except Mime and Clown)
 	icon_state = "cart-c"
-	access = ~(CART_CLOWN|CART_MIME)
-	bot_access_flags = SEC_BOT|MULE_BOT|FLOOR_BOT|CLEAN_BOT|MED_BOT
+	access = ~(CART_CLOWN | CART_MIME)
+	bot_access_flags = SEC_BOT | MULE_BOT | FLOOR_BOT | CLEAN_BOT | MED_BOT
 	spam_enabled = 1
 
 /obj/item/weapon/cartridge/captain/New()
@@ -284,7 +284,7 @@ Code:
 
 
 			for(var/obj/machinery/computer/monitor/pMon in GLOB.machines)
-				if(!(pMon.stat & (NOPOWER|BROKEN)) )
+				if(!(pMon.stat & (NOPOWER | BROKEN)) )
 					powercount++
 					powermonitors += pMon
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -1,3 +1,20 @@
+#define CART_SECURITY	(1<<0)
+#define CART_ENGINE	(1<<1)
+#define CART_ATMOS	(1<<2)
+#define CART_MEDICAL	(1<<3)
+#define CART_MANIFEST	(1<<4)
+#define CART_CLOWN	(1<<5)
+#define CART_MIME	(1<<6)
+#define CART_JANITOR	(1<<7)
+#define CART_REAGENT_SCANNER	(1<<8)
+#define CART_NEWSCASTER	(1<<9)
+#define CART_REMOTE_DOOR	(1<<10)
+#define CART_STATUS_DISPLAY	(1<<11)
+#define CART_QUARTERMASTER	(1<<12)
+#define CART_HYDROPONICS	(1<<13)
+#define CART_DRONEPHONE	(1<<14)
+
+
 /obj/item/weapon/cartridge
 	name = "generic cartridge"
 	desc = "A data cartridge for portable microcomputers."
@@ -7,23 +24,12 @@
 	w_class = WEIGHT_CLASS_TINY
 
 	var/obj/item/radio/integrated/radio = null
-	var/access_security = 0
-	var/access_engine = 0
-	var/access_atmos = 0
-	var/access_medical = 0
-	var/access_manifest = 0
-	var/access_clown = 0
-	var/access_mime = 0
-	var/access_janitor = 0
+
+	var/access = 0 //Bit flags for cartridge access
+
 //	var/access_flora = 0
-	var/access_reagent_scanner = 0
-	var/access_newscaster = 0
-	var/access_remote_door = 0 //Control some blast doors remotely!!
 	var/remote_door_id = ""
-	var/access_status_display = 0
-	var/access_quartermaster = 0
-	var/access_hydroponics = 0
-	var/access_dronephone = 0
+
 	var/bot_access_flags = 0 //Bit flags. Selection: SEC_BOT|MULE_BOT|FLOOR_BOT|CLEAN_BOT|MED_BOT
 	var/spam_enabled = 0 //Enables "Send to All" Option
 
@@ -45,61 +51,56 @@
 /obj/item/weapon/cartridge/engineering
 	name = "\improper Power-ON cartridge"
 	icon_state = "cart-e"
-	access_engine = 1
-	access_dronephone = 1
+	access = CART_ENGINE|CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT
 
 /obj/item/weapon/cartridge/atmos
 	name = "\improper BreatheDeep cartridge"
 	icon_state = "cart-a"
-	access_atmos = 1
-	access_dronephone = 1
+	access = CART_ATMOS|CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT
 
 /obj/item/weapon/cartridge/medical
 	name = "\improper Med-U cartridge"
 	icon_state = "cart-m"
-	access_medical = 1
+	access = CART_MEDICAL
 	bot_access_flags = MED_BOT
 
 /obj/item/weapon/cartridge/chemistry
 	name = "\improper ChemWhiz cartridge"
 	icon_state = "cart-chem"
-	access_reagent_scanner = 1
+	access = CART_REAGENT_SCANNER
 	bot_access_flags = MED_BOT
 
 /obj/item/weapon/cartridge/security
 	name = "\improper R.O.B.U.S.T. cartridge"
 	icon_state = "cart-s"
-	access_security = 1
+	access = CART_SECURITY
 	bot_access_flags = SEC_BOT
 
 /obj/item/weapon/cartridge/detective
 	name = "\improper D.E.T.E.C.T. cartridge"
 	icon_state = "cart-s"
-	access_security = 1
-	access_medical = 1
-	access_manifest = 1
+	access = CART_SECURITY|CART_MEDICAL|CART_MANIFEST
 	bot_access_flags = SEC_BOT
 
 /obj/item/weapon/cartridge/janitor
 	name = "\improper CustodiPRO cartridge"
 	desc = "The ultimate in clean-room design."
 	icon_state = "cart-j"
-	access_janitor = 1
-	access_dronephone = 1
+	access = CART_JANITOR|CART_DRONEPHONE
 	bot_access_flags = CLEAN_BOT
 
 /obj/item/weapon/cartridge/lawyer
 	name = "\improper P.R.O.V.E. cartridge"
 	icon_state = "cart-s"
-	access_security = 1
+	access = CART_SECURITY
 	spam_enabled = 1
 
 /obj/item/weapon/cartridge/curator
 	name = "\improper Lib-Tweet cartridge"
 	icon_state = "cart-s"
-	access_newscaster = 1
+	access = CART_NEWSCASTER
 
 /*
 /obj/item/weapon/cartridge/botanist
@@ -112,7 +113,7 @@
 	name = "\improper B.O.O.P. Remote Control cartridge"
 	desc = "Packed with heavy duty triple-bot interlink!"
 	bot_access_flags = FLOOR_BOT|CLEAN_BOT|MED_BOT
-	access_dronephone = 1
+	access = CART_DRONEPHONE
 
 /obj/item/weapon/cartridge/signal
 	name = "generic signaler cartridge"
@@ -122,8 +123,7 @@
 	name = "\improper Signal Ace 2 cartridge"
 	desc = "Complete with integrated radio signaler!"
 	icon_state = "cart-tox"
-	access_reagent_scanner = 1
-	access_atmos = 1
+	access = CART_REAGENT_SCANNER|CART_ATMOS
 
 /obj/item/weapon/cartridge/signal/New()
 	..()
@@ -135,63 +135,43 @@
 	name = "space parts & space vendors cartridge"
 	desc = "Perfect for the Quartermaster on the go!"
 	icon_state = "cart-q"
-	access_quartermaster = 1
+	access = CART_QUARTERMASTER
 	bot_access_flags = MULE_BOT
 
 /obj/item/weapon/cartridge/head
 	name = "\improper Easy-Record DELUXE cartridge"
 	icon_state = "cart-h"
-	access_manifest = 1
-	access_status_display = 1
+	access = CART_MANIFEST|CART_STATUS_DISPLAY
 
 /obj/item/weapon/cartridge/hop
 	name = "\improper HumanResources9001 cartridge"
 	icon_state = "cart-h"
-	access_manifest = 1
-	access_status_display = 1
+	access = CART_MANIFEST|CART_STATUS_DISPLAY|CART_JANITOR|CART_SECURITY|CART_NEWSCASTER|CART_QUARTERMASTER|CART_DRONEPHONE
 	bot_access_flags = MULE_BOT|CLEAN_BOT
-	access_janitor = 1
-	access_security = 1
-	access_newscaster = 1
-	access_quartermaster = 1
-	access_dronephone = 1
 
 /obj/item/weapon/cartridge/hos
 	name = "\improper R.O.B.U.S.T. DELUXE cartridge"
 	icon_state = "cart-hos"
-	access_manifest = 1
-	access_status_display = 1
-	access_security = 1
+	access = CART_MANIFEST|CART_STATUS_DISPLAY|CART_SECURITY
 	bot_access_flags = SEC_BOT
 
 
 /obj/item/weapon/cartridge/ce
 	name = "\improper Power-On DELUXE cartridge"
 	icon_state = "cart-ce"
-	access_manifest = 1
-	access_status_display = 1
-	access_engine = 1
-	access_atmos = 1
-	access_dronephone = 1
+	access = CART_MANIFEST|CART_STATUS_DISPLAY|CART_ENGINE|CART_ATMOS|CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT
 
 /obj/item/weapon/cartridge/cmo
 	name = "\improper Med-U DELUXE cartridge"
 	icon_state = "cart-cmo"
-	access_manifest = 1
-	access_status_display = 1
-	access_reagent_scanner = 1
-	access_medical = 1
+	access = CART_MANIFEST|CART_STATUS_DISPLAY|CART_REAGENT_SCANNER|CART_MEDICAL
 	bot_access_flags = MED_BOT
 
 /obj/item/weapon/cartridge/rd
 	name = "\improper Signal Ace DELUXE cartridge"
 	icon_state = "cart-rd"
-	access_manifest = 1
-	access_status_display = 1
-	access_reagent_scanner = 1
-	access_atmos = 1
-	access_dronephone = 1
+	access = CART_MANIFEST|CART_STATUS_DISPLAY|CART_REAGENT_SCANNER|CART_ATMOS|CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT|CLEAN_BOT|MED_BOT
 
 /obj/item/weapon/cartridge/rd/New()
@@ -202,17 +182,7 @@
 	name = "\improper Value-PAK cartridge"
 	desc = "Now with 350% more value!" //Give the Captain...EVERYTHING! (Except Mime and Clown)
 	icon_state = "cart-c"
-	access_manifest = 1
-	access_engine = 1
-	access_security = 1
-	access_medical = 1
-	access_reagent_scanner = 1
-	access_status_display = 1
-	access_atmos = 1
-	access_newscaster = 1
-	access_quartermaster = 1
-	access_janitor = 1
-	access_dronephone = 1
+	access = ~(CART_CLOWN|CART_MIME)
 	bot_access_flags = SEC_BOT|MULE_BOT|FLOOR_BOT|CLEAN_BOT|MED_BOT
 	spam_enabled = 1
 

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -67,8 +67,7 @@
 		var/difficulty = 0
 		if(target.cartridge)
 			difficulty += BitCount(target.cartridge.access&(CART_MEDICAL|CART_SECURITY|CART_ENGINE|CART_CLOWN|CART_JANITOR|CART_MANIFEST))
-			if(target.cartridge.access&CART_MANIFEST) //if cartridge has manifest access it has extra snowflake difficulty
-				difficulty++
+			if(target.cartridge.access&CART_MANIFEST) difficulty++ //if cartridge has manifest access it has extra snowflake difficulty
 		else
 			difficulty += 2
 		if(!target.detonatable || prob(difficulty * 15) || (target.hidden_uplink))

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -70,7 +70,7 @@
 			if(target.cartridge.access&CART_MANIFEST) difficulty++ //if cartridge has manifest access it has extra snowflake difficulty
 		else
 			difficulty += 2
-		if(prob(difficulty * 15) || (target.hidden_uplink))
+		if(!target.detonatable || prob(difficulty * 15) || (target.hidden_uplink))
 			U.show_message("<span class='danger'>An error flashes on your [src].</span>", 1)
 		else
 			U.show_message("<span class='notice'>Success!</span>", 1)

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -67,7 +67,8 @@
 		var/difficulty = 0
 		if(target.cartridge)
 			difficulty += BitCount(target.cartridge.access&(CART_MEDICAL|CART_SECURITY|CART_ENGINE|CART_CLOWN|CART_JANITOR|CART_MANIFEST))
-			if(target.cartridge.access&CART_MANIFEST) difficulty++ //if cartridge has manifest access it has extra snowflake difficulty
+			if(target.cartridge.access&CART_MANIFEST) //if cartridge has manifest access it has extra snowflake difficulty
+				difficulty++
 		else
 			difficulty += 2
 		if(!target.detonatable || prob(difficulty * 15) || (target.hidden_uplink))

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -66,12 +66,8 @@
 		charges--
 		var/difficulty = 0
 		if(target.cartridge)
-			difficulty += target.cartridge.access_medical
-			difficulty += target.cartridge.access_security
-			difficulty += target.cartridge.access_engine
-			difficulty += target.cartridge.access_clown
-			difficulty += target.cartridge.access_janitor
-			difficulty += target.cartridge.access_manifest * 2
+			difficulty += BitCount(target.cartridge.access&(CART_MEDICAL|CART_SECURITY|CART_ENGINE|CART_CLOWN|CART_JANITOR|CART_MANIFEST))
+			if(target.cartridge.access&CART_MANIFEST) difficulty++ //if cartridge has manifest access it has extra snowflake difficulty
 		else
 			difficulty += 2
 		if(prob(difficulty * 15) || (target.hidden_uplink))

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -21,7 +21,7 @@
 	name = "\improper Honkworks 5.0 cartridge"
 	icon_state = "cart-clown"
 	desc = "A data cartridge for portable microcomputers. It smells vaguely of banannas"
-	access_clown = 1
+	access = CART_CLOWN
 
 /obj/item/weapon/cartridge/virus/clown/send_virus(obj/item/device/pda/target, mob/living/U)
 	if(charges <= 0)
@@ -37,7 +37,7 @@
 /obj/item/weapon/cartridge/virus/mime
 	name = "\improper Gestur-O 1000 cartridge"
 	icon_state = "cart-mi"
-	access_mime = 1
+	access = CART_MIME
 
 /obj/item/weapon/cartridge/virus/mime/send_virus(obj/item/device/pda/target, mob/living/U)
 	if(charges <= 0)
@@ -54,7 +54,7 @@
 /obj/item/weapon/cartridge/virus/syndicate
 	name = "\improper Detomatix cartridge"
 	icon_state = "cart"
-	access_remote_door = 1
+	access = CART_REMOTE_DOOR
 	remote_door_id = "smindicate" //Make sure this matches the syndicate shuttle's shield/door id!!	//don't ask about the name, testing.
 	charges = 4
 

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -66,8 +66,8 @@
 		charges--
 		var/difficulty = 0
 		if(target.cartridge)
-			difficulty += BitCount(target.cartridge.access&(CART_MEDICAL|CART_SECURITY|CART_ENGINE|CART_CLOWN|CART_JANITOR|CART_MANIFEST))
-		if(target.cartridge.access&CART_MANIFEST) 
+			difficulty += BitCount(target.cartridge.access&(CART_MEDICAL | CART_SECURITY | CART_ENGINE | CART_CLOWN | CART_JANITOR | CART_MANIFEST))
+		if(target.cartridge.access & CART_MANIFEST) 
 			difficulty++ //if cartridge has manifest access it has extra snowflake difficulty
 		else
 			difficulty += 2

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -67,7 +67,8 @@
 		var/difficulty = 0
 		if(target.cartridge)
 			difficulty += BitCount(target.cartridge.access&(CART_MEDICAL|CART_SECURITY|CART_ENGINE|CART_CLOWN|CART_JANITOR|CART_MANIFEST))
-			if(target.cartridge.access&CART_MANIFEST) difficulty++ //if cartridge has manifest access it has extra snowflake difficulty
+		if(target.cartridge.access&CART_MANIFEST) 
+			difficulty++ //if cartridge has manifest access it has extra snowflake difficulty
 		else
 			difficulty += 2
 		if(!target.detonatable || prob(difficulty * 15) || (target.hidden_uplink))


### PR DESCRIPTION
Instead of an ungodly amount of vars they are now bit flags with an ungodly amount of #define's.

Also I renamed the detonate var and fixed a thing where the virus sending PDA will no longer return success when the target PDAs aren't detonatable in the first place.