### PR TITLE
Fixes pimpin ride janicart (and other ridden vehicles) being spaceworthy

### DIFF
--- a/code/datums/riding.dm
+++ b/code/datums/riding.dm
@@ -106,9 +106,6 @@
 	if(ridden.has_gravity())
 		return 1
 
-	if(ridden.pulledby)
-		return 1
-
 	return 0
 
 /datum/riding/space/Process_Spacemove(direction)


### PR DESCRIPTION
:cl:
fix: After a janitorial audit Nanotrasen has decided to further cut costs by removing the janicart's secret space propulsion functionality
/:cl:

This bug was essentially fixed before in https://github.com/tgstation/tgstation/pull/22495 but was reintroduced with the riding datum refactor https://github.com/tgstation/tgstation/pull/22420.

Instead of copying the fix I instead asked "Should a riding datum handling riding ever need to check for pulling?" and the answer was "No."

Fixes https://github.com/tgstation/tgstation/issues/28417