### PR TITLE
Minor telecom code cleanup

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -48,23 +48,23 @@
 //Checks if the list is empty
 /proc/isemptylist(list/L)
 	if(!L.len)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 //Checks for specific types in a list
 /proc/is_type_in_list(atom/A, list/L)
 	if(!L || !L.len || !A)
-		return 0
+		return FALSE
 	for(var/type in L)
 		if(istype(A, type))
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
 //Checks for specific types in specifically structured (Assoc "type" = TRUE) lists ('typecaches')
 /proc/is_type_in_typecache(atom/A, list/L)
 	if(!L || !L.len || !A)
 
-		return 0
+		return FALSE
 	if(ispath(A))
 		. = L[A]
 	else
@@ -76,7 +76,7 @@
 		return
 	for(var/V in L)
 		if(string == V)
-			return 1
+			return TRUE
 	return
 
 //Removes a string from a list

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -153,7 +153,7 @@
 //Use this to test if an obj can communicate with a Telecommunications Network
 
 /atom/proc/test_telecomms()
-	var/datum/signal/signal = src.telecomms_process()
+	var/datum/signal/signal = telecomms_process()
 	var/turf/position = get_turf(src)
 	return (position.z in signal.data["level"] && signal.data["done"])
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -205,11 +205,6 @@
 				temp = "<font color = #666633>-% [src] has been [toggled ? "activated" : "deactivated"].</font color>"
 				update_power()
 
-			/*
-			if("hide")
-				hide = !hide
-				temp = "<font color = #666633>-% Shadow Link has been [hide ? "activated" : "deactivated"].</font color>"
-			*/
 
 			if("id")
 				var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID for this machine", src, id) as null|text),1,MAX_MESSAGE_LEN)
@@ -260,7 +255,7 @@
 			if(T)
 				temp = "<font color = #666633>-% Removed \ref[T] [T.name] from linked entities. %-</font color>"
 
-				// Remove link entries from both T and
+				// Remove link entries from both T and src.
 
 				if(T.links)
 					T.links.Remove(src)

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -5,12 +5,8 @@
 
 */
 
-#define STATION_Z 1
-#define TELECOMM_Z 3
-
 /obj/machinery/telecomms
 	var/temp = "" // output message
-
 
 /obj/machinery/telecomms/attackby(obj/item/P, mob/user, params)
 
@@ -54,9 +50,9 @@
 
 	user.set_machine(src)
 	var/dat
-	dat = "<font face = \"Courier\"><HEAD><TITLE>[src.name]</TITLE></HEAD><center><H3>[src.name] Access</H3></center>"
+	dat = "<font face = \"Courier\"><HEAD><TITLE>[name]</TITLE></HEAD><center><H3>[name] Access</H3></center>"
 	dat += "<br>[temp]<br>"
-	dat += "<br>Power Status: <a href='?src=\ref[src];input=toggle'>[src.toggled ? "On" : "Off"]</a>"
+	dat += "<br>Power Status: <a href='?src=\ref[src];input=toggle'>[toggled ? "On" : "Off"]</a>"
 	if(on && toggled)
 		if(id != "" && id)
 			dat += "<br>Identification String: <a href='?src=\ref[src];input=id'>[id]</a>"
@@ -74,7 +70,7 @@
 		var/i = 0
 		for(var/obj/machinery/telecomms/T in links)
 			i++
-			if(T.hide && !src.hide)
+			if(T.hide && !hide)
 				continue
 			dat += "<li>\ref[T] [T.name] ([T.id])  <a href='?src=\ref[src];unlink=[i]'>\[X\]</a></li>"
 		dat += "</ol>"
@@ -110,8 +106,7 @@
 
 // Off-Site Relays
 //
-// You are able to send/receive signals from the station's z level (changeable in the STATION_Z #define) if
-// the relay is on the telecomm satellite (changable in the TELECOMM_Z #define)
+// You are able to send/receive signals from the station's z level (changeable in the ZLEVEL_STATION #define) if
 
 
 /obj/machinery/telecomms/relay/proc/toggle_level()
@@ -119,13 +114,10 @@
 	var/turf/position = get_turf(src)
 
 	// Toggle on/off getting signals from the station or the current Z level
-	if(src.listening_level == STATION_Z) // equals the station
-		src.listening_level = position.z
-		return 1
-	else if(position.z == TELECOMM_Z)
-		src.listening_level = STATION_Z
-		return 1
-	return 0
+	if(listening_level == ZLEVEL_STATION) // equals the station
+		listening_level = position.z
+		return TRUE
+	return FALSE
 
 // Returns a multitool from a user depending on their mobtype.
 
@@ -158,8 +150,6 @@
 
 /obj/machinery/telecomms/relay/Options_Menu()
 	var/dat = ""
-	if(src.z == TELECOMM_Z)
-		dat += "<br>Signal Locked to Station: <A href='?src=\ref[src];change_listening=1'>[listening_level == STATION_Z ? "TRUE" : "FALSE"]</a>"
 	dat += "<br>Broadcasting: <A href='?src=\ref[src];broadcast=1'>[broadcasting ? "YES" : "NO"]</a>"
 	dat += "<br>Receiving:    <A href='?src=\ref[src];receive=1'>[receiving ? "YES" : "NO"]</a>"
 	return dat
@@ -172,14 +162,6 @@
 	if(href_list["broadcast"])
 		broadcasting = !broadcasting
 		temp = "<font color = #666633>-% Broadcasting mode changed. %-</font color>"
-	if(href_list["change_listening"])
-		//Lock to the station OR lock to the current position!
-		//You need at least two receivers and two broadcasters for this to work, this includes the machine.
-		var/result = toggle_level()
-		if(result)
-			temp = "<font color = #666633>-% [src]'s signal has been successfully changed.</font color>"
-		else
-			temp = "<font color = #666633>-% [src] could not lock its signal onto the station. Two broadcasters or receivers required.</font color>"
 
 // BUS
 
@@ -219,14 +201,14 @@
 
 			if("toggle")
 
-				src.toggled = !src.toggled
-				temp = "<font color = #666633>-% [src] has been [src.toggled ? "activated" : "deactivated"].</font color>"
+				toggled = !toggled
+				temp = "<font color = #666633>-% [src] has been [toggled ? "activated" : "deactivated"].</font color>"
 				update_power()
 
 			/*
 			if("hide")
-				src.hide = !hide
-				temp = "<font color = #666633>-% Shadow Link has been [src.hide ? "activated" : "deactivated"].</font color>"
+				hide = !hide
+				temp = "<font color = #666633>-% Shadow Link has been [hide ? "activated" : "deactivated"].</font color>"
 			*/
 
 			if("id")
@@ -278,7 +260,7 @@
 			if(T)
 				temp = "<font color = #666633>-% Removed \ref[T] [T.name] from linked entities. %-</font color>"
 
-				// Remove link entries from both T and src.
+				// Remove link entries from both T and
 
 				if(T.links)
 					T.links.Remove(src)
@@ -295,8 +277,8 @@
 				if(!(src in T.links))
 					T.links.Add(src)
 
-				if(!(T in src.links))
-					src.links.Add(T)
+				if(!(T in links))
+					links.Add(T)
 
 				temp = "<font color = #666633>-% Successfully linked with \ref[T] [T.name] %-</font color>"
 
@@ -314,7 +296,7 @@
 		temp = "<font color = #666633>-% Buffer successfully flushed. %-</font color>"
 		P.buffer = null
 
-	src.Options_Topic(href, href_list)
+	Options_Topic(href, href_list)
 
 	usr.set_machine(src)
 
@@ -322,8 +304,5 @@
 
 /obj/machinery/telecomms/proc/canAccess(mob/user)
 	if(issilicon(user) || in_range(user, src))
-		return 1
-	return 0
-
-#undef TELECOMM_Z
-#undef STATION_Z
+		return TRUE
+	return FALSE

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -270,10 +270,10 @@
 			var/obj/machinery/telecomms/T = P.buffer
 			if(istype(T) && T != src)
 				if(!(src in T.links))
-					T.links.Add(src)
+					T.links += src
 
 				if(!(T in links))
-					links.Add(T)
+					links += T
 
 				temp = "<font color = #666633>-% Successfully linked with \ref[T] [T.name] %-</font color>"
 

--- a/code/game/machinery/telecomms/machines/relay.dm
+++ b/code/game/machinery/telecomms/machines/relay.dm
@@ -30,19 +30,19 @@
 
 /obj/machinery/telecomms/relay/proc/can(datum/signal/signal)
 	if(!on)
-		return 0
+		return FALSE
 	if(!is_freq_listening(signal))
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /obj/machinery/telecomms/relay/proc/can_send(datum/signal/signal)
 	if(!can(signal))
-		return 0
+		return FALSE
 	return broadcasting
 
 /obj/machinery/telecomms/relay/proc/can_receive(datum/signal/signal)
 	if(!can(signal))
-		return 0
+		return FALSE
 	return receiving
 
 /obj/machinery/telecomms/relay/New()

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -124,13 +124,13 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 	..()
 
 /obj/machinery/telecomms/proc/is_freq_listening(datum/signal/signal)
-	// return 1 if found, 0 if not found
+	// return TRUE if found, 0 if not found
 	if(!signal)
-		return 0
+		return FALSE
 	if((signal.frequency in freq_listening) || (!freq_listening.len))
-		return 1
+		return TRUE
 	else
-		return 0
+		return FALSE
 
 
 /obj/machinery/telecomms/New()
@@ -171,7 +171,7 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 /obj/machinery/telecomms/proc/add_link(obj/machinery/telecomms/T)
 	var/turf/position = get_turf(src)
 	var/turf/T_position = get_turf(T)
-	if((position.z == T_position.z) || (src.long_range_link && T.long_range_link))
+	if((position.z == T_position.z) || (long_range_link && T.long_range_link))
 		if(src != T)
 			for(var/x in autolinkers)
 				if(x in T.autolinkers)

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -124,7 +124,7 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 	..()
 
 /obj/machinery/telecomms/proc/is_freq_listening(datum/signal/signal)
-	// return TRUE if found, 0 if not found
+	// return TRUE if found, FALSE if not found
 	if(!signal)
 		return FALSE
 	if((signal.frequency in freq_listening) || (!freq_listening.len))

--- a/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
@@ -62,7 +62,7 @@
 
 /datum/ntnet_conversation/proc/change_title(newtitle, datum/computer_file/program/chatclient/client)
 	if(operator != client)
-		return 0 // Not Authorised
+		return FALSE // Not Authorised
 
 	add_status_message("[client.username] has changed channel title from [title] to [newtitle]")
 	title = newtitle

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -53,7 +53,7 @@ GLOBAL_DATUM_INIT(ntnet_global, /datum/ntnet, new)
 // Checks whether NTNet operates. If parameter is passed checks whether specific function is enabled.
 /datum/ntnet/proc/check_function(specific_action = 0)
 	if(!relays || !relays.len) // No relays found. NTNet is down
-		return 0
+		return FALSE
 
 	var/operating = 0
 
@@ -65,7 +65,7 @@ GLOBAL_DATUM_INIT(ntnet_global, /datum/ntnet, new)
 			break
 
 	if(setting_disabled)
-		return 0
+		return FALSE
 
 	switch(specific_action)
 		if(NTNET_SOFTWAREDOWNLOAD)
@@ -120,7 +120,7 @@ GLOBAL_DATUM_INIT(ntnet_global, /datum/ntnet, new)
 // Updates maximal amount of stored logs. Use this instead of setting the number, it performs required checks.
 /datum/ntnet/proc/update_max_log_count(lognumber)
 	if(!lognumber)
-		return 0
+		return FALSE
 	// Trim the value if necessary
 	lognumber = max(MIN_NTNET_LOGS, min(lognumber, MAX_NTNET_LOGS))
 	setting_maxlogcount = lognumber


### PR DESCRIPTION
Removes STATION_Z define, we have that already as ZLEVEL_STATION.
Removes TELECOMM_Z, as we don't have a telecoms sat anymore
Removes anything that uses src.var instead of just the var's name.
Makes return 1/0 into return TRUE/FALSE