### PR TITLE
Removes the need for GLOB.

### DIFF
--- a/code/__DATASTRUCTURES/globals.dm
+++ b/code/__DATASTRUCTURES/globals.dm
@@ -22,18 +22,18 @@
 
 #define GLOBAL_RAW(X) /datum/controller/global_vars/var/global##X
 
-#define GLOBAL_VAR_INIT(X, InitValue)  GLOBAL_REAL(/##X); GLOBAL_RAW(/##X); GLOBAL_MANAGED(X, InitValue)
+#define GLOBAL_VAR_INIT(X, InitValue)  GLOBAL_REAL_VAR(/##X); GLOBAL_RAW(/##X); GLOBAL_MANAGED(X, InitValue)
 
-#define GLOBAL_VAR_CONST(X, InitValue)  GLOBAL_REAL(/const/##X) = InitValue; GLOBAL_RAW(/const/##X) = InitValue; GLOBAL_UNMANAGED(X, InitValue)
+#define GLOBAL_VAR_CONST(X, InitValue)  GLOBAL_REAL_VAR(/const/##X) = InitValue; GLOBAL_RAW(/const/##X) = InitValue; GLOBAL_UNMANAGED(X, InitValue)
 
-#define GLOBAL_LIST_INIT(X, InitValue) GLOBAL_REAL(/list/##X); GLOBAL_RAW(/list/##X); GLOBAL_MANAGED(X, InitValue)
+#define GLOBAL_LIST_INIT(X, InitValue) GLOBAL_REAL_VAR(/list/##X); GLOBAL_RAW(/list/##X); GLOBAL_MANAGED(X, InitValue)
 
 #define GLOBAL_LIST_EMPTY(X) GLOBAL_LIST_INIT(X, list())
 
-#define GLOBAL_DATUM_INIT(X, Typepath, InitValue) GLOBAL_REAL(Typepath/##X); GLOBAL_RAW(Typepath/##X); GLOBAL_MANAGED(X, InitValue)
+#define GLOBAL_DATUM_INIT(X, Typepath, InitValue) GLOBAL_REAL_VAR(Typepath/##X); GLOBAL_RAW(Typepath/##X); GLOBAL_MANAGED(X, InitValue)
 
-#define GLOBAL_VAR(X) GLOBAL_REAL(/##X); GLOBAL_RAW(/##X); GLOBAL_MANAGED(X, null)
+#define GLOBAL_VAR(X) GLOBAL_REAL_VAR(/##X); GLOBAL_RAW(/##X); GLOBAL_MANAGED(X, null)
 
-#define GLOBAL_LIST(X) GLOBAL_REAL(/list/##X); GLOBAL_RAW(/list/##X); GLOBAL_MANAGED(X, null)
+#define GLOBAL_LIST(X) GLOBAL_REAL_VAR(/list/##X); GLOBAL_RAW(/list/##X); GLOBAL_MANAGED(X, null)
 
-#define GLOBAL_DATUM(X, Typepath) GLOBAL_REAL(Typepath/##X); GLOBAL_RAW(Typepath/##X); GLOBAL_MANAGED(X, null)
+#define GLOBAL_DATUM(X, Typepath) GLOBAL_REAL_VAR(Typepath/##X); GLOBAL_RAW(Typepath/##X); GLOBAL_MANAGED(X, null)

--- a/code/__DATASTRUCTURES/globals.dm
+++ b/code/__DATASTRUCTURES/globals.dm
@@ -4,6 +4,7 @@
     ##X = ##InitValue;\
     gvars_datum_init_order += #X;\
 }
+//todo, remove the need for this by making global init check hascall
 #define GLOBAL_UNMANAGED(X, InitValue) /datum/controller/global_vars/proc/InitGlobal##X()
 
 #ifndef TESTING
@@ -21,18 +22,18 @@
 
 #define GLOBAL_RAW(X) /datum/controller/global_vars/var/global##X
 
-#define GLOBAL_VAR_INIT(X, InitValue) GLOBAL_RAW(/##X); GLOBAL_MANAGED(X, InitValue)
+#define GLOBAL_VAR_INIT(X, InitValue)  GLOBAL_REAL(/##X); GLOBAL_RAW(/##X); GLOBAL_MANAGED(X, InitValue)
 
-#define GLOBAL_VAR_CONST(X, InitValue) GLOBAL_RAW(/const/##X) = InitValue; GLOBAL_UNMANAGED(X, InitValue)
+#define GLOBAL_VAR_CONST(X, InitValue)  GLOBAL_REAL(/const/##X) = InitValue; GLOBAL_RAW(/const/##X) = InitValue; GLOBAL_UNMANAGED(X, InitValue)
 
-#define GLOBAL_LIST_INIT(X, InitValue) GLOBAL_RAW(/list/##X); GLOBAL_MANAGED(X, InitValue)
+#define GLOBAL_LIST_INIT(X, InitValue) GLOBAL_REAL(/list/##X); GLOBAL_RAW(/list/##X); GLOBAL_MANAGED(X, InitValue)
 
 #define GLOBAL_LIST_EMPTY(X) GLOBAL_LIST_INIT(X, list())
 
-#define GLOBAL_DATUM_INIT(X, Typepath, InitValue) GLOBAL_RAW(Typepath/##X); GLOBAL_MANAGED(X, InitValue)
+#define GLOBAL_DATUM_INIT(X, Typepath, InitValue) GLOBAL_REAL(Typepath/##X); GLOBAL_RAW(Typepath/##X); GLOBAL_MANAGED(X, InitValue)
 
-#define GLOBAL_VAR(X) GLOBAL_RAW(/##X); GLOBAL_MANAGED(X, null)
+#define GLOBAL_VAR(X) GLOBAL_REAL(/##X); GLOBAL_RAW(/##X); GLOBAL_MANAGED(X, null)
 
-#define GLOBAL_LIST(X) GLOBAL_RAW(/list/##X); GLOBAL_MANAGED(X, null)
+#define GLOBAL_LIST(X) GLOBAL_REAL(/list/##X); GLOBAL_RAW(/list/##X); GLOBAL_MANAGED(X, null)
 
-#define GLOBAL_DATUM(X, Typepath) GLOBAL_RAW(Typepath/##X); GLOBAL_MANAGED(X, null)
+#define GLOBAL_DATUM(X, Typepath) GLOBAL_REAL(Typepath/##X); GLOBAL_RAW(Typepath/##X); GLOBAL_MANAGED(X, null)


### PR DESCRIPTION
A birdy once told me that static vars with the same name share a value.

the /global/ keyword is a synonym for static, and global_real uses it, so global_real vars with the same name as a managed global var share a value, so this is a stupid easy way to get what we want (if true, i haven't actually tested half of these assertions)

@Cyberboss 