### PR TITLE
Fixes grenade belt and bandolier UI obscuring half the screen

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -289,7 +289,7 @@
 	icon_state = "grenadebeltnew"
 	item_state = "security"
 	max_w_class = WEIGHT_CLASS_BULKY
-	display_contents_with_number = 1
+	display_contents_with_number = TRUE
 	storage_slots = 30
 	max_combined_w_class = 60 //needs to be this high
 	can_hold = list(
@@ -376,7 +376,7 @@
 	icon_state = "bandolier"
 	item_state = "bandolier"
 	storage_slots = 18
-	display_contents_with_number = 1
+	display_contents_with_number = TRUE
 	can_hold = list(
 		/obj/item/ammo_casing/shotgun
 		)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -289,7 +289,9 @@
 	icon_state = "grenadebeltnew"
 	item_state = "security"
 	max_w_class = WEIGHT_CLASS_BULKY
+	display_contents_with_number = 1
 	storage_slots = 30
+	max_combined_w_class = 60 //needs to be this high
 	can_hold = list(
 		/obj/item/weapon/grenade,
 		/obj/item/weapon/screwdriver,
@@ -374,6 +376,7 @@
 	icon_state = "bandolier"
 	item_state = "bandolier"
 	storage_slots = 18
+	display_contents_with_number = 1
 	can_hold = list(
 		/obj/item/ammo_casing/shotgun
 		)


### PR DESCRIPTION



:cl: 
fix: Grenade belts and bandoliers will no longer obscure half the screen when they're completely filled.
/:cl:

Also fixes storage size of the grenade belts so you can put stuff back in if you take it out