### PR TITLE
Makes movement delay calculation not round to the tick

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -109,10 +109,12 @@
 			mob.control_object.loc = get_step(mob.control_object,direct)
 	return
 
-
+#define MOVEMENT_DELAY_BUFFER 0.75
+#define MOVEMENT_DELAY_BUFFER_DELTA 1.25
 /client/Move(n, direct)
 	if(world.time < move_delay)
 		return 0
+	var/old_move_delay = move_delay
 	move_delay = world.time+world.tick_lag //this is here because Move() can now be called mutiple times per tick
 	if(!mob || !mob.loc)
 		return 0
@@ -159,6 +161,9 @@
 
 	//We are now going to move
 	moving = 1
+	var/delay = mob.movement_delay()
+	if (move_delay + (delay*MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER) > world.time)
+		move_delay += mob.movement_delay()
 	move_delay = mob.movement_delay() + world.time
 
 	if(mob.confused)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -163,8 +163,9 @@
 	moving = 1
 	var/delay = mob.movement_delay()
 	if (move_delay + (delay*MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER) > world.time)
-		move_delay += mob.movement_delay()
-	move_delay = mob.movement_delay() + world.time
+		move_delay = old_move_delay + delay
+	else
+		move_delay = delay + world.time
 
 	if(mob.confused)
 		if(mob.confused > 40)
@@ -194,6 +195,7 @@
 	. = ..()
 	for(var/obj/O in contents)
 		O.on_mob_turn(newDir, src)
+
 
 ///Process_Grab()
 ///Called by client/Move()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -162,7 +162,7 @@
 	//We are now going to move
 	moving = 1
 	var/delay = mob.movement_delay()
-	if (move_delay + (delay*MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER > world.time)
+	if (old_move_delay + (delay*MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER > world.time)
 		move_delay = old_move_delay + delay
 	else
 		move_delay = delay + world.time

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -162,7 +162,7 @@
 	//We are now going to move
 	moving = 1
 	var/delay = mob.movement_delay()
-	if (move_delay + (delay*MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER) > world.time)
+	if (move_delay + (delay*MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER > world.time)
 		move_delay = old_move_delay + delay
 	else
 		move_delay = delay + world.time


### PR DESCRIPTION
Before:
if:
run_delay = 0.75ds
tick_lag = 0.5ds

Moves would be at 0ds, 1ds, 2ds, 3ds, 4ds, 5ds, 6ds, 7ds.

Now,

moves at 0ds, 1ds, 1.5ds, 2.5ds, 3ds, 4ds, 4.5ds, 5.5ds.

