### PR TITLE
Adds some custom force strings and fixes a bug

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -672,7 +672,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(!force_string_override)
 		openToolTip(user,src,params,title = name,content = "[desc]<br>[force ? "<b>Force:</b> [force_string]" : ""]",theme = "")
 	else
-		openToolTip(user,src,params,title = name,content = "[desc]<br><b>Force:</b> [force_string],theme = "")
+		openToolTip(user,src,params,title = name,content = "[desc]<br><b>Force:</b> [force_string]",theme = "")
 
 /obj/item/MouseEntered(location, control, params)
 	if(in_inventory && usr.client.prefs.enable_tips)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -669,7 +669,10 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/openTip(location, control, params, user)
 	if(last_force_string_check != force && !force_string_override)
 		set_force_string()
-	openToolTip(user,src,params,title = name,content = "[desc]<br>[force ? "<b>Force:</b> [force_string]" : ""]",theme = "")
+	if(!force_string_override)
+		openToolTip(user,src,params,title = name,content = "[desc]<br>[force ? "<b>Force:</b> [force_string]" : ""]",theme = "")
+	else
+		openToolTip(user,src,params,title = name,content = "[desc]<br><b>Force:</b> [force_string],theme = "")
 
 /obj/item/MouseEntered(location, control, params)
 	if(in_inventory && usr.client.prefs.enable_tips)

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -21,6 +21,7 @@
 	throw_speed = 3
 	throw_range = 7
 	var/cleanspeed = 50 //slower than mop
+	force_string = "robust... against germs"
 
 /obj/item/weapon/soap/nanotrasen
 	desc = "A Nanotrasen brand bar of soap. Smells of plasma."
@@ -108,6 +109,7 @@
 	var/next_usable = 0
 	var/honksound = 'sound/items/bikehorn.ogg'
 	var/cooldowntime = 20
+	force_string = "HONK!"
 
 /obj/item/weapon/bikehorn/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] solemnly points the horn at [user.p_their()] temple! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -137,6 +139,7 @@
 	honksound = 'sound/items/airhorn2.ogg'
 	cooldowntime = 50
 	origin_tech = "materials=4;engineering=4"
+	force_string = "HOOOOOOOONK!"
 
 /obj/item/weapon/bikehorn/golden
 	name = "golden bike horn"

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -109,7 +109,6 @@
 	var/next_usable = 0
 	var/honksound = 'sound/items/bikehorn.ogg'
 	var/cooldowntime = 20
-	force_string = "HONK!"
 
 /obj/item/weapon/bikehorn/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] solemnly points the horn at [user.p_their()] temple! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -139,7 +138,6 @@
 	honksound = 'sound/items/airhorn2.ogg'
 	cooldowntime = 50
 	origin_tech = "materials=4;engineering=4"
-	force_string = "HOOOOOOOONK!"
 
 /obj/item/weapon/bikehorn/golden
 	name = "golden bike horn"

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -23,7 +23,6 @@
 	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
 	hitsound = 'sound/weapons/chainhit.ogg'
 	materials = list(MAT_METAL = 1000)
-	force_string = "disciplinary"
 
 /obj/item/weapon/melee/chainofcommand/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is strangling [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -60,7 +59,6 @@
 	attack_verb = list("slashed", "cut")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	materials = list(MAT_METAL = 1000)
-	force_string = "classy"
 
 /obj/item/weapon/melee/sabre/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
 	if(attack_type == PROJECTILE_ATTACK)
@@ -78,7 +76,6 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	var/cooldown = 0
 	var/on = 1
-	force_string = "pinnacle of perp prejudice"
 
 /obj/item/weapon/melee/classic_baton/attack(mob/target, mob/living/user)
 	if(!on)

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -23,6 +23,7 @@
 	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
 	hitsound = 'sound/weapons/chainhit.ogg'
 	materials = list(MAT_METAL = 1000)
+	force_string = "disciplinary"
 
 /obj/item/weapon/melee/chainofcommand/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is strangling [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -59,6 +60,7 @@
 	attack_verb = list("slashed", "cut")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	materials = list(MAT_METAL = 1000)
+	force_string = "classy"
 
 /obj/item/weapon/melee/sabre/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
 	if(attack_type == PROJECTILE_ATTACK)
@@ -76,6 +78,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	var/cooldown = 0
 	var/on = 1
+	force_string = "pinnacle of perp prejudice"
 
 /obj/item/weapon/melee/classic_baton/attack(mob/target, mob/living/user)
 	if(!on)
@@ -185,6 +188,7 @@
 	var/obj/machinery/power/supermatter_shard/shard
 	var/balanced = 1
 	origin_tech = "combat=7;materials=6"
+	force_string = "INFINITE"
 
 /obj/item/weapon/melee/supermatter_sword/New()
 	..()

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -14,6 +14,7 @@
 	var/mopcount = 0
 	var/mopcap = 5
 	var/mopspeed = 30
+	force_string = "robust... against germs"
 
 /obj/item/weapon/mop/New()
 	..()

--- a/code/game/objects/items/weapons/singularityhammer.dm
+++ b/code/game/objects/items/weapons/singularityhammer.dm
@@ -14,6 +14,7 @@
 	origin_tech = "combat=4;bluespace=4;plasmatech=7"
 	armor = list(melee = 50, bullet = 50, laser = 50, energy = 0, bomb = 50, bio = 0, rad = 0, fire = 100, acid = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	force_string = "LORD SINGULOTH HIMSELF"
 
 /obj/item/weapon/twohanded/singularityhammer/New()
 	..()

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 	item_state = "bible"
 	var/mob/affecting = null
 	var/deity_name = "Christ"
-	force_string = "Holy"
+	force_string = "holy"
 
 /obj/item/weapon/storage/book/bible/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is offering [user.p_them()]self to [deity_name]! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -25,6 +25,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 	item_state = "bible"
 	var/mob/affecting = null
 	var/deity_name = "Christ"
+	force_string = "Holy"
 
 /obj/item/weapon/storage/book/bible/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is offering [user.p_them()]self to [deity_name]! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -15,7 +15,6 @@
 	obj_integrity = 150
 	max_integrity = 150
 	var/folder_path = /obj/item/weapon/folder //this is the path of the folder that gets spawned in New()
-	force_string = "professional"
 
 /obj/item/weapon/storage/briefcase/PopulateContents()
 	new /obj/item/weapon/pen(src)

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -15,6 +15,7 @@
 	obj_integrity = 150
 	max_integrity = 150
 	var/folder_path = /obj/item/weapon/folder //this is the path of the folder that gets spawned in New()
+	force_string = "professional"
 
 /obj/item/weapon/storage/briefcase/PopulateContents()
 	new /obj/item/weapon/pen(src)


### PR DESCRIPTION
my tooltip PR had this ability, I just didn't use it.

:cl: Tacolizard
add: Some items now have custom force strings in their tooltips.
fix: items with no force can still use a custom force string.
/:cl:
