### PR TITLE
Var-edit Cleanup and Fixes: Mk3 - The Revenge

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -91,7 +91,6 @@
 "ao" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/effect/decal/sandeffect,

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -315,8 +315,7 @@
 /area/ruin/powered/beach)
 "ba" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/pod/dark{
 	baseturf = /turf/open/floor/plating/asteroid/basalt;
@@ -346,7 +345,6 @@
 /area/ruin/powered/beach)
 "bf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/pod/dark{

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -494,8 +494,7 @@
 /area/ruin/powered/beach)
 "bB" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -538,8 +537,7 @@
 /area/ruin/powered/beach)
 "bH" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/effect/mob_spawn/human/beach/alive{
 	flavour_text = "You're a spunky lifeguard! It's up to you to make sure nobody drowns or gets eaten by sharks and stuff.";

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -92,8 +92,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/sandeffect,
 /obj/structure/mirror{

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -607,7 +607,6 @@
 /area/ruin/powered/clownplanet)
 "bo" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -172,7 +172,6 @@
 /area/lavaland/surface/outdoors)
 "ay" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -53,7 +53,6 @@
 /area/ruin/powered/golem_ship)
 "h" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/structure/window/reinforced{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -119,8 +119,7 @@
 /obj/structure/statue/gold/rd,
 /obj/structure/window/reinforced{
 	dir = 4;
-	name = "shrine of the liberator";
-	pixel_x = 0
+	name = "shrine of the liberator"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -163,8 +162,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
-	name = "shrine of the liberator";
-	pixel_x = 0
+	name = "shrine of the liberator"
 	},
 /turf/open/floor/mineral/titanium/purple{
 	baseturf = /turf/open/floor/plating/lava/smooth

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -78,8 +78,7 @@
 /area/ruin/unpowered)
 "l" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop{
@@ -334,8 +333,7 @@
 /area/ruin/unpowered)
 "P" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -153,7 +153,6 @@
 /area/ruin/powered/seedvault)
 "u" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -190,7 +189,6 @@
 "y" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/freezer{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -191,8 +191,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/lava/smooth

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -389,8 +389,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -585,7 +584,6 @@
 /area/ruin/powered/syndicate_lava_base)
 "br" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/computer/pandemic,
@@ -1186,8 +1184,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 30
@@ -1222,8 +1219,7 @@
 	dir = 8;
 	freerange = 1;
 	listening = 1;
-	name = "Pirate Radio Listening Channel";
-	pixel_x = 0
+	name = "Pirate Radio Listening Channel"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -1293,8 +1289,7 @@
 	dir = 8;
 	freerange = 1;
 	listening = 0;
-	name = "Pirate Radio Broadcast Channel";
-	pixel_x = 0
+	name = "Pirate Radio Broadcast Channel"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -388,7 +388,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/vault{
@@ -1183,7 +1182,6 @@
 "cK" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -2101,6 +2101,14 @@
 	},
 /turf/open/floor/circuit/red,
 /area/ruin/powered/syndicate_lava_base)
+"gm" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
+"gn" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/powered)
 
 (1,1,1) = {"
 aa
@@ -2452,7 +2460,7 @@ ge
 cG
 cW
 cG
-gj
+ge
 cG
 dv
 ac
@@ -2848,7 +2856,7 @@ cn
 cw
 cf
 aq
-gf
+fL
 cT
 cY
 dg
@@ -2896,8 +2904,8 @@ ad
 ad
 ad
 ad
-dv
-du
+gm
+ab
 ab
 ab
 ab
@@ -2927,10 +2935,10 @@ aY
 co
 cy
 aY
-gc
+fT
 aY
 aY
-gg
+fT
 aY
 cv
 dn
@@ -2967,10 +2975,10 @@ aZ
 cp
 cz
 aZ
-gd
+fU
 aZ
 aZ
-gh
+fU
 aZ
 cA
 dn
@@ -3016,8 +3024,8 @@ dv
 dv
 dv
 dv
-dv
-du
+gn
+ab
 ab
 ab
 ab
@@ -3124,8 +3132,8 @@ ap
 aq
 bP
 ad
-fY
-gb
+fX
+ga
 cf
 aq
 cM
@@ -3236,7 +3244,7 @@ au
 aO
 aT
 aq
-fO
+fN
 ae
 bu
 bu
@@ -3402,7 +3410,7 @@ fQ
 bI
 ap
 bU
-fW
+fV
 ad
 ct
 cC

--- a/_maps/RandomRuins/SpaceRuins/DJstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation.dmm
@@ -96,7 +96,6 @@
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -194,8 +193,7 @@
 	dir = 8;
 	freerange = 1;
 	listening = 1;
-	name = "Pirate Radio Listening Channel";
-	pixel_x = 0
+	name = "Pirate Radio Listening Channel"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/djstation)
@@ -246,8 +244,7 @@
 	dir = 8;
 	freerange = 1;
 	listening = 0;
-	name = "Pirate Radio Broadcast Channel";
-	pixel_x = 0
+	name = "Pirate Radio Broadcast Channel"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/djstation)
@@ -354,7 +351,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/cafeteria,

--- a/_maps/RandomRuins/SpaceRuins/DJstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation.dmm
@@ -322,7 +322,6 @@
 /area/djstation)
 "be" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -2710,7 +2710,6 @@
 /area/derelict/medical/chapel)
 "hV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/airless/white,
@@ -2986,7 +2985,6 @@
 /area/derelict/medical)
 "iO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -3293,14 +3291,12 @@
 /area/ruin/unpowered/no_grav)
 "jH" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/derelict/arrival)
 "jI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -4082,7 +4082,6 @@
 /area/derelict/atmospherics)
 "lO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating/airless,
@@ -4134,7 +4133,6 @@
 /area/derelict/atmospherics)
 "lV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating/airless,

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -946,8 +946,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/derelict/bridge/access)
@@ -1651,8 +1650,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/derelict/bridge/access)
@@ -1663,8 +1661,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/derelict/bridge/access)
@@ -1672,8 +1669,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/derelict/bridge)
@@ -2155,8 +2151,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/derelict/bridge/access)
@@ -2164,8 +2159,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
 /area/derelict/bridge/access)
@@ -3590,8 +3584,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/derelict/hallway/primary)
@@ -3599,8 +3592,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless{
 	icon_state = "floorscorched1"
@@ -3610,8 +3602,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
 /area/derelict/hallway/primary)
@@ -3624,8 +3615,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless,
 /area/derelict/hallway/primary)
@@ -4733,8 +4723,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
 /area/derelict/se_solar)

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -373,8 +373,7 @@
 	lighting = 0;
 	locked = 0;
 	name = "Starboard Solar APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -700,8 +699,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Worn-out APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -740,8 +738,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
 /area/derelict/bridge/ai_upload)
@@ -783,8 +780,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
 /area/derelict/bridge/ai_upload)
@@ -832,8 +828,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/closed/wall,
 /area/derelict/bridge/access)
@@ -1499,8 +1494,7 @@
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/derelict/gravity_generator)
@@ -1600,8 +1594,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/derelict/bridge/access)
@@ -1645,8 +1638,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1729,8 +1721,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/derelict/bridge)
@@ -2681,8 +2672,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
 /area/derelict/hallway/primary)
@@ -3101,8 +3091,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless,
 /area/derelict/hallway/primary)
@@ -3250,8 +3239,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Worn-out APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -4448,8 +4436,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Worn-out APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/airless,
 /area/derelict/hallway/secondary)
@@ -4485,7 +4472,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Worn-out APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -4865,8 +4851,7 @@
 	lighting = 0;
 	locked = 0;
 	name = "Worn-out APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plating/airless,
 /area/derelict/se_solar)
@@ -4981,8 +4966,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
@@ -5062,8 +5046,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/template_noop,

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -20,8 +20,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/abandonedzoo)
@@ -93,8 +92,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/ruin/abandonedzoo)
@@ -202,8 +200,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "Bio Containment";
@@ -226,8 +223,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -246,8 +242,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/abandonedzoo)
@@ -256,8 +251,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/gun/energy/floragun,
 /turf/open/floor/plasteel{
@@ -268,8 +262,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/darkgreen,
 /area/ruin/abandonedzoo)
@@ -279,8 +272,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "dark"
@@ -295,8 +287,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -325,8 +316,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/abandonedzoo)
@@ -373,8 +363,7 @@
 	lighting = 0;
 	locked = 0;
 	name = "Worn-out APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -396,8 +385,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/rack,
 /obj/item/clothing/suit/space/hardsuit/medical,
@@ -485,8 +473,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkgreen,
 /area/ruin/abandonedzoo)
@@ -495,8 +482,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkgreen,
 /area/ruin/abandonedzoo)
@@ -515,8 +501,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "dark"
@@ -593,8 +578,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -633,8 +617,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "dark"
@@ -644,8 +627,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -50,8 +50,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -233,8 +232,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/ruin/abandonedzoo)
@@ -292,8 +290,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -583,8 +580,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -779,8 +775,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -157,7 +157,6 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/weapon/razor,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -175,8 +174,7 @@
 	},
 /obj/item/weapon/storage/box/beakers,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	icon_state = "dark"
@@ -677,7 +675,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel{

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -122,7 +122,6 @@
 "av" = (
 /obj/structure/table,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -758,7 +757,6 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -70,8 +70,7 @@
 	cell_type = 0;
 	dir = 4;
 	name = "Cargo Bay APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -116,8 +115,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargobay)
@@ -501,8 +499,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/powerstorage)
@@ -778,8 +775,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -835,8 +831,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargobay)
@@ -894,7 +889,6 @@
 	cell_type = 0;
 	dir = 2;
 	name = "Tradepost APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -953,7 +947,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel,
@@ -968,7 +961,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel,
@@ -978,7 +970,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel,
@@ -1020,8 +1011,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1040,7 +1030,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel,
@@ -1055,7 +1044,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -1066,7 +1054,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel,
@@ -1081,7 +1068,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel,
@@ -1183,7 +1169,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/janitorialcart,
@@ -1199,7 +1184,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/item/weapon/mop,
@@ -1221,7 +1205,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel,
@@ -1242,7 +1225,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel,
@@ -1258,7 +1240,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel,
@@ -1277,8 +1258,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargobay)
@@ -1466,7 +1446,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel,
@@ -1492,7 +1471,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plating,
@@ -1614,8 +1592,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/ruin/derelictoutpost)
@@ -1746,8 +1723,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/ruin/derelictoutpost)
@@ -1836,8 +1812,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/ruin/derelictoutpost)
@@ -1891,8 +1866,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/ruin/derelictoutpost)
@@ -2066,8 +2040,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/ruin/derelictoutpost)
@@ -2127,8 +2100,7 @@
 	cell_type = 0;
 	dir = 4;
 	name = "Cargo Storage APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -2193,8 +2165,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargostorage)
@@ -2246,8 +2217,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargostorage)
@@ -2335,7 +2305,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -144,7 +144,6 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/yellow,
@@ -162,7 +161,6 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/yellow,

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -780,8 +780,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/powerstorage)
@@ -936,8 +935,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/powerstorage)
@@ -946,8 +944,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/powerstorage)
@@ -960,8 +957,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/powerstorage)
@@ -969,8 +965,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargobay)
@@ -1029,8 +1024,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargobay)
@@ -1043,8 +1037,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
@@ -1053,8 +1046,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost)
@@ -1067,8 +1059,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost)
@@ -1159,8 +1150,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargobay)
@@ -1168,8 +1158,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/janitorialcart,
 /turf/open/floor/plasteel,
@@ -1183,8 +1172,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/weapon/mop,
 /turf/open/floor/plasteel,
@@ -1204,8 +1192,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargobay)
@@ -1224,8 +1211,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargobay)
@@ -1239,8 +1225,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargobay)
@@ -1425,8 +1410,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargobay)
@@ -1445,8 +1429,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargobay)
@@ -1470,8 +1453,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/derelictoutpost/cargobay)
@@ -2284,8 +2266,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/derelictoutpost/cargostorage)
@@ -2304,8 +2285,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/derelictoutpost/cargostorage)

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -105,7 +105,6 @@
 /area/ruin/powered)
 "as" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /turf/closed/wall/mineral/plastitanium,
@@ -228,7 +227,6 @@
 /area/ruin/unpowered/no_grav)
 "aO" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /turf/closed/wall/mineral/plastitanium,
@@ -634,7 +632,6 @@
 /area/ruin/unpowered)
 "cb" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /turf/closed/wall/mineral/titanium,

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1106,7 +1106,6 @@
 /area/awaymission/BMPship/Aft)
 "dr" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/structure/window/reinforced{

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1131,7 +1131,6 @@
 /area/awaymission/BMPship/Fore)
 "dv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -1759,7 +1758,6 @@
 /area/awaymission/BMPship/Fore)
 "eU" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/closet,

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -136,8 +136,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/awaymission/BMPship/Midship)
@@ -330,8 +329,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/awaymission/BMPship/Midship)
@@ -340,8 +338,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/awaymission/BMPship/Midship)
@@ -349,8 +346,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -505,8 +501,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/hand_labeler,
 /turf/open/floor/plating,
@@ -515,8 +510,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/awaymission/BMPship/Aft)
@@ -524,8 +518,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/storage/box,
 /turf/open/floor/plating,
@@ -774,8 +767,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/BMPship/Fore)
@@ -1024,8 +1016,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/bar,
 /area/awaymission/BMPship/Midship)
@@ -1065,8 +1056,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/awaymission/BMPship/Aft)
@@ -1074,8 +1064,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1088,8 +1077,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1172,8 +1160,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/bar,
 /area/awaymission/BMPship/Midship)
@@ -1213,8 +1200,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/BMPship/Aft)
@@ -1264,8 +1250,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/BMPship/Fore)
@@ -1400,8 +1385,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/awaymission/BMPship/Aft)
@@ -1563,8 +1547,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1583,8 +1566,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/BMPship/Fore)
@@ -1618,8 +1600,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1724,8 +1705,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/awaymission/BMPship/Aft)
@@ -1818,8 +1798,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/weapon/stock_parts/cell/high,
 /turf/open/floor/plasteel,
@@ -1836,8 +1815,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/unpowered/shuttle,
 /turf/open/floor/carpet,
@@ -1962,8 +1940,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/awaymission/BMPship/Fore)
@@ -1971,8 +1948,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
@@ -2015,8 +1991,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/awaymission/BMPship/Aft)
@@ -2070,8 +2045,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
 /area/awaymission/BMPship/Fore)
@@ -2100,8 +2074,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/awaymission/BMPship/Aft)
@@ -2160,8 +2133,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/BMPship/Aft)
@@ -2326,8 +2298,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/BMPship/Aft)
@@ -2448,8 +2419,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/awaymission/BMPship/Midship)
@@ -2458,8 +2428,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/closed/wall/mineral/titanium/interior,
 /area/awaymission/BMPship/Midship)
@@ -2467,8 +2436,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/BMPship/Aft)

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -3888,8 +3888,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating{

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -1140,7 +1140,6 @@
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -2082,7 +2081,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/black{
@@ -3056,7 +3054,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24;
 	tag = "icon-alarm0 (EAST)"
 	},
@@ -3475,7 +3472,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/floorgrime{

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -3054,8 +3054,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -24;
-	tag = "icon-alarm0 (EAST)"
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -104,7 +104,6 @@
 /area/ruin/deepstorage/kitchen)
 "ap" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/freezer{
@@ -514,7 +513,6 @@
 	pixel_x = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/machinery/firealarm{
@@ -533,7 +531,6 @@
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -548,7 +545,6 @@
 	pixel_y = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/item/weapon/kitchen/knife,
@@ -604,7 +600,6 @@
 "bg" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
@@ -618,7 +613,6 @@
 /obj/item/weapon/storage/bag/plants/portaseeder,
 /obj/item/weapon/storage/bag/plants,
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/hydrofloor{
@@ -628,7 +622,6 @@
 "bi" = (
 /obj/machinery/vending/hydronutrients,
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -643,7 +636,6 @@
 	slogan_delay = 700
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/hydrofloor{
@@ -653,7 +645,6 @@
 "bk" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/light{
@@ -663,7 +654,6 @@
 "bl" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/machinery/light{
@@ -700,7 +690,6 @@
 /area/ruin/deepstorage/storage)
 "bp" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -709,7 +698,6 @@
 /area/ruin/deepstorage/storage)
 "bq" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -1405,7 +1393,6 @@
 /area/ruin/deepstorage/storage)
 "cC" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/cable/yellow{
@@ -1423,7 +1410,6 @@
 	req_access_txt = "200"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -1438,7 +1424,6 @@
 /area/ruin/deepstorage/storage)
 "cE" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -1459,7 +1444,6 @@
 /area/ruin/deepstorage)
 "cG" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -2143,7 +2127,6 @@
 /area/ruin/deepstorage/dorm)
 "dR" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/cable/yellow{
@@ -2157,7 +2140,6 @@
 /area/ruin/deepstorage/dorm)
 "dS" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -2187,7 +2169,6 @@
 /area/ruin/deepstorage)
 "dU" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -2196,7 +2177,6 @@
 /area/ruin/deepstorage)
 "dV" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/yellow,
@@ -2225,7 +2205,6 @@
 /area/ruin/deepstorage)
 "dX" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -2261,7 +2240,6 @@
 /area/ruin/deepstorage)
 "dZ" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2289,7 +2267,6 @@
 /area/ruin/deepstorage)
 "eb" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -2305,7 +2282,6 @@
 /area/ruin/deepstorage)
 "ec" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2346,7 +2322,6 @@
 	req_access_txt = "200"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -2361,7 +2336,6 @@
 /area/ruin/deepstorage/armory)
 "ef" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/cable/yellow{
@@ -2544,7 +2518,6 @@
 /area/ruin/deepstorage/armory)
 "ev" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/black{
@@ -2601,7 +2574,6 @@
 /area/ruin/deepstorage/dorm)
 "eA" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/wood{
@@ -2613,7 +2585,6 @@
 	name = "Personal Dorm"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2665,8 +2636,6 @@
 /area/ruin/deepstorage)
 "eG" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -2678,8 +2647,6 @@
 /area/ruin/deepstorage)
 "eH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/closed/wall/mineral/iron{
@@ -2710,8 +2677,6 @@
 	req_access_txt = "200"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen{
@@ -2727,8 +2692,6 @@
 /area/ruin/deepstorage/airlock)
 "eJ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
@@ -2748,8 +2711,6 @@
 /area/ruin/deepstorage/airlock)
 "eK" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2768,8 +2729,6 @@
 /area/ruin/deepstorage/airlock)
 "eL" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/cable/yellow{
@@ -3128,8 +3087,6 @@
 /area/ruin/deepstorage)
 "fr" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/machinery/light/small{
@@ -3142,8 +3099,6 @@
 /area/ruin/deepstorage)
 "fs" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/closed/wall/mineral/iron{
@@ -3152,8 +3107,6 @@
 /area/ruin/deepstorage/airlock)
 "ft" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -3168,8 +3121,6 @@
 /area/ruin/deepstorage/airlock)
 "fu" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/light,
@@ -3237,8 +3188,6 @@
 "fz" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -3247,8 +3196,6 @@
 /area/ruin/deepstorage/power)
 "fA" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -3258,8 +3205,6 @@
 "fB" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
@@ -3410,7 +3355,6 @@
 /area/ruin/deepstorage)
 "fR" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -3428,7 +3372,6 @@
 /area/ruin/deepstorage)
 "fS" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3570,7 +3513,6 @@
 	name = "Personal Dorm"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/wood{
@@ -3762,8 +3704,6 @@
 /area/ruin/deepstorage/power)
 "gu" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -4144,7 +4084,6 @@
 "hf" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -4180,7 +4119,6 @@
 /area/ruin/deepstorage)
 "hi" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/yellow{

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -95,7 +95,6 @@
 	on = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer{
@@ -770,7 +769,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -971,7 +969,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/beans,
 /obj/item/weapon/reagent_containers/food/snacks/beans,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -1879,7 +1876,6 @@
 /obj/item/weapon/storage/box/donkpockets,
 /obj/item/weapon/storage/box/donkpockets,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/weapon/vending_refill/coffee,
@@ -1947,7 +1943,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -2444,7 +2439,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -2758,7 +2752,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -3464,7 +3457,6 @@
 "gg" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -3525,7 +3517,6 @@
 /area/ruin/deepstorage/power)
 "gk" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -219,8 +219,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -234,7 +233,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Recycling APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plating{
@@ -759,8 +757,7 @@
 /obj/machinery/microwave,
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -814,8 +811,7 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/hydrofloor{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -873,8 +869,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -887,8 +882,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -901,8 +895,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -916,7 +909,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Kitchen APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -956,8 +948,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/hydrofloor{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -1075,8 +1066,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -1087,8 +1077,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced/fulltile,
@@ -1101,8 +1090,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/hydrofloor{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -1112,8 +1100,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/hydrofloor{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -1123,8 +1110,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	on = 1;
@@ -1144,8 +1130,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Hydroponics APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/hydrofloor{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -1411,8 +1396,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -1506,8 +1490,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 24
@@ -1533,8 +1516,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Storage APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -1595,8 +1577,7 @@
 /obj/machinery/vending/cigarette,
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -1716,8 +1697,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/floorgrime{
@@ -1732,8 +1712,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -1751,8 +1730,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -1762,8 +1740,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -1778,8 +1755,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2139,8 +2115,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -2177,7 +2152,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Main Area APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -2204,8 +2178,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2223,8 +2196,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2238,8 +2210,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2250,8 +2221,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2264,8 +2234,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/floorgrime{
@@ -2301,8 +2270,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2319,8 +2287,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2333,8 +2300,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2344,8 +2310,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2364,8 +2329,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Armory APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2532,8 +2496,7 @@
 	pixel_y = 6
 	},
 /obj/item/weapon/gun/ballistic/automatic/wt550{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
@@ -2656,7 +2619,6 @@
 	id = "bunkerinterior";
 	name = "interior blastdoor access";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "200"
 	},
 /obj/machinery/button/door{
@@ -2673,7 +2635,6 @@
 	dir = 1;
 	name = "Bunker Entrance";
 	network = list("Bunker1");
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -2707,8 +2668,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -2728,7 +2688,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Airlock Control APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -2855,8 +2814,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2888,8 +2846,7 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -2961,8 +2918,7 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -3229,8 +3185,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Dormory APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -3411,14 +3366,12 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/structure/sign/electricshock{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating{
@@ -3434,8 +3387,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -3585,8 +3537,7 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -3651,7 +3602,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/sign/electricshock{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating{
@@ -3665,8 +3615,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -3856,8 +3805,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -3871,8 +3819,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -3941,8 +3888,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4056,8 +4002,7 @@
 /area/ruin/deepstorage/power)
 "he" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4107,8 +4052,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -589,8 +589,6 @@
 /area/ruin/deepstorage)
 "bf" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -728,8 +726,6 @@
 /area/ruin/deepstorage/kitchen)
 "bt" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -1583,8 +1579,6 @@
 /area/ruin/deepstorage)
 "cV" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -2219,8 +2213,6 @@
 /area/ruin/deepstorage)
 "dY" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -2594,8 +2586,6 @@
 /area/ruin/deepstorage/dorm)
 "eC" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -3042,7 +3032,6 @@
 /area/ruin/deepstorage/power)
 "fm" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -3219,7 +3208,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "o2_out_bunker";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -3521,8 +3509,6 @@
 /area/ruin/deepstorage/dorm)
 "gf" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -3716,7 +3702,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2_out_bunker";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -4108,8 +4093,6 @@
 /area/ruin/deepstorage)
 "hh" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -4136,8 +4119,6 @@
 /area/ruin/deepstorage)
 "hj" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/yellow{

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -947,7 +947,6 @@
 "bR" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/hydrofloor{
@@ -1488,7 +1487,6 @@
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -22,8 +22,7 @@
 /area/ruin/gasthelizard)
 "e" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -71,8 +70,7 @@
 /area/ruin/gasthelizard)
 "j" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector,
 /obj/effect/turf_decal/stripes/line{
@@ -325,8 +323,7 @@
 /area/ruin/gasthelizard)
 "N" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/light,
 /obj/structure/table,

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -232,7 +232,6 @@
 "A" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/ruin/gasthelizard)

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -229,7 +229,7 @@
 /area/ruin/gasthelizard)
 "A" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ruin/gasthelizard)

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -200,8 +200,7 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ruin/gasthelizard)

--- a/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -33,7 +33,6 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (WEST)";
-	icon_state = "heater";
 	dir = 8
 	},
 /turf/open/floor/plating/airless,

--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -110,8 +110,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
 /area/tcommsat/chamber)

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -172,7 +172,6 @@
 /area/ruin/onehalf/dorms_med)
 "aB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/table,

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -254,8 +254,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Crew Quarters APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/onehalf/dorms_med)

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -681,7 +681,6 @@
 "bM" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -746,7 +745,6 @@
 "bS" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -811,7 +809,6 @@
 "bY" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -876,7 +873,6 @@
 "ce" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -1415,7 +1411,6 @@
 "dm" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -1499,7 +1494,6 @@
 "du" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -2355,7 +2349,6 @@
 /area/ruin/hotel/dock)
 "fP" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -2029,16 +2029,14 @@
 "eL" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	pixel_y = -24;
-	tag = "icon-alarm0 (NORTH)"
+	pixel_y = -24
 	},
 /turf/open/floor/plating,
 /area/ruin/hotel/bar)
 "eM" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	pixel_y = -24;
-	tag = "icon-alarm0 (NORTH)"
+	pixel_y = -24
 	},
 /turf/open/floor/plating,
 /area/ruin/hotel)
@@ -3661,8 +3659,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 1;
-	pixel_y = -24;
-	tag = "icon-alarm0 (NORTH)"
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -2029,7 +2029,6 @@
 "eL" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -24;
 	tag = "icon-alarm0 (NORTH)"
 	},
@@ -2038,7 +2037,6 @@
 "eM" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -24;
 	tag = "icon-alarm0 (NORTH)"
 	},
@@ -3663,7 +3661,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -24;
 	tag = "icon-alarm0 (NORTH)"
 	},

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -684,8 +684,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 32
@@ -750,8 +749,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 32
@@ -816,8 +814,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 32
@@ -882,8 +879,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 32
@@ -1168,7 +1164,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1185,7 +1180,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1198,7 +1192,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1211,7 +1204,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -1232,7 +1224,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1246,7 +1237,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -1261,8 +1251,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/carpet,
 /area/ruin/hotel)
@@ -1435,8 +1424,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 32
@@ -1450,7 +1438,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Guest Room APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -1521,8 +1508,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 32
@@ -1536,7 +1522,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Guest Room APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -1734,7 +1719,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1747,7 +1731,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2031,7 +2014,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plating,
@@ -2168,8 +2150,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/ruin/hotel)
@@ -2460,8 +2441,7 @@
 /area/ruin/hotel/dock)
 "fX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/carpet,
 /area/ruin/hotel/dock)
@@ -3148,7 +3128,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -3167,7 +3146,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -3318,7 +3296,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/door/firedoor,
@@ -3402,14 +3379,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/sign/fire{
 	desc = "A poster designed to remind the reader to wear appropriate insulation and head protection when working with material.";
 	icon_state = "safety";
 	name = "Safety Poster";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -3423,7 +3398,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/airalarm{
@@ -3440,7 +3414,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Power Storage APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -3630,7 +3603,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -3647,7 +3619,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -3658,7 +3629,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3672,7 +3642,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -3690,7 +3659,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/airalarm{
@@ -3715,7 +3683,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -3732,7 +3699,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3745,7 +3711,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -4114,8 +4079,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -4237,8 +4201,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -5060,7 +5023,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5191,8 +5153,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
 /area/ruin/hotel/workroom)
@@ -5209,7 +5170,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/carpet,
@@ -5227,8 +5187,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/ruin/hotel)
@@ -5237,7 +5196,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -35,8 +35,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
@@ -62,8 +61,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
@@ -1163,8 +1161,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1179,8 +1176,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1191,8 +1187,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1203,8 +1198,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1223,8 +1217,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1236,8 +1229,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -1718,8 +1710,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -1730,8 +1721,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -2013,8 +2003,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/hotel)
@@ -3123,14 +3112,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -3141,8 +3128,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
@@ -3291,8 +3277,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3335,8 +3320,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
@@ -3374,8 +3358,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/sign/fire{
 	desc = "A poster designed to remind the reader to wear appropriate insulation and head protection when working with material.";
@@ -3393,8 +3376,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -3598,8 +3580,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -3614,8 +3595,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plating,
@@ -3624,8 +3604,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3637,8 +3616,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3654,8 +3632,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
 	dir = 1;
@@ -3676,8 +3653,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -3692,8 +3668,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3704,8 +3679,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -4251,8 +4225,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
 	tag = "icon-yellow (SOUTHEAST)";
@@ -4673,8 +4646,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -5016,8 +4988,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5134,8 +5105,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/ruin/hotel/workroom)
@@ -5163,8 +5133,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/ruin/hotel)
@@ -5172,8 +5141,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/carpet,
 /area/ruin/hotel)
@@ -5189,8 +5157,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -2485,7 +2485,6 @@
 /obj/structure/table/wood,
 /obj/machinery/light{
 	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -2860,7 +2859,6 @@
 /obj/structure/kitchenspike,
 /obj/machinery/light{
 	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -2892,7 +2890,6 @@
 "hp" = (
 /obj/machinery/light{
 	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -4089,7 +4086,6 @@
 "kg" = (
 /obj/machinery/light{
 	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -4388,7 +4384,6 @@
 "kU" = (
 /obj/machinery/light{
 	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -4595,7 +4590,6 @@
 "lz" = (
 /obj/machinery/light{
 	tag = "icon-tube1 (EAST)";
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{

--- a/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -182,8 +182,7 @@
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/orange,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ruin/turretedoutpost)
@@ -282,7 +281,6 @@
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/meat,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,

--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -72,8 +72,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /turf/open/floor/carpet,
@@ -82,8 +81,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -99,8 +97,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -124,8 +121,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/wood{
 	name = "Headmaster Room"
@@ -141,8 +137,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -220,8 +215,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -327,8 +321,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/weapon/pen/red,
 /turf/open/floor/carpet,
@@ -368,8 +361,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/weapon/dice/d20,
 /turf/open/floor/carpet,
@@ -391,8 +383,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -424,8 +415,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -561,8 +551,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -572,8 +561,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/awaymission/academy/headmaster)
@@ -582,8 +570,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -660,8 +647,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -694,8 +680,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/awaymission/academy/classrooms)
@@ -716,8 +701,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
 /area/awaymission/academy/headmaster)
@@ -739,8 +723,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/weapon/pen/red,
 /turf/open/floor/plasteel,
@@ -782,8 +765,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/awaymission/academy/headmaster)
@@ -796,8 +778,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/plasteel,
@@ -824,8 +805,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -838,8 +818,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/plasma,
 /turf/open/floor/carpet,
@@ -880,8 +859,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/academy/classrooms)
@@ -957,8 +935,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/academy/classrooms)
@@ -966,8 +943,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/awaymission/academy/classrooms)
@@ -1110,8 +1086,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/circuit/green,
@@ -1120,8 +1095,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1145,8 +1119,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/academy/classrooms)
@@ -1214,8 +1187,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/green/side{
 	dir = 4
@@ -1226,8 +1198,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/academy/classrooms)
@@ -1235,8 +1206,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/academy/classrooms)
@@ -1261,8 +1231,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/academy/classrooms)
@@ -1286,8 +1255,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/academy/classrooms)
@@ -1316,8 +1284,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
@@ -1372,8 +1339,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/classrooms)
@@ -1430,8 +1396,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/awaymission/academy/classrooms)
@@ -1444,8 +1409,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/academy/classrooms)
@@ -1504,8 +1468,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/barber{
 	dir = 8
@@ -1541,8 +1504,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -1594,8 +1556,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
@@ -1646,8 +1607,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/classrooms)
@@ -1655,8 +1615,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1669,8 +1628,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/awaymission/academy/classrooms)
@@ -1679,8 +1637,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/bar,
 /area/awaymission/academy/classrooms)
@@ -1688,8 +1645,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/escape{
 	dir = 6
@@ -1700,8 +1656,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/escape{
 	dir = 6
@@ -1712,8 +1667,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/barber{
 	dir = 8
@@ -1723,8 +1677,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/barber{
 	dir = 8
@@ -1830,8 +1783,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/noticeboard{
 	pixel_y = -32
@@ -1871,8 +1823,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/classrooms)
@@ -1889,8 +1840,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/academyaft)
@@ -1916,8 +1866,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1928,8 +1877,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1
@@ -2080,8 +2028,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/awaymission/academy/academyaft)
@@ -2102,8 +2049,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
@@ -2147,8 +2093,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/awaymission/academy/classrooms)
@@ -2176,8 +2121,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -2262,8 +2206,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/academyaft)
@@ -2350,8 +2293,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -2367,8 +2309,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/classrooms)
@@ -2376,8 +2317,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -2451,8 +2391,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/academyaft)
@@ -2496,8 +2435,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/awaymission/academy/academyaft)
@@ -2573,8 +2511,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/awaymission/academy/academyaft)
@@ -2582,8 +2519,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/academy/academyaft)
@@ -2591,8 +2527,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/awaymission/academy/academyaft)
@@ -2631,8 +2566,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/awaymission/academy/academyaft)
@@ -2648,8 +2582,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2662,8 +2595,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
@@ -2672,8 +2604,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2691,8 +2622,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/green/side{
 	dir = 8
@@ -2702,8 +2632,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/academy/academyaft)
@@ -2711,8 +2640,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/green/side{
 	dir = 4
@@ -2722,8 +2650,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2736,8 +2663,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -2750,8 +2676,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/caution,
 /turf/open/floor/plasteel/green/side{
@@ -2786,8 +2711,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/awaymission/academy/academyaft)
@@ -2887,8 +2811,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2922,8 +2845,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/academy/academyaft)
@@ -3036,8 +2958,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 2
@@ -3172,8 +3093,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -3192,8 +3112,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/academyaft)
@@ -3202,8 +3121,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable,
 /obj/structure/window/reinforced/fulltile,
@@ -3267,8 +3185,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -3300,8 +3217,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3316,8 +3232,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/airless{
 	icon_state = "whitered";
@@ -3342,8 +3257,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -3353,8 +3267,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -3377,8 +3290,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/airless/white{
 	dir = 4
@@ -3503,8 +3415,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3535,8 +3446,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3602,8 +3512,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/academygate)
@@ -3626,8 +3535,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window,
 /turf/open/floor/carpet,
@@ -3640,8 +3548,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3654,8 +3561,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/academygate)
@@ -3876,8 +3782,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/weapon/book/manual/ripley_build_and_repair,
 /turf/open/floor/plasteel,
@@ -3890,8 +3795,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4025,8 +3929,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "0-2";

--- a/_maps/RandomZLevels/Cabin.dmm
+++ b/_maps/RandomZLevels/Cabin.dmm
@@ -532,7 +532,6 @@
 "bQ" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/cabin)

--- a/_maps/RandomZLevels/Cabin.dmm
+++ b/_maps/RandomZLevels/Cabin.dmm
@@ -80,7 +80,6 @@
 "as" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -90,7 +89,6 @@
 /area/awaymission/cabin)
 "at" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -492,7 +490,6 @@
 "bJ" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/freezer,

--- a/_maps/RandomZLevels/Cabin.dmm
+++ b/_maps/RandomZLevels/Cabin.dmm
@@ -206,8 +206,7 @@
 /area/awaymission/cabin)
 "aI" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -543,8 +542,7 @@
 /area/awaymission/cabin)
 "bU" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/food/drinks/shaker,
@@ -557,8 +555,7 @@
 /area/awaymission/cabin)
 "bW" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -570,8 +567,7 @@
 /area/awaymission/cabin)
 "bY" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/processor,
 /turf/open/floor/plasteel/freezer,
@@ -703,8 +699,7 @@
 /area/awaymission/cabin)
 "cv" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular,
@@ -820,8 +815,7 @@
 /area/awaymission/cabin)
 "cQ" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/awaymission/cabin)

--- a/_maps/RandomZLevels/Cabin.dmm
+++ b/_maps/RandomZLevels/Cabin.dmm
@@ -81,8 +81,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_y = 28
@@ -193,8 +192,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
@@ -495,8 +493,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/freezer,
 /area/awaymission/cabin)
@@ -800,7 +797,6 @@
 /area/awaymission/cabin)
 "cL" = (
 /obj/structure/sign/barsign{
-	pixel_x = 0;
 	pixel_y = 32;
 	req_access = null
 	},

--- a/_maps/RandomZLevels/Cabin.dmm
+++ b/_maps/RandomZLevels/Cabin.dmm
@@ -528,7 +528,7 @@
 /area/awaymission/cabin)
 "bQ" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/cabin)

--- a/_maps/RandomZLevels/beach2.dmm
+++ b/_maps/RandomZLevels/beach2.dmm
@@ -86,7 +86,6 @@
 "as" = (
 /obj/structure/dresser{
 	density = 0;
-	pixel_x = 0;
 	pixel_y = 18
 	},
 /turf/open/floor/wood{

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1216,8 +1216,7 @@
 "cE" = (
 /obj/structure/sign/vacuum{
 	name = "\improper LOW AIR AREA";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/stack/rods,
 /turf/open/floor/plasteel{
@@ -1409,8 +1408,7 @@
 "cZ" = (
 /obj/structure/sign/vacuum{
 	name = "\improper LOW AIR AREA";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/basalt;

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1285,7 +1285,6 @@
 "cM" = (
 /obj/machinery/light{
 	tag = "icon-tube1 (WEST)";
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plating{

--- a/_maps/RandomZLevels/centcomAway.dmm
+++ b/_maps/RandomZLevels/centcomAway.dmm
@@ -495,7 +495,6 @@
 "bC" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomZLevels/centcomAway.dmm
+++ b/_maps/RandomZLevels/centcomAway.dmm
@@ -319,7 +319,6 @@
 "aZ" = (
 /obj/structure/table,
 /obj/machinery/processor{
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/green{
@@ -621,8 +620,7 @@
 "bY" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /obj/item/weapon/storage/firstaid/regular{
 	pixel_x = -2;
@@ -688,7 +686,6 @@
 "ch" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/hydrofloor,
@@ -1108,7 +1105,6 @@
 "dF" = (
 /obj/structure/table,
 /obj/machinery/processor{
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/red,
@@ -2522,7 +2518,6 @@
 /area/awaymission/centcomAway/general)
 "hX" = (
 /obj/machinery/button/crematorium{
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/open/floor/engine,
@@ -3841,8 +3836,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/centcomAway/thunderdome)

--- a/_maps/RandomZLevels/centcomAway.dmm
+++ b/_maps/RandomZLevels/centcomAway.dmm
@@ -2376,7 +2376,6 @@
 /area/awaymission/centcomAway/general)
 "hA" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -3761,7 +3760,6 @@
 /area/awaymission/centcomAway/thunderdome)
 "lD" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -3835,7 +3833,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/white,

--- a/_maps/RandomZLevels/challenge.dmm
+++ b/_maps/RandomZLevels/challenge.dmm
@@ -750,7 +750,6 @@
 	desc = "Used for watching evil areas.";
 	name = "Security Monitor";
 	network = "";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/table/reinforced,
@@ -788,7 +787,6 @@
 	desc = "Used for watching evil areas.";
 	name = "Security Monitor";
 	network = "";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/carpet,
@@ -820,7 +818,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/black,
@@ -906,9 +903,7 @@
 /obj/structure/table/wood,
 /obj/item/weapon/paper{
 	info = "Congratulations,<br><br>Your station has been selected to carry out the Gateway Project.<br><br>The equipment will be shipped to you at the start of the next quarter.<br> You are to prepare a secure location to house the equipment as outlined in the attached documents.<br><br>--Nanotrasen Blue Space Research";
-	name = "Confidential Correspondence, Pg 1";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Confidential Correspondence, Pg 1"
 	},
 /obj/item/weapon/folder/blue,
 /turf/open/floor/carpet,
@@ -1178,8 +1173,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
 /area/awaymission/challenge/end)
@@ -1264,8 +1258,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;

--- a/_maps/RandomZLevels/challenge.dmm
+++ b/_maps/RandomZLevels/challenge.dmm
@@ -176,7 +176,6 @@
 /area/awaymission/challenge/main)
 "aJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/airless,
@@ -548,7 +547,6 @@
 /area/awaymission/challenge/main)
 "by" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -984,7 +982,6 @@
 /area/awaymission/challenge/end)
 "cE" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/circuit,
@@ -995,7 +992,6 @@
 /area/awaymission/challenge/end)
 "cG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/circuit,

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -847,8 +847,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black{
 	heat_capacity = 1e+006
@@ -1031,8 +1030,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1126,8 +1124,7 @@
 "bz" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/trash/plate,
 /obj/item/weapon/cigbutt,
@@ -1163,8 +1160,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
@@ -1192,7 +1188,6 @@
 	frequency = 1439;
 	locked = 1;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = "150"
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -1316,8 +1311,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/highsecurity{
 	icon_state = "closed";
@@ -1570,8 +1564,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -1588,7 +1581,6 @@
 	})
 "cg" = (
 /obj/structure/sign/securearea{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -1625,8 +1617,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -1790,8 +1781,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
@@ -1805,8 +1795,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
@@ -1822,8 +1811,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
@@ -1839,8 +1827,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Power Maintenance";
@@ -1883,8 +1870,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2043,7 +2029,6 @@
 	dir = 2;
 	locked = 1;
 	name = "Worn-out APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = "150";
 	start_charge = 0
@@ -2166,7 +2151,6 @@
 	frequency = 1439;
 	locked = 1;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = "150"
 	},
 /obj/machinery/light{
@@ -2283,7 +2267,6 @@
 	id = "awaydorm4";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -2321,7 +2304,6 @@
 	id = "awaydorm5";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -2406,7 +2388,6 @@
 	frequency = 1439;
 	locked = 1;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2447,7 +2428,6 @@
 	frequency = 1439;
 	locked = 1;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = "150"
 	},
 /turf/open/floor/wood{
@@ -2719,7 +2699,6 @@
 /obj/structure/sign/vacuum{
 	desc = "A warning sign which reads 'HOSTILE ATMOSPHERE AHEAD'";
 	name = "\improper HOSTILE ATMOSPHERE AHEAD";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -3255,8 +3234,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -3347,7 +3325,6 @@
 	desc = "A wall-mounted ignition device. This one has been applied with an acid-proof coating.";
 	id = "awayxenobio";
 	name = "Acid-Proof mounted igniter";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/alien/weeds{
@@ -3437,8 +3414,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
@@ -3623,8 +3599,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/chair/office/light{
@@ -3802,8 +3777,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/newspaper,
 /turf/open/floor/plating{
@@ -3817,8 +3791,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
 	broken = 1;
@@ -3833,8 +3806,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	desc = "Your instincts say you shouldn't be following these.";
@@ -3852,8 +3824,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -3866,8 +3837,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "201";
@@ -3889,8 +3859,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	desc = "Your instincts say you shouldn't be following these.";
@@ -4023,8 +3992,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/white,
@@ -4116,8 +4084,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -4145,8 +4112,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
 	broken = 1;
@@ -4161,8 +4127,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -4194,8 +4159,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4215,8 +4179,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -4239,8 +4202,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
@@ -4254,8 +4216,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -4268,8 +4229,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -4286,8 +4246,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/alien/weeds/node,
 /turf/open/floor/plasteel/white,
@@ -4353,8 +4312,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
 /area/awaycontent/a2{
@@ -4496,8 +4454,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -4514,8 +4471,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -4528,8 +4484,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -4632,8 +4587,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -4658,7 +4612,6 @@
 "fZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -4766,8 +4719,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -4778,8 +4730,7 @@
 	})
 "gi" = (
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8;
@@ -4827,8 +4778,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -5050,8 +5000,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8;
@@ -5258,8 +5207,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/stack/rods,
 /turf/open/floor/plating{
@@ -5276,7 +5224,6 @@
 	id = "Awaybiohazard";
 	name = "Biohazard Shutter Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "201"
 	},
 /obj/machinery/light/small{
@@ -5337,7 +5284,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -5493,7 +5439,6 @@
 	desc = "A wall-mounted ignition device. This one has been applied with an acid-proof coating.";
 	id = "awayxenobio";
 	name = "Acid-Proof mounted igniter";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/structure/alien/weeds{
@@ -5523,8 +5468,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -5552,8 +5496,7 @@
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 10;
@@ -5664,7 +5607,6 @@
 "ho" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/gloves{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -5679,8 +5621,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating{
@@ -5849,7 +5790,6 @@
 "hA" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/fire{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/machinery/firealarm{
@@ -5952,7 +5892,6 @@
 "hH" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -5961,7 +5900,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel/white/side{
@@ -6083,8 +6021,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/urinal{
 	pixel_y = 29
@@ -6137,8 +6074,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
 	burnt = 1;
@@ -6302,7 +6238,6 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white/side{
@@ -6329,7 +6264,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light/small{
@@ -6346,8 +6280,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	desc = "Oh no, seven years of bad luck!";
@@ -6411,14 +6344,12 @@
 /obj/machinery/button/door{
 	id = "Awaybiohazard";
 	name = "Biohazard Shutter Control";
-	pixel_x = 0;
 	pixel_y = 8;
 	req_access_txt = "201"
 	},
 /obj/machinery/button/door{
 	id = "AwayRD";
 	name = "Privacy Shutter Control";
-	pixel_x = 0;
 	pixel_y = -2;
 	req_access_txt = "201"
 	},
@@ -6467,8 +6398,7 @@
 	})
 "it" = (
 /obj/item/weapon/storage/secure/safe{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/weapon/pen,
@@ -6608,8 +6538,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -6646,7 +6575,6 @@
 	})
 "iH" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/light/small{
@@ -6669,7 +6597,6 @@
 	})
 "iI" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -6765,8 +6692,7 @@
 	})
 "iP" = (
 /obj/machinery/shower{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/open/floor/plasteel/freezer{
 	heat_capacity = 1e+006
@@ -6814,7 +6740,6 @@
 	})
 "iT" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/closed/wall/rust,
@@ -7029,8 +6954,7 @@
 	pixel_x = 3
 	},
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "awaykitchen";
@@ -7070,8 +6994,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating{
@@ -7139,7 +7062,6 @@
 	})
 "jv" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel{
@@ -7169,7 +7091,6 @@
 	})
 "jx" = (
 /obj/structure/sign/science{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -7282,7 +7203,6 @@
 	dir = 1;
 	locked = 0;
 	name = "Worn-out APC";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access = null;
 	start_charge = 100
@@ -7310,7 +7230,6 @@
 	})
 "jJ" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -7438,8 +7357,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -7456,8 +7374,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -7470,8 +7387,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
@@ -7485,8 +7401,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel{
@@ -7500,8 +7415,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/cigbutt,
 /turf/open/floor/plasteel/floorgrime{
@@ -7519,8 +7433,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
 	frequency = 1439;
@@ -7540,8 +7453,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/purple/corner{
 	dir = 1;
@@ -7555,8 +7467,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/purple/corner{
@@ -7571,8 +7482,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor{
 	density = 1;
@@ -7590,8 +7500,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	burnt = 1;
@@ -7609,8 +7518,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	broken = 1;
@@ -7628,8 +7536,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime{
@@ -7649,8 +7556,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
@@ -7666,8 +7572,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	burnt = 1;
@@ -7685,8 +7590,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
 	broken = 1;
@@ -7703,8 +7607,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	broken = 1;
@@ -7722,8 +7625,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor{
@@ -7744,8 +7646,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
@@ -7852,7 +7753,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -7896,7 +7796,6 @@
 "kw" = (
 /obj/machinery/light/small,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/camera{
@@ -8194,7 +8093,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -8295,8 +8193,7 @@
 	})
 "lb" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/machinery/camera{
 	c_tag = "Kitchen";
@@ -8461,7 +8358,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/carpet{
@@ -8492,7 +8388,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel/bar{
@@ -8536,7 +8431,6 @@
 	id = "awaykitchen";
 	name = "Kitchen Shutters Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "0"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -8741,8 +8635,7 @@
 /obj/structure/table/wood,
 /obj/item/weapon/lighter,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006
@@ -8870,8 +8763,7 @@
 	})
 "lZ" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/awaycontent/a1{
@@ -8907,7 +8799,6 @@
 	})
 "md" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/light/small{
@@ -9116,8 +9007,7 @@
 /obj/structure/grille,
 /obj/structure/sign/vacuum{
 	desc = "A warning sign which reads 'HOSTILE ATMOSPHERE AHEAD'";
-	name = "\improper HOSTILE ATMOSPHERE AHEAD";
-	pixel_x = 0
+	name = "\improper HOSTILE ATMOSPHERE AHEAD"
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating{
@@ -9158,12 +9048,10 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/carpet{
@@ -9232,8 +9120,7 @@
 	pixel_y = 8
 	},
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 3;
-	pixel_y = 0
+	pixel_x = 3
 	},
 /turf/open/floor/plasteel/black,
 /area/awaycontent/a1{
@@ -9318,8 +9205,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard{
 	dir = 8;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/weapon/paper{
 	info = "<p><p align=center><h2>Welcome to Moon Outpost 19! Property of Nanotrasen Inc.</h2></p><hr><br><br>Staff Roster:<br>-Dr. Gerald Rosswell: Research Director & Acting Captain<br>-Dr. Sakuma Sano: Xenobiologist<br>-Dr. Mark Douglas: Xenobiologist<br>-Kenneth Cunningham: Security Officer-Ivan Volodin: Engineer<br>-Mathias Kuester: Bartender<br>-Sven Edling: Chef<br>-Steve: Assistant<br><br>Please enjoy your stay, and report any abnormalities to an officer.";
@@ -9428,7 +9314,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/carpet{
@@ -9580,7 +9465,6 @@
 	})
 "nh" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/light/small,
@@ -9642,7 +9526,6 @@
 /obj/structure/sign/vacuum{
 	desc = "A warning sign which reads 'HOSTILE ATMOSPHERE AHEAD'";
 	name = "\improper HOSTILE ATMOSPHERE AHEAD";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating{
@@ -9806,7 +9689,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -9956,7 +9838,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -10122,8 +10003,7 @@
 	})
 "nU" = (
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -3442,7 +3442,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
-	icon_state = "manifold";
 	level = 2
 	},
 /turf/open/floor/plasteel/white,

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -5606,9 +5606,7 @@
 	})
 "ho" = (
 /obj/structure/table,
-/obj/item/weapon/storage/box/gloves{
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/box/gloves,
 /turf/open/floor/plasteel/white/corner{
 	dir = 8;
 	heat_capacity = 1e+006
@@ -5789,9 +5787,7 @@
 	})
 "hA" = (
 /obj/structure/table,
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/firstaid/fire,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 28
@@ -5891,9 +5887,7 @@
 	})
 "hH" = (
 /obj/structure/table,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/firstaid/regular,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
 	dir = 8;
@@ -6739,9 +6733,7 @@
 	name = "MO19 Arrivals"
 	})
 "iT" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 0
-	},
+/obj/machinery/computer/security/telescreen/entertainment,
 /turf/closed/wall/rust,
 /area/awaycontent/a1{
 	has_gravity = 1;

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -294,8 +294,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -32;
-	tag = "icon-alarm0 (EAST)"
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
 	tag = "icon-whiteyellow (EAST)";
@@ -850,8 +849,7 @@
 /obj/item/weapon/storage/firstaid/regular,
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -32;
-	tag = "icon-alarm0 (EAST)"
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/black,
 /area/awaymission/research/interior/gateway)
@@ -1754,8 +1752,7 @@
 "eT" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -32;
-	tag = "icon-alarm0 (EAST)"
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/black,
 /area/awaymission/research/interior/secure)
@@ -3299,8 +3296,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 1;
-	pixel_y = -32;
-	tag = "icon-alarm0 (NORTH)"
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/darkpurple,
 /area/awaymission/research/interior/genetics)

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -294,7 +294,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -32;
 	tag = "icon-alarm0 (EAST)"
 	},
@@ -851,7 +850,6 @@
 /obj/item/weapon/storage/firstaid/regular,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -32;
 	tag = "icon-alarm0 (EAST)"
 	},
@@ -1756,7 +1754,6 @@
 "eT" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -32;
 	tag = "icon-alarm0 (EAST)"
 	},
@@ -3302,7 +3299,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -32;
 	tag = "icon-alarm0 (NORTH)"
 	},
@@ -4384,7 +4380,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 32;
 	tag = "icon-alarm0 (WEST)"
 	},
@@ -4829,7 +4824,6 @@
 "mX" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 32;
 	tag = "icon-alarm0 (WEST)"
 	},

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -2167,7 +2167,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/black,
@@ -2193,7 +2193,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/black,

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -280,8 +280,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -378,8 +377,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -510,8 +508,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
@@ -595,8 +592,7 @@
 /area/awaymission/research/interior/engineering)
 "bO" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
 	tag = "icon-whiteyellowcorner (NORTH)";
@@ -704,8 +700,7 @@
 	cell_type = 12000;
 	dir = 4;
 	name = "Gateway APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -726,8 +721,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
@@ -790,8 +784,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/black,
@@ -808,8 +801,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -937,8 +929,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/awaymission/research/interior/gateway)
@@ -1027,8 +1018,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/highsecurity{
 	aiDisabledIdScanner = 1;
@@ -1047,8 +1037,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Genetics APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -1151,8 +1140,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/awaymission/research/interior)
@@ -1161,8 +1149,7 @@
 /area/awaymission/research/interior/genetics)
 "di" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/purple,
@@ -1223,8 +1210,7 @@
 /area/awaymission/research/interior/genetics)
 "dr" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/open/floor/plasteel/purple,
 /area/awaymission/research/interior/genetics)
@@ -1263,8 +1249,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/plating,
@@ -1413,8 +1398,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/ammo_casing/c45,
 /turf/open/floor/plating,
@@ -1517,8 +1501,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/light/small{
@@ -1813,8 +1796,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Cryostatis APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -1893,8 +1875,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	tag = "icon-whitepurple (EAST)";
@@ -1996,8 +1977,7 @@
 	cell_type = 12000;
 	dir = 4;
 	name = "Vault APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -2091,8 +2071,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	tag = "icon-whitepurple (SOUTHEAST)";
@@ -2149,8 +2128,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitered,
 /area/awaymission/research/interior/security)
@@ -2162,8 +2140,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/chair{
 	dir = 4
@@ -2183,8 +2160,7 @@
 /area/awaymission/research/interior/security)
 "gc" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/whitered/side{
 	tag = "icon-whitered (WEST)";
@@ -2206,8 +2182,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2221,8 +2196,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	tag = "icon-0-4";
@@ -2239,8 +2213,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/awaymission/research/interior/secure)
@@ -2248,8 +2221,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/awaymission/research/interior/secure)
@@ -2437,8 +2409,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitepurple,
 /area/awaymission/research/interior)
@@ -2601,8 +2572,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitepurple,
 /area/awaymission/research/interior)
@@ -2680,8 +2650,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitered/side{
 	tag = "icon-whitered (WEST)";
@@ -2747,8 +2716,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	tag = "icon-tube1 (EAST)";
@@ -2867,8 +2835,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/vending/security,
 /turf/open/floor/plasteel/whitered/side{
@@ -2956,8 +2923,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/table,
 /turf/open/floor/plasteel/whitered/side{
@@ -3116,8 +3082,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -3183,8 +3148,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
@@ -3239,8 +3203,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
@@ -3249,8 +3212,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Genetics APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -3880,8 +3842,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Dorms APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4005,8 +3966,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
@@ -4017,8 +3977,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	tag = "icon-whitegreen (EAST)";
@@ -4029,8 +3988,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitegreen,
 /area/awaymission/research/interior)
@@ -4038,8 +3996,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	tag = "icon-whitegreen (WEST)";
@@ -4050,8 +4007,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
@@ -4494,8 +4450,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -259,8 +259,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/snow;
@@ -590,8 +589,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/snow;
@@ -2259,8 +2257,7 @@
 /obj/machinery/button/door{
 	id = "sekret";
 	name = "shutter control";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/darkred{
 	baseturf = /turf/open/floor/plating/asteroid/snow
@@ -4267,8 +4264,7 @@
 	dir = 8;
 	freerange = 1;
 	listening = 1;
-	name = "Pirate Radio Listening Channel";
-	pixel_x = 0
+	name = "Pirate Radio Listening Channel"
 	},
 /turf/open/floor/plasteel/purple{
 	baseturf = /turf/open/floor/plating/asteroid/snow
@@ -4350,8 +4346,7 @@
 	dir = 8;
 	freerange = 1;
 	listening = 0;
-	name = "Pirate Radio Broadcast Channel";
-	pixel_x = 0
+	name = "Pirate Radio Broadcast Channel"
 	},
 /turf/open/floor/plasteel/purple{
 	baseturf = /turf/open/floor/plating/asteroid/snow
@@ -4943,8 +4938,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 30

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -1558,8 +1558,7 @@
 	dir = 2;
 	id = "spacebattlestorage";
 	name = "Secure Storage";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
@@ -1955,8 +1954,7 @@
 	dir = 2;
 	id = "spacebattlestorage";
 	name = "Secure Storage";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/cruiser)
@@ -2538,8 +2536,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/freezer,
 /area/awaymission/spacebattle/cruiser)
@@ -2852,9 +2849,7 @@
 /obj/machinery/button/door{
 	dir = 2;
 	id = "spacebattlearmory";
-	name = "Weapon Cache";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Weapon Cache"
 	},
 /turf/open/floor/plasteel/blue/side{
 	dir = 1
@@ -2865,9 +2860,7 @@
 /obj/machinery/button/door{
 	dir = 2;
 	id = "spacebattlearmory2";
-	name = "Weapon Cache";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Weapon Cache"
 	},
 /turf/open/floor/plasteel/blue/side{
 	dir = 1
@@ -2878,9 +2871,7 @@
 /obj/machinery/button/door{
 	dir = 2;
 	id = "spacebattlearmory1";
-	name = "Weapon Cache";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Weapon Cache"
 	},
 /turf/open/floor/plasteel/blue/side{
 	dir = 1

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -10736,7 +10736,6 @@
 	})
 "pj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel{
@@ -10998,7 +10997,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -11824,7 +11822,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -11859,7 +11856,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/machinery/camera{
@@ -13123,7 +13119,6 @@
 	})
 "sh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -13733,7 +13728,6 @@
 	})
 "sX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel{
@@ -14830,7 +14824,6 @@
 	})
 "uu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/table/reinforced,
@@ -14999,7 +14992,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 1;
 	initialize_directions = 12
 	},

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -11753,7 +11753,7 @@
 	})
 "qM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot{
@@ -13549,7 +13549,7 @@
 	})
 "sZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6;
+	dir = 6
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -14767,7 +14767,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 1;
+	dir = 1
 	},
 /obj/machinery/meter{
 	layer = 3.3

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -11433,7 +11433,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -11921,7 +11920,6 @@
 "qM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot{
@@ -13274,7 +13272,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "UO45_mix_in";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -13753,7 +13750,6 @@
 "sZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6;
-	initialize_directions = 6
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -14993,7 +14989,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1;
-	initialize_directions = 12
 	},
 /obj/machinery/meter{
 	layer = 3.3
@@ -15331,7 +15326,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "UO45_n2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -15359,7 +15353,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "UO45_o2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -14805,7 +14805,6 @@
 	})
 "ut" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -4276,9 +4276,7 @@
 	})
 "gN" = (
 /obj/structure/table,
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/white/side{
 	dir = 2;
 	heat_capacity = 1e+006
@@ -6015,9 +6013,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
 /obj/item/weapon/folder/white,
-/obj/item/weapon/disk/tech_disk{
-	pixel_y = 0
-	},
+/obj/item/weapon/disk/tech_disk,
 /obj/item/weapon/disk/design_disk,
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
@@ -12475,9 +12471,7 @@
 	})
 "rJ" = (
 /obj/structure/table,
-/obj/item/weapon/storage/box/gloves{
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/box/gloves,
 /turf/open/floor/plasteel/white/side{
 	dir = 8;
 	heat_capacity = 1e+006

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -695,8 +695,7 @@
 	})
 "bk" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel{
@@ -1419,8 +1418,7 @@
 	},
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006
@@ -1474,7 +1472,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1519,8 +1516,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006
@@ -1597,7 +1593,6 @@
 	id = "awaydorm2";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -1661,7 +1656,6 @@
 	id = "awaydorm1";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -1983,7 +1977,6 @@
 "dm" = (
 /obj/machinery/firealarm{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel{
@@ -2052,7 +2045,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -2100,7 +2092,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel{
@@ -2280,7 +2271,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/green/side{
@@ -2373,7 +2363,6 @@
 	},
 /obj/structure/chair,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -2547,8 +2536,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command{
 	icon_state = "closed";
@@ -2960,8 +2948,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side{
@@ -3091,7 +3078,6 @@
 	pixel_y = 8
 	},
 /obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/weapon/watertank,
@@ -3111,7 +3097,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating{
@@ -3247,7 +3232,6 @@
 	dir = 2;
 	locked = 0;
 	name = "Hydroponics APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 100
@@ -3268,11 +3252,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/green/side{
@@ -3287,8 +3269,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/green/side{
@@ -3303,8 +3284,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/green/side{
 	dir = 2;
@@ -3319,8 +3299,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/green/side{
 	dir = 2;
@@ -3421,7 +3400,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel/green/side{
@@ -3487,8 +3465,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3508,8 +3485,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3576,7 +3552,6 @@
 	id = "awaydorm3";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -3723,8 +3698,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3740,7 +3714,6 @@
 "fQ" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/carpet{
@@ -3799,7 +3772,6 @@
 "fU" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/camera{
@@ -3816,7 +3788,6 @@
 	})
 "fV" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3853,7 +3824,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/black{
@@ -3886,8 +3856,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3981,8 +3950,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4247,8 +4215,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4310,7 +4277,6 @@
 "gN" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/white/side{
@@ -4348,8 +4314,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4466,7 +4431,6 @@
 "gZ" = (
 /obj/machinery/firealarm{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/white{
@@ -4561,7 +4525,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel{
@@ -4656,8 +4619,7 @@
 	})
 "hp" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria{
@@ -4698,7 +4660,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/camera{
@@ -4910,7 +4871,6 @@
 /obj/structure/table,
 /obj/item/trash/chips,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/bar{
@@ -5015,8 +4975,7 @@
 "hR" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/weapon/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
@@ -5086,8 +5045,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -5167,7 +5125,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5370,8 +5327,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window{
 	name = "Gateway Chamber";
@@ -5628,8 +5584,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5674,8 +5629,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -5840,7 +5794,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel/bar{
@@ -5856,8 +5809,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/bar{
 	heat_capacity = 1e+006
@@ -5874,7 +5826,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -5921,7 +5872,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/camera{
@@ -5954,8 +5904,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6067,7 +6016,6 @@
 /obj/structure/table,
 /obj/item/weapon/folder/white,
 /obj/item/weapon/disk/tech_disk{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/item/weapon/disk/design_disk,
@@ -6211,8 +6159,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6300,7 +6247,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -6443,7 +6389,6 @@
 	dir = 1;
 	locked = 0;
 	name = "UO45 Bar APC";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access = null;
 	start_charge = 100
@@ -6459,8 +6404,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -6485,8 +6429,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
@@ -6507,8 +6450,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6531,8 +6473,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6551,8 +6492,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6572,8 +6512,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6706,8 +6645,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6831,8 +6769,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -6891,7 +6828,6 @@
 /obj/item/weapon/storage/belt/utility,
 /obj/item/clothing/head/welding,
 /obj/structure/sign/biohazard{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/device/assembly/prox_sensor,
@@ -7228,7 +7164,6 @@
 	})
 "kW" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -7347,7 +7282,6 @@
 "lf" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel{
@@ -7371,7 +7305,6 @@
 	dir = 5
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/bar{
@@ -7447,8 +7380,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7505,8 +7437,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -7523,8 +7454,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -7556,8 +7486,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7573,8 +7502,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7615,8 +7543,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/white{
@@ -7630,8 +7557,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -7648,8 +7574,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7669,8 +7594,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7687,8 +7611,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -7703,12 +7626,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7731,8 +7652,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7755,8 +7675,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7775,8 +7694,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7797,8 +7715,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7816,8 +7733,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -7844,8 +7760,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/junction{
@@ -7854,7 +7769,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -7876,7 +7790,6 @@
 	dir = 2;
 	locked = 0;
 	name = "UO45 Research Division APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 100
@@ -7964,7 +7877,6 @@
 "lN" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/camera{
@@ -8045,8 +7957,7 @@
 "lT" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/weapon/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
@@ -8066,7 +7977,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/bar{
@@ -8094,8 +8004,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8240,8 +8149,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -8321,7 +8229,6 @@
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small,
 /obj/structure/sign/securearea{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -8350,8 +8257,7 @@
 "mo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/purple/corner{
 	dir = 1;
@@ -8377,8 +8283,7 @@
 /obj/structure/table,
 /obj/item/weapon/newspaper,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
@@ -8391,7 +8296,6 @@
 "mr" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/carpet{
@@ -8431,8 +8335,7 @@
 "mu" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006
@@ -8503,8 +8406,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8571,7 +8473,6 @@
 	})
 "mD" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/rack{
@@ -8596,7 +8497,6 @@
 	dir = 2;
 	locked = 0;
 	name = "UO45 Gateway APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 100
@@ -8620,7 +8520,6 @@
 "mF" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/rack{
@@ -8687,8 +8586,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -8707,8 +8605,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8870,7 +8767,6 @@
 	id = "awaydorm5";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -8932,7 +8828,6 @@
 	id = "awaydorm7";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -9024,8 +8919,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9165,8 +9059,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9187,8 +9080,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9207,8 +9099,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9231,8 +9122,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9385,8 +9275,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -9429,8 +9318,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -9469,8 +9357,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9487,7 +9374,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light/small{
@@ -9588,7 +9474,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light{
@@ -9666,7 +9551,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -9700,8 +9584,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9722,8 +9605,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9744,8 +9626,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9765,8 +9646,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9789,8 +9669,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9810,8 +9689,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -9835,8 +9713,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
 	frequency = 1439;
@@ -9863,8 +9740,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9882,8 +9758,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9904,8 +9779,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9928,8 +9802,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9949,8 +9822,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9973,8 +9845,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9993,8 +9864,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -10016,8 +9886,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10039,8 +9908,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10064,8 +9932,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-y";
@@ -10084,8 +9951,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10133,8 +9999,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10150,8 +10015,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10183,7 +10047,6 @@
 	desc = "A remote control-switch whichs locks the research division down in the event of a biohazard leak or contamination.";
 	id = "UO45_biohazard";
 	name = "Biohazard Door Control";
-	pixel_x = 0;
 	pixel_y = 8;
 	req_access_txt = "201"
 	},
@@ -10191,7 +10054,6 @@
 	desc = "A remote control-switch that controls the privacy shutters.";
 	id = "UO45_rdprivacy";
 	name = "Privacy Shutter Control";
-	pixel_x = 0;
 	pixel_y = -2;
 	req_access_txt = "201"
 	},
@@ -10239,8 +10101,7 @@
 	})
 "oC" = (
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side{
@@ -10337,7 +10198,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -10359,7 +10219,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -10456,15 +10315,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/airalarm{
 	dir = 8;
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/light/small{
@@ -10487,8 +10344,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -10573,8 +10429,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -10653,7 +10508,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -10722,7 +10576,6 @@
 	desc = "A remote control-switch whichs locks the research division down in the event of a biohazard leak or contamination.";
 	id = "UO45_biohazard";
 	name = "Biohazard Door Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "201"
 	},
@@ -10749,8 +10602,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10969,8 +10821,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -11013,8 +10864,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11080,8 +10930,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11192,7 +11041,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -11252,7 +11100,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -11304,8 +11151,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer{
@@ -11358,8 +11204,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/airlock/glass_engineering{
@@ -11408,8 +11253,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11500,8 +11344,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -11;
-	pixel_y = 0
+	pixel_x = -11
 	},
 /obj/structure/mirror{
 	pixel_x = -28
@@ -11599,7 +11442,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/carpet{
@@ -11627,7 +11469,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/carpet{
@@ -11646,7 +11487,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel/freezer{
@@ -11660,8 +11500,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer{
@@ -11779,8 +11618,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -11816,8 +11654,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -11869,7 +11706,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/item/device/multitool,
@@ -11904,8 +11740,6 @@
 	node1_concentration = 0.8;
 	node2_concentration = 0.2;
 	on = 1;
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access = null;
 	target_pressure = 4500
 	},
@@ -11950,8 +11784,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11968,8 +11801,7 @@
 	},
 /obj/machinery/airalarm/server{
 	dir = 4;
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/machinery/r_n_d/server/core{
 	id_with_download_string = "3";
@@ -12085,8 +11917,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12102,7 +11933,6 @@
 "qY" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/item/weapon/pen,
@@ -12157,8 +11987,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/freezer{
 	heat_capacity = 1e+006
@@ -12179,8 +12008,7 @@
 "re" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -12193,8 +12021,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -12274,7 +12101,6 @@
 "rl" = (
 /obj/machinery/firealarm{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/tank_dispenser{
@@ -12294,20 +12120,16 @@
 	},
 /obj/structure/table,
 /obj/item/weapon/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/item/weapon/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -12329,7 +12151,6 @@
 /obj/item/weapon/storage/box,
 /obj/item/weapon/storage/box,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -12360,7 +12181,6 @@
 	locked = 1;
 	name = "UO45 Engineering APC";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access = list(201);
 	start_charge = 100
 	},
@@ -12503,8 +12323,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -12657,7 +12476,6 @@
 "rJ" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/gloves{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/white/side{
@@ -12672,8 +12490,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12761,8 +12578,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel{
@@ -12776,8 +12592,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12797,8 +12612,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12818,8 +12632,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12840,8 +12653,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
 	frequency = 1439;
@@ -12867,8 +12679,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12894,8 +12705,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12916,8 +12726,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12938,8 +12747,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12963,8 +12771,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12983,8 +12790,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13156,7 +12962,6 @@
 	dir = 2;
 	locked = 0;
 	name = "UO45 Mining APC";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access = null;
 	start_charge = 100
@@ -13319,7 +13124,6 @@
 /obj/structure/sign/deathsposal{
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -13424,8 +13228,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -13486,7 +13289,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/caution/corner{
@@ -13563,8 +13365,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -13698,8 +13499,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
@@ -13857,8 +13657,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13877,8 +13676,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13991,8 +13789,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14035,8 +13832,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -14086,8 +13882,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14182,8 +13977,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
@@ -14345,8 +14139,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14365,8 +14158,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -14389,8 +14181,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14408,8 +14199,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14430,8 +14220,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14453,8 +14242,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14502,8 +14290,7 @@
 	})
 "tX" = (
 /obj/machinery/shower{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/open/floor/plasteel/freezer{
 	heat_capacity = 1e+006
@@ -14514,8 +14301,7 @@
 	})
 "tY" = (
 /obj/machinery/shower{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/weapon/bikehorn/rubberducky,
 /turf/open/floor/plasteel/freezer{
@@ -14540,8 +14326,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/brown/corner{
@@ -14587,8 +14372,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14643,8 +14427,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -14731,7 +14514,6 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -14908,8 +14690,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -14961,8 +14742,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/airlock/engineering{
@@ -15061,8 +14841,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plating{
 	broken = 1;
@@ -15184,8 +14963,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -15226,8 +15004,7 @@
 	dir = 4
 	},
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/yellow/side{
@@ -15270,8 +15047,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "UO45_Engineering";
@@ -15497,8 +15273,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/brown{
@@ -15542,8 +15317,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15563,8 +15337,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -15589,8 +15362,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15606,8 +15378,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -15624,8 +15395,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4;
@@ -15639,8 +15409,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
@@ -15657,8 +15426,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -15798,8 +15566,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/glass_mining{
@@ -15870,8 +15637,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16104,8 +15870,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -16168,8 +15933,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -16216,7 +15980,6 @@
 	id = "awaydorm8";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -16281,8 +16044,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
@@ -16356,8 +16118,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -16390,7 +16151,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -16419,8 +16179,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel{
@@ -16440,8 +16199,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
@@ -16485,8 +16243,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral{
@@ -16512,8 +16269,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/light/small,
 /obj/structure/mirror{
@@ -16543,7 +16299,6 @@
 	id = "awaydorm9";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -16574,8 +16329,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -16592,8 +16346,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
@@ -16649,8 +16402,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -16660,7 +16412,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16689,7 +16440,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/closet/secure_closet/miner{
@@ -16724,8 +16474,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 2;
@@ -16837,8 +16586,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -16954,14 +16702,12 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = 23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	heat_capacity = 1e+006
@@ -17015,8 +16761,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -17097,8 +16842,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -17228,8 +16972,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -17246,8 +16989,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -17464,7 +17206,6 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null
 	},
 /obj/structure/closet/emcloset,
@@ -17535,8 +17276,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -4928,7 +4928,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -14590,7 +14589,6 @@
 "aCS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/side{
 	icon_state = "red";
@@ -37611,7 +37609,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -39440,7 +39437,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/engine{
@@ -41081,7 +41077,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -43537,7 +43532,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5;
-	initialize_directions = 12
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -43555,7 +43549,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
-	initialize_directions = 12
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -43596,7 +43589,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
-	initialize_directions = 12
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -43692,7 +43684,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -51193,7 +51184,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
 	pixel_x = 0;
-	initialize_directions = 10
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -51854,7 +51844,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "n2 vent";
 	on = 1;
@@ -51908,7 +51897,6 @@
 "bPt" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel{
@@ -53030,7 +53018,6 @@
 "bRv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -53759,7 +53746,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "o2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "oxygen vent";
 	on = 1;
@@ -54759,7 +54745,6 @@
 "bUY" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel{
@@ -55005,7 +54990,6 @@
 "bVt" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -55750,7 +55734,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "co2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "co2 vent";
 	on = 1;
@@ -55787,7 +55770,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "tox_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "plasma vent";
 	on = 1;
@@ -55825,7 +55807,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2o_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "n2o vent";
 	on = 1;
@@ -55862,7 +55843,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "mix_in";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "distro vent";
 	on = 1;
@@ -66293,7 +66273,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 0;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -68101,7 +68080,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
 	pixel_x = 0;
-	initialize_directions = 10
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	tag = "icon-whitepurple (NORTH)";
@@ -68484,7 +68462,6 @@
 "cub" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/white{
@@ -70872,7 +70849,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -82551,7 +82527,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -82815,7 +82790,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
@@ -82988,7 +82962,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 0;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 0;
 	pressure_checks = 2;
@@ -87195,7 +87168,6 @@
 "deg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90455,7 +90427,6 @@
 "dmf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91251,7 +91222,6 @@
 "dnR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -92006,7 +91976,6 @@
 "dpi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used to watch the various criminals inside their cells.";
@@ -94848,7 +94817,6 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -3457,7 +3457,6 @@
 	name = "navigation beacon (CellBlockUpRight)"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -3764,7 +3763,6 @@
 "ahJ" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -3773,7 +3771,6 @@
 /area/security/prison)
 "ahK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3805,7 +3802,6 @@
 	})
 "ahN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -3819,7 +3815,6 @@
 /area/security/prison)
 "ahO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -4908,7 +4903,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -5334,7 +5328,6 @@
 /area/security/prison)
 "akQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -5779,7 +5772,6 @@
 	req_one_access_txt = "38;2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
@@ -5790,7 +5782,6 @@
 /area/security/processing)
 "alS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -5816,7 +5807,6 @@
 /area/security/prison)
 "alU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
@@ -5866,7 +5856,6 @@
 /area/security/prison)
 "alW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -5882,7 +5871,6 @@
 	name = "navigation beacon (CellBlockMidLeft)"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -5903,7 +5891,6 @@
 "alZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -5922,7 +5909,6 @@
 	name = "navigation beacon (CellBlockMidRight)"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -5931,7 +5917,6 @@
 /area/security/prison)
 "amb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -5974,7 +5959,6 @@
 /area/security/prison)
 "ame" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -5993,7 +5977,6 @@
 	req_one_access_txt = "38;2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
@@ -6004,7 +5987,6 @@
 /area/security/prison)
 "amg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -6044,7 +6026,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -6053,7 +6034,6 @@
 /area/security/prison)
 "amk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -6932,7 +6912,6 @@
 /area/security/prison)
 "anQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -6951,8 +6930,6 @@
 /area/security/prison)
 "anS" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall{
@@ -7377,7 +7354,6 @@
 /area/security/prison)
 "aoM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -7848,7 +7824,6 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -9177,7 +9152,6 @@
 /area/security/warden)
 "aso" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9760,7 +9734,6 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -10240,7 +10213,6 @@
 /area/security/prison)
 "auv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13241,7 +13213,6 @@
 	req_access_txt = "58"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/wood{
@@ -13254,7 +13225,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -13264,7 +13234,6 @@
 "aAr" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/item/weapon/storage/fancy/donut_box,
@@ -13424,7 +13393,6 @@
 /area/security/brig)
 "aAF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black{
@@ -14404,7 +14372,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -14414,7 +14381,6 @@
 "aCD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/orange{
@@ -14433,7 +14399,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/orange{
@@ -14446,7 +14411,6 @@
 /area/security/brig)
 "aCF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -14467,7 +14431,6 @@
 /area/security/brig)
 "aCG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
@@ -14491,7 +14454,6 @@
 /area/security/brig)
 "aCI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
@@ -14546,7 +14508,6 @@
 /area/security/brig)
 "aCM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -14571,7 +14532,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
@@ -14616,7 +14576,6 @@
 /area/security/brig)
 "aCR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -35973,8 +35932,6 @@
 /area/hallway/primary/central)
 "bnQ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	tag = "icon-intact (NORTH)";
-	icon_state = "intact";
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
@@ -36762,7 +36719,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/engine{
@@ -36787,7 +36743,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/engine{
@@ -36798,7 +36753,6 @@
 "bpg" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black{
@@ -36810,7 +36764,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/engine{
@@ -36820,7 +36773,6 @@
 /area/engine/engineering)
 "bpi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -37555,7 +37507,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/engine{
@@ -39323,7 +39274,6 @@
 /area/engine/engineering)
 "btq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black{
@@ -39401,7 +39351,6 @@
 "btv" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/machinery/door/firedoor,
@@ -41848,7 +41797,6 @@
 /area/engine/supermatter)
 "bxA" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/machinery/meter,
@@ -42751,7 +42699,6 @@
 /area/hydroponics)
 "bzl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkgreen/side{
@@ -42762,7 +42709,6 @@
 "bzm" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkgreen{
@@ -42806,8 +42752,6 @@
 /area/maintenance/asteroid/central)
 "bzs" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall/r_wall{
@@ -42817,8 +42761,6 @@
 "bzt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -42832,8 +42774,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -42843,8 +42783,6 @@
 "bzv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -42855,8 +42793,6 @@
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
@@ -42872,8 +42808,6 @@
 /area/engine/break_room)
 "bzx" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall/r_wall{
@@ -42884,8 +42818,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5;
-	icon_state = "intact";
-	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -43390,7 +43322,6 @@
 	req_access_txt = "35"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkgreen{
@@ -43400,7 +43331,6 @@
 "bAs" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/grass{
@@ -43497,8 +43427,6 @@
 /area/maintenance/asteroid/central)
 "bAC" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -43511,8 +43439,6 @@
 /area/maintenance/asteroid/central)
 "bAD" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/closed/wall/r_wall{
@@ -43521,8 +43447,6 @@
 /area/engine/break_room)
 "bAE" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall/r_wall{
@@ -44238,8 +44162,6 @@
 /area/maintenance/asteroid/central)
 "bBF" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating/astplate{
@@ -44248,8 +44170,6 @@
 /area/maintenance/asteroid/central)
 "bBG" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating/astplate{
@@ -44258,8 +44178,6 @@
 /area/maintenance/asteroid/central)
 "bBH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating/astplate{
@@ -44755,7 +44673,6 @@
 /area/hydroponics)
 "bCA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkgreen/side{
@@ -44848,8 +44765,6 @@
 /area/engine/break_room)
 "bCM" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall{
@@ -44949,8 +44864,6 @@
 /area/engine/engineering)
 "bCX" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
@@ -47021,7 +46934,6 @@
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -47042,7 +46954,6 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
@@ -47052,7 +46963,6 @@
 /area/engine/atmos)
 "bGP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -48742,7 +48652,6 @@
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/engineering_construction,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -49143,7 +49052,6 @@
 "bKA" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -49154,8 +49062,6 @@
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10;
-	icon_state = "intact";
-	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -52620,7 +52526,6 @@
 /area/engine/atmos)
 "bQw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel{
@@ -53112,8 +53017,6 @@
 /area/engine/atmos)
 "bRu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/meter,
@@ -53917,7 +53820,6 @@
 /area/engine/atmos)
 "bTb" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -54199,8 +54101,6 @@
 /area/engine/atmos)
 "bTF" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel{
@@ -54539,8 +54439,6 @@
 /area/engine/atmos)
 "bUm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black{
@@ -54550,8 +54448,6 @@
 "bUn" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -54630,7 +54526,6 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -54830,7 +54725,6 @@
 /area/engine/atmos)
 "bUU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -54874,8 +54768,6 @@
 /area/engine/atmos)
 "bUZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel{
@@ -55121,8 +55013,6 @@
 /area/engine/atmos)
 "bVu" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/window/reinforced{
@@ -55138,8 +55028,6 @@
 /area/engine/atmos)
 "bVv" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/window/reinforced,
@@ -55243,8 +55131,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel{
@@ -55434,8 +55320,6 @@
 /area/chapel/main)
 "bVU" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/machinery/light{
@@ -55648,8 +55532,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating{
@@ -74414,7 +74296,6 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -75292,7 +75173,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -80321,8 +80201,6 @@
 "cPL" = (
 /obj/item/stack/rods,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating/astplate{
@@ -82334,7 +82212,6 @@
 /area/security/prison)
 "cTY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -82385,8 +82262,6 @@
 "cUc" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating/astplate{
@@ -82457,8 +82332,6 @@
 /area/maintenance/asteroid/central)
 "cUl" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating{
@@ -82480,8 +82353,6 @@
 /area/maintenance/asteroid/central)
 "cUn" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating{
@@ -82491,8 +82362,6 @@
 "cUo" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating{
@@ -82502,8 +82371,6 @@
 "cUp" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating{
@@ -82542,8 +82409,6 @@
 /area/maintenance/asteroid/central)
 "cUt" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating{
@@ -82558,8 +82423,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating{
@@ -82889,7 +82752,6 @@
 	id = "incineratorturbine"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -86007,8 +85869,6 @@
 /area/shuttle/escape)
 "dbn" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -86019,8 +85879,6 @@
 /area/shuttle/escape)
 "dbp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -86731,7 +86589,6 @@
 /area/hydroponics)
 "dcX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkgreen{
@@ -86740,7 +86597,6 @@
 /area/hydroponics)
 "dcY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -86751,7 +86607,6 @@
 "dcZ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkgreen/side{
@@ -86864,7 +86719,6 @@
 	req_access_txt = "35"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/hydrofloor{
@@ -86873,7 +86727,6 @@
 /area/hydroponics)
 "ddm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black{
@@ -86967,7 +86820,6 @@
 /area/maintenance/asteroid/port/east)
 "ddt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -87274,7 +87126,6 @@
 /area/engine/atmos)
 "ddZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel{
@@ -87329,7 +87180,6 @@
 /area/engine/atmos)
 "dee" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -87453,8 +87303,6 @@
 "deq" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -89024,8 +88872,6 @@
 "dir" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5;
-	icon_state = "intact";
-	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -90212,8 +90058,6 @@
 /area/security/prison)
 "dlo" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/red/side{
@@ -90348,8 +90192,6 @@
 /area/security/prison)
 "dlB" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel{
@@ -90604,7 +90446,6 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -90918,7 +90759,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -90927,7 +90767,6 @@
 /area/security/prison)
 "dmK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -91055,7 +90894,6 @@
 /area/security/prison)
 "dna" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -91070,7 +90908,6 @@
 "dnb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -91276,7 +91113,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -91289,7 +91125,6 @@
 /area/security/prison)
 "dnA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -91303,7 +91138,6 @@
 /area/security/prison)
 "dnB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -91321,7 +91155,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -91454,7 +91287,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -91463,7 +91295,6 @@
 /area/security/prison)
 "dnV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -91835,7 +91666,6 @@
 /area/security/processing)
 "doD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall{
@@ -91844,7 +91674,6 @@
 /area/security/prison)
 "doE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -91867,7 +91696,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -92074,8 +91902,6 @@
 /area/security/prison)
 "doX" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall{
@@ -92141,7 +91967,6 @@
 /area/security/processing)
 "dpf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -92156,7 +91981,6 @@
 /area/security/processing)
 "dpg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -92173,7 +91997,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating{
@@ -92199,8 +92022,6 @@
 /area/security/prison)
 "dpj" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall{
@@ -92531,7 +92352,6 @@
 /area/security/armory)
 "dpV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -92548,7 +92368,6 @@
 /area/security/armory)
 "dpW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/camera/motion{
@@ -92570,7 +92389,6 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkred/side{
@@ -93037,7 +92855,6 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -93483,7 +93300,6 @@
 /area/security/prison)
 "drC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall{
@@ -93492,7 +93308,6 @@
 /area/security/prison)
 "drD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall{
@@ -93501,7 +93316,6 @@
 /area/security/prison)
 "drE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall{
@@ -93510,7 +93324,6 @@
 /area/security/prison)
 "drF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall{
@@ -93732,7 +93545,6 @@
 /area/security/prison)
 "dsc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating/astplate{
@@ -93886,7 +93698,6 @@
 /area/security/armory)
 "dsu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -93913,7 +93724,6 @@
 /area/security/prison)
 "dsw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -93937,7 +93747,6 @@
 /area/security/prison)
 "dsx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -94246,7 +94055,6 @@
 "dsY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black{
@@ -94991,7 +94799,6 @@
 /area/crew_quarters/heads/hos)
 "duC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black{
@@ -95000,7 +94807,6 @@
 /area/crew_quarters/heads/hos)
 "duD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black{
@@ -95009,7 +94815,6 @@
 /area/crew_quarters/heads/hos)
 "duE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black{
@@ -95018,7 +94823,6 @@
 /area/crew_quarters/heads/hos)
 "duF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/orange{
@@ -95034,7 +94838,6 @@
 /area/security/main)
 "duG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -95105,7 +94908,6 @@
 "duO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black{
@@ -95114,7 +94916,6 @@
 /area/security/brig)
 "duP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -95126,7 +94927,6 @@
 /area/security/brig)
 "duQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/closed/wall{
@@ -95543,7 +95343,6 @@
 /area/security/main)
 "dvG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
@@ -95555,7 +95354,6 @@
 /area/security/brig)
 "dvH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/orange{
@@ -95579,7 +95377,6 @@
 /area/security/brig)
 "dvJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/orange{
@@ -95595,7 +95392,6 @@
 /area/security/brig)
 "dvK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -95622,7 +95418,6 @@
 /area/security/brig)
 "dvM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -97052,7 +96847,6 @@
 /area/security/brig)
 "dys" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -97061,7 +96855,6 @@
 /area/security/brig)
 "dyt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -97472,7 +97265,6 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/engine{

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -36211,7 +36211,6 @@
 /area/medical/surgery)
 "bom" = (
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = "";
 	name = "Surgery Observation";
 	req_access_txt = "0"
 	},

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -3457,7 +3457,7 @@
 	name = "navigation beacon (CellBlockUpRight)"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -3763,7 +3763,7 @@
 "ahJ" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -3771,7 +3771,7 @@
 /area/security/prison)
 "ahK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/orange{
@@ -3815,7 +3815,7 @@
 /area/security/prison)
 "ahO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -4927,7 +4927,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -5327,7 +5327,7 @@
 /area/security/prison)
 "akQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -5771,7 +5771,7 @@
 	req_one_access_txt = "38;2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
 	icon_state = "red";
@@ -5781,7 +5781,7 @@
 /area/security/processing)
 "alS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -5806,7 +5806,7 @@
 /area/security/prison)
 "alU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
 	icon_state = "red";
@@ -5855,7 +5855,7 @@
 /area/security/prison)
 "alW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
 	icon_state = "redcorner";
@@ -5870,7 +5870,7 @@
 	name = "navigation beacon (CellBlockMidLeft)"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -5890,7 +5890,7 @@
 "alZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -5908,7 +5908,7 @@
 	name = "navigation beacon (CellBlockMidRight)"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -5916,7 +5916,7 @@
 /area/security/prison)
 "amb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
 	tag = "icon-redcorner (EAST)";
@@ -5976,7 +5976,7 @@
 	req_one_access_txt = "38;2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
 	icon_state = "red";
@@ -5986,7 +5986,7 @@
 /area/security/prison)
 "amg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/orange{
@@ -6025,7 +6025,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -6911,7 +6911,7 @@
 /area/security/prison)
 "anQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -7353,7 +7353,7 @@
 /area/security/prison)
 "aoM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -7823,7 +7823,7 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -9733,7 +9733,7 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -10212,7 +10212,7 @@
 /area/security/prison)
 "auv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/orange{
@@ -14588,7 +14588,7 @@
 /area/security/brig)
 "aCS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
 	icon_state = "red";
@@ -36717,7 +36717,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -36741,7 +36741,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -36751,7 +36751,7 @@
 "bpg" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -36762,7 +36762,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -37608,7 +37608,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -39436,7 +39436,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
+	dir = 8
 	},
 /obj/machinery/meter,
 /turf/open/floor/engine{
@@ -41076,7 +41076,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -42812,7 +42812,7 @@
 "bzy" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5;
+	dir = 5
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -42821,7 +42821,6 @@
 "bzz" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	tag = "icon-manifold (EAST)";
 	name = "scrubbers pipe";
 	icon_state = "manifold";
 	dir = 4
@@ -43531,7 +43530,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5;
+	dir = 5
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -43548,7 +43547,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -43588,7 +43587,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -43683,7 +43682,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -46925,7 +46924,7 @@
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
 	tag = "icon-yellow (EAST)";
@@ -46945,7 +46944,7 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/yellow{
@@ -46954,7 +46953,7 @@
 /area/engine/atmos)
 "bGP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
 	tag = "icon-yellow (WEST)";
@@ -49043,7 +49042,7 @@
 "bKA" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -49052,7 +49051,7 @@
 "bKB" = (
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -51183,7 +51182,7 @@
 "bOn" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
-	pixel_x = 0;
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -51896,7 +51895,7 @@
 /area/engine/atmos)
 "bPt" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel{
@@ -53005,7 +53004,7 @@
 /area/engine/atmos)
 "bRu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/yellow/side{
@@ -53017,7 +53016,7 @@
 /area/engine/atmos)
 "bRv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -53056,7 +53055,6 @@
 /area/engine/atmos)
 "bRz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	tag = "icon-manifold (NORTH)";
 	name = "scrubbers pipe";
 	icon_state = "manifold";
 	dir = 1
@@ -53072,7 +53070,6 @@
 	name = "Waste Loop"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	tag = "icon-manifold (EAST)";
 	name = "scrubbers pipe";
 	icon_state = "manifold";
 	dir = 4
@@ -54113,7 +54110,6 @@
 /area/engine/atmos)
 "bTI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	tag = "icon-manifold (EAST)";
 	icon_state = "manifold";
 	dir = 4
 	},
@@ -54491,7 +54487,6 @@
 /area/engine/atmos)
 "bUt" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
-	tag = "icon-manifold (EAST)";
 	icon_state = "manifold";
 	dir = 4
 	},
@@ -54744,7 +54739,7 @@
 /area/engine/atmos)
 "bUY" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1;
+	dir = 1
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel{
@@ -54989,7 +54984,7 @@
 /area/engine/atmos)
 "bVt" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -55012,7 +55007,7 @@
 /area/engine/atmos)
 "bVv" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -68079,7 +68074,7 @@
 "ctn" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
-	pixel_x = 0;
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	tag = "icon-whitepurple (NORTH)";
@@ -68461,7 +68456,7 @@
 /area/science/mixing)
 "cub" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/white{
@@ -74272,7 +74267,7 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -82188,7 +82183,7 @@
 /area/security/prison)
 "cTY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -82227,7 +82222,6 @@
 /area/maintenance/asteroid/central)
 "cUb" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden{
-	tag = "icon-manifold (NORTH)";
 	icon_state = "manifold";
 	dir = 1
 	},
@@ -82526,7 +82520,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -82789,7 +82783,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
@@ -86793,7 +86787,7 @@
 /area/maintenance/asteroid/port/east)
 "ddt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -87167,7 +87161,7 @@
 /area/engine/atmos)
 "deg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/closed/wall/r_wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -87275,7 +87269,7 @@
 "deq" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -88843,7 +88837,7 @@
 /area/maintenance/asteroid/port/west)
 "dir" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5;
+	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -90418,7 +90412,7 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90426,7 +90420,7 @@
 /area/security/processing)
 "dmf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90730,7 +90724,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90738,7 +90732,7 @@
 /area/security/prison)
 "dmK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/item/device/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -90865,7 +90859,7 @@
 /area/security/prison)
 "dna" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -90879,7 +90873,7 @@
 "dnb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91084,7 +91078,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d2 = 4;
@@ -91096,7 +91090,7 @@
 /area/security/prison)
 "dnA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -91109,7 +91103,7 @@
 /area/security/prison)
 "dnB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/orange{
@@ -91126,7 +91120,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d2 = 8;
@@ -91222,6 +91216,7 @@
 "dnR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
+	
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91257,7 +91252,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91636,7 +91631,7 @@
 /area/security/processing)
 "doD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91644,7 +91639,7 @@
 /area/security/prison)
 "doE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/orange{
@@ -91937,7 +91932,7 @@
 /area/security/processing)
 "dpf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/orange{
@@ -91951,7 +91946,7 @@
 /area/security/processing)
 "dpg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -91967,7 +91962,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -91975,7 +91970,7 @@
 /area/security/prison)
 "dpi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used to watch the various criminals inside their cells.";
@@ -92321,7 +92316,7 @@
 /area/security/armory)
 "dpV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -92337,7 +92332,7 @@
 /area/security/armory)
 "dpW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/camera/motion{
 	c_tag = "Armory North";
@@ -92358,7 +92353,7 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkred/side{
 	icon_state = "darkred";
@@ -92824,7 +92819,7 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -93514,7 +93509,7 @@
 /area/security/prison)
 "dsc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -93667,7 +93662,7 @@
 /area/security/armory)
 "dsu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -93693,7 +93688,7 @@
 /area/security/prison)
 "dsw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -93716,7 +93711,7 @@
 /area/security/prison)
 "dsx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -94816,7 +94811,7 @@
 "duH" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -97233,7 +97228,7 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -125415,7 +125410,7 @@ bPp
 bLN
 bNn
 bOk
-bSX
+bPp
 bLN
 bUl
 bOk
@@ -125674,7 +125669,7 @@ bNo
 bLP
 bPq
 bTz
-bUm
+bVW
 bLP
 bVt
 bVU
@@ -125934,7 +125929,7 @@ deh
 deq
 dev
 bVu
-bUm
+bVW
 bDR
 cGJ
 bXE
@@ -126188,7 +126183,7 @@ bNp
 bNp
 bSY
 bTA
-bUn
+bSY
 bUT
 bVv
 deE
@@ -126446,9 +126441,9 @@ bQs
 bSZ
 bQs
 bUZ
-bUU
+bUq
 bVw
-bUm
+bVW
 bLN
 bLN
 bLN
@@ -126703,7 +126698,7 @@ ddW
 deb
 dei
 bUo
-bUU
+bUq
 bVx
 bVV
 bWu
@@ -126960,7 +126955,7 @@ ddX
 bPu
 dej
 def
-bUU
+bUq
 bVy
 bVW
 bOk
@@ -130720,7 +130715,7 @@ arQ
 asO
 arQ
 ava
-dsY
+aBi
 dtz
 ayx
 azQ

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -428,7 +428,6 @@
 	},
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
-	pixel_x = 0;
 	pixel_y = 32;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
@@ -486,7 +485,6 @@
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/item/device/radio/intercom{
@@ -494,7 +492,6 @@
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/item/device/radio/intercom{
@@ -517,7 +514,6 @@
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/item/device/radio/intercom{
@@ -533,7 +529,6 @@
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/circuit{
@@ -630,7 +625,6 @@
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/machinery/turretid{
@@ -917,7 +911,6 @@
 	id = "smindicate";
 	name = "external door control";
 	pixel_x = -26;
-	pixel_y = 0;
 	req_access_txt = "150"
 	},
 /obj/docking_port/mobile{
@@ -1088,8 +1081,7 @@
 	dir = 2;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "robot_old";
-	name = "Cyborg Statue";
-	pixel_x = 0
+	name = "Cyborg Statue"
 	},
 /turf/open/floor/circuit{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -1134,8 +1126,7 @@
 	dir = 2;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "robot_old";
-	name = "Cyborg Statue";
-	pixel_x = 0
+	name = "Cyborg Statue"
 	},
 /turf/open/floor/circuit{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -1660,7 +1651,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Telecoms Server APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -2023,7 +2013,6 @@
 "aet" = (
 /obj/machinery/flasher{
 	id = "Cell 6";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/holopad,
@@ -2766,7 +2755,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/machinery/turretid{
 	name = "AI Chamber turret control";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/black{
@@ -2910,7 +2898,6 @@
 /obj/machinery/door_timer{
 	id = "Cell 6";
 	name = "Cell 6";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -3870,7 +3857,6 @@
 	},
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
-	pixel_x = 0;
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
@@ -3883,7 +3869,6 @@
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
 	pixel_x = -32;
-	pixel_y = 0;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -5299,7 +5284,6 @@
 /obj/structure/bed,
 /obj/machinery/flasher{
 	id = "PermaCell";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plating{
@@ -5822,7 +5806,6 @@
 /obj/machinery/button/flasher{
 	id = "PermaCell";
 	name = "Perma Flash";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/button/door{
@@ -6027,7 +6010,6 @@
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
 	name = "Prison Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24;
 	prison_radio = 1
 	},
@@ -6652,7 +6634,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Disposals APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/asteroid/end,
@@ -7052,7 +7033,6 @@
 	department = "Captain's Desk";
 	departmentType = 5;
 	name = "Captain RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/wood{
@@ -7567,7 +7547,6 @@
 	},
 /obj/machinery/computer/shuttle/pod{
 	pixel_x = -32;
-	pixel_y = 0;
 	possible_destinations = "pod_lavaland1";
 	shuttleId = "pod1"
 	},
@@ -8539,7 +8518,6 @@
 /obj/machinery/button/door{
 	id = "MiningWarehouse";
 	name = "Mining Warehouse Shutters";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/reagent_dispensers/fueltank,
@@ -9183,7 +9161,6 @@
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
 	pixel_x = 32;
-	pixel_y = 0;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -9422,7 +9399,6 @@
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
 	pixel_x = -32;
-	pixel_y = 0;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
 /obj/structure/closet/crate,
@@ -9538,7 +9514,6 @@
 /obj/machinery/button/door{
 	id = "MiningWarehouse";
 	name = "Mining Warehouse Shutters";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel{
@@ -13295,7 +13270,6 @@
 	id = "armoryaccess";
 	name = "Armory Shutter Access";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access_txt = "3"
 	},
 /turf/open/floor/plasteel/showroomfloor{
@@ -14195,7 +14169,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	name = "cargo display";
-	pixel_x = 0;
 	pixel_y = 32;
 	supply_display = 1
 	},
@@ -14209,7 +14182,6 @@
 	},
 /obj/structure/sign/poster/random{
 	name = "random official poster";
-	pixel_x = 0;
 	pixel_y = 32;
 	random_basetype = /obj/structure/sign/poster/official
 	},
@@ -14272,7 +14244,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mining Dock APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -14733,7 +14704,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel{
@@ -15564,7 +15534,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Head of Security's Personal Quarters APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -16841,7 +16810,6 @@
 	department = "Cargo Bay";
 	departmentType = 2;
 	name = "Cargo RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16874,7 +16842,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	name = "cargo display";
-	pixel_x = 0;
 	pixel_y = 32;
 	supply_display = 1
 	},
@@ -16916,7 +16883,6 @@
 /obj/machinery/computer/stockexchange,
 /obj/structure/sign/poster/random{
 	name = "random official poster";
-	pixel_x = 0;
 	pixel_y = 32;
 	random_basetype = /obj/structure/sign/poster/official
 	},
@@ -18922,7 +18888,6 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF PAD WHEN IN USE'.";
 	name = "KEEP CLEAR OF PAD WHEN IN USE";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -19264,7 +19229,6 @@
 	id = "hopexternal";
 	name = "External Lockdown";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access_txt = "57"
 	},
 /turf/open/floor/wood{
@@ -19807,7 +19771,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/neutral{
@@ -20024,7 +19987,6 @@
 	dir = 8;
 	icon_state = "nboard00";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-nboard00 (WEST)"
 	},
 /obj/item/weapon/paper{
@@ -20260,7 +20222,6 @@
 /obj/machinery/button/door{
 	id = "lawyerexterior";
 	name = "Privacy Shutters";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/wood{
@@ -20770,7 +20731,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Fore Asteroid Maintenace APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/end,
@@ -23955,7 +23915,6 @@
 	id = "GulagCivExit3";
 	name = "Gulag Door Exit";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plating{
@@ -24541,7 +24500,6 @@
 	id = "GulagCivExit2";
 	name = "Gulag Door Exit";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -25423,7 +25381,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating{
@@ -25465,7 +25422,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating{
@@ -26346,7 +26302,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating{
@@ -27995,7 +27950,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Hallway APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/cobweb,
@@ -28107,7 +28061,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Asteroid Maintence APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -28153,7 +28106,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating{
@@ -28209,7 +28161,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating{
@@ -28314,7 +28265,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Bar APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -28705,7 +28655,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Kitchen APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -28904,7 +28853,6 @@
 "bbF" = (
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
-	pixel_x = 0;
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
@@ -29012,7 +28960,6 @@
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
 	pixel_x = -32;
-	pixel_y = 0;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
 /turf/open/floor/plating/astplate{
@@ -31174,7 +31121,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/grass{
@@ -31282,7 +31228,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -31330,7 +31275,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -34834,7 +34778,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/airalarm{
@@ -35044,7 +34987,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating{
@@ -35402,7 +35344,6 @@
 /obj/machinery/button/door{
 	id = "cmooffice";
 	name = "Office Emergency Lockdown";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /mob/living/simple_animal/pet/cat/Runtime,
@@ -36131,7 +36072,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Morgue APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -37895,7 +37835,6 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
-	pixel_x = 0;
 	pixel_y = -30;
 	pixel_z = 0
 	},
@@ -38080,7 +38019,6 @@
 	},
 /obj/machinery/light/small,
 /obj/machinery/computer/shuttle/pod{
-	pixel_x = 0;
 	pixel_y = 32;
 	possible_destinations = "pod_lavaland3";
 	shuttleId = "pod3"
@@ -38088,7 +38026,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/camera{
@@ -38324,7 +38261,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -38390,7 +38326,6 @@
 "brR" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /obj/structure/cable{
@@ -38688,7 +38623,6 @@
 "bsl" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /obj/structure/cable{
@@ -39739,7 +39673,6 @@
 	idDoor = "virology_airlock_exterior";
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Button";
-	pixel_x = 0;
 	pixel_y = -28;
 	req_access_txt = "39"
 	},
@@ -39758,7 +39691,6 @@
 	idDoor = "virology_airlock_interior";
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Button";
-	pixel_x = 0;
 	pixel_y = -28;
 	req_access_txt = "39"
 	},
@@ -39795,7 +39727,6 @@
 	idInterior = "virology_airlock_interior";
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Console";
-	pixel_x = 0;
 	pixel_y = -22;
 	req_access_txt = "39"
 	},
@@ -40421,7 +40352,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Central Asteroid Maintenance APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -41966,7 +41896,6 @@
 /obj/machinery/button/door{
 	id = "medmain";
 	name = "Medbay Foyer Doors";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/requests_console{
@@ -41975,7 +41904,6 @@
 	departmentType = 1;
 	name = "Medbay RC";
 	pixel_x = 30;
-	pixel_y = 0;
 	pixel_z = 0
 	},
 /turf/open/floor/plasteel/white{
@@ -44551,7 +44479,6 @@
 	id = "cloningmain";
 	name = "Cloning Door";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/camera{
@@ -45205,8 +45132,6 @@
 	c_tag = "Hydroponics Storage";
 	dir = 1;
 	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /turf/open/floor/plasteel/hydrofloor{
@@ -45383,7 +45308,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Engineering APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -45918,7 +45842,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Atmospherics APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -46601,7 +46524,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/vault{
@@ -46639,7 +46561,6 @@
 "bGo" = (
 /obj/structure/sign/poster/random{
 	name = "random official poster";
-	pixel_x = 0;
 	pixel_y = 32;
 	random_basetype = /obj/structure/sign/poster/official
 	},
@@ -49241,7 +49162,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Chemistry APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -49335,7 +49255,6 @@
 	departmentType = 1;
 	name = "Medbay RC";
 	pixel_x = 30;
-	pixel_y = 0;
 	pixel_z = 0
 	},
 /turf/open/floor/plasteel/white{
@@ -49859,7 +49778,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -50295,15 +50213,12 @@
 "bMH" = (
 /obj/structure/table,
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/clothing/neck/stethoscope,
@@ -50671,7 +50586,6 @@
 	id = "engiestoragesmes";
 	name = "Engineering SMES Blast Door Control";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "10;11"
 	},
 /obj/machinery/button/door{
@@ -50888,7 +50802,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Genetics APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -51142,8 +51055,7 @@
 /area/engine/atmos)
 "bOn" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10;
-	pixel_x = 0
+	dir = 10
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -51551,7 +51463,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Medbay Storage APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -51738,7 +51649,6 @@
 "bPh" = (
 /obj/structure/sign/poster/random{
 	name = "random official poster";
-	pixel_x = 0;
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/official
 	},
@@ -52802,7 +52712,6 @@
 	dir = 8;
 	icon_state = "nboard00";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-nboard00 (WEST)"
 	},
 /turf/open/floor/plasteel{
@@ -53121,7 +53030,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -53738,8 +53646,6 @@
 	node1_concentration = 0.8;
 	node2_concentration = 0.2;
 	on = 1;
-	pixel_x = 0;
-	pixel_y = 0;
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel{
@@ -54256,7 +54162,6 @@
 	},
 /obj/structure/sign/poster/random{
 	name = "random official poster";
-	pixel_x = 0;
 	pixel_y = 32;
 	random_basetype = /obj/structure/sign/poster/official
 	},
@@ -54284,7 +54189,6 @@
 	},
 /obj/structure/sign/poster/random{
 	name = "random official poster";
-	pixel_x = 0;
 	pixel_y = 32;
 	random_basetype = /obj/structure/sign/poster/official
 	},
@@ -55354,7 +55258,6 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -55881,7 +55784,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Eastern External Waste Belt APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
@@ -56850,7 +56752,6 @@
 /obj/item/chair/stool,
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
-	pixel_x = 0;
 	pixel_y = 32;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
@@ -57083,7 +56984,6 @@
 	},
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
-	pixel_x = 0;
 	pixel_y = 32;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
@@ -57225,7 +57125,6 @@
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
 	pixel_x = -32;
-	pixel_y = 0;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
 /turf/open/floor/wood{
@@ -57370,7 +57269,6 @@
 "caw" = (
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
-	pixel_x = 0;
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
@@ -57651,7 +57549,6 @@
 /obj/structure/closet/lasertag/blue,
 /obj/structure/sign/poster/random{
 	name = "random official poster";
-	pixel_x = 0;
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/official
 	},
@@ -57686,7 +57583,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel{
@@ -57703,7 +57599,6 @@
 /obj/structure/closet/lasertag/red,
 /obj/structure/sign/poster/random{
 	name = "random official poster";
-	pixel_x = 0;
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/official
 	},
@@ -57724,7 +57619,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel{
@@ -57779,7 +57673,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating{
@@ -57835,7 +57728,6 @@
 /obj/machinery/computer/slot_machine,
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
-	pixel_x = 0;
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
@@ -58961,7 +58853,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/darkblue/side{
@@ -60916,7 +60807,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating{
@@ -61187,7 +61077,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating{
@@ -61230,7 +61119,6 @@
 /obj/item/weapon/stock_parts/micro_laser/high,
 /obj/machinery/requests_console{
 	department = "Tech storage";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating{
@@ -62005,7 +61893,6 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF PAD WHEN IN USE'.";
 	name = "KEEP CLEAR OF PAD WHEN IN USE";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/black{
@@ -62068,7 +61955,6 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF PAD WHEN IN USE'.";
 	name = "KEEP CLEAR OF PAD WHEN IN USE";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -62550,7 +62436,6 @@
 	dir = 4;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null;
 	req_one_access_txt = "24;10"
 	},
@@ -62998,7 +62883,6 @@
 	dir = 8;
 	icon_state = "nboard00";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-nboard00 (WEST)"
 	},
 /obj/item/weapon/paper{
@@ -63849,7 +63733,6 @@
 /area/shuttle/pod_2)
 "cmD" = (
 /obj/machinery/computer/shuttle/pod{
-	pixel_x = 0;
 	pixel_y = -32;
 	possible_destinations = "pod_lavaland2";
 	shuttleId = "pod2"
@@ -63868,7 +63751,6 @@
 	pixel_y = -28
 	},
 /obj/item/device/radio/intercom{
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/chair{
@@ -66253,7 +66135,6 @@
 	id_tag = "tox_airlock_control";
 	interior_door_tag = "tox_airlock_interior";
 	pixel_x = -24;
-	pixel_y = 0;
 	sanitize_external = 1;
 	sensor_tag = "tox_airlock_sensor"
 	},
@@ -66537,7 +66418,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Aft Asteroid Hallway APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -66973,12 +66853,8 @@
 /area/science/lab)
 "crC" = (
 /obj/item/weapon/folder/white,
-/obj/item/weapon/disk/tech_disk{
-	pixel_x = 0
-	},
-/obj/item/weapon/disk/tech_disk{
-	pixel_x = 0
-	},
+/obj/item/weapon/disk/tech_disk,
+/obj/item/weapon/disk/tech_disk,
 /obj/item/weapon/disk/design_disk,
 /obj/item/weapon/disk/design_disk,
 /obj/structure/table/glass,
@@ -68012,8 +67888,7 @@
 /area/science/mixing)
 "ctn" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10;
-	pixel_x = 0
+	dir = 10
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	tag = "icon-whitepurple (NORTH)";
@@ -68154,7 +68029,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -68267,7 +68141,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -69113,7 +68986,6 @@
 	pixel_y = -2
 	},
 /obj/item/device/assembly/prox_sensor{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -69859,7 +69731,6 @@
 /area/science/mixing)
 "cwj" = (
 /obj/item/device/assembly/signaler{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /obj/item/device/assembly/signaler{
@@ -69918,9 +69789,7 @@
 	pixel_x = 6;
 	pixel_y = -4
 	},
-/obj/item/device/assembly/timer{
-	pixel_x = 0
-	},
+/obj/item/device/assembly/timer,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/whitepurple/side{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -70753,7 +70622,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Toxins Lab APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable/orange{
@@ -71663,7 +71531,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/red/side{
@@ -72205,7 +72072,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "RnD Server APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/disposalpipe/segment{
@@ -72505,7 +72371,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Research Director's Office APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable/orange{
@@ -73159,7 +73024,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel{
@@ -73349,7 +73213,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Testing Lab APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable/orange{
@@ -73461,7 +73324,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "South-Eastern External Waste Belt APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -73513,7 +73375,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "South-Western External Waste Belt APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
@@ -73904,7 +73765,6 @@
 	},
 /obj/structure/sign/poster/random{
 	name = "random official poster";
-	pixel_x = 0;
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/official
 	},
@@ -74602,7 +74462,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/sign/poster/random{
 	name = "random official poster";
-	pixel_x = 0;
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/official
 	},
@@ -78442,7 +78301,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Asteroid Maintence APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -78943,7 +78801,6 @@
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
 	pixel_x = -32;
-	pixel_y = 0;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
 /obj/item/clothing/head/sombrero,
@@ -79387,7 +79244,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Theatre APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -79920,7 +79776,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Morgue APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/table,
@@ -81148,7 +81003,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Toxins Storage APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable/orange{
@@ -82924,9 +82778,7 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "cVu" = (
-/obj/structure/sign/fire{
-	pixel_x = 0
-	},
+/obj/structure/sign/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "cVv" = (
@@ -83185,7 +83037,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Security Transfer Range APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -85261,7 +85112,6 @@
 /area/shuttle/escape)
 "cZZ" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/black,
@@ -85272,7 +85122,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/darkred/side{
@@ -85556,7 +85405,6 @@
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /turf/open/floor/plasteel/neutral,
@@ -85626,7 +85474,6 @@
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /turf/open/floor/plasteel,
@@ -85972,7 +85819,6 @@
 "dbJ" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/whiteblue/side,
@@ -85990,7 +85836,6 @@
 /area/shuttle/escape)
 "dbL" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -86180,7 +86025,6 @@
 "dcj" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/yellow/side,
@@ -86195,7 +86039,6 @@
 /area/shuttle/escape)
 "dcm" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -86656,8 +86499,6 @@
 	c_tag = "Hydroponics South 1";
 	dir = 1;
 	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /turf/open/floor/plasteel/darkgreen{
@@ -86685,8 +86526,6 @@
 	c_tag = "Hydroponics South 2";
 	dir = 1;
 	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /turf/open/floor/plasteel/darkgreen{
@@ -87629,7 +87468,6 @@
 /obj/machinery/button/door{
 	id = "armoryaccess2";
 	name = "Armory Shutter Access";
-	pixel_x = 0;
 	pixel_y = -28;
 	req_access_txt = "3"
 	},
@@ -89906,7 +89744,6 @@
 "dlj" = (
 /obj/machinery/flasher{
 	id = "Cell 5";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/holopad,
@@ -90308,7 +90145,6 @@
 /obj/machinery/button/flasher{
 	id = "gulagshuttleflasher";
 	name = "Flash Control";
-	pixel_x = 0;
 	pixel_y = -26;
 	req_access_txt = "1"
 	},
@@ -90678,7 +90514,6 @@
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
 	name = "Prison Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24;
 	prison_radio = 1
 	},
@@ -90689,7 +90524,6 @@
 "dmL" = (
 /obj/machinery/flasher{
 	id = "PCell 1";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -91206,7 +91040,6 @@
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
 	name = "Prison Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24;
 	prison_radio = 1
 	},
@@ -91217,7 +91050,6 @@
 "dnW" = (
 /obj/machinery/flasher{
 	id = "PCell 2";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -91614,7 +91446,6 @@
 "doG" = (
 /obj/machinery/flasher{
 	id = "PCell 3";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -92163,7 +91994,6 @@
 "dpL" = (
 /obj/machinery/flasher{
 	id = "PCell 4";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -92287,7 +92117,6 @@
 /obj/machinery/button/door{
 	id = "armoryaccess";
 	name = "Armory Shutter Access";
-	pixel_x = 0;
 	pixel_y = 28;
 	req_access_txt = "3"
 	},
@@ -92718,7 +92547,6 @@
 	},
 /obj/item/weapon/shield/riot,
 /obj/item/weapon/shield/riot{
-	pixel_x = 0;
 	pixel_y = 1;
 	pixel_x = 3;
 	pixel_y = -3
@@ -92767,7 +92595,6 @@
 "dqN" = (
 /obj/machinery/flasher{
 	id = "PCell 5";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -93413,7 +93240,6 @@
 "drZ" = (
 /obj/machinery/flasher{
 	id = "PCell 6";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -95166,7 +94992,6 @@
 	id = "brigfront";
 	name = "Emergency Brig Lockdown";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "1"
 	},
 /turf/open/floor/carpet,

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -53756,8 +53756,7 @@
 "bSX" = (
 /obj/machinery/meter,
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple";
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall{

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -40310,7 +40310,6 @@
 "buY" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
@@ -42841,7 +42840,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black{
@@ -53077,7 +53075,6 @@
 "bRz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel{
@@ -53092,7 +53089,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -54130,7 +54126,6 @@
 /area/engine/atmos)
 "bTI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -54507,7 +54502,6 @@
 /area/engine/atmos)
 "bUt" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/meter,
@@ -71310,7 +71304,6 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black{
@@ -82256,7 +82249,6 @@
 /area/maintenance/asteroid/central)
 "cUb" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating/astplate{
@@ -84701,7 +84693,6 @@
 "cYE" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced,

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -2445,6 +2445,7 @@
 	charge = 5e+006
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/circuit{
@@ -25646,6 +25647,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -25701,6 +25704,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/light/small{
@@ -26182,6 +26186,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/light/small{
@@ -26761,6 +26766,7 @@
 "aXj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/tracker,
@@ -26845,6 +26851,8 @@
 "aXs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
@@ -27312,6 +27320,8 @@
 "aYA" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -27805,6 +27815,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -27978,6 +27990,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -28587,6 +28601,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -30016,6 +30032,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -31709,6 +31727,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -49798,6 +49818,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -49813,6 +49834,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable{
@@ -58626,6 +58648,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -58704,6 +58728,8 @@
 	pixel_x = 28
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -59381,6 +59407,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -76427,6 +76454,8 @@
 /obj/machinery/door/airlock/glass,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -76474,6 +76503,8 @@
 "cIw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -78436,6 +78467,8 @@
 	pixel_x = -22
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -79466,6 +79499,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/stripes/asteroid/end,
@@ -80649,6 +80683,8 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral{
@@ -83419,6 +83455,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -83477,6 +83514,8 @@
 /area/hallway/secondary/bridges/com_engi)
 "cWf" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
@@ -83498,6 +83537,8 @@
 "cWj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
@@ -83529,6 +83570,8 @@
 "cWo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
@@ -83588,12 +83631,16 @@
 /area/hallway/secondary/bridges/com_serv)
 "cWv" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
 /area/hallway/secondary/bridges/com_serv)
 "cWw" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
@@ -83609,6 +83656,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
@@ -83703,6 +83752,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/engine,
@@ -83867,6 +83917,8 @@
 /area/hallway/secondary/bridges/dock_med)
 "cXb" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
@@ -83878,6 +83930,8 @@
 	network = list("SS13")
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
@@ -83885,6 +83939,8 @@
 "cXd" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -83893,6 +83949,8 @@
 /area/hallway/primary/starboard/aft)
 "cXe" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -83905,6 +83963,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -83917,6 +83977,8 @@
 	pixel_x = 24
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -84407,6 +84469,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -112258,7 +112322,7 @@ cWv
 cWv
 cWv
 aYA
-cWy
+aYW
 aZy
 aZY
 aZY

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -357,7 +357,6 @@
 /obj/item/stack/cable_coil,
 /obj/item/weapon/crowbar/red,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -543,8 +542,7 @@
 /area/ai_monitored/turret_protected/ai)
 "abp" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/black{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -818,7 +816,6 @@
 "abT" = (
 /obj/machinery/suit_storage_unit/syndicate,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -907,8 +904,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/syndicate)
@@ -1193,8 +1189,7 @@
 /area/shuttle/syndicate)
 "acG" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/syndicate)
@@ -1272,7 +1267,6 @@
 	syndie = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -1438,7 +1432,6 @@
 "adj" = (
 /obj/structure/bed/roller,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -1454,8 +1447,7 @@
 /obj/item/weapon/storage/toolbox/syndicate,
 /obj/item/weapon/crowbar/red,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/syndicate)
@@ -1501,7 +1493,6 @@
 	installation = /obj/item/weapon/gun/energy/e_gun
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/circuit{
@@ -1540,7 +1531,6 @@
 	installation = /obj/item/weapon/gun/energy/e_gun
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/circuit{
@@ -2138,7 +2128,6 @@
 /obj/item/weapon/surgicaldrill,
 /obj/item/weapon/circular_saw,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -4084,7 +4073,6 @@
 	dir = 5
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
@@ -4979,8 +4967,7 @@
 "akg" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkred{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -8581,7 +8568,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
@@ -8782,8 +8768,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -9458,7 +9443,6 @@
 /area/quartermaster/storage)
 "asX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/newscaster{
@@ -9512,7 +9496,6 @@
 /area/quartermaster/office)
 "atb" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9573,7 +9556,6 @@
 "ath" = (
 /obj/structure/table,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -9585,8 +9567,7 @@
 "atj" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/mining)
@@ -9773,7 +9754,6 @@
 /area/maintenance/asteroid/fore/com_north)
 "atA" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -10722,7 +10702,6 @@
 "avo" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -14615,7 +14594,6 @@
 /obj/item/weapon/gavelhammer,
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -18771,7 +18749,6 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22456,7 +22433,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -24837,7 +24813,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black{
@@ -25042,7 +25017,6 @@
 /area/hallway/primary/fore)
 "aUn" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -25230,7 +25204,6 @@
 /area/hallway/primary/fore)
 "aUG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -25501,7 +25474,6 @@
 /area/hallway/primary/fore)
 "aVh" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/cable/orange{
@@ -25919,7 +25891,6 @@
 /obj/structure/filingcabinet,
 /obj/item/weapon/folder/documents,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/circuit,
@@ -26567,7 +26538,6 @@
 /area/hallway/primary/starboard/fore)
 "aWT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -27633,7 +27603,6 @@
 "aZe" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/grass{
@@ -28614,7 +28583,6 @@
 /area/hallway/primary/starboard)
 "baV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -29415,7 +29383,6 @@
 "bcx" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/grass{
@@ -29663,8 +29630,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
@@ -30679,8 +30645,7 @@
 "beS" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/grass{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -31103,7 +31068,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/sign/poster/random{
@@ -31234,7 +31198,6 @@
 /area/crew_quarters/rehab_dome)
 "bfV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/table,
@@ -32828,8 +32791,7 @@
 /obj/structure/table,
 /obj/machinery/microwave,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -35987,7 +35949,6 @@
 /area/engine/engineering)
 "bnU" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -36083,7 +36044,6 @@
 /area/hallway/primary/starboard)
 "boa" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36318,7 +36278,6 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -37515,7 +37474,6 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -37980,7 +37938,6 @@
 /obj/structure/table,
 /obj/item/stack/packageWrap,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white{
@@ -40882,8 +40839,7 @@
 /area/storage/primary)
 "bvX" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -41335,7 +41291,6 @@
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -42052,7 +42007,6 @@
 "bxX" = (
 /obj/structure/bed/roller,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -42440,7 +42394,6 @@
 /area/maintenance/asteroid/central)
 "byM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -42573,7 +42526,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -43204,7 +43156,6 @@
 "bAf" = (
 /obj/machinery/clonepod,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/cable/orange{
@@ -43517,7 +43468,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -45926,7 +45876,6 @@
 /area/engine/atmos)
 "bEX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -46710,8 +46659,7 @@
 /area/crew_quarters/fitness)
 "bGp" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/vault{
@@ -47786,8 +47734,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/sign/poster/random{
 	name = "random official poster";
@@ -47836,7 +47783,6 @@
 /area/maintenance/asteroid/port/east)
 "bIh" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -47893,8 +47839,7 @@
 /area/engine/atmos)
 "bIn" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/button/door{
 	id = "atmodesk";
@@ -48120,7 +48065,6 @@
 /area/maintenance/asteroid/central)
 "bIK" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -48836,7 +48780,6 @@
 "bKf" = (
 /obj/structure/closet/wardrobe/genetics_white,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white{
@@ -50698,8 +50641,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -51702,7 +51644,6 @@
 /area/crew_quarters/fitness)
 "bOZ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -51783,8 +51724,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/sign/poster/random{
 	name = "random official poster";
@@ -53217,7 +53157,6 @@
 /area/engine/engine_smes)
 "bRN" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -54517,8 +54456,7 @@
 	target_pressure = 101
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55214,8 +55152,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/weapon/storage/firstaid/o2,
 /obj/structure/disposalpipe/segment,
@@ -56622,8 +56559,7 @@
 /area/hallway/primary/port)
 "bYK" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -57170,8 +57106,7 @@
 "bZT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -57285,7 +57220,6 @@
 /area/chapel/office)
 "cad" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/sign/poster/random{
@@ -58637,7 +58571,6 @@
 /area/hallway/primary/starboard/aft)
 "ccJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -59478,7 +59411,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -60358,7 +60290,6 @@
 /area/hallway/primary/aft)
 "cgd" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plating{
@@ -60381,7 +60312,6 @@
 /area/shuttle/auxillary_base)
 "cgf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plating{
@@ -60678,7 +60608,6 @@
 /obj/structure/table,
 /obj/item/weapon/aiModule/reset,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black{
@@ -61198,7 +61127,6 @@
 /area/hallway/secondary/exit)
 "chK" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -61517,7 +61445,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/escape{
@@ -61763,7 +61690,6 @@
 /area/hallway/primary/starboard/aft)
 "ciP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -63573,7 +63499,6 @@
 "clS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -64830,7 +64755,6 @@
 /area/maintenance/asteroid/aft/arrivals)
 "cnL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/escape{
@@ -65647,7 +65571,6 @@
 /area/security/checkpoint/checkpoint2)
 "cpj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -66930,8 +66853,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	tag = "icon-whitepurple (EAST)";
@@ -67609,7 +67531,6 @@
 /area/science/research)
 "csw" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/requests_console{
@@ -67665,8 +67586,7 @@
 /obj/item/stack/cable_coil,
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -69119,7 +69039,6 @@
 /area/science/xenobiology)
 "cvi" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/shuttle,
@@ -69137,8 +69056,7 @@
 /area/shuttle/arrival)
 "cvl" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/arrival)
@@ -69848,8 +69766,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -69861,7 +69778,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -70343,7 +70259,6 @@
 /area/maintenance/asteroid/aft/arrivals)
 "cwV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -70381,7 +70296,6 @@
 /area/hallway/secondary/entry)
 "cxb" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -70511,7 +70425,6 @@
 /area/science/misc_lab)
 "cxp" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -70720,8 +70633,7 @@
 /obj/item/weapon/extinguisher,
 /obj/item/weapon/extinguisher,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -71188,7 +71100,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/shuttle,
@@ -71210,8 +71121,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/arrival)
@@ -71327,8 +71237,7 @@
 /area/science/server)
 "cyK" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -72174,7 +72083,6 @@
 /area/science/misc_lab)
 "cAe" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -72549,7 +72457,6 @@
 /area/science/xenobiology)
 "cAL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -72562,7 +72469,6 @@
 /area/hallway/secondary/entry)
 "cAM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -72797,7 +72703,6 @@
 /area/hallway/secondary/entry)
 "cBf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/device/radio/beacon,
@@ -73065,8 +72970,7 @@
 /area/science/misc_lab)
 "cBF" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty,
@@ -75798,7 +75702,6 @@
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -75841,7 +75744,6 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -75952,8 +75854,7 @@
 /area/security/brig)
 "cHz" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -77469,7 +77370,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -81270,7 +81170,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -83513,7 +83412,6 @@
 /area/hallway/secondary/bridges/com_serv)
 "cWg" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -83635,7 +83533,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -83865,7 +83762,6 @@
 /area/hallway/secondary/bridges/dock_med)
 "cWW" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -84329,7 +84225,6 @@
 /area/hallway/secondary/bridges/cargo_ai)
 "cXT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -85579,7 +85474,6 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -85714,7 +85608,6 @@
 /area/shuttle/escape)
 "daQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -85806,7 +85699,6 @@
 /area/shuttle/escape)
 "dbc" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -85959,7 +85851,6 @@
 /area/shuttle/escape)
 "dbx" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue,
@@ -86433,8 +86324,7 @@
 /area/hydroponics)
 "dcF" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics Bee Reserve North";
@@ -86720,7 +86610,6 @@
 /area/hydroponics)
 "ddk" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -86755,8 +86644,7 @@
 /area/hydroponics)
 "ddn" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/grass{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90123,7 +90011,6 @@
 	scrub_Toxins = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -91795,7 +91682,6 @@
 "doP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -93978,7 +93864,6 @@
 "dsN" = (
 /obj/machinery/vending/security,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red{
@@ -95976,7 +95861,6 @@
 "dwM" = (
 /obj/machinery/vending/security,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red{
@@ -96105,8 +95989,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/blue/side{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -96699,8 +96582,7 @@
 /area/security/detectives_office)
 "dya" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 32
@@ -96950,8 +96832,7 @@
 "dyB" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5;

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -6576,9 +6576,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	initialize_directions = 11
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aoN" = (
@@ -8464,7 +8462,6 @@
 "asq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /turf/open/floor/plasteel/yellow,
 /area/engine/atmospherics_engine)
@@ -11033,7 +11030,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmospherics_engine)
@@ -11630,7 +11626,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/yellow,
 /area/engine/atmospherics_engine)
@@ -12121,7 +12116,6 @@
 "aAg" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmospherics_engine)
@@ -18969,7 +18963,6 @@
 "aNT" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -20749,7 +20742,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
@@ -21668,7 +21660,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "co2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "co2 vent";
 	on = 1;
@@ -23583,7 +23574,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "o2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "oxygen vent";
 	on = 1;
@@ -24926,7 +24916,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "tox_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "plasma vent";
 	on = 1;
@@ -24985,7 +24974,6 @@
 "aZp" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -26378,7 +26366,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "n2 vent";
 	on = 1;
@@ -27722,7 +27709,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2o_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "n2o vent";
 	on = 1;
@@ -29667,7 +29653,6 @@
 "biY" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -29692,7 +29677,6 @@
 "bjb" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 1
@@ -29736,7 +29720,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral,
@@ -30382,7 +30365,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -32311,7 +32293,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -33200,7 +33181,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "mix_in";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "distro vent";
 	on = 1;
@@ -51532,7 +51512,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "server vent";
 	on = 1;
@@ -70115,7 +70094,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "server vent";
 	on = 1;
@@ -91805,7 +91783,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "server vent";
 	on = 1;

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -751,8 +751,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -784,8 +783,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Shuttle - Fore Port";
@@ -829,8 +827,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1687,7 +1684,6 @@
 /area/construction/mining/aux_base)
 "adx" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -1867,7 +1863,6 @@
 /obj/item/weapon/clipboard,
 /obj/item/toy/figure/syndie,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -2243,8 +2238,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
@@ -2275,8 +2269,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
@@ -2335,8 +2328,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -2855,7 +2847,6 @@
 /obj/item/weapon/crowbar/red,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/podhatch{
@@ -5184,8 +5175,7 @@
 "alx" = (
 /obj/machinery/computer/security,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
@@ -6359,7 +6349,6 @@
 /obj/item/weapon/circular_saw,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -6974,8 +6963,7 @@
 /area/hallway/secondary/entry)
 "apj" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner,
@@ -11307,8 +11295,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -12370,7 +12357,6 @@
 /area/quartermaster/warehouse)
 "azN" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -12672,7 +12658,6 @@
 "aAy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -12863,7 +12848,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16543,7 +16527,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -16867,7 +16850,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -16961,8 +16943,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Security Post - Cargo";
@@ -16994,7 +16975,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -17568,7 +17548,6 @@
 "aJD" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
@@ -17642,7 +17621,6 @@
 /area/security/checkpoint/supply)
 "aJL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -20256,8 +20234,7 @@
 /obj/item/stack/packageWrap,
 /obj/item/weapon/hand_labeler,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26;
@@ -21028,7 +21005,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/stockexchange,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/newscaster{
@@ -21142,8 +21118,7 @@
 "aQm" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -21160,7 +21135,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -21506,7 +21480,6 @@
 /obj/item/device/electropack,
 /obj/item/device/assembly/signaler,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/clothing/head/helmet/sec,
@@ -22340,8 +22313,7 @@
 "aSo" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = 32
@@ -22651,8 +22623,7 @@
 /area/engine/atmos)
 "aST" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -23678,7 +23649,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -23931,8 +23901,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/stockexchange,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	icon_state = "brown";
@@ -24787,7 +24756,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/light_switch{
@@ -24843,8 +24811,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/stockexchange,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -25688,7 +25655,6 @@
 "aYE" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -26409,7 +26375,6 @@
 /area/crew_quarters/kitchen)
 "aZY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/button/door{
@@ -26439,7 +26404,6 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -26809,8 +26773,7 @@
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/weapon/storage/backpack/satchel/eng,
 /obj/effect/turf_decal/bot,
@@ -27420,8 +27383,7 @@
 /area/engine/atmos)
 "bch" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -30355,7 +30317,6 @@
 "bhP" = (
 /obj/structure/table,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/weapon/clipboard,
@@ -30408,8 +30369,7 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	icon_state = "brown";
@@ -31112,7 +31072,6 @@
 /area/hydroponics)
 "bjw" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/light_switch{
@@ -31752,8 +31711,7 @@
 /area/engine/atmos)
 "bkE" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
@@ -34747,8 +34705,7 @@
 "bpW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -34965,7 +34922,6 @@
 "bqp" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/item/stack/packageWrap,
@@ -37353,7 +37309,6 @@
 /area/security/brig)
 "buJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -38074,7 +38029,6 @@
 "bvT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/item/weapon/wrench,
@@ -38088,7 +38042,6 @@
 "bvU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -39956,7 +39909,6 @@
 /obj/structure/table/reinforced,
 /obj/item/device/aicard,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -39980,7 +39932,6 @@
 /obj/item/device/assembly/signaler,
 /obj/item/device/assembly/signaler,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -41769,7 +41720,6 @@
 /area/security/warden)
 "bBM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -41820,7 +41770,6 @@
 /area/ai_monitored/turret_protected/ai)
 "bBO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -42893,7 +42842,6 @@
 "bDP" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44101,8 +44049,7 @@
 /area/engine/break_room)
 "bFW" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -44918,7 +44865,6 @@
 "bHB" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -46289,7 +46235,6 @@
 /obj/item/weapon/electronics/firealarm,
 /obj/item/weapon/electronics/firealarm,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -46466,7 +46411,6 @@
 "bKt" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -46629,7 +46573,6 @@
 /area/crew_quarters/heads/captain)
 "bKK" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -46646,7 +46589,6 @@
 	pixel_x = -26
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -46754,7 +46696,6 @@
 "bKX" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/status_display{
@@ -47129,8 +47070,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault{
@@ -47353,7 +47293,6 @@
 "bMj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -48490,7 +48429,6 @@
 "bOy" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/device/flashlight/lamp/green,
@@ -50645,7 +50583,6 @@
 "bRP" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/computer/security/telescreen{
@@ -50851,7 +50788,6 @@
 "bSj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -51044,7 +50980,6 @@
 /area/crew_quarters/heads/hop)
 "bSD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -51089,7 +51024,6 @@
 /area/tcommsat/server)
 "bSI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -51141,7 +51075,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/landmark/start/captain,
@@ -51168,7 +51101,6 @@
 "bSQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -54124,7 +54056,6 @@
 "bYb" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -54356,7 +54287,6 @@
 "bYw" = (
 /obj/machinery/vending/snack/random,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -55886,7 +55816,6 @@
 "cbg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/status_display{
@@ -56460,7 +56389,6 @@
 /area/lawoffice)
 "ccj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -59364,7 +59292,6 @@
 /area/crew_quarters/heads/hop)
 "chX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -60100,7 +60027,6 @@
 /obj/item/device/flashlight,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -61763,8 +61689,7 @@
 "cmE" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Courtroom - Aft";
@@ -61782,7 +61707,6 @@
 "cmG" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/weapon/paper_bin,
@@ -62010,8 +61934,7 @@
 /area/engine/engineering)
 "cnm" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -63918,7 +63841,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -64365,7 +64287,6 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/weapon/storage/toolbox/electrical,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -64738,7 +64659,6 @@
 "csr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -64857,8 +64777,7 @@
 /area/crew_quarters/locker)
 "csI" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -66118,7 +66037,6 @@
 "cvc" = (
 /obj/machinery/photocopier,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
@@ -66420,7 +66338,6 @@
 /area/crew_quarters/toilet/restrooms)
 "cvH" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -66991,7 +66908,6 @@
 "cwT" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
@@ -67444,7 +67360,6 @@
 /area/crew_quarters/dorms)
 "cxC" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/vending/coffee,
@@ -68332,7 +68247,6 @@
 /area/engine/engineering)
 "czm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/status_display{
@@ -72203,7 +72117,6 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/arrival{
@@ -74960,7 +74873,6 @@
 "cLW" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -75935,7 +75847,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -76998,7 +76909,6 @@
 "cPS" = (
 /obj/structure/table,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/toy/katana,
@@ -77412,8 +77322,7 @@
 /obj/item/weapon/reagent_containers/glass/beaker,
 /obj/item/weapon/reagent_containers/dropper,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -78176,8 +78085,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/camera{
@@ -78920,7 +78828,6 @@
 "cTN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -79061,7 +78968,6 @@
 "cUc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -79150,7 +79056,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -79221,8 +79126,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
 	icon_state = "red";
@@ -79232,7 +79136,6 @@
 "cUq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -80225,7 +80128,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -80760,8 +80662,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -80906,8 +80807,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -82170,7 +82070,6 @@
 /area/medical/chemistry)
 "dak" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -82222,8 +82121,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chemistry";
@@ -83377,7 +83275,6 @@
 /area/science/xenobiology)
 "dcJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -85679,7 +85576,6 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -85763,7 +85659,6 @@
 /obj/item/weapon/stock_parts/cell/high,
 /obj/machinery/cell_charger,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -85849,7 +85744,6 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/sign/nosmoking_2{
@@ -87085,8 +86979,7 @@
 "dki" = (
 /obj/structure/chair,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -88036,7 +87929,6 @@
 "dmb" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/item/weapon/paper_bin,
@@ -88289,7 +88181,6 @@
 "dmF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -89037,7 +88928,6 @@
 "don" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -89455,7 +89345,6 @@
 /area/science/mixing)
 "dpi" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/sign/securearea{
@@ -89466,7 +89355,6 @@
 /area/science/misc_lab/range)
 "dpj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -90411,7 +90299,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/weapon/hand_labeler,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -90484,7 +90371,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
@@ -90922,8 +90808,7 @@
 /area/medical/surgery)
 "drI" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/surgery)
@@ -90958,8 +90843,7 @@
 /area/medical/surgery)
 "drN" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
@@ -91144,7 +91028,6 @@
 "dsn" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/sign/nosmoking_2{
@@ -91186,7 +91069,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -91355,7 +91237,6 @@
 	pixel_x = -23
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/weapon/folder/white,
@@ -92308,7 +92189,6 @@
 	pixel_x = -23
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /mob/living/simple_animal/pet/cat/Runtime,
@@ -92347,8 +92227,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -92599,7 +92478,6 @@
 /area/science/misc_lab/range)
 "duY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/ai_status_display{
@@ -92641,7 +92519,6 @@
 /area/crew_quarters/heads/hor)
 "dvc" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/bed,
@@ -92659,7 +92536,6 @@
 	},
 /obj/item/weapon/wrench,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/clothing/glasses/welding,
@@ -94044,7 +93920,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -94804,7 +94679,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -95087,7 +94961,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -95992,7 +95865,6 @@
 /obj/item/device/multitool,
 /obj/item/clothing/head/welding,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/newscaster{
@@ -96058,7 +95930,6 @@
 /obj/item/weapon/retractor,
 /obj/item/weapon/hemostat,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/ai_status_display{
@@ -96196,7 +96067,6 @@
 /area/medical/morgue)
 "dBT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/ai_status_display{
@@ -96232,8 +96102,7 @@
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/cmo,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -99653,7 +99522,6 @@
 	pixel_x = -23
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -99743,8 +99611,7 @@
 	pixel_y = 22
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -101561,7 +101428,6 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -101715,8 +101581,7 @@
 /area/medical/virology)
 "dMt" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -102060,7 +101925,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cmo,
@@ -102553,7 +102417,6 @@
 "dOt" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -102878,8 +102741,7 @@
 /area/medical/virology)
 "dPb" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -104211,7 +104073,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -104267,7 +104128,6 @@
 /area/chapel/main)
 "dRU" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -104813,7 +104673,6 @@
 /area/medical/virology)
 "dTc" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -104995,7 +104854,6 @@
 "dTp" = (
 /obj/structure/chair/wood,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -105018,7 +104876,6 @@
 "dTs" = (
 /obj/structure/chair/wood,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/newscaster{
@@ -105350,7 +105207,6 @@
 /area/chapel/main)
 "dTY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -105667,8 +105523,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dUG" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -105916,7 +105771,6 @@
 /area/chapel/office)
 "dVe" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -106272,7 +106126,6 @@
 /area/chapel/office)
 "dVN" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -106316,7 +106169,6 @@
 "dVS" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/sign/nosmoking_2{
@@ -106391,7 +106243,6 @@
 /obj/item/clothing/head/hardhat/red,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -107670,7 +107521,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -108416,7 +108266,6 @@
 	},
 /obj/item/weapon/storage/fancy/candle_box,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/newscaster{
@@ -110034,7 +109883,6 @@
 "efu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/microwave{
@@ -110728,7 +110576,6 @@
 "egy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/weapon/crowbar,
@@ -110743,8 +110590,7 @@
 "egz" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -111038,7 +110884,6 @@
 	name = "tactical chair"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -111076,7 +110921,6 @@
 /area/shuttle/syndicate)
 "ehf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -111127,7 +110971,6 @@
 /area/shuttle/arrival)
 "ehm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/pod/light,
@@ -111169,7 +111012,6 @@
 /area/shuttle/escape)
 "ehr" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -111183,7 +111025,6 @@
 "ehs" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -111203,7 +111044,6 @@
 	icon_state = "plant-21"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -112126,7 +111966,6 @@
 /obj/item/weapon/clipboard,
 /obj/item/toy/figure/syndie,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -112359,7 +112198,6 @@
 	name = "tactical chair"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -112603,7 +112441,6 @@
 /obj/item/weapon/crowbar/red,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/podhatch{
@@ -113022,7 +112859,6 @@
 /area/space)
 "emR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -113356,7 +113192,6 @@
 /obj/item/weapon/circular_saw,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -35630,7 +35630,7 @@
 	},
 /obj/machinery/requests_console{
 	department = "Hydroponics";
-	departmentType = 0;
+	departmentType = 2;
 	name = "Hydroponics RC";
 	pixel_x = 32;
 	pixel_y = -32

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -800,7 +800,6 @@
 "abF" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -1464,7 +1463,6 @@
 /area/hallway/secondary/entry)
 "acZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -1942,7 +1940,6 @@
 /area/shuttle/arrival)
 "aec" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -2610,7 +2607,6 @@
 "afD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -2903,7 +2899,6 @@
 /area/hallway/secondary/entry)
 "agk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/arrival{
@@ -2950,7 +2945,6 @@
 /area/hallway/secondary/entry)
 "ago" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/arrival{
@@ -3200,7 +3194,6 @@
 "agQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/arrival,
@@ -3234,7 +3227,6 @@
 /area/hallway/secondary/entry)
 "agU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/arrival/corner{
@@ -3268,7 +3260,6 @@
 /area/hallway/secondary/entry)
 "agZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/arrival/corner,
@@ -3576,7 +3567,6 @@
 /area/security/checkpoint/checkpoint2)
 "ahO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -4149,7 +4139,6 @@
 /area/maintenance/port/fore)
 "aja" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -4287,7 +4276,6 @@
 /area/security/checkpoint/customs)
 "ajq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -4325,7 +4313,6 @@
 /area/hallway/secondary/entry)
 "ajw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner,
@@ -4594,7 +4581,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -4742,7 +4728,6 @@
 /area/hallway/secondary/entry)
 "aky" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner,
@@ -4951,7 +4936,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -4989,7 +4973,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -5055,7 +5038,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
@@ -5408,7 +5390,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -5537,7 +5518,6 @@
 /area/hallway/secondary/entry)
 "amp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -6198,7 +6178,6 @@
 /area/security/checkpoint/checkpoint2)
 "anI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -7411,7 +7390,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -7503,7 +7481,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -7570,7 +7547,6 @@
 "aqp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -7725,7 +7701,6 @@
 /area/hallway/secondary/entry)
 "aqB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -7818,7 +7793,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -8264,7 +8238,6 @@
 /area/hallway/secondary/entry)
 "arz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -8442,7 +8415,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -9142,7 +9114,6 @@
 /area/quartermaster/warehouse)
 "asY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/closed/wall,
@@ -9264,7 +9235,6 @@
 "atp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8;
-	icon_state = "manifold";
 	name = "scrubbers pipe"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -9412,7 +9382,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -9579,7 +9548,6 @@
 /area/hallway/primary/fore)
 "atX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -10151,7 +10119,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
@@ -10218,7 +10185,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -10321,7 +10287,6 @@
 /area/quartermaster/storage)
 "avD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -10438,7 +10403,6 @@
 "avR" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
@@ -10472,7 +10436,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -10697,7 +10660,6 @@
 "awt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -10775,7 +10737,6 @@
 "awB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -10900,7 +10861,6 @@
 /area/engine/atmospherics_engine)
 "awS" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -11144,7 +11104,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -11153,7 +11112,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/cargo_technician,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -11222,7 +11180,6 @@
 "axz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -11334,7 +11291,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11766,7 +11722,6 @@
 /area/crew_quarters/toilet/auxiliary)
 "ayA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -12239,7 +12194,6 @@
 /area/hallway/primary/fore)
 "azC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -12321,7 +12275,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -12437,7 +12390,6 @@
 /area/quartermaster/storage)
 "azP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -12550,7 +12502,6 @@
 "aAc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
@@ -13245,7 +13196,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -13594,7 +13544,6 @@
 /area/engine/atmospherics_engine)
 "aCh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/yellow,
@@ -14496,7 +14445,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -14588,7 +14536,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -14738,7 +14685,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -14803,7 +14749,6 @@
 "aDZ" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -14987,7 +14932,6 @@
 "aEx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -15532,7 +15476,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -15580,7 +15523,6 @@
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -15661,7 +15603,6 @@
 /area/crew_quarters/bar)
 "aFE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -15812,7 +15753,6 @@
 /area/quartermaster/storage)
 "aFT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -16027,7 +15967,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16079,7 +16018,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16100,7 +16038,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16261,7 +16198,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -16403,7 +16339,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown{
@@ -16489,7 +16424,6 @@
 /area/quartermaster/storage)
 "aHo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -16765,7 +16699,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16898,7 +16831,6 @@
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -17824,7 +17756,6 @@
 /area/security/prison)
 "aJY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -18196,7 +18127,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -18362,7 +18292,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -18550,7 +18479,6 @@
 /area/security/prison)
 "aLy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -18821,7 +18749,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
@@ -19201,7 +19128,6 @@
 /area/hallway/primary/fore)
 "aMQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -19830,7 +19756,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/sortjunction{
@@ -20924,7 +20849,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -20933,7 +20857,6 @@
 /area/maintenance/port/fore)
 "aPK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/closed/wall,
@@ -21607,7 +21530,6 @@
 /area/prison/execution_room)
 "aQT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -22012,7 +21934,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -22027,7 +21948,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -22161,7 +22081,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -22177,7 +22096,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -22273,7 +22191,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
@@ -22519,7 +22436,6 @@
 "aSx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -22561,7 +22477,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkred/side,
@@ -22740,7 +22655,6 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -22884,7 +22798,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -23138,7 +23051,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -23461,7 +23373,6 @@
 "aUu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
@@ -23494,7 +23405,6 @@
 "aUx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -23735,7 +23645,6 @@
 	},
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -23800,7 +23709,6 @@
 /area/hallway/primary/fore)
 "aUV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown/corner{
@@ -23817,7 +23725,6 @@
 /area/quartermaster/office)
 "aUX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -23882,7 +23789,6 @@
 /area/quartermaster/storage)
 "aVe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown,
@@ -24123,7 +24029,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner,
@@ -24186,7 +24091,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/corner,
@@ -24615,7 +24519,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -24756,7 +24659,6 @@
 /area/hydroponics)
 "aWE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/closed/wall,
@@ -24773,7 +24675,6 @@
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
@@ -25595,7 +25496,6 @@
 /area/hydroponics)
 "aYm" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/loadingarea{
@@ -25639,7 +25539,6 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -26260,7 +26159,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -26330,7 +26228,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/greenblue/side{
@@ -26459,7 +26356,6 @@
 	},
 /obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
@@ -26623,7 +26519,6 @@
 /area/quartermaster/miningoffice)
 "bak" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -27018,7 +26913,6 @@
 /area/hydroponics)
 "bbb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -27286,7 +27180,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -27385,7 +27278,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -27754,7 +27646,6 @@
 /area/hallway/primary/fore)
 "bcF" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -27904,7 +27795,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28194,7 +28084,6 @@
 /area/engine/atmos)
 "bdz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -28437,7 +28326,6 @@
 /area/crew_quarters/kitchen)
 "bea" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -28494,7 +28382,6 @@
 /area/hallway/primary/fore)
 "beg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -28502,7 +28389,6 @@
 /area/hallway/primary/fore)
 "beh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -28562,7 +28448,6 @@
 /area/quartermaster/miningoffice)
 "beo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -28574,7 +28459,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -28820,7 +28704,6 @@
 /area/security/brig)
 "beM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
@@ -29164,7 +29047,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -29278,7 +29160,6 @@
 /area/hydroponics)
 "bfC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -29880,7 +29761,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
@@ -30105,7 +29985,6 @@
 "bha" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -30115,7 +29994,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -30254,7 +30132,6 @@
 /area/hydroponics)
 "bhs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -31484,7 +31361,6 @@
 	pixel_x = -23
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
@@ -31609,7 +31485,6 @@
 /area/security/main)
 "bkc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
@@ -31885,7 +31760,6 @@
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -31955,7 +31829,6 @@
 /area/hallway/primary/central)
 "bkO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -31986,7 +31859,6 @@
 /area/hallway/primary/central)
 "bkR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -32057,7 +31929,6 @@
 /area/hallway/primary/central)
 "bkY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown/corner{
@@ -32137,7 +32008,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -33013,7 +32883,6 @@
 /area/hydroponics)
 "bmI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -33497,7 +33366,6 @@
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /obj/item/device/taperecorder,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
@@ -33596,7 +33464,6 @@
 	pixel_x = 4.5
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -33785,7 +33652,6 @@
 /area/engine/atmos)
 "bnY" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -33834,7 +33700,6 @@
 "bod" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34288,7 +34153,6 @@
 /area/hallway/primary/central)
 "boW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -34485,7 +34349,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -34955,7 +34818,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -35357,7 +35219,6 @@
 /area/security/transfer)
 "bqM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
@@ -35495,7 +35356,6 @@
 /area/crew_quarters/heads/hos)
 "brb" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/machinery/light/small{
@@ -35508,7 +35368,6 @@
 /area/engine/atmos)
 "brc" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/meter,
@@ -35543,7 +35402,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
@@ -35737,7 +35595,6 @@
 /area/hallway/primary/port)
 "brw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -36230,7 +36087,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/meter{
@@ -36608,7 +36464,6 @@
 /area/bridge)
 "bsZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -36949,7 +36804,6 @@
 "btI" = (
 /obj/machinery/status_display,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -36962,7 +36816,6 @@
 /area/engine/break_room)
 "btK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -37270,7 +37123,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -38030,7 +37882,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -38141,7 +37992,6 @@
 /area/hallway/primary/central)
 "bvL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -38688,7 +38538,6 @@
 /area/ai_monitored/turret_protected/ai)
 "bwD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -39109,7 +38958,6 @@
 /area/maintenance/port/fore)
 "bxq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/closed/wall,
@@ -39161,7 +39009,6 @@
 /area/storage/primary)
 "bxu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -39747,7 +39594,6 @@
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -39819,7 +39665,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -39923,7 +39768,6 @@
 /area/engine/break_room)
 "byQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -39998,7 +39842,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
@@ -40429,7 +40272,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -40471,7 +40313,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -40544,7 +40385,6 @@
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkblue/side,
@@ -40602,7 +40442,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -40714,7 +40553,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -41202,7 +41040,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41284,7 +41121,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -41322,7 +41158,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -41530,7 +41365,6 @@
 /area/hallway/primary/central)
 "bBb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -41636,7 +41470,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -41720,7 +41553,6 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -41761,7 +41593,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -41809,7 +41640,6 @@
 /area/hallway/primary/central)
 "bBz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -42044,7 +41874,6 @@
 /area/engine/gravity_generator)
 "bBU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -42089,7 +41918,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -42442,7 +42270,6 @@
 /area/hallway/primary/central)
 "bCH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -42571,7 +42398,6 @@
 /area/bridge)
 "bCW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -42591,7 +42417,6 @@
 "bCY" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -43320,7 +43145,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -43439,7 +43263,6 @@
 /area/storage/primary)
 "bEv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -43997,7 +43820,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/circuit/green,
@@ -44246,7 +44068,6 @@
 "bFS" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -44299,7 +44120,6 @@
 /area/engine/break_room)
 "bFY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/closet/firecloset,
@@ -44746,7 +44566,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -44866,7 +44685,6 @@
 /area/security/brig)
 "bHf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -45142,7 +44960,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -45286,7 +45103,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -45376,7 +45192,6 @@
 /area/security/checkpoint/engineering)
 "bHV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -45549,7 +45364,6 @@
 /area/bridge/meeting_room/council)
 "bIl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -45697,7 +45511,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -46143,7 +45956,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -46633,7 +46445,6 @@
 /obj/structure/table/wood,
 /obj/item/weapon/storage/fancy/donut_box,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -46696,7 +46507,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -46911,7 +46721,6 @@
 /area/security/detectives_office)
 "bKT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -47002,7 +46811,6 @@
 /area/security/brig)
 "bLd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -47425,7 +47233,6 @@
 /area/hallway/primary/port)
 "bLW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -47696,7 +47503,6 @@
 /area/crew_quarters/heads/captain)
 "bME" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -49074,7 +48880,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/meter,
@@ -49159,7 +48964,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -49220,7 +49024,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault,
@@ -49679,7 +49482,6 @@
 /area/hallway/primary/port)
 "bPX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -49859,7 +49661,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -49905,7 +49706,6 @@
 /area/hallway/primary/central)
 "bQm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -50203,7 +50003,6 @@
 /area/hallway/primary/starboard)
 "bQQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -50434,7 +50233,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -50669,7 +50467,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -50937,7 +50734,6 @@
 /area/crew_quarters/heads/chief)
 "bSa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -51874,7 +51670,6 @@
 	},
 /obj/machinery/door/window/southright,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -52060,7 +51855,6 @@
 /area/aisat)
 "bTO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/door/window/southleft,
@@ -52383,7 +52177,6 @@
 /area/hallway/primary/port)
 "bUs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -52451,7 +52244,6 @@
 /area/hallway/primary/port)
 "bUy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -52530,7 +52322,6 @@
 /area/crew_quarters/heads/hop)
 "bUH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -52636,7 +52427,6 @@
 /area/crew_quarters/heads/captain/private)
 "bUU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -52675,7 +52465,6 @@
 /area/hallway/primary/starboard)
 "bUX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -52735,7 +52524,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -52795,7 +52583,6 @@
 /area/hallway/primary/starboard)
 "bVh" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -54075,7 +53862,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -54141,7 +53927,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -54305,7 +54090,6 @@
 /area/library)
 "bXX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -54532,7 +54316,6 @@
 /area/crew_quarters/heads/captain/private)
 "bYr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -54733,7 +54516,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -55020,7 +54802,6 @@
 /area/engine/engineering)
 "bZt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow,
@@ -55199,7 +54980,6 @@
 /area/library)
 "bZI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -55256,7 +55036,6 @@
 /area/library)
 "bZO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/blue/corner,
@@ -55391,7 +55170,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/circuit/green{
@@ -55450,7 +55228,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/circuit/green{
@@ -55772,7 +55549,6 @@
 	},
 /obj/effect/landmark/start/lawyer,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -55862,7 +55638,6 @@
 /area/security/brig)
 "caJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -56342,7 +56117,6 @@
 /area/library)
 "cbz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -56414,7 +56188,6 @@
 	},
 /obj/item/weapon/storage/lockbox/loyalty,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -56589,7 +56362,6 @@
 /area/security/courtroom)
 "cbZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -56700,7 +56472,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -56723,7 +56494,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -56739,7 +56509,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -56840,7 +56609,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56870,7 +56638,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -57794,7 +57561,6 @@
 /area/security/brig)
 "ceg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -57914,7 +57680,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/circuit/green,
@@ -57943,7 +57708,6 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "cev" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/circuit/green,
@@ -58168,7 +57932,6 @@
 /area/hallway/primary/central)
 "ceW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -58342,7 +58105,6 @@
 /area/teleporter)
 "cfq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -58366,7 +58128,6 @@
 /area/security/courtroom)
 "cft" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -58815,7 +58576,6 @@
 /area/library)
 "cgn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -58842,7 +58602,6 @@
 /area/library)
 "cgr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -58934,7 +58693,6 @@
 /area/teleporter)
 "cgB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -59000,7 +58758,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -59043,7 +58800,6 @@
 "cgM" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/side{
@@ -59176,7 +58932,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -59507,7 +59262,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -59569,7 +59323,6 @@
 /area/library)
 "chP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -59816,7 +59569,6 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -60038,7 +59790,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/junction{
@@ -60369,7 +60120,6 @@
 "cjg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -60410,7 +60160,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -60529,7 +60278,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -60861,7 +60609,6 @@
 "ckg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -61316,7 +61063,6 @@
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -61370,7 +61116,6 @@
 /area/teleporter)
 "cli" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -61399,7 +61144,6 @@
 /area/teleporter)
 "cll" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -61724,7 +61468,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -61852,7 +61595,6 @@
 /area/library)
 "cmn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -62323,7 +62065,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow,
@@ -62461,7 +62202,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -62494,7 +62234,6 @@
 /area/library)
 "cnG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -62557,7 +62296,6 @@
 /area/hallway/secondary/command)
 "cnN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -62659,7 +62397,6 @@
 /area/hallway/secondary/command)
 "cnW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/item/device/radio/intercom{
@@ -62753,7 +62490,6 @@
 /area/hallway/primary/central)
 "cof" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -62876,7 +62612,6 @@
 /area/crew_quarters/locker)
 "cor" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -62893,7 +62628,6 @@
 /area/crew_quarters/locker)
 "cot" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -62925,7 +62659,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -63363,7 +63096,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -63484,7 +63216,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -63650,7 +63381,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -63707,7 +63437,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -63773,7 +63502,6 @@
 /area/crew_quarters/locker)
 "cpT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -63806,7 +63534,6 @@
 "cpW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
@@ -64188,7 +63915,6 @@
 /area/hallway/secondary/command)
 "cqL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -64247,7 +63973,6 @@
 /area/hallway/secondary/command)
 "cqR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -64316,7 +64041,6 @@
 /area/hallway/primary/central)
 "cra" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -64435,7 +64159,6 @@
 /area/hallway/primary/central)
 "crj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -64522,7 +64245,6 @@
 /obj/structure/table,
 /obj/item/device/camera,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -65488,7 +65210,6 @@
 "ctq" = (
 /obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -65852,7 +65573,6 @@
 /area/gateway)
 "cub" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -66011,7 +65731,6 @@
 /area/crew_quarters/locker)
 "cun" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -66031,7 +65750,6 @@
 "cup" = (
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -66139,7 +65857,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -66163,7 +65880,6 @@
 /area/crew_quarters/fitness/recreation)
 "cuE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/stacklifter,
@@ -66584,7 +66300,6 @@
 /area/gateway)
 "cvw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -66766,7 +66481,6 @@
 /area/crew_quarters/dorms)
 "cvQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -66788,7 +66502,6 @@
 /area/crew_quarters/fitness/recreation)
 "cvS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -66916,7 +66629,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -67408,7 +67120,6 @@
 "cxe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -67426,7 +67137,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -67608,7 +67318,6 @@
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/pink,
@@ -68114,7 +67823,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -68204,7 +67912,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -68644,7 +68351,6 @@
 /area/engine/engineering)
 "czo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -68807,7 +68513,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -68978,7 +68683,6 @@
 "czT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -68994,7 +68698,6 @@
 /area/ai_monitored/storage/eva)
 "czV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -69122,7 +68825,6 @@
 /area/gateway)
 "cAi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -69287,7 +68989,6 @@
 	pixel_x = -12
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -69463,7 +69164,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -69660,7 +69360,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -70329,7 +70028,6 @@
 /area/engine/engineering)
 "cCw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -71021,7 +70719,6 @@
 /area/hallway/primary/central)
 "cDN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -71091,7 +70788,6 @@
 /area/hallway/primary/central)
 "cDU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel{
@@ -71158,7 +70854,6 @@
 /area/hallway/primary/central)
 "cEb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -71433,7 +71128,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -71681,7 +71375,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -71767,7 +71460,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -71788,7 +71480,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -72055,7 +71746,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -72123,7 +71813,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -72262,7 +71951,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -72484,7 +72172,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -72560,7 +72247,6 @@
 /area/crew_quarters/dorms)
 "cGd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -72674,7 +72360,6 @@
 /area/maintenance/port)
 "cGt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -72712,7 +72397,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72763,7 +72447,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -72780,7 +72463,6 @@
 "cGE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -72840,7 +72522,6 @@
 /area/maintenance/port)
 "cGM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -72928,7 +72609,6 @@
 /area/hallway/primary/central)
 "cGU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -73373,7 +73053,6 @@
 /area/maintenance/department/electrical)
 "cHL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -73792,7 +73471,6 @@
 /area/maintenance/starboard/aft)
 "cIL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -73849,7 +73527,6 @@
 /area/crew_quarters/fitness/recreation)
 "cIT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -73967,7 +73644,6 @@
 "cJf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -74094,7 +73770,6 @@
 "cJv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -74193,7 +73868,6 @@
 	},
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -74639,7 +74313,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -74662,7 +74335,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -75045,7 +74717,6 @@
 /area/science/xenobiology)
 "cLo" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -75347,7 +75018,6 @@
 /area/maintenance/starboard/aft)
 "cMd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -75478,7 +75148,6 @@
 /area/maintenance/department/electrical)
 "cMt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/meter,
@@ -75965,7 +75634,6 @@
 /area/science/research)
 "cNn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -76064,7 +75732,6 @@
 /area/medical/medbay/central)
 "cNz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -76709,7 +76376,6 @@
 /area/science/xenobiology)
 "cOO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -77078,7 +76744,6 @@
 /area/medical/medbay/central)
 "cPw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -77238,7 +76903,6 @@
 /area/medical/medbay/central)
 "cPJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -77426,7 +77090,6 @@
 /area/maintenance/port)
 "cQd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
@@ -77448,7 +77111,6 @@
 "cQf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -77601,7 +77263,6 @@
 /area/science/xenobiology)
 "cQv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -77680,7 +77341,6 @@
 /area/science/xenobiology)
 "cQD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -77772,7 +77432,6 @@
 /area/science/research)
 "cQL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -78848,7 +78507,6 @@
 /area/medical/medbay/central)
 "cSR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -78924,7 +78582,6 @@
 "cSZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -79127,7 +78784,6 @@
 /area/science/xenobiology)
 "cTz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -79640,7 +79296,6 @@
 /area/medical/medbay/central)
 "cUx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/redblue,
@@ -79665,7 +79320,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -79776,7 +79430,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -80335,7 +79988,6 @@
 /area/hallway/primary/aft)
 "cVK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -80563,7 +80215,6 @@
 /area/medical/medbay/central)
 "cWk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/redblue,
@@ -80840,7 +80491,6 @@
 /area/maintenance/port)
 "cWN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -81169,7 +80819,6 @@
 "cXn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -81392,7 +81041,6 @@
 /area/medical/medbay/central)
 "cXM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -81700,7 +81348,6 @@
 "cYw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -81778,7 +81425,6 @@
 /area/maintenance/port)
 "cYC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -81899,7 +81545,6 @@
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -82052,7 +81697,6 @@
 /area/medical/medbay/central)
 "cZk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -82316,7 +81960,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -82740,7 +82383,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -83069,7 +82711,6 @@
 /area/science/research)
 "dbm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -83464,7 +83105,6 @@
 /area/medical/medbay/central)
 "dca" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/side{
@@ -83498,7 +83138,6 @@
 /area/medical/medbay/central)
 "dce" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -83520,7 +83159,6 @@
 "dci" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -84768,7 +84406,6 @@
 /area/medical/chemistry)
 "deR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
@@ -84985,7 +84622,6 @@
 /area/medical/medbay/central)
 "dfn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
@@ -85015,7 +84651,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -85097,7 +84732,6 @@
 "dfz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -85939,7 +85573,6 @@
 /area/science/research)
 "dhr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85955,7 +85588,6 @@
 /area/science/research)
 "dht" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -86364,7 +85996,6 @@
 /area/medical/medbay/central)
 "dia" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
@@ -86405,7 +86036,6 @@
 /area/medical/medbay/central)
 "dif" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -86578,7 +86208,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -86734,7 +86363,6 @@
 "diW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -86880,7 +86508,6 @@
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -87089,7 +86716,6 @@
 /area/crew_quarters/heads/hor)
 "djv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -87129,7 +86755,6 @@
 /area/crew_quarters/heads/hor)
 "djy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -87147,7 +86772,6 @@
 /area/science/research)
 "djA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -87241,7 +86865,6 @@
 /area/hallway/primary/aft)
 "djL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -87290,7 +86913,6 @@
 /area/hallway/primary/aft)
 "djQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -87327,7 +86949,6 @@
 /area/medical/genetics/cloning)
 "djV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -87736,7 +87357,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -87755,7 +87375,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -87774,7 +87393,6 @@
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/ointment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -87922,7 +87540,6 @@
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -88128,7 +87745,6 @@
 /area/science/research)
 "dlp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -88194,7 +87810,6 @@
 /area/science/robotics/mechbay)
 "dlx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -88232,7 +87847,6 @@
 "dlC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -88281,7 +87895,6 @@
 /area/medical/genetics/cloning)
 "dlJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -88312,7 +87925,6 @@
 /area/medical/genetics/cloning)
 "dlM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -88920,7 +88532,6 @@
 /area/medical/medbay/central)
 "dnj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
@@ -88958,7 +88569,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -89002,7 +88612,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue,
@@ -89036,7 +88645,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -89530,7 +89138,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -89903,7 +89510,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -89946,7 +89552,6 @@
 /area/crew_quarters/heads/hor)
 "dpq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -90334,7 +89939,6 @@
 	},
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/blue,
@@ -90395,7 +89999,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -90484,7 +90087,6 @@
 "dql" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -90678,7 +90280,6 @@
 /area/science/mixing)
 "dqI" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	icon_state = "heater";
 	dir = 8;
 	on = 1
 	},
@@ -90891,7 +90492,6 @@
 /area/science/robotics/mechbay)
 "drb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -90966,7 +90566,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -91076,7 +90675,6 @@
 /area/medical/genetics)
 "drq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -91114,7 +90712,6 @@
 /area/medical/genetics)
 "drt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -91281,7 +90878,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -91308,7 +90904,6 @@
 /area/medical/medbay/central)
 "drF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
@@ -91435,7 +91030,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -91566,7 +91160,6 @@
 /area/science/mixing)
 "dso" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -91801,7 +91394,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -91895,7 +91487,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -91984,7 +91575,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -92043,7 +91633,6 @@
 /area/crew_quarters/heads/cmo)
 "dsZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cmo,
@@ -92391,7 +91980,6 @@
 /area/science/mixing)
 "dtN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -92626,7 +92214,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -93425,7 +93012,6 @@
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cmo,
@@ -93663,7 +93249,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -93893,7 +93478,6 @@
 /area/crew_quarters/heads/hor)
 "dwB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -93940,7 +93524,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -94047,7 +93630,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cmo,
@@ -94079,7 +93661,6 @@
 /area/crew_quarters/heads/cmo)
 "dwV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -94218,7 +93799,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -94461,7 +94041,6 @@
 /area/crew_quarters/heads/hor)
 "dxG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -94542,7 +94121,6 @@
 /area/science/robotics/lab)
 "dxM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -94906,7 +94484,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -95103,7 +94680,6 @@
 /area/hallway/primary/aft)
 "dyW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -95675,7 +95251,6 @@
 /area/science/research)
 "dAc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -95747,7 +95322,6 @@
 /area/science/robotics/lab)
 "dAk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
@@ -95792,7 +95366,6 @@
 "dAn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating{
@@ -95941,7 +95514,6 @@
 	},
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -95976,7 +95548,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -96329,7 +95900,6 @@
 /area/science/storage)
 "dBp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -96551,7 +96121,6 @@
 "dBK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -96602,7 +96171,6 @@
 /area/medical/morgue)
 "dBQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -97174,7 +96742,6 @@
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -97395,7 +96962,6 @@
 /area/medical/medbay/central)
 "dDo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitegreen/corner,
@@ -97421,7 +96987,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -97482,7 +97047,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -97688,7 +97252,6 @@
 /area/science/mixing)
 "dDS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -97724,7 +97287,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -98169,7 +97731,6 @@
 /area/maintenance/port/aft)
 "dEO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -98464,7 +98025,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitegreen/side{
@@ -98869,7 +98429,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -98905,7 +98464,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -99669,7 +99227,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -99795,7 +99352,6 @@
 /area/maintenance/aft)
 "dHR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitegreen/side{
@@ -100018,7 +99574,6 @@
 /area/science/research)
 "dIp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -100050,7 +99605,6 @@
 "dIs" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -100859,7 +100413,6 @@
 "dKd" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -101450,7 +101003,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/green,
@@ -101635,7 +101187,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -101712,7 +101263,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -101785,7 +101335,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -102202,7 +101751,6 @@
 /area/library/abandoned)
 "dMy" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -102230,7 +101778,6 @@
 "dMC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -102268,7 +101815,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -102363,7 +101909,6 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -102561,7 +102106,6 @@
 /area/medical/virology)
 "dNj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -103419,7 +102963,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -103492,7 +103035,6 @@
 /area/chapel/main)
 "dPt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -103834,14 +103376,12 @@
 	},
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "dQe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -104027,7 +103567,6 @@
 /area/medical/virology)
 "dQB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -104494,7 +104033,6 @@
 /area/medical/virology)
 "dRv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitegreen/corner,
@@ -104677,7 +104215,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -104857,7 +104394,6 @@
 /area/medical/virology)
 "dSj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -105087,7 +104623,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dSM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -105097,7 +104632,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dSN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -105619,7 +105153,6 @@
 	pixel_x = -12
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -105665,7 +105198,6 @@
 	},
 /obj/item/weapon/paper_bin,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -105716,7 +105248,6 @@
 /area/maintenance/port/aft)
 "dTO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -106109,7 +105640,6 @@
 /area/chapel/main)
 "dUC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel{
@@ -106830,7 +106360,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -106843,7 +106372,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dVY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -107090,7 +106618,6 @@
 /area/chapel/main)
 "dWz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -107127,7 +106654,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dWD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -108859,7 +108385,6 @@
 /area/chapel/office)
 "dZM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -109666,7 +109191,6 @@
 /area/maintenance/port/fore)
 "ece" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -109803,7 +109327,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -109972,7 +109495,6 @@
 "ede" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/hydrofloor,
@@ -110025,7 +109547,6 @@
 /area/shuttle/auxillary_base)
 "edl" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced,
@@ -110098,7 +109619,6 @@
 /area/shuttle/transport)
 "ees" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -110108,7 +109628,6 @@
 /area/shuttle/transport)
 "eet" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -110683,7 +110202,6 @@
 /area/security/detectives_office)
 "efI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -112163,7 +111681,6 @@
 /area/hallway/secondary/command)
 "eiQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -112310,7 +111827,6 @@
 /area/crew_quarters/dorms)
 "eji" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -114375,7 +113891,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -540,6 +540,8 @@
 /area/maintenance/solars/starboard/fore)
 "abm" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/light/small{
@@ -553,6 +555,7 @@
 "abn" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -598,6 +601,8 @@
 "abs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -610,6 +615,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -622,6 +629,8 @@
 	req_access_txt = "10"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -637,9 +646,13 @@
 /area/maintenance/solars/starboard/fore)
 "abv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -843,6 +856,8 @@
 /area/construction/mining/aux_base)
 "abJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1074,6 +1089,8 @@
 /area/construction/mining/aux_base)
 "ace" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1149,6 +1166,8 @@
 "acp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1229,6 +1248,8 @@
 "acx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -1367,6 +1388,8 @@
 	dir = 9
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -1492,6 +1515,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -1550,6 +1575,8 @@
 "adk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -1618,6 +1645,7 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -1634,11 +1662,15 @@
 "adv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/lightsout,
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -1817,6 +1849,8 @@
 /area/construction/mining/aux_base)
 "adR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -1945,6 +1979,8 @@
 /area/construction/mining/aux_base)
 "aef" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -2119,6 +2155,8 @@
 /area/construction/mining/aux_base)
 "aeB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2312,6 +2350,8 @@
 "aeS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2364,6 +2404,8 @@
 /area/maintenance/starboard/fore)
 "aeZ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2373,6 +2415,8 @@
 "afa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -2380,6 +2424,8 @@
 "afb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -2479,6 +2525,8 @@
 /area/maintenance/starboard/fore)
 "afq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -2573,6 +2621,8 @@
 "afE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2584,6 +2634,8 @@
 "afF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -2749,6 +2801,8 @@
 "afU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -2916,6 +2970,7 @@
 /area/hallway/secondary/entry)
 "agq" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -2937,6 +2992,8 @@
 /area/hallway/secondary/entry)
 "agr" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -3027,6 +3084,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -3158,6 +3217,8 @@
 /area/hallway/secondary/entry)
 "agS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3273,6 +3334,8 @@
 "ahg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -3417,6 +3480,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3712,6 +3777,8 @@
 "aip" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3727,6 +3794,8 @@
 /area/security/checkpoint/customs)
 "air" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/photocopier,
@@ -3767,6 +3836,8 @@
 /area/security/checkpoint/checkpoint2)
 "aiw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/table/reinforced,
@@ -3795,6 +3866,8 @@
 /area/maintenance/starboard/fore)
 "aiz" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3806,6 +3879,8 @@
 /area/maintenance/starboard/fore)
 "aiA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3818,6 +3893,8 @@
 "aiB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3827,6 +3904,8 @@
 /area/maintenance/starboard/fore)
 "aiC" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3836,6 +3915,8 @@
 /area/maintenance/starboard/fore)
 "aiD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -4130,6 +4211,8 @@
 /area/security/vacantoffice)
 "ajl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4137,6 +4220,7 @@
 /area/maintenance/port/fore)
 "ajm" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -4154,9 +4238,13 @@
 /area/security/checkpoint/customs)
 "ajn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/holopad,
@@ -4273,9 +4361,13 @@
 /area/security/checkpoint/checkpoint2)
 "ajz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/holopad,
@@ -4287,6 +4379,7 @@
 /area/security/checkpoint/checkpoint2)
 "ajA" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -4309,6 +4402,8 @@
 /area/maintenance/starboard/fore)
 "ajC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -4484,6 +4579,7 @@
 /area/crew_quarters/electronic_marketing_den)
 "akb" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -4493,6 +4589,8 @@
 /area/maintenance/port/fore)
 "akc" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -4553,6 +4651,8 @@
 "akm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4569,6 +4669,8 @@
 /area/security/checkpoint/customs)
 "ako" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -4664,6 +4766,8 @@
 /area/security/checkpoint/checkpoint2)
 "akB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -4696,6 +4800,7 @@
 /area/maintenance/starboard/fore)
 "akF" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -4841,6 +4946,8 @@
 /area/crew_quarters/electronic_marketing_den)
 "alc" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -4877,6 +4984,8 @@
 /area/security/vacantoffice)
 "alh" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -4887,6 +4996,8 @@
 /area/security/vacantoffice)
 "ali" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4901,6 +5012,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4915,6 +5028,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4930,9 +5045,13 @@
 /area/security/vacantoffice)
 "all" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -4960,9 +5079,13 @@
 /area/security/checkpoint/customs)
 "aln" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/chair/office/dark{
@@ -4972,6 +5095,8 @@
 /area/security/checkpoint/customs)
 "alo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -4985,9 +5110,13 @@
 "alp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor/southright{
@@ -5021,9 +5150,13 @@
 "alu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -5033,6 +5166,8 @@
 /area/security/checkpoint/checkpoint2)
 "alv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -5050,9 +5185,13 @@
 /area/security/checkpoint/checkpoint2)
 "alw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/chair/office/dark{
@@ -5081,6 +5220,8 @@
 "alz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -5116,6 +5257,8 @@
 /area/maintenance/starboard/fore)
 "alE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/chair/stool/bar,
@@ -5299,6 +5442,8 @@
 /area/maintenance/port/fore)
 "amd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5320,6 +5465,8 @@
 /area/security/vacantoffice)
 "amh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -5340,6 +5487,8 @@
 "amj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5356,6 +5505,8 @@
 /area/security/checkpoint/customs)
 "aml" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -5436,6 +5587,8 @@
 /area/security/checkpoint/checkpoint2)
 "amw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -5456,6 +5609,8 @@
 "amy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -5480,6 +5635,8 @@
 /area/maintenance/starboard/fore)
 "amD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
@@ -5797,6 +5954,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/wood,
@@ -5806,6 +5965,8 @@
 /obj/item/weapon/folder/red,
 /obj/item/weapon/pen,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
@@ -5816,6 +5977,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5823,12 +5986,16 @@
 /area/crew_quarters/electronic_marketing_den)
 "anj" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
 "ank" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/wood{
@@ -5845,6 +6012,8 @@
 /area/crew_quarters/electronic_marketing_den)
 "anm" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5942,6 +6111,8 @@
 /area/security/checkpoint/customs)
 "any" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6008,6 +6179,8 @@
 /area/security/checkpoint/checkpoint2)
 "anG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6032,9 +6205,13 @@
 /area/maintenance/starboard/fore)
 "anJ" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6045,6 +6222,8 @@
 /area/maintenance/starboard/fore)
 "anK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6057,6 +6236,8 @@
 /area/maintenance/starboard/fore)
 "anL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6066,6 +6247,8 @@
 /area/maintenance/starboard/fore)
 "anM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6077,6 +6260,8 @@
 /area/maintenance/starboard/fore)
 "anN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -6089,6 +6274,8 @@
 /area/maintenance/starboard/fore)
 "anO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6266,6 +6453,8 @@
 /area/crew_quarters/electronic_marketing_den)
 "aoe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood{
@@ -6327,6 +6516,8 @@
 "aom" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6334,6 +6525,8 @@
 /area/maintenance/port/fore)
 "aon" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6352,6 +6545,8 @@
 /area/security/checkpoint/customs)
 "aoo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6370,6 +6565,8 @@
 /area/security/checkpoint/checkpoint2)
 "aop" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -6586,6 +6783,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
@@ -6644,12 +6843,16 @@
 /area/maintenance/port/fore)
 "aoU" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoV" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -6657,6 +6860,8 @@
 "aoW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -6665,6 +6870,8 @@
 /area/maintenance/port/fore)
 "aoX" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -6674,6 +6881,8 @@
 "aoY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -6681,9 +6890,13 @@
 "aoZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6694,9 +6907,13 @@
 /area/maintenance/port/fore)
 "apa" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -6704,9 +6921,13 @@
 "apb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6790,6 +7011,8 @@
 "apl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -7131,6 +7354,8 @@
 "apV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -7138,6 +7363,8 @@
 "apW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -7146,21 +7373,29 @@
 /area/maintenance/port/fore)
 "apX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "apY" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side,
 /area/maintenance/port/fore)
 "apZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7171,6 +7406,8 @@
 "aqa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -7181,6 +7418,8 @@
 /area/maintenance/port/fore)
 "aqb" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7191,6 +7430,8 @@
 "aqc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7201,6 +7442,8 @@
 "aqd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7213,6 +7456,8 @@
 /area/maintenance/port/fore)
 "aqe" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7223,9 +7468,13 @@
 /area/maintenance/port/fore)
 "aqf" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -7233,6 +7482,8 @@
 /area/maintenance/port/fore)
 "aqg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7242,9 +7493,13 @@
 /area/maintenance/port/fore)
 "aqh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -7358,6 +7613,8 @@
 /area/maintenance/port/fore)
 "aqt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -7368,6 +7625,8 @@
 /area/maintenance/port/fore)
 "aqu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7385,6 +7644,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7403,6 +7664,8 @@
 /area/maintenance/port/fore)
 "aqw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7418,6 +7681,8 @@
 /area/hallway/secondary/entry)
 "aqx" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -7516,9 +7781,13 @@
 /area/maintenance/starboard/fore)
 "aqG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -7527,6 +7796,8 @@
 "aqH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7537,9 +7808,13 @@
 "aqI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -7551,6 +7826,8 @@
 "aqJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -7901,6 +8178,8 @@
 /area/engine/atmospherics_engine)
 "arp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -7964,6 +8243,8 @@
 /area/hallway/secondary/entry)
 "arx" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8033,6 +8314,8 @@
 "arF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -8062,6 +8345,8 @@
 /area/maintenance/starboard/fore)
 "arI" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8075,6 +8360,8 @@
 "arJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8090,6 +8377,8 @@
 "arK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8103,6 +8392,8 @@
 /area/maintenance/starboard/fore)
 "arL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8117,6 +8408,8 @@
 /area/maintenance/starboard/fore)
 "arM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8130,6 +8423,8 @@
 "arN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8142,6 +8437,8 @@
 /area/maintenance/starboard/fore)
 "arO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -8158,6 +8455,8 @@
 "arP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8173,9 +8472,13 @@
 "arQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8188,6 +8491,8 @@
 /area/maintenance/starboard/fore)
 "arR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8213,6 +8518,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8232,6 +8539,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -8245,6 +8554,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -8257,6 +8568,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8273,6 +8586,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown,
@@ -8285,6 +8600,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -8300,6 +8617,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -8317,6 +8636,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -8570,6 +8890,8 @@
 /area/maintenance/port/fore)
 "asE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -8622,6 +8944,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/clothing/under/maid,
@@ -8714,6 +9037,8 @@
 	name = "Auxiliary Restroom"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8798,6 +9123,8 @@
 "asX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -8844,6 +9171,8 @@
 "atd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -8983,6 +9312,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -9076,6 +9407,8 @@
 /area/maintenance/port/fore)
 "atG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -9121,6 +9454,8 @@
 "atJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9220,6 +9555,8 @@
 /area/crew_quarters/toilet/auxiliary)
 "atU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -9271,6 +9608,8 @@
 "aub" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9607,6 +9946,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -9668,6 +10009,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -9703,6 +10046,8 @@
 "avc" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -9752,6 +10097,7 @@
 /area/crew_quarters/toilet/auxiliary)
 "avl" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -9768,6 +10114,8 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -9787,6 +10135,8 @@
 /area/hallway/primary/fore)
 "avo" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -9796,6 +10146,8 @@
 /area/hallway/primary/fore)
 "avp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -9813,6 +10165,8 @@
 "avq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -9836,6 +10190,8 @@
 "avr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9857,6 +10213,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -10018,6 +10376,7 @@
 /area/quartermaster/storage)
 "avK" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -10205,6 +10564,8 @@
 "awf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -10217,6 +10578,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
@@ -10275,6 +10638,8 @@
 /area/hallway/primary/fore)
 "awn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -10296,6 +10661,8 @@
 "awp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10320,6 +10687,8 @@
 "aws" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10462,6 +10831,7 @@
 "awK" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -10621,6 +10991,8 @@
 "axb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10640,6 +11012,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -10733,6 +11107,8 @@
 /area/crew_quarters/toilet/auxiliary)
 "axl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -10746,6 +11122,8 @@
 /area/hallway/primary/fore)
 "axn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10761,6 +11139,8 @@
 /area/quartermaster/warehouse)
 "axp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -10878,6 +11258,7 @@
 "axD" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -10886,9 +11267,11 @@
 /area/quartermaster/storage)
 "axE" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -10898,9 +11281,11 @@
 /area/quartermaster/storage)
 "axF" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -11151,6 +11536,8 @@
 /area/hydroponics/garden/abandoned)
 "ayj" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11162,6 +11549,8 @@
 "ayk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11175,6 +11564,8 @@
 "ayl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11187,6 +11578,8 @@
 /area/maintenance/port/fore)
 "aym" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11200,6 +11593,8 @@
 "ayn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11212,6 +11607,8 @@
 /area/maintenance/port/fore)
 "ayo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11224,9 +11621,13 @@
 /area/maintenance/port/fore)
 "ayp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11241,6 +11642,8 @@
 "ayq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -11255,9 +11658,13 @@
 "ayr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11369,6 +11776,8 @@
 "ayB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11385,6 +11794,8 @@
 /area/quartermaster/warehouse)
 "ayE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11520,6 +11931,8 @@
 	id = "cargounload"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor{
@@ -11668,6 +12081,8 @@
 /area/hydroponics/garden/abandoned)
 "azp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11704,9 +12119,13 @@
 /area/maintenance/port/fore)
 "azu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -11717,6 +12136,8 @@
 "azv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11727,6 +12148,8 @@
 /area/maintenance/port/fore)
 "azw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -11735,6 +12158,8 @@
 "azx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11748,6 +12173,8 @@
 "azy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11764,6 +12191,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11779,6 +12208,8 @@
 /area/maintenance/port/fore)
 "azA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11791,12 +12222,16 @@
 /area/hallway/primary/fore)
 "azB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -11814,6 +12249,8 @@
 "azD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11829,6 +12266,8 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -11852,6 +12291,8 @@
 "azF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11870,9 +12311,13 @@
 "azG" = (
 /obj/effect/decal/cleanable/oil,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -11888,9 +12333,13 @@
 "azH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11904,6 +12353,8 @@
 "azI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11917,6 +12368,8 @@
 "azJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -11924,6 +12377,8 @@
 /area/quartermaster/warehouse)
 "azK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -11933,6 +12388,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/maintenance{
@@ -11945,6 +12402,7 @@
 "azM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -12035,6 +12493,8 @@
 /area/quartermaster/storage)
 "azW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -12183,6 +12643,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12235,6 +12697,8 @@
 /area/hallway/secondary/service)
 "aAw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -12286,6 +12750,8 @@
 "aAC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12639,6 +13105,8 @@
 /area/engine/atmospherics_engine)
 "aBh" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -12648,6 +13116,8 @@
 /area/engine/atmospherics_engine)
 "aBi" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -12662,6 +13132,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
@@ -12671,12 +13142,16 @@
 "aBk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics/garden/abandoned)
 "aBl" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/hydrofloor,
@@ -12684,6 +13159,8 @@
 "aBm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12691,6 +13168,8 @@
 /area/hydroponics/garden/abandoned)
 "aBn" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/hydrofloor,
@@ -12698,6 +13177,8 @@
 "aBo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12758,6 +13239,8 @@
 /area/hallway/secondary/service)
 "aBv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -12791,6 +13274,7 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -12914,6 +13398,7 @@
 "aBJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -12928,9 +13413,13 @@
 /area/hallway/primary/fore)
 "aBK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -12957,6 +13446,8 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mining{
@@ -13128,6 +13619,8 @@
 /area/engine/atmospherics_engine)
 "aCk" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13142,6 +13635,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13152,6 +13647,8 @@
 "aCm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -13231,6 +13728,8 @@
 "aCv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -13255,6 +13754,8 @@
 /area/hydroponics/garden/abandoned)
 "aCy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13317,6 +13818,8 @@
 /area/hallway/secondary/service)
 "aCG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13367,6 +13870,8 @@
 /area/crew_quarters/bar)
 "aCJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13513,6 +14018,8 @@
 /area/quartermaster/sorting)
 "aCX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13743,6 +14250,8 @@
 	id = "cargoload"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -13778,6 +14287,8 @@
 /area/security/prison)
 "aDo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/item/weapon/cultivator,
@@ -13792,9 +14303,13 @@
 	pixel_y = 28
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -13810,6 +14325,8 @@
 /area/security/prison)
 "aDq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/weapon/reagent_containers/glass/bucket,
@@ -13849,6 +14366,7 @@
 "aDt" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/light/small{
@@ -13861,6 +14379,8 @@
 /area/maintenance/solars/port/fore)
 "aDu" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/sign/directions/engineering{
@@ -13939,6 +14459,8 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/vault,
@@ -13951,6 +14473,7 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/vault,
@@ -13968,6 +14491,8 @@
 "aDE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -13979,6 +14504,8 @@
 /area/engine/atmospherics_engine)
 "aDF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13993,6 +14520,8 @@
 	},
 /obj/machinery/light,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14011,6 +14540,8 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14021,6 +14552,8 @@
 /area/engine/atmospherics_engine)
 "aDI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14034,9 +14567,13 @@
 /area/engine/atmospherics_engine)
 "aDJ" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14046,6 +14583,8 @@
 /area/engine/atmospherics_engine)
 "aDK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -14057,6 +14596,8 @@
 /area/engine/atmospherics_engine)
 "aDL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -14070,6 +14611,8 @@
 /area/engine/atmospherics_engine)
 "aDM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/sign/electricshock{
@@ -14082,9 +14625,13 @@
 /area/engine/atmospherics_engine)
 "aDN" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14140,6 +14687,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
@@ -14154,6 +14703,8 @@
 "aDT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14177,9 +14728,13 @@
 /area/hallway/secondary/service)
 "aDV" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -14196,6 +14751,8 @@
 "aDW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -14218,6 +14775,8 @@
 /area/crew_quarters/bar)
 "aDX" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14232,6 +14791,8 @@
 /area/crew_quarters/bar)
 "aDY" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14319,6 +14880,8 @@
 /area/quartermaster/sorting)
 "aEm" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14342,6 +14905,7 @@
 /area/quartermaster/sorting)
 "aEp" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -14452,9 +15016,11 @@
 /area/quartermaster/storage)
 "aEA" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -14463,6 +15029,7 @@
 /area/quartermaster/storage)
 "aEB" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
@@ -14494,6 +15061,7 @@
 /area/shuttle/supply)
 "aEG" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -14503,6 +15071,8 @@
 "aEH" = (
 /obj/machinery/seed_extractor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -14510,6 +15080,8 @@
 /area/security/prison)
 "aEI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -14520,18 +15092,26 @@
 /area/security/prison)
 "aEJ" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/security/prison)
 "aEK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -14543,6 +15123,8 @@
 "aEL" = (
 /obj/machinery/biogenerator,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -14550,6 +15132,7 @@
 /area/security/prison)
 "aEM" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -14620,9 +15203,13 @@
 /area/maintenance/solars/port/fore)
 "aER" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -14645,6 +15232,8 @@
 	req_one_access_txt = "13; 24"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -14727,6 +15316,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -14760,6 +15351,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/oil,
@@ -14786,6 +15378,8 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14814,6 +15408,8 @@
 "aFf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -14838,12 +15434,17 @@
 "aFh" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14853,6 +15454,8 @@
 "aFi" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
@@ -14877,6 +15480,7 @@
 "aFj" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -14893,6 +15497,8 @@
 /area/maintenance/port/fore)
 "aFl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14903,6 +15509,8 @@
 "aFm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14914,9 +15522,13 @@
 /area/maintenance/port/fore)
 "aFn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -14977,6 +15589,8 @@
 /area/hallway/secondary/service)
 "aFu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -15066,6 +15680,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -15097,6 +15713,8 @@
 /area/quartermaster/sorting)
 "aFJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15122,10 +15740,12 @@
 /area/quartermaster/sorting)
 "aFM" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -15135,6 +15755,8 @@
 "aFN" = (
 /obj/machinery/computer/security,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red,
@@ -15144,15 +15766,21 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/security/checkpoint/supply)
 "aFP" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -15164,6 +15792,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -15239,6 +15868,8 @@
 /area/security/prison)
 "aGb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -15348,6 +15979,8 @@
 	name = "Mix to Turbine"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -15355,6 +15988,8 @@
 /area/maintenance/disposal/incinerator)
 "aGq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -15365,12 +16000,18 @@
 /area/maintenance/disposal/incinerator)
 "aGr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15381,6 +16022,8 @@
 /area/maintenance/disposal/incinerator)
 "aGs" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -15399,6 +16042,8 @@
 	req_access_txt = "24"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15415,6 +16060,8 @@
 "aGu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15427,6 +16074,8 @@
 /area/engine/atmospherics_engine)
 "aGv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -15461,6 +16110,8 @@
 /area/engine/atmospherics_engine)
 "aGz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -15490,6 +16141,8 @@
 /area/engine/atmospherics_engine)
 "aGC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -15603,6 +16256,8 @@
 /area/hallway/secondary/service)
 "aGQ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -15743,6 +16398,8 @@
 /area/quartermaster/sorting)
 "aHg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -15783,6 +16440,8 @@
 /area/security/checkpoint/supply)
 "aHk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -15878,6 +16537,7 @@
 /area/security/prison)
 "aHv" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -15890,12 +16550,18 @@
 /area/security/prison)
 "aHw" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass{
@@ -15905,6 +16571,7 @@
 /area/security/prison)
 "aHx" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -16079,6 +16746,8 @@
 /area/engine/atmospherics_engine)
 "aHQ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -16120,6 +16789,8 @@
 /area/engine/atmospherics_engine)
 "aHT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/computer/monitor{
@@ -16133,6 +16804,7 @@
 /area/engine/atmospherics_engine)
 "aHU" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes{
@@ -16140,6 +16812,7 @@
 	},
 /obj/machinery/light/small,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/circuit/green,
@@ -16152,6 +16825,7 @@
 	charge = 5e+006
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/item/device/radio/intercom{
@@ -16165,6 +16839,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "aHX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16231,6 +16907,8 @@
 /area/hallway/secondary/service)
 "aIe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/airalarm{
@@ -16282,6 +16960,8 @@
 /area/quartermaster/sorting)
 "aIl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16306,6 +16986,7 @@
 /area/quartermaster/sorting)
 "aIn" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/door_timer{
@@ -16326,9 +17007,13 @@
 /area/security/checkpoint/supply)
 "aIo" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -16428,6 +17113,8 @@
 /obj/structure/table,
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -16435,6 +17122,8 @@
 "aIz" = (
 /obj/structure/easel,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -16450,6 +17139,8 @@
 /area/security/prison)
 "aIA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16460,6 +17151,8 @@
 /area/security/prison)
 "aIB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16470,12 +17163,18 @@
 /area/security/prison)
 "aIC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -16484,6 +17183,8 @@
 /area/security/prison)
 "aID" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16494,6 +17195,8 @@
 /area/security/prison)
 "aIE" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16504,6 +17207,8 @@
 "aIF" = (
 /obj/structure/table,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/paper_bin,
@@ -16518,6 +17223,8 @@
 /obj/structure/table,
 /obj/item/weapon/clipboard,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/toy/figure/syndie,
@@ -16530,9 +17237,13 @@
 /area/security/prison)
 "aIH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
@@ -16542,6 +17253,8 @@
 /area/security/prison)
 "aII" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/punching_bag,
@@ -16724,6 +17437,8 @@
 "aJc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16798,6 +17513,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "aJn" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -16832,6 +17548,8 @@
 /area/hallway/secondary/service)
 "aJs" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16855,6 +17573,7 @@
 /area/crew_quarters/bar/atrium)
 "aJv" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/light{
@@ -16950,6 +17669,7 @@
 /area/quartermaster/sorting)
 "aJI" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -16958,12 +17678,18 @@
 /area/security/checkpoint/supply)
 "aJJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -16975,6 +17701,7 @@
 /area/security/checkpoint/supply)
 "aJK" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -17069,6 +17796,8 @@
 "aJV" = (
 /obj/structure/table,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/paper,
@@ -17398,6 +18127,8 @@
 /area/engine/atmos)
 "aKA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -17460,6 +18191,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -17530,6 +18263,8 @@
 /area/crew_quarters/bar/atrium)
 "aKU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -17584,6 +18319,7 @@
 "aLc" = (
 /obj/structure/table,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/item/stack/wrapping_paper{
@@ -17607,6 +18343,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/cargo_technician,
@@ -17614,9 +18352,13 @@
 /area/quartermaster/sorting)
 "aLe" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -17627,6 +18369,8 @@
 /area/quartermaster/sorting)
 "aLf" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -17651,6 +18395,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -17659,6 +18404,8 @@
 /area/security/checkpoint/supply)
 "aLi" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/closet/secure_closet/brig{
@@ -17671,9 +18418,13 @@
 /area/security/checkpoint/supply)
 "aLj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -17726,6 +18477,8 @@
 /area/quartermaster/storage)
 "aLr" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -17733,6 +18486,8 @@
 /area/quartermaster/storage)
 "aLs" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
@@ -17746,6 +18501,8 @@
 /area/quartermaster/storage)
 "aLt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -17756,6 +18513,8 @@
 "aLu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -17763,6 +18522,8 @@
 /area/quartermaster/storage)
 "aLv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -17773,6 +18534,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -17821,6 +18583,8 @@
 "aLC" = (
 /obj/structure/table,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/toy/cards/deck,
@@ -18131,6 +18895,8 @@
 /area/engine/atmos)
 "aMg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -18231,6 +18997,8 @@
 "aMs" = (
 /obj/structure/chair/stool/bar,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18239,6 +19007,8 @@
 "aMu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -18260,6 +19030,8 @@
 /area/crew_quarters/theatre)
 "aMx" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -18293,6 +19065,8 @@
 /area/hallway/secondary/service)
 "aMB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -18316,6 +19090,8 @@
 /area/crew_quarters/bar/atrium)
 "aMD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -18414,6 +19190,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18464,6 +19242,8 @@
 /area/quartermaster/sorting)
 "aMT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -18499,15 +19279,21 @@
 /area/security/checkpoint/supply)
 "aMX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/supply)
 "aMY" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/chair{
@@ -18520,10 +19306,12 @@
 /area/security/checkpoint/supply)
 "aMZ" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -18553,6 +19341,8 @@
 /area/quartermaster/storage)
 "aNd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -18579,6 +19369,7 @@
 /area/quartermaster/qm)
 "aNh" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -18587,9 +19378,11 @@
 /area/quartermaster/qm)
 "aNi" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -18598,6 +19391,7 @@
 /area/quartermaster/qm)
 "aNj" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -18606,23 +19400,28 @@
 /area/quartermaster/qm)
 "aNk" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "aNl" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -18922,6 +19721,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -19010,6 +19811,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "aOb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -19017,9 +19820,13 @@
 /area/crew_quarters/abandoned_gambling_den)
 "aOc" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -19037,6 +19844,8 @@
 /area/maintenance/port/fore)
 "aOd" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19060,6 +19869,8 @@
 /area/crew_quarters/theatre)
 "aOe" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19080,6 +19891,8 @@
 "aOf" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19093,9 +19906,13 @@
 /area/crew_quarters/theatre)
 "aOg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -19109,6 +19926,8 @@
 /area/crew_quarters/theatre)
 "aOh" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19124,6 +19943,8 @@
 /area/crew_quarters/theatre)
 "aOi" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19139,6 +19960,8 @@
 "aOj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -19158,6 +19981,8 @@
 /area/crew_quarters/theatre)
 "aOk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19169,12 +19994,18 @@
 /area/hallway/secondary/service)
 "aOl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -19184,6 +20015,8 @@
 "aOm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -19203,6 +20036,8 @@
 /area/crew_quarters/bar/atrium)
 "aOn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -19218,6 +20053,8 @@
 /area/crew_quarters/bar/atrium)
 "aOo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19231,6 +20068,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19261,6 +20100,8 @@
 /area/crew_quarters/bar/atrium)
 "aOt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -19269,6 +20110,8 @@
 "aOu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_mining{
@@ -19306,6 +20149,7 @@
 /area/security/checkpoint/supply)
 "aOy" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -19318,12 +20162,18 @@
 "aOz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -19344,6 +20194,7 @@
 /area/security/checkpoint/supply)
 "aOA" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -19409,6 +20260,8 @@
 /area/quartermaster/storage)
 "aOH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/brown{
@@ -19442,6 +20295,7 @@
 /area/quartermaster/qm)
 "aOL" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -19497,6 +20351,8 @@
 "aOP" = (
 /obj/structure/bed,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/bedsheet/qm,
@@ -19574,6 +20430,8 @@
 	name = "Cell 2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -19638,6 +20496,8 @@
 /area/prison/execution_room)
 "aOZ" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/table/reinforced,
@@ -19681,9 +20541,13 @@
 /area/prison/execution_room)
 "aPa" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -19696,6 +20560,8 @@
 /area/prison/execution_room)
 "aPb" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
@@ -19708,10 +20574,14 @@
 /area/prison/execution_room)
 "aPc" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/closet/secure_closet/injection,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19850,6 +20720,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -19859,6 +20731,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -19870,6 +20744,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -19990,6 +20866,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "aPG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20003,6 +20881,8 @@
 "aPH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20016,6 +20896,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/barricade/wooden,
@@ -20032,9 +20914,13 @@
 /area/crew_quarters/abandoned_gambling_den)
 "aPJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -20109,6 +20995,8 @@
 /area/hallway/secondary/service)
 "aPR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/storage/pod{
@@ -20206,6 +21094,8 @@
 /area/crew_quarters/bar/atrium)
 "aQc" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -20241,6 +21131,8 @@
 /area/quartermaster/office)
 "aQf" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -20299,6 +21191,7 @@
 	pixel_y = 28
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/brown{
@@ -20314,6 +21207,8 @@
 /area/quartermaster/office)
 "aQl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/brown{
@@ -20337,6 +21232,8 @@
 /area/quartermaster/office)
 "aQn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
@@ -20403,6 +21300,8 @@
 /area/quartermaster/storage)
 "aQu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20463,6 +21362,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -20511,6 +21412,8 @@
 /area/quartermaster/qm)
 "aQF" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -20603,6 +21506,8 @@
 /area/security/prison)
 "aQN" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -20688,6 +21593,8 @@
 /area/prison/execution_room)
 "aQS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/chair/office/dark{
@@ -20719,6 +21626,8 @@
 /area/prison/execution_room)
 "aQV" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkred/side{
@@ -20863,6 +21772,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -20979,6 +21890,8 @@
 /area/crew_quarters/theatre)
 "aRA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
@@ -21040,6 +21953,8 @@
 /area/crew_quarters/bar/atrium)
 "aRJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sortjunction{
@@ -21092,6 +22007,8 @@
 "aRO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -21105,6 +22022,8 @@
 /area/quartermaster/office)
 "aRP" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -21118,6 +22037,8 @@
 /area/quartermaster/office)
 "aRQ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21130,6 +22051,8 @@
 /area/quartermaster/office)
 "aRR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21139,6 +22062,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -21146,6 +22071,8 @@
 "aRS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21155,12 +22082,16 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/office)
 "aRT" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21177,6 +22108,8 @@
 "aRU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mining{
@@ -21200,9 +22133,13 @@
 /area/quartermaster/storage)
 "aRV" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21219,6 +22156,8 @@
 /area/quartermaster/storage)
 "aRW" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -21233,6 +22172,8 @@
 /area/quartermaster/storage)
 "aRX" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -21247,6 +22188,8 @@
 "aRY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21261,6 +22204,8 @@
 "aRZ" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/quartermaster,
@@ -21273,6 +22218,8 @@
 /area/quartermaster/storage)
 "aSa" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21285,6 +22232,8 @@
 /area/quartermaster/storage)
 "aSb" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21298,6 +22247,8 @@
 /area/quartermaster/storage)
 "aSc" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21307,12 +22258,18 @@
 /area/quartermaster/storage)
 "aSd" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -21326,6 +22283,8 @@
 /area/quartermaster/storage)
 "aSe" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -21343,6 +22302,8 @@
 /area/quartermaster/qm)
 "aSf" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -21352,12 +22313,16 @@
 /area/quartermaster/qm)
 "aSg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/qm)
 "aSh" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /mob/living/simple_animal/sloth/citrus,
@@ -21366,9 +22331,13 @@
 "aSi" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -21377,6 +22346,8 @@
 "aSj" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/folder/yellow,
@@ -21388,9 +22359,13 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/quartermaster,
@@ -21398,6 +22373,8 @@
 /area/quartermaster/qm)
 "aSl" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -21407,6 +22384,8 @@
 /area/quartermaster/qm)
 "aSm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -21424,12 +22403,18 @@
 /area/quartermaster/qm)
 "aSn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/quartermaster,
@@ -21510,6 +22495,8 @@
 /area/security/prison)
 "aSv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -21569,6 +22556,8 @@
 /area/prison/execution_room)
 "aSA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -21798,6 +22787,8 @@
 "aTa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -21860,6 +22851,7 @@
 /area/engine/atmos)
 "aTh" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -21879,9 +22871,13 @@
 /area/hallway/secondary/service)
 "aTi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/newscaster{
@@ -21949,6 +22945,8 @@
 /area/crew_quarters/bar/atrium)
 "aTr" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sortjunction{
@@ -22102,6 +23100,8 @@
 /area/quartermaster/storage)
 "aTI" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22162,6 +23162,8 @@
 /area/quartermaster/qm)
 "aTO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -22211,6 +23213,8 @@
 /area/quartermaster/qm)
 "aTS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -22232,6 +23236,7 @@
 /area/quartermaster/qm)
 "aTU" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -22240,6 +23245,7 @@
 /area/quartermaster/qm)
 "aTV" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -22258,6 +23264,7 @@
 /area/security/prison)
 "aTX" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -22300,6 +23307,8 @@
 /area/security/prison)
 "aUd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -22492,6 +23501,8 @@
 /area/engine/atmos)
 "aUy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -22551,6 +23562,8 @@
 /area/maintenance/port/fore)
 "aUE" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -22566,9 +23579,13 @@
 /area/maintenance/port/fore)
 "aUF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -22582,6 +23599,8 @@
 /area/maintenance/port/fore)
 "aUG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -22591,6 +23610,8 @@
 /area/maintenance/port/fore)
 "aUH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sortjunction{
@@ -22606,12 +23627,18 @@
 /area/maintenance/port/fore)
 "aUI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -22625,6 +23652,8 @@
 "aUJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22636,6 +23665,8 @@
 "aUK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22646,6 +23677,8 @@
 "aUL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22656,6 +23689,8 @@
 /area/maintenance/port/fore)
 "aUM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -22675,6 +23710,8 @@
 /area/hallway/secondary/service)
 "aUN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22687,9 +23724,13 @@
 /area/hallway/secondary/service)
 "aUO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/lightsout,
@@ -22750,6 +23791,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22900,6 +23943,8 @@
 /area/quartermaster/storage)
 "aVl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/storage/pod{
@@ -22970,6 +24015,8 @@
 /area/quartermaster/qm)
 "aVs" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/brown,
@@ -22988,9 +24035,11 @@
 /area/quartermaster/qm)
 "aVu" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -23001,6 +24050,7 @@
 "aVv" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -23010,6 +24060,8 @@
 "aVw" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/corner,
@@ -23034,9 +24086,13 @@
 /area/security/prison)
 "aVz" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23044,18 +24100,26 @@
 /area/security/prison)
 "aVA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/corner,
 /area/security/prison)
 "aVB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -23066,6 +24130,8 @@
 /area/security/prison)
 "aVC" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23075,6 +24141,8 @@
 /area/security/prison)
 "aVD" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -23094,6 +24162,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23106,6 +24176,8 @@
 /area/security/prison)
 "aVF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/security/telescreen{
@@ -23121,9 +24193,13 @@
 /area/security/prison)
 "aVG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -23136,9 +24212,13 @@
 /area/security/prison)
 "aVH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23160,9 +24240,13 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23175,6 +24259,8 @@
 /area/security/prison)
 "aVJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23189,9 +24275,13 @@
 /area/security/prison)
 "aVK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -23199,6 +24289,8 @@
 /area/security/prison)
 "aVL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23221,6 +24313,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23232,9 +24326,13 @@
 /area/security/prison)
 "aVN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23244,9 +24342,13 @@
 /area/security/prison)
 "aVO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -23263,12 +24365,18 @@
 /area/security/prison)
 "aVP" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/button/door{
@@ -23286,6 +24394,8 @@
 /area/security/prison)
 "aVQ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23298,9 +24408,13 @@
 "aVR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -23317,6 +24431,8 @@
 /area/security/prison)
 "aVS" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -23326,6 +24442,8 @@
 /area/security/prison)
 "aVT" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -23338,6 +24456,8 @@
 /area/security/prison)
 "aVU" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -23346,6 +24466,8 @@
 /area/security/prison)
 "aVV" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -23519,6 +24641,8 @@
 /area/engine/atmos)
 "aWr" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -23596,6 +24720,8 @@
 /area/maintenance/port/fore)
 "aWA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -23611,6 +24737,8 @@
 /area/hydroponics)
 "aWD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -23656,6 +24784,8 @@
 /area/hallway/secondary/service)
 "aWH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23874,6 +25004,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mining{
@@ -23895,6 +25027,7 @@
 /area/quartermaster/qm)
 "aXj" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
@@ -23904,6 +25037,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white,
@@ -23911,18 +25045,26 @@
 /area/quartermaster/qm)
 "aXk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXl" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -23939,6 +25081,8 @@
 	},
 /obj/machinery/light,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -23950,9 +25094,13 @@
 /area/security/prison)
 "aXn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -23962,6 +25110,8 @@
 /area/security/prison)
 "aXo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24020,6 +25170,8 @@
 /area/security/prison)
 "aXu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/lightsout,
@@ -24059,6 +25211,8 @@
 /area/security/prison)
 "aXx" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -24123,6 +25277,8 @@
 /area/security/prison)
 "aXD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -24299,6 +25455,8 @@
 "aXV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -24375,6 +25533,8 @@
 /area/hydroponics)
 "aYf" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24445,6 +25605,8 @@
 /area/hallway/secondary/service)
 "aYn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24564,6 +25726,8 @@
 /area/hallway/primary/fore)
 "aYz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -24694,6 +25858,8 @@
 /area/quartermaster/miningoffice)
 "aYL" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24773,6 +25939,8 @@
 	req_access_txt = "1"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24820,6 +25988,8 @@
 "aZa" = (
 /obj/structure/rack,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/restraints/handcuffs,
@@ -24857,6 +26027,8 @@
 	name = "Prisoner Locker"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault,
@@ -24881,6 +26053,8 @@
 /area/security/prison)
 "aZg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/table,
@@ -25059,6 +26233,8 @@
 /area/maintenance/port/fore)
 "aZB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -25079,6 +26255,8 @@
 /area/hydroponics)
 "aZE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -25095,6 +26273,8 @@
 /area/hydroponics)
 "aZF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25112,6 +26292,8 @@
 /area/hydroponics)
 "aZG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25124,9 +26306,13 @@
 /area/hydroponics)
 "aZH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25139,6 +26325,8 @@
 /area/hydroponics)
 "aZI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -25152,6 +26340,8 @@
 /area/hydroponics)
 "aZJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25163,6 +26353,8 @@
 "aZK" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -25182,6 +26374,8 @@
 /area/hallway/secondary/service)
 "aZL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25189,6 +26383,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/bot,
@@ -25196,9 +26392,13 @@
 /area/hallway/secondary/service)
 "aZM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -25208,6 +26408,8 @@
 "aZN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -25227,6 +26429,8 @@
 /area/crew_quarters/kitchen)
 "aZO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25238,6 +26442,8 @@
 /area/crew_quarters/kitchen)
 "aZP" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25247,6 +26453,8 @@
 /area/crew_quarters/kitchen)
 "aZQ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/cook,
@@ -25258,6 +26466,8 @@
 /area/crew_quarters/kitchen)
 "aZR" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -25440,6 +26650,8 @@
 /area/quartermaster/miningoffice)
 "bao" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -25483,6 +26695,7 @@
 /area/quartermaster/miningoffice)
 "bau" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white,
@@ -25492,9 +26705,11 @@
 /area/quartermaster/miningoffice)
 "bav" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -25503,9 +26718,11 @@
 /area/quartermaster/miningoffice)
 "baw" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -25515,6 +26732,7 @@
 /area/quartermaster/miningoffice)
 "bax" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
@@ -25565,6 +26783,8 @@
 	name = "Prison Blast door"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -25763,6 +26983,8 @@
 "baX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -25855,6 +27077,8 @@
 "bbi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -26052,9 +27276,13 @@
 /area/quartermaster/miningoffice)
 "bbK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -26141,9 +27369,13 @@
 /area/shuttle/mining)
 "bbX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/sign/securearea{
@@ -26163,6 +27395,8 @@
 /area/security/prison)
 "bbY" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26182,6 +27416,8 @@
 	req_access_txt = "63"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26196,6 +27432,8 @@
 "bca" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -26203,6 +27441,8 @@
 	req_access_txt = "63"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -26219,6 +27459,8 @@
 /area/security/prison)
 "bcb" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -26233,6 +27475,8 @@
 "bcc" = (
 /obj/structure/closet/l3closet/security,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -26430,6 +27674,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -26496,6 +27742,8 @@
 /area/crew_quarters/kitchen)
 "bcE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
@@ -26651,6 +27899,8 @@
 "bcV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -26781,6 +28031,8 @@
 	req_access_txt = "1"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -26794,6 +28046,7 @@
 /area/security/brig)
 "bdk" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -26825,6 +28078,7 @@
 /area/security/main)
 "bdn" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -26864,6 +28118,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/caution{
@@ -26927,6 +28182,8 @@
 /area/engine/atmos)
 "bdy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -27086,6 +28343,8 @@
 "bdQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/green/side{
@@ -27190,6 +28449,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -27308,6 +28569,8 @@
 /area/quartermaster/miningoffice)
 "bep" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -27318,6 +28581,8 @@
 /area/quartermaster/miningoffice)
 "beq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27330,6 +28595,8 @@
 /area/quartermaster/miningoffice)
 "ber" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -27350,6 +28617,8 @@
 /area/quartermaster/miningoffice)
 "bes" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27362,6 +28631,8 @@
 /area/quartermaster/miningoffice)
 "bet" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -27369,9 +28640,13 @@
 /area/quartermaster/miningoffice)
 "beu" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27462,6 +28737,7 @@
 /area/shuttle/mining)
 "beF" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -27504,6 +28780,7 @@
 /area/security/brig)
 "beJ" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -27515,6 +28792,8 @@
 /area/security/brig)
 "beK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27528,6 +28807,8 @@
 "beL" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27554,9 +28835,13 @@
 /area/security/main)
 "beO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -27565,6 +28850,8 @@
 /area/security/main)
 "beP" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
@@ -27576,6 +28863,8 @@
 /area/security/main)
 "beQ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -27595,6 +28884,8 @@
 /area/security/main)
 "beR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/newscaster/security_unit{
@@ -27606,6 +28897,8 @@
 /area/security/main)
 "beS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
@@ -27651,6 +28944,7 @@
 /area/crew_quarters/heads/hos)
 "beX" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -27663,12 +28957,15 @@
 /area/crew_quarters/heads/hos)
 "beY" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -27681,6 +28978,7 @@
 /area/crew_quarters/heads/hos)
 "beZ" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -27789,6 +29087,8 @@
 /area/engine/atmos)
 "bfk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27798,6 +29098,8 @@
 /area/engine/atmos)
 "bfl" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -27805,6 +29107,8 @@
 /area/engine/atmos)
 "bfm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27818,6 +29122,8 @@
 /area/engine/atmos)
 "bfn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27832,9 +29138,13 @@
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27849,6 +29159,8 @@
 /area/engine/atmos)
 "bfp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -27859,6 +29171,8 @@
 /area/engine/atmos)
 "bfq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -28031,6 +29345,8 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -28174,6 +29490,8 @@
 /area/hallway/primary/fore)
 "bfX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sortjunction{
@@ -28231,6 +29549,8 @@
 "bge" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -28261,9 +29581,13 @@
 /area/quartermaster/miningoffice)
 "bgi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -28271,12 +29595,16 @@
 /area/quartermaster/miningoffice)
 "bgj" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/purple/side,
 /area/quartermaster/miningoffice)
 "bgk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/requests_console{
@@ -28294,6 +29622,8 @@
 /area/quartermaster/miningoffice)
 "bgl" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown,
@@ -28304,6 +29634,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/purple/side,
@@ -28312,6 +29644,8 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/folder/yellow,
@@ -28323,6 +29657,7 @@
 /area/quartermaster/miningoffice)
 "bgo" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
@@ -28330,6 +29665,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -28338,6 +29674,7 @@
 /area/quartermaster/miningoffice)
 "bgp" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
@@ -28456,10 +29793,12 @@
 /area/shuttle/mining)
 "bgt" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -28469,6 +29808,8 @@
 "bgu" = (
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/clothing/gloves/color/latex,
@@ -28488,12 +29829,16 @@
 /area/security/brig)
 "bgv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bgw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -28504,9 +29849,13 @@
 /area/security/brig)
 "bgx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/glass_medical{
@@ -28521,9 +29870,13 @@
 /area/security/brig)
 "bgy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -28536,9 +29889,13 @@
 /area/security/brig)
 "bgz" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -28561,6 +29918,8 @@
 /area/security/main)
 "bgC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/corner,
@@ -28624,6 +29983,8 @@
 "bgL" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/device/taperecorder{
@@ -28765,6 +30126,8 @@
 "bhc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -28842,6 +30205,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -28941,6 +30306,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -29203,6 +30570,8 @@
 "bib" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/loadingarea{
@@ -29213,6 +30582,7 @@
 "bic" = (
 /obj/structure/table,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/item/weapon/storage/firstaid/regular,
@@ -29259,6 +30629,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29360,15 +30732,21 @@
 /area/security/brig)
 "bis" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/security/brig)
 "bit" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -29379,6 +30757,7 @@
 "biu" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -29396,6 +30775,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -29431,6 +30812,7 @@
 /area/security/main)
 "biC" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -29466,6 +30848,8 @@
 /area/crew_quarters/heads/hos)
 "biF" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -29714,6 +31098,8 @@
 /area/engine/atmos)
 "bjf" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -29807,6 +31193,8 @@
 "bjp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -29875,6 +31263,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -29934,6 +31324,8 @@
 	name = "Fore Primary Hallway"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -30015,6 +31407,8 @@
 "bjL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30032,6 +31426,7 @@
 /area/maintenance/starboard/fore)
 "bjM" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -30040,9 +31435,11 @@
 /area/quartermaster/miningoffice)
 "bjN" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -30051,9 +31448,11 @@
 /area/security/transfer)
 "bjO" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -30062,9 +31461,11 @@
 /area/security/transfer)
 "bjP" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -30092,6 +31493,8 @@
 /area/security/brig)
 "bjS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30121,6 +31524,7 @@
 	pixel_x = -26
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30136,9 +31540,13 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -30219,6 +31627,7 @@
 "bke" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -30243,6 +31652,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30274,6 +31685,7 @@
 /area/crew_quarters/heads/hos)
 "bkk" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -30296,6 +31708,7 @@
 /area/crew_quarters/heads/hos)
 "bkn" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -30450,6 +31863,8 @@
 "bkD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -30530,6 +31945,8 @@
 	dir = 9
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -30603,6 +32020,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -30691,6 +32110,8 @@
 /area/hallway/primary/central)
 "bld" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30702,6 +32123,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -30710,6 +32132,8 @@
 /area/hallway/primary/central)
 "ble" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -30727,6 +32151,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30743,6 +32169,8 @@
 "blg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30757,6 +32185,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30787,6 +32217,8 @@
 "blm" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -30839,6 +32271,7 @@
 /area/security/transfer)
 "blr" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -30847,6 +32280,8 @@
 /area/security/transfer)
 "bls" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/lightsout,
@@ -30860,6 +32295,8 @@
 /area/security/main)
 "blu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -30897,6 +32334,8 @@
 /area/security/main)
 "blz" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30910,6 +32349,8 @@
 /area/security/main)
 "blA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -30921,12 +32362,18 @@
 /area/security/main)
 "blB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/command{
@@ -30943,9 +32390,13 @@
 /area/crew_quarters/heads/hos)
 "blC" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -30956,12 +32407,18 @@
 "blD" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -30972,6 +32429,8 @@
 "blE" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/folder/red,
@@ -30986,6 +32445,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/head_of_security,
@@ -30996,6 +32457,8 @@
 /area/crew_quarters/heads/hos)
 "blG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31006,6 +32469,8 @@
 /area/crew_quarters/heads/hos)
 "blH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -31014,12 +32479,18 @@
 /area/crew_quarters/heads/hos)
 "blI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/command{
@@ -31033,12 +32504,16 @@
 /area/crew_quarters/heads/hos)
 "blJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "blK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/head_of_security,
@@ -31046,6 +32521,8 @@
 /area/crew_quarters/heads/hos)
 "blL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/crew,
@@ -31053,10 +32530,12 @@
 /area/crew_quarters/heads/hos)
 "blM" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -31265,6 +32744,8 @@
 /area/engine/atmos)
 "bmj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -31341,6 +32822,8 @@
 /area/hallway/primary/port)
 "bmt" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31356,6 +32839,8 @@
 /area/hallway/primary/port)
 "bmu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31372,6 +32857,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31388,6 +32875,8 @@
 "bmw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31400,6 +32889,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31409,6 +32900,8 @@
 /area/maintenance/port/fore)
 "bmy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31421,6 +32914,8 @@
 "bmz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31433,6 +32928,8 @@
 /area/maintenance/port/fore)
 "bmA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31444,6 +32941,8 @@
 "bmB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
@@ -31455,9 +32954,13 @@
 "bmC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31519,6 +33022,8 @@
 /area/hallway/primary/central)
 "bmJ" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -31526,6 +33031,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31540,6 +33047,8 @@
 /area/hallway/primary/central)
 "bmK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31551,6 +33060,8 @@
 /area/hallway/primary/central)
 "bmL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31560,6 +33071,8 @@
 /area/hallway/primary/central)
 "bmM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -31574,6 +33087,8 @@
 "bmN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31589,6 +33104,8 @@
 /area/hallway/primary/central)
 "bmO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31600,6 +33117,8 @@
 /area/hallway/primary/central)
 "bmP" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31611,6 +33130,8 @@
 /area/hallway/primary/central)
 "bmQ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31622,6 +33143,8 @@
 /area/hallway/primary/central)
 "bmR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31639,6 +33162,8 @@
 "bmS" = (
 /obj/effect/landmark/lightsout,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -31646,9 +33171,13 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -31665,6 +33194,8 @@
 /area/hallway/primary/central)
 "bmT" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -31673,6 +33204,8 @@
 /area/hallway/primary/central)
 "bmU" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -31681,6 +33214,8 @@
 /area/hallway/primary/central)
 "bmV" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -31691,6 +33226,8 @@
 /area/hallway/primary/central)
 "bmW" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -31699,12 +33236,16 @@
 /area/hallway/primary/central)
 "bmX" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
 "bmY" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31713,6 +33254,8 @@
 "bmZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -31725,6 +33268,8 @@
 /area/hallway/primary/central)
 "bna" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -31735,6 +33280,8 @@
 /area/hallway/primary/central)
 "bnb" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -31744,9 +33291,13 @@
 /area/hallway/primary/central)
 "bnc" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -31787,6 +33338,8 @@
 /area/security/transfer)
 "bnh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -31823,6 +33376,7 @@
 "bnm" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -31843,6 +33397,8 @@
 /area/security/brig)
 "bno" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -31866,6 +33422,8 @@
 "bnq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -31897,6 +33455,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -31955,6 +33515,8 @@
 /area/security/main)
 "bny" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -31978,6 +33540,7 @@
 "bnA" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -31993,6 +33556,8 @@
 /area/crew_quarters/heads/hos)
 "bnB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -32005,6 +33570,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -32037,6 +33604,8 @@
 "bnE" = (
 /obj/machinery/computer/security,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -32314,6 +33883,8 @@
 /area/engine/atmos)
 "boi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -32337,6 +33908,7 @@
 /area/engine/atmos)
 "bok" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -32409,6 +33981,8 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -32440,6 +34014,8 @@
 /area/storage/tech)
 "box" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32499,6 +34075,8 @@
 /area/hydroponics)
 "boD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -32722,6 +34300,8 @@
 /area/hallway/primary/central)
 "boX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32763,6 +34343,7 @@
 /area/shuttle/labor)
 "bpd" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -32771,9 +34352,12 @@
 /area/security/transfer)
 "bpe" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/grille,
@@ -32783,9 +34367,12 @@
 /area/security/transfer)
 "bpf" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/grille,
@@ -32794,6 +34381,8 @@
 /area/security/transfer)
 "bpg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -32803,9 +34392,13 @@
 /area/security/transfer)
 "bph" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32848,6 +34441,8 @@
 /area/security/transfer)
 "bpl" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32860,12 +34455,18 @@
 "bpm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -32879,6 +34480,8 @@
 /area/security/transfer)
 "bpn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -32894,12 +34497,18 @@
 /area/security/brig)
 "bpo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -32914,6 +34523,8 @@
 /area/security/brig)
 "bpp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32927,12 +34538,18 @@
 "bpq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -32948,6 +34565,8 @@
 /area/security/main)
 "bpr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -32960,9 +34579,13 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -32976,6 +34599,8 @@
 "bpt" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/folder/red,
@@ -32988,6 +34613,8 @@
 "bpu" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/paper_bin,
@@ -32999,6 +34626,8 @@
 /area/security/main)
 "bpv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -33010,6 +34639,8 @@
 /area/security/main)
 "bpw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -33020,6 +34651,8 @@
 /area/security/main)
 "bpx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -33029,9 +34662,13 @@
 /area/security/main)
 "bpy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -33066,12 +34703,16 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bpC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -33289,9 +34930,13 @@
 /area/engine/atmos)
 "bqb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -33305,6 +34950,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -33323,12 +34970,18 @@
 	req_access_txt = "24"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -33346,6 +34999,8 @@
 "bqe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33356,6 +35011,8 @@
 /area/engine/atmos)
 "bqf" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -33367,6 +35024,8 @@
 /area/engine/atmos)
 "bqg" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -33407,10 +35066,14 @@
 "bql" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -33419,6 +35082,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -33461,6 +35126,8 @@
 "bqr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33496,6 +35163,8 @@
 "bqv" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -33593,9 +35262,13 @@
 /area/security/transfer)
 "bqG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33605,6 +35278,8 @@
 /area/security/transfer)
 "bqH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -33618,9 +35293,13 @@
 /area/security/transfer)
 "bqI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33633,9 +35312,13 @@
 /area/security/transfer)
 "bqJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33648,6 +35331,8 @@
 /area/security/transfer)
 "bqK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33659,6 +35344,7 @@
 /area/security/transfer)
 "bqL" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
@@ -33680,6 +35366,8 @@
 /area/security/brig)
 "bqN" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33729,6 +35417,8 @@
 /area/security/main)
 "bqU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -33768,6 +35458,8 @@
 "bqY" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/storage/fancy/donut_box,
@@ -33920,6 +35612,8 @@
 "brm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -33986,6 +35680,8 @@
 "brr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -34016,6 +35712,7 @@
 /area/engine/atmos)
 "bru" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -34044,6 +35741,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction,
@@ -34066,6 +35765,7 @@
 /area/storage/tech)
 "brz" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -34074,12 +35774,15 @@
 /area/storage/tech)
 "brA" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -34088,6 +35791,7 @@
 /area/storage/tech)
 "brB" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -34134,6 +35838,8 @@
 /area/hallway/primary/central)
 "brI" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -34167,6 +35873,8 @@
 /area/hallway/primary/central)
 "brO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -34180,6 +35888,7 @@
 /area/hallway/primary/central)
 "brQ" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -34267,6 +35976,8 @@
 "brZ" = (
 /obj/structure/closet/emcloset,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34276,9 +35987,13 @@
 /area/security/transfer)
 "bsa" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -34300,6 +36015,8 @@
 /area/security/transfer)
 "bsd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side,
@@ -34358,6 +36075,8 @@
 /area/security/main)
 "bsl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34377,9 +36096,11 @@
 "bsn" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -34396,6 +36117,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bsp" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
@@ -34407,9 +36130,11 @@
 	charge = 5e+006
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/sign/electricshock{
@@ -34425,6 +36150,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bsr" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
@@ -34527,6 +36254,8 @@
 "bsB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34575,9 +36304,13 @@
 "bsE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -34587,6 +36320,8 @@
 /area/engine/atmos)
 "bsF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34598,6 +36333,8 @@
 "bsG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -34612,6 +36349,8 @@
 	opacity = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -34619,6 +36358,8 @@
 	name = "Atmospherics Lockdown Blast door"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34646,6 +36387,8 @@
 	dir = 5
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sortjunction{
@@ -34662,6 +36405,8 @@
 	},
 /obj/item/weapon/circuitboard/computer/mecha_control,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34681,12 +36426,18 @@
 	pixel_y = -3
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -34704,6 +36455,8 @@
 	pixel_y = -3
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34754,9 +36507,11 @@
 /area/hydroponics)
 "bsS" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -34769,9 +36524,11 @@
 /area/bridge)
 "bsT" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -34784,9 +36541,11 @@
 /area/bridge)
 "bsU" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -34802,6 +36561,7 @@
 /area/bridge)
 "bsW" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -34814,12 +36574,15 @@
 /area/bridge)
 "bsX" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -34832,6 +36595,7 @@
 /area/bridge)
 "bsY" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -34853,6 +36617,8 @@
 /area/hallway/primary/central)
 "bta" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -34872,10 +36638,12 @@
 /area/hallway/primary/central)
 "btc" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -34887,6 +36655,7 @@
 /area/hallway/primary/central)
 "btd" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -34965,9 +36734,13 @@
 "btn" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -34979,6 +36752,7 @@
 /area/security/transfer)
 "bto" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -35018,6 +36792,7 @@
 /area/security/main)
 "bts" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -35026,12 +36801,18 @@
 /area/security/main)
 "btt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security{
@@ -35045,6 +36826,7 @@
 /area/security/main)
 "btu" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -35091,6 +36873,8 @@
 /area/ai_monitored/turret_protected/ai)
 "btz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -35217,6 +37001,8 @@
 /area/engine/break_room)
 "btP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -35246,6 +37032,8 @@
 "btS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -35259,6 +37047,7 @@
 /area/engine/atmos)
 "btU" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -35284,6 +37073,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -35316,6 +37107,8 @@
 /area/storage/tech)
 "bua" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -35339,6 +37132,8 @@
 /area/storage/tech)
 "buc" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35380,6 +37175,8 @@
 "buh" = (
 /obj/machinery/computer/med_data,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkblue/side{
@@ -35405,6 +37202,8 @@
 "buk" = (
 /obj/machinery/computer/security,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkred/side{
@@ -35428,6 +37227,8 @@
 "bun" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkyellow/side{
@@ -35451,15 +37252,21 @@
 /area/bridge)
 "buq" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
 "bur" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -35473,12 +37280,18 @@
 /area/hallway/primary/central)
 "bus" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/vault{
@@ -35495,6 +37308,8 @@
 /area/hallway/primary/central)
 "but" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -35511,6 +37326,8 @@
 	req_access_txt = "53"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/sign/electricshock{
@@ -35528,6 +37345,8 @@
 /area/security/nuke_storage)
 "buv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -35540,6 +37359,8 @@
 	layer = 2
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -35551,12 +37372,15 @@
 /area/security/nuke_storage)
 "bux" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/green,
 /area/security/nuke_storage)
 "buy" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -35600,6 +37424,8 @@
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -35609,9 +37435,13 @@
 /area/security/transfer)
 "buD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -35703,6 +37533,7 @@
 /area/security/main)
 "buO" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -35720,6 +37551,8 @@
 /area/security/main)
 "buQ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -35764,6 +37597,8 @@
 /area/ai_monitored/turret_protected/ai)
 "buU" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35773,6 +37608,8 @@
 /area/ai_monitored/turret_protected/ai)
 "buV" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -35780,9 +37617,13 @@
 /area/ai_monitored/turret_protected/ai)
 "buW" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35792,12 +37633,18 @@
 /area/ai_monitored/turret_protected/ai)
 "buX" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/ai_slipper{
@@ -35810,9 +37657,13 @@
 /area/ai_monitored/turret_protected/ai)
 "buY" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35822,6 +37673,8 @@
 /area/ai_monitored/turret_protected/ai)
 "buZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35832,6 +37685,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bva" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35908,6 +37763,7 @@
 /area/engine/break_room)
 "bvj" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -35988,6 +37844,8 @@
 "bvr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -36013,6 +37871,7 @@
 	pixel_x = -32
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/modular_computer/console/preset/engineering,
@@ -36028,18 +37887,24 @@
 /area/engine/atmos)
 "bvv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/holopad,
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bvw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -36050,6 +37915,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/caution{
@@ -36059,9 +37926,13 @@
 "bvy" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/item/weapon/folder/yellow,
@@ -36091,6 +37962,8 @@
 	dir = 6
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -36114,12 +37987,18 @@
 "bvC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/highsecurity{
@@ -36141,9 +38020,13 @@
 /area/storage/tech)
 "bvE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -36155,6 +38038,8 @@
 /area/maintenance/port/fore)
 "bvF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36169,6 +38054,8 @@
 "bvG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36182,9 +38069,13 @@
 "bvH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36202,6 +38093,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36217,6 +38110,8 @@
 /area/maintenance/port/fore)
 "bvJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36229,9 +38124,13 @@
 /area/hallway/primary/central)
 "bvK" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36283,6 +38182,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -36304,6 +38205,8 @@
 /area/bridge)
 "bvR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -36352,9 +38255,11 @@
 "bvW" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -36363,6 +38268,7 @@
 /area/hallway/primary/central)
 "bvX" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -36533,6 +38439,8 @@
 /area/security/transfer)
 "bwg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -36585,6 +38493,8 @@
 /area/security/brig)
 "bwm" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36650,9 +38560,11 @@
 "bws" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -36664,6 +38576,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -36672,6 +38586,8 @@
 /area/security/main)
 "bwu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/device/radio/intercom{
@@ -36739,6 +38655,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bwA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36757,6 +38675,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bwC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36777,6 +38697,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bwE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -36938,6 +38860,7 @@
 /area/engine/break_room)
 "bwS" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
@@ -36982,6 +38905,8 @@
 /area/engine/break_room)
 "bwY" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -37089,6 +39014,8 @@
 "bxg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -37135,6 +39062,8 @@
 /area/storage/tech)
 "bxl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -37169,6 +39098,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -37211,6 +39142,8 @@
 	opacity = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37242,6 +39175,7 @@
 /area/hallway/primary/central)
 "bxw" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -37313,6 +39247,8 @@
 "bxE" = (
 /obj/machinery/computer/cargo/request,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkyellow/side{
@@ -37338,6 +39274,8 @@
 /area/bridge)
 "bxH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -37350,6 +39288,8 @@
 /area/bridge)
 "bxI" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/beacon,
@@ -37359,6 +39299,8 @@
 /area/bridge)
 "bxJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -37391,6 +39333,8 @@
 /area/bridge)
 "bxM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/modular_computer/console/preset/command,
@@ -37502,9 +39446,13 @@
 /area/shuttle/labor)
 "bxX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -37552,6 +39500,8 @@
 /area/security/brig)
 "byd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37667,6 +39617,8 @@
 /area/ai_monitored/turret_protected/ai)
 "byp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -37688,6 +39640,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bys" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green,
@@ -37758,6 +39712,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37835,6 +39791,7 @@
 /area/engine/break_room)
 "byI" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -37852,9 +39809,13 @@
 	req_access_txt = "19"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -37871,12 +39832,15 @@
 /area/engine/break_room)
 "byK" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
@@ -37895,9 +39859,13 @@
 	req_access_txt = "19"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37913,6 +39881,7 @@
 /area/engine/break_room)
 "byM" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -37981,6 +39950,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37992,6 +39962,8 @@
 /area/engine/break_room)
 "byT" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38004,9 +39976,13 @@
 /area/engine/break_room)
 "byU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38088,6 +40064,8 @@
 /area/engine/atmos)
 "bzb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -38119,6 +40097,8 @@
 /area/storage/tech)
 "bzf" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -38181,6 +40161,8 @@
 /area/storage/primary)
 "bzn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -38299,9 +40281,13 @@
 /area/storage/primary)
 "bzs" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/lightsout,
@@ -38316,6 +40302,8 @@
 /area/hallway/primary/central)
 "bzt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38331,9 +40319,13 @@
 "bzu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -38353,6 +40345,8 @@
 /area/bridge)
 "bzv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38367,6 +40361,8 @@
 /area/bridge)
 "bzw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -38387,12 +40383,18 @@
 "bzx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -38409,6 +40411,8 @@
 /area/bridge)
 "bzy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38420,6 +40424,8 @@
 /area/bridge)
 "bzz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -38433,9 +40439,13 @@
 "bzA" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
@@ -38456,6 +40466,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -38471,12 +40483,18 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38488,9 +40506,13 @@
 /area/bridge)
 "bzD" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38502,6 +40524,8 @@
 "bzE" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38511,6 +40535,8 @@
 /area/bridge)
 "bzF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/southright{
@@ -38526,12 +40552,18 @@
 "bzG" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38541,9 +40573,13 @@
 /area/bridge)
 "bzH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -38556,9 +40592,13 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -38574,6 +40614,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38585,6 +40627,8 @@
 /area/bridge)
 "bzK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38601,9 +40645,13 @@
 "bzL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -38620,6 +40668,8 @@
 /area/bridge)
 "bzM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -38636,9 +40686,13 @@
 "bzN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -38655,6 +40709,8 @@
 /area/bridge)
 "bzO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -38668,9 +40724,13 @@
 /area/hallway/primary/central)
 "bzP" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -38721,6 +40781,8 @@
 /area/security/transfer)
 "bzU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sortjunction{
@@ -38818,6 +40880,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bAe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/ai_slipper{
@@ -38880,6 +40944,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bAi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/ai_slipper{
@@ -38941,9 +41007,13 @@
 "bAm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -38966,6 +41036,8 @@
 /area/engine/gravity_generator)
 "bAo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -38976,6 +41048,8 @@
 "bAp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -38988,6 +41062,8 @@
 	req_access_txt = "19;23"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -39000,9 +41076,13 @@
 /area/engine/gravity_generator)
 "bAr" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -39013,6 +41093,8 @@
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -39020,6 +41102,8 @@
 /area/engine/gravity_generator)
 "bAt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -39032,6 +41116,8 @@
 "bAu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
@@ -39052,6 +41138,8 @@
 /area/engine/break_room)
 "bAv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39064,9 +41152,13 @@
 /area/engine/break_room)
 "bAw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -39083,6 +41175,8 @@
 /area/engine/break_room)
 "bAx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39098,9 +41192,13 @@
 /area/engine/break_room)
 "bAy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -39117,6 +41215,8 @@
 /area/engine/break_room)
 "bAz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39130,6 +41230,8 @@
 "bAA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
@@ -39150,6 +41252,8 @@
 /area/engine/break_room)
 "bAB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers,
@@ -39163,6 +41267,8 @@
 /area/engine/break_room)
 "bAC" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39173,6 +41279,8 @@
 /area/engine/break_room)
 "bAD" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -39186,6 +41294,8 @@
 /area/engine/break_room)
 "bAE" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -39196,6 +41306,8 @@
 /area/engine/break_room)
 "bAF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39205,6 +41317,8 @@
 /area/engine/break_room)
 "bAG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -39215,9 +41329,13 @@
 /area/engine/break_room)
 "bAH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -39245,6 +41363,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -39322,6 +41442,7 @@
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/bot,
@@ -39329,6 +41450,8 @@
 /area/storage/primary)
 "bAS" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -39337,6 +41460,8 @@
 /area/storage/primary)
 "bAT" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -39349,6 +41474,8 @@
 /area/storage/primary)
 "bAU" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -39360,6 +41487,8 @@
 /area/storage/primary)
 "bAV" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -39410,6 +41539,8 @@
 "bBc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -39453,6 +41584,8 @@
 "bBf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -39498,6 +41631,8 @@
 /area/bridge)
 "bBi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -39523,6 +41658,8 @@
 /area/bridge)
 "bBk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39570,6 +41707,8 @@
 "bBp" = (
 /obj/machinery/computer/communications,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39617,6 +41756,8 @@
 /area/bridge)
 "bBu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -39657,6 +41798,8 @@
 /area/hallway/primary/central)
 "bBy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39676,6 +41819,7 @@
 /area/hallway/primary/central)
 "bBA" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -39688,9 +41832,13 @@
 /area/security/transfer)
 "bBB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -39704,6 +41852,7 @@
 /area/security/transfer)
 "bBC" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -39713,6 +41862,8 @@
 /area/security/transfer)
 "bBD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -39763,6 +41914,7 @@
 /area/security/warden)
 "bBJ" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -39918,6 +42070,8 @@
 /area/engine/gravity_generator)
 "bBX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -40044,6 +42198,8 @@
 /area/engine/break_room)
 "bCk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40150,6 +42306,7 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -40167,6 +42324,8 @@
 /area/hallway/primary/port)
 "bCu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -40271,6 +42430,8 @@
 /area/storage/primary)
 "bCG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -40350,6 +42511,8 @@
 /area/bridge)
 "bCP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -40419,6 +42582,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -40476,6 +42641,8 @@
 /area/bridge)
 "bDe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -40511,6 +42678,7 @@
 /area/security/detectives_office)
 "bDj" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -40544,6 +42712,7 @@
 /area/hallway/primary/starboard)
 "bDn" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -40581,6 +42750,7 @@
 /area/security/brig)
 "bDq" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -40598,9 +42768,13 @@
 /area/security/brig)
 "bDs" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40611,6 +42785,8 @@
 /area/security/brig)
 "bDt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40623,6 +42799,8 @@
 "bDu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
@@ -40638,6 +42816,8 @@
 /area/security/warden)
 "bDv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40649,9 +42829,13 @@
 /area/security/warden)
 "bDw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40663,6 +42847,8 @@
 /area/security/warden)
 "bDx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -40676,6 +42862,8 @@
 /area/security/warden)
 "bDy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -40684,12 +42872,18 @@
 /area/security/warden)
 "bDz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -40706,6 +42900,8 @@
 /area/security/warden)
 "bDA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -40716,6 +42912,8 @@
 "bDB" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -40724,6 +42922,7 @@
 /area/security/warden)
 "bDC" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -40819,6 +43018,8 @@
 /area/engine/gravity_generator)
 "bDK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -40908,15 +43109,21 @@
 /area/engine/break_room)
 "bDU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/break_room)
 "bDV" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -40924,12 +43131,16 @@
 /area/engine/break_room)
 "bDW" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/break_room)
 "bDX" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -40940,6 +43151,8 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -40957,6 +43170,8 @@
 /area/engine/break_room)
 "bDZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -40964,6 +43179,8 @@
 /area/engine/break_room)
 "bEa" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/lightsout,
@@ -40972,6 +43189,8 @@
 "bEb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -40981,6 +43200,8 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -40989,9 +43210,13 @@
 	req_one_access_txt = "32;19"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41005,6 +43230,8 @@
 "bEd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -41013,12 +43240,18 @@
 /area/hallway/primary/port)
 "bEe" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -41035,6 +43268,7 @@
 "bEg" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/item/weapon/folder/yellow,
@@ -41051,6 +43285,8 @@
 /area/storage/tech)
 "bEh" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -41063,6 +43299,8 @@
 /area/storage/tech)
 "bEi" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -41072,9 +43310,13 @@
 /area/storage/tech)
 "bEj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -41221,6 +43463,8 @@
 "bEz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command{
@@ -41301,6 +43545,8 @@
 /area/bridge)
 "bEG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -41370,6 +43616,8 @@
 	req_access_txt = "20"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -41381,6 +43629,8 @@
 /area/crew_quarters/heads/captain)
 "bEP" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -41395,6 +43645,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41408,6 +43660,8 @@
 "bER" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -41417,15 +43671,21 @@
 "bES" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bET" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -41435,6 +43695,8 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -41445,9 +43707,13 @@
 "bEX" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/clothing/head/fedora/det_hat{
@@ -41464,6 +43730,8 @@
 "bEY" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/weapon/book/manual/wiki/security_space_law,
@@ -41473,6 +43741,7 @@
 "bEZ" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -41487,15 +43756,21 @@
 "bFa" = (
 /obj/structure/filingcabinet/security,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/vault,
 /area/security/detectives_office)
 "bFb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/trunk,
@@ -41553,12 +43828,17 @@
 "bFi" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/grille,
@@ -41571,6 +43851,8 @@
 /area/security/brig)
 "bFj" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -41579,6 +43861,8 @@
 /area/security/brig)
 "bFk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -41587,12 +43871,18 @@
 /area/security/brig)
 "bFl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/westright{
@@ -41606,6 +43896,8 @@
 /area/security/brig)
 "bFm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -41613,9 +43905,13 @@
 /area/security/brig)
 "bFn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -41639,6 +43935,8 @@
 /area/security/warden)
 "bFq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -41694,6 +43992,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bFw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -41722,6 +44022,7 @@
 /area/ai_monitored/turret_protected/ai)
 "bFz" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41744,6 +44045,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bFB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41773,6 +44076,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bFE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/hatch{
@@ -41877,6 +44182,7 @@
 /area/crew_quarters/heads/chief)
 "bFM" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -41947,6 +44253,8 @@
 /area/engine/break_room)
 "bFT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42029,6 +44337,8 @@
 /area/hallway/primary/port)
 "bGd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -42083,6 +44393,7 @@
 /obj/item/weapon/stock_parts/console_screen,
 /obj/item/weapon/stock_parts/console_screen,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/vault{
@@ -42173,6 +44484,8 @@
 /area/bridge/meeting_room/council)
 "bGt" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -42183,6 +44496,8 @@
 /area/bridge/meeting_room/council)
 "bGu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/light_switch{
@@ -42214,6 +44529,8 @@
 /area/tcommsat/computer)
 "bGz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -42248,6 +44565,8 @@
 	pixel_y = 26
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -42316,6 +44635,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -42329,6 +44650,8 @@
 "bGN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -42339,6 +44662,8 @@
 	req_access_txt = "4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -42355,6 +44680,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -42363,9 +44690,13 @@
 /area/security/detectives_office)
 "bGQ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -42378,6 +44709,8 @@
 /area/security/detectives_office)
 "bGR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42387,12 +44720,18 @@
 /area/security/detectives_office)
 "bGS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42402,6 +44741,8 @@
 /area/security/detectives_office)
 "bGT" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -42412,6 +44753,8 @@
 /area/security/detectives_office)
 "bGU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -42510,6 +44853,8 @@
 /area/security/brig)
 "bHe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -42531,6 +44876,7 @@
 /area/security/brig)
 "bHg" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -42540,9 +44886,13 @@
 "bHh" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -42618,6 +44968,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bHo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -42625,12 +44977,16 @@
 /area/ai_monitored/turret_protected/ai)
 "bHp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bHq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/ai_slipper{
@@ -42640,9 +44996,13 @@
 /area/ai_monitored/turret_protected/ai)
 "bHr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -42650,6 +45010,8 @@
 /area/ai_monitored/turret_protected/ai)
 "bHs" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/circuit/green,
@@ -42711,6 +45073,8 @@
 /area/engine/transit_tube)
 "bHz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -42773,6 +45137,8 @@
 /area/crew_quarters/heads/chief)
 "bHF" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -42785,9 +45151,13 @@
 /area/crew_quarters/heads/chief)
 "bHG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/firedoor,
@@ -42796,6 +45166,8 @@
 	req_access_txt = "56"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42815,6 +45187,8 @@
 	name = "Chief's Lockdown Shutters"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42830,6 +45204,8 @@
 /area/engine/break_room)
 "bHI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42840,6 +45216,8 @@
 /area/engine/break_room)
 "bHJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42855,6 +45233,8 @@
 /area/engine/break_room)
 "bHK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42867,6 +45247,8 @@
 /area/engine/break_room)
 "bHL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -42880,6 +45262,8 @@
 /area/engine/break_room)
 "bHM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42892,9 +45276,13 @@
 /area/engine/break_room)
 "bHN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -42908,9 +45296,13 @@
 /area/engine/break_room)
 "bHO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -42932,6 +45324,7 @@
 /area/security/checkpoint/engineering)
 "bHR" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -42943,9 +45336,13 @@
 /area/security/checkpoint/engineering)
 "bHS" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -42960,6 +45357,7 @@
 /area/security/checkpoint/engineering)
 "bHT" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -43110,6 +45508,8 @@
 /area/bridge/meeting_room/council)
 "bIi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/chair/comfy/brown,
@@ -43120,6 +45520,8 @@
 /area/bridge/meeting_room/council)
 "bIj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/chair/comfy/black,
@@ -43216,6 +45618,8 @@
 /area/tcommsat/computer)
 "bIs" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -43288,6 +45692,8 @@
 /area/crew_quarters/heads/captain)
 "bIA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -43360,6 +45766,8 @@
 /area/storage/tools)
 "bIJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -43419,6 +45827,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43559,9 +45969,13 @@
 /area/security/warden)
 "bJd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -43738,6 +46152,7 @@
 /area/aisat)
 "bJt" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43749,6 +46164,8 @@
 /area/aisat)
 "bJu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/hatch{
@@ -43765,6 +46182,8 @@
 "bJv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43775,6 +46194,8 @@
 "bJw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43785,6 +46206,8 @@
 "bJx" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43794,6 +46217,8 @@
 /area/space)
 "bJy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/hatch{
@@ -43809,6 +46234,8 @@
 /area/engine/transit_tube)
 "bJz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43820,6 +46247,8 @@
 /area/engine/transit_tube)
 "bJA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -43829,6 +46258,8 @@
 /area/engine/transit_tube)
 "bJB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43886,6 +46317,8 @@
 /area/crew_quarters/heads/chief)
 "bJI" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -43957,6 +46390,8 @@
 /area/engine/break_room)
 "bJQ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -43980,6 +46415,7 @@
 /area/engine/break_room)
 "bJU" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -44052,6 +46488,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44106,6 +46544,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -44118,6 +46557,8 @@
 /area/bridge/meeting_room/council)
 "bKk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/photocopier,
@@ -44126,6 +46567,8 @@
 "bKl" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -44137,6 +46580,8 @@
 	icon_state = "comfychair"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
@@ -44144,6 +46589,8 @@
 "bKn" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/folder/blue,
@@ -44153,9 +46600,13 @@
 "bKo" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/weapon/folder/red,
@@ -44165,9 +46616,13 @@
 "bKp" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/weapon/folder/yellow,
@@ -44224,6 +46679,8 @@
 /area/tcommsat/computer)
 "bKw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -44234,6 +46691,8 @@
 /area/tcommsat/computer)
 "bKx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -44244,10 +46703,14 @@
 /area/tcommsat/computer)
 "bKy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -44293,9 +46756,13 @@
 "bKF" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44304,12 +46771,16 @@
 /area/crew_quarters/heads/captain)
 "bKG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bKH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -44324,6 +46795,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -44338,6 +46811,8 @@
 	},
 /obj/item/clothing/mask/cigarette/cigar,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -44370,6 +46845,8 @@
 /area/storage/tools)
 "bKM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -44382,6 +46859,8 @@
 /area/storage/tools)
 "bKN" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -44442,6 +46921,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -44530,6 +47011,8 @@
 /area/security/brig)
 "bLe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -44564,9 +47047,13 @@
 /area/security/warden)
 "bLh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -44583,6 +47070,7 @@
 /area/security/warden)
 "bLj" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -44714,6 +47202,8 @@
 "bLx" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -44792,6 +47282,8 @@
 "bLG" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/item/weapon/folder/blue{
@@ -44807,6 +47299,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44817,9 +47311,13 @@
 /area/crew_quarters/heads/chief)
 "bLI" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/light{
@@ -44847,6 +47345,8 @@
 "bLM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -44874,6 +47374,7 @@
 /area/engine/break_room)
 "bLP" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white,
@@ -44916,6 +47417,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -45089,6 +47592,8 @@
 /area/bridge/meeting_room/council)
 "bMp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/chair/comfy/brown{
@@ -45145,6 +47650,8 @@
 /area/tcommsat/computer)
 "bMy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -45197,6 +47704,8 @@
 "bMF" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45336,6 +47845,8 @@
 /area/security/detectives_office)
 "bMU" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45343,18 +47854,28 @@
 /area/security/detectives_office)
 "bMV" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -45362,6 +47883,8 @@
 "bMW" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/item/weapon/paper_bin,
@@ -45375,6 +47898,8 @@
 	},
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/button/door{
@@ -45420,12 +47945,18 @@
 /area/security/detectives_office)
 "bNb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/westright{
@@ -45447,12 +47978,18 @@
 /area/security/warden)
 "bNd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45532,6 +48069,8 @@
 "bNl" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/portable_atmospherics/canister/air,
@@ -45548,6 +48087,7 @@
 	charge = 5e+006
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
@@ -45699,6 +48239,8 @@
 "bNG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45709,6 +48251,8 @@
 "bNH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45767,6 +48311,8 @@
 "bNN" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/clipboard,
@@ -45785,6 +48331,7 @@
 /area/crew_quarters/heads/chief)
 "bNP" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -45861,6 +48408,8 @@
 /area/engine/engineering)
 "bNW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -45884,6 +48433,7 @@
 /area/engine/engineering)
 "bNZ" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -45892,9 +48442,13 @@
 /area/security/checkpoint/engineering)
 "bOa" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -45907,6 +48461,7 @@
 /area/security/checkpoint/engineering)
 "bOb" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -45935,6 +48490,8 @@
 "bOf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -46052,6 +48609,8 @@
 /area/bridge/meeting_room/council)
 "bOo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -46147,6 +48706,8 @@
 /obj/item/weapon/pen/fourcolor,
 /obj/item/weapon/stamp/captain,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -46253,6 +48814,8 @@
 	req_access_txt = "4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -46320,6 +48883,8 @@
 /area/security/brig)
 "bOR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46345,9 +48910,13 @@
 /area/security/warden)
 "bOT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -46356,6 +48925,7 @@
 "bOU" = (
 /obj/machinery/computer/prisoner,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -46499,6 +49069,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPc" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -46826,6 +49398,8 @@
 "bPE" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/cartridge/engineering{
@@ -46852,6 +49426,8 @@
 /area/crew_quarters/heads/chief)
 "bPG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46863,12 +49439,18 @@
 /area/crew_quarters/heads/chief)
 "bPH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -46889,6 +49471,8 @@
 /area/crew_quarters/heads/chief)
 "bPI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46900,6 +49484,8 @@
 /area/crew_quarters/heads/chief)
 "bPJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46909,9 +49495,13 @@
 /area/crew_quarters/heads/chief)
 "bPK" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/chief_engineer,
@@ -46922,6 +49512,8 @@
 /area/crew_quarters/heads/chief)
 "bPL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -46935,6 +49527,7 @@
 /area/crew_quarters/heads/chief)
 "bPM" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -46955,6 +49548,8 @@
 /area/engine/engineering)
 "bPO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/beacon,
@@ -46974,6 +49569,7 @@
 /area/engine/engineering)
 "bPQ" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -46988,6 +49584,8 @@
 /area/engine/engineering)
 "bPR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
@@ -47016,6 +49614,7 @@
 	pixel_y = 36
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -47032,6 +49631,8 @@
 /area/security/checkpoint/engineering)
 "bPU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -47065,9 +49666,13 @@
 /area/security/checkpoint/engineering)
 "bPW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -47078,6 +49683,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -47090,6 +49697,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -47105,6 +49714,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -47116,6 +49727,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -47128,6 +49741,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -47136,10 +49751,14 @@
 /area/hallway/primary/port)
 "bQc" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -47148,6 +49767,8 @@
 /area/hallway/primary/port)
 "bQd" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -47159,6 +49780,8 @@
 /area/hallway/primary/port)
 "bQe" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -47170,9 +49793,13 @@
 /area/hallway/primary/port)
 "bQf" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -47182,6 +49809,8 @@
 /area/hallway/primary/port)
 "bQg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -47199,6 +49828,8 @@
 /area/hallway/primary/port)
 "bQh" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -47212,6 +49843,8 @@
 /area/hallway/primary/port)
 "bQi" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -47221,6 +49854,8 @@
 /area/hallway/primary/port)
 "bQj" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -47234,6 +49869,8 @@
 "bQk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -47252,9 +49889,13 @@
 /area/hallway/primary/port)
 "bQl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -47274,6 +49915,8 @@
 /area/crew_quarters/heads/hop)
 "bQo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -47320,6 +49963,8 @@
 /area/tcommsat/server)
 "bQw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -47356,6 +50001,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/captain,
@@ -47516,6 +50163,8 @@
 /area/hallway/primary/starboard)
 "bQN" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47652,6 +50301,8 @@
 /area/security/warden)
 "bQY" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -47768,6 +50419,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/vault{
@@ -47776,6 +50429,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -47783,6 +50438,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -47791,6 +50448,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRj" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
@@ -47801,6 +50460,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -47813,6 +50474,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRl" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47827,6 +50490,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -47847,6 +50512,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47858,9 +50525,13 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -47871,6 +50542,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -47878,9 +50551,13 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRq" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /mob/living/simple_animal/bot/secbot/pingsky,
@@ -47888,6 +50565,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -47895,6 +50574,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRs" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -47905,6 +50586,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -47913,6 +50596,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -47926,6 +50611,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -47938,6 +50625,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -47950,6 +50639,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -47963,6 +50654,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -47971,6 +50664,8 @@
 /area/aisat)
 "bRz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -47983,6 +50678,8 @@
 /area/aisat)
 "bRA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -47995,6 +50692,8 @@
 /area/aisat)
 "bRB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -48003,6 +50702,8 @@
 /area/aisat)
 "bRC" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
@@ -48012,6 +50713,8 @@
 /area/aisat)
 "bRD" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -48174,6 +50877,8 @@
 /area/crew_quarters/heads/chief)
 "bRS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -48213,6 +50918,8 @@
 /area/crew_quarters/heads/chief)
 "bRY" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -48240,6 +50947,8 @@
 /area/engine/engineering)
 "bSb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -48258,10 +50967,12 @@
 /area/engine/engineering)
 "bSd" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -48270,12 +50981,18 @@
 /area/engine/engineering)
 "bSe" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -48288,10 +51005,14 @@
 /area/security/checkpoint/engineering)
 "bSf" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -48299,15 +51020,21 @@
 "bSg" = (
 /obj/structure/chair/office/dark,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/security/checkpoint/engineering)
 "bSh" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -48337,6 +51064,8 @@
 /area/hallway/primary/port)
 "bSk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon{
@@ -48404,6 +51133,8 @@
 /area/hallway/primary/central)
 "bSt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon{
@@ -48490,6 +51221,8 @@
 /area/crew_quarters/heads/hop)
 "bSA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -48541,6 +51274,8 @@
 /area/tcommsat/server)
 "bSG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/fans/tiny,
@@ -48581,6 +51316,8 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -48649,10 +51386,14 @@
 /area/hallway/primary/central)
 "bSR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/lightsout,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/navbeacon{
@@ -48663,6 +51404,8 @@
 /area/hallway/primary/central)
 "bSS" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -48675,6 +51418,8 @@
 "bST" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass{
@@ -48690,6 +51435,8 @@
 /area/hallway/primary/starboard)
 "bSU" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -48697,6 +51444,8 @@
 "bSV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -48707,12 +51456,16 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/starboard)
 "bSX" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -48726,24 +51479,34 @@
 /area/hallway/primary/starboard)
 "bSY" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/starboard)
 "bSZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/starboard)
 "bTa" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -48751,6 +51514,8 @@
 /area/hallway/primary/starboard)
 "bTb" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -48758,6 +51523,8 @@
 /area/hallway/primary/starboard)
 "bTc" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -48768,9 +51535,13 @@
 /area/hallway/primary/starboard)
 "bTd" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -48779,6 +51550,8 @@
 "bTe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -48792,6 +51565,8 @@
 "bTf" = (
 /obj/item/device/radio/beacon,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
@@ -48806,6 +51581,8 @@
 /area/hallway/primary/starboard)
 "bTg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -48822,6 +51599,8 @@
 "bTh" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -48844,9 +51623,13 @@
 /area/security/brig)
 "bTi" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -48862,9 +51645,13 @@
 /area/security/brig)
 "bTj" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -48882,6 +51669,8 @@
 /area/security/brig)
 "bTk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -48895,9 +51684,13 @@
 /area/security/brig)
 "bTl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -48948,9 +51741,13 @@
 /area/security/warden)
 "bTp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -48958,6 +51755,8 @@
 /area/security/warden)
 "bTq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -48970,12 +51769,18 @@
 "bTr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
@@ -48995,6 +51800,8 @@
 /area/ai_monitored/security/armory)
 "bTs" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49007,6 +51814,8 @@
 /area/ai_monitored/security/armory)
 "bTt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49029,6 +51838,8 @@
 	pixel_y = -3
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49039,6 +51850,8 @@
 /area/ai_monitored/security/armory)
 "bTv" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -49102,6 +51915,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -49161,6 +51976,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bTG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -49175,6 +51992,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bTI" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49381,6 +52200,7 @@
 /area/crew_quarters/heads/chief)
 "bUc" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -49394,9 +52214,11 @@
 "bUd" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -49428,6 +52250,8 @@
 "bUf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -49451,6 +52275,8 @@
 /area/engine/engineering)
 "bUi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -49484,6 +52310,8 @@
 /area/security/checkpoint/engineering)
 "bUl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/secure_data,
@@ -49519,6 +52347,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -49688,6 +52518,8 @@
 /area/crew_quarters/heads/hop)
 "bUG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -49735,6 +52567,8 @@
 /area/tcommsat/server)
 "bUM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command{
@@ -49777,6 +52611,8 @@
 	req_access_txt = "20"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -49894,6 +52730,8 @@
 /area/hallway/primary/starboard)
 "bVc" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -49904,6 +52742,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -49940,6 +52780,8 @@
 /area/hallway/primary/starboard)
 "bVg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50002,6 +52844,7 @@
 /area/hallway/primary/starboard)
 "bVn" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -50014,6 +52857,8 @@
 /area/security/brig)
 "bVo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -50027,6 +52872,8 @@
 /area/security/brig)
 "bVp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -50038,6 +52885,7 @@
 /area/security/brig)
 "bVq" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -50046,15 +52894,21 @@
 /area/security/brig)
 "bVr" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/security/brig)
 "bVs" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -50064,12 +52918,18 @@
 "bVt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -50080,6 +52940,8 @@
 /area/security/warden)
 "bVu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50089,9 +52951,13 @@
 /area/security/warden)
 "bVv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/button/door{
@@ -50130,6 +52996,8 @@
 "bVx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security{
@@ -50156,6 +53024,8 @@
 /area/ai_monitored/security/armory)
 "bVA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -50257,6 +53127,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -50384,6 +53256,8 @@
 "bVZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
@@ -50406,6 +53280,8 @@
 /area/engine/engineering)
 "bWb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -50441,6 +53317,8 @@
 	dir = 6
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/yellow/side,
@@ -50514,6 +53392,7 @@
 /area/hallway/primary/central)
 "bWo" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -50527,6 +53406,8 @@
 "bWp" = (
 /obj/machinery/computer/card,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -50535,12 +53416,16 @@
 /area/crew_quarters/heads/hop)
 "bWq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bWr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -50548,9 +53433,13 @@
 /area/crew_quarters/heads/hop)
 "bWs" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -50603,6 +53492,8 @@
 /area/tcommsat/server)
 "bWz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -50651,6 +53542,8 @@
 	pixel_y = 26
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50735,6 +53628,8 @@
 	req_access_txt = "42"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50756,6 +53651,8 @@
 "bWT" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock{
@@ -50892,6 +53789,8 @@
 /area/security/warden)
 "bXf" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50991,6 +53890,8 @@
 /area/ai_monitored/security/armory)
 "bXn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -51013,6 +53914,8 @@
 /area/engine/engineering)
 "bXp" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/grille,
@@ -51021,6 +53924,8 @@
 /area/engine/engineering)
 "bXq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/grille,
@@ -51029,6 +53934,8 @@
 /area/engine/engineering)
 "bXr" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/grille,
@@ -51039,6 +53946,8 @@
 /area/engine/engineering)
 "bXs" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/grille,
@@ -51047,9 +53956,13 @@
 /area/engine/engineering)
 "bXt" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/grille,
@@ -51058,6 +53971,8 @@
 /area/engine/engineering)
 "bXu" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/grille,
@@ -51155,6 +54070,8 @@
 /area/engine/engineering)
 "bXD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -51162,6 +54079,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/sortjunction{
@@ -51175,6 +54094,8 @@
 /area/engine/engineering)
 "bXE" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51188,6 +54109,8 @@
 /area/engine/engineering)
 "bXF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -51203,12 +54126,18 @@
 /area/engine/engineering)
 "bXG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -51222,9 +54151,12 @@
 /area/engine/engineering)
 "bXH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -51233,9 +54165,12 @@
 /area/engine/engineering)
 "bXI" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/power/smes/engineering{
@@ -51245,6 +54180,7 @@
 /area/engine/engineering)
 "bXJ" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/engineering{
@@ -51259,6 +54195,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -51292,6 +54230,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -51379,6 +54318,8 @@
 /area/hallway/primary/central)
 "bXY" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -51408,6 +54349,8 @@
 /area/crew_quarters/heads/hop)
 "bYc" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -51422,6 +54365,8 @@
 /area/crew_quarters/heads/hop)
 "bYe" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/camera{
@@ -51438,6 +54383,8 @@
 /area/tcommsat/server)
 "bYf" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -51448,6 +54395,8 @@
 /area/tcommsat/server)
 "bYg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -51465,6 +54414,8 @@
 /area/tcommsat/server)
 "bYh" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -51475,6 +54426,8 @@
 /area/tcommsat/server)
 "bYi" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -51487,10 +54440,14 @@
 "bYj" = (
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/folder/yellow,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/green{
@@ -51501,6 +54458,8 @@
 /area/tcommsat/server)
 "bYl" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -51520,6 +54479,8 @@
 /area/tcommsat/server)
 "bYm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -51530,6 +54491,8 @@
 /area/tcommsat/server)
 "bYn" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -51551,6 +54514,8 @@
 /area/crew_quarters/heads/captain/private)
 "bYp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -51672,6 +54637,8 @@
 	pixel_y = 26
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51712,6 +54679,8 @@
 /area/lawoffice)
 "bYK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -51773,6 +54742,8 @@
 /area/security/brig)
 "bYQ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -51852,6 +54823,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "bZa" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -51904,6 +54877,8 @@
 /area/engine/engineering)
 "bZh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/grille,
@@ -51914,6 +54889,8 @@
 /area/engine/engineering)
 "bZi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/grille,
@@ -51924,6 +54901,8 @@
 /area/engine/engineering)
 "bZj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -51936,6 +54915,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -51949,6 +54930,8 @@
 "bZl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/fans/tiny,
@@ -51958,6 +54941,8 @@
 /area/engine/engineering)
 "bZm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -51968,12 +54953,16 @@
 "bZn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/engineering)
 "bZo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -51984,18 +54973,24 @@
 /area/engine/engineering)
 "bZp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/engineering)
 "bZq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow,
 /area/engine/engineering)
 "bZr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -52007,10 +55002,14 @@
 "bZs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -52036,12 +55035,16 @@
 "bZv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -52052,9 +55055,13 @@
 "bZw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/glass_engineering{
@@ -52143,6 +55150,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -52162,6 +55171,8 @@
 /area/maintenance/port)
 "bZF" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -52268,6 +55279,8 @@
 /area/hallway/primary/central)
 "bZR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
@@ -52277,12 +55290,18 @@
 /area/crew_quarters/heads/hop)
 "bZS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -52294,6 +55313,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -52322,6 +55342,8 @@
 /area/tcommsat/server)
 "bZW" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/vault{
@@ -52333,6 +55355,8 @@
 "bZX" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -52346,6 +55370,8 @@
 /area/tcommsat/server)
 "bZY" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -52360,6 +55386,8 @@
 "bZZ" = (
 /obj/machinery/message_server,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
@@ -52374,6 +55402,8 @@
 /area/tcommsat/server)
 "caa" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -52389,12 +55419,18 @@
 "cab" = (
 /obj/machinery/telecomms/hub/preset,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -52409,6 +55445,8 @@
 "cad" = (
 /obj/machinery/blackbox_recorder,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
@@ -52424,6 +55462,8 @@
 "cae" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -52437,6 +55477,8 @@
 /area/tcommsat/server)
 "caf" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/power/terminal{
@@ -52444,6 +55486,7 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -52480,6 +55523,8 @@
 	icon_state = "comfychair"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/start/captain,
@@ -52491,6 +55536,8 @@
 /area/crew_quarters/heads/captain/private)
 "caj" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -52505,9 +55552,13 @@
 "cak" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -52519,6 +55570,8 @@
 /area/crew_quarters/heads/captain/private)
 "cal" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -52533,6 +55586,8 @@
 	req_access_txt = "20"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -52599,6 +55654,8 @@
 /area/security/courtroom)
 "cau" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -52609,6 +55666,8 @@
 /area/security/courtroom)
 "cav" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52618,9 +55677,13 @@
 /area/security/courtroom)
 "caw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -52628,6 +55691,8 @@
 /area/security/courtroom)
 "cax" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52640,6 +55705,8 @@
 "cay" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -52654,9 +55721,13 @@
 /area/lawoffice)
 "caz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52666,6 +55737,8 @@
 /area/lawoffice)
 "caA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52676,9 +55749,13 @@
 "caB" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52689,6 +55766,8 @@
 /area/lawoffice)
 "caC" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/lawyer,
@@ -52709,6 +55788,8 @@
 "caE" = (
 /obj/machinery/computer/security,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -52731,6 +55812,8 @@
 "caG" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/button/flasher{
@@ -52788,9 +55871,13 @@
 /area/security/brig)
 "caK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/lightsout,
@@ -52802,6 +55889,8 @@
 "caL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -52815,6 +55904,8 @@
 /area/security/brig)
 "caM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52826,6 +55917,8 @@
 /area/security/brig)
 "caN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52837,9 +55930,13 @@
 /area/security/brig)
 "caO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52851,6 +55948,7 @@
 /area/security/brig)
 "caP" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -52948,6 +56046,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "caZ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -53049,6 +56149,8 @@
 /area/engine/engineering)
 "cbk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53096,6 +56198,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -53106,6 +56210,7 @@
 "cbo" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -53132,6 +56237,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -53148,6 +56255,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -53167,6 +56276,8 @@
 	on = 1
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -53185,6 +56296,8 @@
 "cbt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -53202,6 +56315,8 @@
 /area/maintenance/port)
 "cbw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -53275,6 +56390,8 @@
 /area/crew_quarters/heads/hop)
 "cbG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -53304,6 +56421,8 @@
 /area/crew_quarters/heads/hop)
 "cbJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -53330,6 +56449,8 @@
 "cbM" = (
 /obj/machinery/ntnet_relay,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green{
@@ -53348,6 +56469,8 @@
 /area/tcommsat/server)
 "cbO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -53404,6 +56527,8 @@
 /area/crew_quarters/heads/captain/private)
 "cbT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -53514,6 +56639,8 @@
 /area/security/courtroom)
 "cce" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -53565,6 +56692,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/newscaster{
@@ -53605,6 +56734,8 @@
 /area/lawoffice)
 "ccm" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -53626,6 +56757,8 @@
 /area/lawoffice)
 "cco" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/table/reinforced,
@@ -53646,6 +56779,8 @@
 /area/security/brig)
 "ccq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/filingcabinet/chestdrawer,
@@ -53666,6 +56801,8 @@
 /area/security/brig)
 "ccs" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -53673,12 +56810,18 @@
 /area/security/brig)
 "cct" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/westright{
@@ -53692,6 +56835,8 @@
 /area/security/brig)
 "ccu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -53702,18 +56847,26 @@
 /area/security/brig)
 "ccv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/security/brig)
 "ccw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -53725,6 +56878,7 @@
 /area/security/brig)
 "ccx" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -53758,9 +56912,13 @@
 /area/security/brig)
 "ccA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -53772,6 +56930,8 @@
 /area/security/brig)
 "ccB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -53780,6 +56940,8 @@
 "ccC" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -53787,6 +56949,8 @@
 /area/security/brig)
 "ccD" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -53798,6 +56962,8 @@
 /area/security/brig)
 "ccE" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -53812,6 +56978,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -53834,9 +57002,11 @@
 /area/space)
 "ccH" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -53849,6 +57019,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ccI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -53869,6 +57041,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ccJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -53877,9 +57051,13 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ccK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53889,6 +57067,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ccL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53900,12 +57080,18 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ccM" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -53918,6 +57104,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ccN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53929,6 +57117,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ccO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53936,6 +57126,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ccP" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -53960,9 +57152,11 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ccQ" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -54048,6 +57242,8 @@
 /area/engine/engineering)
 "cda" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -54065,6 +57261,8 @@
 "cdc" = (
 /obj/machinery/vending/engivend,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -54075,6 +57273,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -54089,6 +57289,7 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/camera{
@@ -54120,6 +57321,8 @@
 "cdi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -54223,6 +57426,8 @@
 "cdx" = (
 /obj/machinery/computer/security/mining,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -54232,6 +57437,8 @@
 "cdy" = (
 /obj/structure/chair/office/dark,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/head_of_personnel,
@@ -54248,6 +57455,8 @@
 /area/crew_quarters/heads/hop)
 "cdA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green{
@@ -54313,6 +57522,8 @@
 	req_access_txt = "20"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54375,6 +57586,8 @@
 /area/security/courtroom)
 "cdP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54452,6 +57665,8 @@
 /area/lawoffice)
 "cdW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54472,6 +57687,8 @@
 /area/lawoffice)
 "cdZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/sign/nanotrasen{
@@ -54490,9 +57707,13 @@
 /area/security/brig)
 "cea" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -54512,9 +57733,13 @@
 	req_access_txt = "63"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -54526,6 +57751,8 @@
 /area/security/brig)
 "cec" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -54535,6 +57762,8 @@
 /area/security/brig)
 "ced" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/chair{
@@ -54554,6 +57783,8 @@
 /area/security/brig)
 "cef" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -54602,6 +57833,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -54613,9 +57846,13 @@
 /obj/machinery/recharger,
 /obj/machinery/light,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side,
@@ -54626,6 +57863,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side,
@@ -54634,6 +57873,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/side,
@@ -54668,6 +57909,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "cer" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -54684,6 +57927,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "cet" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -54869,6 +58114,8 @@
 "ceP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -54960,6 +58207,8 @@
 "cfb" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54982,6 +58231,8 @@
 /area/tcommsat/server)
 "cff" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command{
@@ -55026,6 +58277,8 @@
 /area/teleporter)
 "cfl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/camera/motion{
@@ -55048,6 +58301,8 @@
 /area/teleporter)
 "cfm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55061,6 +58316,8 @@
 /area/teleporter)
 "cfn" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55150,6 +58407,8 @@
 /area/security/courtroom)
 "cfz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -55206,6 +58465,8 @@
 /area/lawoffice)
 "cfG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -55223,6 +58484,7 @@
 /area/lawoffice)
 "cfI" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -55234,12 +58496,18 @@
 /area/security/brig)
 "cfJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -55260,6 +58528,7 @@
 /area/security/brig)
 "cfK" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -55305,6 +58574,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "cfO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -55312,6 +58583,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "cfP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/ai_slipper{
@@ -55443,10 +58716,14 @@
 "cgd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -55456,6 +58733,8 @@
 /area/engine/engineering)
 "cge" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -55464,6 +58743,8 @@
 /area/engine/engineering)
 "cgf" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/station_engineer,
@@ -55472,6 +58753,7 @@
 "cgg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -55514,6 +58796,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -55604,6 +58888,8 @@
 /area/crew_quarters/heads/hop)
 "cgw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -55628,6 +58914,8 @@
 /area/teleporter)
 "cgA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -55743,6 +59031,8 @@
 /area/security/courtroom)
 "cgL" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -55781,6 +59071,8 @@
 /area/lawoffice)
 "cgQ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -55879,6 +59171,8 @@
 /area/security/range)
 "cgZ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -55977,6 +59271,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "chk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/flasher{
@@ -55990,6 +59286,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "chl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green,
@@ -56159,6 +59457,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -56168,6 +59468,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -56178,6 +59480,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -56189,6 +59493,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -56196,6 +59502,8 @@
 "chL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -56203,9 +59511,13 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -56217,6 +59529,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56232,6 +59546,8 @@
 /area/library)
 "chN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56241,6 +59557,8 @@
 /area/library)
 "chO" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56303,6 +59621,8 @@
 /area/crew_quarters/heads/hop)
 "chY" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -56310,9 +59630,13 @@
 /area/crew_quarters/heads/hop)
 "chZ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -56337,6 +59661,8 @@
 /area/tcommsat/server)
 "cic" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -56380,6 +59706,7 @@
 	pixel_y = 28
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -56403,6 +59730,8 @@
 /area/teleporter)
 "cii" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -56512,6 +59841,8 @@
 /area/security/courtroom)
 "cis" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -56541,6 +59872,8 @@
 "ciw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/blobstart,
@@ -56555,6 +59888,8 @@
 "cix" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -56566,6 +59901,8 @@
 /area/maintenance/starboard)
 "ciy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -56577,9 +59914,13 @@
 "ciz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56593,6 +59934,8 @@
 /area/maintenance/starboard)
 "ciA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
@@ -56610,6 +59953,8 @@
 /area/maintenance/starboard)
 "ciB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56622,6 +59967,8 @@
 /area/maintenance/starboard)
 "ciC" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -56636,6 +59983,8 @@
 "ciD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56650,6 +59999,8 @@
 "ciE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56663,6 +60014,8 @@
 "ciF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56675,9 +60028,13 @@
 /area/maintenance/starboard)
 "ciG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -56708,6 +60065,8 @@
 /area/security/range)
 "ciI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56727,15 +60086,23 @@
 /area/security/range)
 "ciJ" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -56747,6 +60114,8 @@
 /area/security/range)
 "ciK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -56765,6 +60134,8 @@
 /area/security/range)
 "ciL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/westright{
@@ -56775,12 +60146,16 @@
 /area/security/range)
 "ciM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/security/range)
 "ciN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -56789,9 +60164,13 @@
 /area/security/range)
 "ciO" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/target/syndicate,
@@ -56801,6 +60180,7 @@
 /area/security/range)
 "ciP" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -56850,6 +60230,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ciT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/table/reinforced,
@@ -56998,6 +60380,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57021,6 +60405,8 @@
 /area/library)
 "cjk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -57117,6 +60503,8 @@
 /area/crew_quarters/heads/hop)
 "cjx" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57127,6 +60515,8 @@
 /area/crew_quarters/heads/hop)
 "cjy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -57134,6 +60524,8 @@
 /area/crew_quarters/heads/hop)
 "cjz" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -57180,6 +60572,8 @@
 /area/tcommsat/server)
 "cjE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -57241,6 +60635,8 @@
 "cjK" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57255,6 +60651,8 @@
 /area/teleporter)
 "cjL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57269,9 +60667,13 @@
 /area/teleporter)
 "cjM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57285,6 +60687,8 @@
 /area/teleporter)
 "cjN" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -57356,6 +60760,8 @@
 /area/security/courtroom)
 "cjU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -57384,6 +60790,8 @@
 "cjY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -57461,6 +60869,8 @@
 "ckh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -57484,6 +60894,7 @@
 	pixel_x = -26
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -57493,9 +60904,13 @@
 /area/security/range)
 "ckk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -57575,6 +60990,8 @@
 /area/security/range)
 "ckr" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -57748,6 +61165,8 @@
 "ckL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57763,18 +61182,23 @@
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood,
 /area/library)
 "ckN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/library)
 "ckO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57840,6 +61264,8 @@
 "ckY" = (
 /obj/machinery/disposal/bin,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/trunk{
@@ -57861,6 +61287,8 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57898,6 +61326,8 @@
 /area/tcommsat/server)
 "cle" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57992,6 +61422,8 @@
 /area/teleporter)
 "cln" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -58034,12 +61466,16 @@
 /area/security/courtroom)
 "clt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral/side,
 /area/security/courtroom)
 "clu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -58051,6 +61487,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -58061,6 +61498,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -58086,6 +61525,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -58117,6 +61558,8 @@
 	req_access_txt = "63"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -58181,6 +61624,8 @@
 /area/space)
 "clM" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -58274,6 +61719,8 @@
 /area/engine/engineering)
 "clW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -58369,6 +61816,8 @@
 /area/maintenance/port)
 "cmh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -58438,6 +61887,8 @@
 /area/crew_quarters/heads/hop)
 "cms" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -58458,6 +61909,7 @@
 /area/hallway/secondary/command)
 "cmu" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -58471,6 +61923,8 @@
 /area/hallway/secondary/command)
 "cmw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -58614,6 +62068,8 @@
 /area/security/courtroom)
 "cmL" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -58661,6 +62117,8 @@
 /area/maintenance/starboard)
 "cmR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -58674,6 +62132,8 @@
 /area/maintenance/starboard)
 "cmT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -58843,6 +62303,8 @@
 "cnp" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
@@ -58856,6 +62318,8 @@
 /area/engine/engineering)
 "cnq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -58992,6 +62456,8 @@
 "cnD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -59050,6 +62516,8 @@
 /area/library)
 "cnJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59098,6 +62566,8 @@
 /area/hallway/secondary/command)
 "cnO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -59127,6 +62597,8 @@
 /area/hallway/secondary/command)
 "cnR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59155,6 +62627,8 @@
 /area/hallway/secondary/command)
 "cnT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -59198,6 +62672,8 @@
 /area/hallway/secondary/command)
 "cnX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59367,6 +62843,8 @@
 /area/security/courtroom)
 "coo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -59442,6 +62920,8 @@
 /area/maintenance/starboard)
 "cow" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -59466,6 +62946,8 @@
 /area/maintenance/starboard)
 "coz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -59474,12 +62956,16 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "coA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -59491,15 +62977,21 @@
 /area/maintenance/starboard)
 "coB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "coC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -59631,6 +63123,8 @@
 /area/engine/engineering)
 "coT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -59788,12 +63282,18 @@
 /area/library)
 "cpm" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59807,6 +63307,8 @@
 /area/hallway/primary/central)
 "cpn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -59817,6 +63319,8 @@
 /area/hallway/primary/central)
 "cpo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -59836,6 +63340,8 @@
 /area/hallway/secondary/command)
 "cpp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59847,9 +63353,13 @@
 /area/hallway/secondary/command)
 "cpq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -59862,6 +63372,8 @@
 /area/hallway/secondary/command)
 "cpr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59878,6 +63390,8 @@
 /area/hallway/secondary/command)
 "cps" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59894,9 +63408,13 @@
 /area/hallway/secondary/command)
 "cpt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -59909,6 +63427,8 @@
 /area/hallway/secondary/command)
 "cpu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -59918,12 +63438,18 @@
 /area/hallway/secondary/command)
 "cpv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59935,6 +63461,8 @@
 /area/hallway/secondary/command)
 "cpw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59947,6 +63475,8 @@
 /area/hallway/secondary/command)
 "cpx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/sign/electricshock{
@@ -59958,6 +63488,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -59966,6 +63498,8 @@
 /area/hallway/secondary/command)
 "cpy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59981,6 +63515,8 @@
 /area/hallway/secondary/command)
 "cpz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/black,
@@ -59992,12 +63528,18 @@
 /area/hallway/secondary/command)
 "cpA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/device/radio/beacon,
@@ -60011,6 +63553,8 @@
 /area/hallway/secondary/command)
 "cpB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/black,
@@ -60025,6 +63569,8 @@
 /area/hallway/secondary/command)
 "cpC" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/table/wood,
@@ -60039,6 +63585,8 @@
 /area/hallway/secondary/command)
 "cpD" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/sign/electricshock{
@@ -60053,6 +63601,8 @@
 /area/hallway/secondary/command)
 "cpE" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60063,12 +63613,18 @@
 /area/hallway/secondary/command)
 "cpF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60078,6 +63634,8 @@
 /area/hallway/secondary/command)
 "cpG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60087,6 +63645,8 @@
 /area/hallway/secondary/command)
 "cpH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -60097,9 +63657,13 @@
 /area/hallway/secondary/command)
 "cpI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60110,6 +63674,8 @@
 /area/hallway/secondary/command)
 "cpJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -60123,6 +63689,8 @@
 /area/hallway/secondary/command)
 "cpK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -60134,6 +63702,8 @@
 /area/hallway/secondary/command)
 "cpL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -60146,9 +63716,13 @@
 /area/hallway/primary/central)
 "cpM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -60173,6 +63747,8 @@
 /area/security/courtroom)
 "cpP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -60239,6 +63815,8 @@
 "cpX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -60377,6 +63955,8 @@
 /area/engine/engineering)
 "cqm" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
@@ -60415,6 +63995,8 @@
 "cqq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -60563,6 +64145,8 @@
 /area/ai_monitored/storage/eva)
 "cqI" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -60636,6 +64220,8 @@
 /area/hallway/secondary/command)
 "cqO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -60678,6 +64264,8 @@
 /area/gateway)
 "cqU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -60881,6 +64469,8 @@
 /area/crew_quarters/locker)
 "crl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -60968,6 +64558,8 @@
 "crv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -61063,6 +64655,8 @@
 /area/engine/engineering)
 "crH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/status_display{
@@ -61080,6 +64674,8 @@
 "crJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -61187,6 +64783,8 @@
 /area/ai_monitored/storage/eva)
 "crX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -61209,6 +64807,7 @@
 	pixel_y = 26
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -61255,6 +64854,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -61263,9 +64863,13 @@
 /area/hallway/secondary/command)
 "cse" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -61275,6 +64879,8 @@
 /area/hallway/secondary/command)
 "csf" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/table/wood,
@@ -61283,6 +64889,8 @@
 /area/hallway/secondary/command)
 "csg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/black{
@@ -61293,15 +64901,21 @@
 /area/hallway/secondary/command)
 "csh" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/blue/corner,
 /area/hallway/secondary/command)
 "csi" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/black{
@@ -61311,6 +64925,8 @@
 /area/hallway/secondary/command)
 "csj" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -61320,6 +64936,8 @@
 /area/hallway/secondary/command)
 "csk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -61331,6 +64949,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -61345,6 +64964,7 @@
 /area/gateway)
 "csn" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -61360,6 +64980,8 @@
 /area/gateway)
 "cso" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -61471,6 +65093,8 @@
 /area/crew_quarters/locker)
 "csC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -61531,6 +65155,8 @@
 "csK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61545,6 +65171,8 @@
 "csL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61560,6 +65188,8 @@
 /area/maintenance/starboard)
 "csM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61578,6 +65208,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61596,6 +65228,8 @@
 /area/crew_quarters/fitness/recreation)
 "csO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61610,6 +65244,8 @@
 /area/crew_quarters/fitness/recreation)
 "csP" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -61701,6 +65337,8 @@
 /area/engine/engineering)
 "ctb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/airalarm{
@@ -61759,6 +65397,8 @@
 /area/engine/storage)
 "cth" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -61766,6 +65406,8 @@
 "cti" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -61774,6 +65416,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -61782,6 +65426,8 @@
 /area/maintenance/port)
 "ctk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -61789,6 +65435,8 @@
 "ctl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -61797,6 +65445,8 @@
 /area/maintenance/port)
 "ctm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -61804,12 +65454,18 @@
 /area/maintenance/port)
 "ctn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -61960,6 +65616,8 @@
 /area/ai_monitored/storage/eva)
 "ctE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -61971,6 +65629,8 @@
 /area/ai_monitored/storage/eva)
 "ctF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -61981,9 +65641,13 @@
 /area/ai_monitored/storage/eva)
 "ctG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -61991,6 +65655,8 @@
 /area/ai_monitored/storage/eva)
 "ctH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -62001,6 +65667,8 @@
 /area/ai_monitored/storage/eva)
 "ctI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -62012,6 +65680,8 @@
 /area/ai_monitored/storage/eva)
 "ctJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -62022,6 +65692,8 @@
 "ctK" = (
 /obj/machinery/cell_charger,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -62032,6 +65704,7 @@
 /area/ai_monitored/storage/eva)
 "ctL" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -62040,6 +65713,8 @@
 /area/ai_monitored/storage/eva)
 "ctM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -62064,6 +65739,7 @@
 /area/hallway/secondary/command)
 "ctR" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -62073,6 +65749,8 @@
 "ctS" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -62081,9 +65759,13 @@
 /area/gateway)
 "ctT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -62094,9 +65776,13 @@
 /area/gateway)
 "ctU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -62125,6 +65811,7 @@
 /area/gateway)
 "ctX" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -62296,6 +65983,8 @@
 /area/crew_quarters/locker)
 "cul" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -62445,6 +66134,8 @@
 /area/crew_quarters/fitness/recreation)
 "cuB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -62623,6 +66314,8 @@
 "cuU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -62844,6 +66537,7 @@
 /area/ai_monitored/storage/eva)
 "cvr" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -62859,6 +66553,8 @@
 /area/bridge/showroom/corporate)
 "cvt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -62898,9 +66594,13 @@
 /area/gateway)
 "cvx" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -62912,6 +66612,8 @@
 /area/gateway)
 "cvy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -62923,6 +66625,8 @@
 "cvz" = (
 /obj/structure/table,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/clipboard,
@@ -62936,6 +66640,7 @@
 "cvA" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -62954,6 +66659,7 @@
 "cvC" = (
 /obj/machinery/gateway/centerstation,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -63007,6 +66713,8 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -63067,6 +66775,8 @@
 /area/crew_quarters/fitness/recreation)
 "cvR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -63201,6 +66911,8 @@
 /area/engine/engineering)
 "cwg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -63266,6 +66978,8 @@
 "cwn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -63426,6 +67140,8 @@
 /area/ai_monitored/storage/eva)
 "cwG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced,
@@ -63450,6 +67166,8 @@
 /area/bridge/showroom/corporate)
 "cwI" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -63457,6 +67175,8 @@
 /area/bridge/showroom/corporate)
 "cwJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -63492,6 +67212,8 @@
 /area/bridge/showroom/corporate)
 "cwO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced,
@@ -63541,6 +67263,8 @@
 /area/gateway)
 "cwR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -63584,9 +67308,12 @@
 "cwW" = (
 /obj/machinery/gateway,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -63690,6 +67417,7 @@
 /area/crew_quarters/toilet/restrooms)
 "cxf" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -63757,9 +67485,13 @@
 /area/crew_quarters/toilet/restrooms)
 "cxk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63773,6 +67505,8 @@
 /area/crew_quarters/locker)
 "cxl" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63783,6 +67517,8 @@
 "cxm" = (
 /obj/structure/chair/stool,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63795,6 +67531,8 @@
 /obj/item/weapon/folder,
 /obj/item/weapon/pen,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63806,6 +67544,8 @@
 /obj/structure/table,
 /obj/item/device/paicard,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63816,6 +67556,8 @@
 "cxp" = (
 /obj/structure/table,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/toy/gun,
@@ -63827,9 +67569,13 @@
 "cxq" = (
 /obj/structure/chair/stool,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/assistant,
@@ -63841,6 +67587,8 @@
 /area/crew_quarters/locker)
 "cxr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63851,6 +67599,7 @@
 /area/crew_quarters/locker)
 "cxs" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -63996,6 +67745,8 @@
 /area/crew_quarters/fitness/recreation)
 "cxD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -64069,9 +67820,13 @@
 /area/engine/engineering)
 "cxN" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -64087,12 +67842,18 @@
 	req_access_txt = "32"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -64106,6 +67867,8 @@
 "cxP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -64136,6 +67899,8 @@
 "cxT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -64162,6 +67927,8 @@
 "cxX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -64298,9 +68065,13 @@
 /area/ai_monitored/storage/eva)
 "cym" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/power/apc{
@@ -64309,12 +68080,15 @@
 	pixel_x = -26
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "cyn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -64325,12 +68099,18 @@
 /area/bridge/showroom/corporate)
 "cyo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -64341,9 +68121,13 @@
 /area/bridge/showroom/corporate)
 "cyp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/brown{
@@ -64355,9 +68139,13 @@
 "cyq" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
@@ -64366,9 +68154,13 @@
 "cyr" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/storage/fancy/donut_box,
@@ -64377,9 +68169,13 @@
 "cys" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/paper_bin,
@@ -64387,9 +68183,13 @@
 /area/bridge/showroom/corporate)
 "cyt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/chair/comfy/black{
@@ -64399,6 +68199,8 @@
 /area/bridge/showroom/corporate)
 "cyu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -64409,6 +68211,8 @@
 /area/bridge/showroom/corporate)
 "cyv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -64419,9 +68223,13 @@
 /area/bridge/showroom/corporate)
 "cyw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/airalarm{
@@ -64512,6 +68320,8 @@
 /area/gateway)
 "cyy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -64540,6 +68350,7 @@
 /area/gateway)
 "cyB" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -64560,6 +68371,8 @@
 /area/gateway)
 "cyD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -64626,6 +68439,8 @@
 /area/crew_quarters/toilet/restrooms)
 "cyL" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -64661,6 +68476,8 @@
 /area/crew_quarters/toilet/restrooms)
 "cyQ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/closet/wardrobe/white,
@@ -64671,6 +68488,8 @@
 /area/crew_quarters/locker)
 "cyR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -64843,6 +68662,8 @@
 /area/engine/engineering)
 "czq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -64870,6 +68691,8 @@
 "czs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -64880,6 +68703,8 @@
 /area/engine/storage)
 "czt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -64889,6 +68714,8 @@
 /area/engine/storage)
 "czu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -64898,6 +68725,8 @@
 /area/engine/storage)
 "czv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -64915,6 +68744,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -64972,6 +68802,8 @@
 /area/maintenance/port)
 "czC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -65203,6 +69035,8 @@
 "czZ" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/clipboard,
@@ -65221,6 +69055,8 @@
 "cAc" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/folder/blue,
@@ -65230,6 +69066,8 @@
 "cAd" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/clothing/mask/cigarette/cigar/cohiba{
@@ -65244,6 +69082,8 @@
 "cAe" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/lighter,
@@ -65259,6 +69099,8 @@
 "cAg" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/storage/secure/briefcase,
@@ -65290,6 +69132,8 @@
 /area/gateway)
 "cAj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65300,6 +69144,8 @@
 /area/gateway)
 "cAk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65311,6 +69157,8 @@
 /area/gateway)
 "cAl" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65323,12 +69171,18 @@
 /area/gateway)
 "cAm" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -65349,6 +69203,8 @@
 /area/gateway)
 "cAn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65362,6 +69218,8 @@
 "cAo" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65437,6 +69295,8 @@
 /area/crew_quarters/toilet/restrooms)
 "cAv" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65451,9 +69311,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65466,6 +69330,8 @@
 /area/crew_quarters/toilet/restrooms)
 "cAx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65481,6 +69347,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65493,6 +69361,8 @@
 /area/crew_quarters/toilet/restrooms)
 "cAz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -65504,6 +69374,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65513,6 +69385,8 @@
 /area/crew_quarters/toilet/restrooms)
 "cAB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65523,6 +69397,8 @@
 "cAC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -65541,6 +69417,8 @@
 /area/crew_quarters/toilet/restrooms)
 "cAD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65580,6 +69458,8 @@
 /area/crew_quarters/locker)
 "cAH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -65681,6 +69561,7 @@
 /area/holodeck/rec_center)
 "cAU" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -65688,6 +69569,8 @@
 /area/engine/engineering)
 "cAV" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/grille,
@@ -65698,6 +69581,8 @@
 /area/engine/engineering)
 "cAW" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/grille,
@@ -65708,6 +69593,8 @@
 /area/engine/engineering)
 "cAX" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/grille,
@@ -65718,6 +69605,8 @@
 /area/engine/engineering)
 "cAY" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
@@ -65728,6 +69617,8 @@
 	req_access_txt = "10; 13"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -65740,6 +69631,8 @@
 /area/engine/engineering)
 "cBa" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/fans/tiny,
@@ -65750,6 +69643,8 @@
 "cBb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -65760,6 +69655,8 @@
 /area/engine/engineering)
 "cBc" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -65774,6 +69671,8 @@
 /area/engine/engineering)
 "cBd" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -65781,6 +69680,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -65793,6 +69694,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -65850,6 +69753,8 @@
 /area/engine/storage)
 "cBk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -65955,6 +69860,8 @@
 "cBz" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/folder/blue,
@@ -65988,6 +69895,8 @@
 /area/bridge/showroom/corporate)
 "cBC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/chair/comfy/brown{
@@ -65997,6 +69906,8 @@
 /area/bridge/showroom/corporate)
 "cBD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -66004,6 +69915,8 @@
 /area/bridge/showroom/corporate)
 "cBE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/chair/comfy/black{
@@ -66034,6 +69947,8 @@
 "cBH" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/folder/red,
@@ -66125,6 +70040,8 @@
 /area/gateway)
 "cBR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/lightsout,
@@ -66146,6 +70063,8 @@
 /area/crew_quarters/toilet/restrooms)
 "cBT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -66206,6 +70125,8 @@
 /area/crew_quarters/locker)
 "cCb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -66314,6 +70235,8 @@
 /area/engine/engineering)
 "cCn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/grille,
@@ -66324,6 +70247,8 @@
 /area/engine/engineering)
 "cCo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/grille,
@@ -66334,6 +70259,8 @@
 /area/engine/engineering)
 "cCp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/grille,
@@ -66344,9 +70271,13 @@
 /area/engine/engineering)
 "cCq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/grille,
@@ -66357,6 +70288,8 @@
 /area/engine/engineering)
 "cCr" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/grille,
@@ -66410,6 +70343,8 @@
 "cCx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -66422,6 +70357,8 @@
 /area/engine/engineering)
 "cCy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -66522,6 +70459,8 @@
 "cCJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -66675,6 +70614,8 @@
 	req_access_txt = "19"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -66781,6 +70722,8 @@
 "cDj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -66826,6 +70769,8 @@
 "cDn" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock{
@@ -66957,6 +70902,8 @@
 	req_access_txt = "10"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -66971,6 +70918,8 @@
 /area/engine/engineering)
 "cDB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -67003,6 +70952,8 @@
 "cDG" = (
 /obj/effect/landmark/lightsout,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67102,6 +71053,8 @@
 /area/hallway/primary/central)
 "cDQ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67246,6 +71199,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -67300,6 +71255,8 @@
 /area/crew_quarters/dorms)
 "cEm" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -67313,6 +71270,8 @@
 /area/crew_quarters/dorms)
 "cEn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67325,6 +71284,8 @@
 /area/crew_quarters/dorms)
 "cEo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -67336,6 +71297,8 @@
 "cEp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -67354,6 +71317,8 @@
 /area/crew_quarters/dorms)
 "cEq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67365,9 +71330,13 @@
 /area/crew_quarters/dorms)
 "cEr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67382,6 +71351,8 @@
 /area/crew_quarters/dorms)
 "cEs" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67394,6 +71365,8 @@
 /area/crew_quarters/dorms)
 "cEt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67405,6 +71378,8 @@
 /area/crew_quarters/dorms)
 "cEu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67421,6 +71396,8 @@
 /area/crew_quarters/dorms)
 "cEv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -67431,6 +71408,8 @@
 "cEw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -67449,6 +71428,8 @@
 /area/crew_quarters/dorms)
 "cEx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -67461,9 +71442,13 @@
 /area/crew_quarters/fitness/recreation)
 "cEy" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -67676,6 +71661,8 @@
 "cET" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -67689,6 +71676,8 @@
 "cEU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -67700,6 +71689,8 @@
 "cEV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -67719,6 +71710,8 @@
 "cEX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -67731,6 +71724,8 @@
 /area/maintenance/port)
 "cEY" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -67744,9 +71739,13 @@
 "cEZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -67758,9 +71757,13 @@
 "cFa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -67775,9 +71778,13 @@
 "cFb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -67785,6 +71792,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -67796,6 +71805,8 @@
 /area/maintenance/port)
 "cFc" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67809,6 +71820,8 @@
 "cFd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67822,6 +71835,8 @@
 "cFe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67838,9 +71853,13 @@
 "cFf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67854,6 +71873,8 @@
 "cFg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67868,9 +71889,13 @@
 /area/maintenance/port)
 "cFh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67884,6 +71909,8 @@
 "cFi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67898,6 +71925,8 @@
 /area/maintenance/port)
 "cFj" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67912,6 +71941,8 @@
 /area/maintenance/port)
 "cFk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67926,9 +71957,13 @@
 "cFl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -67941,6 +71976,8 @@
 "cFm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67950,6 +71987,8 @@
 /area/maintenance/port)
 "cFn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67960,6 +71999,8 @@
 "cFo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -67969,6 +72010,8 @@
 /area/maintenance/port)
 "cFp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -67981,6 +72024,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -67991,6 +72036,8 @@
 /area/maintenance/port)
 "cFr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68003,6 +72050,8 @@
 /area/maintenance/port)
 "cFs" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -68013,9 +72062,13 @@
 /area/maintenance/port)
 "cFt" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68029,6 +72082,8 @@
 /area/maintenance/port)
 "cFu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68046,6 +72101,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -68061,6 +72118,8 @@
 /area/maintenance/port)
 "cFw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -68077,9 +72136,13 @@
 /area/hallway/primary/central)
 "cFx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -68094,6 +72157,8 @@
 /area/hallway/primary/central)
 "cFy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -68102,9 +72167,13 @@
 /area/hallway/primary/central)
 "cFz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -68114,6 +72183,8 @@
 /area/hallway/primary/central)
 "cFA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -68122,6 +72193,8 @@
 /area/hallway/primary/central)
 "cFB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -68130,6 +72203,8 @@
 /area/hallway/primary/central)
 "cFC" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -68146,6 +72221,8 @@
 /area/hallway/primary/central)
 "cFD" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -68159,6 +72236,8 @@
 /area/hallway/primary/central)
 "cFE" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -68167,6 +72246,8 @@
 /area/hallway/primary/central)
 "cFF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -68176,6 +72257,8 @@
 /area/hallway/primary/central)
 "cFG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -68186,9 +72269,13 @@
 /area/hallway/primary/central)
 "cFH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -68196,6 +72283,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
@@ -68206,6 +72295,8 @@
 /area/hallway/primary/central)
 "cFI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68227,6 +72318,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68245,6 +72338,8 @@
 /area/maintenance/starboard/aft)
 "cFK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68258,6 +72353,8 @@
 "cFL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68302,13 +72399,19 @@
 "cFP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -68320,6 +72423,8 @@
 "cFQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68333,6 +72438,8 @@
 "cFR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68352,6 +72459,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68370,6 +72479,8 @@
 /area/maintenance/starboard/aft)
 "cFT" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -68456,6 +72567,8 @@
 /area/crew_quarters/dorms)
 "cGe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -68483,6 +72596,8 @@
 /area/crew_quarters/fitness/recreation)
 "cGi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -68591,6 +72706,8 @@
 "cGx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -68641,6 +72758,8 @@
 /area/maintenance/port)
 "cGC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -68668,6 +72787,8 @@
 /area/maintenance/port)
 "cGF" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -68708,6 +72829,8 @@
 "cGL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -68893,6 +73016,8 @@
 /area/maintenance/starboard/aft)
 "cHe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -68903,6 +73028,8 @@
 "cHf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -68913,6 +73040,8 @@
 /area/maintenance/starboard/aft)
 "cHg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -68923,6 +73052,8 @@
 /area/maintenance/starboard/aft)
 "cHh" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -68930,6 +73061,8 @@
 /area/maintenance/starboard/aft)
 "cHi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -68949,6 +73082,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -69158,6 +73293,8 @@
 /area/crew_quarters/fitness/recreation)
 "cHB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/lightsout,
@@ -69257,6 +73394,8 @@
 	req_access_txt = "10"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -69287,6 +73426,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -69628,6 +73769,8 @@
 "cIJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -69905,6 +74048,8 @@
 "cJq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -70000,6 +74145,8 @@
 "cJB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -70010,6 +74157,8 @@
 /area/maintenance/port)
 "cJC" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -70027,6 +74176,8 @@
 /area/science/xenobiology)
 "cJD" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -70036,6 +74187,8 @@
 /area/science/xenobiology)
 "cJE" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -70108,6 +74261,8 @@
 /area/science/research)
 "cJN" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -70192,6 +74347,8 @@
 /area/science/research)
 "cJY" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -70357,6 +74514,7 @@
 /area/maintenance/starboard/aft)
 "cKx" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -70375,9 +74533,13 @@
 /area/medical/storage)
 "cKy" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -70391,6 +74553,8 @@
 /area/medical/storage)
 "cKz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -70403,6 +74567,8 @@
 /area/medical/storage)
 "cKA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -70419,6 +74585,8 @@
 /area/medical/storage)
 "cKB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
@@ -70443,9 +74611,13 @@
 "cKC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -70462,6 +74634,8 @@
 "cKD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -70472,6 +74646,8 @@
 /area/maintenance/starboard/aft)
 "cKE" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -70481,6 +74657,8 @@
 /area/maintenance/starboard/aft)
 "cKF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -70495,6 +74673,8 @@
 /area/maintenance/starboard/aft)
 "cKG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -70513,6 +74693,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -70531,6 +74713,8 @@
 /area/maintenance/starboard/aft)
 "cKI" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -70752,9 +74936,13 @@
 /area/maintenance/department/electrical)
 "cLg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -70766,6 +74954,8 @@
 "cLh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -70777,6 +74967,8 @@
 "cLi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -70787,6 +74979,8 @@
 "cLj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -70797,6 +74991,7 @@
 /obj/item/weapon/stock_parts/cell/high,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -70809,6 +75004,8 @@
 "cLl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -70819,6 +75016,8 @@
 "cLm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/research{
@@ -70892,6 +75091,8 @@
 /area/science/research)
 "cLt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -71097,6 +75298,8 @@
 /area/medical/storage)
 "cLX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/cmo,
@@ -71175,6 +75378,8 @@
 /area/maintenance/starboard/aft)
 "cMh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -71332,6 +75537,8 @@
 	dir = 9
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -71364,6 +75571,8 @@
 /area/maintenance/department/electrical)
 "cMG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -71395,6 +75604,7 @@
 /area/science/xenobiology)
 "cMK" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -71405,6 +75615,8 @@
 /area/science/xenobiology)
 "cML" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -71412,12 +75624,16 @@
 /area/science/xenobiology)
 "cMM" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/camera{
@@ -71435,6 +75651,8 @@
 	pixel_y = 26
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -71457,6 +75675,7 @@
 /area/science/xenobiology)
 "cMP" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -71469,9 +75688,13 @@
 /area/science/xenobiology)
 "cMQ" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -71489,6 +75712,7 @@
 /area/science/xenobiology)
 "cMR" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -71502,6 +75726,7 @@
 /area/science/xenobiology)
 "cMS" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -71514,9 +75739,13 @@
 /area/science/xenobiology)
 "cMT" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -71534,6 +75763,7 @@
 /area/science/xenobiology)
 "cMU" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -71547,6 +75777,7 @@
 /area/science/xenobiology)
 "cMV" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -71559,9 +75790,13 @@
 /area/science/xenobiology)
 "cMW" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -71579,6 +75814,7 @@
 /area/science/xenobiology)
 "cMX" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -71592,6 +75828,7 @@
 /area/science/xenobiology)
 "cMY" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -71601,9 +75838,13 @@
 /area/science/xenobiology)
 "cMZ" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/glass_research{
@@ -71620,6 +75861,7 @@
 /area/science/xenobiology)
 "cNa" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -71628,6 +75870,8 @@
 /area/science/xenobiology)
 "cNb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/purple,
@@ -72055,6 +76299,8 @@
 /area/medical/medbay/central)
 "cNR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -72206,6 +76452,8 @@
 "cOm" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -72235,6 +76483,8 @@
 /area/maintenance/department/electrical)
 "cOq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -72274,6 +76524,8 @@
 /area/science/xenobiology)
 "cOv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -72317,6 +76569,8 @@
 /area/science/xenobiology)
 "cOA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -72421,6 +76675,8 @@
 /area/science/xenobiology)
 "cOK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -72462,6 +76718,8 @@
 /area/science/research)
 "cOP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -72471,6 +76729,8 @@
 /area/science/research)
 "cOQ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -72484,12 +76744,18 @@
 "cOR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/security{
@@ -72509,6 +76775,8 @@
 /area/security/checkpoint/science/research)
 "cOS" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -72520,9 +76788,13 @@
 /area/security/checkpoint/science/research)
 "cOT" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/chair/office/dark{
@@ -72532,6 +76804,8 @@
 /area/security/checkpoint/science/research)
 "cOU" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/security,
@@ -72544,6 +76818,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -72812,6 +77087,7 @@
 /area/medical/medbay/central)
 "cPx" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -72843,6 +77119,7 @@
 /area/security/checkpoint/medical)
 "cPB" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -73313,6 +77590,8 @@
 /area/science/xenobiology)
 "cQu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -73354,6 +77633,8 @@
 /area/science/xenobiology)
 "cQz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -73374,6 +77655,8 @@
 /area/science/xenobiology)
 "cQB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -73406,6 +77689,8 @@
 /area/science/xenobiology)
 "cQE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -73426,6 +77711,8 @@
 /area/science/xenobiology)
 "cQG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -73511,6 +77798,8 @@
 /area/security/checkpoint/science/research)
 "cQO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -73615,10 +77904,12 @@
 /area/medical/medbay/central)
 "cRd" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -73628,6 +77919,8 @@
 "cRe" = (
 /obj/machinery/computer/security,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red,
@@ -73646,9 +77939,13 @@
 "cRh" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/security{
@@ -73684,6 +77981,8 @@
 /area/medical/storage)
 "cRk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whiteblue/side,
@@ -73740,6 +78039,8 @@
 /area/medical/medbay/central)
 "cRp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -73756,6 +78057,7 @@
 /area/maintenance/starboard/aft)
 "cRr" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -73770,9 +78072,13 @@
 /area/crew_quarters/fitness/recreation)
 "cRs" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -73894,6 +78200,8 @@
 "cRI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -73916,9 +78224,13 @@
 /area/science/xenobiology)
 "cRK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -73936,6 +78248,8 @@
 /area/science/xenobiology)
 "cRL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -73948,12 +78262,18 @@
 /area/science/xenobiology)
 "cRM" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -73963,6 +78283,8 @@
 /area/science/xenobiology)
 "cRN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -73970,6 +78292,8 @@
 /area/science/xenobiology)
 "cRO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -73979,6 +78303,8 @@
 "cRP" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -73988,6 +78314,8 @@
 /area/science/xenobiology)
 "cRQ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/shower{
@@ -74005,6 +78333,8 @@
 /area/science/xenobiology)
 "cRR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -74017,12 +78347,18 @@
 /area/science/xenobiology)
 "cRS" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/lightsout,
@@ -74036,6 +78372,8 @@
 /area/science/xenobiology)
 "cRT" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/shower{
@@ -74053,12 +78391,18 @@
 /area/science/xenobiology)
 "cRU" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -74068,6 +78412,8 @@
 /area/science/xenobiology)
 "cRV" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -74076,9 +78422,13 @@
 /area/science/xenobiology)
 "cRW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/scientist,
@@ -74116,6 +78466,7 @@
 /area/science/research)
 "cSb" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/door_timer{
@@ -74149,9 +78500,13 @@
 /area/security/checkpoint/science/research)
 "cSc" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/red/side,
@@ -74379,6 +78734,8 @@
 /area/security/checkpoint/medical)
 "cSF" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -74795,6 +79152,8 @@
 /area/science/xenobiology)
 "cTC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -74825,6 +79184,8 @@
 /area/science/xenobiology)
 "cTG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -74834,6 +79195,8 @@
 /area/science/xenobiology)
 "cTH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -74854,6 +79217,8 @@
 /area/science/xenobiology)
 "cTJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -74908,6 +79273,7 @@
 /area/science/research)
 "cTO" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -74916,12 +79282,18 @@
 /area/security/checkpoint/science/research)
 "cTP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -74933,6 +79305,7 @@
 /area/security/checkpoint/science/research)
 "cTQ" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -75141,6 +79514,7 @@
 /area/medical/medbay/central)
 "cUn" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/door_timer{
@@ -75170,9 +79544,13 @@
 /area/security/checkpoint/medical)
 "cUo" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -75228,6 +79606,8 @@
 /area/medical/medbay/central)
 "cUt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -75280,6 +79660,8 @@
 /area/medical/medbay/central)
 "cUB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -75294,9 +79676,13 @@
 /area/maintenance/starboard/aft)
 "cUC" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -75310,6 +79696,8 @@
 /area/maintenance/starboard/aft)
 "cUD" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -75324,6 +79712,8 @@
 /area/maintenance/starboard/aft)
 "cUE" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -75337,6 +79727,8 @@
 /area/maintenance/starboard/aft)
 "cUF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -75350,6 +79742,8 @@
 /area/maintenance/starboard/aft)
 "cUG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -75363,6 +79757,8 @@
 /area/maintenance/starboard/aft)
 "cUH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -75375,6 +79771,8 @@
 /area/maintenance/starboard/aft)
 "cUI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -75388,6 +79786,8 @@
 /area/maintenance/starboard/aft)
 "cUJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -75401,6 +79801,8 @@
 /area/maintenance/starboard/aft)
 "cUK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -75420,6 +79822,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -75438,6 +79842,8 @@
 /area/crew_quarters/fitness/recreation)
 "cUM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -75453,6 +79859,8 @@
 /area/crew_quarters/fitness/recreation)
 "cUN" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -75589,6 +79997,8 @@
 /area/science/xenobiology)
 "cVd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -75621,6 +80031,8 @@
 /area/science/xenobiology)
 "cVh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -75699,6 +80111,8 @@
 /area/science/xenobiology)
 "cVo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/scientist,
@@ -75721,6 +80135,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -75729,6 +80144,8 @@
 /area/security/checkpoint/science/research)
 "cVr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/chair{
@@ -75740,12 +80157,18 @@
 /area/security/checkpoint/science/research)
 "cVs" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -75754,6 +80177,8 @@
 /area/security/checkpoint/science/research)
 "cVt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/closet/secure_closet/brig{
@@ -75766,6 +80191,7 @@
 /area/security/checkpoint/science/research)
 "cVu" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -75978,6 +80404,7 @@
 /area/medical/chemistry)
 "cVR" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -76043,6 +80470,7 @@
 /area/medical/medbay/central)
 "cVZ" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -76051,12 +80479,18 @@
 /area/security/checkpoint/medical)
 "cWa" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -76068,6 +80502,7 @@
 /area/security/checkpoint/medical)
 "cWb" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -76086,6 +80521,8 @@
 /area/medical/medbay/central)
 "cWe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -76151,6 +80588,8 @@
 /area/maintenance/starboard/aft)
 "cWn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -76327,6 +80766,7 @@
 	pixel_y = 28
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -76346,6 +80786,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -76358,6 +80800,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -76372,6 +80816,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -76383,6 +80829,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -76406,6 +80854,7 @@
 /area/science/xenobiology)
 "cWP" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -76416,6 +80865,8 @@
 /area/science/xenobiology)
 "cWQ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/airalarm{
@@ -76447,6 +80898,7 @@
 /area/science/xenobiology)
 "cWT" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -76460,9 +80912,13 @@
 /area/science/xenobiology)
 "cWU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -76480,6 +80936,7 @@
 /area/science/xenobiology)
 "cWV" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -76492,6 +80949,7 @@
 /area/science/xenobiology)
 "cWW" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -76505,9 +80963,13 @@
 /area/science/xenobiology)
 "cWX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -76525,6 +80987,7 @@
 /area/science/xenobiology)
 "cWY" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -76537,6 +81000,7 @@
 /area/science/xenobiology)
 "cWZ" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -76550,9 +81014,13 @@
 /area/science/xenobiology)
 "cXa" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -76570,6 +81038,7 @@
 /area/science/xenobiology)
 "cXb" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -76595,9 +81064,13 @@
 /area/science/xenobiology)
 "cXe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -76607,6 +81080,8 @@
 /area/science/xenobiology)
 "cXf" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -76617,6 +81092,8 @@
 /area/science/xenobiology)
 "cXg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -76629,6 +81106,7 @@
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
@@ -76654,6 +81132,8 @@
 /area/security/checkpoint/science/research)
 "cXj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side,
@@ -76848,6 +81328,8 @@
 /area/medical/chemistry)
 "cXF" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -76923,6 +81405,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -76931,6 +81414,8 @@
 /area/security/checkpoint/medical)
 "cXO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/chair{
@@ -76942,9 +81427,13 @@
 /area/security/checkpoint/medical)
 "cXP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -76962,6 +81451,8 @@
 /area/security/checkpoint/medical)
 "cXR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/blue,
@@ -77217,12 +81708,16 @@
 "cYx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -77231,6 +81726,8 @@
 "cYy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -77241,6 +81738,8 @@
 /area/maintenance/port)
 "cYz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -77251,6 +81750,8 @@
 "cYA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -77260,9 +81761,13 @@
 /area/maintenance/port)
 "cYB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -77344,9 +81849,11 @@
 "cYL" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -77571,15 +82078,21 @@
 /area/security/checkpoint/medical)
 "cZn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/medical)
 "cZo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -77589,10 +82102,12 @@
 /area/security/checkpoint/medical)
 "cZp" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -77611,6 +82126,8 @@
 /area/medical/medbay/central)
 "cZr" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -77662,6 +82179,8 @@
 /area/maintenance/starboard/aft)
 "cZA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -77706,6 +82225,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
@@ -77806,6 +82327,7 @@
 /area/science/xenobiology)
 "cZS" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -77818,12 +82340,18 @@
 /area/science/xenobiology)
 "cZT" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -77845,6 +82373,7 @@
 /area/science/xenobiology)
 "cZU" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -77930,6 +82459,7 @@
 /obj/item/weapon/stock_parts/console_screen,
 /obj/item/weapon/stock_parts/console_screen,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -77945,6 +82475,8 @@
 /area/science/lab)
 "daf" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -77952,6 +82484,8 @@
 /area/science/lab)
 "dag" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -77963,6 +82497,8 @@
 	pixel_x = -16
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -78083,12 +82619,18 @@
 "das" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -78140,6 +82682,8 @@
 "dax" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -78185,9 +82729,13 @@
 /area/maintenance/starboard/aft)
 "daC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -78206,6 +82754,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78226,6 +82776,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -78317,6 +82869,7 @@
 "daR" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/clothing/gloves/color/fyellow,
@@ -78352,6 +82905,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "daV" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -78371,6 +82926,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "daY" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78391,6 +82948,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78410,6 +82969,8 @@
 /area/maintenance/port)
 "dbc" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78429,6 +82990,8 @@
 /area/maintenance/port)
 "dbe" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78440,6 +83003,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -78671,6 +83236,8 @@
 /area/science/lab)
 "dbC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/table,
@@ -78776,6 +83343,8 @@
 /area/medical/chemistry)
 "dbO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -78882,6 +83451,8 @@
 /area/medical/medbay/central)
 "dbZ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -78956,6 +83527,8 @@
 /area/maintenance/starboard/aft)
 "dcj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -78969,6 +83542,8 @@
 	name = "emergency shower"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -79057,9 +83632,13 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dcx" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79069,6 +83648,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dcy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79080,6 +83661,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dcz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -79092,9 +83675,13 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dcA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79139,6 +83726,8 @@
 "dcH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -79259,6 +83848,8 @@
 /area/science/lab)
 "dcW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/scientist,
@@ -79358,6 +83949,8 @@
 /area/medical/chemistry)
 "ddh" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
@@ -79366,6 +83959,8 @@
 /area/medical/medbay/central)
 "ddi" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -79373,24 +83968,32 @@
 /area/medical/medbay/central)
 "ddj" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/medical/medbay/central)
 "ddk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue,
 /area/medical/medbay/central)
 "ddl" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whiteblue,
 /area/medical/medbay/central)
 "ddm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -79398,9 +84001,13 @@
 /area/medical/medbay/central)
 "ddn" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/beacon,
@@ -79410,6 +84017,8 @@
 /area/medical/medbay/central)
 "ddo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -79417,6 +84026,8 @@
 /area/medical/medbay/central)
 "ddp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
@@ -79430,15 +84041,21 @@
 /area/medical/medbay/central)
 "ddq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue,
 /area/medical/medbay/central)
 "ddr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -79449,6 +84066,8 @@
 /area/medical/medbay/central)
 "dds" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -79456,15 +84075,21 @@
 /area/medical/medbay/central)
 "ddt" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue,
 /area/medical/medbay/central)
 "ddu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -79472,15 +84097,21 @@
 /area/medical/medbay/central)
 "ddv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/blue,
 /area/medical/medbay/central)
 "ddw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -79491,6 +84122,8 @@
 /area/medical/medbay/central)
 "ddx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -79498,6 +84131,8 @@
 /area/medical/medbay/central)
 "ddy" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whiteblue/side{
@@ -79506,6 +84141,8 @@
 /area/medical/medbay/central)
 "ddz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -79522,6 +84159,8 @@
 /area/medical/medbay/central)
 "ddA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -79531,9 +84170,13 @@
 /area/maintenance/starboard/aft)
 "ddB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -79552,6 +84195,8 @@
 	pixel_x = -28
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -79635,6 +84280,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "ddO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -79667,6 +84314,8 @@
 "ddS" = (
 /obj/structure/table/wood/poker,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/storage/wallet/random,
@@ -79779,6 +84428,8 @@
 /area/maintenance/port)
 "deg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80037,6 +84688,8 @@
 /area/science/lab)
 "deK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80138,6 +84791,8 @@
 /area/medical/chemistry)
 "deT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/item/device/radio/intercom{
@@ -80152,6 +84807,8 @@
 /area/medical/chemistry)
 "deU" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -80170,6 +84827,8 @@
 	req_access_txt = "5; 33"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -80185,6 +84844,8 @@
 /area/medical/chemistry)
 "deW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -80234,6 +84895,8 @@
 /area/medical/medbay/central)
 "dfb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -80289,6 +84952,8 @@
 /area/medical/medbay/central)
 "dfi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -80345,6 +85010,8 @@
 /area/maintenance/starboard/aft)
 "dfq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -80485,6 +85152,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dfF" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -80498,15 +85166,20 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dfG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/window/northright,
@@ -80517,6 +85190,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dfH" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -80530,9 +85204,11 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dfI" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -80543,9 +85219,11 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dfJ" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
@@ -80636,6 +85314,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -80646,6 +85326,8 @@
 "dfW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -80692,6 +85374,8 @@
 /area/science/explab)
 "dgb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -80739,6 +85423,7 @@
 /area/science/research)
 "dgi" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -80748,9 +85433,13 @@
 "dgj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/research{
@@ -80768,6 +85457,7 @@
 /area/science/misc_lab/range)
 "dgk" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -80800,6 +85490,7 @@
 /area/crew_quarters/heads/hor)
 "dgp" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -80812,9 +85503,11 @@
 /area/crew_quarters/heads/hor)
 "dgq" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -80831,6 +85524,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -80873,6 +85567,8 @@
 	req_one_access_txt = "7;29"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -80953,6 +85649,8 @@
 /area/medical/genetics/cloning)
 "dgG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -80967,6 +85665,8 @@
 /area/medical/medbay/central)
 "dgH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -81028,6 +85728,8 @@
 /area/maintenance/starboard/aft)
 "dgO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -81054,6 +85756,7 @@
 "dgS" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -81077,6 +85780,7 @@
 "dgV" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -81193,6 +85897,8 @@
 /area/science/explab)
 "dhl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -81282,6 +85988,7 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/firealarm{
@@ -81300,12 +86007,18 @@
 /area/science/misc_lab/range)
 "dhw" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -81338,6 +86051,7 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -81359,6 +86073,8 @@
 /area/crew_quarters/heads/hor)
 "dhz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -81431,6 +86147,8 @@
 /area/science/robotics/mechbay)
 "dhG" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -81440,6 +86158,8 @@
 /area/science/robotics/mechbay)
 "dhH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -81449,10 +86169,14 @@
 /area/science/robotics/mechbay)
 "dhI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -81462,6 +86186,8 @@
 /area/science/robotics/mechbay)
 "dhJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -81472,6 +86198,7 @@
 /area/science/robotics/mechbay)
 "dhK" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -81601,6 +86328,7 @@
 "dhX" = (
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -81623,6 +86351,8 @@
 /area/medical/medbay/central)
 "dhZ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -81684,6 +86414,8 @@
 /area/medical/medbay/central)
 "dig" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -81753,6 +86485,8 @@
 /area/medical/surgery)
 "dir" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -81761,6 +86495,8 @@
 /area/maintenance/starboard/aft)
 "dis" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -82005,9 +86741,13 @@
 /area/maintenance/port)
 "diX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -82020,6 +86760,8 @@
 /area/maintenance/port)
 "diY" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -82040,6 +86782,8 @@
 /area/science/explab)
 "diZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82050,6 +86794,8 @@
 /area/science/explab)
 "dja" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -82062,6 +86808,8 @@
 /area/science/explab)
 "djb" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82077,6 +86825,8 @@
 /area/science/explab)
 "djc" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82092,6 +86842,8 @@
 "djd" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/stack/sheet/mineral/plasma{
@@ -82259,6 +87011,8 @@
 "djp" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
@@ -82314,6 +87068,8 @@
 /area/crew_quarters/heads/hor)
 "djt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
@@ -82418,6 +87174,8 @@
 /area/science/robotics/mechbay)
 "djD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -82582,6 +87340,8 @@
 /area/medical/genetics/cloning)
 "djX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82599,6 +87359,8 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82614,6 +87376,8 @@
 /area/medical/genetics/cloning)
 "djZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -82627,9 +87391,13 @@
 /area/medical/medbay/central)
 "dka" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82705,6 +87473,8 @@
 /area/medical/surgery)
 "dkj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -82866,6 +87636,8 @@
 "dkF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -82873,6 +87645,8 @@
 /area/science/research/abandoned)
 "dkG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82883,6 +87657,8 @@
 /area/science/research/abandoned)
 "dkH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82895,6 +87671,8 @@
 /area/science/research/abandoned)
 "dkI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82906,6 +87684,8 @@
 "dkJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82931,6 +87711,8 @@
 	name = "Decrepit Blast Door"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82949,6 +87731,8 @@
 "dkL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -82961,9 +87745,13 @@
 /area/maintenance/port)
 "dkM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -83142,9 +87930,13 @@
 /area/science/misc_lab/range)
 "dle" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -83156,6 +87948,8 @@
 /area/science/misc_lab/range)
 "dlf" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -83165,9 +87959,13 @@
 "dlg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/command{
@@ -83185,9 +87983,13 @@
 /area/crew_quarters/heads/hor)
 "dlh" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
@@ -83196,9 +87998,13 @@
 /area/crew_quarters/heads/hor)
 "dli" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -83207,9 +88013,13 @@
 /area/crew_quarters/heads/hor)
 "dlj" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83222,6 +88032,8 @@
 /area/crew_quarters/heads/hor)
 "dlk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -83238,6 +88050,8 @@
 /area/crew_quarters/heads/hor)
 "dll" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83252,9 +88066,13 @@
 "dlm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/command{
@@ -83285,6 +88103,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -83300,6 +88120,8 @@
 	icon_state = "pipe-j2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/purple,
@@ -83322,6 +88144,8 @@
 /area/science/robotics/mechbay)
 "dlr" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -83497,6 +88321,8 @@
 /area/medical/medbay/central)
 "dlN" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -83579,6 +88405,7 @@
 "dlZ" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -83670,6 +88497,8 @@
 /area/maintenance/port)
 "dmk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -83770,6 +88599,8 @@
 /area/science/misc_lab/range)
 "dmy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/northright{
@@ -83805,6 +88636,8 @@
 "dmC" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -83854,6 +88687,8 @@
 "dmG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -83879,6 +88714,8 @@
 /area/science/robotics/mechbay)
 "dmJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -84028,6 +88865,8 @@
 /area/medical/medbay/central)
 "dnd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -84191,6 +89030,8 @@
 /area/medical/surgery)
 "dnu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -84223,6 +89064,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dnz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/eastleft,
@@ -84329,6 +89172,8 @@
 /area/science/misc_lab/range)
 "dnO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -84343,6 +89188,8 @@
 /area/science/misc_lab/range)
 "dnQ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/disposal/bin,
@@ -84354,6 +89201,8 @@
 /area/crew_quarters/heads/hor)
 "dnR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -84363,9 +89212,13 @@
 "dnS" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/button/door{
@@ -84423,6 +89276,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/purple,
@@ -84477,6 +89332,7 @@
 /area/medical/genetics)
 "doe" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -84490,9 +89346,13 @@
 	req_access_txt = "9"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -84506,6 +89366,7 @@
 /area/medical/genetics)
 "dog" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -84515,6 +89376,7 @@
 /area/medical/genetics)
 "doh" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -84529,9 +89391,13 @@
 /area/medical/medbay/central)
 "doi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -84641,9 +89507,13 @@
 /area/medical/surgery)
 "dow" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -84655,6 +89525,8 @@
 /area/maintenance/starboard/aft)
 "dox" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -84671,6 +89543,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -84742,6 +89616,7 @@
 "doG" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -84753,9 +89628,11 @@
 /area/crew_quarters/abandoned_gambling_den)
 "doH" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -84765,6 +89642,7 @@
 "doI" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -84872,6 +89750,8 @@
 "doV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -85013,9 +89893,13 @@
 "dpm" = (
 /obj/machinery/computer/aifixer,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -85029,6 +89913,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/research_director,
@@ -85038,6 +89924,8 @@
 "dpo" = (
 /obj/machinery/computer/mecha,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -85045,6 +89933,7 @@
 /area/crew_quarters/heads/hor)
 "dpp" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -85070,6 +89959,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -85101,6 +89992,8 @@
 /area/science/robotics/mechbay)
 "dpv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -85253,6 +90146,8 @@
 /area/medical/genetics)
 "dpM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -85291,6 +90186,7 @@
 /area/medical/genetics)
 "dpP" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -85309,6 +90205,7 @@
 /area/medical/medbay/central)
 "dpR" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -85369,9 +90266,13 @@
 /area/crew_quarters/heads/cmo)
 "dpX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -85381,6 +90282,8 @@
 /area/medical/medbay/central)
 "dpY" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -85392,6 +90295,8 @@
 "dpZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/medical{
@@ -85410,6 +90315,8 @@
 /area/medical/surgery)
 "dqa" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -85421,6 +90328,8 @@
 /area/medical/surgery)
 "dqb" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/medical_doctor,
@@ -85432,6 +90341,8 @@
 /area/medical/surgery)
 "dqc" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -85448,6 +90359,8 @@
 	req_access_txt = "45"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -85463,6 +90376,8 @@
 /area/medical/surgery)
 "dqe" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -85475,6 +90390,8 @@
 "dqf" = (
 /obj/machinery/computer/operating,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -85487,9 +90404,13 @@
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -85500,6 +90421,8 @@
 "dqh" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -85510,6 +90433,8 @@
 /area/medical/surgery)
 "dqi" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -85523,6 +90448,8 @@
 	req_access_txt = "45"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -85538,9 +90465,13 @@
 /area/medical/surgery)
 "dqk" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -85676,6 +90607,8 @@
 /area/science/research/abandoned)
 "dqA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -85769,6 +90702,8 @@
 /area/science/misc_lab/range)
 "dqK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -85787,6 +90722,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/storage/secure/briefcase,
@@ -85804,6 +90741,8 @@
 /area/crew_quarters/heads/hor)
 "dqN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -85812,9 +90751,13 @@
 /area/crew_quarters/heads/hor)
 "dqO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -85844,6 +90787,8 @@
 "dqR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/purple,
@@ -85876,6 +90821,8 @@
 /area/science/robotics/mechbay)
 "dqU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85886,6 +90833,8 @@
 "dqV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -85893,6 +90842,8 @@
 /area/science/robotics/mechbay)
 "dqW" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -85906,6 +90857,8 @@
 /area/science/robotics/mechbay)
 "dqX" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -85913,6 +90866,8 @@
 /area/science/robotics/mechbay)
 "dqY" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -86006,6 +90961,8 @@
 /area/medical/genetics)
 "drh" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -86020,6 +90977,8 @@
 /area/medical/genetics)
 "dri" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86031,6 +90990,7 @@
 "drj" = (
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/item/weapon/clipboard,
@@ -86104,6 +91064,8 @@
 /area/medical/genetics)
 "drp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86138,6 +91100,7 @@
 /area/medical/genetics)
 "drs" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
@@ -86160,9 +91123,13 @@
 /area/medical/medbay/central)
 "dru" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86173,6 +91140,8 @@
 /area/medical/medbay/central)
 "drv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86187,12 +91156,18 @@
 	req_access_txt = "40"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86208,6 +91183,8 @@
 /area/crew_quarters/heads/cmo)
 "drx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86219,9 +91196,13 @@
 /area/crew_quarters/heads/cmo)
 "dry" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86231,12 +91212,16 @@
 /area/crew_quarters/heads/cmo)
 "drz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "drA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86246,6 +91231,8 @@
 /area/crew_quarters/heads/cmo)
 "drB" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86262,12 +91249,18 @@
 	req_access_txt = "40"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86283,6 +91276,8 @@
 /area/crew_quarters/heads/cmo)
 "drD" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -86295,9 +91290,13 @@
 /area/medical/medbay/central)
 "drE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/lightsout,
@@ -86353,6 +91352,8 @@
 /area/medical/surgery)
 "drL" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whiteblue/side,
@@ -86373,6 +91374,8 @@
 /area/medical/surgery)
 "drO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -86621,6 +91624,8 @@
 "dsv" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/grille,
@@ -86630,12 +91635,18 @@
 "dsw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/command{
@@ -86654,6 +91665,7 @@
 /area/crew_quarters/heads/hor)
 "dsx" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -86664,6 +91676,8 @@
 "dsy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
@@ -86710,6 +91724,8 @@
 "dsD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_research{
@@ -86762,9 +91778,13 @@
 /area/medical/genetics)
 "dsH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -86776,6 +91796,8 @@
 /area/medical/genetics)
 "dsI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -86789,6 +91811,8 @@
 /area/medical/genetics)
 "dsJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86808,9 +91832,13 @@
 	req_access_txt = "9"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86829,6 +91857,8 @@
 /area/medical/genetics)
 "dsL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86843,6 +91873,8 @@
 /area/medical/genetics)
 "dsM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86858,6 +91890,8 @@
 /area/medical/genetics)
 "dsN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -86871,6 +91905,8 @@
 /area/medical/genetics)
 "dsO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86883,6 +91919,8 @@
 /area/medical/genetics)
 "dsP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/holopad,
@@ -86923,10 +91961,12 @@
 /area/medical/genetics)
 "dsS" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -86939,6 +91979,8 @@
 /area/medical/genetics)
 "dsT" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -86951,9 +91993,13 @@
 /area/medical/medbay/central)
 "dsU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -86981,6 +92027,8 @@
 /area/crew_quarters/heads/cmo)
 "dsX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -87103,6 +92151,7 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/bot,
@@ -87112,6 +92161,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -87263,6 +92314,8 @@
 "dtG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -87272,6 +92325,8 @@
 /area/maintenance/port)
 "dtH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -87284,6 +92339,8 @@
 "dtI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -87295,6 +92352,8 @@
 /area/maintenance/port)
 "dtJ" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -87389,6 +92448,8 @@
 /area/crew_quarters/heads/hor)
 "dtU" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -87479,6 +92540,8 @@
 /area/science/robotics/lab)
 "dub" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -87558,6 +92621,8 @@
 /area/medical/genetics)
 "duh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -87666,6 +92731,8 @@
 /area/crew_quarters/heads/cmo)
 "duu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
@@ -87679,6 +92746,8 @@
 "duw" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -87687,6 +92756,7 @@
 "dux" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
@@ -87718,6 +92788,8 @@
 /area/medical/medbay/central)
 "duz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -87730,6 +92802,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -87742,6 +92816,8 @@
 /area/hallway/secondary/construction)
 "duB" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/item/device/radio/intercom{
@@ -87756,6 +92832,7 @@
 "duC" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/light/small{
@@ -87851,6 +92928,8 @@
 "duP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -87860,6 +92939,7 @@
 /area/maintenance/port)
 "duQ" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -87873,6 +92953,8 @@
 /area/science/mixing)
 "duR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -87882,6 +92964,8 @@
 /area/science/mixing)
 "duS" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -87916,6 +93000,8 @@
 /obj/item/target/syndicate,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -87949,6 +93035,8 @@
 /area/crew_quarters/heads/hor)
 "dva" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/research_director,
@@ -87998,6 +93086,8 @@
 /area/science/robotics/lab)
 "dve" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -88008,6 +93098,8 @@
 "dvf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -88017,6 +93109,8 @@
 /area/science/robotics/lab)
 "dvg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -88026,6 +93120,8 @@
 /area/science/robotics/lab)
 "dvh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -88063,6 +93159,7 @@
 /area/science/robotics/lab)
 "dvk" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -88076,6 +93173,8 @@
 "dvl" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/button/door{
@@ -88097,9 +93196,13 @@
 /area/medical/genetics)
 "dvm" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -88215,6 +93318,8 @@
 /area/medical/genetics)
 "dvz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -88236,6 +93341,7 @@
 /area/medical/medbay/central)
 "dvB" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -88255,6 +93361,8 @@
 "dvC" = (
 /obj/machinery/disposal/bin,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -88265,12 +93373,18 @@
 /area/crew_quarters/heads/cmo)
 "dvD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -88282,6 +93396,8 @@
 "dvE" = (
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/paper_bin,
@@ -88293,9 +93409,13 @@
 "dvF" = (
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/weapon/folder/blue{
@@ -88314,6 +93434,8 @@
 /obj/machinery/computer/med_data/laptop,
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -88323,6 +93445,7 @@
 /area/crew_quarters/heads/cmo)
 "dvH" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -88370,6 +93493,8 @@
 /area/maintenance/starboard/aft)
 "dvO" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -88383,6 +93508,8 @@
 /area/maintenance/starboard/aft)
 "dvP" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -88396,6 +93523,8 @@
 /area/maintenance/starboard/aft)
 "dvQ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -88406,9 +93535,13 @@
 /area/maintenance/starboard/aft)
 "dvR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -88416,6 +93549,8 @@
 /area/maintenance/starboard/aft)
 "dvS" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -88426,6 +93561,8 @@
 /area/maintenance/starboard/aft)
 "dvT" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -88435,6 +93572,8 @@
 /area/maintenance/starboard/aft)
 "dvU" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -88449,9 +93588,13 @@
 /area/maintenance/starboard/aft)
 "dvV" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -88464,9 +93607,13 @@
 /area/maintenance/starboard/aft)
 "dvW" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -88478,9 +93625,13 @@
 /area/maintenance/starboard/aft)
 "dvX" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -88494,6 +93645,8 @@
 /area/maintenance/starboard/aft)
 "dvY" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -88504,6 +93657,8 @@
 /area/maintenance/starboard/aft)
 "dvZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -88520,6 +93675,8 @@
 	req_access_txt = "10"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -88636,6 +93793,8 @@
 /area/science/mixing)
 "dwq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -88664,6 +93823,8 @@
 /area/science/misc_lab/range)
 "dwu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -88697,6 +93858,8 @@
 /area/crew_quarters/heads/hor)
 "dwy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/camera{
@@ -88710,6 +93873,8 @@
 /area/crew_quarters/heads/hor)
 "dwz" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -88769,6 +93934,8 @@
 /area/science/robotics/lab)
 "dwE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -88814,6 +93981,8 @@
 "dwL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/centcom{
@@ -88843,6 +94012,8 @@
 "dwP" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -88871,6 +94042,8 @@
 /area/crew_quarters/heads/cmo)
 "dwR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -88969,6 +94142,8 @@
 /area/medical/medbay/central)
 "dxa" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -89036,6 +94211,8 @@
 /area/maintenance/starboard/aft)
 "dxi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -89162,6 +94339,8 @@
 /area/science/research/abandoned)
 "dxw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -89215,6 +94394,8 @@
 /area/science/mixing)
 "dxz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -89243,6 +94424,8 @@
 "dxD" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -89338,6 +94521,8 @@
 "dxK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -89421,6 +94606,8 @@
 /area/medical/morgue)
 "dxT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -89504,6 +94691,8 @@
 /area/medical/morgue)
 "dyd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -89526,6 +94715,8 @@
 /area/crew_quarters/heads/cmo)
 "dyf" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/vending/wallmed{
@@ -89642,6 +94833,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -89723,6 +94916,8 @@
 /area/science/mixing)
 "dyA" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/scientist,
@@ -89750,6 +94945,8 @@
 /area/science/storage)
 "dyE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -89852,6 +95049,8 @@
 /area/science/robotics/lab)
 "dyP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -89896,6 +95095,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -89926,6 +95127,8 @@
 "dyZ" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -89967,6 +95170,8 @@
 "dzh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -89985,6 +95190,8 @@
 "dzk" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/grille,
@@ -89998,12 +95205,15 @@
 	req_access_txt = "40"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "dzm" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -90051,6 +95261,7 @@
 /area/crew_quarters/theatre/abandoned)
 "dzr" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -90118,6 +95329,8 @@
 /area/security/detectives_office/private_investigators_office)
 "dzz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -90226,6 +95439,8 @@
 /area/science/mixing)
 "dzL" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -90324,6 +95539,8 @@
 /area/science/storage)
 "dzS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -90357,6 +95574,7 @@
 /area/science/storage)
 "dzW" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/computer/rdservercontrol,
@@ -90379,9 +95597,13 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/vault{
@@ -90394,6 +95616,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -90410,6 +95634,8 @@
 	req_access_txt = "30"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -90422,6 +95648,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -90433,10 +95661,14 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -90451,6 +95683,7 @@
 "dAd" = (
 /obj/machinery/disposal/bin,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -90466,9 +95699,13 @@
 /area/science/robotics/lab)
 "dAe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -90564,9 +95801,13 @@
 /area/medical/morgue)
 "dAo" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -90578,6 +95819,8 @@
 "dAp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -90588,6 +95831,8 @@
 /area/medical/morgue)
 "dAq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -90598,6 +95843,8 @@
 "dAr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/medical_doctor,
@@ -90610,6 +95857,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -90620,6 +95869,8 @@
 /area/medical/morgue)
 "dAt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -90627,6 +95878,8 @@
 /area/medical/morgue)
 "dAu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -90648,6 +95901,8 @@
 "dAv" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/centcom{
@@ -90667,6 +95922,8 @@
 /area/medical/morgue)
 "dAw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -90678,6 +95935,8 @@
 /area/medical/morgue)
 "dAx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -90690,6 +95949,8 @@
 "dAy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -90700,12 +95961,18 @@
 /area/medical/morgue)
 "dAz" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -90751,6 +96018,8 @@
 /area/crew_quarters/heads/cmo)
 "dAF" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -90771,6 +96040,8 @@
 /area/maintenance/starboard/aft)
 "dAH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -90787,6 +96058,8 @@
 /area/crew_quarters/theatre/abandoned)
 "dAK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -90835,6 +96108,8 @@
 /area/security/detectives_office/private_investigators_office)
 "dAR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -90993,6 +96268,8 @@
 /area/science/mixing)
 "dBi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -91028,6 +96305,8 @@
 /area/science/mixing)
 "dBn" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -91038,6 +96317,8 @@
 /area/science/storage)
 "dBo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -91073,6 +96354,7 @@
 /area/science/storage)
 "dBs" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -91089,9 +96371,13 @@
 	req_access_txt = "30"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -91100,6 +96386,7 @@
 /area/science/server)
 "dBu" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -91115,6 +96402,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -91144,6 +96433,8 @@
 /area/science/robotics/lab)
 "dBx" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -91227,6 +96518,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -91317,6 +96610,8 @@
 "dBR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -91401,6 +96696,8 @@
 /area/crew_quarters/theatre/abandoned)
 "dCb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
@@ -91433,6 +96730,7 @@
 /area/crew_quarters/theatre/abandoned)
 "dCf" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -91445,6 +96743,8 @@
 /area/security/detectives_office/private_investigators_office)
 "dCg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/xeno_spawn,
@@ -91571,9 +96871,13 @@
 /area/science/mixing)
 "dCt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -91584,6 +96888,8 @@
 /area/science/mixing)
 "dCu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -91598,6 +96904,8 @@
 "dCv" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -91622,6 +96930,8 @@
 /area/science/mixing)
 "dCw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -91637,6 +96947,8 @@
 /area/science/mixing)
 "dCx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -91649,12 +96961,18 @@
 /area/science/mixing)
 "dCy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -91662,6 +96980,8 @@
 /area/science/mixing)
 "dCz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -91671,6 +96991,8 @@
 /area/science/mixing)
 "dCA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -91691,6 +97013,8 @@
 	name = "Toxins Lab Shutters"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -91706,12 +97030,16 @@
 /area/science/mixing)
 "dCC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -91721,6 +97049,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -91730,6 +97060,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -91740,6 +97072,8 @@
 "dCF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -91747,6 +97081,8 @@
 /area/science/storage)
 "dCG" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -91811,9 +97147,13 @@
 /area/science/research)
 "dCL" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -91825,6 +97165,7 @@
 /area/science/research)
 "dCM" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -91852,6 +97193,8 @@
 /area/science/robotics/lab)
 "dCO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -91985,6 +97328,8 @@
 /area/medical/morgue)
 "dDg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -92042,6 +97387,8 @@
 /area/medical/medbay/central)
 "dDn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitegreen/side,
@@ -92062,9 +97409,13 @@
 /area/maintenance/starboard/aft)
 "dDq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92084,6 +97435,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -92100,6 +97453,8 @@
 /area/crew_quarters/theatre/abandoned)
 "dDs" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -92109,6 +97464,8 @@
 /area/crew_quarters/theatre/abandoned)
 "dDt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -92120,6 +97477,8 @@
 "dDu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -92315,6 +97674,8 @@
 /area/science/mixing)
 "dDR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -92356,6 +97717,8 @@
 /area/science/mixing)
 "dDV" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92471,6 +97834,8 @@
 /area/science/research)
 "dEi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -92478,6 +97843,8 @@
 /area/science/research)
 "dEj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92521,6 +97888,8 @@
 "dEm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -92543,6 +97912,8 @@
 "dEo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/virology{
@@ -92675,6 +98046,8 @@
 /area/science/mixing)
 "dED" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -92693,6 +98066,8 @@
 /area/science/mixing)
 "dEE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92733,6 +98108,8 @@
 	req_access_txt = "47"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -92755,6 +98132,8 @@
 /area/maintenance/port/aft)
 "dEK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92825,18 +98204,24 @@
 /area/hallway/primary/aft)
 "dES" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/aft)
 "dET" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92848,6 +98233,8 @@
 /area/hallway/primary/aft)
 "dEU" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92862,6 +98249,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92877,6 +98266,8 @@
 /area/hallway/primary/aft)
 "dEW" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92888,6 +98279,8 @@
 /area/maintenance/aft)
 "dEX" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92897,6 +98290,8 @@
 /area/maintenance/aft)
 "dEY" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92907,6 +98302,8 @@
 /area/maintenance/aft)
 "dEZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92920,6 +98317,8 @@
 /area/maintenance/aft)
 "dFa" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -92932,21 +98331,29 @@
 /area/maintenance/aft)
 "dFb" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dFc" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -92974,6 +98381,8 @@
 /area/maintenance/aft)
 "dFe" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/rack,
@@ -92988,6 +98397,8 @@
 /area/maintenance/aft)
 "dFf" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -92999,9 +98410,13 @@
 /area/maintenance/aft)
 "dFg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -93013,6 +98428,8 @@
 /area/maintenance/aft)
 "dFh" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -93042,6 +98459,8 @@
 /area/medical/medbay/central)
 "dFk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -93298,6 +98717,8 @@
 /area/maintenance/port/aft)
 "dFQ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -93342,6 +98763,8 @@
 "dFV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -93410,6 +98833,8 @@
 /area/science/research)
 "dGf" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -93434,9 +98859,13 @@
 /area/maintenance/port/aft)
 "dGi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -93447,6 +98876,8 @@
 /area/maintenance/port/aft)
 "dGj" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -93457,6 +98888,8 @@
 /area/maintenance/port/aft)
 "dGk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93466,6 +98899,8 @@
 /area/maintenance/port/aft)
 "dGl" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -93474,9 +98909,13 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -93484,6 +98923,8 @@
 /area/maintenance/port/aft)
 "dGm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93494,6 +98935,8 @@
 /area/maintenance/port/aft)
 "dGn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -93509,6 +98952,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93524,6 +98969,8 @@
 /area/hallway/primary/aft)
 "dGp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93535,6 +98982,8 @@
 /area/hallway/primary/aft)
 "dGq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93548,6 +98997,8 @@
 /area/hallway/primary/aft)
 "dGr" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93652,6 +99103,8 @@
 /area/maintenance/aft)
 "dGD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -93662,6 +99115,8 @@
 /area/maintenance/aft)
 "dGE" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93671,6 +99126,8 @@
 /area/maintenance/aft)
 "dGF" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93718,6 +99175,8 @@
 /area/maintenance/aft)
 "dGL" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -93728,6 +99187,8 @@
 /area/maintenance/aft)
 "dGM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -93739,6 +99200,8 @@
 /area/maintenance/aft)
 "dGN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -93758,6 +99221,8 @@
 /area/medical/medbay/central)
 "dGO" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -93767,15 +99232,23 @@
 /area/medical/medbay/central)
 "dGP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/lightsout,
@@ -93787,9 +99260,13 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/bot,
@@ -93797,6 +99274,8 @@
 /area/medical/medbay/central)
 "dGQ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93811,6 +99290,8 @@
 "dGR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -93830,6 +99311,8 @@
 /area/medical/medbay/central)
 "dGS" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93840,6 +99323,8 @@
 /area/maintenance/starboard/aft)
 "dGT" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93849,6 +99334,8 @@
 /area/maintenance/starboard/aft)
 "dGU" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -93859,6 +99346,8 @@
 /area/maintenance/starboard/aft)
 "dGV" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -93869,6 +99358,8 @@
 /area/maintenance/starboard/aft)
 "dGW" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93878,6 +99369,8 @@
 /area/maintenance/starboard/aft)
 "dGX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -94029,10 +99522,14 @@
 "dHt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -94040,6 +99537,8 @@
 "dHu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -94049,6 +99548,8 @@
 /area/maintenance/port/aft)
 "dHv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -94059,6 +99560,8 @@
 "dHw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -94069,9 +99572,13 @@
 "dHx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -94080,6 +99587,8 @@
 "dHy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -94091,6 +99600,8 @@
 /area/maintenance/port/aft)
 "dHz" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -94145,12 +99656,16 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/science/research)
 "dHF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -94164,6 +99679,8 @@
 /area/science/research)
 "dHG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -94192,6 +99709,8 @@
 /area/maintenance/port/aft)
 "dHJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -94201,6 +99720,8 @@
 "dHK" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -94283,6 +99804,8 @@
 /area/medical/medbay/central)
 "dHS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -94372,6 +99895,8 @@
 	dir = 6
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -94384,6 +99909,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -94395,6 +99922,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -94404,6 +99933,8 @@
 "dIf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -94439,6 +99970,8 @@
 "dIk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -94500,6 +100033,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -94547,6 +100082,8 @@
 /area/maintenance/port/aft)
 "dIv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -94575,6 +100112,8 @@
 /area/security/checkpoint/customs)
 "dIx" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -94726,6 +100265,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
@@ -94779,6 +100320,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -94816,6 +100359,8 @@
 /area/maintenance/port/aft)
 "dIY" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -94835,6 +100380,8 @@
 /area/security/checkpoint/customs)
 "dJa" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -94917,6 +100464,8 @@
 "dJn" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -94965,6 +100514,7 @@
 "dJr" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -94973,9 +100523,11 @@
 "dJs" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -95010,6 +100562,8 @@
 "dJx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -95049,6 +100603,7 @@
 "dJE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -95059,6 +100614,8 @@
 "dJF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -95066,9 +100623,13 @@
 /area/maintenance/port/aft)
 "dJG" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -95106,6 +100667,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -95146,6 +100708,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -95179,6 +100743,8 @@
 /area/maintenance/port/aft)
 "dJT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -95190,6 +100756,7 @@
 "dJU" = (
 /obj/machinery/computer/card,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -95207,12 +100774,18 @@
 /area/security/checkpoint/customs)
 "dJV" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -95222,6 +100795,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -95230,6 +100805,8 @@
 "dJX" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/folder/blue,
@@ -95239,9 +100816,13 @@
 "dJY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/window/brigdoor/southright{
@@ -95308,6 +100889,8 @@
 /area/medical/virology)
 "dKf" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -95343,6 +100926,8 @@
 /area/medical/virology)
 "dKj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
@@ -95386,6 +100971,8 @@
 /area/medical/virology)
 "dKo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/filingcabinet/chestdrawer,
@@ -95437,6 +101024,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -95477,6 +101066,8 @@
 "dKB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -95507,6 +101098,8 @@
 "dKF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -95532,6 +101125,8 @@
 /area/maintenance/port/aft)
 "dKI" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -95540,6 +101135,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -95556,6 +101153,8 @@
 /area/maintenance/port/aft)
 "dKK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -95647,6 +101246,8 @@
 /area/medical/virology)
 "dKW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -95659,6 +101260,8 @@
 /area/medical/virology)
 "dKX" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -95672,6 +101275,8 @@
 "dKY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -95700,12 +101305,18 @@
 /area/medical/virology)
 "dKZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -95718,12 +101329,18 @@
 /area/medical/virology)
 "dLa" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small{
@@ -95744,6 +101361,8 @@
 	req_access_txt = "39"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -95756,6 +101375,8 @@
 /area/medical/virology)
 "dLc" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -95771,9 +101392,13 @@
 /area/medical/virology)
 "dLd" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -95820,6 +101445,8 @@
 /area/medical/virology)
 "dLi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -95841,6 +101468,8 @@
 /area/medical/virology)
 "dLl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/bed,
@@ -95944,9 +101573,13 @@
 "dLz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -95956,6 +101589,8 @@
 /area/maintenance/port/aft)
 "dLA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -95966,6 +101601,8 @@
 "dLB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -95976,9 +101613,13 @@
 "dLC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -95989,6 +101630,8 @@
 /area/maintenance/port/aft)
 "dLD" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -95996,15 +101639,21 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dLE" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -96014,6 +101663,8 @@
 /area/maintenance/port/aft)
 "dLF" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -96026,6 +101677,8 @@
 /area/maintenance/port/aft)
 "dLG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -96036,9 +101689,13 @@
 /area/maintenance/port/aft)
 "dLH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -96049,6 +101706,8 @@
 /area/maintenance/port/aft)
 "dLI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -96057,6 +101716,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -96066,6 +101727,8 @@
 /area/maintenance/port/aft)
 "dLJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -96076,6 +101739,8 @@
 /area/maintenance/port/aft)
 "dLK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -96086,6 +101751,8 @@
 /area/maintenance/port/aft)
 "dLL" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -96099,6 +101766,8 @@
 /area/maintenance/port/aft)
 "dLM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -96110,6 +101779,8 @@
 /area/maintenance/port/aft)
 "dLN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -96123,9 +101794,13 @@
 /area/maintenance/port/aft)
 "dLO" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -96135,6 +101810,8 @@
 "dLQ" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/storage/box/ids,
@@ -96345,15 +102022,21 @@
 /area/medical/virology)
 "dMj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/green,
 /area/medical/virology)
 "dMk" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -96367,6 +102050,8 @@
 	req_access_txt = "39"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -96379,6 +102064,8 @@
 /area/medical/virology)
 "dMm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -96387,6 +102074,8 @@
 /area/medical/virology)
 "dMn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -96397,12 +102086,18 @@
 /area/medical/virology)
 "dMo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -96413,6 +102108,8 @@
 /area/medical/virology)
 "dMp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitegreen/corner,
@@ -96423,6 +102120,8 @@
 	req_access_txt = "39"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -96435,6 +102134,8 @@
 /area/medical/virology)
 "dMr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -96447,9 +102148,13 @@
 /area/medical/virology)
 "dMs" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/virologist,
@@ -96501,6 +102206,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -96534,6 +102241,8 @@
 "dMD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -96554,6 +102263,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -96606,6 +102317,8 @@
 /area/maintenance/port/aft)
 "dML" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -96638,6 +102351,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dMP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -96662,6 +102377,7 @@
 "dMR" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -96670,6 +102386,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dMS" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -96832,6 +102549,8 @@
 /area/medical/virology)
 "dNi" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -96873,6 +102592,8 @@
 /area/medical/virology)
 "dNn" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -96894,6 +102615,8 @@
 /area/medical/virology)
 "dNq" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -96915,6 +102638,7 @@
 "dNt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -96930,6 +102654,8 @@
 "dNu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood{
@@ -96938,12 +102664,16 @@
 /area/library/abandoned)
 "dNv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/library/abandoned)
 "dNw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -96951,6 +102681,8 @@
 "dNx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -96990,6 +102722,8 @@
 /area/library/abandoned)
 "dND" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -97006,6 +102740,8 @@
 "dNG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -97025,6 +102761,8 @@
 /area/chapel/main)
 "dNJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -97131,6 +102869,8 @@
 /area/medical/virology)
 "dOb" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/green,
@@ -97155,6 +102895,8 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/structure/table,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/storage/box/donkpockets,
@@ -97186,6 +102928,8 @@
 /area/medical/virology)
 "dOj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -97229,6 +102973,8 @@
 "dOq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -97251,6 +102997,8 @@
 /area/chapel/office)
 "dOs" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -97321,6 +103069,8 @@
 /area/chapel/main)
 "dOy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -97377,6 +103127,8 @@
 /area/chapel/main)
 "dOF" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -97387,6 +103139,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dOG" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -97401,9 +103155,13 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dOH" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -97413,6 +103171,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dOI" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -97422,6 +103182,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dOJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -97503,9 +103265,11 @@
 "dOV" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -97514,9 +103278,11 @@
 "dOW" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -97525,9 +103291,11 @@
 "dOX" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -97536,6 +103304,7 @@
 "dOY" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -97552,9 +103321,13 @@
 /area/medical/virology)
 "dPa" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -97571,6 +103344,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -97630,6 +103404,8 @@
 /area/maintenance/port/aft)
 "dPj" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -97638,6 +103414,8 @@
 /area/maintenance/port/aft)
 "dPk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -97672,6 +103450,8 @@
 /area/chapel/main)
 "dPo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -97746,6 +103526,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dPw" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -97804,6 +103586,8 @@
 "dPE" = (
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/clothing/gloves/color/latex,
@@ -97831,6 +103615,8 @@
 /area/medical/virology)
 "dPG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/pandemic,
@@ -97857,6 +103643,8 @@
 /area/medical/virology)
 "dPJ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -97887,6 +103675,8 @@
 /area/medical/virology)
 "dPM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/lightsout,
@@ -97973,6 +103763,8 @@
 /area/library/abandoned)
 "dPW" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -97984,6 +103776,8 @@
 "dPX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -98003,6 +103797,8 @@
 /area/chapel/office)
 "dPZ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/chaplain,
@@ -98032,6 +103828,8 @@
 /area/chapel/main)
 "dQd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/lightsout,
@@ -98086,6 +103884,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dQk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -98151,6 +103951,8 @@
 	},
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/reagentgrinder{
@@ -98172,6 +103974,8 @@
 /area/medical/virology)
 "dQv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -98190,6 +103994,8 @@
 /area/medical/virology)
 "dQy" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -98210,6 +104016,7 @@
 "dQA" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -98229,15 +104036,21 @@
 /area/medical/virology)
 "dQC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/medical/virology)
 "dQD" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -98316,6 +104129,8 @@
 "dQP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -98332,6 +104147,8 @@
 /area/maintenance/port/aft)
 "dQR" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -98398,6 +104215,8 @@
 /area/chapel/main)
 "dQZ" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -98483,12 +104302,18 @@
 /area/shuttle/escape)
 "dRl" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
@@ -98499,6 +104324,8 @@
 /area/medical/virology)
 "dRm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
@@ -98507,12 +104334,18 @@
 /area/medical/virology)
 "dRn" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -98523,6 +104356,8 @@
 /area/medical/virology)
 "dRo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
@@ -98534,6 +104369,8 @@
 /area/medical/virology)
 "dRp" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -98543,12 +104380,18 @@
 /area/medical/virology)
 "dRq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -98564,6 +104407,8 @@
 /area/medical/virology)
 "dRr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -98582,12 +104427,18 @@
 	req_access_txt = "39"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -98606,6 +104457,8 @@
 /area/medical/virology)
 "dRt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -98621,9 +104474,13 @@
 /area/medical/virology)
 "dRu" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -98649,6 +104506,7 @@
 "dRx" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -98662,9 +104520,13 @@
 	req_access_txt = "39"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -98678,6 +104540,7 @@
 "dRz" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -98770,6 +104633,8 @@
 /area/library/abandoned)
 "dRL" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -98788,6 +104653,8 @@
 /area/chapel/office)
 "dRN" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
@@ -98931,6 +104798,8 @@
 	pixel_x = -23
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/book/manual/wiki/infections,
@@ -98957,6 +104826,8 @@
 /area/medical/virology)
 "dSe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -98972,6 +104843,8 @@
 /area/medical/virology)
 "dSh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -98993,6 +104866,8 @@
 /area/medical/virology)
 "dSk" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -99026,6 +104901,8 @@
 /area/medical/virology)
 "dSo" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
@@ -99138,6 +105015,8 @@
 /area/maintenance/port/aft)
 "dSE" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -99151,6 +105030,8 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -99223,6 +105104,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dSO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -99311,6 +105194,8 @@
 "dSV" = (
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/storage/box/beakers{
@@ -99336,6 +105221,8 @@
 /area/medical/virology)
 "dSX" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/disposal/bin,
@@ -99363,6 +105250,8 @@
 /area/medical/virology)
 "dTa" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -99400,9 +105289,13 @@
 /area/medical/virology)
 "dTd" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
@@ -99410,6 +105303,8 @@
 /area/medical/virology)
 "dTe" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -99424,12 +105319,18 @@
 	req_access_txt = "39"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -99445,9 +105346,13 @@
 /area/medical/virology)
 "dTg" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -99459,6 +105364,8 @@
 /area/medical/virology)
 "dTh" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -99466,9 +105373,13 @@
 /area/medical/virology)
 "dTi" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/holopad,
@@ -99481,6 +105392,8 @@
 /area/medical/virology)
 "dTj" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -99491,9 +105404,13 @@
 "dTk" = (
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/folder/white,
@@ -99506,6 +105423,8 @@
 /area/medical/virology)
 "dTl" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -99530,6 +105449,8 @@
 	req_access_txt = "27"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -99634,6 +105555,7 @@
 /obj/structure/grille,
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -99642,6 +105564,7 @@
 "dTA" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
@@ -99651,6 +105574,7 @@
 "dTB" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white,
@@ -99659,6 +105583,8 @@
 /area/medical/virology)
 "dTC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -99684,6 +105610,8 @@
 /area/medical/virology)
 "dTF" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/sink{
@@ -99728,6 +105656,8 @@
 "dTJ" = (
 /obj/structure/table/glass,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/newscaster{
@@ -99794,6 +105724,8 @@
 "dTP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -99819,6 +105751,8 @@
 	pixel_y = 26
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -99834,6 +105768,7 @@
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel{
@@ -99843,6 +105778,8 @@
 /area/chapel/main)
 "dTU" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -99852,6 +105789,8 @@
 /area/chapel/main)
 "dTV" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -99861,6 +105800,8 @@
 /area/chapel/main)
 "dTW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -99959,6 +105900,8 @@
 /area/medical/virology)
 "dUh" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/table,
@@ -100013,6 +105956,8 @@
 "dUn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -100022,6 +105967,8 @@
 /area/maintenance/port/aft)
 "dUo" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -100029,6 +105976,8 @@
 "dUp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -100036,9 +105985,13 @@
 "dUq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/blue/side,
@@ -100046,6 +105999,8 @@
 "dUr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue/side,
@@ -100053,16 +106008,22 @@
 "dUs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dUt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue/side,
@@ -100070,6 +106031,8 @@
 "dUu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -100093,6 +106056,8 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -100275,6 +106240,7 @@
 "dUS" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/light/small{
@@ -100287,6 +106253,8 @@
 /area/maintenance/solars/port/aft)
 "dUT" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/camera{
@@ -100309,6 +106277,8 @@
 "dUV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -100371,6 +106341,8 @@
 	req_access_txt = "18"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
@@ -100418,6 +106390,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -100636,9 +106610,13 @@
 /area/maintenance/solars/port/aft)
 "dVB" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -100657,6 +106635,8 @@
 	req_access_txt = "10"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -100672,6 +106652,8 @@
 /area/maintenance/solars/port/aft)
 "dVD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -100708,6 +106690,8 @@
 /area/maintenance/port/aft)
 "dVI" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -100744,6 +106728,8 @@
 /area/chapel/office)
 "dVM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -100839,6 +106825,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dVW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -100989,6 +106977,8 @@
 /area/maintenance/port/aft)
 "dWo" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -101001,6 +106991,8 @@
 /area/maintenance/port/aft)
 "dWp" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -101047,6 +107039,8 @@
 /area/chapel/office)
 "dWt" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -101120,6 +107114,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dWC" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -101235,6 +107231,8 @@
 "dWR" = (
 /obj/structure/rack,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -101273,6 +107271,8 @@
 	req_access_txt = "27"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -101320,6 +107320,8 @@
 "dXa" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -101337,6 +107339,7 @@
 /area/security/checkpoint/checkpoint2)
 "dXb" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -101346,9 +107349,13 @@
 "dXc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -101361,6 +107368,7 @@
 /area/security/checkpoint/checkpoint2)
 "dXd" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -101374,9 +107382,11 @@
 /area/security/checkpoint/checkpoint2)
 "dXf" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -101387,9 +107397,13 @@
 "dXg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -101406,9 +107420,11 @@
 /area/security/checkpoint/checkpoint2)
 "dXh" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -101418,9 +107434,11 @@
 /area/security/checkpoint/checkpoint2)
 "dXi" = (
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -101429,6 +107447,7 @@
 /area/security/checkpoint/checkpoint2)
 "dXj" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -101557,6 +107576,8 @@
 "dXq" = (
 /obj/structure/rack,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -101666,6 +107687,8 @@
 /area/chapel/office)
 "dXv" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -101789,6 +107812,8 @@
 /area/security/checkpoint/checkpoint2)
 "dXH" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -101807,6 +107832,8 @@
 "dXJ" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/folder/red,
@@ -101842,6 +107869,8 @@
 /area/security/checkpoint/checkpoint2)
 "dXO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -101967,6 +107996,8 @@
 /area/maintenance/port/aft)
 "dYe" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -101977,9 +108008,13 @@
 /area/maintenance/port/aft)
 "dYf" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -101990,6 +108025,8 @@
 "dYg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -102000,9 +108037,13 @@
 "dYh" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -102010,6 +108051,8 @@
 /area/maintenance/port/aft)
 "dYi" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -102019,9 +108062,13 @@
 /area/maintenance/port/aft)
 "dYj" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -102032,6 +108079,8 @@
 /area/maintenance/port/aft)
 "dYk" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -102091,6 +108140,7 @@
 "dYs" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/light{
@@ -102112,9 +108162,13 @@
 /area/security/checkpoint/checkpoint2)
 "dYt" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -102126,9 +108180,13 @@
 "dYu" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -102139,15 +108197,21 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/security/checkpoint/checkpoint2)
 "dYw" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -102158,6 +108222,8 @@
 /area/security/checkpoint/checkpoint2)
 "dYx" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -102167,6 +108233,8 @@
 "dYy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -102183,6 +108251,8 @@
 /area/security/checkpoint/checkpoint2)
 "dYz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -102195,6 +108265,8 @@
 /area/security/checkpoint/checkpoint2)
 "dYA" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -102204,12 +108276,18 @@
 /area/security/checkpoint/checkpoint2)
 "dYB" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -102300,6 +108378,8 @@
 /area/maintenance/port/aft)
 "dYO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
@@ -102310,6 +108390,8 @@
 /area/maintenance/port/aft)
 "dYP" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -102337,6 +108419,8 @@
 /area/maintenance/port/aft)
 "dYS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -102345,6 +108429,8 @@
 /area/maintenance/port/aft)
 "dYT" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -102379,6 +108465,8 @@
 /area/chapel/office)
 "dYW" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -102393,6 +108481,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -102505,6 +108594,8 @@
 "dZj" = (
 /obj/machinery/computer/prisoner,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -102557,9 +108648,13 @@
 "dZp" = (
 /obj/structure/table,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/item/weapon/restraints/handcuffs,
@@ -102572,6 +108667,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side,
@@ -102581,6 +108678,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -102599,10 +108698,12 @@
 /area/security/checkpoint/checkpoint2)
 "dZs" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -102817,9 +108918,11 @@
 "dZS" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -102828,6 +108931,7 @@
 /area/security/checkpoint/checkpoint2)
 "dZT" = (
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -103501,6 +109605,8 @@
 /area/hallway/primary/central)
 "ebV" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/beacon,
@@ -103530,6 +109636,8 @@
 /area/maintenance/starboard/fore)
 "ebZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/ai_slipper{
@@ -103627,6 +109735,8 @@
 /area/hydroponics/garden/abandoned)
 "ecm" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -103674,6 +109784,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "ecu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -103686,6 +109798,8 @@
 /area/maintenance/port/fore)
 "ecv" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -103756,6 +109870,8 @@
 /area/crew_quarters/abandoned_gambling_den)
 "ecR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -103877,6 +109993,8 @@
 	req_access_txt = "39"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -104540,6 +110658,8 @@
 /area/security/transfer)
 "efG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security{
@@ -104608,9 +110728,13 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor/northright{
@@ -104632,6 +110756,8 @@
 /area/security/warden)
 "efM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/table/reinforced,
@@ -104653,6 +110779,8 @@
 /obj/item/clothing/under/rank/security/grey,
 /obj/item/clothing/under/rank/security/grey,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/item/weapon/storage/backpack/satchel/sec,
@@ -104821,6 +110949,8 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -105121,6 +111251,8 @@
 	dir = 9
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -105138,6 +111270,7 @@
 	name = "departures camera"
 	},
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -105196,6 +111329,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -105217,6 +111352,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "egM" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -105640,6 +111777,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -105768,9 +111907,13 @@
 /area/maintenance/solars/starboard/aft)
 "eip" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -105899,6 +112042,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -105918,16 +112062,21 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/starboard)
 "eiG" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -105937,6 +112086,7 @@
 "eiH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -105948,6 +112098,8 @@
 /area/maintenance/starboard/aft)
 "eiI" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -105961,12 +112113,15 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/aft)
 "eiK" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -106017,6 +112172,8 @@
 /area/hallway/secondary/command)
 "eiR" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -106032,6 +112189,8 @@
 /area/hallway/secondary/command)
 "eiS" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -106069,6 +112228,8 @@
 /area/crew_quarters/dorms)
 "eiZ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -106078,6 +112239,8 @@
 /area/crew_quarters/dorms)
 "eja" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -106099,6 +112262,8 @@
 /area/crew_quarters/dorms)
 "ejc" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -106269,6 +112434,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
@@ -108066,6 +114233,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -108133,6 +114302,8 @@
 "epm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -146478,7 +152649,7 @@ dEQ
 dGo
 ahA
 ahA
-dJd
+ahC
 dJY
 dKO
 ahA
@@ -148299,7 +154470,7 @@ dMY
 dRe
 dXj
 dXR
-dYE
+ahM
 dZs
 dZU
 aaf
@@ -153942,7 +160113,7 @@ dMh
 dJp
 dJr
 dJp
-dKq
+dJq
 dTz
 aaa
 aaa
@@ -155479,7 +161650,7 @@ dLa
 dMh
 aaf
 aaf
-dKq
+dJq
 dPJ
 dQy
 dRq
@@ -157025,7 +163196,7 @@ dKl
 dKl
 dOY
 dRw
-dKq
+dJq
 dTf
 dTE
 dKl
@@ -158815,7 +164986,7 @@ dHd
 dyq
 aaf
 aaf
-dKq
+dJq
 dLl
 dMs
 dNq

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -601,7 +601,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral,
@@ -743,7 +742,6 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/machinery/camera{
@@ -1168,7 +1166,6 @@
 /area/construction/mining/aux_base)
 "acq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -1359,7 +1356,6 @@
 "acM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -1368,7 +1364,6 @@
 /area/construction/mining/aux_base)
 "acN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/cable/white{
@@ -1745,7 +1740,6 @@
 "adH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -1773,7 +1767,6 @@
 /area/hallway/secondary/entry)
 "adK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -2117,7 +2110,6 @@
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -2130,7 +2122,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/yellow/side,
@@ -3006,7 +2997,6 @@
 /area/hallway/secondary/entry)
 "agx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/arrival{
@@ -3112,7 +3102,6 @@
 /area/hallway/secondary/entry)
 "agL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/arrival,
@@ -3253,7 +3242,6 @@
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/arrival,
@@ -3537,7 +3525,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
@@ -3551,7 +3538,6 @@
 	},
 /obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3565,7 +3551,6 @@
 "ahR" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red,
@@ -3573,7 +3558,6 @@
 "ahS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -3584,7 +3568,6 @@
 /area/maintenance/starboard/fore)
 "ahU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -3595,7 +3578,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
@@ -3604,7 +3586,6 @@
 "ahW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -3808,7 +3789,6 @@
 /area/security/checkpoint/checkpoint2)
 "aiy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -3850,7 +3830,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -4118,7 +4097,6 @@
 /area/security/vacantoffice)
 "ajg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/wood,
@@ -4857,7 +4835,6 @@
 /obj/structure/frame/computer,
 /obj/item/stack/cable_coil/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/wood,
@@ -6988,7 +6965,6 @@
 /obj/item/clothing/glasses/meson/engine,
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/bot,
@@ -7764,8 +7740,6 @@
 /area/engine/atmospherics_engine)
 "ara" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral,
@@ -7981,7 +7955,6 @@
 /area/crew_quarters/toilet/auxiliary)
 "arw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -8076,7 +8049,6 @@
 "arG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
@@ -8095,7 +8067,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
@@ -8364,7 +8335,6 @@
 /area/space)
 "asb" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
@@ -8372,7 +8342,6 @@
 /area/space)
 "asc" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -8381,7 +8350,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8413,7 +8381,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -8870,7 +8837,6 @@
 /area/quartermaster/storage)
 "atb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall,
@@ -8911,7 +8877,6 @@
 /area/space)
 "atg" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/lattice,
@@ -9140,7 +9105,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/item/weapon/grenade/chem_grenade/cleaner,
@@ -9467,7 +9431,6 @@
 /area/solar/port/fore)
 "auv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/space,
@@ -9548,7 +9511,6 @@
 "auD" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
@@ -9880,7 +9842,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
@@ -11018,7 +10979,6 @@
 /area/engine/atmospherics_engine)
 "axP" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
@@ -11041,7 +11001,6 @@
 /area/engine/supermatter)
 "axS" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/machinery/meter,
@@ -11091,7 +11050,6 @@
 /area/engine/atmospherics_engine)
 "axX" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -11105,7 +11063,6 @@
 "axY" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
@@ -11114,7 +11071,6 @@
 "axZ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/space,
@@ -11213,7 +11169,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
@@ -11721,7 +11676,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
@@ -11868,7 +11822,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
@@ -11946,7 +11899,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
@@ -12348,7 +12300,6 @@
 "aAD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/brown,
@@ -12356,7 +12307,6 @@
 "aAE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
@@ -12533,7 +12483,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12548,7 +12497,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12700,7 +12648,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/yellow,
@@ -13119,7 +13066,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -13141,7 +13087,6 @@
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -13158,7 +13103,6 @@
 /area/engine/atmospherics_engine)
 "aCg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/yellow,
@@ -13207,7 +13151,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/yellow,
@@ -14714,7 +14657,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -15155,7 +15097,6 @@
 "aFI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/loadingarea,
@@ -15165,7 +15106,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -15388,7 +15328,6 @@
 /area/maintenance/disposal/incinerator)
 "aGl" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/neutral,
@@ -15824,7 +15763,6 @@
 "aHh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/machinery/conveyor_switch/oneway{
@@ -15855,7 +15793,6 @@
 	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral,
@@ -16820,7 +16757,6 @@
 "aJf" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/space,
@@ -16828,7 +16764,6 @@
 "aJg" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/space,
@@ -16836,7 +16771,6 @@
 "aJh" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/space,
@@ -16844,7 +16778,6 @@
 "aJi" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/space,
@@ -17090,7 +17023,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating{
@@ -17406,7 +17338,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault,
@@ -17423,7 +17354,6 @@
 /area/engine/atmos)
 "aKu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -17432,7 +17362,6 @@
 /area/engine/atmos)
 "aKv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -17440,7 +17369,6 @@
 /area/engine/atmos)
 "aKw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -17455,21 +17383,18 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault,
 /area/engine/atmos)
 "aKy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault,
 /area/engine/atmos)
 "aKz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -17482,7 +17407,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -17490,7 +17414,6 @@
 /area/engine/atmos)
 "aKB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -17784,7 +17707,6 @@
 /area/quartermaster/storage)
 "aLn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -17792,7 +17714,6 @@
 /area/quartermaster/storage)
 "aLo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -17899,7 +17820,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -18045,7 +17965,6 @@
 /area/maintenance/disposal/incinerator)
 "aLT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -18183,7 +18102,6 @@
 /obj/item/weapon/electronics/firealarm,
 /obj/item/weapon/electronics/firealarm,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/caution{
@@ -18211,7 +18129,6 @@
 "aMf" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
@@ -19324,7 +19241,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/carpet,
@@ -19764,7 +19680,6 @@
 /obj/item/weapon/restraints/handcuffs,
 /obj/item/device/taperecorder,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/darkred/side{
@@ -19807,7 +19722,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/darkred/side{
@@ -19834,7 +19748,6 @@
 "aPf" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
@@ -20248,7 +20161,6 @@
 /area/crew_quarters/bar/atrium)
 "aPV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/carpet,
@@ -20273,7 +20185,6 @@
 "aPZ" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -20328,7 +20239,6 @@
 /obj/item/device/multitool,
 /obj/item/weapon/pen/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/brown{
@@ -20351,7 +20261,6 @@
 /area/quartermaster/office)
 "aQg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/brown{
@@ -20504,7 +20413,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
@@ -20895,7 +20803,6 @@
 "aRb" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20905,14 +20812,12 @@
 /area/engine/atmos)
 "aRc" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aRd" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -20920,7 +20825,6 @@
 /area/engine/atmos)
 "aRe" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -20928,7 +20832,6 @@
 /area/engine/atmos)
 "aRf" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -20944,14 +20847,12 @@
 /area/engine/atmos)
 "aRg" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/caution,
 /area/engine/atmos)
 "aRh" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -20960,7 +20861,6 @@
 /area/engine/atmos)
 "aRi" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -20968,7 +20868,6 @@
 /area/engine/atmos)
 "aRj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -21654,7 +21553,6 @@
 /obj/item/weapon/pen,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/red/side{
@@ -21704,7 +21602,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/darkred/side,
@@ -21717,7 +21614,6 @@
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkred/side{
@@ -22227,7 +22123,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -22640,7 +22535,6 @@
 /area/engine/atmos)
 "aUC" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -22673,7 +22567,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -23035,7 +22928,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -23406,7 +23298,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/red/side{
@@ -24046,7 +23937,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -24428,7 +24318,6 @@
 /area/engine/atmos)
 "aXW" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -25840,14 +25729,12 @@
 "baS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "baT" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -25873,7 +25760,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/vault{
@@ -26448,7 +26334,6 @@
 /area/engine/atmos)
 "bck" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/neutral,
@@ -27009,7 +26894,6 @@
 "bdt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
@@ -28024,7 +27908,6 @@
 /area/engine/atmos)
 "bfu" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -28036,7 +27919,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -28044,7 +27926,6 @@
 "bfw" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/space,
@@ -28871,7 +28752,6 @@
 /area/engine/atmos)
 "bgZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -28904,7 +28784,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -28927,7 +28806,6 @@
 "bhf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28936,7 +28814,6 @@
 /area/engine/atmos)
 "bhg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -28946,7 +28823,6 @@
 /area/engine/atmos)
 "bhh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
@@ -29204,7 +29080,6 @@
 /obj/item/clothing/suit/apron/chef,
 /obj/item/weapon/kitchen/rollingpin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/bot,
@@ -29764,7 +29639,6 @@
 /area/engine/atmos)
 "biU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/bot,
@@ -29780,7 +29654,6 @@
 /area/engine/atmos)
 "biW" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/bot,
@@ -29847,7 +29720,6 @@
 /area/engine/atmos)
 "bje" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -29885,7 +29757,6 @@
 	amount = 50
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/bot,
@@ -29905,7 +29776,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/bot,
@@ -29922,7 +29792,6 @@
 /area/engine/atmos)
 "bjl" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -29933,7 +29802,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -29941,7 +29809,6 @@
 "bjn" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/space,
@@ -30562,7 +30429,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -30577,7 +30443,6 @@
 /area/engine/atmos)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -30588,7 +30453,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/figure/atmos,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -30596,7 +30460,6 @@
 /area/engine/atmos)
 "bkC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -30610,7 +30473,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -30676,7 +30538,6 @@
 /area/hydroponics)
 "bkM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -30688,7 +30549,6 @@
 /area/hallway/primary/central)
 "bkN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/cable/white{
@@ -30922,7 +30782,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/delivery,
@@ -31347,7 +31206,6 @@
 /area/engine/atmos)
 "bma" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -31376,7 +31234,6 @@
 /area/engine/atmos)
 "bmd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/caution{
@@ -31412,7 +31269,6 @@
 /area/engine/atmos)
 "bmh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/effect/landmark/start/atmospheric_technician,
@@ -31424,7 +31280,6 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -31435,7 +31290,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
@@ -31495,7 +31349,6 @@
 /area/engine/atmos)
 "bmr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -31907,7 +31760,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral,
@@ -32258,7 +32110,6 @@
 	req_access_txt = "58"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/grimy,
@@ -32405,7 +32256,6 @@
 /area/engine/atmos)
 "boa" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -32470,7 +32320,6 @@
 /obj/item/weapon/storage/belt/utility,
 /obj/item/device/t_scanner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -32491,7 +32340,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -32517,7 +32365,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32582,7 +32429,6 @@
 /area/hallway/primary/port)
 "bos" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/cable/white{
@@ -32649,7 +32495,6 @@
 /area/hydroponics)
 "boB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -33367,7 +33212,6 @@
 "bpP" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/space,
@@ -33375,7 +33219,6 @@
 "bpQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/green/side{
@@ -33384,7 +33227,6 @@
 /area/engine/atmos)
 "bpR" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -33398,7 +33240,6 @@
 "bpS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -33412,7 +33253,6 @@
 /area/engine/atmos)
 "bpU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -33448,7 +33288,6 @@
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -33457,14 +33296,12 @@
 "bpY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "bpZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -33522,7 +33359,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -33539,7 +33375,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -33551,7 +33386,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -33563,7 +33397,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -33572,7 +33405,6 @@
 "bqh" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/bot,
@@ -34104,7 +33936,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34134,7 +33965,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -34157,7 +33987,6 @@
 /area/engine/atmos)
 "brp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -34170,7 +33999,6 @@
 /area/engine/atmos)
 "brq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
@@ -34645,7 +34473,6 @@
 "bst" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34842,7 +34669,6 @@
 /area/hallway/primary/port)
 "bsJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/cable/white{
@@ -35123,7 +34949,6 @@
 /area/security/nuke_storage)
 "bth" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/circuit/green,
@@ -35353,14 +35178,12 @@
 /area/engine/break_room)
 "btG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
 "btH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -35375,7 +35198,6 @@
 /area/engine/break_room)
 "btJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
@@ -35476,7 +35298,6 @@
 /area/engine/atmos)
 "btV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -35748,7 +35569,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/vault{
@@ -35973,7 +35793,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/circuit/green,
@@ -36042,7 +35861,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/circuit/green,
@@ -36296,7 +36114,6 @@
 /area/hallway/primary/port)
 "bvA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/cable/white{
@@ -36989,7 +36806,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/circuit/green,
@@ -37021,7 +36837,6 @@
 /area/engine/gravity_generator)
 "bwI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/vault{
@@ -37039,7 +36854,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -37053,7 +36867,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37069,7 +36882,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -37091,7 +36903,6 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/cable/white{
@@ -37288,7 +37099,6 @@
 	name = "Atmospherics Lockdown Blast door"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -37984,7 +37794,6 @@
 "byC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -37998,7 +37807,6 @@
 "byD" = (
 /obj/structure/sign/radiation,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -38024,7 +37832,6 @@
 /area/engine/gravity_generator)
 "byF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -38039,7 +37846,6 @@
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -38049,7 +37855,6 @@
 /area/engine/gravity_generator)
 "byH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall,
@@ -38061,7 +37866,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -38105,7 +37909,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -38124,7 +37927,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -38146,7 +37948,6 @@
 /area/engine/break_room)
 "byN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -38163,7 +37964,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -38171,7 +37971,6 @@
 /area/engine/break_room)
 "byP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -38190,7 +37989,6 @@
 /area/engine/break_room)
 "byR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -38212,7 +38010,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -38224,7 +38021,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -38240,7 +38036,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
@@ -38808,7 +38603,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -39256,7 +39050,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/delivery,
@@ -39273,7 +39066,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -39289,7 +39081,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -39306,7 +39097,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -39322,7 +39112,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -39357,7 +39146,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -39376,7 +39164,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -39405,7 +39192,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -39430,7 +39216,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -39440,7 +39225,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -39472,7 +39256,6 @@
 /area/engine/break_room)
 "bAJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
@@ -39495,7 +39278,6 @@
 /area/hallway/primary/port)
 "bAM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -40148,7 +39930,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -40157,7 +39938,6 @@
 "bBW" = (
 /obj/structure/sign/radiation,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -40167,7 +39947,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -40192,7 +39971,6 @@
 /obj/structure/closet/radiation,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/machinery/light/small,
@@ -40295,7 +40073,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -40318,7 +40095,6 @@
 /area/engine/break_room)
 "bCm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -40340,7 +40116,6 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -40352,7 +40127,6 @@
 /area/engine/break_room)
 "bCo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -40654,7 +40428,6 @@
 /obj/structure/table/wood,
 /obj/item/device/taperecorder,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/grimy,
@@ -40692,7 +40465,6 @@
 /obj/item/weapon/folder/blue,
 /obj/item/weapon/pen,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/grimy,
@@ -40995,7 +40767,6 @@
 /area/ai_monitored/turret_protected/ai)
 "bDE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -41010,7 +40781,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -41021,7 +40791,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -41041,7 +40810,6 @@
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -41052,7 +40820,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41325,7 +41092,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/neutral,
@@ -41785,7 +41551,6 @@
 "bFf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
@@ -41986,7 +41751,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/machinery/power/apc{
@@ -42106,7 +41870,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
@@ -42129,7 +41892,6 @@
 	req_access_txt = "56"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -42146,7 +41908,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -42160,7 +41921,6 @@
 	name = "Chief's Lockdown Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -42176,7 +41936,6 @@
 /area/engine/break_room)
 "bFO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -42187,7 +41946,6 @@
 /area/engine/break_room)
 "bFP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/sortjunction{
@@ -42218,7 +41976,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -42228,7 +41985,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -42236,7 +41992,6 @@
 /area/engine/break_room)
 "bFV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -42247,7 +42002,6 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -42257,7 +42011,6 @@
 "bFX" = (
 /obj/structure/sign/securearea,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall,
@@ -42767,7 +42520,6 @@
 /area/security/brig)
 "bHc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/bed,
@@ -42837,7 +42589,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/vault{
@@ -42863,7 +42614,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
@@ -42936,7 +42686,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -42952,7 +42701,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/vault{
@@ -43029,21 +42777,18 @@
 /area/crew_quarters/heads/chief)
 "bHC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/crew_quarters/heads/chief)
 "bHD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side,
 /area/crew_quarters/heads/chief)
 "bHE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -43080,7 +42825,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -43100,7 +42844,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -43116,7 +42859,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -43127,7 +42869,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -43143,7 +42884,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
@@ -43169,7 +42909,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -43224,7 +42963,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -43486,14 +43224,12 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bIr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/machinery/camera{
@@ -43516,7 +43252,6 @@
 /area/tcommsat/computer)
 "bIt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/grimy,
@@ -43527,7 +43262,6 @@
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/grimy,
@@ -43702,7 +43436,6 @@
 "bIP" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/grimy,
@@ -43772,7 +43505,6 @@
 /area/security/detectives_office)
 "bIW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/machinery/light/small{
@@ -43963,7 +43695,6 @@
 "bJl" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -43984,7 +43715,6 @@
 /area/ai_monitored/turret_protected/ai)
 "bJn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/machinery/camera/motion{
@@ -44074,7 +43804,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/space,
@@ -44085,7 +43814,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/space,
@@ -44130,7 +43858,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
@@ -44553,7 +44280,6 @@
 /area/tcommsat/computer)
 "bKz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/grimy,
@@ -44724,7 +44450,6 @@
 /area/security/detectives_office)
 "bKS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/vault{
@@ -45484,7 +45209,6 @@
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/wood,
@@ -45516,7 +45240,6 @@
 /area/crew_quarters/heads/captain)
 "bMH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/wood,
@@ -46005,7 +45728,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/space,
@@ -46016,7 +45738,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/space,
@@ -46797,7 +46518,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -46859,7 +46579,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/vault{
@@ -47028,7 +46747,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/transit_tube/curved,
@@ -47163,7 +46881,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -47186,7 +46903,6 @@
 	req_access_txt = "56"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -47202,7 +46918,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -47214,7 +46929,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -47228,7 +46942,6 @@
 	},
 /obj/effect/landmark/start/chief_engineer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -47295,7 +47008,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47306,7 +47018,6 @@
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
@@ -47320,7 +47031,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/button/door{
@@ -47340,7 +47050,6 @@
 /area/security/checkpoint/engineering)
 "bPT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
@@ -47935,7 +47644,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/machinery/light{
@@ -48168,7 +47876,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
@@ -48455,7 +48162,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
@@ -49129,7 +48835,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/disposalpipe/sortjunction{
@@ -49353,7 +49058,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/bot,
@@ -49405,7 +49109,6 @@
 "bTz" = (
 /obj/structure/sign/nosmoking_2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -49831,7 +49534,6 @@
 /area/security/checkpoint/engineering)
 "bUn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -50407,7 +50109,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -50763,7 +50464,6 @@
 /area/hallway/primary/port)
 "bWe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/cable/white{
@@ -50773,7 +50473,6 @@
 /area/hallway/primary/port)
 "bWf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/closet/emcloset,
@@ -51272,7 +50971,6 @@
 "bXk" = (
 /obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -51427,7 +51125,6 @@
 "bXz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
@@ -51440,7 +51137,6 @@
 /area/engine/engineering)
 "bXA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -51458,7 +51154,6 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -51525,7 +51220,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -51926,7 +51620,6 @@
 "bYu" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/grimy,
@@ -52373,7 +52066,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/cable/white{
@@ -52397,7 +52089,6 @@
 	req_access_txt = "32"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -52414,7 +52105,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -52432,7 +52122,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -52458,7 +52147,6 @@
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/cable{
@@ -52675,7 +52363,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/circuit{
@@ -52689,7 +52376,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -52719,7 +52405,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -52740,7 +52425,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/circuit/green{
@@ -52770,7 +52454,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/circuit{
@@ -53237,7 +52920,6 @@
 /area/security/brig)
 "caS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/red/side{
@@ -53287,7 +52969,6 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "caY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/circuit/green,
@@ -53312,7 +52993,6 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "cbb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/circuit/green,
@@ -53375,7 +53055,6 @@
 /area/engine/engineering)
 "cbi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -53385,7 +53064,6 @@
 /area/engine/engineering)
 "cbj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -53402,7 +53080,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -53426,7 +53103,6 @@
 /area/engine/engineering)
 "cbm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -53439,7 +53115,6 @@
 /area/engine/engineering)
 "cbn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -53463,7 +53138,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -53732,7 +53406,6 @@
 	},
 /obj/item/weapon/reagent_containers/food/drinks/flask/gold,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/item/weapon/razor,
@@ -53774,7 +53447,6 @@
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/machinery/camera{
@@ -53877,7 +53549,6 @@
 /area/security/courtroom)
 "ccf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -53996,7 +53667,6 @@
 /area/security/brig)
 "ccp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/neutral,
@@ -54240,7 +53910,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/circuit/green,
@@ -54279,7 +53948,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
@@ -54757,7 +54425,6 @@
 /obj/structure/table/wood,
 /obj/item/weapon/paper_bin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/blue/side{
@@ -55424,7 +55091,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
@@ -55589,7 +55255,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -55610,7 +55275,6 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -56946,7 +56610,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/disposalpipe/junction{
@@ -57592,7 +57255,6 @@
 /area/teleporter)
 "cjI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral,
@@ -57640,7 +57302,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/junction{
@@ -57732,7 +57393,6 @@
 /area/security/courtroom)
 "cjV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -57770,7 +57430,6 @@
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -58167,7 +57826,6 @@
 	},
 /obj/effect/landmark/start/librarian,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/carpet,
@@ -58656,7 +58314,6 @@
 /area/engine/engineering)
 "clX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -58670,7 +58327,6 @@
 	name = "Engineering Secure Storage Lockdown"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -58684,7 +58340,6 @@
 "clZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -58696,7 +58351,6 @@
 /obj/machinery/shieldgen,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -58705,7 +58359,6 @@
 "cmb" = (
 /obj/machinery/field/generator,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -58715,7 +58368,6 @@
 /obj/machinery/field/generator,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/bot,
@@ -59428,7 +59080,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral,
@@ -59783,7 +59434,6 @@
 /area/crew_quarters/locker)
 "cos" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -59801,7 +59451,6 @@
 /area/crew_quarters/locker)
 "cou" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/item/weapon/storage/pod{
@@ -59997,7 +59646,6 @@
 /area/engine/engineering)
 "coS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -60014,7 +59662,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -60023,7 +59670,6 @@
 "coU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -60038,7 +59684,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -61874,7 +61519,6 @@
 /obj/structure/table,
 /obj/item/toy/cards/deck,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/neutral,
@@ -61898,7 +61542,6 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/closet/wardrobe/black,
@@ -61918,7 +61561,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
@@ -61984,7 +61626,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
@@ -62227,7 +61868,6 @@
 /obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -62235,14 +61875,12 @@
 "cts" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "ctt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -62289,7 +61927,6 @@
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/librarian,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -62354,7 +61991,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -62365,7 +62001,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -62386,7 +62021,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -62398,7 +62032,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -62494,7 +62127,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -62505,7 +62137,6 @@
 "ctV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -62748,7 +62379,6 @@
 /area/crew_quarters/locker)
 "cuq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/junction,
@@ -62765,7 +62395,6 @@
 "cus" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -62884,7 +62513,6 @@
 /area/crew_quarters/fitness/recreation)
 "cuG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -63513,7 +63141,6 @@
 /area/crew_quarters/fitness/recreation)
 "cvW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/neutral,
@@ -63621,14 +63248,12 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
 "cwi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/power/port_gen/pacman,
@@ -63637,14 +63262,12 @@
 /area/engine/storage)
 "cwj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/storage)
 "cwk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/yellow,
@@ -64592,7 +64215,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/grimy,
@@ -64603,28 +64225,24 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cyb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cyc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
 "cyd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -64638,14 +64256,12 @@
 /area/library)
 "cye" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall,
 /area/library)
 "cyf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -64653,7 +64269,6 @@
 "cyg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -65168,7 +64783,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -65192,7 +64806,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -65250,7 +64863,6 @@
 "czp" = (
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -65262,7 +64874,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -65279,7 +64890,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -65290,7 +64900,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -65301,7 +64910,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -65311,7 +64919,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/yellow,
@@ -65429,7 +65036,6 @@
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -65507,7 +65113,6 @@
 /area/library)
 "czM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
@@ -66497,7 +66102,6 @@
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/bot,
@@ -66511,7 +66115,6 @@
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/bot,
@@ -66806,7 +66409,6 @@
 /area/engine/engineering)
 "cCu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -66814,7 +66416,6 @@
 /area/engine/engineering)
 "cCv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -66839,7 +66440,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -66852,7 +66452,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/item/clothing/head/cone,
@@ -66866,7 +66465,6 @@
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -67417,7 +67015,6 @@
 "cDE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -67746,7 +67343,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -67966,7 +67562,6 @@
 	name = "Holodeck Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -67982,7 +67577,6 @@
 	name = "Holodeck Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -68055,7 +67649,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -68069,7 +67662,6 @@
 /obj/item/device/flashlight,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -68082,7 +67674,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -68093,7 +67684,6 @@
 "cER" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -68103,7 +67693,6 @@
 /area/maintenance/port)
 "cES" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -68117,7 +67706,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -68142,7 +67730,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -68152,7 +67739,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -68163,7 +67749,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -68176,7 +67761,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -68193,7 +67777,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -68476,7 +68059,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
@@ -68838,7 +68420,6 @@
 "cFV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/table,
@@ -68978,7 +68559,6 @@
 "cGp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -68987,14 +68567,12 @@
 /area/maintenance/port)
 "cGq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cGr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -69002,7 +68580,6 @@
 "cGs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -69019,7 +68596,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -69028,7 +68604,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -69036,7 +68611,6 @@
 "cGw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -69057,7 +68631,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -69067,7 +68640,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -69080,7 +68652,6 @@
 	name = "2maintenance loot spawner"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -69091,7 +68662,6 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -69111,7 +68681,6 @@
 "cGD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -69129,7 +68698,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -69419,7 +68987,6 @@
 /area/maintenance/starboard/aft)
 "cHl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -69443,7 +69010,6 @@
 /area/crew_quarters/dorms)
 "cHo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -69731,7 +69297,6 @@
 /area/maintenance/department/electrical)
 "cHP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /mob/living/simple_animal/cockroach,
@@ -70200,7 +69765,6 @@
 	name = "Holodeck Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -70216,7 +69780,6 @@
 	name = "Holodeck Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -70467,7 +70030,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/delivery,
@@ -70516,7 +70078,6 @@
 "cJF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -70942,7 +70503,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -71015,7 +70575,6 @@
 "cKJ" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -71326,7 +70885,6 @@
 /area/science/xenobiology)
 "cLp" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -71337,7 +70895,6 @@
 /area/science/xenobiology)
 "cLq" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
@@ -71577,7 +71134,6 @@
 /area/medical/storage)
 "cLZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/cmo,
@@ -71609,7 +71165,6 @@
 "cMc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/delivery,
@@ -71651,7 +71206,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
@@ -71727,7 +71281,6 @@
 /area/maintenance/port)
 "cMr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/machinery/light/small{
@@ -71798,14 +71351,12 @@
 "cMA" = (
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
 /area/maintenance/department/electrical)
 "cMB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/cable/white{
@@ -71815,7 +71366,6 @@
 /area/maintenance/department/electrical)
 "cMC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/neutral,
@@ -72169,7 +71719,6 @@
 /area/science/research)
 "cNj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
@@ -72339,7 +71888,6 @@
 /area/medical/medbay/central)
 "cND" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -72773,7 +72321,6 @@
 "cOx" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/bot,
@@ -72993,7 +72540,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/red/side{
@@ -73039,7 +72585,6 @@
 /area/science/research)
 "cOX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
@@ -73264,7 +72809,6 @@
 /area/medical/medbay/central)
 "cPu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
@@ -73338,7 +72882,6 @@
 /area/security/checkpoint/medical)
 "cPC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -73585,7 +73128,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -73609,7 +73151,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -73990,7 +73531,6 @@
 /area/security/checkpoint/science/research)
 "cQN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/red/side{
@@ -74871,7 +74411,6 @@
 	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral,
@@ -74908,7 +74447,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -75112,7 +74650,6 @@
 /area/crew_quarters/fitness/recreation)
 "cTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -75348,7 +74885,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/purple,
@@ -75668,7 +75204,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/red/side,
@@ -75999,7 +75534,6 @@
 /area/crew_quarters/fitness/recreation)
 "cUT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -76094,7 +75628,6 @@
 /area/science/xenobiology)
 "cVe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -76289,7 +75822,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -76303,7 +75835,6 @@
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
@@ -76617,7 +76148,6 @@
 /obj/machinery/holopad,
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/redblue,
@@ -76744,7 +76274,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/purple/side{
@@ -76761,7 +76290,6 @@
 /area/maintenance/port)
 "cWB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -76772,7 +76300,6 @@
 "cWC" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -76783,7 +76310,6 @@
 "cWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -76799,7 +76325,6 @@
 "cWF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -76810,7 +76335,6 @@
 /area/maintenance/port)
 "cWG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/light/small{
@@ -76823,7 +76347,6 @@
 /area/maintenance/port)
 "cWH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -76838,7 +76361,6 @@
 /area/maintenance/port)
 "cWI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -76849,7 +76371,6 @@
 "cWJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -76862,7 +76383,6 @@
 /area/maintenance/port)
 "cWK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -76877,7 +76397,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -76889,7 +76408,6 @@
 "cWM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -77111,7 +76629,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/whitepurple/side,
@@ -77688,7 +77205,6 @@
 /area/maintenance/port)
 "cYs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -78248,7 +77764,6 @@
 "cZK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -78256,7 +77771,6 @@
 "cZL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -78270,7 +77784,6 @@
 	name = "3maintenance loot spawner"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -78282,7 +77795,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -78295,14 +77807,12 @@
 	name = "2maintenance loot spawner"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cZP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -78892,7 +78402,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -78902,7 +78411,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -78914,7 +78422,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -78925,7 +78432,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -78935,7 +78441,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -78946,7 +78451,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -78956,7 +78460,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -79021,7 +78524,6 @@
 /area/science/research)
 "dbl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -79183,7 +78685,6 @@
 /area/science/lab)
 "dbA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -79295,7 +78796,6 @@
 /area/medical/chemistry)
 "dbN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
@@ -79563,7 +79063,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/vault{
@@ -79572,14 +79071,12 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dcv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dcw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -79594,7 +79091,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -79604,7 +79100,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -79617,7 +79112,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -79632,7 +79126,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /mob/living/simple_animal/cockroach,
@@ -79649,7 +79142,6 @@
 "dcC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/vault{
@@ -80217,7 +79709,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -80319,7 +79810,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -80327,7 +79817,6 @@
 "deh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -80335,7 +79824,6 @@
 "dei" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -80425,7 +79913,6 @@
 /area/science/explab)
 "deu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -80434,14 +79921,12 @@
 /area/science/research)
 "dev" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/research)
 "dew" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -80449,7 +79934,6 @@
 /area/science/research)
 "dex" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -80584,7 +80068,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -81173,7 +80656,6 @@
 "dfU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -82819,7 +82301,6 @@
 /area/science/misc_lab/range)
 "djq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
@@ -82896,7 +82377,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -82915,7 +82395,6 @@
 	name = "Research Director's Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -83425,7 +82904,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -83436,7 +82914,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -83449,7 +82926,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -83461,7 +82937,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/barricade/wooden,
@@ -83487,7 +82962,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/girder,
@@ -83530,7 +83004,6 @@
 /area/maintenance/port)
 "dkN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -83768,7 +83241,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -85150,7 +84622,6 @@
 	name = "medbay camera"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -85172,7 +84643,6 @@
 "dot" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/neutral,
@@ -85439,7 +84909,6 @@
 /area/maintenance/port)
 "doW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -85483,7 +84952,6 @@
 /area/science/explab)
 "dpc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -85626,7 +85094,6 @@
 /area/science/research)
 "dpr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -85637,7 +85104,6 @@
 /area/science/research)
 "dps" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -85648,7 +85114,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -85657,7 +85122,6 @@
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -86289,7 +85753,6 @@
 /area/science/mixing)
 "dqF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -86302,7 +85765,6 @@
 /area/science/mixing)
 "dqH" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -86791,7 +86253,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/cmo,
@@ -86807,7 +86268,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/cmo,
@@ -87456,7 +86916,6 @@
 /obj/machinery/holopad,
 /obj/effect/landmark/start/geneticist,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
@@ -87792,14 +87251,12 @@
 /area/science/research/abandoned)
 "dtC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
 /area/science/research/abandoned)
 "dtD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -87809,7 +87266,6 @@
 /area/science/research/abandoned)
 "dtE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -87817,7 +87273,6 @@
 /area/science/research/abandoned)
 "dtF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/barricade/wooden,
@@ -87839,7 +87294,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -87849,7 +87303,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -87862,7 +87315,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -87874,7 +87326,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -87884,7 +87335,6 @@
 "dtK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -88388,7 +87838,6 @@
 /area/science/research/abandoned)
 "duJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -88433,7 +87882,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/neutral,
@@ -88533,7 +87981,6 @@
 	},
 /obj/effect/landmark/start/research_director,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/purple,
@@ -88799,7 +88246,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
@@ -88946,7 +88392,6 @@
 "dvN" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -89081,7 +88526,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -89556,7 +89000,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -89634,7 +89077,6 @@
 /area/maintenance/starboard/aft)
 "dxj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -89808,7 +89250,6 @@
 /area/science/mixing)
 "dxA" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -89882,7 +89323,6 @@
 /area/science/research)
 "dxH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -89899,7 +89339,6 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -89915,7 +89354,6 @@
 /area/science/robotics/lab)
 "dxJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -89931,7 +89369,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -89942,7 +89379,6 @@
 /area/science/robotics/lab)
 "dxL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -89957,7 +89393,6 @@
 "dxN" = (
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -90908,7 +90343,6 @@
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -91635,7 +91069,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -91677,7 +91110,6 @@
 "dBt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -91701,7 +91133,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -91827,7 +91258,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/neutral,
@@ -91948,7 +91378,6 @@
 /area/crew_quarters/heads/cmo)
 "dBU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -92103,7 +91532,6 @@
 /area/science/mixing)
 "dCn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -92297,7 +91725,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -92310,7 +91737,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/cable/white{
@@ -92952,7 +92378,6 @@
 /obj/item/clothing/head/hardhat/red,
 /obj/item/clothing/mask/gas,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/bot,
@@ -92979,7 +92404,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -92988,7 +92412,6 @@
 "dDY" = (
 /obj/structure/sign/securearea,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -92998,7 +92421,6 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -93012,7 +92434,6 @@
 /area/science/storage)
 "dEa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/bot,
@@ -93045,7 +92466,6 @@
 "dEe" = (
 /obj/machinery/r_n_d/server/core,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/circuit/green{
@@ -93064,7 +92484,6 @@
 "dEg" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/circuit/green{
@@ -93357,7 +92776,6 @@
 "dEJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -93713,7 +93131,6 @@
 "dFq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -94494,7 +93911,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -94656,7 +94072,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -94708,7 +94123,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -94984,7 +94398,6 @@
 /area/maintenance/port/aft)
 "dIc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/cable/white{
@@ -95139,7 +94552,6 @@
 "dIt" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/dr_gibb,
@@ -96222,7 +95634,6 @@
 /area/hallway/primary/aft)
 "dKQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
@@ -96280,7 +95691,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -96382,7 +95792,6 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -96466,7 +95875,6 @@
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/medical,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/vault,
@@ -96571,7 +95979,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -97519,7 +96926,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/neutral,
@@ -98359,7 +97765,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dPv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
@@ -98817,7 +98222,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -99177,7 +98581,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
@@ -99334,7 +98737,6 @@
 /obj/item/weapon/folder,
 /obj/item/weapon/pen,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/wood,
@@ -99383,7 +98785,6 @@
 /area/library/abandoned)
 "dRJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/black,
@@ -99662,7 +99063,6 @@
 /area/medical/virology)
 "dSp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -99681,7 +99081,6 @@
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -99868,7 +99267,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dSQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -100044,7 +99442,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/whitegreen/corner,
@@ -100116,7 +99513,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/green,
@@ -100381,7 +99777,6 @@
 "dTK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -100431,7 +99826,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -100586,7 +99980,6 @@
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -100602,7 +99995,6 @@
 /obj/item/weapon/wrench,
 /obj/item/weapon/restraints/handcuffs,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
@@ -100713,7 +100105,6 @@
 /area/maintenance/port/aft)
 "dUv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/machinery/button/crematorium{
@@ -100750,7 +100141,6 @@
 /area/chapel/main)
 "dUy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel{
@@ -101120,7 +100510,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dVm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -101130,7 +100519,6 @@
 /area/medical/virology)
 "dVn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
@@ -101316,7 +100704,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -101454,7 +100841,6 @@
 /area/chapel/main)
 "dVT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/delivery,
@@ -101648,7 +101034,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -101722,7 +101107,6 @@
 /obj/machinery/holopad,
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/machinery/camera{
@@ -101749,7 +101133,6 @@
 /area/chapel/main)
 "dWA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -101809,7 +101192,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dWG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -102362,7 +101744,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/black,
@@ -102846,7 +102227,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -103417,7 +102797,6 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -103428,7 +102807,6 @@
 	},
 /obj/effect/landmark/start/chaplain,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/carpet,
@@ -104167,7 +103545,6 @@
 /area/maintenance/starboard/fore)
 "ebX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red,
@@ -104175,7 +103552,6 @@
 "ebY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
@@ -104413,7 +103789,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -105706,7 +105081,6 @@
 /obj/item/weapon/storage/toolbox/electrical,
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -108847,7 +108221,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/highpressure/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -108905,7 +108278,6 @@
 /area/engine/atmospherics_engine)
 "epA" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 1
 	},
 /turf/closed/wall/r_wall,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -8461,7 +8461,7 @@
 /area/engine/atmospherics_engine)
 "asq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plasteel/yellow,
 /area/engine/atmospherics_engine)
@@ -11029,7 +11029,7 @@
 /obj/machinery/meter,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmospherics_engine)
@@ -11046,7 +11046,7 @@
 /area/engine/atmospherics_engine)
 "axX" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -11059,7 +11059,7 @@
 "axY" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
 /turf/open/floor/plating,
@@ -11625,7 +11625,7 @@
 "azj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/yellow,
 /area/engine/atmospherics_engine)
@@ -12115,7 +12115,7 @@
 /area/engine/atmospherics_engine)
 "aAg" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmospherics_engine)
@@ -12477,7 +12477,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
@@ -12491,7 +12491,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
@@ -16758,14 +16758,14 @@
 "aJg" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/space,
 /area/space)
 "aJh" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/space,
 /area/space)
@@ -17348,7 +17348,7 @@
 /area/engine/atmos)
 "aKu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 10
@@ -17356,14 +17356,14 @@
 /area/engine/atmos)
 "aKv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aKw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 6
@@ -17377,19 +17377,19 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault,
 /area/engine/atmos)
 "aKy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault,
 /area/engine/atmos)
 "aKz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault{
@@ -17401,14 +17401,14 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aKB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault{
@@ -18962,7 +18962,7 @@
 /area/engine/atmos)
 "aNT" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -20741,7 +20741,7 @@
 	opened = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
@@ -20795,7 +20795,7 @@
 "aRb" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -20804,27 +20804,27 @@
 /area/engine/atmos)
 "aRc" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aRd" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aRe" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution,
 /area/engine/atmos)
 "aRf" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 1;
@@ -20839,13 +20839,13 @@
 /area/engine/atmos)
 "aRg" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/caution,
 /area/engine/atmos)
 "aRh" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -20853,14 +20853,14 @@
 /area/engine/atmos)
 "aRi" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aRj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -23563,7 +23563,6 @@
 /obj/machinery/meter,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple";
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -24974,6 +24973,7 @@
 "aZp" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
+	
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -25716,9 +25716,7 @@
 /area/engine/atmos)
 "baS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "baT" = (
@@ -27894,7 +27892,7 @@
 /area/engine/atmos)
 "bfu" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/vault{
@@ -28770,7 +28768,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral,
@@ -28792,7 +28790,7 @@
 "bhf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line,
@@ -28800,7 +28798,7 @@
 /area/engine/atmos)
 "bhg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -29652,7 +29650,7 @@
 /area/engine/atmos)
 "biY" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
+	dir = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -29676,7 +29674,7 @@
 /area/engine/atmos)
 "bjb" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 1
@@ -29704,7 +29702,7 @@
 /area/engine/atmos)
 "bje" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -29719,7 +29717,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral,
@@ -30364,7 +30362,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
+	dir = 8
 	},
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -30425,7 +30423,7 @@
 /area/engine/atmos)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -30435,14 +30433,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/figure/atmos,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bkC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30454,9 +30452,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	on = 1
@@ -31251,7 +31247,7 @@
 /area/engine/atmos)
 "bmh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1
+	dir = 2
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel/neutral,
@@ -31262,7 +31258,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -32292,7 +32288,7 @@
 "bof" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -32301,7 +32297,7 @@
 /obj/item/weapon/storage/belt/utility,
 /obj/item/device/t_scanner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -32321,7 +32317,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral,
@@ -32346,7 +32342,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -33199,7 +33195,7 @@
 "bpQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/green/side{
 	dir = 10
@@ -33207,7 +33203,7 @@
 /area/engine/atmos)
 "bpR" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
@@ -33220,7 +33216,7 @@
 "bpS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -33267,22 +33263,20 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bpY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "bpZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -33355,7 +33349,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -33366,7 +33360,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -33377,7 +33371,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -33945,7 +33939,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33967,7 +33961,7 @@
 /area/engine/atmos)
 "brp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35164,7 +35158,7 @@
 /area/engine/break_room)
 "btH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
@@ -36834,7 +36828,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
@@ -36847,7 +36841,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -36862,7 +36856,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -37774,7 +37768,7 @@
 "byC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -37787,7 +37781,7 @@
 "byD" = (
 /obj/structure/sign/radiation,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
@@ -37812,7 +37806,7 @@
 /area/engine/gravity_generator)
 "byF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -37826,7 +37820,7 @@
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -37835,7 +37829,7 @@
 /area/engine/gravity_generator)
 "byH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall,
 /area/engine/break_room)
@@ -37846,7 +37840,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/break_room)
@@ -37889,7 +37883,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/break_room)
@@ -37907,7 +37901,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -37928,7 +37922,7 @@
 /area/engine/break_room)
 "byN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -37944,14 +37938,14 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "byP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/side{
@@ -37969,7 +37963,7 @@
 /area/engine/break_room)
 "byR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
@@ -37990,7 +37984,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
@@ -38001,7 +37995,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/caution{
@@ -38583,7 +38577,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -39046,7 +39040,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -39061,7 +39055,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -39077,7 +39071,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -39092,7 +39086,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -39126,7 +39120,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -39144,7 +39138,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -39172,7 +39166,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -39196,7 +39190,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/break_room)
@@ -39205,7 +39199,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/break_room)
@@ -39910,7 +39904,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -39918,7 +39912,7 @@
 "bBW" = (
 /obj/structure/sign/radiation,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
@@ -39927,7 +39921,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -40053,7 +40047,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40075,7 +40069,7 @@
 /area/engine/break_room)
 "bCm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40096,7 +40090,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40107,7 +40101,7 @@
 /area/engine/break_room)
 "bCo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40761,7 +40755,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
@@ -40771,7 +40765,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Gravity Generator";
@@ -40790,7 +40784,7 @@
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -41872,7 +41866,7 @@
 	req_access_txt = "56"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41888,7 +41882,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41901,7 +41895,7 @@
 	name = "Chief's Lockdown Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41916,7 +41910,7 @@
 /area/engine/break_room)
 "bFO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41956,7 +41950,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/break_room)
@@ -41965,14 +41959,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bFV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/break_room)
@@ -41982,7 +41976,7 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
@@ -41991,7 +41985,7 @@
 "bFX" = (
 /obj/structure/sign/securearea,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall,
 /area/engine/break_room)
@@ -42763,13 +42757,13 @@
 /area/crew_quarters/heads/chief)
 "bHD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side,
 /area/crew_quarters/heads/chief)
 "bHE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner{
@@ -42805,7 +42799,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42824,7 +42818,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42839,7 +42833,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -42849,7 +42843,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -42889,7 +42883,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46883,7 +46877,7 @@
 	req_access_txt = "56"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -46898,7 +46892,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -46909,7 +46903,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/chief)
@@ -46922,7 +46916,7 @@
 	},
 /obj/effect/landmark/start/chief_engineer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/chief)
@@ -51117,7 +51111,7 @@
 /area/engine/engineering)
 "bXA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51134,7 +51128,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51200,7 +51194,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52068,7 +52062,7 @@
 	req_access_txt = "32"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52084,7 +52078,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -52101,7 +52095,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -53043,7 +53037,7 @@
 /area/engine/engineering)
 "cbj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -53059,7 +53053,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -53082,7 +53076,7 @@
 /area/engine/engineering)
 "cbm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -53094,7 +53088,7 @@
 /area/engine/engineering)
 "cbn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -53117,7 +53111,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -58293,7 +58287,7 @@
 /area/engine/engineering)
 "clX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -58306,7 +58300,7 @@
 	name = "Engineering Secure Storage Lockdown"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -58319,7 +58313,7 @@
 "clZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -58330,7 +58324,7 @@
 /obj/machinery/shieldgen,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -58338,7 +58332,7 @@
 "cmb" = (
 /obj/machinery/field/generator,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -59625,7 +59619,7 @@
 /area/engine/engineering)
 "coS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -59641,7 +59635,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
@@ -59649,7 +59643,7 @@
 "coU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -59663,7 +59657,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61847,20 +61841,20 @@
 /obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cts" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "ctt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -63227,13 +63221,13 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
 "cwi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/bot,
@@ -63241,7 +63235,7 @@
 /area/engine/storage)
 "cwj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/storage)
@@ -64204,7 +64198,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
@@ -64216,13 +64210,13 @@
 /area/library)
 "cyc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
 "cyd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
@@ -64842,7 +64836,7 @@
 "czp" = (
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral,
@@ -64853,7 +64847,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -64869,7 +64863,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
@@ -64879,7 +64873,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -64889,7 +64883,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/storage)
@@ -66395,7 +66389,7 @@
 /area/engine/engineering)
 "cCv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -66419,7 +66413,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -66431,7 +66425,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/item/clothing/head/cone,
 /obj/item/clothing/head/cone,
@@ -67641,7 +67635,7 @@
 /obj/item/device/flashlight,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1;
@@ -67653,7 +67647,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1;
@@ -67663,7 +67657,7 @@
 "cER" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1;
@@ -67672,7 +67666,7 @@
 /area/maintenance/port)
 "cES" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1;
@@ -67685,7 +67679,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1;
@@ -67709,7 +67703,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -67728,7 +67722,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1;
@@ -67740,7 +67734,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1;
@@ -67756,7 +67750,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -68575,7 +68569,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -68610,7 +68604,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side,
 /area/maintenance/port)
@@ -68619,7 +68613,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -68631,7 +68625,7 @@
 	name = "2maintenance loot spawner"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side,
 /area/maintenance/port)
@@ -68641,7 +68635,7 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side,
 /area/maintenance/port)
@@ -68660,7 +68654,7 @@
 "cGD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -71329,7 +71323,7 @@
 "cMA" = (
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/maintenance/department/electrical)
@@ -76268,7 +76262,7 @@
 /area/maintenance/port)
 "cWB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1;
@@ -76278,7 +76272,7 @@
 "cWC" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1;
@@ -76288,7 +76282,7 @@
 "cWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1;
@@ -76303,7 +76297,7 @@
 "cWF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/side{
@@ -76313,7 +76307,7 @@
 /area/maintenance/port)
 "cWG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -76325,7 +76319,7 @@
 /area/maintenance/port)
 "cWH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -76349,7 +76343,7 @@
 "cWJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -76361,7 +76355,7 @@
 /area/maintenance/port)
 "cWK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -76375,7 +76369,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -76386,7 +76380,7 @@
 "cWM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -77749,7 +77743,7 @@
 "cZL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -77762,7 +77756,7 @@
 	name = "3maintenance loot spawner"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -77785,13 +77779,13 @@
 	name = "2maintenance loot spawner"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cZP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -78400,7 +78394,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side,
 /area/maintenance/port)
@@ -78419,7 +78413,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side,
 /area/maintenance/port)
@@ -79049,13 +79043,13 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dcv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dcw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -79069,7 +79063,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
@@ -79078,7 +79072,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -79090,7 +79084,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -79104,7 +79098,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plasteel/vault{
@@ -79795,7 +79789,7 @@
 "deh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -79899,13 +79893,13 @@
 /area/science/research)
 "dev" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/research)
 "dew" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -82355,7 +82349,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -82373,7 +82367,7 @@
 	name = "Research Director's Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
@@ -82892,7 +82886,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -82904,7 +82898,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -82915,7 +82909,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -82940,7 +82934,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/girder,
 /obj/structure/grille,
@@ -82982,7 +82976,7 @@
 /area/maintenance/port)
 "dkN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -85072,7 +85066,7 @@
 /area/science/research)
 "dpr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/white{
@@ -85082,7 +85076,7 @@
 /area/science/research)
 "dps" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -85092,7 +85086,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
@@ -85100,7 +85094,7 @@
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -87229,13 +87223,13 @@
 /area/science/research/abandoned)
 "dtC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/science/research/abandoned)
 "dtD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -87244,14 +87238,14 @@
 /area/science/research/abandoned)
 "dtE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dtF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -87281,7 +87275,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -87293,7 +87287,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -87304,7 +87298,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -89301,7 +89295,7 @@
 /area/science/research)
 "dxH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
@@ -89317,7 +89311,7 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89332,7 +89326,7 @@
 /area/science/robotics/lab)
 "dxJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -89347,7 +89341,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -89357,7 +89351,7 @@
 /area/science/robotics/lab)
 "dxL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/science/robotics/lab)
@@ -89371,7 +89365,7 @@
 "dxN" = (
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/science/robotics/lab)
@@ -92381,7 +92375,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -92389,7 +92383,7 @@
 "dDY" = (
 /obj/structure/sign/securearea,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -92398,7 +92392,7 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Science - Toxins Secure Storage";
@@ -102774,7 +102768,7 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/chapel/office)
@@ -103766,7 +103760,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault{
@@ -105058,7 +105052,7 @@
 /obj/item/weapon/storage/toolbox/electrical,
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/poster/official/report_crimes{
@@ -108254,9 +108248,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmospherics_engine)
 "epA" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 
@@ -128458,7 +128450,7 @@ bZf
 cCm
 bVT
 cyh
-cGq
+duO
 ceO
 cJg
 cdj
@@ -128468,7 +128460,7 @@ bZC
 bZD
 cdj
 cMq
-cGq
+duO
 bZC
 cJc
 aaf
@@ -128715,7 +128707,7 @@ cAU
 cCn
 bVT
 bZD
-cGq
+duO
 cHJ
 cHJ
 cHJ
@@ -128972,7 +128964,7 @@ bZf
 cAW
 bVT
 bZC
-cGr
+duK
 cHJ
 efW
 cKW
@@ -129229,7 +129221,7 @@ cAV
 cCo
 bVT
 cEN
-cGs
+duM
 cHK
 cJi
 cKX
@@ -130000,7 +129992,7 @@ cAW
 bVT
 bVT
 cEP
-cGq
+duO
 cHJ
 cJl
 cLa
@@ -130215,7 +130207,7 @@ aWd
 aNU
 aWd
 aNU
-bpP
+aSL
 aNU
 aaH
 btD
@@ -130257,7 +130249,7 @@ cAX
 cCp
 bVT
 cEQ
-cGs
+duM
 cHJ
 cHJ
 cLb
@@ -130472,7 +130464,7 @@ aWe
 aIZ
 aWe
 aIU
-bjm
+aSM
 aIZ
 aIZ
 btF
@@ -130513,8 +130505,8 @@ czk
 bZf
 cAW
 bVT
-cyf
-cGv
+cJA
+duL
 cHJ
 cJm
 cLc
@@ -130524,7 +130516,7 @@ cQj
 cRz
 cTn
 cHJ
-cWI
+chI
 cYu
 bWg
 daR
@@ -130771,7 +130763,7 @@ cAU
 cCq
 bVT
 cER
-cGs
+duM
 cHJ
 cJn
 cLd
@@ -131028,7 +131020,7 @@ bZf
 cAW
 bVT
 cES
-cGq
+duO
 cHJ
 cJo
 cLe
@@ -131285,7 +131277,7 @@ cAY
 cCr
 bVT
 cER
-cGw
+duN
 cHN
 cJp
 cLf
@@ -131747,7 +131739,7 @@ aSR
 aUo
 aWi
 aXO
-aZp
+aUo
 baL
 bcg
 aSR
@@ -132312,7 +132304,7 @@ czm
 bZm
 cCt
 bVT
-cEW
+cYz
 cGA
 cHJ
 cJt
@@ -132827,7 +132819,7 @@ cBb
 cCu
 bVT
 cEY
-cGq
+duO
 cHJ
 cHJ
 cHJ
@@ -132837,7 +132829,7 @@ cHJ
 cHJ
 cHJ
 cHJ
-cGq
+duO
 cYz
 bWg
 bWg
@@ -133039,10 +133031,10 @@ bds
 bfl
 bgZ
 bjb
-aXW
-aXW
+aUz
+aUz
 bof
-aXW
+aUz
 bri
 aIZ
 btM
@@ -133354,7 +133346,7 @@ cMH
 cMH
 cYC
 cZK
-daZ
+cFn
 dcE
 ddX
 dfO
@@ -133610,7 +133602,7 @@ cHS
 cHS
 cHS
 cHS
-cyf
+cJA
 dba
 dcF
 ddY
@@ -133856,7 +133848,7 @@ cCy
 bVT
 cFc
 bZC
-cGq
+duO
 cJx
 cHS
 cMI
@@ -133867,8 +133859,8 @@ cMI
 cMI
 cMI
 cHS
-cyf
-dbb
+cJA
+cFm
 dcE
 ddZ
 dfQ
@@ -134639,7 +134631,7 @@ cOs
 cHS
 cHS
 cZM
-dbd
+cFo
 dcE
 dec
 dfQ
@@ -134830,8 +134822,8 @@ aRc
 aTb
 aUz
 aWs
-aXW
-aXW
+aUz
+aUz
 baS
 bck
 bdz
@@ -134895,8 +134887,8 @@ cTw
 cVb
 cWP
 cHS
-cZN
-dbb
+cJw
+cFm
 dcE
 ded
 dfS
@@ -135863,9 +135855,9 @@ aWe
 aIZ
 aSM
 aIU
-bfv
+aWe
 aIZ
-bjm
+aSM
 aIZ
 bmq
 bop
@@ -136120,7 +136112,7 @@ aWd
 aNU
 aSL
 aNU
-bfw
+aWd
 bhj
 aJg
 aIZ
@@ -136707,7 +136699,7 @@ dej
 dej
 dej
 dej
-cEW
+cYz
 duL
 cJc
 aaa
@@ -138506,7 +138498,7 @@ dnG
 dpc
 dqB
 dej
-cEW
+cYz
 duN
 dwm
 bZC
@@ -139503,7 +139495,7 @@ crL
 cts
 cuZ
 cww
-cyb
+cgp
 czH
 bWi
 cCK
@@ -140531,7 +140523,7 @@ bWi
 bWi
 bWi
 bWi
-cye
+cji
 czL
 bWi
 cCK
@@ -140552,7 +140544,7 @@ cYI
 cHS
 dbm
 dcL
-dex
+cPe
 dgh
 dhu
 djj
@@ -140788,7 +140780,7 @@ crP
 ctw
 cvd
 bWi
-cyf
+cJA
 czM
 cBo
 cCO
@@ -140809,7 +140801,7 @@ cYJ
 cHS
 dbn
 cLI
-dex
+cPe
 cJL
 cJL
 djn
@@ -141066,7 +141058,7 @@ cHS
 cHS
 dbo
 cLH
-dex
+cPe
 dgi
 dhv
 djo
@@ -150987,7 +150979,7 @@ afE
 afU
 agB
 ahg
-ahP
+afE
 aiD
 ajG
 aeX

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1009,7 +1009,7 @@
 /area/prison/execution_room)
 "acn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -1157,7 +1157,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/darkred{
 	dir = 4
@@ -1220,7 +1220,7 @@
 /area/security/prison)
 "acG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-13"
@@ -1880,7 +1880,7 @@
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 2
@@ -1926,7 +1926,7 @@
 /area/security/prison)
 "adQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/closed/wall,
 /area/security/prison)
@@ -3044,7 +3044,7 @@
 /area/security/prison)
 "afK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -3065,7 +3065,7 @@
 /area/security/prison)
 "afM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -3114,7 +3114,7 @@
 /area/security/prison)
 "afQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/effect/landmark/lightsout,
 /turf/open/floor/plasteel/red/corner{
@@ -3123,7 +3123,7 @@
 /area/security/prison)
 "afR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3145,7 +3145,7 @@
 /area/security/prison)
 "afT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/red/corner{
@@ -4979,7 +4979,7 @@
 "ajw" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -5743,7 +5743,7 @@
 /area/security/main)
 "akS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -6519,7 +6519,7 @@
 /area/security/main)
 "aml" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -7571,7 +7571,7 @@
 /area/security/brig)
 "aor" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7912,7 +7912,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -7925,7 +7925,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=14.8-Dorms-Lockers";
@@ -8609,7 +8609,7 @@
 /area/engine/gravity_generator)
 "aqu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8647,7 +8647,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8919,7 +8919,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -9057,7 +9057,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -9089,7 +9089,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/red/side,
@@ -10726,7 +10726,7 @@
 "auh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -10739,7 +10739,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/effect/landmark/lightsout,
 /turf/open/floor/plasteel,
@@ -11297,7 +11297,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -11564,7 +11564,7 @@
 /area/maintenance/starboard/fore)
 "avH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -12314,7 +12314,7 @@
 /area/shuttle/labor)
 "awZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -12365,7 +12365,7 @@
 /area/security/brig)
 "axd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 8
@@ -12378,7 +12378,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -12404,7 +12404,7 @@
 /area/security/brig)
 "axh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/machinery/door_timer{
 	id = "Cell 3";
@@ -12476,7 +12476,7 @@
 /area/security/brig)
 "axn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -12502,7 +12502,7 @@
 /area/security/brig)
 "axq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -12557,7 +12557,7 @@
 /area/security/brig)
 "axu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -12672,7 +12672,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -13287,7 +13287,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -13343,7 +13343,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -14153,7 +14153,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -14542,7 +14542,7 @@
 /area/security/brig)
 "aBg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
@@ -14763,7 +14763,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -15384,7 +15384,7 @@
 /area/crew_quarters/dorms)
 "aCH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -16049,7 +16049,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/structure/urinal{
 	pixel_y = 29
@@ -16546,7 +16546,7 @@
 /area/hallway/primary/fore)
 "aEQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -16925,7 +16925,7 @@
 /area/engine/engineering)
 "aFv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16934,7 +16934,7 @@
 /area/engine/engineering)
 "aFw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -16946,7 +16946,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -18660,7 +18660,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/item/device/radio/intercom{
 	freerange = 0;
@@ -18720,7 +18720,7 @@
 /area/construction/storage/wing)
 "aIA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -19225,7 +19225,7 @@
 /area/quartermaster/storage)
 "aJI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
@@ -19331,7 +19331,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aJT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 8
@@ -19794,7 +19794,7 @@
 /area/quartermaster/storage)
 "aKW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -20482,7 +20482,7 @@
 /area/storage/primary)
 "aMD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -21412,7 +21412,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -21449,7 +21449,7 @@
 /area/crew_quarters/locker)
 "aOE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -21463,7 +21463,7 @@
 /area/crew_quarters/locker)
 "aOF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22137,7 +22137,7 @@
 /area/crew_quarters/locker)
 "aPL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -22607,7 +22607,7 @@
 	pixel_x = -27
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 8
@@ -23333,7 +23333,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -23555,7 +23555,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -24427,7 +24427,7 @@
 /area/quartermaster/storage)
 "aUg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -24903,7 +24903,7 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/assistantformal,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/item/clothing/suit/hooded/wintercoat,
 /obj/item/clothing/shoes/winterboots,
@@ -25824,7 +25824,7 @@
 /area/hallway/secondary/entry)
 "aWY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
@@ -28071,7 +28071,7 @@
 /area/hallway/primary/central)
 "baJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28100,7 +28100,7 @@
 /area/hallway/primary/central)
 "baL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -28133,7 +28133,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -28163,7 +28163,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -28179,7 +28179,7 @@
 /area/hallway/primary/central)
 "baR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -28227,7 +28227,7 @@
 /area/hallway/primary/central)
 "baW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/neutral/corner{
@@ -28249,7 +28249,7 @@
 /area/hallway/primary/central)
 "baY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -28260,7 +28260,7 @@
 /area/hallway/primary/central)
 "baZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/item/device/radio/intercom{
 	freerange = 0;
@@ -28580,7 +28580,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -29291,7 +29291,7 @@
 /area/security/checkpoint/customs)
 "bcX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/book/manual/wiki/security_space_law{
@@ -29477,7 +29477,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -29517,7 +29517,7 @@
 /area/hallway/primary/port)
 "bds" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -32414,7 +32414,7 @@
 /area/hallway/primary/port)
 "biO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -32892,7 +32892,7 @@
 /area/hallway/primary/starboard)
 "bjF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -32936,7 +32936,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -32974,7 +32974,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -33624,7 +33624,7 @@
 /area/crew_quarters/heads/captain/private)
 "bkQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral/corner{
@@ -33680,7 +33680,7 @@
 /area/hallway/primary/starboard)
 "bkV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -33693,7 +33693,7 @@
 /area/hallway/primary/starboard)
 "bkW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/caution/corner{
 	dir = 8
@@ -33743,7 +33743,7 @@
 /area/hallway/primary/starboard)
 "blb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -33760,7 +33760,7 @@
 /area/hallway/primary/starboard)
 "blc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/caution/corner{
 	dir = 8
@@ -33805,7 +33805,7 @@
 /area/hallway/primary/starboard)
 "blg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=13.2-Tcommstore";
@@ -35970,7 +35970,7 @@
 /area/engine/break_room)
 "bpk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -36793,7 +36793,7 @@
 /area/hallway/primary/central)
 "bqA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -37219,7 +37219,7 @@
 	sortType = 19
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37276,7 +37276,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -37918,7 +37918,7 @@
 /area/hallway/primary/port)
 "bsu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -37971,7 +37971,7 @@
 /area/hallway/primary/port)
 "bsz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -38071,7 +38071,7 @@
 /area/hallway/primary/port)
 "bsI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -38905,7 +38905,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39045,7 +39045,7 @@
 /area/bridge)
 "buw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/black,
 /area/bridge)
@@ -39278,7 +39278,7 @@
 /area/maintenance/starboard)
 "buZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 8
@@ -39701,7 +39701,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -39735,7 +39735,7 @@
 /area/hallway/primary/port)
 "bvP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -39747,7 +39747,7 @@
 	location = "5-Customs"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -39785,7 +39785,7 @@
 /area/maintenance/department/science/xenobiology)
 "bvU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -40469,13 +40469,13 @@
 /area/engine/atmos)
 "bxh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bxi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -41200,7 +41200,7 @@
 /area/crew_quarters/bar)
 "byG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
@@ -41886,7 +41886,7 @@
 /area/hallway/secondary/command)
 "bzS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -42126,7 +42126,7 @@
 /area/crew_quarters/theatre)
 "bAt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
@@ -42321,7 +42321,7 @@
 /area/engine/atmos)
 "bAP" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
+	dir = 8
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -43030,7 +43030,7 @@
 /area/engine/atmos)
 "bCj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -43109,21 +43109,17 @@
 /area/engine/atmos)
 "bCt" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	color = "purple";
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bCu" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	color = "purple"
-	},
+/obj/machinery/atmospherics/pipe/manifold/purple/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bCv" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple";
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43134,16 +43130,14 @@
 	name = "Air to Mix";
 	on = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple";
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bCx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple";
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/green/side{
@@ -43153,16 +43147,14 @@
 "bCy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple";
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bCz" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple";
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -43878,8 +43870,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bDY" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	color = "purple";
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44102,7 +44093,7 @@
 /area/library)
 "bEx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/library)
@@ -44147,7 +44138,7 @@
 /area/hallway/primary/central)
 "bEC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -44214,7 +44205,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -44304,7 +44295,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -44317,7 +44308,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/machinery/newscaster{
 	pixel_y = -29
@@ -44352,7 +44343,7 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -44520,7 +44511,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -44575,7 +44566,7 @@
 /area/hallway/secondary/command)
 "bFc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -44593,7 +44584,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -44646,7 +44637,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -44965,7 +44956,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -45108,15 +45099,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bFR" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple";
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bFS" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple";
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -45564,7 +45553,7 @@
 /area/maintenance/central)
 "bGV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -45608,7 +45597,7 @@
 /area/crew_quarters/bar)
 "bHa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
@@ -45823,16 +45812,14 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6;
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bHx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple"
-	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -45868,7 +45855,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -46452,7 +46439,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 2
@@ -46488,7 +46475,7 @@
 "bIK" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -46555,7 +46542,7 @@
 /area/engine/atmos)
 "bIQ" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -46574,15 +46561,13 @@
 /area/engine/atmos)
 "bIT" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bIU" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple"
-	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -47381,7 +47366,7 @@
 "bKy" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -48156,7 +48141,7 @@
 /area/engine/atmos)
 "bMb" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 8
@@ -48999,7 +48984,7 @@
 /area/crew_quarters/kitchen)
 "bNz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -49936,7 +49921,7 @@
 /area/engine/atmos)
 "bPt" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -50402,7 +50387,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -51459,7 +51444,7 @@
 /area/engine/atmos)
 "bSi" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/meter,
 /obj/item/weapon/wrench,
@@ -51845,7 +51830,7 @@
 /area/hydroponics)
 "bSX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52222,7 +52207,7 @@
 /area/hallway/primary/central)
 "bTF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -52308,7 +52293,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -52340,7 +52325,7 @@
 /area/hallway/primary/central)
 "bTQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -52348,7 +52333,7 @@
 /area/hallway/primary/central)
 "bTR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -52380,7 +52365,7 @@
 /area/hallway/primary/central)
 "bTU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/machinery/power/apc{
 	cell_type = 10000;
@@ -52398,7 +52383,7 @@
 /area/hallway/primary/central)
 "bTV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/sign/map/left{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -52789,7 +52774,7 @@
 "bUE" = (
 /obj/item/weapon/cigbutt,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -54194,8 +54179,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/manifold/dark/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -54206,16 +54190,14 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXk" = (
 /obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -54225,23 +54207,19 @@
 	dir = 1;
 	on = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXm" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXn" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	color = "#330000"
-	},
+/obj/machinery/atmospherics/pipe/manifold/dark/visible,
 /obj/machinery/meter{
 	color = ""
 	},
@@ -54779,9 +54757,7 @@
 	},
 /area/engine/atmos)
 "bYw" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000"
-	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bYx" = (
@@ -56217,9 +56193,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000"
-	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel/red,
 /area/engine/atmos)
 "cbf" = (
@@ -56807,7 +56781,7 @@
 /area/science/research)
 "ccj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -57137,37 +57111,32 @@
 	icon_state = "term";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 6
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
 "ccL" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "ccM" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/atmos)
 "ccN" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/atmos)
 "ccO" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 9
 	},
 /turf/open/floor/plasteel/black,
@@ -57189,7 +57158,7 @@
 /area/engine/atmos)
 "ccT" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/atmos)
@@ -57488,7 +57457,7 @@
 /area/medical/medbay/central)
 "cdz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -57567,7 +57536,7 @@
 /area/hallway/primary/aft)
 "cdI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/purple/corner{
 	dir = 2
@@ -57776,7 +57745,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
@@ -57990,7 +57959,7 @@
 /area/medical/storage)
 "cey" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -58546,6 +58515,7 @@
 "cfs" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
+	
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
@@ -59928,7 +59898,7 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -60132,7 +60102,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
@@ -60632,7 +60602,7 @@
 "cjx" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/medical/surgery)
@@ -60701,7 +60671,7 @@
 /area/medical/sleeper)
 "cjF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
@@ -60772,7 +60742,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -60788,7 +60758,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -61006,7 +60976,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -61372,7 +61342,7 @@
 "ckX" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/black,
 /area/medical/surgery)
@@ -61432,7 +61402,7 @@
 /area/medical/sleeper)
 "cle" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 10
@@ -61502,7 +61472,7 @@
 /area/medical/medbay/central)
 "cll" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -62649,7 +62619,7 @@
 /area/medical/cryo)
 "cnv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/medical1{
 	pixel_x = -3
@@ -62875,7 +62845,7 @@
 /area/hallway/primary/aft)
 "cnP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/purple/side{
 	dir = 4
@@ -63894,7 +63864,7 @@
 /area/science/explab)
 "cpD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -64550,7 +64520,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -64602,7 +64572,7 @@
 "cqL" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -64618,7 +64588,7 @@
 /area/science/research)
 "cqN" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 2
@@ -64631,7 +64601,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whitepurple/side{
@@ -67362,7 +67332,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
@@ -67695,7 +67665,7 @@
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -68147,7 +68117,7 @@
 /area/medical/medbay/aft)
 "cxk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -68182,7 +68152,7 @@
 /area/medical/genetics/cloning)
 "cxo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/whiteblue/side{
@@ -68311,7 +68281,7 @@
 /area/hallway/primary/aft)
 "cxB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.1-Escape-1";
@@ -68696,7 +68666,7 @@
 /area/hallway/primary/aft)
 "cyo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -68773,7 +68743,7 @@
 /area/science/research)
 "cyx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -69143,7 +69113,7 @@
 /area/hallway/primary/aft)
 "czh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/button/door{
 	dir = 2;
@@ -69583,7 +69553,7 @@
 	},
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -70015,7 +69985,7 @@
 /area/science/mixing)
 "cAF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -70351,7 +70321,7 @@
 /area/science/research)
 "cBp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 4
@@ -70449,7 +70419,7 @@
 /area/science/mixing)
 "cBA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -71833,7 +71803,7 @@
 /area/hallway/primary/aft)
 "cEh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/purple/side{
 	dir = 4
@@ -73557,7 +73527,7 @@
 /area/science/research)
 "cHc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 2
@@ -73581,7 +73551,7 @@
 /area/science/server)
 "cHf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/closed/wall/r_wall,
 /area/science/server)
@@ -73694,7 +73664,7 @@
 /obj/structure/grille,
 /obj/structure/window/fulltile,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -73722,7 +73692,7 @@
 /area/medical/virology)
 "cHu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel/whitegreen/side,
 /area/medical/virology)
@@ -74086,7 +74056,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
@@ -76219,7 +76189,7 @@
 /area/chapel/office)
 "cLX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -77373,7 +77343,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/effect/landmark/xmastree,
 /turf/open/floor/carpet,
@@ -77447,7 +77417,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -77691,7 +77661,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "cOU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -77739,7 +77709,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "cOZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -78901,7 +78871,7 @@
 /area/science/xenobiology)
 "cRC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -80658,8 +80628,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/syndicate)
 "cUR" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/valve/digital{
@@ -83646,7 +83615,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6;
+	dir = 6
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -84346,7 +84315,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -84399,7 +84368,7 @@
 /area/science/xenobiology)
 "dcl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -85101,7 +85070,7 @@
 /obj/structure/chair,
 /obj/item/weapon/cigbutt,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -85150,6 +85119,7 @@
 "ddD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
+	
 	},
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria{
@@ -85162,8 +85132,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "ddF" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	color = "purple";
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -85319,7 +85288,7 @@
 "ded" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
 /turf/open/floor/plating,
@@ -86034,7 +86003,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel{
 	dir = 1
@@ -91444,6 +91413,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"dBC" = (
+/obj/machinery/meter,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 
 (1,1,1) = {"
 aaa
@@ -131685,7 +131662,7 @@ bZE
 cba
 ccK
 cef
-cfs
+chK
 czH
 cLC
 cjb
@@ -133943,7 +133920,7 @@ avz
 axY
 axY
 ayW
-ddR
+bTq
 aBO
 aCX
 dej
@@ -136548,7 +136525,7 @@ aaf
 aaa
 aaf
 bAR
-bCA
+dBC
 bza
 bFZ
 bAR

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1010,7 +1010,6 @@
 "acn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -1159,7 +1158,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/darkred{
 	dir = 4
@@ -1223,7 +1221,6 @@
 "acG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-13"
@@ -1884,7 +1881,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 2
@@ -1931,7 +1927,6 @@
 "adQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/closed/wall,
 /area/security/prison)
@@ -3050,7 +3045,6 @@
 "afK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -3072,7 +3066,6 @@
 "afM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -3122,7 +3115,6 @@
 "afQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/effect/landmark/lightsout,
 /turf/open/floor/plasteel/red/corner{
@@ -3132,7 +3124,6 @@
 "afR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3155,7 +3146,6 @@
 "afT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/red/corner{
@@ -4990,7 +4980,6 @@
 /obj/structure/closet/bombcloset,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -5755,7 +5744,6 @@
 "akS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -6532,7 +6520,6 @@
 "aml" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -7585,7 +7572,6 @@
 "aor" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7927,7 +7913,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -7941,7 +7926,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=14.8-Dorms-Lockers";
@@ -8626,7 +8610,6 @@
 "aqu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8665,7 +8648,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8938,7 +8920,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -9077,7 +9058,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -9110,7 +9090,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/red/side,
@@ -10748,7 +10727,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -10762,7 +10740,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/effect/landmark/lightsout,
 /turf/open/floor/plasteel,
@@ -11321,7 +11298,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -11589,7 +11565,6 @@
 "avH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -12340,7 +12315,6 @@
 "awZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -12392,7 +12366,6 @@
 "axd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 8
@@ -12406,7 +12379,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -12433,7 +12405,6 @@
 "axh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/machinery/door_timer{
 	id = "Cell 3";
@@ -12506,7 +12477,6 @@
 "axn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -12533,7 +12503,6 @@
 "axq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -12589,7 +12558,6 @@
 "axu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -12705,7 +12673,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -13321,7 +13288,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -13378,7 +13344,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -14189,7 +14154,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -14579,7 +14543,6 @@
 "aBg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
@@ -14801,7 +14764,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -15423,7 +15385,6 @@
 "aCH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -16089,7 +16050,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/structure/urinal{
 	pixel_y = 29
@@ -16587,7 +16547,6 @@
 "aEQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -16967,7 +16926,6 @@
 "aFv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16977,7 +16935,6 @@
 "aFw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -16990,7 +16947,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -18705,7 +18661,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/item/device/radio/intercom{
 	freerange = 0;
@@ -18766,7 +18721,6 @@
 "aIA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -19272,7 +19226,6 @@
 "aJI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
@@ -19379,7 +19332,6 @@
 "aJT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 8
@@ -19843,7 +19795,6 @@
 "aKW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -20532,7 +20483,6 @@
 "aMD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -21463,7 +21413,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -21501,7 +21450,6 @@
 "aOE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -21516,7 +21464,6 @@
 "aOF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22191,7 +22138,6 @@
 "aPL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -22662,7 +22608,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 8
@@ -23389,7 +23334,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -23612,7 +23556,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -24485,7 +24428,6 @@
 "aUg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -24962,7 +24904,6 @@
 /obj/item/clothing/under/assistantformal,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/item/clothing/suit/hooded/wintercoat,
 /obj/item/clothing/shoes/winterboots,
@@ -25884,7 +25825,6 @@
 "aWY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
@@ -28132,7 +28072,6 @@
 "baJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28162,7 +28101,6 @@
 "baL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -28196,7 +28134,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -28227,7 +28164,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -28244,7 +28180,6 @@
 "baR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -28293,7 +28228,6 @@
 "baW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/neutral/corner{
@@ -28316,7 +28250,6 @@
 "baY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -28328,7 +28261,6 @@
 "baZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/item/device/radio/intercom{
 	freerange = 0;
@@ -28649,7 +28581,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -29361,7 +29292,6 @@
 "bcX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/book/manual/wiki/security_space_law{
@@ -29548,7 +29478,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -29589,7 +29518,6 @@
 "bds" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -32487,7 +32415,6 @@
 "biO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -32966,7 +32893,6 @@
 "bjF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -33011,7 +32937,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -33050,7 +32975,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -33701,7 +33625,6 @@
 "bkQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral/corner{
@@ -33758,7 +33681,6 @@
 "bkV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -33772,7 +33694,6 @@
 "bkW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/caution/corner{
 	dir = 8
@@ -33823,7 +33744,6 @@
 "blb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -33841,7 +33761,6 @@
 "blc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/caution/corner{
 	dir = 8
@@ -33887,7 +33806,6 @@
 "blg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=13.2-Tcommstore";
@@ -36053,7 +35971,6 @@
 "bpk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -36877,7 +36794,6 @@
 "bqA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -37304,7 +37220,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37362,7 +37277,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -38005,7 +37919,6 @@
 "bsu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -38059,7 +37972,6 @@
 "bsz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -38160,7 +38072,6 @@
 "bsI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -38995,7 +38906,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39136,7 +39046,6 @@
 "buw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/black,
 /area/bridge)
@@ -39370,7 +39279,6 @@
 "buZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 8
@@ -39794,7 +39702,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -39829,7 +39736,6 @@
 "bvP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -39842,7 +39748,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -39881,7 +39786,6 @@
 "bvU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -40566,14 +40470,12 @@
 "bxh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bxi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -41299,7 +41201,6 @@
 "byG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
@@ -41986,7 +41887,6 @@
 "bzS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -42227,7 +42127,6 @@
 "bAt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
@@ -42423,7 +42322,6 @@
 "bAP" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -43133,7 +43031,6 @@
 "bCj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -43285,7 +43182,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "mix_in";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -44207,7 +44103,6 @@
 "bEx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/carpet,
 /area/library)
@@ -44253,7 +44148,6 @@
 "bEC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -44321,7 +44215,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -44412,7 +44305,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -44426,7 +44318,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/machinery/newscaster{
 	pixel_y = -29
@@ -44462,7 +44353,6 @@
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -44631,7 +44521,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -44687,7 +44576,6 @@
 "bFc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -44706,7 +44594,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -44760,7 +44647,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -45080,7 +44966,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -45680,7 +45565,6 @@
 "bGV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -45725,7 +45609,6 @@
 "bHa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
@@ -45941,7 +45824,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6;
-	initialize_directions = 6
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -45987,7 +45869,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -46572,7 +46453,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 2
@@ -46609,7 +46489,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -46677,7 +46556,6 @@
 "bIQ" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -46697,7 +46575,6 @@
 "bIT" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -46771,7 +46648,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2o_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -47506,7 +47382,6 @@
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -48282,7 +48157,6 @@
 "bMb" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 8
@@ -49126,7 +49000,6 @@
 "bNz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -50064,7 +49937,6 @@
 "bPt" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -50109,7 +49981,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "tox_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -50532,7 +50403,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -51590,7 +51460,6 @@
 "bSi" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /obj/item/weapon/wrench,
@@ -51977,7 +51846,6 @@
 "bSX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52355,7 +52223,6 @@
 "bTF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -52442,7 +52309,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -52475,7 +52341,6 @@
 "bTQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -52484,7 +52349,6 @@
 "bTR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -52517,7 +52381,6 @@
 "bTU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/machinery/power/apc{
 	cell_type = 10000;
@@ -52536,7 +52399,6 @@
 "bTV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/sign/map/left{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -52928,7 +52790,6 @@
 /obj/item/weapon/cigbutt,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -52965,7 +52826,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "co2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -56948,7 +56808,6 @@
 "ccj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -57331,7 +57190,6 @@
 "ccT" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/atmos)
@@ -57631,7 +57489,6 @@
 "cdz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -57711,7 +57568,6 @@
 "cdI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/purple/corner{
 	dir = 2
@@ -57921,7 +57777,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
@@ -58136,7 +57991,6 @@
 "cey" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -58692,7 +58546,6 @@
 "cfs" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
@@ -59959,7 +59812,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -59988,7 +59840,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "o2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -60078,7 +59929,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -60283,7 +60133,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
@@ -60784,7 +60633,6 @@
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/black,
 /area/medical/surgery)
@@ -60854,7 +60702,6 @@
 "cjF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
@@ -60926,7 +60773,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -60943,7 +60789,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -61162,7 +61007,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -61529,7 +61373,6 @@
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/black,
 /area/medical/surgery)
@@ -61590,7 +61433,6 @@
 "cle" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 10
@@ -61661,7 +61503,6 @@
 "cll" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -62610,7 +62451,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 0;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "incinerator output intake";
 	on = 0;
@@ -62810,7 +62650,6 @@
 "cnv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/closet/secure_closet/medical1{
 	pixel_x = -3
@@ -63037,7 +62876,6 @@
 "cnP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/purple/side{
 	dir = 4
@@ -64057,7 +63895,6 @@
 "cpD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -64715,7 +64552,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -64768,7 +64604,6 @@
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -64785,7 +64620,6 @@
 "cqN" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 2
@@ -64799,7 +64633,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whitepurple/side{
@@ -67531,7 +67364,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
@@ -67865,7 +67697,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -68318,7 +68149,6 @@
 "cxk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -68354,7 +68184,6 @@
 "cxo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/whiteblue/side{
@@ -68484,7 +68313,6 @@
 "cxB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.1-Escape-1";
@@ -68870,7 +68698,6 @@
 "cyo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -68948,7 +68775,6 @@
 "cyx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -69319,7 +69145,6 @@
 "czh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/button/door{
 	dir = 2;
@@ -69760,7 +69585,6 @@
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -70193,7 +70017,6 @@
 "cAF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -70530,7 +70353,6 @@
 "cBp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 4
@@ -70629,7 +70451,6 @@
 "cBA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -72014,7 +71835,6 @@
 "cEh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/purple/side{
 	dir = 4
@@ -72171,7 +71991,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 0;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -73740,7 +73559,6 @@
 "cHc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 2
@@ -73765,7 +73583,6 @@
 "cHf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/closed/wall/r_wall,
 /area/science/server)
@@ -73879,7 +73696,6 @@
 /obj/structure/window/fulltile,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -73908,7 +73724,6 @@
 "cHu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whitegreen/side,
 /area/medical/virology)
@@ -74273,7 +74088,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
@@ -75309,7 +75123,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -76408,7 +76221,6 @@
 "cLX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -77563,7 +77375,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/effect/landmark/xmastree,
 /turf/open/floor/carpet,
@@ -77638,7 +77449,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -77883,7 +77693,6 @@
 "cOU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -77932,7 +77741,6 @@
 "cOZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -79095,7 +78903,6 @@
 "cRC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -83841,7 +83648,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6;
-	initialize_directions = 6
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -84542,7 +84348,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -84596,7 +84401,6 @@
 "dcl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -85299,7 +85103,6 @@
 /obj/item/weapon/cigbutt,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -85328,7 +85131,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -85349,7 +85151,6 @@
 "ddD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria{
@@ -85520,7 +85321,6 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
 /turf/open/floor/plating,
@@ -86236,7 +86036,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel{
 	dir = 1

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -52199,7 +52199,6 @@
 /area/maintenance/solars/port/aft)
 "bTq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -85943,7 +85942,6 @@
 /area/engine/engineering)
 "dfj" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
@@ -85993,7 +85991,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/engine,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -51641,7 +51641,6 @@
 	name = "Service Shutter"
 	},
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = "";
 	name = "Service Door";
 	req_access_txt = "0";
 	req_one_access_txt = "35;28"
@@ -55713,7 +55712,6 @@
 "caJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = "";
 	name = "Hydroponics";
 	req_access_txt = "35"
 	},
@@ -62021,7 +62019,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass_medical{
 	glass = 0;
-	id_tag = "";
 	name = "Research Break Room";
 	opacity = 1;
 	req_access_txt = "0";
@@ -63856,7 +63853,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = "";
 	name = "Surgery Observation";
 	req_access_txt = "0"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -16246,12 +16246,16 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEq" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16264,6 +16268,8 @@
 /area/engine/engineering)
 "aEr" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16963,6 +16969,8 @@
 /area/engine/engineering)
 "aFD" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -20303,6 +20311,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -24185,12 +24195,16 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTK" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -24200,6 +24214,8 @@
 /area/engine/engineering)
 "aTM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -24209,6 +24225,8 @@
 /area/engine/engineering)
 "aTN" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -81651,6 +81669,8 @@
 /area/shuttle/abandoned)
 "cXz" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -83383,6 +83403,8 @@
 /area/crew_quarters/heads/hop)
 "dbg" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -83395,6 +83417,8 @@
 /area/engine/engineering)
 "dbh" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -83679,6 +83703,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/space,
@@ -83733,6 +83759,7 @@
 "dbT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/space,
@@ -84974,6 +85001,8 @@
 "deh" = (
 /obj/structure/grille,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/window/reinforced/highpressure/fulltile,
@@ -84981,6 +85010,8 @@
 /area/engine/engineering)
 "dei" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -84990,6 +85021,8 @@
 /area/engine/engineering)
 "dej" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85006,6 +85039,8 @@
 	name = "Mix to Gas"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85015,6 +85050,8 @@
 /area/engine/engineering)
 "del" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85032,6 +85069,8 @@
 	name = "Gas to Mix"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85114,6 +85153,8 @@
 /area/engine/engineering)
 "deu" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -85126,6 +85167,8 @@
 /area/engine/engineering)
 "dev" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85137,6 +85180,8 @@
 "dew" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_engineering{
@@ -85147,21 +85192,29 @@
 /area/engine/engineering)
 "dex" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dey" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "deA" = (
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -85446,12 +85499,14 @@
 /area/engine/engineering)
 "dfA" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dfB" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/emitter{
@@ -85463,6 +85518,7 @@
 /area/engine/engineering)
 "dfC" = (
 /obj/structure/cable/white{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/emitter{
@@ -85529,6 +85585,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85545,6 +85603,8 @@
 	name = "Cooling Loop Bypass"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85557,6 +85617,8 @@
 /area/engine/engineering)
 "dfJ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85569,21 +85631,29 @@
 /area/engine/engineering)
 "dfM" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dfO" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "dfP" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -85595,6 +85665,8 @@
 /area/engine/engineering)
 "dfQ" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -85614,6 +85686,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -85621,6 +85695,8 @@
 /area/engine/engineering)
 "dfS" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6010,7 +6010,6 @@
 /area/maintenance/starboard)
 "als" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -6994,7 +6993,6 @@
 "anj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -16059,7 +16057,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19109,8 +19106,7 @@
 /obj/item/clothing/glasses/meson/engine,
 /obj/item/clothing/glasses/meson/engine,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -19142,7 +19138,6 @@
 /area/quartermaster/storage)
 "aJC" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/conveyor{
@@ -20064,7 +20059,6 @@
 	on = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -21895,7 +21889,6 @@
 	pixel_x = 30
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -22434,7 +22427,6 @@
 	opened = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -22481,7 +22473,6 @@
 /obj/structure/table,
 /obj/item/weapon/aiModule/reset,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/ai_status_display{
@@ -22556,7 +22547,6 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aQE" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -22605,7 +22595,6 @@
 /area/security/courtroom)
 "aQK" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -23074,7 +23063,6 @@
 /area/construction/mining/aux_base)
 "aRF" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/computer/camera_advanced/base_construction,
@@ -24374,7 +24362,6 @@
 /area/quartermaster/storage)
 "aUf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -25692,7 +25679,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/circuit,
@@ -25734,7 +25720,6 @@
 /area/ai_monitored/turret_protected/ai)
 "aWR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/ai_status_display{
@@ -25830,8 +25815,7 @@
 	network = list("SS13")
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 4
@@ -27193,8 +27177,7 @@
 "aZs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -28489,8 +28472,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/computer/security/telescreen{
@@ -30306,7 +30288,6 @@
 	pixel_y = 12
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -31018,7 +30999,6 @@
 "bgv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -33508,8 +33488,7 @@
 	pixel_y = 13
 	},
 /obj/machinery/light{
-	dir = 2;
-	icon_state = "tube1"
+	dir = 2
 	},
 /obj/effect/landmark/start/captain,
 /obj/machinery/light_switch{
@@ -33820,8 +33799,7 @@
 /area/engine/break_room)
 "blr" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -37793,8 +37771,7 @@
 	pixel_y = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 4
@@ -37819,8 +37796,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
@@ -38523,7 +38499,6 @@
 	pixel_x = -22
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -38703,8 +38678,7 @@
 /area/hallway/primary/port)
 "btZ" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
@@ -39975,8 +39949,7 @@
 /area/bridge)
 "bwz" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
@@ -40319,8 +40292,7 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
@@ -40984,7 +40956,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -42131,7 +42102,6 @@
 /area/engine/atmos)
 "bAG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/table,
@@ -48485,8 +48455,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -49481,7 +49450,6 @@
 /area/gateway)
 "bOM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault,
@@ -49502,7 +49470,6 @@
 "bOO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -50107,7 +50074,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -50641,8 +50607,7 @@
 	},
 /obj/machinery/photocopier,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -54443,7 +54408,6 @@
 	pixel_x = 27
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -54615,8 +54579,7 @@
 "bYB" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/atmos)
@@ -58647,7 +58610,6 @@
 "cgb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -59957,7 +59919,6 @@
 	pixel_x = -2
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/noticeboard{
@@ -60770,8 +60731,7 @@
 /area/science/research)
 "ckh" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/closet/firecloset,
 /obj/machinery/airalarm{
@@ -61437,8 +61397,7 @@
 /obj/item/weapon/stock_parts/scanning_module,
 /obj/item/weapon/stock_parts/scanning_module,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 30
@@ -61915,8 +61874,7 @@
 "cmE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/sign/science{
 	pixel_x = 32
@@ -61932,7 +61890,6 @@
 	pixel_x = -28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -62437,7 +62394,6 @@
 	pixel_y = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/barber{
@@ -64661,8 +64617,7 @@
 /area/medical/medbay/central)
 "crx" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -64723,8 +64678,7 @@
 /area/crew_quarters/heads/cmo)
 "crC" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = 26;
@@ -65946,7 +65900,6 @@
 "ctN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
@@ -66280,8 +66233,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -67971,7 +67923,6 @@
 "cxz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -68418,7 +68369,6 @@
 	},
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/circuit,
@@ -70802,8 +70752,7 @@
 /area/medical/medbay/aft)
 "cCT" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -70989,7 +70938,6 @@
 "cDj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -72061,7 +72009,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/table,
@@ -72328,8 +72275,7 @@
 	pixel_x = -4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -73107,7 +73053,6 @@
 	pixel_x = -22
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/r_n_d/circuit_imprinter,
@@ -74224,7 +74169,6 @@
 	pixel_x = 29
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -76486,7 +76430,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -76853,7 +76796,6 @@
 	},
 /obj/item/weapon/restraints/handcuffs,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/item/device/radio/off,
@@ -77504,7 +77446,6 @@
 	pixel_x = -23
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/chapel,
@@ -77533,8 +77474,7 @@
 /area/chapel/main)
 "cPr" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
@@ -77740,7 +77680,6 @@
 	network = list("SS13")
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -78539,7 +78478,6 @@
 "cRB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -79741,7 +79679,6 @@
 /obj/item/weapon/clipboard,
 /obj/item/toy/figure/syndie,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -80200,7 +80137,6 @@
 /obj/item/weapon/circular_saw,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -80369,8 +80305,7 @@
 	pixel_y = -8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
@@ -80670,7 +80605,6 @@
 /area/shuttle/abandoned)
 "cVQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -82356,7 +82290,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
@@ -82914,7 +82847,6 @@
 	pixel_y = 3
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -85267,8 +85199,7 @@
 "deL" = (
 /obj/structure/cable/white,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -85313,8 +85244,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
 /turf/open/floor/engine,
@@ -85410,8 +85340,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/engine,
@@ -85518,8 +85447,7 @@
 	state = 2
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -86044,7 +85972,6 @@
 /area/maintenance/port/fore)
 "dhp" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -86494,8 +86421,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -87011,7 +86937,6 @@
 /area/maintenance/starboard/aft)
 "diV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -87421,7 +87346,6 @@
 	name = "tactical chair"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -87500,7 +87424,6 @@
 /obj/item/weapon/crowbar/red,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/podhatch{
@@ -87592,7 +87515,6 @@
 /area/shuttle/syndicate)
 "dkI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -87832,7 +87754,6 @@
 /area/shuttle/escape)
 "dlt" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -87853,7 +87774,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
@@ -87873,7 +87793,6 @@
 /area/shuttle/escape)
 "dly" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -87883,7 +87802,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/brig,
@@ -87896,7 +87814,6 @@
 /area/shuttle/labor)
 "dlB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -87909,7 +87826,6 @@
 /area/shuttle/supply)
 "dlD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -91121,8 +91037,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/engine,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31001,7 +31001,6 @@
 /area/shuttle/arrival)
 "bgt" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
@@ -80511,7 +80510,6 @@
 /area/shuttle/transport)
 "cVr" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced,
@@ -80526,7 +80524,6 @@
 /area/shuttle/transport)
 "cVw" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -80881,7 +80878,6 @@
 /area/shuttle/abandoned)
 "cWe" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -84843,7 +84839,6 @@
 /area/shuttle/transport)
 "ddL" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -64033,7 +64033,6 @@
 	req_one_access_txt = "24;10"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/engine,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9259,9 +9259,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
 "arO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -10180,9 +10178,7 @@
 	name = "Gravity Generator Room";
 	req_access_txt = "19;23"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel{
 	name = "floor"
@@ -11879,9 +11875,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -12022,9 +12016,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aws" = (
@@ -12419,9 +12411,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
@@ -12545,9 +12535,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -13125,9 +13113,7 @@
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "ayB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
 	cyclelinkeddir = 2;
@@ -13216,9 +13202,7 @@
 	req_access = null;
 	req_access_txt = "4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/detectives_office)
 "ayI" = (
@@ -13703,9 +13687,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "azI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -13820,9 +13802,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "azT" = (
@@ -14502,9 +14482,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "aBc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -26
@@ -14599,9 +14577,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aBn" = (
@@ -15159,9 +15135,7 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "aCn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
 	cyclelinkeddir = 1;
@@ -15623,9 +15597,7 @@
 /area/quartermaster/miningoffice)
 "aDk" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aDl" = (
@@ -15776,9 +15748,7 @@
 	},
 /area/hallway/primary/fore)
 "aDB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
@@ -16373,9 +16343,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/loadingarea{
 	dir = 1
 	},
@@ -17059,9 +17027,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/brown{
 	dir = 2
 	},
@@ -17082,9 +17048,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel{
@@ -17905,9 +17869,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -18135,9 +18097,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aHB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
 	},
@@ -19205,9 +19165,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aJF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -19270,9 +19228,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aJL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -19349,9 +19305,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aJV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -20418,9 +20372,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aMw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aMx" = (
@@ -22030,9 +21982,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aPA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -22062,9 +22012,7 @@
 "aPD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/security/courtroom)
 "aPE" = (
@@ -22377,9 +22325,7 @@
 	icon_state = "crateopen";
 	opened = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
@@ -24714,9 +24660,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aUE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Fore Primary Hallway"
@@ -25249,9 +25193,7 @@
 /turf/closed/wall,
 /area/quartermaster/storage)
 "aVH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/weapon/storage/firstaid/regular,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel{
@@ -25477,9 +25419,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aWg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
 	},
@@ -25859,9 +25799,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aXd" = (
@@ -26830,9 +26768,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -26919,9 +26855,7 @@
 /area/quartermaster/storage)
 "aYQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -27239,9 +27173,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -27676,9 +27608,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -27889,9 +27819,7 @@
 /area/quartermaster/office)
 "bau" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_mining{
 	glass = 0;
@@ -28286,9 +28214,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bbb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - Starboard Corner";
 	dir = 8;
@@ -28690,9 +28616,7 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "bbI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -28748,9 +28672,7 @@
 /area/quartermaster/sorting)
 "bbQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Cargo Office APC";
@@ -28931,9 +28853,7 @@
 	},
 /area/hallway/primary/central)
 "bcm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
@@ -29450,9 +29370,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -29719,9 +29637,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bdQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -30385,9 +30301,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -30731,9 +30645,7 @@
 	},
 /area/hallway/primary/central)
 "bfF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 4
 	},
@@ -32239,9 +32151,7 @@
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/turret_protected/ai)
 "biu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32655,9 +32565,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -33647,9 +33555,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bkS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -34651,9 +34557,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 2
@@ -35234,9 +35138,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Arrivals - Station Entrance";
 	dir = 4;
@@ -35895,9 +35797,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -36472,9 +36372,7 @@
 /turf/open/floor/plasteel/black,
 /area/aisat)
 "bqb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
@@ -36701,9 +36599,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
 	icon_state = "pipe-j1s";
@@ -38330,9 +38226,7 @@
 	name = "Captain's Desk";
 	req_access_txt = "20"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/item/weapon/stamp/captain,
 /turf/open/floor/wood,
@@ -38526,9 +38420,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -38739,9 +38631,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "btT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -38845,9 +38735,7 @@
 /turf/open/floor/wood,
 /area/library)
 "buh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Library"
@@ -39124,9 +39012,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "buI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -39166,9 +39052,7 @@
 	},
 /area/hallway/primary/central)
 "buM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
@@ -39255,9 +39139,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -39689,9 +39571,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bvL" = (
@@ -39844,9 +39724,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "bwd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/library)
 "bwe" = (
@@ -40218,9 +40096,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bwJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral/corner{
@@ -40391,9 +40267,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bwZ" = (
@@ -41124,9 +40998,7 @@
 	},
 /area/hallway/primary/central)
 "byw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -41779,9 +41651,7 @@
 	dir = 8;
 	network = list("SS13")
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/library)
 "bzG" = (
@@ -44101,9 +43971,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/library)
 "bEz" = (
@@ -44492,9 +44360,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -45271,9 +45137,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -45494,9 +45358,7 @@
 	name = "Gateway Atrium";
 	req_access_txt = "62"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -45571,9 +45433,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bGX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -45706,9 +45566,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bHm" = (
@@ -46254,9 +46112,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -46331,9 +46187,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bIs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
 	},
@@ -46419,9 +46273,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -47179,9 +47031,7 @@
 	},
 /area/hallway/primary/central)
 "bKd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -47681,9 +47531,7 @@
 /turf/open/floor/wood,
 /area/library)
 "bLj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/lightsout,
 /turf/open/floor/carpet,
 /area/library)
@@ -48517,9 +48365,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "bMK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -49266,9 +49112,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bOf" = (
@@ -49326,9 +49170,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/library)
 "bOm" = (
@@ -50068,9 +49910,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bPK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -50747,9 +50587,7 @@
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bRg" = (
@@ -50899,9 +50737,7 @@
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
 "bRy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "bRz" = (
@@ -51388,9 +51224,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -51726,9 +51560,7 @@
 /turf/open/floor/plating,
 /area/bridge/showroom/corporate)
 "bSK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Corporate Showroom";
@@ -51774,9 +51606,7 @@
 	},
 /area/hallway/primary/central)
 "bSR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/green/corner{
 	dir = 2
 	},
@@ -51937,9 +51767,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -52308,9 +52136,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
@@ -52471,9 +52297,7 @@
 	},
 /area/hallway/primary/central)
 "bUc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/botany{
 	pixel_x = 32;
 	pixel_y = 32
@@ -52642,9 +52466,7 @@
 	dir = 2;
 	sortType = 20
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -53026,9 +52848,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel{
 	icon_state = "L1"
 	},
@@ -53175,9 +52995,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bVp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -53260,9 +53078,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -54003,9 +53819,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -54362,9 +54176,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -54420,9 +54232,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
@@ -54450,9 +54260,7 @@
 	},
 /area/hallway/primary/central)
 "bXS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
@@ -54530,9 +54338,7 @@
 	req_access_txt = "0";
 	req_one_access_txt = "12;35;47"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bYc" = (
@@ -54909,9 +54715,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "0";
 	req_one_access_txt = "12;5;39;25;28"
@@ -55075,9 +54879,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white/side{
 	dir = 2
@@ -55112,9 +54914,7 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "bZf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Aft Primary Hallway"
@@ -55431,9 +55231,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -55647,9 +55445,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cam" = (
@@ -55683,9 +55479,7 @@
 	},
 /area/medical/medbay/central)
 "caq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
@@ -56476,9 +56270,7 @@
 	icon_state = "pipe-j1s";
 	sortType = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cbC" = (
@@ -57018,9 +56810,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -57320,9 +57110,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cdk" = (
@@ -57442,9 +57230,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/shower{
 	dir = 4;
 	name = "emergency shower"
@@ -57508,9 +57294,7 @@
 	},
 /area/medical/medbay/central)
 "cdG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -57690,9 +57474,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -58037,9 +57819,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 2
 	},
@@ -58788,9 +58568,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whiteblue,
 /area/medical/medbay/central)
 "cfU" = (
@@ -58852,9 +58630,7 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "cgb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 8
@@ -58991,9 +58767,7 @@
 	req_access_txt = "47";
 	req_one_access_txt = "0"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/science/research)
 "cgq" = (
@@ -59383,9 +59157,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "MedbayFoyer";
@@ -59463,9 +59235,7 @@
 	},
 /area/medical/chemistry)
 "chg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
 	},
@@ -59606,9 +59376,7 @@
 	},
 /area/science/research)
 "chv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -59871,9 +59639,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -60351,9 +60117,7 @@
 /area/science/research)
 "ciQ" = (
 /obj/item/weapon/cigbutt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -60410,9 +60174,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -60730,9 +60492,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cjM" = (
@@ -61409,9 +61169,7 @@
 	},
 /area/medical/sleeper)
 "clf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -61461,9 +61219,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
 	on = 1
@@ -61599,9 +61355,7 @@
 	},
 /area/medical/chemistry)
 "clx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -61997,9 +61751,7 @@
 	name = "Observation";
 	req_access_txt = "0"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "cmo" = (
@@ -62010,9 +61762,7 @@
 /area/medical/sleeper)
 "cmp" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
@@ -62029,9 +61779,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -62141,9 +61889,7 @@
 	},
 /area/medical/chemistry)
 "cmD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/chemistry{
 	pixel_x = -32
 	},
@@ -62545,9 +62291,7 @@
 	},
 /area/medical/surgery)
 "cns" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white/side{
 	dir = 2
 	},
@@ -62630,9 +62374,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "cnw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -63239,9 +62981,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "coE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
 	on = 1
@@ -63471,9 +63211,7 @@
 	},
 /area/hallway/primary/aft)
 "coZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
@@ -64013,9 +63751,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -64205,9 +63941,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -64941,9 +64675,7 @@
 /area/crew_quarters/heads/cmo)
 "crz" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -64999,9 +64731,7 @@
 /area/crew_quarters/heads/cmo)
 "crD" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "crE" = (
@@ -65010,15 +64740,11 @@
 	req_access_txt = "5; 33"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "crF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/device/radio/intercom{
 	freerange = 0;
 	frequency = 1459;
@@ -65073,9 +64799,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "crJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -65263,9 +64987,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -65973,9 +65695,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -66084,9 +65804,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -66154,9 +65872,7 @@
 /turf/closed/wall,
 /area/medical/genetics)
 "ctE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
@@ -66685,9 +66401,7 @@
 /turf/open/floor/plasteel/blue,
 /area/medical/genetics)
 "cuA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/blue/side{
 	dir = 8
 	},
@@ -67092,9 +66806,7 @@
 /area/medical/patients_rooms/room_a)
 "cvq" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/examroom{
 	pixel_x = -32
 	},
@@ -67475,9 +67187,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -67546,9 +67256,7 @@
 /area/maintenance/port/aft)
 "cwm" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -67637,9 +67345,7 @@
 /turf/open/floor/plating,
 /area/medical/patients_rooms/room_b)
 "cws" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -67774,9 +67480,7 @@
 	},
 /area/medical/genetics)
 "cwF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -68252,9 +67956,7 @@
 	},
 /area/medical/genetics)
 "cxz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 8
@@ -68455,9 +68157,7 @@
 /turf/closed/wall,
 /area/medical/medbay/aft)
 "cxV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -69084,9 +68784,7 @@
 /turf/closed/wall,
 /area/medical/genetics)
 "czf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/device/radio/intercom{
 	freerange = 0;
 	frequency = 1459;
@@ -69510,9 +69208,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
@@ -70200,9 +69896,7 @@
 /area/hallway/primary/aft)
 "cBe" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
 	},
@@ -70342,9 +70036,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -70650,9 +70342,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -71787,9 +71477,7 @@
 /turf/closed/wall,
 /area/hallway/primary/aft)
 "cEg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -72187,9 +71875,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cEO" = (
@@ -72257,9 +71943,7 @@
 	icon_state = "pipe-j2";
 	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
 /area/medical/morgue)
 "cEW" = (
@@ -72722,9 +72406,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/device/radio/intercom{
 	freerange = 0;
 	frequency = 1459;
@@ -72805,9 +72487,7 @@
 /turf/open/floor/plasteel/black,
 /area/hallway/primary/aft)
 "cFZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
@@ -73312,9 +72992,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 4
 	},
@@ -73402,9 +73080,7 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "cGU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -73773,9 +73449,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 4
 	},
@@ -74188,9 +73862,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -74337,9 +74009,7 @@
 /area/space)
 "cIz" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -74394,9 +74064,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cIE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/escape{
 	dir = 2
 	},
@@ -74893,9 +74561,7 @@
 /turf/open/floor/plasteel/vault,
 /area/hallway/secondary/exit/departure_lounge)
 "cJE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Departure Lounge"
@@ -77196,9 +76862,7 @@
 /area/maintenance/aft)
 "cNU" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -86656,9 +86320,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -87019,9 +86681,7 @@
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "diA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
 	},
@@ -109034,7 +108694,7 @@ bHP
 bvW
 bLf
 bJs
-bOj
+aLd
 bPK
 bRf
 bSv
@@ -109553,7 +109213,7 @@ alK
 alK
 alC
 bSs
-bTu
+bzC
 bWb
 dux
 bYL
@@ -111334,7 +110994,7 @@ bkq
 bmi
 boc
 bqt
-bsF
+bsy
 buh
 bwd
 bwd
@@ -111626,7 +111286,7 @@ cmn
 cns
 coE
 cpZ
-crp
+coB
 csp
 ctp
 duH
@@ -121340,7 +121000,7 @@ aIR
 aMP
 aOl
 aPD
-aQI
+aSa
 aSa
 aTp
 aIT
@@ -123177,10 +122837,10 @@ bTS
 aYX
 bWF
 bYb
-bZp
+cmZ
 diA
 crJ
-cdT
+cJb
 ceY
 cgm
 chr
@@ -126282,7 +125942,7 @@ cuX
 cvZ
 dvY
 cub
-cyL
+cKc
 czC
 cAJ
 cBE
@@ -127551,16 +127211,16 @@ caQ
 bST
 bST
 cfg
-cgr
-cgr
+cJa
+cJa
 ciX
-cgr
+cJa
 clW
 cIk
-cgr
+cJa
 cpG
-cgr
-cgr
+cJa
+cJa
 ctk
 cuc
 cvb

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -171,7 +171,6 @@
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
 	name = "Prison Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24;
 	prison_radio = 1
 	},
@@ -294,9 +293,7 @@
 /area/lavaland/surface/outdoors/explored)
 "aU" = (
 /obj/machinery/flasher{
-	id = "Labor";
-	pixel_x = 0;
-	pixel_y = 0
+	id = "Labor"
 	},
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -342,7 +339,6 @@
 /obj/machinery/button/door{
 	id = "Labor";
 	name = "Labor Camp Lockdown";
-	pixel_x = 0;
 	pixel_y = 28;
 	req_access_txt = "2"
 	},
@@ -421,7 +417,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel{
@@ -498,8 +493,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -571,8 +565,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -586,8 +579,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -723,8 +715,7 @@
 "bN" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
@@ -763,8 +754,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
@@ -775,8 +765,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_mining{
 	name = "Mining Station EVA";
@@ -801,8 +790,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
@@ -896,8 +884,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Labor Camp Security APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Labor Camp Monitoring";
@@ -996,8 +983,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -1134,8 +1120,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -1216,8 +1201,7 @@
 /area/mine/production)
 "cP" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/brown{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
@@ -1251,8 +1235,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -1309,8 +1292,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1479,8 +1461,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -1667,8 +1648,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -1794,8 +1774,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Station Maintenance";
@@ -1804,8 +1783,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
@@ -1873,8 +1851,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/brown{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
@@ -1941,8 +1918,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/brown{
@@ -2028,8 +2004,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -2040,8 +2015,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -2054,8 +2028,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2086,8 +2059,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -2103,8 +2075,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
@@ -2115,8 +2086,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_mining{
 	name = "Mining Station Bridge";
@@ -2136,8 +2106,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
@@ -2151,8 +2120,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -2162,8 +2130,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_mining{
 	name = "Mining Station Bridge";
@@ -2180,8 +2147,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2577,7 +2543,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -2677,8 +2642,7 @@
 	pixel_y = 9
 	},
 /obj/item/weapon/reagent_containers/food/drinks/beer{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /turf/open/floor/plasteel/bar{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -2741,7 +2705,6 @@
 	network = list("MINE")
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/light,
@@ -2778,7 +2741,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -2817,7 +2779,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -712,9 +712,9 @@
 	req_access_txt = "2"
 	},
 /obj/structure/cable{
-	icon_state = "1-10";
-	d1 = 2;
-	d2 = 4
+	d1 = 1;
+	d2 = 10;
+	icon_state = "1-10"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -918,9 +918,9 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "5-6";
-	d1 = 2;
-	d2 = 4
+	d1 = 5;
+	d2 = 6;
+	icon_state = "5-6"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -1103,9 +1103,9 @@
 	d2 = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-9";
-	d1 = 2;
-	d2 = 4
+	d1 = 0;
+	d2 = 9;
+	icon_state = "0-9"
 	},
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -9750,7 +9750,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "mix_in";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "distro vent";
 	on = 1;
@@ -11132,7 +11131,6 @@
 "arz" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -11818,7 +11816,6 @@
 "asG" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 2;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /obj/effect/decal/cleanable/dirt,
@@ -11827,7 +11824,6 @@
 "asH" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
@@ -12932,7 +12928,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "n2 vent";
 	on = 1;
@@ -12989,7 +12984,6 @@
 "auv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -15040,7 +15034,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "o2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "oxygen vent";
 	on = 1;
@@ -16222,7 +16215,6 @@
 "aAo" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/neutral,
@@ -16258,7 +16250,6 @@
 "aAs" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /obj/structure/cable/white{
 	tag = "icon-2-8";
@@ -16873,7 +16864,6 @@
 "aBw" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -16881,7 +16871,6 @@
 "aBx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -17436,7 +17425,6 @@
 "aCt" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
@@ -20962,7 +20950,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
-	initialize_directions = 12
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -20997,7 +20984,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
-	initialize_directions = 12
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -28605,7 +28591,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "server vent";
 	on = 1;
@@ -36189,7 +36174,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	name = "server vent";
 	on = 1;

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1601,8 +1601,7 @@
 "acK" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -3529,7 +3528,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -4064,7 +4062,6 @@
 	pixel_x = -23
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -4106,7 +4103,6 @@
 "agM" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/status_display{
@@ -5475,7 +5471,6 @@
 	},
 /obj/item/weapon/gun/energy/e_gun/advtaser,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/status_display{
@@ -7086,7 +7081,6 @@
 "akW" = (
 /obj/vehicle/secway,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -7131,8 +7125,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner,
 /area/security/brig)
@@ -7333,8 +7326,7 @@
 	icon_state = "plant-22"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/white{
 	d1 = 1;
@@ -8675,7 +8667,6 @@
 /obj/item/weapon/storage/box/firingpins,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/requests_console{
@@ -10074,7 +10065,6 @@
 	pixel_x = -23
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -10919,8 +10909,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Brig Aft";
@@ -10956,8 +10945,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -11460,7 +11448,6 @@
 /area/security/brig)
 "arD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/status_display{
@@ -13985,8 +13972,7 @@
 	name = "Distribution Loop"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -15654,8 +15640,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
@@ -18546,8 +18531,7 @@
 /area/crew_quarters/dorms)
 "aDF" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -21707,8 +21691,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner,
@@ -23613,8 +23596,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26143,8 +26125,7 @@
 /area/engine/engineering)
 "aPJ" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26692,7 +26673,6 @@
 /area/tcommsat/server)
 "aQI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -28397,7 +28377,6 @@
 /area/tcommsat/server)
 "aTZ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -28902,8 +28881,7 @@
 /obj/item/weapon/storage/crayons,
 /obj/item/weapon/storage/crayons,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
@@ -32001,8 +31979,7 @@
 /area/hallway/primary/central)
 "baH" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -33368,8 +33345,7 @@
 "bdg" = (
 /obj/machinery/computer/security,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/white{
 	d1 = 4;
@@ -33455,8 +33431,7 @@
 /area/science/robotics/mechbay)
 "bdo" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
@@ -33477,8 +33452,7 @@
 /area/science/research)
 "bdr" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -35881,8 +35855,7 @@
 /area/science/xenobiology)
 "bhi" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -37190,7 +37163,6 @@
 	},
 /obj/item/weapon/storage/fancy/candle_box,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/newscaster{
@@ -37441,8 +37413,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -37936,8 +37907,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -38457,7 +38427,6 @@
 /area/space)
 "bmC" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38628,7 +38597,6 @@
 /obj/item/weapon/clipboard,
 /obj/item/toy/figure/syndie,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -39699,7 +39667,6 @@
 /obj/item/weapon/circular_saw,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -40670,7 +40637,6 @@
 	name = "tactical chair"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -40749,7 +40715,6 @@
 /obj/item/weapon/crowbar/red,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/podhatch{
@@ -40841,7 +40806,6 @@
 /area/shuttle/syndicate)
 "btY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -375,7 +375,6 @@
 	department = "Bridge";
 	departmentType = 5;
 	name = "Bridge RC";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkyellow/side{
@@ -399,8 +398,7 @@
 /obj/item/device/assembly/flash/handheld,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -498,8 +496,7 @@
 /obj/item/weapon/storage/secure/briefcase,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Fore Starboard";
@@ -716,7 +713,6 @@
 	icon_state = "doors";
 	name = "WARNING: PRESSURIZED DOORS";
 	pixel_x = -32;
-	pixel_y = 0;
 	tag = "icon-doors"
 	},
 /obj/structure/cable/white{
@@ -805,7 +801,6 @@
 	icon_state = "doors";
 	name = "WARNING: PRESSURIZED DOORS";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-doors"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -875,8 +870,7 @@
 /obj/item/weapon/pen,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/light{
 	dir = 1
@@ -1933,8 +1927,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	name = "cargo display";
-	pixel_x = 0;
-	pixel_y = 0;
 	supply_display = 1
 	},
 /turf/closed/wall,
@@ -2073,7 +2065,6 @@
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = -26;
-	pixel_y = 0;
 	req_access_txt = "0";
 	use_power = 0
 	},
@@ -2175,8 +2166,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -2295,8 +2285,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay North"
@@ -2367,7 +2356,6 @@
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
 	name = "WARNING: BLAST DOORS";
-	pixel_x = 0;
 	pixel_y = 32;
 	tag = "icon-doors"
 	},
@@ -2633,7 +2621,6 @@
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /obj/item/device/radio/intercom{
@@ -2817,7 +2804,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Head of Personnel Quarter's APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel/vault{
@@ -2848,7 +2834,6 @@
 	density = 0;
 	name = "cargo display";
 	pixel_x = -32;
-	pixel_y = 0;
 	supply_display = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3006,7 +2991,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Detective's Office APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
@@ -3098,7 +3082,6 @@
 	dir = 4;
 	icon_state = "fire0";
 	pixel_x = 24;
-	pixel_y = 0;
 	tag = "icon-fire0 (EAST)"
 	},
 /obj/machinery/camera{
@@ -3128,8 +3111,6 @@
 	dir = 4;
 	name = "ai camera";
 	network = list("Sat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -3170,8 +3151,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Starboard Access";
@@ -3444,8 +3424,7 @@
 /obj/item/device/camera/detective,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -3481,8 +3460,7 @@
 	department = "Detective's Office";
 	departmentType = 0;
 	name = "Detective RC";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/camera{
 	c_tag = "Detective's Office - Desk";
@@ -3536,7 +3514,6 @@
 	department = "Captain's Desk";
 	departmentType = 5;
 	name = "Captain RC";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
@@ -3705,7 +3682,6 @@
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/extinguisher_cabinet{
@@ -3924,8 +3900,7 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -4133,8 +4108,7 @@
 /obj/item/weapon/aiModule/reset,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -4210,16 +4184,13 @@
 	frequency = 1447;
 	listening = 0;
 	name = "AI Intercom";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/camera{
 	c_tag = "AI Core - Starboard";
 	dir = 8;
 	name = "ai camera";
 	network = list("Sat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -4293,8 +4264,7 @@
 "ahk" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/light_switch{
 	pixel_x = -24;
@@ -4518,8 +4488,7 @@
 /obj/machinery/photocopier,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable/white{
 	tag = "icon-2-4";
@@ -4639,7 +4608,6 @@
 /obj/machinery/button/door{
 	id = "captainhall";
 	name = "Captain's Hall Shutters Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "20"
 	},
@@ -4658,7 +4626,6 @@
 "ahM" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/table/wood,
@@ -4721,7 +4688,6 @@
 "ahU" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/circuit/green,
@@ -5113,8 +5079,7 @@
 	frequency = 1447;
 	listening = 0;
 	name = "AI Intercom";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/white{
 	tag = "icon-1-2";
@@ -5558,7 +5523,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -5710,7 +5674,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -5763,7 +5726,6 @@
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
 	name = "WARNING: PRESSURIZED DOORS";
-	pixel_x = 0;
 	pixel_y = 32;
 	tag = "icon-doors"
 	},
@@ -5903,8 +5865,7 @@
 	department = "Cargo Office";
 	departmentType = 0;
 	name = "Cargo Office RC";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/brown{
 	tag = "icon-brown (EAST)";
@@ -5955,8 +5916,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -6830,8 +6790,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Office APC";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -7088,7 +7047,6 @@
 	dir = 1;
 	icon_state = "direction_bridge";
 	name = "command department";
-	pixel_x = 0;
 	pixel_y = 8;
 	tag = "icon-direction_bridge"
 	},
@@ -7177,7 +7135,6 @@
 	dir = 4;
 	icon_state = "nboard00";
 	pixel_x = -32;
-	pixel_y = 0;
 	tag = "icon-nboard00 (EAST)"
 	},
 /obj/item/weapon/clipboard,
@@ -7233,8 +7190,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Cargo Bay APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable/white{
 	tag = "icon-0-8";
@@ -7491,7 +7447,6 @@
 	id = "teleportershutters";
 	name = "Teleporter Shutters";
 	pixel_x = -26;
-	pixel_y = 0;
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
@@ -7739,8 +7694,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -7785,7 +7739,6 @@
 "amy" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/light,
@@ -7815,8 +7768,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/item/stack/packageWrap,
 /obj/item/stack/cable_coil/white,
@@ -7873,8 +7825,7 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Office";
@@ -7978,7 +7929,6 @@
 "amP" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/light/small,
@@ -8025,8 +7975,7 @@
 /obj/item/weapon/hand_labeler,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Teleporter";
@@ -8192,7 +8141,6 @@
 	dir = 4;
 	icon_state = "fire0";
 	pixel_x = 24;
-	pixel_y = 0;
 	tag = "icon-fire0 (EAST)"
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -8277,7 +8225,6 @@
 /obj/structure/closet/secure_closet/miner,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -8297,8 +8244,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Mining Dock APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 26
@@ -8372,8 +8318,7 @@
 	department = "Security";
 	departmentType = 0;
 	name = "Security RC";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/weapon/gun/energy/e_gun/dragnet,
 /obj/item/weapon/gun/energy/e_gun/dragnet,
@@ -8553,7 +8498,6 @@
 	dir = 4;
 	name = "RCD Storage";
 	pixel_x = 1;
-	pixel_y = 0;
 	req_access_txt = "19"
 	},
 /obj/structure/window/reinforced,
@@ -8665,7 +8609,6 @@
 	dir = 4;
 	name = "RCD Storage";
 	pixel_x = 1;
-	pixel_y = 0;
 	req_access_txt = "19"
 	},
 /obj/structure/window/reinforced,
@@ -8677,8 +8620,7 @@
 	dir = 8
 	},
 /obj/machinery/status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -8710,8 +8652,7 @@
 	department = "E.V.A. Storage";
 	departmentType = 0;
 	name = "E.V.A. RC";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8963,8 +8904,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 8
@@ -9715,8 +9655,7 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -9854,8 +9793,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -9923,8 +9861,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
@@ -10097,8 +10034,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
@@ -10326,8 +10262,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/sign/pods{
-	name = "MINING POD";
-	pixel_x = 0
+	name = "MINING POD"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
@@ -10454,8 +10389,7 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -10628,7 +10562,6 @@
 	department = "Primary Tool Storage";
 	departmentType = 0;
 	name = "Primary Tool Storage RC";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -10735,7 +10668,6 @@
 	icon_state = "doors";
 	name = "WARNING: PRESSURIZED DOORS";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-doors"
 	},
 /turf/open/floor/plating,
@@ -10792,8 +10724,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
@@ -10807,7 +10738,6 @@
 	department = "Mining";
 	departmentType = 0;
 	name = "Mining Dock RC";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/item/weapon/folder/yellow,
@@ -11809,7 +11739,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/vault{
@@ -11842,7 +11771,6 @@
 /obj/item/device/assembly/flash/handheld,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -12127,7 +12055,6 @@
 	dir = 4;
 	icon_state = "fire0";
 	pixel_x = 24;
-	pixel_y = 0;
 	tag = "icon-fire0 (EAST)"
 	},
 /obj/machinery/light{
@@ -12367,8 +12294,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Atmospherics Engine APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable/white{
 	d2 = 2;
@@ -12647,8 +12573,7 @@
 /area/crew_quarters/theatre)
 "aua" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
@@ -12775,8 +12700,7 @@
 /obj/item/stack/cable_coil/random,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/bar)
@@ -13247,8 +13171,7 @@
 /area/crew_quarters/theatre)
 "avd" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -13779,8 +13702,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/light_switch{
 	pixel_x = -24;
@@ -13876,8 +13798,7 @@
 /area/crew_quarters/theatre)
 "awi" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
@@ -14071,8 +13992,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -14356,7 +14276,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/vault{
@@ -14841,7 +14760,6 @@
 	departmentType = 0;
 	name = "Bar RC";
 	pixel_x = 32;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -14943,8 +14861,6 @@
 	node1_concentration = 0.8;
 	node2_concentration = 0.2;
 	on = 1;
-	pixel_x = 0;
-	pixel_y = 0;
 	target_pressure = 4500
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -15037,8 +14953,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -15206,8 +15121,7 @@
 /area/crew_quarters/theatre)
 "ayH" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -15318,7 +15232,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Central Starborad Maintenance APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -15407,7 +15320,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -15475,7 +15387,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/mineral/plastitanium/brig,
@@ -15740,7 +15651,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16828,8 +16738,7 @@
 	department = "Atmospherics Office";
 	departmentType = 0;
 	name = "Atmospherics RC";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26;
@@ -16970,8 +16879,7 @@
 	department = "Theatre Backstage";
 	departmentType = 0;
 	name = "Theatre RC";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/camera{
 	c_tag = "Theatre Storage"
@@ -16994,7 +16902,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Theatre Backstage APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/extinguisher_cabinet{
@@ -17090,7 +16997,6 @@
 	dir = 4;
 	icon_state = "fire0";
 	pixel_x = 24;
-	pixel_y = 0;
 	tag = "icon-fire0 (EAST)"
 	},
 /turf/open/floor/plasteel/vault{
@@ -17362,7 +17268,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -17493,8 +17398,7 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -17601,8 +17505,7 @@
 /obj/item/toy/figure/chef,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/camera{
 	c_tag = "Kitchen";
@@ -17631,7 +17534,6 @@
 	department = "Kitchen";
 	departmentType = 0;
 	name = "Kitchen RC";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault,
@@ -17680,8 +17582,7 @@
 /obj/item/weapon/pen,
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light{
 	dir = 8
@@ -17777,8 +17678,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -17844,8 +17744,7 @@
 "aDw" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -18131,8 +18030,7 @@
 "aDX" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -18390,8 +18288,7 @@
 	name = "Engineering Power Monitoring Console"
 	},
 /obj/machinery/status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/cable/white{
 	d2 = 2;
@@ -18588,8 +18485,7 @@
 /obj/machinery/vending/clothing,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -18694,7 +18590,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/vault{
@@ -18930,8 +18825,6 @@
 "aFp" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "0";
 	use_power = 0
 	},
@@ -18950,7 +18843,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/bot,
@@ -19051,9 +18943,7 @@
 /obj/machinery/camera{
 	c_tag = "SMES Access";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -19355,8 +19245,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -19502,8 +19391,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
 	tag = "icon-0-8";
@@ -19697,7 +19585,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Central Port Maintenance APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -19875,8 +19762,7 @@
 /obj/machinery/holopad,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar{
@@ -20008,9 +19894,7 @@
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 4
@@ -20028,7 +19912,6 @@
 /obj/machinery/button/door{
 	id = "engstorage";
 	name = "Engineering Secure Storage Control";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "10"
 	},
@@ -20141,8 +20024,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
 	tag = "icon-4-8";
@@ -20718,7 +20600,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -20732,7 +20613,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -20746,7 +20626,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -20766,12 +20645,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -20790,8 +20667,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -20807,7 +20683,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -20824,7 +20699,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -20843,7 +20717,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -20857,7 +20730,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/effect/landmark/start/station_engineer,
@@ -20976,8 +20848,7 @@
 	department = "Engineering";
 	departmentType = 0;
 	name = "Engineering RC";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -21104,7 +20975,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -21129,7 +20999,6 @@
 	department = "Hydroponics";
 	departmentType = 0;
 	name = "Hydroponics RC";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -21254,8 +21123,7 @@
 "aIX" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light{
 	dir = 8
@@ -21399,7 +21267,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Gravity Generator APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -21423,7 +21290,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/structure/cable/white{
@@ -21474,8 +21340,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -21483,8 +21348,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21547,8 +21411,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -21686,7 +21549,6 @@
 	department = "Custodial Closet";
 	departmentType = 0;
 	name = "Custodial RC";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/device/radio/intercom{
@@ -21708,7 +21570,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Custodial Closet APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
@@ -22036,8 +21897,7 @@
 "aKp" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/vault,
 /area/engine/gravity_generator)
@@ -22103,8 +21963,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -22192,8 +22051,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
@@ -22228,8 +22086,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22559,7 +22416,6 @@
 	dir = 4;
 	icon_state = "fire0";
 	pixel_x = 24;
-	pixel_y = 0;
 	tag = "icon-fire0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -22710,7 +22566,6 @@
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = -26;
-	pixel_y = 0;
 	req_access_txt = "0";
 	use_power = 0
 	},
@@ -22726,8 +22581,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/escape)
@@ -22856,8 +22710,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -22916,8 +22769,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -22993,8 +22845,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plating,
 /area/janitor)
@@ -23413,8 +23264,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engsm";
@@ -23490,8 +23340,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engsm";
@@ -23510,8 +23359,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -23624,8 +23472,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/structure/cable/white{
 	tag = "icon-1-2";
@@ -23659,7 +23506,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/bot,
@@ -23752,7 +23598,6 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/light,
@@ -23913,8 +23758,7 @@
 /obj/item/weapon/stamp,
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/brown{
 	tag = "icon-brown (WEST)";
@@ -23939,7 +23783,6 @@
 /obj/structure/closet/crate,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/light,
@@ -23963,7 +23806,6 @@
 /obj/structure/closet/crate,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/delivery,
@@ -23982,7 +23824,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -24002,7 +23843,6 @@
 	pixel_y = 1
 	},
 /obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = 0;
 	pixel_y = -1
 	},
 /obj/item/weapon/storage/toolbox/emergency{
@@ -24101,7 +23941,6 @@
 /obj/machinery/computer/telecomms/monitor,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/vault{
@@ -24116,8 +23955,7 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -24135,8 +23973,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24159,8 +23996,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engsm";
@@ -24180,8 +24016,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -24193,8 +24028,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Engine Room APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable/white,
 /obj/effect/decal/cleanable/dirt,
@@ -24449,8 +24283,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engsm";
@@ -24481,8 +24314,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engsm";
@@ -24750,7 +24582,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -25096,7 +24927,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -25561,7 +25391,6 @@
 "aQf" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25703,7 +25532,6 @@
 "aQu" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25726,7 +25554,6 @@
 "aQx" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26026,9 +25853,7 @@
 "aRa" = (
 /obj/structure/sign/kiddieplaque{
 	desc = "A long list of rules to be followed when in the library, extolling the virtues of being quiet at all times and threatening those who would dare eat hot food inside.";
-	name = "Library Rules Sign";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Library Rules Sign"
 	},
 /turf/closed/wall,
 /area/library)
@@ -26270,8 +26095,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -26312,8 +26136,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -26493,7 +26316,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/vault{
@@ -26617,7 +26439,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Chemistry Lab APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
@@ -26770,7 +26591,6 @@
 	department = "Research Lab";
 	departmentType = 0;
 	name = "Research RC";
-	pixel_x = 0;
 	pixel_y = 32;
 	receive_ore_updates = 1
 	},
@@ -26797,8 +26617,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -27021,8 +26840,7 @@
 	pixel_x = -5
 	},
 /obj/item/weapon/tank/internals/emergency_oxygen/engi{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 5
 	},
 /obj/item/device/geiger_counter,
 /obj/item/device/geiger_counter,
@@ -27122,8 +26940,7 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plating,
 /area/medical/morgue)
@@ -27174,7 +26991,6 @@
 /obj/machinery/door/window/southright,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/vault,
@@ -27636,8 +27452,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plating,
 /area/medical/morgue)
@@ -27798,8 +27613,7 @@
 /obj/item/weapon/stock_parts/manipulator,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27827,8 +27641,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Research Division APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -27902,8 +27715,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 7
@@ -28151,7 +27963,6 @@
 	departmentType = 0;
 	name = "Chemistry RC";
 	pixel_x = 32;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/whiteyellow/corner,
@@ -28576,7 +28387,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/light,
@@ -28656,7 +28466,6 @@
 "aWn" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/light,
@@ -28854,9 +28663,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -28954,7 +28761,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/grimy,
@@ -29082,8 +28888,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
@@ -29218,8 +29023,7 @@
 	id = "MedbayFoyer";
 	name = "Medbay Doors Control";
 	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/machinery/light{
 	dir = 4
@@ -29479,7 +29283,6 @@
 	departmentType = 1;
 	name = "Medbay RC";
 	pixel_x = -30;
-	pixel_y = 0;
 	pixel_z = 0
 	},
 /obj/machinery/camera{
@@ -29503,7 +29306,6 @@
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/machinery/light_switch{
@@ -29665,7 +29467,6 @@
 "aYi" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -29705,7 +29506,6 @@
 /obj/machinery/light,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -29759,8 +29559,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -29776,7 +29575,6 @@
 /obj/structure/cable/white,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -30282,7 +30080,6 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/status_display{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/newscaster{
@@ -30614,14 +30411,12 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/power/apc{
 	cell_type = 10000;
 	dir = 1;
 	name = "Mech Bay APC";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/structure/cable/white{
@@ -30777,7 +30572,6 @@
 	department = "Robotics Lab";
 	departmentType = 0;
 	name = "Robotics RC";
-	pixel_x = 0;
 	pixel_y = 32;
 	receive_ore_updates = 1
 	},
@@ -30896,8 +30690,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medbay APC";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/structure/cable/white,
 /obj/effect/turf_decal/delivery,
@@ -30928,7 +30721,6 @@
 /obj/machinery/vending/medical,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30942,7 +30734,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/sign/bluecross_2,
 /obj/structure/sign/nosmoking_1{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31038,9 +30829,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -31095,8 +30884,7 @@
 "baN" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -31455,7 +31243,6 @@
 	dir = 4;
 	icon_state = "fire0";
 	pixel_x = 24;
-	pixel_y = 0;
 	tag = "icon-fire0 (EAST)"
 	},
 /obj/machinery/light{
@@ -31535,8 +31322,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Security Checkpoint APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -31833,7 +31619,6 @@
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = -26;
-	pixel_y = 0;
 	req_access_txt = "0";
 	use_power = 0
 	},
@@ -31846,7 +31631,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/blue,
@@ -32185,8 +31969,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Port Maintenance APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32473,8 +32256,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Robotics Lab APC";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
@@ -32614,7 +32396,6 @@
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/syndicate{
 	icon_state = "deck_syndicate_full";
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/machinery/light/small{
@@ -32737,7 +32518,6 @@
 "bdS" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32764,7 +32544,6 @@
 "bdU" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32829,7 +32608,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -32904,7 +32682,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -32963,7 +32740,6 @@
 /obj/machinery/cell_charger,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -33197,7 +32973,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/red/side{
@@ -33486,8 +33261,7 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/blue/corner{
 	tag = "icon-bluecorner (WEST)";
@@ -34073,7 +33847,6 @@
 "bfX" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel{
@@ -34091,7 +33864,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Chapel APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/effect/landmark/start/assistant,
@@ -34136,7 +33908,6 @@
 	desc = "A plaque commemorating the fallen, may they rest in peace, forever asleep amongst the stars. Someone has drawn a picture of a crying badger at the bottom.";
 	icon_state = "kiddieplaque";
 	name = "Remembrance Plaque";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -34164,8 +33935,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -34298,8 +34068,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
 	dir = 2;
-	network = list("Xeno","RD");
-	pixel_x = 0
+	network = list("Xeno","RD")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 4
@@ -34392,7 +34161,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -34830,7 +34598,6 @@
 	dir = 4;
 	icon_state = "nboard00";
 	pixel_x = -32;
-	pixel_y = 0;
 	tag = "icon-nboard00 (EAST)"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -34942,7 +34709,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Arrivals APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
@@ -35183,7 +34949,6 @@
 	desc = "A plaque commemorating the fallen, may they rest in peace, forever asleep amongst the stars. Someone has drawn a picture of a crying badger at the bottom.";
 	icon_state = "kiddieplaque";
 	name = "Remembrance Plaque";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35371,7 +35136,6 @@
 "bit" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -35663,7 +35427,6 @@
 /obj/machinery/button/door{
 	id = "chapelprivacy";
 	name = "Chapel Privacy Shutters";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "0"
 	},
@@ -35710,9 +35473,7 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway 3";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -36088,8 +35849,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
@@ -36115,7 +35875,6 @@
 	department = "Chapel Office";
 	departmentType = 0;
 	name = "Chapel RC";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/status_display{
@@ -36127,8 +35886,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36160,8 +35918,7 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -36194,7 +35951,6 @@
 	department = "Xenobiology Lab";
 	departmentType = 0;
 	name = "Xenobiology RC";
-	pixel_x = 0;
 	pixel_y = -32;
 	receive_ore_updates = 1
 	},
@@ -36233,8 +35989,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Xenobiology Lab APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -36242,7 +35997,6 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable/white{
@@ -36632,8 +36386,6 @@
 "bkF" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "0";
 	use_power = 0
 	},
@@ -36942,9 +36694,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Starboard";
 	dir = 8;
-	network = list("SS13","Engine");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13","Engine")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36976,7 +36726,6 @@
 	c_tag = "Aft Primary Hallway 1";
 	dir = 8;
 	network = list("SS13");
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/purple/corner,
@@ -37034,8 +36783,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
 	dir = 2;
-	network = list("Xeno","RD");
-	pixel_x = 0
+	network = list("Xeno","RD")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -37071,9 +36819,7 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway 2";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37773,7 +37519,6 @@
 	id = "smindicate";
 	name = "external door control";
 	pixel_x = -26;
-	pixel_y = 0;
 	req_access_txt = "150"
 	},
 /obj/docking_port/mobile{
@@ -37809,8 +37554,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
@@ -38094,8 +37838,7 @@
 /area/shuttle/syndicate)
 "bpM" = (
 /obj/item/weapon/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/item/weapon/reagent_containers/glass/bottle/charcoal{
 	pixel_x = -3
@@ -38549,8 +38292,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 30
@@ -39814,8 +39556,7 @@
 "buA" = (
 /obj/machinery/requests_console{
 	department = "Arrival shuttle";
-	name = "Arrivals Shuttle console";
-	pixel_y = 0
+	name = "Arrivals Shuttle console"
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/arrival)
@@ -39853,8 +39594,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Telecoms Server Room APC";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -39929,8 +39669,7 @@
 /obj/machinery/telecomms/receiver/preset_left/birdstation,
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/circuit/green{
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -40374,8 +40113,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/transport)
@@ -40576,8 +40314,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -474,8 +474,6 @@
 /area/bridge)
 "aaS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -1205,8 +1203,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault,
@@ -1245,8 +1241,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -1292,8 +1286,6 @@
 /area/bridge)
 "acm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault,
@@ -1622,8 +1614,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -1818,8 +1808,6 @@
 /area/bridge)
 "adf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -2028,8 +2016,6 @@
 /area/security/detectives_office)
 "adB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -2246,8 +2232,6 @@
 /area/bridge)
 "adT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -2752,8 +2736,6 @@
 /area/bridge)
 "aeH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -2986,8 +2968,6 @@
 /area/security/detectives_office)
 "afe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -3101,8 +3081,6 @@
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -3188,8 +3166,6 @@
 /area/ai_monitored/turret_protected/ai)
 "aft" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -3629,8 +3605,6 @@
 /area/bridge)
 "agf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -3975,8 +3949,6 @@
 /obj/item/weapon/folder/red,
 /obj/item/weapon/hand_labeler,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -4256,8 +4228,6 @@
 /area/ai_monitored/turret_protected/ai)
 "ahe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -5389,8 +5359,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -5548,8 +5516,6 @@
 	})
 "aji" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -5842,8 +5808,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -5927,8 +5891,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/landmark/start/cargo_technician,
@@ -6072,8 +6034,6 @@
 /area/security/brig)
 "ajW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -6178,8 +6138,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -6360,8 +6318,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -6541,8 +6497,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel{
@@ -6652,8 +6606,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -6752,8 +6704,6 @@
 	})
 "akK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -6902,8 +6852,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -7267,8 +7215,6 @@
 /area/quartermaster/storage)
 "alD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -7341,8 +7287,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
@@ -7351,8 +7295,6 @@
 /area/security/brig)
 "alJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -7457,8 +7399,6 @@
 /area/security/brig)
 "alR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -7810,8 +7750,6 @@
 	})
 "amu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -7976,8 +7914,6 @@
 /area/security/brig)
 "amL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner,
@@ -8810,8 +8746,6 @@
 	})
 "aoa" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -9060,8 +8994,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner,
@@ -9136,8 +9068,6 @@
 /area/security/brig)
 "aoB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -9289,8 +9219,6 @@
 /area/maintenance/port/central)
 "aoN" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -9452,8 +9380,6 @@
 	})
 "aoZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -9804,8 +9730,6 @@
 "apz" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -9864,8 +9788,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -9928,8 +9850,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
@@ -10585,8 +10505,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -11239,8 +11157,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -11466,8 +11382,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -11519,8 +11433,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -11797,8 +11709,6 @@
 /area/engine/atmos)
 "asE" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -12021,8 +11931,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -12198,8 +12106,6 @@
 /area/crew_quarters/theatre)
 "ath" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/closed/wall,
@@ -12266,8 +12172,6 @@
 /area/maintenance/starboard/central)
 "atp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -12436,8 +12340,6 @@
 /area/engine/atmos)
 "atF" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -12526,8 +12428,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -12587,8 +12487,6 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/weapon/storage/box/lights/mixed,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -13027,8 +12925,6 @@
 /area/engine/atmos)
 "auB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -13097,8 +12993,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/corner,
@@ -13207,8 +13101,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -13235,8 +13127,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -13364,8 +13254,6 @@
 	icon_state = "plant-22"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -13383,8 +13271,6 @@
 "avf" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -13493,8 +13379,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -13503,8 +13387,6 @@
 /area/crew_quarters/bar)
 "avr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/closed/wall,
@@ -13520,8 +13402,6 @@
 /area/maintenance/starboard/central)
 "avt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -13847,8 +13727,6 @@
 	})
 "avU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -14037,8 +13915,6 @@
 "awm" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -14175,8 +14051,6 @@
 /area/crew_quarters/bar)
 "awx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -14342,8 +14216,6 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -14441,8 +14313,6 @@
 	})
 "awW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -14597,7 +14467,6 @@
 "axm" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8;
-	icon_state = "manifold";
 	name = "scrubbers pipe"
 	},
 /obj/machinery/meter,
@@ -14614,9 +14483,6 @@
 "axo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 2;
-	icon_state = "manifold";
-	name = "scrubbers pipe";
-	tag = "icon-manifold (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
@@ -14624,9 +14490,6 @@
 "axp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 2;
-	icon_state = "manifold";
-	name = "scrubbers pipe";
-	tag = "icon-manifold (NORTH)"
 	},
 /obj/structure/cable/white{
 	tag = "icon-1-2";
@@ -14982,8 +14845,6 @@
 	receive_ore_updates = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -15133,9 +14994,6 @@
 /area/engine/atmos)
 "ayj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	tag = "icon-manifold (NORTH)";
-	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -15338,8 +15196,6 @@
 /area/crew_quarters/theatre)
 "ayG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -15354,8 +15210,6 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -15720,8 +15574,6 @@
 "azr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -15773,8 +15625,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/loadingarea,
@@ -15875,8 +15725,6 @@
 /area/crew_quarters/theatre)
 "azG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -16016,8 +15864,6 @@
 	})
 "azT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -16370,8 +16216,6 @@
 /area/engine/atmos)
 "aAC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -16527,8 +16371,6 @@
 	})
 "aAQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -16553,8 +16395,6 @@
 	})
 "aAS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -16664,8 +16504,6 @@
 	})
 "aBa" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -16878,7 +16716,6 @@
 "aBy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8;
-	icon_state = "manifold";
 	name = "scrubbers pipe"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -16886,9 +16723,6 @@
 /area/engine/atmos)
 "aBz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	tag = "icon-manifold (NORTH)";
-	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -17007,8 +16841,6 @@
 /area/engine/atmos)
 "aBK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -18028,8 +17860,6 @@
 	})
 "aDx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -18052,8 +17882,6 @@
 	})
 "aDz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/caution{
@@ -18163,8 +17991,6 @@
 /area/crew_quarters/theatre)
 "aDL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -18283,8 +18109,6 @@
 "aDU" = (
 /obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -18317,8 +18141,6 @@
 /area/crew_quarters/kitchen)
 "aDY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/closed/wall,
@@ -18688,8 +18510,6 @@
 	})
 "aED" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -18707,8 +18527,6 @@
 	})
 "aEF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
@@ -18757,8 +18575,6 @@
 	})
 "aEJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -18951,8 +18767,6 @@
 /obj/item/clothing/suit/apron/chef,
 /obj/item/weapon/kitchen/rollingpin,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -19032,8 +18846,6 @@
 /area/crew_quarters/kitchen)
 "aFg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -19053,8 +18865,6 @@
 /area/maintenance/starboard/central)
 "aFh" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -19107,8 +18917,6 @@
 	})
 "aFn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -19290,8 +19098,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -19352,8 +19158,6 @@
 	})
 "aFF" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -19425,8 +19229,6 @@
 	})
 "aFK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -19496,8 +19298,6 @@
 "aFP" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -19530,8 +19330,6 @@
 /area/crew_quarters/kitchen)
 "aFT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -19667,8 +19465,6 @@
 "aGj" = (
 /obj/machinery/status_display,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
@@ -19767,8 +19563,6 @@
 	})
 "aGq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -19850,8 +19644,6 @@
 	})
 "aGx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -20073,8 +19865,6 @@
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -20180,8 +19970,6 @@
 /area/crew_quarters/kitchen)
 "aGX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -20380,8 +20168,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20447,8 +20233,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
@@ -20575,8 +20359,6 @@
 /area/engine/engineering)
 "aHC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -20681,8 +20463,6 @@
 "aHI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -20727,8 +20507,6 @@
 /area/maintenance/port/central)
 "aHL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -20773,8 +20551,6 @@
 /area/hydroponics)
 "aHP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/closed/wall,
@@ -20798,8 +20574,6 @@
 	})
 "aHS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -21421,8 +21195,6 @@
 /area/crew_quarters/kitchen)
 "aIT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -21489,8 +21261,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -21732,9 +21502,6 @@
 /area/engine/engineering)
 "aJs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	tag = "icon-manifold (EAST)";
-	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/meter,
@@ -21860,8 +21627,6 @@
 "aJE" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
@@ -22042,8 +21807,6 @@
 /area/hydroponics)
 "aJS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/greenblue/side{
@@ -22077,8 +21840,6 @@
 /area/hydroponics)
 "aJW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -22311,8 +22072,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -22841,8 +22600,6 @@
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -23076,8 +22833,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -23261,8 +23016,6 @@
 "aMg" = (
 /obj/effect/landmark/start/janitor,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/green/side{
@@ -23358,8 +23111,6 @@
 /area/hydroponics)
 "aMp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -23721,7 +23472,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -24116,8 +23866,6 @@
 "aND" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -24906,8 +24654,6 @@
 	})
 "aOR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -24926,8 +24672,6 @@
 	})
 "aOS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -25002,8 +24746,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/item/device/radio/intercom{
@@ -25221,8 +24963,6 @@
 /area/hallway/primary/central)
 "aPi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -25243,8 +24983,6 @@
 /area/hallway/primary/central)
 "aPj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -25327,8 +25065,6 @@
 /area/hallway/primary/central)
 "aPp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -25419,8 +25155,6 @@
 	})
 "aPv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -25450,8 +25184,6 @@
 	})
 "aPx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -25817,8 +25549,6 @@
 	})
 "aQe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -25893,8 +25623,6 @@
 /area/hallway/primary/central)
 "aQl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -25958,8 +25686,6 @@
 /area/hallway/primary/central)
 "aQs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel{
@@ -26029,8 +25755,6 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -26236,7 +25960,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27423,8 +27146,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -27640,8 +27361,6 @@
 /area/science/lab)
 "aTM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -28112,8 +27831,6 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -28162,8 +27879,6 @@
 /area/maintenance/starboard)
 "aUM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -28281,8 +27996,6 @@
 /area/library)
 "aUY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -28332,8 +28045,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -28382,8 +28093,6 @@
 /obj/machinery/holopad,
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
@@ -28449,8 +28158,6 @@
 /area/medical/chemistry)
 "aVo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -28481,8 +28188,6 @@
 /area/hallway/primary/central)
 "aVs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -28557,8 +28262,6 @@
 /area/science/research)
 "aVz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -28615,8 +28318,6 @@
 "aVF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -29537,8 +29238,6 @@
 /area/hallway/primary/central)
 "aXw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -29591,8 +29290,6 @@
 /area/science/research)
 "aXB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -29895,8 +29592,6 @@
 /area/medical/medbay/zone3)
 "aYa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -30022,8 +29717,6 @@
 /area/science/research)
 "aYn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -30329,8 +30022,6 @@
 /area/medical/medbay/zone3)
 "aYM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue,
@@ -30361,8 +30052,6 @@
 /area/medical/medbay/zone3)
 "aYQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/blue,
@@ -30437,8 +30126,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/purple/corner,
@@ -30875,8 +30562,6 @@
 /area/medical/medbay/zone3)
 "aZQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -31163,8 +30848,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
@@ -31300,8 +30983,6 @@
 /area/medical/medbay/zone3)
 "baA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -31548,8 +31229,6 @@
 /area/science/robotics/lab)
 "baW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -31787,8 +31466,6 @@
 /area/medical/medbay/zone3)
 "bbv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -31872,8 +31549,6 @@
 /area/hallway/primary/central)
 "bbB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -31909,8 +31584,6 @@
 "bbE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/mech_bay_recharge_floor,
@@ -31974,8 +31647,6 @@
 /area/science/robotics/lab)
 "bbJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -32301,8 +31972,6 @@
 /area/hallway/primary/central)
 "bcr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -32568,8 +32237,6 @@
 	pixel_x = -12
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -32695,8 +32362,6 @@
 /area/hallway/primary/central)
 "bdi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
@@ -32738,8 +32403,6 @@
 "bdl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -32793,8 +32456,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -32879,8 +32540,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -33680,8 +33339,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -33723,8 +33380,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -33859,8 +33514,6 @@
 /area/hallway/primary/central)
 "bfg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -34095,8 +33748,6 @@
 /area/chapel/main)
 "bfy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/closed/wall,
@@ -34215,8 +33866,6 @@
 /area/hallway/primary/central)
 "bfJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -34292,8 +33941,6 @@
 /area/hallway/primary/central)
 "bfO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -34384,8 +34031,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -34515,8 +34160,6 @@
 /area/maintenance/port)
 "bge" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -34567,8 +34210,6 @@
 /area/hallway/primary/central)
 "bgj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -34771,8 +34412,6 @@
 /area/chapel/main)
 "bgE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -34799,8 +34438,6 @@
 /obj/structure/table/wood/fancy,
 /obj/item/device/flashlight/lantern,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -34826,8 +34463,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -35212,8 +34847,6 @@
 /area/chapel/main)
 "bhv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -35366,8 +34999,6 @@
 /area/hallway/secondary/entry)
 "bhJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -35540,8 +35171,6 @@
 /area/chapel/main)
 "bic" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -35965,8 +35594,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
@@ -36632,8 +36259,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -36852,8 +36477,6 @@
 /area/hallway/secondary/entry)
 "bkl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37199,8 +36822,6 @@
 /area/shuttle/arrival)
 "blf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -37332,8 +36953,6 @@
 /area/engine/engineering)
 "blo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -39514,8 +39133,6 @@
 	})
 "bsP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -39531,8 +39148,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
@@ -41026,7 +40641,6 @@
 /area/engine/gravity_generator)
 "bxj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/closed/wall/r_wall,

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -403,8 +403,6 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/machinery/camera{
@@ -568,8 +566,6 @@
 	},
 /obj/structure/cable/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -592,8 +588,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -610,8 +604,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -632,8 +624,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -646,8 +636,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -671,8 +659,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -685,8 +671,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -704,8 +688,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/vault{
@@ -1161,8 +1143,6 @@
 	req_access_txt = "20"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/grimy,
@@ -1215,8 +1195,6 @@
 /obj/item/weapon/pinpointer,
 /obj/item/weapon/disk/nuclear,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/grimy,
@@ -1335,8 +1313,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/item/toy/figure/hop{
@@ -1360,8 +1336,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/item/weapon/bedsheet/hop,
@@ -1375,8 +1349,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/wood,
@@ -1419,8 +1391,6 @@
 /area/crew_quarters/heads/hop)
 "acu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/delivery,
@@ -1664,8 +1634,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/grimy,
@@ -1896,8 +1864,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/wood,
@@ -1953,8 +1919,6 @@
 	pixel_x = 12
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -2097,8 +2061,6 @@
 	pixel_x = 12
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -3632,8 +3594,6 @@
 /area/crew_quarters/heads/captain/private)
 "agc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/wood,
@@ -4099,8 +4059,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/landmark/start/captain,
@@ -4115,8 +4073,6 @@
 /obj/item/weapon/clipboard,
 /obj/item/weapon/folder/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/item/weapon/melee/chainofcommand,
@@ -4145,8 +4101,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -4171,8 +4125,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -5912,8 +5864,6 @@
 	})
 "ajF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -9324,8 +9274,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -9445,8 +9393,6 @@
 /area/maintenance/starboard/central)
 "aoU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/cable/white{
@@ -9675,8 +9621,6 @@
 /area/quartermaster/miningdock)
 "apk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/cable/white{
@@ -10527,24 +10471,18 @@
 /area/engine/atmos)
 "aqA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aqB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aqC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/grille,
@@ -10555,8 +10493,6 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -10565,8 +10501,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -10576,8 +10510,6 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -10587,8 +10519,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating/astplate,
@@ -10597,8 +10527,6 @@
 	})
 "aqH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -11098,8 +11026,6 @@
 /area/shuttle/mining)
 "arq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/grille,
@@ -11427,8 +11353,6 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/vault{
@@ -11803,8 +11727,6 @@
 /obj/machinery/meter,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (NORTH)";
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -12320,8 +12242,6 @@
 /area/crew_quarters/bar)
 "atl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall,
@@ -12334,8 +12254,6 @@
 /area/crew_quarters/bar)
 "atn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall,
@@ -12460,8 +12378,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (NORTH)";
-	icon_state = "intact";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -12516,8 +12432,6 @@
 /area/engine/atmos)
 "atE" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/caution{
@@ -13031,8 +12945,6 @@
 /obj/machinery/meter,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (NORTH)";
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -13100,8 +13012,6 @@
 /area/engine/atmos)
 "auy" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -13662,8 +13572,6 @@
 "avx" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (NORTH)";
-	icon_state = "intact";
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
@@ -13692,7 +13600,6 @@
 /area/engine/atmos)
 "avA" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -13725,8 +13632,6 @@
 /area/engine/atmos)
 "avE" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -13975,8 +13880,6 @@
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -14764,8 +14667,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/delivery,
@@ -16046,8 +15947,6 @@
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -16164,8 +16063,6 @@
 "azX" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/bot,
@@ -16264,8 +16161,6 @@
 	},
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (NORTH)";
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -16275,8 +16170,6 @@
 /area/engine/atmos)
 "aAj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16287,8 +16180,6 @@
 "aAk" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -16308,8 +16199,6 @@
 "aAl" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16319,8 +16208,6 @@
 /area/engine/atmos)
 "aAm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16328,8 +16215,6 @@
 /area/engine/atmos)
 "aAn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/neutral,
@@ -16535,8 +16420,6 @@
 /area/crew_quarters/dorms)
 "aAG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
@@ -16942,8 +16825,6 @@
 	sensors = list("air_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/window/reinforced{
@@ -16957,8 +16838,6 @@
 /area/engine/atmos)
 "aBr" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -16976,8 +16855,6 @@
 /area/engine/atmos)
 "aBt" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -17079,8 +16956,6 @@
 /area/engine/atmos)
 "aBE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/cable/white{
@@ -17551,8 +17426,6 @@
 	},
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (NORTH)";
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -17591,8 +17464,6 @@
 /area/engine/atmos)
 "aCw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/closet/wardrobe/atmospherics_yellow,
@@ -17617,8 +17488,6 @@
 /area/engine/atmos)
 "aCy" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/atmospherics,
@@ -17690,8 +17559,6 @@
 /area/engine/atmos)
 "aCE" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/cable/white{
@@ -17902,8 +17769,6 @@
 /area/crew_quarters/theatre)
 "aCU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -18100,8 +17965,6 @@
 /area/shuttle/escape)
 "aDn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
@@ -18112,16 +17975,12 @@
 /area/engine/atmos)
 "aDp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aDq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
@@ -18393,8 +18252,6 @@
 "aDQ" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -18831,8 +18688,6 @@
 	})
 "aEC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/cable/white{
@@ -19878,8 +19733,6 @@
 "aGm" = (
 /obj/structure/sign/radiation,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
@@ -20419,8 +20272,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -20435,8 +20286,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -20450,8 +20299,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20468,8 +20315,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -20487,8 +20332,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20530,8 +20373,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20570,8 +20411,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20586,8 +20425,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
@@ -20606,8 +20443,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
@@ -20649,8 +20484,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -20670,8 +20503,6 @@
 	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/cable/white{
@@ -20927,8 +20758,6 @@
 /area/hydroponics)
 "aHN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall,
@@ -21997,8 +21826,6 @@
 	tag = "icon-0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -22021,8 +21848,6 @@
 /obj/item/weapon/grenade/chem_grenade/metalfoam,
 /obj/item/weapon/grenade/chem_grenade/metalfoam,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -22035,16 +21860,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow,
 /area/engine/engineering)
 "aJD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -22774,8 +22595,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/yellow,
@@ -23045,8 +22864,6 @@
 /area/crew_quarters/kitchen)
 "aLl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall,
@@ -23319,7 +23136,6 @@
 /area/engine/supermatter)
 "aLP" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
@@ -25838,8 +25654,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -25854,8 +25668,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -25864,8 +25676,6 @@
 "aPR" = (
 /obj/structure/girder,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -25876,8 +25686,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -25890,8 +25698,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
@@ -26334,7 +26140,6 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -26816,8 +26621,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -26833,8 +26636,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -26857,7 +26658,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/neutral,
@@ -27416,8 +27216,6 @@
 /area/tcommsat/server)
 "aSO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
@@ -28013,7 +27811,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -28095,8 +27892,6 @@
 /area/library)
 "aUg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/cable/white{
@@ -28357,8 +28152,6 @@
 /area/science/research)
 "aUJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -29008,8 +28801,6 @@
 /area/medical/morgue)
 "aWa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -29063,8 +28854,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
@@ -29238,8 +29027,6 @@
 /area/science/research)
 "aWt" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -29250,8 +29037,6 @@
 "aWu" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/circuit/green{
@@ -30567,7 +30352,6 @@
 /area/medical/medbay/zone3)
 "aYN" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -30743,8 +30527,6 @@
 /area/science/robotics/lab)
 "aZk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
@@ -30757,8 +30539,6 @@
 /area/science/robotics/lab)
 "aZm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -30909,8 +30689,6 @@
 /area/maintenance/port)
 "aZB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall,
@@ -31561,8 +31339,6 @@
 /area/medical/medbay/zone3)
 "baD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/blue,
@@ -32298,8 +32074,6 @@
 /area/maintenance/port)
 "bbT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall,
@@ -32352,8 +32126,6 @@
 /area/maintenance/port)
 "bbX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall,
@@ -33000,8 +32772,6 @@
 "bdn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/circuit/green,
@@ -33896,8 +33666,6 @@
 /area/science/robotics/lab)
 "beQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
@@ -33941,8 +33709,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -33954,8 +33720,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -33987,8 +33751,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -34002,8 +33764,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -34014,8 +33774,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -34030,8 +33788,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -34062,8 +33818,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -34350,8 +34104,6 @@
 /area/chapel/main)
 "bfx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall,
@@ -34375,8 +34127,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -34385,8 +34135,6 @@
 /area/chapel/main)
 "bfA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall,
@@ -34403,8 +34151,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34420,8 +34166,6 @@
 /area/chapel/main)
 "bfD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -35899,8 +35643,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/structure/cable/white{
@@ -36604,8 +36346,6 @@
 /area/science/xenobiology)
 "bju" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/turf_decal/delivery,
@@ -36617,8 +36357,6 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/end,
@@ -36633,8 +36371,6 @@
 /area/science/xenobiology)
 "bjx" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
@@ -39939,8 +39675,6 @@
 	})
 "btb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/structure/cable/white{
@@ -39957,8 +39691,6 @@
 	})
 "btc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/effect/turf_decal/delivery,
@@ -41209,7 +40941,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -41228,14 +40959,12 @@
 /area/engine/gravity_generator)
 "bwY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
 "bwZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -41255,7 +40984,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -41272,7 +41000,6 @@
 /area/space)
 "bxd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/mineral/random/labormineral,
@@ -41281,7 +41008,6 @@
 	})
 "bxe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/mineral/random/labormineral,
@@ -41290,7 +41016,6 @@
 	})
 "bxf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/mineral/random/labormineral,
@@ -41299,21 +41024,18 @@
 	})
 "bxg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
 "bxh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
 "bxi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -41327,7 +41049,6 @@
 /area/tcommsat/server)
 "bxk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -41346,7 +41067,6 @@
 /area/tcommsat/server)
 "bxo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
@@ -41355,7 +41075,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -41364,7 +41083,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -41373,7 +41091,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -41382,7 +41099,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -37459,7 +37459,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41502,7 +41501,6 @@
 /area/shuttle/transport)
 "bwc" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced,
@@ -41556,7 +41554,6 @@
 /area/shuttle/transport)
 "bwo" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -41630,7 +41627,6 @@
 /area/shuttle/transport)
 "bwB" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced{

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -41,11 +41,11 @@
 	})
 "aai" = (
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -58,7 +58,7 @@
 /area/bridge)
 "aaj" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -74,7 +74,7 @@
 /area/bridge)
 "aal" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -87,7 +87,7 @@
 /area/bridge)
 "aam" = (
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -100,11 +100,11 @@
 /area/bridge)
 "aan" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -117,11 +117,11 @@
 /area/bridge)
 "aao" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -134,7 +134,7 @@
 /area/bridge)
 "aap" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
@@ -170,8 +170,10 @@
 /obj/item/weapon/wrench,
 /obj/item/device/multitool,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault{
@@ -181,8 +183,10 @@
 "aat" = (
 /obj/machinery/computer/communications,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -192,8 +196,10 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault{
@@ -221,11 +227,11 @@
 /area/bridge)
 "aax" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -274,8 +280,10 @@
 "aaB" = (
 /obj/machinery/computer/security,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
@@ -305,8 +313,10 @@
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /obj/item/device/taperecorder,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault{
@@ -319,8 +329,10 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -331,8 +343,10 @@
 /obj/item/weapon/folder/blue,
 /obj/item/weapon/pen,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault{
@@ -359,8 +373,10 @@
 "aaJ" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/darkyellow/side{
 	tag = "icon-darkyellow (NORTH)";
@@ -428,8 +444,10 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -462,8 +480,10 @@
 /area/bridge)
 "aaR" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -521,11 +541,13 @@
 	})
 "aaX" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -535,7 +557,8 @@
 /area/bridge)
 "aaY" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -547,11 +570,13 @@
 /area/bridge)
 "aaZ" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/power/apc{
@@ -569,7 +594,8 @@
 /area/bridge)
 "aba" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -591,11 +617,13 @@
 /area/bridge)
 "abc" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -607,15 +635,18 @@
 /area/bridge)
 "abd" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -627,7 +658,8 @@
 /area/bridge)
 "abe" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -643,11 +675,13 @@
 /area/bridge)
 "abf" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/fireaxecabinet{
@@ -662,7 +696,8 @@
 /area/bridge)
 "abg" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -675,11 +710,13 @@
 /area/bridge)
 "abh" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -716,8 +753,10 @@
 	tag = "icon-doors"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -747,7 +786,7 @@
 /area/bridge)
 "abn" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/modular_computer/console/preset/command,
@@ -762,8 +801,10 @@
 /area/bridge)
 "abp" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -793,8 +834,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -831,7 +874,7 @@
 /area/crew_quarters/heads/captain/private)
 "abx" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -845,8 +888,10 @@
 "aby" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -883,12 +928,15 @@
 /obj/structure/table/wood,
 /obj/item/weapon/paper_bin,
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -896,18 +944,21 @@
 /area/bridge)
 "abD" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault,
 /area/bridge)
 "abE" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/holopad,
@@ -918,12 +969,15 @@
 /obj/structure/table/wood,
 /obj/item/weapon/lighter,
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -959,8 +1013,10 @@
 "abI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -971,7 +1027,7 @@
 /area/bridge)
 "abJ" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -1141,8 +1197,10 @@
 "aca" = (
 /obj/structure/dresser,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1152,8 +1210,10 @@
 "acb" = (
 /obj/structure/bed,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1192,8 +1252,10 @@
 /area/crew_quarters/heads/captain/private)
 "acd" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -1209,7 +1271,7 @@
 /area/bridge)
 "acf" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -1230,8 +1292,10 @@
 /area/bridge)
 "ach" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -1254,8 +1318,10 @@
 /area/bridge)
 "ack" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1286,8 +1352,10 @@
 "acn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault,
 /area/bridge)
@@ -1317,8 +1385,10 @@
 "acp" = (
 /obj/structure/bed,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1330,8 +1400,10 @@
 "acq" = (
 /obj/structure/dresser,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -1603,8 +1675,10 @@
 /area/crew_quarters/heads/captain/private)
 "acR" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -1613,8 +1687,10 @@
 /area/crew_quarters/heads/captain/private)
 "acS" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -1638,11 +1714,14 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/vault{
@@ -1651,7 +1730,8 @@
 /area/bridge)
 "acV" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -1661,11 +1741,13 @@
 /area/bridge)
 "acW" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/command{
@@ -1683,7 +1765,8 @@
 /area/bridge)
 "acX" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1695,7 +1778,8 @@
 /area/bridge)
 "acY" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1706,8 +1790,10 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/bridge)
@@ -1756,23 +1842,28 @@
 /area/bridge)
 "adc" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/bridge)
 "add" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/command{
@@ -1791,7 +1882,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -1803,11 +1895,14 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -1821,7 +1916,8 @@
 	pixel_x = -22
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -1831,15 +1927,19 @@
 /area/crew_quarters/heads/hop)
 "adh" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1849,15 +1949,18 @@
 /area/crew_quarters/heads/hop)
 "adi" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1872,7 +1975,8 @@
 /area/crew_quarters/heads/hop)
 "adj" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -2074,7 +2178,8 @@
 "adI" = (
 /obj/structure/filingcabinet,
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -2091,15 +2196,18 @@
 /area/crew_quarters/heads/captain/private)
 "adJ" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -2119,15 +2227,18 @@
 /area/crew_quarters/heads/captain/private)
 "adK" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2138,7 +2249,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/sign/goldenplaque{
@@ -2152,8 +2264,10 @@
 "adM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -2181,7 +2295,7 @@
 	name = "AI Core Shutters"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
@@ -2198,7 +2312,7 @@
 	name = "AI Core Shutters"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -2222,8 +2336,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -2242,8 +2358,10 @@
 "adV" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/command{
@@ -2393,8 +2511,10 @@
 	id = "cargounload"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/door/poddoor{
 	id = "cargounload";
@@ -2528,8 +2648,10 @@
 	req_access_txt = "20"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -2583,8 +2705,10 @@
 /area/ai_monitored/turret_protected/ai)
 "aeA" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/ai)
@@ -2645,7 +2769,8 @@
 	},
 /obj/effect/landmark/start/ai,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/ai_slipper{
@@ -2669,7 +2794,8 @@
 	req_access_txt = "16"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -2678,11 +2804,14 @@
 /area/ai_monitored/turret_protected/ai)
 "aeE" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/vault,
@@ -2723,8 +2852,10 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -2737,7 +2868,7 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -2757,8 +2888,10 @@
 /area/crew_quarters/heads/hop)
 "aeK" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2794,7 +2927,7 @@
 	},
 /obj/item/weapon/storage/box/ids,
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -2892,8 +3025,10 @@
 /area/quartermaster/storage)
 "aeY" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
@@ -2953,7 +3088,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/wood,
@@ -2964,7 +3100,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
@@ -2978,7 +3115,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
@@ -2991,7 +3129,7 @@
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/wood,
@@ -3041,8 +3179,10 @@
 /area/crew_quarters/heads/captain/private)
 "afn" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3116,8 +3256,10 @@
 /area/ai_monitored/turret_protected/ai)
 "afr" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
@@ -3165,12 +3307,15 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -3179,11 +3324,13 @@
 "afv" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/command{
@@ -3201,7 +3348,8 @@
 /area/crew_quarters/heads/hop)
 "afw" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3213,15 +3361,18 @@
 /area/crew_quarters/heads/hop)
 "afx" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -3231,11 +3382,13 @@
 /area/crew_quarters/heads/hop)
 "afy" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/holopad,
@@ -3248,7 +3401,8 @@
 /area/crew_quarters/heads/hop)
 "afz" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/requests_console{
@@ -3353,8 +3507,7 @@
 "afJ" = (
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /obj/structure/cable/white,
 /obj/structure/grille,
@@ -3429,8 +3582,10 @@
 "afQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -3470,7 +3625,8 @@
 /area/security/detectives_office)
 "afV" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3488,7 +3644,8 @@
 	req_access_txt = "20"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3498,7 +3655,8 @@
 /area/crew_quarters/heads/captain/private)
 "afX" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -3513,7 +3671,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/camera{
@@ -3535,8 +3694,10 @@
 /area/crew_quarters/heads/captain/private)
 "agb" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/grimy,
@@ -3554,7 +3715,7 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -3569,8 +3730,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -3622,7 +3785,7 @@
 "agi" = (
 /obj/machinery/doomsday_device,
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -3660,8 +3823,10 @@
 "agm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -3694,8 +3859,10 @@
 "agp" = (
 /obj/machinery/pdapainter,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -3714,8 +3881,10 @@
 /obj/item/weapon/pen,
 /obj/item/weapon/stamp/hop,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
@@ -3909,8 +4078,10 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -3948,8 +4119,10 @@
 /area/security/detectives_office)
 "agN" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3969,7 +4142,7 @@
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -3977,7 +4150,8 @@
 /area/crew_quarters/heads/captain/private)
 "agP" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -3985,7 +4159,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/carpet,
@@ -3997,7 +4172,8 @@
 	icon_state = "comfychair"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4009,7 +4185,8 @@
 "agR" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/clipboard,
@@ -4027,11 +4204,13 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -4039,7 +4218,8 @@
 /area/crew_quarters/heads/captain/private)
 "agT" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4055,15 +4235,18 @@
 	req_access_txt = "20"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4077,12 +4260,15 @@
 "agV" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -4111,14 +4297,16 @@
 /area/ai_monitored/turret_protected/ai)
 "agY" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "agZ" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -4133,18 +4321,21 @@
 /area/ai_monitored/turret_protected/ai)
 "aha" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/start/cyborg,
@@ -4154,7 +4345,8 @@
 /area/ai_monitored/turret_protected/ai)
 "ahb" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -4166,7 +4358,8 @@
 /area/ai_monitored/turret_protected/ai)
 "ahc" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/circuit/green,
@@ -4207,8 +4400,10 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -4365,8 +4560,10 @@
 	id = "cargoload"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor{
@@ -4486,7 +4683,8 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/vault,
@@ -4494,15 +4692,18 @@
 "ahC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -4513,7 +4714,8 @@
 /obj/item/weapon/pen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -4535,7 +4737,8 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -4555,8 +4758,10 @@
 /area/security/detectives_office)
 "ahG" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4668,8 +4873,10 @@
 /area/ai_monitored/turret_protected/ai)
 "ahS" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -4714,8 +4921,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -4912,7 +5121,7 @@
 /area/security/brig)
 "aiq" = (
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -4922,7 +5131,8 @@
 "air" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -4940,11 +5150,13 @@
 "ais" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -4961,7 +5173,7 @@
 /area/security/brig)
 "ait" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -4988,8 +5200,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -5016,8 +5230,10 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -5038,8 +5254,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -5075,8 +5293,10 @@
 	pixel_x = 28
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -5095,8 +5315,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -5120,7 +5342,7 @@
 	})
 "aiE" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -5291,8 +5513,7 @@
 "aiU" = (
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -5312,8 +5533,10 @@
 /area/security/brig)
 "aiX" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -5343,7 +5566,7 @@
 /area/security/brig)
 "aiZ" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
@@ -5378,7 +5601,8 @@
 	},
 /obj/structure/chair,
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -5396,7 +5620,7 @@
 /area/security/brig)
 "ajc" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -5427,8 +5651,10 @@
 	})
 "aje" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5483,8 +5709,10 @@
 	})
 "ajj" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5556,8 +5784,10 @@
 	})
 "ajo" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5622,8 +5852,10 @@
 	})
 "ajt" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5703,8 +5935,10 @@
 	})
 "ajz" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/corner{
@@ -5744,8 +5978,10 @@
 	})
 "ajC" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5758,8 +5994,10 @@
 	})
 "ajD" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -5916,7 +6154,8 @@
 /area/security/brig)
 "ajS" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5955,7 +6194,8 @@
 	pixel_y = -3
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5966,7 +6206,7 @@
 "ajU" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -5994,12 +6234,15 @@
 /area/security/brig)
 "ajX" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6011,7 +6254,8 @@
 /area/security/brig)
 "ajY" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6023,15 +6267,18 @@
 /area/security/brig)
 "ajZ" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/westright{
@@ -6048,7 +6295,8 @@
 /area/security/brig)
 "aka" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -6060,11 +6308,13 @@
 /area/security/brig)
 "akb" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -6082,11 +6332,14 @@
 "akd" = (
 /obj/effect/landmark/lightsout,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -6098,7 +6351,8 @@
 	})
 "ake" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6113,7 +6367,8 @@
 	})
 "akf" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -6127,7 +6382,8 @@
 	})
 "akg" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -6142,7 +6398,8 @@
 	})
 "akh" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6158,11 +6415,13 @@
 	})
 "aki" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -6175,7 +6434,8 @@
 	})
 "akj" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6200,7 +6460,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -6212,11 +6473,13 @@
 	})
 "akl" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6229,7 +6492,8 @@
 	})
 "akm" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6243,11 +6507,13 @@
 	})
 "akn" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6260,11 +6526,13 @@
 	})
 "ako" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -6277,11 +6545,13 @@
 	})
 "akp" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6296,7 +6566,8 @@
 	})
 "akq" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6312,20 +6583,24 @@
 	})
 "akr" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -6337,11 +6612,13 @@
 	})
 "aks" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6356,14 +6633,16 @@
 	})
 "akt" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel{
@@ -6374,7 +6653,8 @@
 	})
 "aku" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6389,7 +6669,8 @@
 	})
 "akv" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6397,7 +6678,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel{
@@ -6408,11 +6690,13 @@
 	})
 "akw" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6420,7 +6704,8 @@
 	},
 /obj/effect/landmark/lightsout,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel{
@@ -6431,7 +6716,8 @@
 	})
 "akx" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -6443,7 +6729,8 @@
 	})
 "aky" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -6457,14 +6744,16 @@
 	})
 "akz" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel{
@@ -6477,7 +6766,8 @@
 	})
 "akA" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6489,11 +6779,13 @@
 	})
 "akB" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -6503,22 +6795,26 @@
 	})
 "akC" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -6527,11 +6823,13 @@
 	})
 "akD" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6544,15 +6842,18 @@
 	})
 "akE" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -6565,15 +6866,18 @@
 	})
 "akF" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6586,11 +6890,13 @@
 	})
 "akG" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6604,14 +6910,16 @@
 	})
 "akH" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -6629,7 +6937,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -6642,7 +6951,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -6657,7 +6967,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -6728,7 +7039,7 @@
 	pixel_x = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -6738,15 +7049,19 @@
 "akU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/security{
@@ -6763,7 +7078,7 @@
 /area/security/brig)
 "akV" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -6797,8 +7112,10 @@
 /area/security/brig)
 "akY" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -6838,8 +7155,10 @@
 	})
 "alc" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
@@ -6901,8 +7220,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/door/airlock/command{
 	name = "Teleport Access";
@@ -6947,8 +7268,10 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "L2"
@@ -6971,8 +7294,10 @@
 "alo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "L6"
@@ -7015,8 +7340,10 @@
 	icon_state = "tube1"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "L14"
@@ -7062,8 +7389,10 @@
 	})
 "alw" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
@@ -7108,8 +7437,10 @@
 "alz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/brown/corner{
 	tag = "icon-browncorner (EAST)";
@@ -7169,7 +7500,8 @@
 "alE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/lightsout,
@@ -7183,7 +7515,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -7229,8 +7561,10 @@
 /area/security/brig)
 "alI" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -7286,8 +7620,10 @@
 /area/security/brig)
 "alN" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
@@ -7327,7 +7663,8 @@
 	},
 /obj/structure/chair,
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -7355,8 +7692,10 @@
 	})
 "alS" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -7462,11 +7801,14 @@
 /area/teleporter)
 "amb" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -7478,7 +7820,8 @@
 "amc" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -7489,7 +7832,7 @@
 /area/teleporter)
 "amd" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -7498,7 +7841,7 @@
 /area/teleporter)
 "ame" = (
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -7510,12 +7853,15 @@
 "amf" = (
 /obj/structure/closet/crate/bin,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -7533,8 +7879,10 @@
 "amh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central{
@@ -7561,12 +7909,15 @@
 "aml" = (
 /obj/structure/closet/emcloset,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -7575,7 +7926,7 @@
 	})
 "amm" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -7586,7 +7937,7 @@
 	})
 "amn" = (
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -7609,7 +7960,8 @@
 /obj/item/weapon/stock_parts/cell/high,
 /obj/item/weapon/stock_parts/cell/high,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -7621,12 +7973,15 @@
 "amp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -7697,8 +8052,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/brown/corner{
 	tag = "icon-browncorner (EAST)";
@@ -7745,8 +8102,10 @@
 "amA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/brown,
 /area/quartermaster/storage)
@@ -7829,8 +8188,10 @@
 "amI" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
@@ -7861,12 +8222,15 @@
 /area/security/brig)
 "amM" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7878,15 +8242,18 @@
 /area/security/brig)
 "amN" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/westright{
@@ -7993,8 +8360,10 @@
 /area/teleporter)
 "amW" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -8020,7 +8389,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -8031,8 +8401,10 @@
 "ana" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -8058,7 +8430,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -8086,8 +8459,10 @@
 "ang" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -8157,8 +8532,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -8196,8 +8573,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -8241,7 +8620,7 @@
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8317,8 +8696,10 @@
 /area/security/brig)
 "anz" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral,
@@ -8389,8 +8770,10 @@
 /area/security/brig)
 "anE" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
@@ -8442,8 +8825,10 @@
 "anI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -8514,8 +8899,10 @@
 "anO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -8549,8 +8936,10 @@
 	name = "Atrium"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -8619,8 +9008,10 @@
 	})
 "anV" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8679,8 +9070,10 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/brown/corner{
 	tag = "icon-browncorner (EAST)";
@@ -8764,8 +9157,10 @@
 "aog" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/brown/corner{
 	tag = "icon-browncorner (EAST)";
@@ -8822,8 +9217,10 @@
 "aok" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/brown{
@@ -8901,11 +9298,14 @@
 /area/security/brig)
 "aot" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -8919,7 +9319,8 @@
 "aou" = (
 /obj/machinery/computer/security,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -9076,8 +9477,10 @@
 /area/teleporter)
 "aoH" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -9157,15 +9560,19 @@
 "aoO" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -9179,7 +9586,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -9192,7 +9600,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -9209,7 +9618,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -9227,7 +9637,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -9241,7 +9652,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -9252,7 +9664,8 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/caution{
@@ -9326,15 +9739,19 @@
 	},
 /obj/effect/landmark/lightsout,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/brown/corner,
@@ -9347,7 +9764,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -9362,7 +9780,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown/corner{
@@ -9376,7 +9795,8 @@
 "apd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown/corner{
@@ -9392,7 +9812,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown,
@@ -9402,7 +9823,8 @@
 "apf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown/corner,
@@ -9418,11 +9840,13 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/brown/corner,
@@ -9435,7 +9859,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -9453,7 +9878,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -9466,7 +9892,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -9477,7 +9904,8 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -9489,7 +9917,8 @@
 "apl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/purple/side{
@@ -9614,15 +10043,19 @@
 "apx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -9664,11 +10097,14 @@
 /area/security/brig)
 "apA" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9681,7 +10117,8 @@
 /area/security/brig)
 "apB" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9697,7 +10134,8 @@
 	req_access_txt = "63"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9710,7 +10148,8 @@
 /area/security/brig)
 "apD" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -9721,7 +10160,8 @@
 /area/security/brig)
 "apE" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9740,7 +10180,8 @@
 	req_access_txt = "63"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9753,7 +10194,8 @@
 /area/security/brig)
 "apG" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9768,11 +10210,14 @@
 	})
 "apH" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -9824,7 +10269,7 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -9835,7 +10280,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -9867,7 +10313,8 @@
 /area/maintenance/port/central)
 "apQ" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9882,7 +10329,8 @@
 "apR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9901,7 +10349,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -9920,7 +10369,8 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -9934,15 +10384,19 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -9994,8 +10448,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/caution,
 /area/maintenance/starboard/central)
@@ -10038,7 +10494,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -10055,7 +10512,7 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -10118,8 +10575,10 @@
 "aqi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/brown/corner,
 /area/hallway/primary/central{
@@ -10388,8 +10847,10 @@
 /area/security/brig)
 "aqJ" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/vault{
@@ -10411,8 +10872,7 @@
 "aqL" = (
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -10438,8 +10898,10 @@
 /area/security/brig)
 "aqO" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -10491,8 +10953,10 @@
 /area/security/brig)
 "aqS" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
@@ -10518,7 +10982,7 @@
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -10578,8 +11042,10 @@
 /area/maintenance/port/central)
 "aqZ" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/yellow/side{
@@ -10605,8 +11071,10 @@
 	name = "Atrium"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -10664,8 +11132,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -10694,8 +11164,10 @@
 "arj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central{
@@ -11008,7 +11480,8 @@
 /area/security/brig)
 "arE" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -11023,7 +11496,8 @@
 /area/security/brig)
 "arF" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -11034,7 +11508,8 @@
 "arG" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -11051,11 +11526,13 @@
 /area/security/brig)
 "arH" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11068,7 +11545,8 @@
 /area/security/brig)
 "arI" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -11080,11 +11558,13 @@
 /area/security/brig)
 "arJ" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -11095,7 +11575,8 @@
 /area/security/brig)
 "arK" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11108,11 +11589,13 @@
 "arL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -11130,7 +11613,8 @@
 "arM" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -11177,7 +11661,8 @@
 	pixel_y = 38
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/security_officer,
@@ -11216,8 +11701,10 @@
 "arQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 9
@@ -11255,7 +11742,8 @@
 /area/storage/primary)
 "arV" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11272,7 +11760,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11285,15 +11774,18 @@
 /area/maintenance/port/central)
 "arX" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -11303,7 +11795,8 @@
 /area/maintenance/port/central)
 "arY" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11313,7 +11806,8 @@
 /area/maintenance/port/central)
 "arZ" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11324,7 +11818,8 @@
 "asa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11336,15 +11831,18 @@
 /area/maintenance/port/central)
 "asb" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -11355,7 +11853,8 @@
 "asc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11392,8 +11891,10 @@
 "asf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar{
@@ -11432,7 +11933,8 @@
 "ask" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -11442,7 +11944,8 @@
 	dir = 5
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -11453,7 +11956,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -11465,7 +11969,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -11476,7 +11981,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -11486,7 +11992,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -11497,7 +12004,8 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -11739,8 +12247,10 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/corner{
@@ -11823,7 +12333,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -11837,14 +12348,17 @@
 /area/security/brig)
 "asT" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -11863,7 +12377,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -11876,11 +12391,13 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -11896,7 +12413,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -11907,7 +12425,8 @@
 /obj/item/device/flashlight,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -11917,7 +12436,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -11931,7 +12451,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -11947,7 +12468,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -11958,7 +12480,8 @@
 "atb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11975,8 +12498,10 @@
 "atd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -12001,8 +12526,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -12072,8 +12599,10 @@
 "ato" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -12084,8 +12613,10 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central{
@@ -12278,8 +12809,7 @@
 	},
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12317,8 +12847,10 @@
 	req_access_txt = "63"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12344,8 +12876,10 @@
 	})
 "atN" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -12513,8 +13047,10 @@
 "atW" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12546,8 +13082,10 @@
 "atZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/theatre)
@@ -12692,8 +13230,10 @@
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -12716,8 +13256,10 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central{
@@ -12833,8 +13375,10 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
@@ -12888,7 +13432,8 @@
 	})
 "auH" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -12901,7 +13446,8 @@
 	})
 "auI" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -12915,11 +13461,13 @@
 	})
 "auJ" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -12930,7 +13478,8 @@
 	})
 "auK" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -12947,14 +13496,16 @@
 "auL" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/red/corner,
@@ -12963,7 +13514,8 @@
 	})
 "auM" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -12983,7 +13535,8 @@
 	})
 "auN" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12997,18 +13550,21 @@
 	})
 "auO" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/camera{
@@ -13023,7 +13579,8 @@
 	})
 "auP" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -13037,7 +13594,8 @@
 	})
 "auQ" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13051,7 +13609,8 @@
 	})
 "auR" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13066,7 +13625,8 @@
 	})
 "auS" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13140,8 +13700,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
@@ -13173,8 +13735,10 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar{
@@ -13293,8 +13857,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -13317,8 +13883,10 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central{
@@ -13428,8 +13996,10 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
@@ -13443,7 +14013,8 @@
 /area/engine/atmos)
 "avI" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -13458,7 +14029,8 @@
 "avJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13470,7 +14042,8 @@
 	})
 "avK" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -13490,7 +14063,8 @@
 	})
 "avL" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -13503,7 +14077,8 @@
 	})
 "avM" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -13612,8 +14187,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -13726,7 +14303,7 @@
 	},
 /obj/item/stack/cable_coil/white,
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -13762,8 +14339,10 @@
 /obj/effect/landmark/start/clown,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
@@ -13790,8 +14369,10 @@
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar{
@@ -13847,7 +14428,8 @@
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/black,
@@ -13858,7 +14440,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -13875,7 +14458,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -13888,7 +14472,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -13898,7 +14483,8 @@
 "awu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -13915,7 +14501,8 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -13933,7 +14520,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -13946,15 +14534,19 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -14076,8 +14668,10 @@
 	on = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14099,8 +14693,10 @@
 /area/engine/atmos)
 "awM" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Atmospherics Maintenance";
@@ -14133,8 +14729,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -14163,8 +14761,10 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
@@ -14185,8 +14785,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar{
@@ -14218,8 +14820,10 @@
 /area/crew_quarters/bar)
 "awY" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -14283,8 +14887,10 @@
 "axe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -14382,8 +14988,10 @@
 	dir = 2
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
@@ -14409,8 +15017,10 @@
 /area/engine/atmos)
 "axr" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14532,8 +15142,10 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -14628,8 +15240,10 @@
 /area/crew_quarters/dorms)
 "axL" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner,
@@ -14656,23 +15270,29 @@
 /obj/effect/landmark/start/mime,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "axO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -14681,7 +15301,8 @@
 	})
 "axP" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -14691,7 +15312,8 @@
 "axQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -14700,7 +15322,8 @@
 	})
 "axR" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -14714,7 +15337,8 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/black,
@@ -14744,8 +15368,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/maintenance/starboard/central)
@@ -14884,8 +15510,10 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14897,8 +15525,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -14959,7 +15589,8 @@
 /obj/item/weapon/storage/belt/utility,
 /obj/item/device/t_scanner,
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -14975,7 +15606,7 @@
 	name = "Atmospherics Lockdown Blast door"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -14983,8 +15614,10 @@
 "ayt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -15056,8 +15689,10 @@
 /area/crew_quarters/dorms)
 "ayD" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
@@ -15084,8 +15719,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
@@ -15118,8 +15755,10 @@
 "ayJ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar{
@@ -15195,7 +15834,7 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -15241,7 +15880,7 @@
 "ayW" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -15257,7 +15896,7 @@
 	pixel_y = 23
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -15274,7 +15913,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -15293,7 +15933,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -15308,7 +15949,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -15434,8 +16076,10 @@
 "azp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15444,8 +16088,10 @@
 /area/engine/atmos)
 "azq" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15466,7 +16112,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15482,7 +16128,8 @@
 /area/engine/atmos)
 "azu" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15492,7 +16139,8 @@
 /area/engine/atmos)
 "azv" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15502,7 +16150,8 @@
 /area/engine/atmos)
 "azw" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -15512,11 +16161,13 @@
 /area/engine/atmos)
 "azx" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15528,7 +16179,8 @@
 /area/engine/atmos)
 "azy" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -15541,15 +16193,18 @@
 "azz" = (
 /obj/machinery/computer/atmos_alert,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/caution{
@@ -15608,8 +16263,10 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/theatre)
@@ -15644,8 +16301,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar{
@@ -15694,8 +16353,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/side,
 /area/maintenance/starboard/central)
@@ -15720,8 +16381,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -15793,8 +16456,10 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit{
@@ -15955,7 +16620,8 @@
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -15965,7 +16631,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -15975,30 +16642,36 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aAt" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16014,15 +16687,18 @@
 	req_access_txt = "24"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16032,7 +16708,8 @@
 /area/engine/atmos)
 "aAv" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/caution/corner{
@@ -16041,11 +16718,13 @@
 /area/engine/atmos)
 "aAw" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -16066,8 +16745,10 @@
 "aAz" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -16084,7 +16765,8 @@
 	density = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/caution{
@@ -16176,8 +16858,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -16194,7 +16878,7 @@
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -16204,23 +16888,29 @@
 "aAO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -16239,7 +16929,8 @@
 /obj/item/weapon/kitchen/fork,
 /obj/effect/landmark/lightsout,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -16251,7 +16942,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -16263,7 +16955,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -16275,7 +16968,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -16291,7 +16985,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16305,7 +17000,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -16316,11 +17012,13 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -16335,7 +17033,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16346,15 +17045,19 @@
 "aAX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -16384,8 +17087,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central{
@@ -16426,8 +17131,10 @@
 "aBf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/red/side,
 /area/hallway/secondary/exit{
@@ -16611,8 +17318,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -16659,8 +17368,10 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/caution,
 /area/engine/atmos)
@@ -16678,8 +17389,10 @@
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/caution,
 /area/engine/atmos)
@@ -16720,11 +17433,14 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -16740,7 +17456,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -16756,7 +17473,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16769,7 +17487,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -16782,7 +17501,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -16792,14 +17512,16 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/crew_quarters/dorms)
 "aBQ" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -16812,7 +17534,7 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -16828,8 +17550,10 @@
 /area/crew_quarters/dorms)
 "aBU" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -16862,8 +17586,7 @@
 /obj/machinery/vending/autodrobe,
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	cell_type = 5000;
@@ -16876,7 +17599,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -16975,7 +17698,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -16985,11 +17708,13 @@
 "aCj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor/southright{
@@ -16999,7 +17724,8 @@
 	},
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/weapon/folder/red,
@@ -17017,11 +17743,11 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -17032,11 +17758,13 @@
 "aCl" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/glass_security{
@@ -17045,8 +17773,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -17061,7 +17791,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -17250,8 +17980,10 @@
 	dir = 5
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -17287,7 +18019,7 @@
 	pixel_x = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -17304,12 +18036,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -17326,7 +18061,7 @@
 	name = "Atmospherics Lockdown Blast door"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -17342,11 +18077,13 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/westright{
@@ -17365,8 +18102,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway East";
@@ -17428,8 +18167,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/theatre)
@@ -17440,8 +18181,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -17526,8 +18269,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -17557,7 +18302,8 @@
 	})
 "aDe" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/escape{
@@ -17570,7 +18316,8 @@
 	})
 "aDg" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -17683,8 +18430,10 @@
 	req_access_txt = "24"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -17725,8 +18474,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 1
@@ -17856,7 +18607,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -17866,11 +18618,13 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -17887,7 +18641,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -17901,15 +18656,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -18009,8 +18768,10 @@
 "aDZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -18255,11 +19016,11 @@
 	},
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/light/small{
@@ -18269,21 +19030,21 @@
 /area/engine/engineering)
 "aEv" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/circuit/green,
 /area/engine/engineering)
 "aEw" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes{
@@ -18294,7 +19055,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/circuit/green,
@@ -18314,8 +19075,10 @@
 "aEy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -18361,8 +19124,10 @@
 	dir = 9
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central{
@@ -18424,8 +19189,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -18589,8 +19356,10 @@
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar{
@@ -18639,7 +19408,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/red,
@@ -18658,7 +19428,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -18666,7 +19437,8 @@
 "aFd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/deepfryer,
@@ -18677,7 +19449,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -18693,7 +19466,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -18706,15 +19480,19 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -18725,8 +19503,10 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -18848,8 +19628,10 @@
 /area/engine/engineering)
 "aFw" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -18929,8 +19711,10 @@
 /area/engine/engineering)
 "aFA" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -18983,15 +19767,19 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -19001,7 +19789,8 @@
 "aFE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -19013,7 +19802,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -19026,7 +19816,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -19038,7 +19829,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/corner,
@@ -19054,7 +19846,8 @@
 	name = "Engineering Foyer"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -19069,7 +19862,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -19084,11 +19878,13 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -19115,8 +19911,10 @@
 "aFM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner,
@@ -19185,8 +19983,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
@@ -19220,8 +20020,10 @@
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -19327,11 +20129,14 @@
 	req_access_txt = "32"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -19356,7 +20161,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19378,8 +20183,10 @@
 	req_access_txt = "10"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -19416,8 +20223,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 8
@@ -19482,8 +20291,10 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -19540,7 +20351,7 @@
 /area/maintenance/port/central)
 "aGD" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -19559,7 +20370,8 @@
 	dir = 6
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -19567,7 +20379,8 @@
 "aGF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19578,7 +20391,8 @@
 "aGG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19589,11 +20403,13 @@
 "aGH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -19607,7 +20423,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -19621,11 +20438,13 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -19636,7 +20455,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -19650,7 +20470,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -19665,7 +20486,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -19678,15 +20500,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -19766,8 +20592,10 @@
 "aGT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -19867,7 +20695,8 @@
 /area/engine/engineering)
 "aHi" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/button/door{
@@ -19887,7 +20716,8 @@
 /area/engine/engineering)
 "aHj" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -19901,7 +20731,8 @@
 /area/engine/engineering)
 "aHk" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -19915,7 +20746,8 @@
 /area/engine/engineering)
 "aHl" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19928,7 +20760,8 @@
 /area/engine/engineering)
 "aHm" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -19945,7 +20778,8 @@
 /area/engine/engineering)
 "aHn" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/sign/electricshock{
@@ -19967,11 +20801,13 @@
 /area/engine/engineering)
 "aHo" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -19988,7 +20824,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20001,7 +20838,8 @@
 /area/engine/engineering)
 "aHq" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -20020,7 +20858,8 @@
 /area/engine/engineering)
 "aHr" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -20037,7 +20876,8 @@
 /area/engine/engineering)
 "aHs" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -20050,11 +20890,13 @@
 /area/engine/engineering)
 "aHt" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -20068,7 +20910,8 @@
 /area/engine/engineering)
 "aHu" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -20102,7 +20945,7 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -20121,12 +20964,15 @@
 	dir = 9
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -20144,7 +20990,7 @@
 	name = "Engineering Lockdown Shutters"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -20159,11 +21005,13 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/door/window/westright{
@@ -20182,7 +21030,7 @@
 	name = "Engineering Lockdown Shutters"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -20205,11 +21053,14 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -20225,7 +21076,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -20238,7 +21090,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -20256,7 +21109,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20269,7 +21123,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20285,15 +21140,18 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20309,7 +21167,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20325,7 +21184,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -20339,11 +21199,13 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -20353,11 +21215,13 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -20382,8 +21246,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -20420,8 +21286,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar{
@@ -20459,8 +21327,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -20472,8 +21342,10 @@
 "aHX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/maintenance/starboard/central)
@@ -20530,8 +21402,10 @@
 /area/engine/gravity_generator)
 "aIf" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = -32
@@ -20647,6 +21521,8 @@
 	tag = ""
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -20716,8 +21592,10 @@
 /area/engine/engineering)
 "aIr" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -20747,8 +21625,10 @@
 /area/engine/engineering)
 "aIt" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -20777,11 +21657,15 @@
 	},
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
@@ -20817,8 +21701,10 @@
 "aIz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -20850,8 +21736,10 @@
 	req_access_txt = "26"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -20879,8 +21767,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -20945,8 +21835,10 @@
 "aIL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -21027,11 +21919,14 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -21047,7 +21942,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -21105,8 +22001,10 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -21190,8 +22088,7 @@
 "aJj" = (
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -21254,8 +22151,7 @@
 	},
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -21283,8 +22179,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -21293,8 +22188,10 @@
 /area/engine/gravity_generator)
 "aJp" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -21382,8 +22279,10 @@
 /area/engine/engineering)
 "aJz" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -21398,8 +22297,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -21432,8 +22330,10 @@
 /area/engine/engineering)
 "aJC" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -21457,8 +22357,10 @@
 /area/engine/engineering)
 "aJF" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 2;
@@ -21477,7 +22379,8 @@
 /area/engine/engineering)
 "aJH" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/computer/apc_control,
@@ -21533,7 +22436,7 @@
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -21543,8 +22446,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -21567,8 +22472,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -21617,8 +22524,10 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/greenblue/side{
 	tag = "icon-greenblue (NORTH)";
@@ -21664,8 +22573,10 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar{
@@ -21727,7 +22638,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/freezer,
@@ -21737,7 +22649,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /mob/living/simple_animal/hostile/retaliate/goat{
@@ -21750,7 +22663,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -21760,15 +22674,19 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -21815,7 +22733,7 @@
 	})
 "aKl" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -21870,11 +22788,13 @@
 "aKs" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -21902,8 +22822,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -21928,7 +22847,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -21944,7 +22864,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -21957,15 +22878,18 @@
 	req_access_txt = "10"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -21976,15 +22900,19 @@
 /area/engine/gravity_generator)
 "aKy" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -22055,11 +22983,14 @@
 /area/engine/engineering)
 "aKG" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -22074,15 +23005,18 @@
 	req_access_txt = "10"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -22092,7 +23026,8 @@
 /area/engine/engineering)
 "aKI" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -22101,11 +23036,13 @@
 /area/engine/engineering)
 "aKJ" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -22113,7 +23050,8 @@
 "aKK" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/clothing/gloves/color/yellow,
@@ -22134,7 +23072,8 @@
 /obj/item/weapon/electronics/airlock,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22148,11 +23087,13 @@
 /obj/item/weapon/folder/yellow,
 /obj/item/device/lightreplacer,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -22162,7 +23103,8 @@
 /area/engine/engineering)
 "aKN" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -22170,15 +23112,18 @@
 "aKO" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -22204,11 +23149,14 @@
 "aKQ" = (
 /obj/effect/landmark/start/janitor,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/green/side{
@@ -22220,7 +23168,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/purple/side{
@@ -22249,8 +23198,10 @@
 "aKU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -22313,8 +23264,10 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -22651,8 +23604,10 @@
 /area/engine/gravity_generator)
 "aLM" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -22741,8 +23696,10 @@
 /area/engine/engineering)
 "aLW" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -22779,7 +23736,8 @@
 /area/engine/engineering)
 "aMd" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -22815,8 +23773,10 @@
 	scrub_Toxins = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/purple/side{
 	dir = 10
@@ -22860,8 +23820,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -22890,7 +23852,8 @@
 /area/hydroponics)
 "aMm" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/greenblue/side,
@@ -22903,7 +23866,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/greenblue/side,
@@ -22913,7 +23877,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/greenblue/side,
@@ -22923,7 +23888,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/greenblue/side,
@@ -22969,11 +23935,14 @@
 "aMu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -22990,7 +23959,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -23005,7 +23975,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -23016,7 +23987,8 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -23183,8 +24155,10 @@
 /area/tcommsat/server)
 "aMO" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -23312,6 +24286,8 @@
 /area/engine/supermatter)
 "aMZ" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
@@ -23432,8 +24408,10 @@
 	pixel_x = -26
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics South West";
@@ -23471,8 +24449,10 @@
 "aNk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -23510,8 +24490,10 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -23604,8 +24586,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -23637,7 +24621,8 @@
 	dir = 5
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -23648,7 +24633,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -23660,7 +24646,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -23671,11 +24658,13 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
@@ -23685,7 +24674,8 @@
 	dir = 9
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -23906,8 +24896,10 @@
 /area/tcommsat/server)
 "aNY" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -23968,6 +24960,8 @@
 /area/engine/supermatter)
 "aOc" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
@@ -24005,8 +24999,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -24022,8 +25018,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -24088,8 +25086,10 @@
 "aOn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/redyellow/side{
 	tag = "icon-redyellow (NORTH)";
@@ -24157,8 +25157,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -24211,8 +25213,10 @@
 /area/tcommsat/server)
 "aOz" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -24284,6 +25288,8 @@
 /area/engine/supermatter)
 "aOF" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -24308,7 +25314,8 @@
 /area/maintenance/port)
 "aOI" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24319,7 +25326,8 @@
 /area/maintenance/port)
 "aOJ" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24330,7 +25338,8 @@
 "aOK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24343,7 +25352,8 @@
 /area/maintenance/port)
 "aOL" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24362,7 +25372,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -24383,7 +25394,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -24400,7 +25412,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -24412,11 +25425,13 @@
 "aOP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24432,7 +25447,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24446,11 +25462,13 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24464,7 +25482,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24479,11 +25498,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24497,7 +25518,8 @@
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -24515,7 +25537,8 @@
 	pixel_y = 26
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -24542,11 +25565,13 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/purple/corner{
@@ -24568,11 +25593,12 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/green/corner{
@@ -24586,11 +25612,13 @@
 "aOY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24607,7 +25635,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24630,7 +25659,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/green/corner{
@@ -24646,7 +25676,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -24662,7 +25693,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -24683,7 +25715,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -24694,7 +25727,8 @@
 "aPe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -24709,7 +25743,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/green/corner{
@@ -24723,7 +25758,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -24740,7 +25776,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/green/corner{
@@ -24754,15 +25791,18 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel{
@@ -24774,7 +25814,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -24787,11 +25828,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel{
@@ -24803,7 +25846,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -24813,7 +25857,8 @@
 "aPm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -24831,7 +25876,8 @@
 	scrub_Toxins = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -24843,7 +25889,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -24856,7 +25903,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24871,7 +25919,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24887,7 +25936,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24902,7 +25952,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24917,7 +25968,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24927,11 +25979,13 @@
 "aPu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24945,7 +25999,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24960,7 +26015,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -24974,11 +26030,13 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -25078,8 +26136,10 @@
 /area/tcommsat/server)
 "aPI" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -25154,8 +26214,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25277,8 +26339,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -25420,8 +26484,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "L2"
@@ -25525,8 +26591,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central{
@@ -25760,8 +26828,10 @@
 /area/maintenance/port)
 "aQV" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
@@ -25796,8 +26866,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -25828,8 +26900,10 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -25900,8 +26974,10 @@
 "aRl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -25966,8 +27042,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -26003,8 +27081,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -26087,7 +27167,8 @@
 /area/tcommsat/server)
 "aRF" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/item/device/radio/intercom{
@@ -26105,7 +27186,8 @@
 /area/engine/engineering)
 "aRG" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26120,7 +27202,8 @@
 /area/engine/engineering)
 "aRH" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26130,7 +27213,8 @@
 /area/engine/engineering)
 "aRI" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -26142,7 +27226,8 @@
 /area/engine/engineering)
 "aRJ" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -26152,7 +27237,8 @@
 /area/engine/engineering)
 "aRK" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -26166,7 +27252,8 @@
 /area/engine/engineering)
 "aRL" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -26232,8 +27319,10 @@
 "aRS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -26317,8 +27406,10 @@
 "aSb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
@@ -26348,8 +27439,10 @@
 /area/medical/morgue)
 "aSf" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault,
@@ -26396,7 +27489,7 @@
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -26457,8 +27550,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -26492,8 +27587,10 @@
 /area/hallway/primary/central)
 "aSu" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/table,
 /obj/item/weapon/disk/tech_disk{
@@ -26575,8 +27672,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -26598,8 +27697,10 @@
 "aSC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/maintenance/starboard)
@@ -26819,8 +27920,10 @@
 /area/engine/engineering)
 "aTb" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -26900,8 +28003,10 @@
 /area/medical/morgue)
 "aTk" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -26969,8 +28074,10 @@
 /area/medical/chemistry)
 "aTr" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 1
@@ -27025,8 +28132,10 @@
 "aTx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -27134,11 +28243,14 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -27151,7 +28263,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -27168,7 +28281,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -27179,15 +28293,18 @@
 "aTP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -27200,7 +28317,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -27213,7 +28331,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -27224,7 +28343,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -27236,7 +28356,8 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -27317,8 +28438,10 @@
 "aUb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/blobstart,
@@ -27332,7 +28455,7 @@
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/black,
@@ -27342,7 +28465,8 @@
 	dir = 6
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -27350,7 +28474,8 @@
 "aUe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -27360,7 +28485,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -27370,7 +28496,8 @@
 	dir = 9
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -27378,18 +28505,21 @@
 "aUh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "aUi" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -27414,8 +28544,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault{
@@ -27472,7 +28604,8 @@
 /area/medical/chemistry)
 "aUt" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
@@ -27483,7 +28616,8 @@
 /area/medical/chemistry)
 "aUu" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow,
@@ -27491,7 +28625,8 @@
 "aUv" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -27580,11 +28715,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -27601,7 +28739,7 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -27630,8 +28768,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/maintenance/starboard)
@@ -27773,8 +28913,10 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
@@ -27805,8 +28947,10 @@
 "aVd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -27898,8 +29042,10 @@
 /area/medical/chemistry)
 "aVm" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
@@ -27924,8 +29070,10 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -27964,7 +29112,7 @@
 	pixel_y = 3
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -27978,7 +29126,8 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -28016,8 +29165,10 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 1
@@ -28084,8 +29235,10 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -28144,8 +29297,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -28206,8 +29361,10 @@
 "aVW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -28237,8 +29394,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -28366,8 +29525,10 @@
 /area/medical/chemistry)
 "aWi" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
@@ -28402,8 +29563,10 @@
 "aWl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/lab)
@@ -28446,8 +29609,10 @@
 "aWq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 1
@@ -28494,8 +29659,10 @@
 "aWv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral/corner,
@@ -28571,8 +29738,10 @@
 "aWF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/black,
 /area/library)
@@ -28595,7 +29764,7 @@
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -28605,7 +29774,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -28655,8 +29825,10 @@
 	req_access_txt = "5; 33"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -28731,8 +29903,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -28759,7 +29933,7 @@
 /area/science/research)
 "aWY" = (
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
@@ -28773,11 +29947,13 @@
 /area/science/research)
 "aWZ" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -28795,7 +29971,7 @@
 /area/science/research)
 "aXa" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
@@ -28809,8 +29985,10 @@
 "aXb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral/corner{
@@ -28825,8 +30003,10 @@
 	})
 "aXd" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner,
@@ -28955,8 +30135,10 @@
 /area/medical/medbay/zone3)
 "aXt" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -29022,7 +30204,8 @@
 "aXz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -29035,7 +30218,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -29047,7 +30231,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -29059,7 +30244,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -29069,15 +30255,19 @@
 "aXD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/lightsout,
@@ -29091,7 +30281,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -29105,7 +30296,8 @@
 	req_access_txt = "30"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29119,7 +30311,8 @@
 "aXG" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29131,12 +30324,15 @@
 /area/science/research)
 "aXH" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -29162,8 +30358,10 @@
 "aXJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -29201,8 +30399,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -29328,8 +30528,10 @@
 /area/medical/medbay/zone3)
 "aXY" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/blue,
@@ -29357,8 +30559,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -29478,8 +30682,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
@@ -29537,7 +30743,7 @@
 /area/science/research)
 "aYs" = (
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/computer/rdservercontrol,
@@ -29551,7 +30757,8 @@
 	dir = 5
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -29567,7 +30774,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -29582,7 +30790,8 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -29625,7 +30834,8 @@
 /area/library)
 "aYz" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29636,7 +30846,8 @@
 "aYA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29648,7 +30859,8 @@
 /area/maintenance/port)
 "aYB" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29661,7 +30873,8 @@
 /area/maintenance/port)
 "aYC" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29673,7 +30886,8 @@
 "aYD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29686,11 +30900,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -29698,7 +30914,8 @@
 /area/maintenance/port)
 "aYF" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29804,8 +31021,10 @@
 /area/medical/medbay/zone3)
 "aYR" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/neutral,
@@ -29846,8 +31065,10 @@
 "aYV" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -29922,8 +31143,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -29964,8 +31187,10 @@
 "aZn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -30014,8 +31239,10 @@
 "aZt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -30065,8 +31292,10 @@
 /area/library)
 "aZx" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
@@ -30129,7 +31358,8 @@
 	pixel_x = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/delivery,
@@ -30137,7 +31367,8 @@
 /area/medical/medbay/zone3)
 "aZD" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -30148,7 +31379,8 @@
 /area/medical/medbay/zone3)
 "aZE" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -30165,7 +31397,8 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30180,7 +31413,8 @@
 /area/medical/medbay/zone3)
 "aZG" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30191,7 +31425,8 @@
 /area/medical/medbay/zone3)
 "aZH" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30204,7 +31439,8 @@
 /area/medical/medbay/zone3)
 "aZI" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -30212,18 +31448,21 @@
 /area/medical/medbay/zone3)
 "aZJ" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/lightsout,
@@ -30232,7 +31471,8 @@
 "aZK" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30244,7 +31484,8 @@
 "aZL" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30254,7 +31495,8 @@
 /area/medical/medbay/zone3)
 "aZM" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30265,11 +31507,13 @@
 /area/medical/medbay/zone3)
 "aZN" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30280,7 +31524,8 @@
 /area/medical/medbay/zone3)
 "aZO" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -30294,7 +31539,8 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30310,7 +31556,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -30323,15 +31570,19 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -30339,8 +31590,7 @@
 "aZS" = (
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -30368,7 +31618,7 @@
 	pixel_y = 28
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/bot,
@@ -30403,8 +31653,10 @@
 "aZZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 4
@@ -30536,8 +31788,10 @@
 "bai" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30586,8 +31840,10 @@
 "bao" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -30725,8 +31981,10 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/medical/medbay/zone3)
@@ -30771,8 +32029,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
@@ -30796,8 +32056,10 @@
 /area/hallway/primary/central)
 "baJ" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/crowbar,
@@ -30840,11 +32102,14 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/camera{
@@ -30860,7 +32125,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -30874,7 +32140,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -30887,7 +32154,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -30906,7 +32174,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -30920,7 +32189,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -30930,15 +32200,19 @@
 "baT" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -31014,8 +32288,10 @@
 "bbb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -31040,7 +32316,8 @@
 /area/maintenance/port)
 "bbf" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31051,7 +32328,8 @@
 /area/maintenance/port)
 "bbg" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31062,7 +32340,8 @@
 "bbh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31073,7 +32352,8 @@
 /area/maintenance/port)
 "bbi" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31087,7 +32367,8 @@
 "bbj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -31099,7 +32380,8 @@
 "bbk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31139,8 +32421,10 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -31162,8 +32446,10 @@
 "bbq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/zone3)
@@ -31213,8 +32499,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -31246,11 +32534,14 @@
 /area/hallway/primary/central)
 "bbz" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/holopad,
@@ -31262,7 +32553,7 @@
 /area/hallway/primary/central)
 "bbA" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -31284,7 +32575,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -31298,7 +32590,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -31348,11 +32641,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -31369,7 +32665,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -31382,7 +32679,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -31397,7 +32695,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -31439,8 +32738,10 @@
 "bbP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/landmark/blobstart,
 /obj/effect/decal/cleanable/dirt,
@@ -31543,8 +32844,10 @@
 /area/maintenance/port)
 "bcb" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
@@ -31652,8 +32955,10 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -31662,8 +32967,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
 	d2 = 2;
-	icon_state = "0-2";
-	tag = "icon-0-2"
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/central)
@@ -31677,8 +32981,10 @@
 /area/hallway/primary/central)
 "bco" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -31705,8 +33011,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -31746,8 +33054,10 @@
 "bcx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
@@ -31763,8 +33073,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -31888,11 +33200,14 @@
 "bcS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31909,7 +33224,7 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -32020,11 +33335,13 @@
 "bdd" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -32034,7 +33351,8 @@
 /area/hallway/primary/central)
 "bde" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
@@ -32052,18 +33370,22 @@
 /area/hallway/primary/central)
 "bdf" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -32075,7 +33397,8 @@
 	icon_state = "tube1"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red,
@@ -32084,7 +33407,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -32101,8 +33424,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -32188,8 +33513,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
@@ -32206,7 +33533,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-0-4";
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/bot,
@@ -32215,15 +33542,19 @@
 "bdu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -32264,8 +33595,10 @@
 /area/science/robotics/lab)
 "bdz" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -32424,8 +33757,10 @@
 "bdO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
@@ -32500,8 +33835,10 @@
 "bdV" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/zone3)
@@ -32593,8 +33930,10 @@
 /area/hallway/primary/central)
 "bed" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
@@ -32614,8 +33953,10 @@
 "bef" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -32671,8 +34012,10 @@
 "bel" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -32696,8 +34039,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -32873,8 +34218,10 @@
 /area/maintenance/port)
 "beD" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -32896,8 +34243,10 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -32925,8 +34274,10 @@
 /area/hallway/primary/central)
 "beI" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side,
@@ -32955,8 +34306,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
@@ -32991,8 +34344,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -33016,8 +34371,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -33035,7 +34392,8 @@
 "beR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33045,15 +34403,18 @@
 /area/maintenance/port)
 "beS" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -33065,7 +34426,8 @@
 "beT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33076,7 +34438,8 @@
 "beU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33086,15 +34449,18 @@
 /area/maintenance/port)
 "beV" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -33105,7 +34471,8 @@
 /area/maintenance/port)
 "beW" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33128,7 +34495,8 @@
 /area/maintenance/port)
 "beY" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33142,7 +34510,8 @@
 /area/maintenance/port)
 "beZ" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33154,15 +34523,18 @@
 "bfa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -33172,7 +34544,8 @@
 /area/maintenance/port)
 "bfb" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33184,7 +34557,8 @@
 /area/maintenance/port)
 "bfc" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33214,8 +34588,10 @@
 /area/hallway/primary/central)
 "bff" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/glass_security{
@@ -33234,12 +34610,15 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
@@ -33249,7 +34628,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -33264,7 +34644,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -33277,7 +34658,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -33289,7 +34671,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
@@ -33301,7 +34684,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -33310,19 +34694,24 @@
 "bfm" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -33332,15 +34721,18 @@
 "bfn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -33353,7 +34745,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -33364,7 +34757,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -33374,7 +34768,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -33383,11 +34778,13 @@
 "bfr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -33399,7 +34796,8 @@
 	dir = 10
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -33408,7 +34806,7 @@
 /area/maintenance/starboard)
 "bft" = (
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -33476,8 +34874,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -33500,8 +34900,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -33525,12 +34927,15 @@
 /area/maintenance/port)
 "bfE" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/blobstart,
@@ -33538,7 +34943,8 @@
 /area/maintenance/port)
 "bfF" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -33548,7 +34954,8 @@
 "bfG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -33561,7 +34968,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -33572,7 +34980,8 @@
 "bfI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -33586,16 +34995,20 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -33604,7 +35017,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -33612,15 +35026,18 @@
 "bfL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -33636,11 +35053,12 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -33651,7 +35069,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -33661,7 +35080,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/purple/corner,
@@ -33671,16 +35091,20 @@
 /area/science/xenobiology)
 "bfQ" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "rdxeno";
@@ -33714,8 +35138,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -33766,8 +35192,10 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -33779,8 +35207,10 @@
 "bfW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -33811,7 +35241,7 @@
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel{
@@ -33890,8 +35320,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -33952,7 +35384,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -33983,8 +35415,10 @@
 "bgr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -34125,8 +35559,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -34151,14 +35587,16 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "bgI" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -34176,11 +35614,14 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel{
@@ -34236,8 +35677,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -34283,8 +35726,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -34351,7 +35796,8 @@
 /area/science/xenobiology)
 "bha" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -34364,7 +35810,8 @@
 	name = "Creature Cell #2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/vault{
@@ -34373,7 +35820,8 @@
 /area/science/xenobiology)
 "bhb" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -34382,7 +35830,8 @@
 "bhc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -34392,19 +35841,24 @@
 "bhd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -34424,11 +35878,13 @@
 	name = "Creature Cell #3"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -34525,8 +35981,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -34559,15 +36017,19 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -34577,7 +36039,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -34587,7 +36050,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -34603,7 +36067,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34614,7 +36079,8 @@
 "bhz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -34625,11 +36091,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/arrival,
@@ -34654,7 +36122,7 @@
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/arrival,
@@ -34677,8 +36145,10 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral/side,
 /area/hallway/secondary/entry)
@@ -34770,8 +36240,10 @@
 "bhQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
@@ -34919,8 +36391,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -34967,8 +36441,10 @@
 	dir = 9
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel{
 	dir = 4;
@@ -35030,7 +36506,8 @@
 "biq" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -35043,7 +36520,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -35059,15 +36537,18 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -35082,7 +36563,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/arrival{
@@ -35094,7 +36576,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -35107,7 +36590,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/arrival{
@@ -35191,8 +36675,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -35265,7 +36751,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/vault{
@@ -35282,7 +36769,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -35296,7 +36784,8 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -35306,7 +36795,8 @@
 /area/chapel/main)
 "biO" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -35321,7 +36811,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel{
@@ -35339,7 +36830,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel{
@@ -35430,7 +36922,7 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -35451,8 +36943,10 @@
 	on = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
@@ -35603,11 +37097,13 @@
 	name = "Creature Cell #1"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/vault{
@@ -35621,7 +37117,8 @@
 	scrub_Toxins = 0
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -35631,11 +37128,14 @@
 "bjr" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/bot,
@@ -35748,8 +37248,10 @@
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/scientist,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
@@ -35894,7 +37396,8 @@
 	receive_ore_updates = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/circuit/green,
@@ -35912,7 +37415,8 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -35939,7 +37443,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/white{
-	tag = "icon-0-8";
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -36544,8 +38048,10 @@
 "blh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2";
@@ -36573,7 +38079,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -36627,8 +38134,10 @@
 	})
 "bln" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Starboard";
@@ -36645,7 +38154,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -36682,7 +38192,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -38526,11 +40037,13 @@
 "bsv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/escape{
@@ -38548,8 +40061,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
@@ -38566,8 +40081,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
@@ -38593,11 +40110,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-4";
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -38611,7 +40130,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38629,7 +40149,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38641,7 +40162,8 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38657,7 +40179,8 @@
 	layer = 4.1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38668,7 +40191,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/light,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38732,7 +40256,8 @@
 	icon_state = "plant-22"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38768,11 +40293,13 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38791,7 +40318,8 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38804,7 +40332,8 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38816,7 +40345,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -38832,11 +40362,13 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38846,7 +40378,8 @@
 "bsR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-2-8";
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -38855,8 +40388,10 @@
 	})
 "bsS" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit{
@@ -38865,8 +40400,10 @@
 "bsT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit{
@@ -38882,8 +40419,10 @@
 "bsV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit{
@@ -38907,8 +40446,10 @@
 	dir = 2
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /turf/open/floor/plasteel{
 	tag = "icon-plasteel_warn_side (EAST)"
@@ -38918,7 +40459,8 @@
 	})
 "bsY" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
@@ -38932,7 +40474,8 @@
 	req_access_txt = "48;50"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38941,7 +40484,8 @@
 	})
 "bta" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -38957,7 +40501,8 @@
 	dir = 6
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -38974,7 +40519,8 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38984,7 +40530,8 @@
 "btd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	tag = "icon-1-8";
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -39673,7 +41220,7 @@
 /area/tcommsat/server)
 "buV" = (
 /obj/structure/cable/white{
-	tag = "icon-0-2";
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/modular_computer/console/preset/research,
@@ -40207,8 +41754,10 @@
 /area/shuttle/transport)
 "bwV" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = "icon-1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -21434,8 +21434,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -21447,8 +21446,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
@@ -21460,8 +21458,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -21479,8 +21476,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -21517,8 +21513,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -21535,8 +21530,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -21553,8 +21547,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -21566,8 +21559,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/station_engineer,
 /obj/effect/turf_decal/stripes/line,
@@ -26681,7 +26673,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -27123,7 +27114,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -27147,7 +27137,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -27161,7 +27150,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -27787,7 +27775,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -28396,7 +28383,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -28412,7 +28398,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -28427,7 +28412,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -28815,7 +28799,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -41070,7 +41053,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -41095,7 +41077,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -41114,7 +41095,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -41133,7 +41113,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -41181,7 +41160,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -41190,7 +41168,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -41201,7 +41178,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)
@@ -41214,7 +41190,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
-	tag = "";
 	temperature = 80
 	},
 /area/tcommsat/server)

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1649,7 +1649,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1998,7 +1997,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2136,7 +2134,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8275,7 +8272,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/effect/turf_decal/bot,
@@ -21785,7 +21781,6 @@
 "aIH" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/effect/turf_decal/delivery,
@@ -23786,7 +23781,6 @@
 "aMh" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/item/weapon/reagent_containers/glass/bucket,
@@ -32884,7 +32878,6 @@
 "bch" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -33260,7 +33253,6 @@
 "bcY" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -35493,7 +35485,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35899,7 +35890,6 @@
 /area/science/xenobiology)
 "bhj" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -39723,7 +39713,6 @@
 "brs" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -5081,9 +5081,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = 3;
 	pixel_y = -3
@@ -12175,9 +12173,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/vest{
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/vest,
 /obj/item/clothing/suit/armor/vest{
 	pixel_x = 3;
 	pixel_y = -3

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -938,7 +938,6 @@
 /obj/item/weapon/storage/lockbox/medal,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
@@ -1625,7 +1624,6 @@
 "acT" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/holopad,
@@ -1820,7 +1818,6 @@
 /obj/structure/closet/secure_closet/hop,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/cable/white{
@@ -3294,7 +3291,6 @@
 "afC" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/brown{
@@ -3591,7 +3587,6 @@
 "agg" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light{
@@ -4646,7 +4641,6 @@
 "ahO" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4716,7 +4710,6 @@
 "ahX" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5170,7 +5163,6 @@
 /obj/structure/filingcabinet/filingcabinet,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/brown{
@@ -6191,7 +6183,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -7948,7 +7939,6 @@
 "amR" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/light/small,
@@ -9073,7 +9063,6 @@
 /obj/machinery/cell_charger,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/vault{
@@ -9284,7 +9273,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -10183,7 +10171,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/bot,
@@ -10718,7 +10705,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/firealarm{
@@ -11720,7 +11706,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/camera{
@@ -12728,7 +12713,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable/white{
@@ -12846,7 +12830,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable/white{
@@ -13291,7 +13274,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -13662,7 +13644,6 @@
 "avW" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13716,7 +13697,6 @@
 /obj/machinery/vending/assist,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/light,
@@ -15042,7 +15022,6 @@
 "ayy" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
@@ -15619,7 +15598,6 @@
 /obj/item/weapon/canvas/twentythreeXtwentythree,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/light,
@@ -16908,7 +16886,6 @@
 "aBY" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light{
@@ -17219,7 +17196,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/light,
@@ -18603,7 +18579,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/vault{
@@ -19823,7 +19798,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/vault{
@@ -20856,7 +20830,6 @@
 "aIA" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
@@ -21727,7 +21700,6 @@
 "aKa" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -22659,7 +22631,6 @@
 /obj/item/clothing/glasses/meson,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -23435,7 +23406,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/light,
@@ -25427,7 +25397,6 @@
 "aQk" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26251,7 +26220,6 @@
 "aRR" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -26405,7 +26373,6 @@
 /obj/structure/closet/wardrobe/chemistry_white,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/item/device/radio/intercom{
@@ -28721,7 +28688,6 @@
 /obj/effect/landmark/start/assistant,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/grimy,
@@ -28902,7 +28868,6 @@
 "aXi" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/black,
@@ -29188,7 +29153,6 @@
 /obj/item/weapon/wrench,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/vault{
@@ -29762,7 +29726,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/effect/turf_decal/delivery,
@@ -31043,7 +31006,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/bot,
@@ -32481,7 +32443,6 @@
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/extinguisher_cabinet{
@@ -32579,7 +32540,6 @@
 "bdY" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/whiteblue/side{
@@ -32975,7 +32935,6 @@
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
@@ -33798,7 +33757,6 @@
 "bfU" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35422,7 +35380,6 @@
 /obj/structure/bookcase,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/firealarm{
@@ -35579,7 +35536,6 @@
 /obj/structure/closet/crate/bin,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/vault{
@@ -35737,7 +35693,6 @@
 "bjy" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -36845,7 +36800,6 @@
 	on = 1
 	},
 /obj/machinery/airalarm{
-	icon_state = "alarm0";
 	dir = 8;
 	pixel_x = 25
 	},

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -561,7 +561,7 @@
 	},
 /obj/structure/cable/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -599,7 +599,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -619,7 +619,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -631,7 +631,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -654,7 +654,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -666,7 +666,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault{
@@ -1322,7 +1322,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/item/weapon/bedsheet/hop,
 /obj/effect/landmark/start/head_of_personnel,
@@ -6139,7 +6139,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -9144,7 +9143,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -10337,7 +10336,7 @@
 /area/engine/atmos)
 "aqC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -10347,7 +10346,7 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -10355,7 +10354,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -10364,7 +10363,7 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -10373,7 +10372,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating/astplate,
 /area/hallway/primary/central{
@@ -10978,7 +10977,7 @@
 /area/engine/atmos)
 "arz" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1;
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -11566,9 +11565,7 @@
 "asx" = (
 /obj/machinery/meter,
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
@@ -11655,7 +11652,7 @@
 /area/engine/atmos)
 "asG" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 2;
+	dir = 2
 	},
 /obj/machinery/meter,
 /obj/effect/decal/cleanable/dirt,
@@ -11663,7 +11660,7 @@
 /area/engine/atmos)
 "asH" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
@@ -12204,9 +12201,7 @@
 "aty" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "atz" = (
@@ -12761,9 +12756,7 @@
 "aur" = (
 /obj/machinery/meter,
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -12805,7 +12798,7 @@
 /area/engine/atmos)
 "auv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -13368,9 +13361,7 @@
 	})
 "avx" = (
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "avy" = (
@@ -14401,14 +14392,14 @@
 /area/engine/atmos)
 "axo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 2;
+	dir = 2
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "axp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 2;
+	dir = 2
 	},
 /obj/structure/cable/white{
 	tag = "icon-1-2";
@@ -15909,9 +15900,7 @@
 	name = "Mixed Air Tank In"
 	},
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -15919,7 +15908,7 @@
 /area/engine/atmos)
 "aAj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
@@ -15929,7 +15918,7 @@
 "aAk" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -15970,7 +15959,7 @@
 /area/engine/atmos)
 "aAo" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1;
+	dir = 1
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/neutral,
@@ -16005,7 +15994,7 @@
 /area/engine/atmos)
 "aAs" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /obj/structure/cable/white{
 	tag = "icon-2-8";
@@ -16577,7 +16566,7 @@
 /area/engine/atmos)
 "aBr" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -16611,14 +16600,14 @@
 /area/engine/atmos)
 "aBw" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aBx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -17152,9 +17141,7 @@
 	name = "Mixed Air Tank Out"
 	},
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -17162,7 +17149,7 @@
 /area/engine/atmos)
 "aCt" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1;
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
@@ -17190,7 +17177,7 @@
 /area/engine/atmos)
 "aCw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/machinery/status_display{
@@ -20604,7 +20591,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -20636,7 +20623,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -25202,7 +25189,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -25216,7 +25203,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -25224,7 +25211,7 @@
 "aPR" = (
 /obj/structure/girder,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -25234,7 +25221,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -25246,7 +25233,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -25677,7 +25664,7 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/server)
@@ -27717,9 +27704,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 7
-	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -31144,7 +31129,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
@@ -33537,7 +33521,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -33545,7 +33529,7 @@
 /area/chapel/main)
 "bfA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall,
 /area/chapel/main)
@@ -33561,7 +33545,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -39606,9 +39590,7 @@
 	},
 /area/tcommsat/server)
 "buI" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 7
-	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/vault{
 	dir = 5;
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -40296,7 +40278,7 @@
 /area/engine/gravity_generator)
 "bwY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
@@ -40336,7 +40318,7 @@
 /area/space)
 "bxd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/mineral/random/labormineral,
 /area/ruin/unpowered{
@@ -40384,7 +40366,7 @@
 /area/tcommsat/server)
 "bxk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
@@ -40410,7 +40392,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/tcommsat/server)
@@ -70874,7 +70856,7 @@ acD
 aad
 abi
 abu
-aqB
+awL
 art
 asA
 atB
@@ -70884,7 +70866,7 @@ awE
 awE
 ayd
 azk
-aAl
+ayd
 aBr
 aCv
 aDp
@@ -71131,7 +71113,7 @@ aad
 aad
 abi
 aik
-aqB
+awL
 aru
 asB
 atC
@@ -72673,7 +72655,7 @@ agE
 abi
 aad
 abi
-aqB
+awL
 arA
 asH
 atI
@@ -72930,7 +72912,7 @@ abi
 aad
 aad
 aaV
-aqB
+awL
 aqz
 aqz
 atJ
@@ -78627,7 +78609,7 @@ bcg
 bcX
 bdS
 aSh
-beX
+bbg
 bfy
 bfY
 bgJ
@@ -81648,7 +81630,7 @@ aak
 aar
 aaD
 aaQ
-abb
+acX
 abn
 abC
 ach
@@ -82676,7 +82658,7 @@ aak
 aav
 aaH
 aaQ
-abb
+acX
 buV
 abF
 ack

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -68,7 +68,6 @@
 /obj/machinery/light,
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/circuit,
@@ -131,8 +130,7 @@
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -183,8 +181,7 @@
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/circuit,
 /area/wreck/ai)
@@ -224,8 +221,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/glass_command{
@@ -328,7 +324,6 @@
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_x = 0;
 	pixel_y = -31
 	},
 /obj/item/device/radio/intercom{
@@ -392,7 +387,6 @@
 	},
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = 20
 	},
 /obj/machinery/ai_status_display{
@@ -420,8 +414,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -437,8 +430,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -451,8 +443,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/white,
@@ -461,8 +452,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/wreck/ai)
@@ -556,8 +546,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/wreck/ai)
@@ -634,8 +623,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "MiniSat Antechamber APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/grimy,
@@ -647,8 +635,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -681,8 +668,6 @@
 	},
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -772,7 +757,6 @@
 	frequency = 1447;
 	listening = 0;
 	name = "Station Intercom (AI Private)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /obj/machinery/camera/motion{
@@ -905,8 +889,7 @@
 	req_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -930,8 +913,7 @@
 /area/ai_monitored/turret_protected/AIsatextAP)
 "acc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1071,8 +1053,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/item/seeds/glowshroom,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -1095,8 +1076,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/prison)
@@ -1106,8 +1086,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -1344,8 +1323,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "MiniSat Port Maintenance APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1359,8 +1337,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1371,8 +1348,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -1391,8 +1367,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1405,8 +1380,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1417,8 +1391,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -1431,8 +1404,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 8
@@ -1462,8 +1434,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Foyer";
@@ -1479,8 +1450,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
@@ -1495,8 +1465,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1510,8 +1479,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -1525,8 +1493,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -1546,8 +1513,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -1560,8 +1526,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "MiniSat Starboard Maintenance APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -1571,8 +1536,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/black,
 /area/security/prison)
@@ -1904,7 +1868,6 @@
 	},
 /obj/machinery/flasher{
 	id = "executionflash";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -2050,16 +2013,14 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -2102,7 +2063,6 @@
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
 	name = "Prison Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24;
 	prison_radio = 1
 	},
@@ -2125,7 +2085,6 @@
 	id = "permabolt2";
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -2149,7 +2108,6 @@
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
 	name = "Prison Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24;
 	prison_radio = 1
 	},
@@ -2177,7 +2135,6 @@
 	id = "permabolt1";
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -2352,7 +2309,6 @@
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "robot_old";
 	name = "Cyborg Statue";
-	pixel_x = 0;
 	pixel_y = 20
 	},
 /turf/open/space,
@@ -2366,8 +2322,7 @@
 	freerange = 0;
 	frequency = 1459;
 	name = "Station Intercom (General)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/table,
 /obj/item/weapon/storage/backpack/duffelbag/sec/surgery{
@@ -2384,8 +2339,7 @@
 	pixel_x = 3
 	},
 /obj/item/device/taperecorder{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /turf/open/floor/plasteel/black,
 /area/security/transfer)
@@ -2565,7 +2519,6 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
 	network = list("Prison");
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2609,8 +2562,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -2626,8 +2578,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
@@ -2696,8 +2647,7 @@
 	icon_state = "tube1"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -2712,8 +2662,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2731,8 +2680,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/security/transfer)
@@ -2751,8 +2699,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -2771,8 +2718,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/transfer)
@@ -2781,8 +2727,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -2814,8 +2759,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -2828,8 +2772,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 4
@@ -2840,8 +2783,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -2852,8 +2794,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -2899,8 +2840,7 @@
 	pixel_x = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/red,
 /area/security/prison)
@@ -3023,8 +2963,7 @@
 /area/security/transfer)
 "agA" = (
 /obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9
@@ -3141,8 +3080,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Armory APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -3215,8 +3153,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/black,
 /area/security/transfer)
@@ -3225,7 +3162,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -3241,8 +3177,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Prisoner Transfer Centre";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -3296,13 +3231,11 @@
 /obj/item/clothing/suit/armor/laserproof,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/black,
 /area/security/armory)
@@ -3384,7 +3317,6 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -3424,7 +3356,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
@@ -3444,8 +3375,7 @@
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red,
 /area/security/main)
@@ -3519,7 +3449,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel/black,
@@ -3670,8 +3599,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Office APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/red/side{
@@ -3713,7 +3641,6 @@
 	desc = "An embossed piece of paper from the University of Nanotrasen at Portpoint.";
 	icon_state = "kiddieplaque";
 	name = "\improper 'Diploma' frame";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/black,
@@ -3727,7 +3654,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/black,
@@ -3751,7 +3677,6 @@
 	department = "Head of Security's Desk";
 	departmentType = 5;
 	name = "Head of Security RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/black,
@@ -3827,7 +3752,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -3871,7 +3795,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -3889,7 +3812,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Crematorium APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -3932,7 +3854,6 @@
 	freerange = 0;
 	frequency = 1459;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/table/glass,
@@ -4064,7 +3985,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/newscaster{
@@ -4178,8 +4098,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4193,8 +4112,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4205,7 +4123,6 @@
 /obj/machinery/button/door{
 	id = "supplybridge";
 	name = "Space Bridge Control";
-	pixel_x = 0;
 	pixel_y = 27;
 	req_access_txt = "0"
 	},
@@ -4222,8 +4139,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4234,8 +4150,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4314,7 +4229,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel/black,
@@ -4342,8 +4256,7 @@
 "ajf" = (
 /obj/item/weapon/storage/box/bodybags,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -4450,7 +4363,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -4661,8 +4573,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -4681,8 +4592,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitered/side{
 	dir = 4
@@ -4692,8 +4602,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
@@ -4702,8 +4611,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4732,8 +4640,7 @@
 	cell_type = 10000;
 	dir = 4;
 	name = "Brig APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -4765,8 +4672,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault,
@@ -4795,8 +4701,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4820,7 +4725,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/light{
@@ -4901,8 +4805,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4920,8 +4823,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4935,8 +4837,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5031,7 +4932,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5115,7 +5015,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5137,8 +5036,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Brig Control APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -5196,7 +5094,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/closed/wall/r_wall,
@@ -5225,7 +5122,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5245,7 +5141,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/floor/carpet,
@@ -5311,8 +5206,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
@@ -5323,8 +5217,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -5370,7 +5263,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5384,8 +5276,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/structure/sign/map{
 	icon_state = "map-pubby";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -5404,8 +5295,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
@@ -5426,8 +5316,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -5503,7 +5392,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -5533,7 +5421,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -5600,8 +5487,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/darkred/side{
 	tag = "icon-darkred (NORTH)";
@@ -5613,8 +5499,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Security's Office";
@@ -5624,7 +5509,6 @@
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /turf/open/floor/plasteel/darkred/side{
@@ -5640,7 +5524,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Head of Security's Office APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -5683,8 +5566,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -5726,8 +5608,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5776,8 +5657,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /mob/living/simple_animal/pet/dog/pug{
 	name = "McGriff"
@@ -5807,7 +5687,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -5822,8 +5701,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5839,8 +5717,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -5848,8 +5725,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -5866,8 +5742,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5878,8 +5753,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -5893,7 +5767,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -5940,8 +5813,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
@@ -5955,8 +5827,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
 	dir = 1
@@ -6063,8 +5934,7 @@
 "amx" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 0
+	name = "Station Intercom (General)"
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -6172,8 +6042,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6189,8 +6058,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6220,8 +6088,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6289,8 +6156,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/item/device/camera_film,
 /turf/open/floor/plating{
@@ -6364,7 +6230,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/closed/wall/r_wall,
@@ -6402,9 +6267,7 @@
 	req_access_txt = "63"
 	},
 /obj/item/weapon/paper_bin{
-	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0
+	layer = 2.9
 	},
 /obj/item/weapon/pen{
 	pixel_x = 4;
@@ -6434,8 +6297,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/structure/disposalpipe/segment,
@@ -6445,8 +6307,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
 /area/security/warden)
@@ -6474,7 +6335,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -6483,8 +6343,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -6501,8 +6360,7 @@
 	dir = 4
 	},
 /obj/item/weapon/storage/pod{
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
@@ -6511,8 +6369,7 @@
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
@@ -6604,8 +6461,7 @@
 "anC" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -31;
-	pixel_y = 0
+	pixel_x = -31
 	},
 /turf/open/floor/mineral/plastitanium/brig,
 /area/shuttle/labor)
@@ -6641,14 +6497,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -6766,7 +6620,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -6898,7 +6751,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/space,
@@ -6919,7 +6771,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/space,
@@ -6960,7 +6811,6 @@
 /obj/machinery/button/flasher{
 	id = "gulagshuttleflasher";
 	name = "Flash Control";
-	pixel_x = 0;
 	pixel_y = -26;
 	req_access_txt = "1"
 	},
@@ -6998,7 +6848,6 @@
 /obj/machinery/button/door{
 	id = "prison release";
 	name = "Labor Camp Shuttle Lockdown";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "2"
 	},
@@ -7017,7 +6866,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel,
@@ -7142,7 +6990,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/weapon/folder/yellow{
@@ -7248,8 +7095,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -7315,8 +7161,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -7436,7 +7281,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/light,
@@ -7667,7 +7511,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Vault APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -7689,8 +7532,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Dormitory Maintenance APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable,
 /obj/machinery/light/small,
@@ -7755,8 +7597,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/closet/emcloset{
 	anchored = 1;
@@ -7791,7 +7632,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/floor/circuit/green,
@@ -7805,8 +7645,7 @@
 "aqi" = (
 /obj/machinery/mineral/labor_claim_console{
 	machinedir = 1;
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/labor)
@@ -7936,8 +7775,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
@@ -7994,7 +7832,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -8148,8 +7985,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8163,8 +7999,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -8266,7 +8101,6 @@
 	req_access_txt = "1"
 	},
 /obj/item/weapon/paper_bin{
-	pixel_x = 0;
 	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
@@ -8322,7 +8156,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -8443,8 +8276,7 @@
 /area/ai_monitored/nuke_storage)
 "arB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8498,7 +8330,6 @@
 /obj/machinery/button/door{
 	id = "Dorm3Shutters";
 	name = "Privacy Shutters Control";
-	pixel_x = 0;
 	pixel_y = 26;
 	req_access_txt = "0"
 	},
@@ -8512,7 +8343,6 @@
 	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
 	icon_state = "monkey_painting";
 	name = "Mr. Deempisi portrait";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -8527,7 +8357,6 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -8579,7 +8408,6 @@
 	desc = "Used for watching the monastery.";
 	name = "Monastery Monitor";
 	network = list("Monastery");
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -9086,7 +8914,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/arrival{
@@ -9126,7 +8953,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Fitness Room APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -9231,8 +9057,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/closed/wall,
 /area/security/brig)
@@ -9264,8 +9089,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
@@ -9372,7 +9196,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -9582,8 +9405,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
@@ -9648,7 +9470,6 @@
 	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
 	icon_state = "monkey_painting";
 	name = "Mr. Deempisi portrait";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/grimy,
@@ -9684,7 +9505,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -9714,7 +9534,6 @@
 	department = "Captain's Desk";
 	departmentType = 5;
 	name = "Captain RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/carpet,
@@ -9725,7 +9544,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/carpet,
@@ -9842,8 +9660,7 @@
 /area/bridge)
 "aux" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -9892,7 +9709,6 @@
 /obj/machinery/button/door{
 	id = "Dorm2Shutters";
 	name = "Privacy Shutters Control";
-	pixel_x = 0;
 	pixel_y = 26;
 	req_access_txt = "0"
 	},
@@ -9906,7 +9722,6 @@
 	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
 	icon_state = "monkey_painting";
 	name = "Mr. Deempisi portrait";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -9921,7 +9736,6 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -9961,8 +9775,6 @@
 	},
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/carpet,
@@ -10036,8 +9848,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -10067,7 +9878,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Solar APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
@@ -10081,7 +9891,6 @@
 	id = "prison release";
 	name = "Labor Camp Shuttle Lockdown";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -10094,7 +9903,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -10302,7 +10110,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/black,
@@ -10439,7 +10246,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/black,
@@ -10648,8 +10454,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/space,
 /area/solar/port)
@@ -10674,8 +10479,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 4;
@@ -10689,8 +10493,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -10698,8 +10501,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 8;
@@ -10718,8 +10520,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -10736,7 +10537,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -10751,7 +10551,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/door/airlock/engineering{
@@ -10761,8 +10560,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -10770,8 +10568,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10784,8 +10581,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -10796,8 +10592,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/vending_refill/cigarette,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -10854,8 +10649,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -10864,8 +10658,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -10946,8 +10739,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -11010,8 +10802,6 @@
 /obj/item/weapon/pen,
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/carpet,
@@ -11230,7 +11020,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/floor/plating{
@@ -11329,8 +11118,7 @@
 "axN" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/black,
 /area/crew_quarters/heads/captain)
@@ -11408,7 +11196,6 @@
 	desc = "Used for watching the monastery.";
 	name = "Monastery Monitor";
 	network = list("Monastery");
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/wood,
@@ -11447,7 +11234,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/bed/dogbed{
@@ -11518,7 +11304,6 @@
 /obj/machinery/button/door{
 	id = "Dorm1Shutters";
 	name = "Privacy Shutters Control";
-	pixel_x = 0;
 	pixel_y = 26;
 	req_access_txt = "0"
 	},
@@ -11532,7 +11317,6 @@
 	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
 	icon_state = "monkey_painting";
 	name = "Mr. Deempisi portrait";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -11547,7 +11331,6 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -11640,7 +11423,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/space,
@@ -11660,7 +11442,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/space,
@@ -11696,8 +11477,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11711,8 +11491,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -11731,7 +11510,6 @@
 	},
 /obj/machinery/requests_console{
 	department = "Detective's office";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/grimy,
@@ -11799,7 +11577,6 @@
 /area/storage/primary)
 "ayL" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -11826,7 +11603,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/item/weapon/screwdriver{
@@ -12063,8 +11839,6 @@
 	},
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/wood,
@@ -12254,7 +12028,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/white/corner,
@@ -12291,7 +12064,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -12378,8 +12150,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Tool Storage APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8
@@ -12531,7 +12302,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/circuit,
@@ -12725,8 +12495,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Head of Personnel APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -12787,8 +12556,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = 23;
-	pixel_y = 0
+	pixel_x = 23
 	},
 /obj/effect/decal/cleanable/deadcockroach,
 /turf/open/floor/plasteel/freezer,
@@ -12828,8 +12596,6 @@
 /obj/item/weapon/pen,
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/carpet,
@@ -12866,8 +12632,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Detective's Office APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -13021,7 +12786,6 @@
 /obj/machinery/computer/upload/ai,
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/circuit,
@@ -13030,8 +12794,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Monastery Maintenance";
@@ -13045,7 +12808,6 @@
 /obj/machinery/computer/upload/borg,
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/circuit,
@@ -13180,13 +12942,10 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/carpet,
@@ -13315,7 +13074,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel/grimy,
@@ -13434,8 +13192,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Emergency Storage APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -13477,8 +13234,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13489,8 +13245,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/freezer,
@@ -13503,8 +13258,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13515,8 +13269,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -13755,8 +13508,6 @@
 /obj/item/weapon/pen,
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /obj/effect/turf_decal/delivery,
@@ -13879,8 +13630,7 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
@@ -13889,7 +13639,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13904,7 +13653,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -13955,7 +13703,6 @@
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
 	layer = 4.1;
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel,
@@ -14144,8 +13891,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -14190,7 +13936,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -14452,8 +14197,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Dormitory Bathrooms APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -15004,8 +14748,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15020,8 +14763,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15089,8 +14831,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 9
@@ -15110,7 +14851,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -15200,8 +14940,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
@@ -15361,8 +15100,7 @@
 /area/crew_quarters/dorms)
 "aFT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -15539,8 +15277,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/red/side{
 	tag = "icon-red (EAST)";
@@ -15557,7 +15294,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -15878,8 +15614,7 @@
 /obj/machinery/photocopier,
 /obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = 23;
-	pixel_y = 0
+	pixel_x = 23
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 5
@@ -16042,7 +15777,6 @@
 	id = "evashutter";
 	name = "EVA Shutters Control";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "18"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16111,8 +15845,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -16126,8 +15859,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -16172,16 +15904,13 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -16210,7 +15939,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/red/side{
@@ -16245,7 +15973,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 30;
 	supply_display = 1
 	},
@@ -16473,7 +16200,6 @@
 "aIu" = (
 /obj/machinery/button/massdriver{
 	id = "trash";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -16602,8 +16328,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Art Storage APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
@@ -16640,7 +16365,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Cafeteria APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -16760,7 +16484,6 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/shoes/magboots{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/item/device/radio/intercom{
@@ -16804,7 +16527,6 @@
 	layer = 2.9
 	},
 /obj/item/weapon/tank/jetpack/carbondioxide{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/item/weapon/tank/jetpack/carbondioxide{
@@ -16991,8 +16713,7 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17033,8 +16754,7 @@
 	},
 /obj/machinery/button/massdriver{
 	id = "trash";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -17160,8 +16880,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel/escape{
 	dir = 1
@@ -17180,8 +16899,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Departure Lounge APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -17290,8 +17008,7 @@
 	},
 /obj/machinery/requests_console{
 	department = "EVA";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/camera{
 	c_tag = "EVA Storage";
@@ -17331,8 +17048,7 @@
 	network = list("SS13")
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/blue/corner{
 	dir = 1
@@ -17360,8 +17076,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -17401,8 +17116,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17757,8 +17471,7 @@
 "aLc" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -17844,8 +17557,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Post - Cargo APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/closet/wardrobe/red,
 /turf/open/floor/plasteel/red/side{
@@ -17912,7 +17624,6 @@
 	id = "qm_warehouse";
 	name = "Warehouse Door Control";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18298,8 +18009,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -18422,8 +18132,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/brown/corner{
 	dir = 1;
@@ -18461,8 +18170,6 @@
 /obj/item/weapon/pen,
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/plasteel,
@@ -18682,7 +18389,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -18882,7 +18588,6 @@
 	id = "qm_warehouse";
 	name = "Warehouse Door Control";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18909,8 +18614,7 @@
 	cell_type = 2500;
 	dir = 4;
 	name = "Cargo Maintenance APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -18932,8 +18636,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Disposal APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -18966,8 +18669,7 @@
 	dir = 4;
 	name = "security camera";
 	pixel_x = 6;
-	pixel_y = -7;
-	pixel_x = 0
+	pixel_y = -7
 	},
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
@@ -19071,7 +18773,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -19289,7 +18990,6 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -19334,7 +19034,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 30;
 	supply_display = 1
 	},
@@ -19399,8 +19098,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -19415,8 +19113,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19432,8 +19129,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -19452,8 +19148,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19467,8 +19162,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19482,8 +19176,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19635,7 +19328,6 @@
 "aOV" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/weapon/reagent_containers/spray/plantbgone{
@@ -19660,7 +19352,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19682,7 +19373,6 @@
 /obj/machinery/requests_console{
 	department = "Kitchen";
 	departmentType = 2;
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -20145,8 +19835,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = 23;
-	pixel_y = 0
+	pixel_x = 23
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
@@ -20298,8 +19987,7 @@
 /area/quartermaster/office)
 "aQp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel/loadingarea{
 	dir = 8
@@ -20337,8 +20025,7 @@
 	icon_state = "tube1"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/conveyor_switch{
 	id = "cargodeliver"
@@ -20464,8 +20151,7 @@
 	},
 /obj/machinery/button/massdriver{
 	id = "chapelgun";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
@@ -20505,7 +20191,6 @@
 	dir = 1;
 	icon_state = "direction_evac";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-direction_evac (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -20601,7 +20286,6 @@
 	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
 	icon_state = "monkey_painting";
 	name = "Mr. Deempisi portrait";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -20636,7 +20320,6 @@
 /obj/machinery/requests_console{
 	department = "Bar";
 	departmentType = 2;
-	pixel_x = 0;
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
@@ -20669,7 +20352,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/black,
@@ -20779,7 +20461,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/redblue,
@@ -20790,8 +20471,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -20827,7 +20507,6 @@
 	dir = 8;
 	layer = 4;
 	pixel_x = 32;
-	pixel_y = 0;
 	supply_display = 1
 	},
 /turf/open/floor/plasteel/brown{
@@ -20935,8 +20614,7 @@
 	layer = 4.1
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/escape{
 	dir = 6
@@ -20948,7 +20626,6 @@
 	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
 	icon_state = "monkey_painting";
 	name = "Mr. Deempisi portrait";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/black,
@@ -20969,7 +20646,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/machinery/light/small{
@@ -21342,7 +21018,6 @@
 	dir = 1
 	},
 /obj/item/device/assembly/timer{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/open/floor/plating,
@@ -21474,7 +21149,6 @@
 /obj/machinery/requests_console{
 	department = "Hydroponics";
 	departmentType = 2;
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/green/corner{
@@ -21486,7 +21160,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/green/side{
@@ -21590,8 +21263,7 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 1
@@ -21786,8 +21458,7 @@
 	pixel_y = 30
 	},
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 9
@@ -21809,7 +21480,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/red/side{
@@ -21860,7 +21530,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -21912,7 +21581,6 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/vault{
@@ -21978,7 +21646,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/black,
@@ -22001,7 +21668,6 @@
 	dir = 4;
 	layer = 4;
 	pixel_x = -32;
-	pixel_y = 0;
 	supply_display = 1
 	},
 /turf/open/floor/plasteel,
@@ -22113,8 +21779,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22180,7 +21845,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/arrival{
@@ -22207,8 +21871,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -22261,8 +21924,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -22273,8 +21935,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22303,8 +21964,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = 23;
-	pixel_y = 0
+	pixel_x = 23
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
@@ -22324,7 +21984,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Custodial Closet APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -22484,13 +22143,10 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -22573,8 +22229,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -22588,7 +22243,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Cargo Bay APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -22605,8 +22259,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22615,7 +22268,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
@@ -22730,8 +22382,6 @@
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/plasteel/red/side,
@@ -22789,7 +22439,6 @@
 	id = "jangarage";
 	name = "Custodial Closet Shutters Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "26"
 	},
 /obj/structure/cable{
@@ -22808,8 +22457,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/janitor)
@@ -22818,8 +22466,7 @@
 /obj/machinery/requests_console{
 	department = "Janitorial";
 	departmentType = 1;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -23105,8 +22752,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -23347,8 +22993,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/item/weapon/storage/belt/fannypack/yellow,
 /turf/open/floor/plasteel/brown{
@@ -23417,8 +23062,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = 23;
-	pixel_y = 0
+	pixel_x = 23
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 5
@@ -23443,8 +23087,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -23452,8 +23095,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Solar Access";
@@ -23466,7 +23108,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -23494,8 +23135,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -23503,8 +23143,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 4;
@@ -23518,8 +23157,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -23527,8 +23165,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 8;
@@ -23543,8 +23180,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/space,
 /area/solar/starboard)
@@ -23583,7 +23219,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -23695,8 +23330,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/janitor)
@@ -23827,8 +23461,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Quartermaster APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1;
@@ -23894,8 +23527,7 @@
 /obj/machinery/requests_console{
 	department = "Mining";
 	departmentType = 0;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/brown/corner,
 /area/quartermaster/miningdock)
@@ -23932,8 +23564,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Solar APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -24295,7 +23926,6 @@
 	dir = 4;
 	layer = 4;
 	pixel_x = -32;
-	pixel_y = 0;
 	supply_display = 1
 	},
 /turf/open/floor/plasteel/brown{
@@ -24365,8 +23995,6 @@
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/plating,
@@ -24440,8 +24068,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -24456,8 +24083,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24469,8 +24095,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24478,7 +24103,6 @@
 /obj/structure/sign/directions/evac{
 	dir = 8;
 	icon_state = "direction_evac";
-	pixel_x = 0;
 	pixel_y = -32;
 	tag = "icon-direction_evac (WEST)"
 	},
@@ -24488,8 +24112,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -24557,7 +24180,6 @@
 	id = "kitchen";
 	name = "Kitchen Shutters Control";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "28"
 	},
 /obj/machinery/light_switch{
@@ -24633,7 +24255,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plating,
@@ -24655,8 +24276,7 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 10
@@ -24666,7 +24286,6 @@
 /obj/structure/table,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/stamp/qm{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/machinery/light,
@@ -24931,7 +24550,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/purple/corner{
@@ -24979,8 +24597,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -25075,7 +24692,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -25093,7 +24709,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /turf/open/floor/circuit/green,
@@ -25106,7 +24721,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/light{
@@ -25114,8 +24728,7 @@
 	icon_state = "tube1"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
@@ -25128,7 +24741,6 @@
 	dir = 8;
 	name = "Mining Dock APC";
 	pixel_x = -24;
-	pixel_y = 0;
 	pixel_z = 0
 	},
 /turf/open/floor/plasteel/brown/corner{
@@ -25420,8 +25032,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25449,8 +25060,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25461,8 +25071,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25477,8 +25086,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25510,8 +25118,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25525,8 +25132,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -25551,8 +25157,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel/brown,
 /area/quartermaster/miningdock)
@@ -25564,8 +25169,7 @@
 "bbm" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 6
@@ -25601,8 +25205,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -25610,8 +25213,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -25741,8 +25343,7 @@
 	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
@@ -25754,8 +25355,7 @@
 	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/camera{
 	c_tag = "Mech Bay";
@@ -25768,7 +25368,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -26010,8 +25609,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -26020,8 +25618,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -26041,8 +25638,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26057,8 +25653,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -26336,8 +25931,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26353,8 +25947,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26530,8 +26123,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 9
@@ -26546,7 +26138,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/red/side{
@@ -26556,7 +26147,6 @@
 "bdy" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -26715,7 +26305,6 @@
 	req_access_txt = "29"
 	},
 /obj/item/weapon/paper_bin{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/item/weapon/pen,
@@ -26731,7 +26320,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
@@ -26848,8 +26436,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -26863,8 +26450,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -26979,8 +26565,6 @@
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /obj/item/weapon/pen,
@@ -27073,8 +26657,6 @@
 /obj/item/weapon/pen,
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -27097,8 +26679,7 @@
 /area/medical/medbay/central)
 "beN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -27260,7 +26841,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -27279,7 +26859,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Robotics Lab APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -27351,7 +26930,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
-	pixel_x = 0;
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -27360,7 +26938,6 @@
 	desc = "A guide to the drone shell dispenser, detailing the constructive and destructive applications of modern repair drones, as well as the development of the uncorruptable cyborg servants of tomorrow, available today.";
 	icon_state = "kiddieplaque";
 	name = "\improper 'Perfect Drone' sign";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/engine,
@@ -27384,8 +26961,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/grille/broken,
 /obj/structure/disposalpipe/segment{
@@ -27401,8 +26977,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/grille/broken,
 /obj/structure/disposalpipe/segment{
@@ -27425,8 +27000,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -27437,8 +27011,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
 	dir = 2;
-	network = list("Xeno","RD");
-	pixel_x = 0
+	network = list("Xeno","RD")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -27571,7 +27144,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Port Emergency Storage APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -27759,7 +27331,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27803,8 +27374,7 @@
 	amount = 50
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/purple/side{
 	dir = 4
@@ -28061,8 +27631,7 @@
 "bgT" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 0
+	pixel_x = 1
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
@@ -28144,8 +27713,7 @@
 "bhd" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-18";
-	layer = 3;
-	pixel_y = 0
+	layer = 3
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/research)
@@ -28168,7 +27736,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -28190,8 +27757,7 @@
 /obj/item/device/assembly/flash/handheld,
 /obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = 23;
-	pixel_y = 0
+	pixel_x = 23
 	},
 /turf/open/floor/plasteel/purple/side{
 	dir = 4
@@ -28268,7 +27834,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -28300,8 +27865,6 @@
 /obj/item/clothing/glasses/science,
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -28394,8 +27957,7 @@
 	},
 /obj/machinery/computer/auxillary_base{
 	density = 0;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
@@ -28417,7 +27979,6 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/structure/closet/secure_closet/personal/patient,
@@ -28462,7 +28023,6 @@
 /obj/machinery/vending/clothing,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /turf/open/floor/plasteel/whiteblue/side{
@@ -28549,7 +28109,6 @@
 	departmentType = 1;
 	name = "Medbay RC";
 	pixel_x = -32;
-	pixel_y = 0;
 	pixel_z = 0
 	},
 /obj/item/device/radio/intercom{
@@ -28558,7 +28117,6 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/whiteblue/side{
@@ -28692,16 +28250,14 @@
 /obj/machinery/button/door{
 	id = "testlab";
 	name = "Window Blast Doors";
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/button/door{
 	id = "telelab";
 	name = "Test Chamber Blast Door";
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -28726,7 +28282,6 @@
 /area/science/explab)
 "bip" = (
 /obj/item/weapon/paper_bin{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/weapon/pen,
@@ -28754,7 +28309,6 @@
 	departmentType = 2;
 	dir = 2;
 	name = "Science Requests Console";
-	pixel_x = 0;
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
@@ -28945,8 +28499,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -28966,8 +28519,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -28978,8 +28530,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -28990,8 +28541,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/black,
@@ -29001,8 +28551,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -29112,8 +28661,6 @@
 	id = "MedbayFoyer";
 	name = "Medbay Door Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel/whiteblue/side{
@@ -29269,8 +28816,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -29446,8 +28992,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
@@ -29536,8 +29081,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -29588,8 +29132,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -29657,8 +29200,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Arrivals APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -29805,8 +29347,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Medbay APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -29824,8 +29365,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medbay APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
@@ -29840,8 +29380,7 @@
 /area/medical/medbay/central)
 "bkq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -29937,7 +29476,6 @@
 	departmentType = 2;
 	name = "Science Requests Console";
 	pixel_x = -32;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /obj/item/weapon/book/manual/research_and_development,
@@ -30230,7 +29768,6 @@
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Moniter";
 	network = list("Xeno");
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -30243,7 +29780,6 @@
 /obj/machinery/button/door{
 	id = "misclab";
 	name = "Test Chamber Blast Doors";
-	pixel_x = 0;
 	pixel_y = -2;
 	req_access_txt = "55"
 	},
@@ -30310,8 +29846,7 @@
 "bll" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -30343,7 +29878,6 @@
 /obj/machinery/button/door{
 	id = "xenobio5";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -30381,7 +29915,6 @@
 /obj/machinery/button/door{
 	id = "xenobio6";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -30445,8 +29978,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -30467,8 +29999,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
@@ -30584,8 +30115,7 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -30689,7 +30219,6 @@
 	pixel_x = -26
 	},
 /obj/item/weapon/disk/tech_disk{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/item/weapon/disk/design_disk,
@@ -30709,8 +30238,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Research Lab APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -30837,7 +30365,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -30851,8 +30378,7 @@
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab";
 	dir = 1;
-	network = list("SS13","RD");
-	pixel_y = 0
+	network = list("SS13","RD")
 	},
 /obj/machinery/airalarm{
 	dir = 1;
@@ -30944,8 +30470,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31069,8 +30594,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/transport)
@@ -31486,7 +31010,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/closed/wall,
@@ -31928,7 +31451,6 @@
 	department = "Chemistry";
 	departmentType = 2;
 	pixel_x = 32;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31939,8 +31461,6 @@
 	c_tag = "Aft Primary Hallway Chemistry";
 	dir = 4;
 	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32024,7 +31544,6 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Research Division APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -32109,8 +31628,7 @@
 "boS" = (
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-18";
-	layer = 4.1;
-	pixel_y = 0
+	layer = 4.1
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
@@ -32166,8 +31684,7 @@
 /area/science/xenobiology)
 "boY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -32378,7 +31895,6 @@
 	departmentType = 1;
 	name = "Medbay RC";
 	pixel_x = -32;
-	pixel_y = 0;
 	pixel_z = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -32409,8 +31925,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
@@ -32832,7 +32347,6 @@
 	idDoor = "xeno_airlock_exterior";
 	idSelf = "xeno_airlock_control";
 	name = "Access Button";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "0"
 	},
@@ -32883,7 +32397,6 @@
 	idDoor = "xeno_airlock_interior";
 	idSelf = "xeno_airlock_control";
 	name = "Access Button";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "0"
 	},
@@ -32918,8 +32431,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
@@ -32928,8 +32440,7 @@
 "bqn" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/stripes/line{
@@ -32959,7 +32470,6 @@
 /obj/machinery/button/door{
 	id = "xenobio1";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -33001,7 +32511,6 @@
 /obj/machinery/button/door{
 	id = "xenobio2";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -33039,7 +32548,6 @@
 /obj/machinery/button/door{
 	id = "xenobio3";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -33077,7 +32585,6 @@
 /obj/machinery/button/door{
 	id = "xenobio4";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -33167,8 +32674,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -33228,8 +32734,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Treatment Center APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,
@@ -33293,8 +32798,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Chemistry APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -33340,7 +32844,6 @@
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
 	pixel_x = -2;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -33501,7 +33004,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white,
@@ -33587,7 +33089,6 @@
 	departmentType = 2;
 	name = "Science Requests Console";
 	pixel_x = 32;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -33623,8 +33124,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -33671,8 +33171,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -33719,8 +33218,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -33767,8 +33265,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -33806,8 +33303,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
@@ -33850,9 +33346,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Monkey Pen";
 	dir = 4;
-	network = list("SS13","RD");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13","RD")
 	},
 /mob/living/carbon/monkey,
 /turf/open/floor/grass,
@@ -33898,8 +33392,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -33968,7 +33461,6 @@
 	department = "Chief Medical Officer's Desk";
 	departmentType = 5;
 	name = "Chief Medical Officer RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/cmo,
@@ -34112,8 +33604,7 @@
 /area/science/explab)
 "bss" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel/purple/side,
 /area/science/explab)
@@ -34290,8 +33781,7 @@
 	department = "Genetics";
 	departmentType = 0;
 	name = "Genetics Requests Console";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
@@ -34321,7 +33811,6 @@
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Button";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "39"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -34465,8 +33954,7 @@
 	layer = 4;
 	name = "Surgery Telescreen";
 	network = list("Surgery");
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
@@ -34550,8 +34038,7 @@
 /obj/structure/closet/wardrobe/red,
 /obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = 23;
-	pixel_y = 0
+	pixel_x = 23
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
@@ -34591,7 +34078,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Toxins Storage APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -34646,7 +34132,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
@@ -34676,8 +34161,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Lab";
 	dir = 2;
-	network = list("SS13","RD");
-	pixel_y = 0
+	network = list("SS13","RD")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34727,8 +34211,6 @@
 	},
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -34744,9 +34226,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics";
 	dir = 1;
-	network = list("SS13","RD");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13","RD")
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/medical/genetics)
@@ -34834,7 +34314,6 @@
 	departmentType = 1;
 	name = "Medbay RC";
 	pixel_x = -32;
-	pixel_y = 0;
 	pixel_z = 0
 	},
 /turf/open/floor/plasteel/white,
@@ -35083,7 +34562,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "RD Office APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -35120,7 +34598,6 @@
 	id = "rndshutters";
 	name = "Research Lockdown";
 	pixel_x = 28;
-	pixel_y = 0;
 	req_access_txt = "47"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -35162,8 +34639,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Science Security APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -35195,8 +34671,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
@@ -35273,7 +34748,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -35303,7 +34777,6 @@
 	departmentType = 2;
 	name = "Science Requests Console";
 	pixel_x = 32;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -35407,8 +34880,7 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -35483,8 +34955,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "CMO's Office APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/cmo,
@@ -35506,8 +34977,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Server Room APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -35599,13 +35069,10 @@
 /obj/item/weapon/pen,
 /obj/structure/table,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -35739,7 +35206,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/structure/cable{
@@ -35891,15 +35357,12 @@
 "bvX" = (
 /obj/structure/table,
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/clothing/glasses/hud/health,
@@ -36007,7 +35470,6 @@
 	id = "CMOCell";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 26;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -36175,7 +35637,6 @@
 	dir = 8;
 	freerange = 1;
 	name = "Station Intercom (Telecoms)";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/red/side,
@@ -36239,7 +35700,6 @@
 	pixel_y = -2
 	},
 /obj/item/device/assembly/prox_sensor{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -36279,8 +35739,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36291,8 +35750,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -36301,16 +35759,14 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the turbine vent.";
 	dir = 8;
 	name = "turbine vent monitor";
 	network = list("Turbine");
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36321,8 +35777,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/closed/wall,
 /area/science/mixing)
@@ -36330,8 +35785,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
@@ -36353,8 +35807,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -36366,8 +35819,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -36377,8 +35829,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins Launch Area";
@@ -36397,8 +35848,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -36409,8 +35859,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -36424,8 +35873,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -36459,8 +35907,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -36471,8 +35918,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -36483,8 +35929,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/cigbutt/cigarbutt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36496,8 +35941,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -36511,8 +35955,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -36598,7 +36041,6 @@
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Button";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "39"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36705,7 +36147,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -36721,7 +36162,6 @@
 	department = "Research Director's Desk";
 	departmentType = 5;
 	name = "Research Director RC";
-	pixel_x = 0;
 	pixel_y = -30;
 	receive_ore_updates = 1
 	},
@@ -36766,7 +36206,6 @@
 	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
 	name = "Research Monitor";
 	network = list("RD","MiniSat");
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/whitepurple/side,
@@ -36836,7 +36275,6 @@
 /area/science/mixing)
 "bxM" = (
 /obj/item/device/assembly/signaler{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /obj/item/device/assembly/signaler{
@@ -36890,7 +36328,6 @@
 	pixel_y = -4
 	},
 /obj/item/device/assembly/timer{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/structure/table/reinforced,
@@ -36962,7 +36399,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
-	pixel_x = 0;
 	},
 /turf/open/floor/plasteel,
 /area/science/mineral_storeroom)
@@ -37087,7 +36523,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Virology APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -37190,7 +36625,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/freezer,
@@ -37471,7 +36905,6 @@
 	dir = 8;
 	freerange = 1;
 	name = "Station Intercom (Telecoms)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/whitegreen/side{
@@ -37582,8 +37015,7 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/freezer,
@@ -37800,8 +37232,7 @@
 /area/maintenance/department/engine/atmos)
 "bzD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -37960,8 +37391,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 8
@@ -37995,8 +37425,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	tag = "icon-whitegreen (EAST)";
@@ -38011,7 +37440,6 @@
 	departmentType = 1;
 	name = "Medbay RC";
 	pixel_x = -30;
-	pixel_y = 0;
 	pixel_z = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -38252,7 +37680,6 @@
 	department = "Head of Security's Desk";
 	departmentType = 5;
 	name = "Head of Security RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -38277,14 +37704,11 @@
 	c_tag = "Atmospherics Toxins";
 	dir = 2;
 	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -38368,7 +37792,6 @@
 	layer = 4;
 	name = "Test Chamber Telescreen";
 	network = list("Toxins");
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -38389,8 +37812,7 @@
 	id = "toxinsdriver"
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/door/window/southleft{
 	dir = 8;
@@ -38568,8 +37990,7 @@
 /area/medical/medbay/central)
 "bBk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
@@ -38609,8 +38030,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Surgery APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -38802,8 +38222,7 @@
 	layer = 2.9
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -38816,8 +38235,7 @@
 /area/science/mineral_storeroom)
 "bBO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/closed/wall,
 /area/science/mineral_storeroom)
@@ -39025,8 +38443,7 @@
 /area/medical/surgery)
 "bCp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -39285,7 +38702,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/engine/vacuum,
@@ -39325,8 +38741,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plating,
 /area/science/mineral_storeroom)
@@ -39395,8 +38810,7 @@
 /obj/item/weapon/storage/box/syringes,
 /obj/structure/reagent_dispensers/virusfood{
 	density = 0;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/whitegreen/side{
@@ -39483,8 +38897,6 @@
 	c_tag = "Aft Primary Hallway Atmospherics";
 	dir = 2;
 	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39494,7 +38906,6 @@
 	dir = 8;
 	freerange = 1;
 	name = "Station Intercom (Telecoms)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
@@ -39764,8 +39175,6 @@
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /obj/item/weapon/pen/red,
@@ -40255,7 +39664,6 @@
 /area/engine/atmos)
 "bFe" = (
 /obj/structure/sign/fire{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/closed/wall/r_wall,
@@ -40488,8 +39896,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40965,7 +40372,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -40989,8 +40395,7 @@
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -41096,8 +40501,7 @@
 	department = "Atmospherics";
 	departmentType = 4;
 	name = "Atmos RC";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -41628,8 +41032,7 @@
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -41671,8 +41074,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel/black,
 /area/storage/tech)
@@ -41693,8 +41095,6 @@
 	c_tag = "Aft Primary Hallway Engineering";
 	dir = 1;
 	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41740,8 +41140,7 @@
 	on = 0
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41857,8 +41256,7 @@
 /area/engine/gravity_generator)
 "bIH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -41974,7 +41372,6 @@
 /obj/item/clothing/glasses/meson,
 /obj/machinery/requests_console{
 	department = "Tech storage";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/black,
@@ -42002,7 +41399,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Tech Storage APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -42212,8 +41608,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 9
@@ -42240,7 +41635,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -42273,7 +41667,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -42460,8 +41853,7 @@
 	department = "Chief Engineer's Desk";
 	departmentType = 3;
 	name = "Chief Engineer RC";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 9
@@ -42594,13 +41986,10 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -42901,7 +42290,6 @@
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "11"
 	},
 /obj/machinery/button/door{
@@ -42995,8 +42383,7 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
@@ -43190,8 +42577,7 @@
 	req_access_txt = "0"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/item/clothing/glasses/meson/gar,
 /turf/open/floor/plasteel/yellow/side{
@@ -43229,8 +42615,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "CE Office APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -43333,8 +42718,7 @@
 	dir = 4;
 	name = "Engine Monitor";
 	network = list("Engine");
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
@@ -43414,8 +42798,7 @@
 	dir = 4;
 	name = "Engine Monitor";
 	network = list("Engine");
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 10
@@ -43430,8 +42813,7 @@
 /area/security/checkpoint/engineering)
 "bLC" = (
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/closet/wardrobe/red,
 /turf/open/floor/plasteel/red/side{
@@ -43528,8 +42910,6 @@
 	c_tag = "Telecoms External Fore";
 	dir = 1;
 	network = list("SS13, Telecoms");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /turf/open/space,
@@ -43646,8 +43026,7 @@
 	cell_type = 10000;
 	dir = 8;
 	name = "Engine Room APC";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/structure/cable,
 /obj/item/stack/sheet/metal{
@@ -44324,7 +43703,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
@@ -44361,8 +43739,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44396,8 +43773,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -44829,8 +44205,6 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/weapon/paper_bin{
 	layer = 2.9;
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /turf/open/floor/plasteel,
@@ -44887,9 +44261,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -45030,8 +44402,7 @@
 "bOV" = (
 /obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45076,8 +44447,7 @@
 "bPa" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45372,7 +44742,6 @@
 	id = "Singularity";
 	name = "Shutters Control";
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "11"
 	},
 /turf/open/floor/plasteel/yellow/side,
@@ -45382,7 +44751,6 @@
 	id = "Singularity";
 	name = "Shutters Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "11"
 	},
 /obj/structure/cable/yellow{
@@ -45413,7 +44781,6 @@
 	id = "Singularity";
 	name = "Shutters Control";
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "11"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -45431,7 +44798,6 @@
 	id = "Singularity";
 	name = "Shutters Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "11"
 	},
 /turf/open/floor/plasteel/yellow/side,
@@ -45630,8 +44996,7 @@
 /area/engine/engineering)
 "bQn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45785,8 +45150,7 @@
 	layer = 4;
 	name = "Telecoms Telescreen";
 	network = list("Telecoms");
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45820,8 +45184,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -46008,8 +45371,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -46050,8 +45412,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -46437,8 +45798,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -46452,8 +45812,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -46709,8 +46068,7 @@
 /area/tcommsat/computer)
 "bSO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
@@ -46746,7 +46104,6 @@
 	department = "Telecoms Admin";
 	departmentType = 5;
 	name = "Telecoms RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -46797,8 +46154,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -46993,8 +46349,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
@@ -47033,7 +46388,6 @@
 	dir = 1;
 	layer = 4;
 	name = "Telecoms Server APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable,
@@ -47391,7 +46745,6 @@
 	frequency = 1447;
 	listening = 0;
 	name = "Station Intercom (AI Private)";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/circuit,
@@ -47490,8 +46843,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -47510,15 +46862,13 @@
 /obj/machinery/button/door{
 	id = "supplybridge";
 	name = "Space Bridge Control";
-	pixel_x = 0;
 	pixel_y = 27;
 	req_access_txt = "0"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -47542,7 +46892,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	pixel_y = 0;
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -47582,8 +46931,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -47649,7 +46997,6 @@
 /area/bridge)
 "bUP" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
@@ -47668,8 +47015,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
 	broken = 1;
@@ -47680,8 +47026,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -47712,8 +47057,7 @@
 "bUW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/red/corner{
 	tag = "icon-redcorner (WEST)";
@@ -47757,7 +47101,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
@@ -47795,8 +47138,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -47919,7 +47261,6 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -47944,8 +47285,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47962,8 +47302,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47984,8 +47323,7 @@
 /area/maintenance/department/cargo)
 "bVz" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -48027,8 +47365,7 @@
 /area/shuttle/escape)
 "bVE" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/storage)
@@ -48038,7 +47375,6 @@
 	dir = 1;
 	icon_state = "direction_evac";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-direction_evac (NORTH)"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -48168,7 +47504,6 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/vault{
@@ -48203,8 +47538,7 @@
 /area/hydroponics)
 "bWd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/black,
@@ -48222,7 +47556,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/carpet{
@@ -48256,7 +47589,6 @@
 	id = "jangarage";
 	name = "Custodial Closet Shutters Control";
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "26"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -48413,8 +47745,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48566,7 +47897,6 @@
 "bWX" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /obj/structure/chair,
@@ -48618,8 +47948,7 @@
 	name = "JoinLate"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
@@ -48666,8 +47995,7 @@
 "bXk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
@@ -48675,8 +48003,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/lounge)
@@ -48737,7 +48064,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Lounge APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -48947,8 +48273,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -49252,9 +48577,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -49408,8 +48731,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/dock)
@@ -49593,8 +48915,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/asteroid{
 	icon_plating = "asteroid"
@@ -49901,9 +49222,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/open/floor/plating,
 /area/chapel/asteroid{
@@ -49923,8 +49242,7 @@
 	department = "Engineering";
 	departmentType = 4;
 	name = "Engineering RC";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -50017,7 +49335,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
@@ -50094,8 +49411,7 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
@@ -50255,14 +49571,12 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/machinery/requests_console{
 	department = "Chapel";
 	departmentType = 2;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/carpet,
 /area/chapel/office)
@@ -50401,7 +49715,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/structure/cable{
@@ -50426,7 +49739,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel/black,
@@ -50436,7 +49748,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel/chapel{
@@ -50454,7 +49765,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/open/floor/plasteel/chapel,
@@ -50572,8 +49882,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -50584,8 +49893,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
@@ -50695,8 +50003,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Chapel Office APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -50714,8 +50021,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
@@ -50744,8 +50050,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
@@ -50950,8 +50255,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -51017,8 +50321,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
@@ -51137,8 +50440,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -51273,8 +50575,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Garden APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -51305,7 +50606,6 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -51317,7 +50617,6 @@
 	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
 	icon_state = "monkey_painting";
 	name = "Mr. Deempisi portrait";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/grimy,
@@ -51394,8 +50693,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
@@ -51409,8 +50707,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault{
@@ -51421,8 +50718,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
 	name = "Garden"
@@ -51547,7 +50843,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/hydrofloor,
@@ -51573,8 +50868,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51696,8 +50990,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
@@ -51768,7 +51061,6 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -51891,8 +51183,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -51956,8 +51247,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -51974,8 +51264,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -51987,8 +51276,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52000,8 +51288,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52013,8 +51300,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52025,8 +51311,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -52312,7 +51597,6 @@
 	id = "smindicate";
 	name = "external door control";
 	pixel_x = -26;
-	pixel_y = 0;
 	req_access_txt = "150"
 	},
 /obj/docking_port/mobile{
@@ -52348,8 +51632,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
@@ -52443,8 +51726,7 @@
 /area/shuttle/syndicate)
 "cgv" = (
 /obj/item/weapon/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/item/weapon/reagent_containers/glass/bottle/charcoal{
 	pixel_x = -3
@@ -52708,8 +51990,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 30
@@ -52977,8 +52258,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/escape{
 	dir = 8
@@ -53062,7 +52342,6 @@
 	c_tag = "Departures - Port";
 	dir = 4;
 	name = "security camera";
-	pixel_x = 0;
 	pixel_y = -7
 	},
 /turf/open/floor/plasteel/escape{
@@ -53156,7 +52435,6 @@
 /obj/item/weapon/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
 	layer = 4.1;
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/escape{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -776,7 +776,7 @@
 	req_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -1224,7 +1224,7 @@
 /area/security/prison)
 "acQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1453,7 +1453,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -1667,7 +1667,7 @@
 "adN" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/security/prison)
@@ -2073,7 +2073,7 @@
 /area/security/prison)
 "aeP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -2815,7 +2815,7 @@
 /area/security/prison)
 "agh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -3887,7 +3887,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4320,7 +4320,7 @@
 /area/security/brig)
 "ajl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -5346,7 +5346,7 @@
 /area/security/warden)
 "alq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -5424,7 +5424,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 6
@@ -6486,7 +6486,7 @@
 /area/security/brig)
 "anG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
@@ -6531,7 +6531,7 @@
 /area/security/brig)
 "anK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6543,7 +6543,7 @@
 /area/security/brig)
 "anM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -6562,7 +6562,7 @@
 	c_tag = "Brig Entrance"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -7265,13 +7265,13 @@
 /area/security/brig)
 "app" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "apq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side,
@@ -7285,7 +7285,7 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/door_timer{
 	id = "Cell 1";
@@ -7302,7 +7302,7 @@
 /area/security/brig)
 "apt" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/door_timer{
 	id = "Cell 2";
@@ -7318,7 +7318,7 @@
 "apv" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/door_timer{
 	id = "Cell 3";
@@ -7329,7 +7329,7 @@
 /area/security/brig)
 "apw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
@@ -7341,13 +7341,13 @@
 "apy" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "apz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 6
@@ -7355,14 +7355,14 @@
 /area/security/brig)
 "apA" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall,
 /area/security/brig)
 "apB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
@@ -7371,7 +7371,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
@@ -7382,7 +7382,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
@@ -7391,7 +7391,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
@@ -7552,7 +7552,7 @@
 /area/crew_quarters/dorms)
 "apV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
@@ -9323,7 +9323,7 @@
 /area/ai_monitored/nuke_storage)
 "atF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -9763,7 +9763,6 @@
 /obj/structure/table/wood,
 /obj/item/weapon/storage/pill_bottle/dice,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (EAST)";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -10175,7 +10174,7 @@
 	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/bridge)
@@ -10697,7 +10696,7 @@
 "awF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -10856,7 +10855,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "axb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/black,
 /area/bridge)
@@ -11349,7 +11348,6 @@
 /area/crew_quarters/dorms)
 "ayl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (EAST)";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11553,7 +11551,7 @@
 /area/security/detectives_office)
 "ayI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
 	tag = "icon-redcorner (WEST)";
@@ -11823,7 +11821,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (EAST)";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
@@ -12040,7 +12037,7 @@
 /area/crew_quarters/dorms)
 "azC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/side,
 /area/crew_quarters/dorms)
@@ -12213,7 +12210,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
@@ -12268,7 +12264,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
@@ -13535,7 +13531,7 @@
 /area/storage/emergency/starboard)
 "aCL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -13940,13 +13936,13 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aDG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14005,6 +14001,7 @@
 "aDM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
+	
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14018,7 +14015,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14059,7 +14056,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/blue/corner{
 	dir = 1
@@ -14119,7 +14116,7 @@
 /area/hallway/primary/central)
 "aDY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/blue/corner{
 	dir = 1
@@ -14356,7 +14353,6 @@
 /area/hallway/primary/central)
 "aED" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (EAST)";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14504,7 +14500,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14547,7 +14543,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Robo";
@@ -14787,7 +14783,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -14918,7 +14914,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16257,7 +16252,7 @@
 "aIB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -17780,7 +17775,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -18477,7 +18472,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -18962,7 +18957,7 @@
 /area/quartermaster/office)
 "aOl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -18996,7 +18991,7 @@
 /area/quartermaster/storage)
 "aOp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -19672,7 +19667,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -21345,7 +21340,7 @@
 /area/quartermaster/storage)
 "aTi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -21960,7 +21955,7 @@
 /area/hallway/primary/central)
 "aUv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -22085,7 +22080,7 @@
 /area/crew_quarters/bar)
 "aUO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/effect/landmark/xmastree,
 /turf/open/floor/carpet{
@@ -23602,7 +23597,7 @@
 /area/hallway/secondary/entry)
 "aYf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -23740,7 +23735,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -24027,7 +24022,7 @@
 	network = list("SS13")
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -25023,7 +25018,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25482,6 +25476,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
+	
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -26403,7 +26398,7 @@
 /area/science/xenobiology)
 "bef" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -26672,7 +26667,6 @@
 "beM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -26929,7 +26923,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -28005,7 +27999,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (NORTH)";
@@ -28602,7 +28596,6 @@
 /area/medical/morgue)
 "bja" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -28881,7 +28874,7 @@
 /area/science/explab)
 "bjB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
@@ -29373,7 +29366,6 @@
 /area/medical/medbay/central)
 "bkp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -29539,7 +29531,7 @@
 	name = "emergency shower"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -30031,7 +30023,7 @@
 "blB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -30564,7 +30556,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
@@ -30662,7 +30654,7 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -30681,7 +30673,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -31246,7 +31238,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/floorgrime,
@@ -31417,7 +31409,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
@@ -31607,7 +31599,6 @@
 /area/science/research)
 "boP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white/side,
@@ -31732,7 +31723,7 @@
 	network = list("SS13","RD")
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
@@ -31898,7 +31889,7 @@
 	pixel_z = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
@@ -31967,7 +31958,7 @@
 /area/medical/sleeper)
 "bpC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -32000,7 +31991,7 @@
 /area/medical/medbay/central)
 "bpH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -32359,7 +32350,7 @@
 /area/science/xenobiology)
 "bqg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32699,7 +32690,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -32867,7 +32858,7 @@
 /area/hallway/primary/aft)
 "bra" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -32938,7 +32929,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -33896,7 +33887,7 @@
 /area/medical/medbay/central)
 "bsW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
@@ -34915,7 +34906,7 @@
 /area/medical/medbay/central)
 "buZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
@@ -35318,7 +35309,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -35534,7 +35525,7 @@
 /area/hallway/primary/aft)
 "bwl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
@@ -35980,26 +35971,26 @@
 /area/maintenance/department/engine)
 "bxd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bxe" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "bxf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "bxg" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/freezer,
@@ -36397,7 +36388,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/science/mineral_storeroom)
@@ -36604,7 +36595,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
@@ -36885,7 +36876,7 @@
 /area/medical/virology)
 "byX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 1
@@ -36912,7 +36903,7 @@
 /area/medical/virology)
 "byZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
 	dir = 1
@@ -37474,7 +37465,6 @@
 /area/medical/surgery)
 "bAg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
@@ -37492,7 +37482,6 @@
 /area/medical/surgery)
 "bAi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/side{
@@ -37520,7 +37509,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
@@ -37617,7 +37606,7 @@
 /area/maintenance/department/engine/atmos)
 "bAw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating,
@@ -39614,7 +39603,7 @@
 /area/engine/atmos)
 "bEX" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40347,7 +40336,7 @@
 "bGI" = (
 /obj/structure/closet/radiation,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	dir = 2;
@@ -40433,13 +40422,13 @@
 /area/hallway/primary/aft)
 "bGR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bGS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
@@ -40537,7 +40526,7 @@
 /area/engine/atmos)
 "bHa" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -40637,7 +40626,7 @@
 /area/storage/tech)
 "bHn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel/black,
 /area/storage/tech)
@@ -40745,7 +40734,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 8
@@ -40842,7 +40831,7 @@
 /area/engine/atmos)
 "bHG" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/item/weapon/wrench,
 /turf/open/floor/plasteel,
@@ -41051,7 +41040,6 @@
 /area/storage/tech)
 "bIg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold-b-f (NORTH)";
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
@@ -42102,7 +42090,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel{
@@ -42472,7 +42460,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -42916,6 +42904,7 @@
 "bLO" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
+	
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
@@ -43364,7 +43353,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -43794,7 +43783,7 @@
 /area/engine/engineering)
 "bNC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -43811,7 +43800,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -43824,7 +43813,7 @@
 /area/engine/engineering)
 "bNG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45996,7 +45985,7 @@
 /area/tcommsat/computer)
 "bSE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /obj/item/device/radio/beacon,
 /turf/open/floor/plasteel,
@@ -47218,7 +47207,7 @@
 /area/hallway/primary/central)
 "bVp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -47396,7 +47385,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "bVI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown/corner{
 	dir = 1;
@@ -48014,7 +48003,7 @@
 /area/hallway/primary/central)
 "bXn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
+	dir = 1
 	},
 /turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/central)
@@ -48238,7 +48227,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -48410,7 +48399,7 @@
 	req_access_txt = "12;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -48767,7 +48756,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -48865,7 +48854,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -49356,7 +49345,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5;
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -49365,6 +49354,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
+	
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -49895,7 +49885,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
@@ -50223,7 +50213,7 @@
 /area/chapel/main/monastery)
 "ccU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
@@ -50695,7 +50685,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -51136,6 +51126,7 @@
 "cfi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
+	
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -67114,7 +67105,7 @@ cax
 cfd
 cfp
 cbh
-aIp
+aKR
 aXJ
 bgH
 bqb
@@ -69681,7 +69672,7 @@ cdP
 cdP
 ceQ
 cdk
-cfi
+cfj
 cfv
 aBW
 aTP
@@ -69939,7 +69930,7 @@ cdP
 ceR
 cdl
 cdb
-cfw
+cft
 aAK
 aTQ
 bby
@@ -70196,7 +70187,7 @@ cdP
 cdC
 cdl
 cdb
-cfw
+cft
 aDy
 aDy
 aDy
@@ -70611,7 +70602,7 @@ amn
 agu
 anA
 ahy
-apk
+alM
 aqg
 aqX
 agv
@@ -74470,7 +74461,7 @@ apr
 aqn
 ahH
 ahH
-atg
+aqq
 bUP
 avd
 awC
@@ -74995,7 +74986,7 @@ aAE
 aBB
 aBC
 axB
-aDD
+ayz
 agu
 aaa
 aaa
@@ -75252,7 +75243,7 @@ aAF
 aBC
 aCm
 axB
-aDD
+ayz
 agu
 aaa
 aaa
@@ -75498,7 +75489,7 @@ apt
 aqq
 ahH
 ahH
-atg
+aqq
 atY
 avf
 awF
@@ -75509,7 +75500,7 @@ aAG
 aBD
 aCn
 axB
-aDD
+ayz
 agv
 aaa
 aaa
@@ -75766,7 +75757,7 @@ aAH
 aBC
 aBC
 axB
-aDE
+aDC
 agv
 agv
 agv
@@ -76526,7 +76517,7 @@ apv
 aqq
 ahH
 ahH
-atg
+aqq
 atX
 avg
 awG
@@ -77077,7 +77068,7 @@ aZj
 aAt
 baN
 bbB
-bbW
+aEa
 bcA
 bdo
 bew
@@ -77105,7 +77096,7 @@ bvP
 bvP
 bvP
 bvP
-bFl
+bFo
 bFP
 boc
 boc
@@ -80416,7 +80407,7 @@ aXy
 aYr
 aXy
 aMY
-baU
+baX
 bbD
 bXn
 bcF
@@ -83500,7 +83491,7 @@ aXE
 bWH
 aKZ
 bWS
-baU
+baX
 axi
 aDI
 bcL
@@ -84016,7 +84007,7 @@ aZs
 bam
 aFw
 aAs
-aDM
+bce
 bcN
 bXB
 beO
@@ -84787,7 +84778,7 @@ aWL
 bal
 baV
 bbE
-bcc
+aDN
 bXy
 bcJ
 beR
@@ -85299,7 +85290,7 @@ aQV
 aUK
 aUL
 bWA
-baU
+baX
 axi
 aDI
 axi
@@ -85815,7 +85806,7 @@ aUL
 bWA
 aFw
 aAs
-aDM
+bce
 aye
 bdK
 bXG
@@ -88378,7 +88369,7 @@ bVG
 aTS
 aUS
 bVG
-bWt
+bVI
 bVG
 axi
 aDd
@@ -89707,7 +89698,7 @@ bJf
 bEY
 bBz
 bKu
-bLO
+bLM
 bMp
 bJI
 bNw
@@ -90480,7 +90471,7 @@ bBB
 bJB
 bEY
 bMr
-caT
+bLR
 aad
 bCQ
 bOo
@@ -92986,7 +92977,7 @@ aBU
 aBv
 aBv
 aBv
-aFe
+aBX
 aFV
 aAw
 aIf
@@ -95085,7 +95076,7 @@ bsD
 btB
 buG
 bvG
-bwK
+bvB
 bxR
 byJ
 bzG
@@ -95327,7 +95318,7 @@ amZ
 aAC
 aUe
 aPB
-bfx
+aUg
 bed
 bht
 biz
@@ -97635,7 +97626,7 @@ aUf
 aYU
 aCg
 aPA
-bbq
+aWV
 aAC
 aGY
 bdf
@@ -97892,7 +97883,7 @@ aUg
 aCg
 aZN
 aCg
-bbq
+aWV
 aAC
 bcq
 bdg
@@ -98149,7 +98140,7 @@ aCg
 aYV
 aZO
 baC
-bbq
+aWV
 aAC
 bcr
 bdh
@@ -98663,7 +98654,7 @@ aXZ
 aVi
 bWN
 aCg
-bbq
+aWV
 aAC
 aAC
 bdi

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2421,8 +2421,6 @@
 /area/security/prison)
 "afv" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/closed/wall,
@@ -2768,8 +2766,6 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -2836,8 +2832,6 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3067,8 +3061,6 @@
 /area/security/prison)
 "agG" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
@@ -3962,8 +3954,6 @@
 /area/security/brig)
 "ais" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
@@ -4289,8 +4279,6 @@
 /area/maintenance/department/security/brig)
 "aiY" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/item/weapon/wrench,
@@ -4341,8 +4329,6 @@
 	network = list("SS13")
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -4387,8 +4373,6 @@
 /area/security/brig)
 "ajh" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -4410,8 +4394,6 @@
 /area/security/brig)
 "ajj" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -4624,8 +4606,6 @@
 /area/maintenance/department/security/brig)
 "ajN" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/machinery/meter,
@@ -4852,8 +4832,6 @@
 	network = list("SS13")
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -4884,8 +4862,6 @@
 "akh" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5810,8 +5786,6 @@
 /area/security/warden)
 "alY" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -7438,8 +7412,6 @@
 /area/shuttle/labor)
 "apo" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
@@ -7480,8 +7452,6 @@
 /area/security/brig)
 "aps" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side,
@@ -23983,8 +23953,6 @@
 /area/maintenance/solars/starboard)
 "aYc" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26170,8 +26138,6 @@
 /area/shuttle/arrival)
 "bcu" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -27939,8 +27905,6 @@
 "bgC" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating{
@@ -27975,8 +27939,6 @@
 /area/hallway/secondary/entry)
 "bgG" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -28887,8 +28849,6 @@
 /area/maintenance/department/chapel/monastery)
 "biE" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/machinery/meter,
@@ -28896,8 +28856,6 @@
 /area/maintenance/department/chapel/monastery)
 "biF" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -38551,8 +38509,6 @@
 /area/medical/virology)
 "bBd" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/machinery/computer/pandemic,
@@ -39211,8 +39167,6 @@
 /area/engine/atmos)
 "bCG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -40382,8 +40336,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -41216,8 +41168,6 @@
 /area/maintenance/department/engine)
 "bHf" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/meter,
@@ -49112,8 +49062,6 @@
 /area/space)
 "bYr" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1699,8 +1699,6 @@
 /obj/item/weapon/pen,
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/black,
@@ -1708,8 +1706,6 @@
 "adN" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -2423,8 +2419,6 @@
 /area/security/prison)
 "afu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall,
@@ -2675,8 +2669,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -2760,8 +2752,6 @@
 	pixel_x = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/structure/cable{
@@ -2803,8 +2793,6 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
@@ -2826,8 +2814,6 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
@@ -2840,8 +2826,6 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
@@ -3027,7 +3011,6 @@
 /area/security/transfer)
 "agy" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
@@ -3040,7 +3023,6 @@
 	pressure_checks = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -3068,8 +3050,6 @@
 /area/security/prison)
 "agD" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/red/side{
@@ -3084,8 +3064,6 @@
 /area/security/prison)
 "agF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
@@ -3109,8 +3087,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/red/side{
@@ -4005,16 +3981,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4026,16 +3998,12 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/red,
 /area/security/brig)
 "aiw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -4386,8 +4354,6 @@
 /area/security/processing/cremation)
 "aje" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -4404,8 +4370,6 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/item/weapon/reagent_containers/syringe{
@@ -4419,8 +4383,6 @@
 /area/security/brig)
 "ajg" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitered/corner{
@@ -4445,8 +4407,6 @@
 	req_access_txt = "0"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitered/side{
@@ -4664,8 +4624,6 @@
 /area/space)
 "ajM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -4681,8 +4639,6 @@
 /area/maintenance/department/security/brig)
 "ajO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -4917,8 +4873,6 @@
 /area/security/main)
 "akf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -4929,8 +4883,6 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -4954,8 +4906,6 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -4970,8 +4920,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4990,8 +4938,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
@@ -5011,8 +4957,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
@@ -5039,8 +4983,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/black,
@@ -5140,7 +5082,6 @@
 	location = "Security"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
@@ -5404,8 +5345,6 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -5418,16 +5357,12 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "alf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5443,8 +5378,6 @@
 /area/maintenance/department/security/brig)
 "alg" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall,
@@ -5567,8 +5500,6 @@
 /area/security/warden)
 "als" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -5581,8 +5512,6 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -5596,8 +5525,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -5611,8 +5538,6 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/red/side{
@@ -6458,8 +6383,6 @@
 /area/security/brig)
 "ane" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -7537,16 +7460,12 @@
 /area/security/brig)
 "app" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "apq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7562,8 +7481,6 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/door_timer{
@@ -7583,8 +7500,6 @@
 /area/security/brig)
 "apt" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/door_timer{
@@ -7601,8 +7516,6 @@
 "apv" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/door_timer{
@@ -7614,8 +7527,6 @@
 /area/security/brig)
 "apw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side,
@@ -7628,16 +7539,12 @@
 "apy" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "apz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
@@ -7646,8 +7553,6 @@
 /area/security/brig)
 "apA" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall,
@@ -7655,8 +7560,6 @@
 "apB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -7666,8 +7569,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -7679,8 +7580,6 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -7690,16 +7589,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
 "apF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/black,
@@ -8912,8 +8807,6 @@
 /area/security/brig)
 "asg" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/black,
@@ -22329,8 +22222,6 @@
 /area/hallway/secondary/entry)
 "aUj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/arrival{
@@ -22343,8 +22234,6 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/arrival{
@@ -22353,8 +22242,6 @@
 /area/hallway/secondary/entry)
 "aUl" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
@@ -22369,8 +22256,6 @@
 /area/hallway/secondary/entry)
 "aUm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel/arrival{
@@ -23826,8 +23711,6 @@
 /area/hallway/secondary/entry)
 "aXr" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23835,8 +23718,6 @@
 /area/hallway/secondary/entry)
 "aXs" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -25543,8 +25424,6 @@
 /area/hallway/primary/central)
 "baW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -26350,8 +26229,6 @@
 	name = "privacy shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -26367,16 +26244,12 @@
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/lounge)
 "bcx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -27015,24 +26888,18 @@
 /area/science/xenobiology)
 "bee" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "bef" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "beg" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -28148,8 +28015,6 @@
 "bgF" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29065,8 +28930,6 @@
 /area/maintenance/department/cargo)
 "biD" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -31356,8 +31219,6 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -31372,8 +31233,6 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -31393,8 +31252,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -31412,8 +31269,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -31490,7 +31345,6 @@
 /area/medical/sleeper)
 "bne" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -36105,8 +35959,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -36114,8 +35966,6 @@
 "bvS" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -36790,32 +36640,24 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bxd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bxe" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "bxf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /mob/living/carbon/monkey,
@@ -36823,8 +36665,6 @@
 /area/medical/virology)
 "bxg" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/effect/landmark/xeno_spawn,
@@ -39358,7 +39198,6 @@
 /area/hallway/primary/aft)
 "bCx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -40582,8 +40421,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -40598,8 +40435,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -40642,8 +40477,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -40672,8 +40505,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating{
@@ -40687,8 +40518,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -41463,8 +41292,6 @@
 /area/engine/atmos)
 "bHe" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/item/weapon/wrench,
@@ -42350,8 +42177,6 @@
 "bIY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -43813,8 +43638,6 @@
 "bLJ" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -47887,8 +47710,6 @@
 /area/security/processing/cremation)
 "bUE" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall,
@@ -48516,8 +48337,6 @@
 /area/hallway/primary/central)
 "bWb" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -48758,8 +48577,6 @@
 "bWD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -49247,8 +49064,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -49424,8 +49239,6 @@
 	req_access_txt = "12;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -49437,7 +49250,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -49886,8 +49698,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -50296,8 +50106,6 @@
 /area/engine/atmos)
 "caG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
@@ -50402,16 +50210,12 @@
 /area/engine/atmos)
 "caU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "caV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall/r_wall,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2144,7 +2144,6 @@
 /area/security/prison)
 "aeU" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -12918,7 +12917,6 @@
 /area/crew_quarters/dorms)
 "aBs" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -15581,7 +15579,6 @@
 /area/crew_quarters/cafeteria/lunchroom)
 "aHt" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -23235,7 +23232,6 @@
 /obj/item/weapon/mop,
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -23571,7 +23567,6 @@
 /area/janitor)
 "aYm" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -28634,7 +28629,6 @@
 "bjo" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32310,7 +32304,6 @@
 "bqm" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -32910,7 +32903,6 @@
 "brr" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -33270,7 +33262,6 @@
 "brW" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -34181,7 +34172,6 @@
 /area/medical/virology)
 "btP" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -35170,7 +35160,6 @@
 /area/medical/virology)
 "bvQ" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -37295,7 +37284,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/whitegreen/side{
@@ -46975,7 +46963,6 @@
 /area/hallway/primary/central)
 "bVi" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -47592,7 +47579,6 @@
 /area/hallway/secondary/entry)
 "bWE" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -47941,7 +47927,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /turf/open/floor/plasteel/white,
@@ -51806,7 +51791,6 @@
 "cgT" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -36385,8 +36385,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#330000";
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -120,8 +120,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/landmark/tripai,
 /obj/item/device/radio/intercom{
@@ -212,8 +211,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/circuit,
 /area/wreck/ai)
@@ -402,8 +400,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -1043,8 +1040,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/prison)
@@ -1070,8 +1066,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1097,8 +1092,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2532,8 +2526,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2709,8 +2702,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -2807,8 +2799,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
@@ -3066,8 +3057,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/armory)
@@ -3161,14 +3151,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/transfer)
@@ -3448,8 +3436,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/processing/cremation)
@@ -3794,14 +3781,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/processing/cremation)
@@ -3984,8 +3969,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -4020,8 +4004,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -4227,8 +4210,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/processing/cremation)
@@ -4361,8 +4343,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/red/side{
@@ -4533,8 +4514,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/processing/cremation)
@@ -4705,8 +4685,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/vault,
@@ -4723,8 +4702,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -4844,8 +4822,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4930,8 +4907,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -5013,8 +4989,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5092,8 +5067,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
 /area/security/warden)
@@ -5120,8 +5094,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
@@ -5139,8 +5112,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -5194,8 +5166,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -5261,8 +5232,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -5285,8 +5255,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5390,8 +5359,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
@@ -5419,8 +5387,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -5474,8 +5441,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/darkred/side{
 	tag = "icon-darkred (NORTH)";
@@ -5587,8 +5553,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -5685,14 +5650,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -5705,8 +5668,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -5765,8 +5727,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -6017,8 +5978,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -6101,8 +6061,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -6222,14 +6181,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
 /area/security/warden)
@@ -6333,8 +6290,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/securearea{
@@ -6495,8 +6451,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6618,8 +6573,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -6749,8 +6703,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/space,
 /area/solar/starboard)
@@ -6769,8 +6722,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/space,
 /area/solar/port)
@@ -6864,8 +6816,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -7195,8 +7146,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -7279,8 +7229,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -7407,8 +7356,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/closed/wall/r_wall,
 /area/bridge)
@@ -7630,8 +7578,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green,
 /area/maintenance/department/security/brig)
@@ -7692,8 +7639,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -7830,8 +7776,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/command{
@@ -8154,8 +8099,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
@@ -8985,8 +8929,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -8994,8 +8937,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -9194,8 +9136,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/command{
@@ -9503,8 +9444,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkblue/side{
@@ -10023,8 +9963,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -10534,8 +10473,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -10548,8 +10486,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Port Solar Access";
@@ -11017,8 +10954,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
 	broken = 1;
@@ -11419,8 +11355,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/space,
 /area/solar/starboard)
@@ -11438,8 +11373,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/space,
 /area/solar/port)
@@ -12059,8 +11993,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12296,8 +12229,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -12464,8 +12396,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -13068,8 +12999,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -13633,8 +13563,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -13647,8 +13576,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13874,8 +13802,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -13930,8 +13857,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -14360,8 +14286,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -15671,8 +15596,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer,
@@ -16301,8 +16225,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -17053,8 +16976,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -17947,8 +17869,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -17978,8 +17899,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18381,8 +18301,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light/small{
@@ -18765,8 +18684,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -19344,8 +19262,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -20566,8 +20483,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/closed/wall,
 /area/maintenance/department/chapel/monastery)
@@ -22437,8 +22353,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/janitor)
@@ -22557,8 +22472,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
@@ -23100,8 +23014,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -24684,8 +24597,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -24701,8 +24613,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
@@ -24713,8 +24624,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -25008,8 +24918,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -25046,8 +24955,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -25359,8 +25267,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -25448,8 +25355,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/lounge)
@@ -26312,8 +26218,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -26832,14 +26737,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -27322,8 +27225,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -27727,8 +27629,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30634,8 +30535,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
@@ -31054,8 +30954,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -31113,8 +31012,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -31135,8 +31033,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -31173,8 +31070,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -31931,8 +31827,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
@@ -32023,8 +31918,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -32089,8 +31983,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
@@ -32154,8 +32047,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -33275,8 +33167,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -34614,8 +34505,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -34734,8 +34624,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -35094,8 +34983,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
@@ -35192,8 +35080,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -35496,8 +35383,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -36341,8 +36227,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -39206,8 +39091,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39247,8 +39131,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -40700,8 +40583,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -40745,8 +40627,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -40776,8 +40657,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -41986,8 +41866,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/landmark/start/depsec/engineering,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -42287,8 +42166,7 @@
 /obj/item/weapon/paper/monitorkey,
 /obj/item/weapon/pen,
 /turf/open/floor/plasteel/yellow/side{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /area/crew_quarters/heads/chief)
 "bKK" = (
@@ -42369,8 +42247,7 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/yellow/side{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /area/engine/engine_smes)
 "bKS" = (
@@ -42564,8 +42441,7 @@
 	},
 /obj/item/clothing/glasses/meson/gar,
 /turf/open/floor/plasteel/yellow/side{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /area/crew_quarters/heads/chief)
 "bLo" = (
@@ -42685,8 +42561,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -42704,8 +42579,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/yellow/side{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /area/engine/engine_smes)
 "bLw" = (
@@ -42717,8 +42591,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
@@ -42742,8 +42615,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42755,8 +42627,7 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -43019,8 +42890,7 @@
 	},
 /obj/item/stack/cable_coil,
 /turf/open/floor/plasteel/yellow/side{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /area/engine/engine_smes)
 "bMd" = (
@@ -43173,8 +43043,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -43186,8 +43055,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -43400,8 +43268,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -43463,8 +43330,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -43980,8 +43846,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -43994,8 +43859,7 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Central";
@@ -44585,8 +44449,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -44634,8 +44497,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -44648,8 +44510,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45178,8 +45039,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -45346,8 +45206,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -45363,8 +45222,7 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4";
@@ -45377,8 +45235,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -45525,8 +45382,7 @@
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -45785,8 +45641,7 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -45799,8 +45654,7 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/light,
 /turf/open/floor/plating/airless,
@@ -45809,8 +45663,7 @@
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -46107,8 +45960,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46182,8 +46034,7 @@
 	pressure_checks = 1
 	},
 /turf/open/floor/plasteel/yellow/side{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /area/tcommsat/computer)
 "bSZ" = (
@@ -46871,8 +46722,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/firealarm{
@@ -48616,8 +48466,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/dock)
@@ -49698,8 +49547,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Port Access";
@@ -49716,8 +49564,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
@@ -49725,8 +49572,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
@@ -49742,8 +49588,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main/monastery)
@@ -49843,8 +49688,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -49882,8 +49726,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 2;
@@ -50116,8 +49959,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -50543,8 +50385,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
@@ -50665,8 +50506,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -51237,8 +51077,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -51301,8 +51140,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -45367,10 +45367,9 @@
 	tag = ""
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4";
-	tag = "90Curve"
+	d1 = 1;
+	d2 = 4
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -45771,10 +45770,9 @@
 /area/engine/engineering)
 "bSb" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4";
-	tag = "90Curve"
+	d1 = 1;
+	d2 = 4
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -46314,7 +46312,6 @@
 	charge = 5e+006
 	},
 /obj/structure/cable{
-	tag = "icon-0-4";
 	icon_state = "0-4"
 	},
 /obj/structure/cable{
@@ -47151,7 +47148,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable,
 /obj/structure/cable{
-	tag = "icon-0-4";
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -47164,7 +47160,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	tag = "icon-0-4";
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2545,6 +2545,8 @@
 /area/security/prison)
 "afM" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
@@ -3450,7 +3452,8 @@
 	name = "prison blast door"
 	},
 /obj/structure/cable{
-	tag = "icon-1-2";
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
@@ -3858,7 +3861,8 @@
 /area/security/brig)
 "ait" = (
 /obj/structure/cable{
-	tag = "icon-1-2";
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -4374,7 +4378,8 @@
 /area/security/main)
 "ajx" = (
 /obj/structure/cable{
-	tag = "icon-1-2";
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -5092,7 +5097,8 @@
 /area/security/main)
 "akS" = (
 /obj/structure/cable{
-	tag = "icon-1-2";
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
@@ -5194,6 +5200,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -6098,6 +6106,8 @@
 /area/maintenance/department/crew_quarters/dorms)
 "amT" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7077,6 +7087,8 @@
 	pixel_x = 32
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/barber,
@@ -7409,6 +7421,8 @@
 /area/bridge)
 "apM" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/closed/wall/r_wall,
@@ -7927,6 +7941,8 @@
 "aqU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8727,6 +8743,8 @@
 	},
 /obj/machinery/light,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/black,
@@ -10181,8 +10199,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -11328,10 +11345,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
@@ -11346,10 +11364,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
@@ -14149,10 +14168,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/space,
@@ -14162,10 +14182,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/space,
@@ -14374,6 +14395,8 @@
 /area/hallway/primary/central)
 "aEN" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
@@ -14385,6 +14408,8 @@
 /area/hallway/primary/central)
 "aEO" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -14513,6 +14538,8 @@
 /area/crew_quarters/dorms)
 "aEY" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
@@ -14611,6 +14638,8 @@
 /area/crew_quarters/toilet/restrooms)
 "aFf" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14679,6 +14708,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -15743,6 +15774,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -16016,6 +16049,8 @@
 /area/maintenance/department/cargo)
 "aIn" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17034,10 +17069,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18245,6 +18281,8 @@
 /area/maintenance/department/crew_quarters/bar)
 "aMX" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -18985,6 +19023,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20347,6 +20387,8 @@
 /area/crew_quarters/theatre)
 "aRl" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -21324,6 +21366,8 @@
 "aTu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -21666,6 +21710,8 @@
 /area/maintenance/department/cargo)
 "aUg" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -21825,6 +21871,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -22990,8 +23038,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -23343,6 +23390,8 @@
 /area/quartermaster/qm)
 "aXP" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -23992,6 +24041,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -24993,6 +25044,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25008,6 +25061,8 @@
 "bbk" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25111,7 +25166,8 @@
 /area/crew_quarters/lounge)
 "bbx" = (
 /obj/structure/cable{
-	tag = "icon-1-2";
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
@@ -25815,6 +25871,8 @@
 /area/maintenance/department/cargo)
 "bde" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -26443,7 +26501,8 @@
 "beC" = (
 /obj/item/weapon/extinguisher,
 /obj/structure/cable{
-	tag = "icon-1-2";
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -26775,6 +26834,8 @@
 /area/science/explab)
 "bfs" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -28406,6 +28467,8 @@
 /area/medical/morgue)
 "biX" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -28466,6 +28529,8 @@
 /area/medical/medbay/central)
 "bjb" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -28670,6 +28735,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -29173,6 +29240,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -30987,8 +31056,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -31024,8 +31092,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -31077,6 +31144,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -32090,8 +32159,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32111,6 +32179,8 @@
 /area/science/research)
 "bqa" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
@@ -33126,6 +33196,8 @@
 /area/maintenance/department/science)
 "brL" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34406,6 +34478,8 @@
 /area/crew_quarters/heads/hor)
 "bun" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
@@ -34809,6 +34883,8 @@
 /area/science/server)
 "bvi" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -37535,6 +37611,8 @@
 /area/engine/atmos)
 "bAG" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -38750,8 +38828,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -38826,6 +38903,8 @@
 /area/maintenance/department/chapel/monastery)
 "bDE" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -39798,6 +39877,8 @@
 /area/maintenance/department/engine)
 "bFV" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -43339,8 +43420,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43384,13 +43464,14 @@
 /area/engine/engineering)
 "bNk" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45054,6 +45135,8 @@
 /area/engine/engineering)
 "bQR" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -45983,7 +46066,8 @@
 /area/tcommsat/computer)
 "bTb" = (
 /obj/structure/cable{
-	tag = "icon-1-2";
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply,
@@ -46048,7 +46132,8 @@
 	req_access_txt = "61"
 	},
 /obj/structure/cable{
-	tag = "icon-1-2";
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -46071,7 +46156,8 @@
 /area/tcommsat/computer)
 "bTk" = (
 /obj/structure/cable{
-	tag = "icon-1-2";
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
@@ -46094,6 +46180,7 @@
 	charge = 5e+006
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable{
@@ -46664,6 +46751,8 @@
 /area/security/main)
 "bUD" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/black,
@@ -46923,6 +47012,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable,
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -46935,6 +47025,7 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -49516,6 +49607,8 @@
 /area/chapel/main/monastery)
 "cbT" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49773,6 +49866,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -49890,6 +49985,8 @@
 /area/chapel/main/monastery)
 "ccM" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50439,6 +50536,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/black,
@@ -50469,6 +50568,8 @@
 /area/hydroponics/garden/monastery)
 "cee" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/grass,
@@ -50978,8 +51079,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/black,
@@ -52233,6 +52333,8 @@
 /area/quartermaster/storage)
 "cij" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
@@ -70346,7 +70448,7 @@ alM
 aqg
 aqX
 agv
-ata
+apl
 amo
 amo
 awr
@@ -73674,7 +73776,7 @@ agH
 ahe
 ahF
 ait
-ajk
+aow
 ajW
 akD
 alk
@@ -82507,7 +82609,7 @@ bNF
 bNB
 bOx
 bNt
-bPo
+bNZ
 bPH
 bPY
 bQq
@@ -85591,7 +85693,7 @@ bNF
 bNB
 bOc
 bNt
-bPx
+bOb
 bPH
 bPY
 bQr

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1522,9 +1522,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
 "adu" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	pixel_y = 0
-	},
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/table,
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -3526,9 +3524,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = 3;
 	pixel_y = -3
@@ -7325,9 +7321,7 @@
 "apD" = (
 /obj/structure/table,
 /obj/item/weapon/folder/red,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
@@ -8047,7 +8041,6 @@
 	req_access_txt = "1"
 	},
 /obj/item/weapon/paper_bin{
-	pixel_y = 0;
 	tag = "every single paper bin is edited to this"
 	},
 /obj/item/weapon/pen{
@@ -12112,9 +12105,7 @@
 /area/storage/primary)
 "azT" = (
 /obj/structure/table/wood,
-/obj/item/weapon/storage/lockbox/medal{
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/lockbox/medal,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "azU" = (
@@ -16412,9 +16403,7 @@
 	pixel_x = -4;
 	pixel_y = 3
 	},
-/obj/item/clothing/shoes/magboots{
-	pixel_y = 0
-	},
+/obj/item/clothing/shoes/magboots,
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
@@ -16455,9 +16444,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/tank/jetpack/carbondioxide{
-	pixel_y = 0
-	},
+/obj/item/weapon/tank/jetpack/carbondioxide,
 /obj/item/weapon/tank/jetpack/carbondioxide{
 	pixel_x = -4;
 	pixel_y = 1
@@ -20938,9 +20925,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/item/device/assembly/timer{
-	pixel_y = 0
-	},
+/obj/item/device/assembly/timer,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aSw" = (
@@ -24202,9 +24187,7 @@
 "aZD" = (
 /obj/structure/table,
 /obj/item/weapon/clipboard,
-/obj/item/weapon/stamp/qm{
-	pixel_y = 0
-	},
+/obj/item/weapon/stamp/qm,
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Cargo Quartermaster's Office";
@@ -26217,9 +26200,7 @@
 	name = "Robotics Desk";
 	req_access_txt = "29"
 	},
-/obj/item/weapon/paper_bin{
-	pixel_y = 0
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
@@ -30128,9 +30109,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/item/weapon/disk/tech_disk{
-	pixel_y = 0
-	},
+/obj/item/weapon/disk/tech_disk,
 /obj/item/weapon/disk/design_disk,
 /turf/open/floor/plasteel,
 /area/science/explab)
@@ -30773,9 +30752,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bnp" = (
-/obj/machinery/disposal/bin{
-	pixel_x = 0
-	},
+/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -36189,12 +36166,8 @@
 /obj/item/device/transfer_valve{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve{
-	pixel_x = 0
-	},
-/obj/item/device/transfer_valve{
-	pixel_x = 0
-	},
+/obj/item/device/transfer_valve,
+/obj/item/device/transfer_valve,
 /obj/item/device/transfer_valve{
 	pixel_x = 5
 	},
@@ -36217,9 +36190,7 @@
 	pixel_x = 6;
 	pixel_y = -4
 	},
-/obj/item/device/assembly/timer{
-	pixel_y = 0
-	},
+/obj/item/device/assembly/timer,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -39548,9 +39519,7 @@
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "bFe" = (
-/obj/structure/sign/fire{
-	pixel_y = 0
-	},
+/obj/structure/sign/fire,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "bFf" = (
@@ -40540,9 +40509,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/computer/cloning{
-	pixel_x = 0
-	},
+/obj/item/weapon/circuitboard/computer/cloning,
 /obj/item/weapon/circuitboard/computer/med_data{
 	pixel_x = 3;
 	pixel_y = -3
@@ -42054,9 +42021,7 @@
 	})
 "bKw" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	pixel_y = 0
-	},
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/plasteel/black,
 /area/library)
 "bKx" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -202,7 +202,6 @@
 	network = list("MiniSat")
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -288,7 +287,6 @@
 	network = list("MiniSat")
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
@@ -1209,8 +1207,7 @@
 "acP" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 8
@@ -1623,7 +1620,6 @@
 /area/ai_monitored/turret_protected/AIsatextAS)
 "adJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -2602,7 +2598,6 @@
 /area/security/armory)
 "afR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -2635,8 +2630,7 @@
 /area/security/main)
 "afV" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -3217,8 +3211,7 @@
 /obj/item/weapon/gun/energy/temperature/security,
 /obj/item/clothing/suit/armor/laserproof,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -3286,8 +3279,7 @@
 	pixel_y = -3
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
@@ -3603,8 +3595,7 @@
 /area/security/main)
 "ahS" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -4239,7 +4230,6 @@
 	pixel_x = -27
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/table/glass,
@@ -5238,7 +5228,6 @@
 /area/security/brig)
 "alj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -5734,8 +5723,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -8017,7 +8005,6 @@
 /area/security/brig)
 "arf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8905,8 +8892,7 @@
 /area/crew_quarters/fitness/recreation)
 "asY" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10749,8 +10735,7 @@
 /obj/item/weapon/folder/blue,
 /obj/item/weapon/stamp/captain,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
@@ -11216,8 +11201,7 @@
 "ayf" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/weapon/crowbar,
 /turf/open/floor/plasteel,
@@ -11324,8 +11308,7 @@
 /area/crew_quarters/fitness/recreation)
 "ayt" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -12948,8 +12931,7 @@
 /area/crew_quarters/toilet/restrooms)
 "aBx" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
@@ -13741,8 +13723,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/freezer,
@@ -15186,8 +15167,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aGq" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Departure Lounge Holding Area";
@@ -16942,8 +16922,7 @@
 "aKe" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -17457,8 +17436,7 @@
 /area/hallway/primary/central)
 "aLn" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/brown/corner{
@@ -18251,8 +18229,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aMV" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
@@ -19871,7 +19848,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/brown/corner{
@@ -19927,8 +19903,7 @@
 /area/quartermaster/office)
 "aQt" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -20021,7 +19996,6 @@
 	pixel_y = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -21228,8 +21202,7 @@
 /area/quartermaster/office)
 "aTg" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -21394,8 +21367,7 @@
 /area/security/checkpoint/customs)
 "aTz" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner,
@@ -21412,8 +21384,7 @@
 /area/janitor)
 "aTB" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -21441,8 +21412,7 @@
 /area/crew_quarters/kitchen)
 "aTG" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
@@ -22255,8 +22225,7 @@
 /area/hallway/secondary/entry)
 "aVr" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/neutral/corner{
@@ -22336,7 +22305,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -22745,8 +22713,7 @@
 /area/hydroponics)
 "aWu" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
@@ -23706,8 +23673,7 @@
 /area/crew_quarters/kitchen)
 "aYz" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -24620,8 +24586,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -25127,8 +25092,7 @@
 /area/shuttle/arrival)
 "bbu" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/neutral/corner,
@@ -25229,8 +25193,7 @@
 /area/hallway/primary/central)
 "bbG" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/button/door{
 	dir = 2;
@@ -26790,8 +26753,7 @@
 /area/science/explab)
 "bfq" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
@@ -27838,7 +27800,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/computer/auxillary_base{
@@ -28101,8 +28062,7 @@
 /obj/machinery/cell_charger,
 /obj/item/weapon/stock_parts/cell/high/plus,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -29876,8 +29836,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/structure/extinguisher_cabinet{
@@ -34384,8 +34343,7 @@
 /area/maintenance/department/engine)
 "bug" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/yellow/corner,
@@ -34722,8 +34680,7 @@
 "buU" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -34917,8 +34874,7 @@
 "bvp" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -37429,8 +37385,7 @@
 /area/hallway/primary/aft)
 "bAr" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -39705,8 +39660,7 @@
 /area/hallway/primary/aft)
 "bFB" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
@@ -40355,15 +40309,13 @@
 	pixel_x = 30
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bGX" = (
 /obj/machinery/pipedispenser/disposal,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -40978,7 +40930,6 @@
 /area/engine/atmos)
 "bIq" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -42621,8 +42572,7 @@
 "bLz" = (
 /obj/structure/tank_dispenser,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
 	tag = "icon-yellow (EAST)";
@@ -44083,8 +44033,7 @@
 /area/engine/engineering)
 "bOy" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
@@ -44970,8 +44919,7 @@
 	network = list("Labor")
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching telecoms.";
@@ -45515,8 +45463,7 @@
 /area/space/nearstation)
 "bRO" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -46302,8 +46249,7 @@
 /area/tcommsat/server)
 "bTF" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkgreen/side{
 	initial_gas_mix = "n2=100;TEMP=80"
@@ -46412,8 +46358,7 @@
 /area/tcommsat/server)
 "bTU" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkyellow/side{
 	dir = 1;
@@ -46797,7 +46742,6 @@
 /area/crew_quarters/dorms)
 "bUO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -46894,8 +46838,7 @@
 "bUZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner,
 /area/hallway/primary/fore)
@@ -46936,8 +46879,7 @@
 "bVf" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/device/taperecorder,
 /turf/open/floor/plasteel,
@@ -47324,8 +47266,7 @@
 "bWa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown/corner{
 	dir = 4
@@ -51266,7 +51207,6 @@
 /obj/item/weapon/clipboard,
 /obj/item/toy/figure/syndie,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -51777,7 +51717,6 @@
 /obj/item/weapon/circular_saw,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -52420,7 +52359,6 @@
 	name = "tactical chair"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -52499,7 +52437,6 @@
 /obj/item/weapon/crowbar/red,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/podhatch{
@@ -52591,7 +52528,6 @@
 /area/shuttle/syndicate)
 "ciZ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -52748,7 +52684,6 @@
 /area/shuttle/labor)
 "cjA" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -52781,7 +52716,6 @@
 /area/shuttle/escape)
 "cjG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -793,7 +793,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -1247,7 +1246,6 @@
 "acQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1486,7 +1484,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -2117,7 +2114,6 @@
 "aeP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -2885,7 +2881,6 @@
 "agh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -4431,7 +4426,6 @@
 "ajl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -5488,7 +5482,6 @@
 "alq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -5569,7 +5562,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 6
@@ -6665,7 +6657,6 @@
 "anG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
@@ -6713,7 +6704,6 @@
 "anK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6726,7 +6716,6 @@
 "anM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -6746,7 +6735,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -7753,7 +7741,6 @@
 "apV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
@@ -9544,7 +9531,6 @@
 "atF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -10413,7 +10399,6 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/black,
 /area/bridge)
@@ -10950,7 +10935,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -11113,7 +11097,6 @@
 "axb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/black,
 /area/bridge)
@@ -11823,7 +11806,6 @@
 "ayI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/red/corner{
 	tag = "icon-redcorner (WEST)";
@@ -12316,7 +12298,6 @@
 "azC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white/side,
 /area/crew_quarters/dorms)
@@ -12547,7 +12528,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
@@ -13835,7 +13815,6 @@
 "aCL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -14247,14 +14226,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aDG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14313,7 +14290,6 @@
 "aDM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14328,7 +14304,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14370,7 +14345,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/blue/corner{
 	dir = 1
@@ -14431,7 +14405,6 @@
 "aDY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/blue/corner{
 	dir = 1
@@ -14818,7 +14791,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14862,7 +14834,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Robo";
@@ -15105,7 +15076,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -16592,7 +16562,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -18131,7 +18100,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -18834,7 +18802,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -19325,7 +19292,6 @@
 "aOl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -19361,7 +19327,6 @@
 "aOp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -20048,7 +20013,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -21740,7 +21704,6 @@
 "aTi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22367,7 +22330,6 @@
 "aUv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -22495,7 +22457,6 @@
 "aUO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/effect/landmark/xmastree,
 /turf/open/floor/carpet{
@@ -24043,7 +24004,6 @@
 "aYf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -24182,7 +24142,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -24473,7 +24432,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -25957,7 +25915,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -26011,9 +25968,7 @@
 /turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/central)
 "bcc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	initialize_directions = 11
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bcd" = (
@@ -27431,7 +27386,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
 	pixel_x = 0;
-	initialize_directions = 10
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -28179,9 +28133,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bgY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	initialize_directions = 11
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bgZ" = (
@@ -28531,7 +28483,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (NORTH)";
@@ -29427,7 +29378,6 @@
 "bjB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
@@ -30094,7 +30044,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -30594,7 +30543,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -31134,7 +31082,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
@@ -31819,7 +31766,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/floorgrime,
@@ -31991,7 +31937,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
@@ -32313,7 +32258,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
@@ -32481,7 +32425,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
@@ -32552,7 +32495,6 @@
 "bpC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -32586,7 +32528,6 @@
 "bpH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -32947,7 +32888,6 @@
 "bqg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -33296,7 +33236,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/machinery/light{
 	dir = 8
@@ -33468,7 +33407,6 @@
 "bra" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -33540,7 +33478,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -34513,7 +34450,6 @@
 "bsW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
@@ -35550,7 +35486,6 @@
 "buZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
@@ -36180,7 +36115,6 @@
 "bwl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
@@ -36220,7 +36154,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -37072,7 +37005,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
 	pixel_x = 0;
-	initialize_directions = 10
 	},
 /turf/open/floor/plasteel,
 /area/science/mineral_storeroom)
@@ -37281,7 +37213,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
@@ -37564,7 +37495,6 @@
 "byX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 1
@@ -37593,7 +37523,6 @@
 "byZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
 	dir = 1
@@ -38207,7 +38136,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
@@ -38305,7 +38233,6 @@
 "bAw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating,
@@ -38869,7 +38796,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "mix_in";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -39428,7 +39354,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 0;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -40049,9 +39974,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bEq" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	initialize_directions = 11
-	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bEr" = (
@@ -40330,7 +40253,6 @@
 "bEX" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40367,7 +40289,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2o_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -41069,7 +40990,6 @@
 /obj/structure/closet/radiation,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/machinery/airalarm{
 	dir = 2;
@@ -41158,14 +41078,12 @@
 "bGR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bGS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
@@ -41265,7 +41183,6 @@
 "bHa" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -41368,7 +41285,6 @@
 "bHn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/black,
 /area/storage/tech)
@@ -41477,7 +41393,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 8
@@ -41575,7 +41490,6 @@
 "bHG" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/item/weapon/wrench,
 /turf/open/floor/plasteel,
@@ -41611,7 +41525,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "tox_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -42852,7 +42765,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel{
@@ -42971,7 +42883,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "co2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -43226,7 +43137,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -43677,7 +43587,6 @@
 "bLO" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
-	initialize_directions = 12
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
@@ -44128,7 +44037,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
-	initialize_directions = 12
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -44562,7 +44470,6 @@
 "bNC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44580,7 +44487,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44594,7 +44500,6 @@
 "bNG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44869,7 +44774,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -44898,7 +44802,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "o2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -46786,7 +46689,6 @@
 "bSE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /obj/item/device/radio/beacon,
 /turf/open/floor/plasteel,
@@ -48026,7 +47928,6 @@
 "bVp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -48211,7 +48112,6 @@
 "bVI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/brown/corner{
 	dir = 1;
@@ -48839,7 +48739,6 @@
 "bXn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/central)
@@ -49600,7 +49499,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -50195,7 +50093,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5;
-	initialize_directions = 12
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -50204,7 +50101,6 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
-	initialize_directions = 12
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -50745,7 +50641,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/office)
@@ -51077,7 +50972,6 @@
 "ccU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main/monastery)
@@ -51557,7 +51451,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -52004,7 +51897,6 @@
 "cfi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1090,7 +1090,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 1;

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4219,7 +4219,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/black,
@@ -18296,7 +18295,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -30895,7 +30893,6 @@
 /obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/item/weapon/storage/box/beakers,
@@ -33423,7 +33420,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -46079,7 +46075,6 @@
 /obj/item/device/radio,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -48617,7 +48612,6 @@
 "bZa" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/black,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -17568,7 +17568,6 @@
 /area/shuttle/supply)
 "aLD" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced,
@@ -24364,7 +24363,6 @@
 /area/shuttle/arrival)
 "aZX" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
@@ -29840,7 +29838,6 @@
 /area/maintenance/department/cargo)
 "bls" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced,
@@ -30475,7 +30472,6 @@
 /area/maintenance/department/cargo)
 "bmM" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -52276,7 +52272,6 @@
 /area/shuttle/transport)
 "cif" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced{

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -2847,7 +2847,6 @@
 /obj/machinery/light/small,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/black,
@@ -2963,7 +2962,6 @@
 /obj/machinery/recharger,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -3073,7 +3071,6 @@
 "agG" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
@@ -5425,7 +5422,6 @@
 "alr" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6650,7 +6646,6 @@
 "anY" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/black,
@@ -7479,7 +7474,6 @@
 "aqd" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -9857,7 +9851,6 @@
 "avQ" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
@@ -10390,7 +10383,6 @@
 /obj/item/wallframe/camera,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/device/assembly/prox_sensor{
@@ -14300,7 +14292,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light_switch{
@@ -14366,7 +14357,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel,
@@ -15316,7 +15306,6 @@
 "aHL" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/closet/l3closet/scientist,
@@ -15443,7 +15432,6 @@
 "aHZ" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/closet/crate/wooden/toy,
@@ -16731,7 +16719,6 @@
 "aKZ" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/camera{
@@ -16804,7 +16791,6 @@
 "aLf" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/wood,
@@ -17139,7 +17125,6 @@
 "aLU" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light/small{
@@ -17822,7 +17807,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/closet/chefcloset,
@@ -18622,7 +18606,6 @@
 /obj/structure/table,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel,
@@ -19489,7 +19472,6 @@
 "aSb" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel,
@@ -20047,7 +20029,6 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
@@ -20226,7 +20207,6 @@
 "aUf" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/camera{
@@ -20377,7 +20357,6 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/black,
@@ -20416,7 +20395,6 @@
 "aUG" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/black,
@@ -20550,7 +20528,6 @@
 "aVa" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/closet/toolcloset,
@@ -21423,7 +21400,6 @@
 "aWQ" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22823,7 +22799,6 @@
 "bag" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/bar,
@@ -22944,7 +22919,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/wood,
@@ -23920,7 +23894,6 @@
 "bcV" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/filingcabinet,
@@ -25237,7 +25210,6 @@
 "bgd" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25369,7 +25341,6 @@
 "bgs" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/freezer,
@@ -25602,7 +25573,6 @@
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/device/camera,
@@ -26816,7 +26786,6 @@
 "bjE" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26989,7 +26958,6 @@
 "bjY" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
@@ -27021,7 +26989,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/black,
@@ -27074,7 +27041,6 @@
 /obj/item/weapon/reagent_containers/dropper,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/white,
@@ -28262,7 +28228,6 @@
 /obj/structure/table/glass,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/item/stack/cable_coil/random,
@@ -28939,7 +28904,6 @@
 /obj/item/weapon/bedsheet/captain,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29030,7 +28994,6 @@
 "boj" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/requests_console{
@@ -29484,7 +29447,6 @@
 "bpi" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -30100,7 +30062,6 @@
 "bqC" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -31868,7 +31829,6 @@
 "bui" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32086,7 +32046,6 @@
 /obj/structure/table,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/computer/stockexchange,
@@ -32205,7 +32164,6 @@
 "buQ" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -33564,7 +33522,6 @@
 /obj/machinery/computer/secure_data,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/red/side{
@@ -33757,7 +33714,6 @@
 "byb" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34173,7 +34129,6 @@
 "byX" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
@@ -34244,7 +34199,6 @@
 "bze" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/shower{
@@ -34306,7 +34260,6 @@
 /obj/machinery/computer/cloning,
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/whiteblue/side{
@@ -35204,7 +35157,6 @@
 "bBj" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/structure/cable{
@@ -35452,7 +35404,6 @@
 "bBI" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/closet/wardrobe/miner,
@@ -35979,7 +35930,6 @@
 "bCS" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36074,7 +36024,6 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/white/side{
@@ -37208,7 +37157,6 @@
 "bFz" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -37281,7 +37229,6 @@
 "bFI" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light/small{
@@ -41901,7 +41848,6 @@
 "bPr" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/closet/l3closet,
@@ -43948,7 +43894,6 @@
 "bUb" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/sink{
@@ -45156,7 +45101,6 @@
 "bWL" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/disposalpipe/segment,
@@ -46114,7 +46058,6 @@
 "bYM" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/structure/disposalpipe/segment{
@@ -46885,7 +46828,6 @@
 /obj/item/clothing/glasses/meson,
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel,
@@ -48427,7 +48369,6 @@
 "cdw" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel,
@@ -48738,7 +48679,6 @@
 "ceg" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/light,
@@ -49379,7 +49319,6 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -50097,7 +50036,6 @@
 /obj/machinery/airalarm{
 	desc = "This particular atmos control unit appears to have no access restrictions.";
 	dir = 8;
-	icon_state = "alarm0";
 	locked = 0;
 	name = "all-access air alarm";
 	pixel_x = 24;
@@ -51052,7 +50990,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/computer/card/minor/ce,
@@ -53905,7 +53842,6 @@
 "cpm" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -53944,7 +53880,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -56370,7 +56305,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/rack,
@@ -59222,7 +59156,6 @@
 "cBe" = (
 /obj/machinery/airalarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/holopad,
@@ -60753,7 +60686,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -61643,7 +61575,6 @@
 "cHa" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/black,

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -245,9 +245,7 @@
 /turf/open/floor/plasteel/barber,
 /area/security/prison)
 "aaM" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	pixel_y = 0
-	},
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/table,
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -392,9 +390,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/device/radio/off,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abl" = (
@@ -612,9 +608,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_y = 0
-	},
+/obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = 3;
 	pixel_y = -3
@@ -3763,9 +3757,7 @@
 "ahV" = (
 /obj/structure/table,
 /obj/item/weapon/folder/red,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /turf/open/floor/plasteel/black,
 /area/security/prison)
 "ahW" = (
@@ -8776,9 +8768,7 @@
 	width = 9
 	},
 /obj/machinery/bluespace_beacon,
-/obj/machinery/computer/auxillary_base{
-	pixel_y = 0
-	},
+/obj/machinery/computer/auxillary_base,
 /turf/closed/wall,
 /area/shuttle/auxillary_base)
 "atm" = (
@@ -9106,9 +9096,7 @@
 /area/lawoffice)
 "auh" = (
 /obj/structure/table/wood,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /obj/item/weapon/cartridge/lawyer,
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -17791,9 +17779,7 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "aNS" = (
-/obj/machinery/bookbinder{
-	pixel_y = 0
-	},
+/obj/machinery/bookbinder,
 /turf/open/floor/wood,
 /area/library)
 "aNT" = (
@@ -18365,9 +18351,7 @@
 /area/library)
 "aPi" = (
 /obj/structure/table/wood,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /obj/item/device/camera,
 /obj/item/device/radio/intercom{
 	pixel_y = 25
@@ -19813,9 +19797,7 @@
 /area/library)
 "aTd" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	pixel_y = 0
-	},
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
@@ -22702,9 +22684,7 @@
 	},
 /area/hallway/primary/central)
 "aZZ" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = 0
-	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
 "baa" = (
@@ -24439,9 +24419,7 @@
 	c_tag = "Captain's Office";
 	dir = 8
 	},
-/obj/item/weapon/storage/lockbox/medal{
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/lockbox/medal,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "beo" = (
@@ -25583,9 +25561,7 @@
 /area/medical/medbay/central)
 "bhf" = (
 /obj/structure/table,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/firstaid/regular,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bhg" = (
@@ -29781,12 +29757,8 @@
 "bpZ" = (
 /obj/item/weapon/folder/white,
 /obj/structure/table,
-/obj/item/weapon/disk/tech_disk{
-	pixel_y = 0
-	},
-/obj/item/weapon/disk/tech_disk{
-	pixel_y = 0
-	},
+/obj/item/weapon/disk/tech_disk,
+/obj/item/weapon/disk/tech_disk,
 /obj/item/weapon/disk/design_disk,
 /obj/item/weapon/disk/design_disk,
 /turf/open/floor/plasteel/white,
@@ -30742,9 +30714,7 @@
 /area/crew_quarters/heads/hop)
 "brX" = (
 /obj/structure/table,
-/obj/item/weapon/storage/box/masks{
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/box/masks,
 /obj/item/weapon/storage/box/gloves{
 	pixel_x = 3;
 	pixel_y = 4
@@ -32945,12 +32915,8 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
-	pixel_y = 0
-	},
-/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
-	pixel_y = 0
-	},
+/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bwK" = (
@@ -33685,9 +33651,7 @@
 "byg" = (
 /obj/structure/table,
 /obj/item/weapon/clipboard,
-/obj/item/weapon/stamp/qm{
-	pixel_y = 0
-	},
+/obj/item/weapon/stamp/qm,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -38902,9 +38866,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/computer/cloning{
-	pixel_x = 0
-	},
+/obj/item/weapon/circuitboard/computer/cloning,
 /obj/item/weapon/circuitboard/computer/med_data{
 	pixel_x = 3;
 	pixel_y = -3
@@ -39284,12 +39246,8 @@
 /obj/item/device/transfer_valve{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve{
-	pixel_x = 0
-	},
-/obj/item/device/transfer_valve{
-	pixel_x = 0
-	},
+/obj/item/device/transfer_valve,
+/obj/item/device/transfer_valve,
 /obj/item/device/transfer_valve{
 	pixel_x = 5
 	},
@@ -39342,9 +39300,7 @@
 	pixel_x = 6;
 	pixel_y = -4
 	},
-/obj/item/device/assembly/timer{
-	pixel_y = 0
-	},
+/obj/item/device/assembly/timer,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -45247,9 +45203,7 @@
 /obj/item/weapon/folder/white,
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /turf/open/floor/plasteel/floorgrime,
 /area/science/misc_lab)
 "bXj" = (
@@ -45673,9 +45627,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bYb" = (
-/obj/machinery/vending/cigarette{
-	pixel_y = 0
-	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bYc" = (
@@ -54286,9 +54238,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cqs" = (
-/obj/structure/sign/fire{
-	pixel_y = 0
-	},
+/obj/structure/sign/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "cqt" = (
@@ -54651,9 +54601,7 @@
 /area/solar/starboard/aft)
 "crl" = (
 /obj/structure/table,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "crm" = (

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -6378,7 +6378,6 @@
 /area/maintenance/solars/port/fore)
 "anj" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -52624,7 +52623,6 @@
 "clm" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -61016,8 +61014,6 @@
 /area/engine/engineering)
 "cDD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	name = "scrubbers pipe";
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/meter,
@@ -61418,7 +61414,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/highpressure/fulltile,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -61610,7 +61605,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -154,7 +154,6 @@
 /area/security/prison)
 "aaw" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -212,8 +211,7 @@
 /area/security/prison)
 "aaG" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -715,8 +713,7 @@
 "abR" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -865,8 +862,7 @@
 /area/ai_monitored/security/armory)
 "acj" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/suit_storage_unit/hos,
 /turf/open/floor/carpet,
@@ -2013,8 +2009,7 @@
 /area/ai_monitored/security/armory)
 "aev" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
@@ -2298,7 +2293,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/rack,
@@ -2928,8 +2922,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3073,8 +3066,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -3417,7 +3409,6 @@
 /obj/item/weapon/reagent_containers/glass/bottle/charcoal,
 /obj/item/weapon/reagent_containers/glass/bottle/epinephrine,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/table/glass,
@@ -4476,7 +4467,6 @@
 /area/security/processing)
 "ajv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4760,7 +4750,6 @@
 /area/security/processing)
 "akb" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -6812,8 +6801,7 @@
 /area/security/processing)
 "aot" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -7895,7 +7883,6 @@
 /area/maintenance/fore)
 "ara" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/requests_console{
@@ -8714,8 +8701,7 @@
 /area/lawoffice)
 "atd" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
@@ -9417,7 +9403,6 @@
 /area/construction/mining/aux_base)
 "auR" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -9852,7 +9837,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -10374,7 +10358,6 @@
 "awU" = (
 /obj/structure/table,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/item/wallframe/camera,
@@ -11599,7 +11582,6 @@
 /area/gateway)
 "azK" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -12199,7 +12181,6 @@
 /area/ai_monitored/storage/eva)
 "aAX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12297,7 +12278,6 @@
 	layer = 2.9
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/weapon/tank/jetpack/carbondioxide,
@@ -12397,8 +12377,7 @@
 /area/ai_monitored/storage/eva)
 "aBu" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/fore)
@@ -12487,7 +12466,6 @@
 /area/hydroponics/garden)
 "aBH" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -14375,7 +14353,6 @@
 	pixel_y = 16
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14574,7 +14551,6 @@
 	amount = 50
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -15925,8 +15901,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/side{
@@ -15969,7 +15944,6 @@
 /obj/item/weapon/extinguisher,
 /obj/item/weapon/extinguisher,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -15987,7 +15961,6 @@
 "aJl" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16793,8 +16766,7 @@
 /area/library)
 "aLh" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -19200,14 +19172,12 @@
 /area/bridge)
 "aRt" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRu" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/chair/stool,
@@ -19241,8 +19211,7 @@
 /area/crew_quarters/kitchen)
 "aRz" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
@@ -19883,8 +19852,7 @@
 /area/chapel/main)
 "aTj" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
@@ -19973,7 +19941,6 @@
 "aTw" = (
 /obj/structure/closet/wardrobe/green,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21105,7 +21072,6 @@
 /area/maintenance/port)
 "aWm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/light_switch{
@@ -21629,7 +21595,6 @@
 /area/hallway/primary/central)
 "aXi" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -21794,8 +21759,7 @@
 /area/crew_quarters/fitness)
 "aXG" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23010,7 +22974,6 @@
 	pixel_x = 27
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23228,7 +23191,6 @@
 /obj/structure/table,
 /obj/item/weapon/aiModule/reset,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -23265,7 +23227,6 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "bbq" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -23889,7 +23850,6 @@
 /area/security/detectives_office)
 "bcW" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24446,7 +24406,6 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "bei" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -25054,8 +25013,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -26176,7 +26134,6 @@
 	receive_ore_updates = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -27163,8 +27120,7 @@
 "bkw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -27269,7 +27225,6 @@
 /area/quartermaster/sorting)
 "bkI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
@@ -28511,8 +28466,7 @@
 /obj/item/weapon/stock_parts/matter_bin,
 /obj/item/weapon/stock_parts/matter_bin,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/weapon/stock_parts/scanning_module{
 	pixel_x = 2;
@@ -28917,7 +28871,6 @@
 	pixel_y = 6
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -31242,7 +31195,6 @@
 /area/science/robotics/lab)
 "bsX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
@@ -32098,8 +32050,7 @@
 /area/quartermaster/office)
 "buK" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -32171,8 +32122,7 @@
 /area/engine/gravity_generator)
 "buS" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Foyer"
@@ -33008,8 +32958,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -33664,7 +33613,6 @@
 /area/crew_quarters/heads/hor)
 "bxX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -33867,8 +33815,7 @@
 "byu" = (
 /obj/structure/displaycase/labcage,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -34116,8 +34063,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -34485,7 +34431,6 @@
 "bzP" = (
 /obj/machinery/computer/cargo,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
@@ -34721,7 +34666,6 @@
 "bAp" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -35451,8 +35395,7 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/heads/cmo)
@@ -35687,8 +35630,7 @@
 /area/quartermaster/miningdock)
 "bCp" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/yellow/corner{
@@ -37818,7 +37760,6 @@
 /area/maintenance/aft)
 "bGX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -38156,7 +38097,6 @@
 /area/storage/tech)
 "bHK" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/door/firedoor/heavy,
@@ -38617,8 +38557,7 @@
 "bIw" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/heads/cmo)
@@ -41152,8 +41091,7 @@
 	network = list("SS13")
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 5
@@ -41759,8 +41697,7 @@
 /area/engine/atmos)
 "bPi" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel/green/side{
@@ -41833,8 +41770,7 @@
 	},
 /obj/structure/closet/l3closet,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -42408,7 +42344,6 @@
 "bQN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -43201,8 +43136,7 @@
 "bSE" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/button/door{
 	id = "atmos";
@@ -43570,8 +43504,7 @@
 	pixel_y = -1
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/device/assembly/timer{
 	pixel_x = -3;
@@ -43984,7 +43917,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -44464,7 +44396,6 @@
 /area/science/xenobiology)
 "bVj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45160,8 +45091,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -45472,8 +45402,7 @@
 	pixel_x = 29
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -46896,14 +46825,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "caF" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -48081,8 +48008,7 @@
 /area/science/misc_lab)
 "ccT" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/floorgrime,
@@ -48260,8 +48186,7 @@
 /area/engine/engineering)
 "cdo" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
@@ -51822,8 +51747,7 @@
 /area/maintenance/disposal/incinerator)
 "clf" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/floorgrime,
@@ -53726,8 +53650,7 @@
 /area/engine/engineering)
 "cpa" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -54393,7 +54316,6 @@
 	amount = 10
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54414,8 +54336,7 @@
 /area/maintenance/port/aft)
 "cqz" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -55313,8 +55234,7 @@
 /area/engine/engineering)
 "csK" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -56764,7 +56684,6 @@
 	installation = /obj/item/weapon/gun/energy/e_gun
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/circuit,
@@ -56798,7 +56717,6 @@
 	installation = /obj/item/weapon/gun/energy/e_gun
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/circuit,
@@ -57131,7 +57049,6 @@
 /area/ai_monitored/turret_protected/ai)
 "cwv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /obj/machinery/status_display{
@@ -57193,7 +57110,6 @@
 /area/ai_monitored/turret_protected/ai)
 "cwB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /obj/machinery/ai_status_display{
@@ -58725,8 +58641,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 4
@@ -60353,8 +60268,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -60777,8 +60691,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
@@ -62173,7 +62086,6 @@
 /obj/item/weapon/clipboard,
 /obj/item/toy/figure/syndie,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -62313,7 +62225,6 @@
 	name = "tactical chair"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -62505,7 +62416,6 @@
 /obj/item/weapon/crowbar/red,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/podhatch{
@@ -62831,7 +62741,6 @@
 /area/shuttle/syndicate)
 "cKg" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -63140,7 +63049,6 @@
 /obj/item/weapon/circular_saw,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -63392,7 +63300,6 @@
 "cLN" = (
 /obj/structure/table,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
@@ -63470,7 +63377,6 @@
 /area/shuttle/abandoned)
 "cMb" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -63527,7 +63433,6 @@
 /area/shuttle/abandoned)
 "cMl" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -252,8 +252,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -485,7 +484,6 @@
 	},
 /obj/machinery/flasher{
 	id = "executionflash";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -654,7 +652,6 @@
 	id = "permabolt3";
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -675,7 +672,6 @@
 	id = "permabolt2";
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -734,7 +730,6 @@
 	department = "Head of Security's Desk";
 	departmentType = 5;
 	name = "Head of Security RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/item/device/radio/intercom{
@@ -763,8 +758,7 @@
 	pixel_y = 23
 	},
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka/badminka,
@@ -788,8 +782,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -895,8 +888,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Armory APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -935,8 +927,7 @@
 /area/crew_quarters/heads/hos)
 "acs" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Security's Office";
@@ -975,8 +966,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -1020,7 +1010,6 @@
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
 	name = "Prison Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24;
 	prison_radio = 1
 	},
@@ -1035,7 +1024,6 @@
 	id = "permabolt1";
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -1057,7 +1045,6 @@
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
 	name = "Prison Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24;
 	prison_radio = 1
 	},
@@ -1080,7 +1067,6 @@
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
 	name = "Prison Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24;
 	prison_radio = 1
 	},
@@ -1391,7 +1377,6 @@
 /obj/machinery/button/door{
 	id = "armory";
 	name = "Armory Shutters";
-	pixel_x = 0;
 	pixel_y = -26;
 	req_access_txt = "3"
 	},
@@ -1442,8 +1427,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plating,
 /area/security/main)
@@ -1467,8 +1451,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1521,8 +1504,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1553,8 +1535,7 @@
 /area/solar/port/fore)
 "adB" = (
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/space,
 /area/space)
@@ -1593,8 +1574,7 @@
 	pixel_x = 3
 	},
 /obj/item/device/taperecorder{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/device/assembly/flash/handheld,
 /obj/item/weapon/reagent_containers/spray/pepper,
@@ -1665,8 +1645,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Head of Security's Office APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -1716,8 +1695,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1748,8 +1726,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1901,7 +1878,6 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
 	network = list("Prison");
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1943,7 +1919,6 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
 	network = list("Prison");
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2003,8 +1978,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Prison Wing APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -2044,8 +2018,7 @@
 	icon_state = "tube1"
 	},
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/showroomfloor,
@@ -2072,8 +2045,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
@@ -2320,8 +2292,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Control Room";
@@ -2359,8 +2330,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/window/southleft{
 	name = "Armory";
@@ -2536,7 +2506,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -2597,8 +2566,7 @@
 /area/security/transfer)
 "afx" = (
 /obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9
@@ -2654,8 +2622,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2817,8 +2784,7 @@
 /area/security/main)
 "aga" = (
 /obj/structure/sign/pods{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -2867,7 +2833,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Prisoner Transfer Centre";
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /turf/open/floor/plasteel/black,
@@ -3093,8 +3058,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
@@ -3188,8 +3152,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
@@ -3434,7 +3397,6 @@
 	freerange = 0;
 	frequency = 1459;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/table/glass,
@@ -3451,8 +3413,7 @@
 "ahu" = (
 /obj/item/weapon/storage/box/bodybags,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/item/weapon/reagent_containers/syringe{
 	name = "steel point"
@@ -3472,8 +3433,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Brig Control APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -3485,8 +3445,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -3494,8 +3453,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3513,8 +3471,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/showroomfloor,
@@ -3568,8 +3525,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -3615,8 +3571,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3633,8 +3588,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3665,8 +3619,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3745,8 +3698,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Security Office APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -3841,8 +3793,7 @@
 /obj/structure/table,
 /obj/item/device/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 0
+	name = "Station Intercom (General)"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -3900,8 +3851,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -3934,8 +3884,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -4074,8 +4023,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side,
 /area/security/main)
@@ -4110,8 +4058,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4133,14 +4080,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -4350,8 +4295,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4364,8 +4308,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4513,8 +4456,7 @@
 /area/security/processing)
 "ajt" = (
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4714,8 +4656,7 @@
 	broadcasting = 0;
 	dir = 8;
 	listening = 1;
-	name = "Station Intercom (Court)";
-	pixel_x = 0
+	name = "Station Intercom (Court)"
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -4811,7 +4752,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
@@ -5095,8 +5035,7 @@
 "akC" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -31;
-	pixel_y = 0
+	pixel_x = -31
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
@@ -5122,7 +5061,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -5456,7 +5394,6 @@
 /obj/machinery/button/flasher{
 	id = "gulagshuttleflasher";
 	name = "Flash Control";
-	pixel_x = 0;
 	pixel_y = -26;
 	req_access_txt = "1"
 	},
@@ -5684,8 +5621,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Courtroom APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -5742,8 +5678,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
@@ -6084,8 +6019,7 @@
 	},
 /obj/structure/noticeboard{
 	dir = 8;
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/item/trash/plate,
 /turf/open/floor/plating,
@@ -6096,16 +6030,14 @@
 "amJ" = (
 /obj/machinery/mineral/labor_claim_console{
 	machinedir = 1;
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/labor)
 "amK" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/closed/wall,
 /area/security/processing)
@@ -6568,7 +6500,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
@@ -6577,8 +6508,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/fore)
@@ -6747,8 +6677,7 @@
 /area/maintenance/fore/secondary)
 "aob" = (
 /obj/machinery/light_switch{
-	pixel_x = -20;
-	pixel_y = 0
+	pixel_x = -20
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = 25
@@ -6809,7 +6738,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/device/multitool,
@@ -6868,7 +6796,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -7037,7 +6964,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Fitness Room APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -7174,8 +7100,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -7489,8 +7414,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -7690,7 +7614,6 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -7790,8 +7713,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
@@ -7988,8 +7910,7 @@
 	},
 /obj/machinery/requests_console{
 	department = "Law office";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/closet/lawcloset,
 /turf/open/floor/wood,
@@ -8066,8 +7987,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 9
@@ -8100,7 +8020,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -8308,8 +8227,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
@@ -8383,8 +8301,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
@@ -8574,7 +8491,6 @@
 	id = "Dorm5";
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -8683,7 +8599,6 @@
 	id = "Dorm6";
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -8975,7 +8890,6 @@
 /obj/machinery/button/door{
 	id = "maint3";
 	name = "Blast Door Control C";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "0"
 	},
@@ -9123,8 +9037,7 @@
 "atV" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -9179,8 +9092,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9212,7 +9124,6 @@
 	dir = 1;
 	name = "Prison Monitor";
 	network = list("Prison");
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /turf/open/floor/wood,
@@ -9239,8 +9150,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9323,8 +9233,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -9365,7 +9274,6 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -9494,8 +9402,7 @@
 /area/maintenance/department/electrical)
 "auM" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9633,7 +9540,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -9661,8 +9567,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Vacant Office B APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
@@ -9695,8 +9600,7 @@
 /area/hallway/primary/fore)
 "avk" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
@@ -9734,8 +9638,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/closed/wall,
 /area/maintenance/department/electrical)
@@ -9880,8 +9783,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10299,8 +10201,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10546,8 +10447,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -10689,8 +10589,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10715,8 +10614,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10751,8 +10649,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10788,8 +10685,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10873,8 +10769,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -10955,8 +10850,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -11135,14 +11029,12 @@
 /area/construction/mining/aux_base)
 "ayr" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11282,8 +11174,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -11341,7 +11232,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "EVA Storage APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -11411,7 +11301,6 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -11476,8 +11365,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 6
@@ -11687,8 +11575,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11771,8 +11658,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11832,8 +11718,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -11864,8 +11749,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
@@ -11911,8 +11795,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -11957,8 +11840,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -11990,8 +11872,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12006,8 +11887,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12132,8 +12012,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/closed/wall,
 /area/maintenance/department/electrical)
@@ -12150,8 +12029,7 @@
 "aAC" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
@@ -12162,7 +12040,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/window/reinforced/fulltile,
@@ -12243,8 +12120,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -12282,8 +12158,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -12354,8 +12229,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
@@ -12652,8 +12526,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -12669,8 +12542,7 @@
 "aBO" = (
 /obj/machinery/requests_console{
 	department = "EVA";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -12686,8 +12558,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -12717,7 +12588,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Vault APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -12810,7 +12680,6 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "0";
 	specialfunctions = 4
 	},
@@ -12826,8 +12695,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
@@ -12843,8 +12711,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -12921,8 +12788,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 4
@@ -12934,8 +12800,7 @@
 	department = "Theatre";
 	departmentType = 0;
 	name = "theatre RC";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/weapon/reagent_containers/food/snacks/baguette,
 /obj/item/toy/dummy,
@@ -13193,7 +13058,6 @@
 "aCY" = (
 /obj/machinery/computer/security,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -13245,8 +13109,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -13441,8 +13304,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -13465,8 +13327,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -13782,7 +13643,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Chapel APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -13913,8 +13773,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Entry Hall APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/arrival{
@@ -14242,8 +14101,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Dormitory Bathrooms APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -14322,8 +14180,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14338,8 +14195,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14379,7 +14235,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Chapel Office APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -14397,8 +14252,7 @@
 	icon_state = "airlock_control_standby";
 	id = "chapelgun";
 	name = "Mass Driver Controller";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/black,
 /area/chapel/main)
@@ -14815,8 +14669,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plating,
@@ -14851,8 +14704,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -14981,8 +14833,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15083,8 +14934,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15251,8 +15101,7 @@
 /area/chapel/office)
 "aHj" = (
 /obj/machinery/light_switch{
-	pixel_x = -20;
-	pixel_y = 0
+	pixel_x = -20
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -15307,8 +15156,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/showroomfloor,
@@ -15338,8 +15186,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
@@ -15906,7 +15753,6 @@
 	id = "aux_base_shutters";
 	name = "Public Shutters Control";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access_txt = "0";
 	req_one_access_txt = "32;47;48"
 	},
@@ -16100,8 +15946,7 @@
 /area/ai_monitored/storage/eva)
 "aJg" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -16545,8 +16390,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Auxillary Base Construction APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -16939,7 +16783,6 @@
 "aLd" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/weapon/reagent_containers/spray/plantbgone{
@@ -17755,8 +17598,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -17772,8 +17614,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -17940,8 +17781,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
@@ -18143,8 +17983,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18239,8 +18078,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -18255,8 +18093,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18270,8 +18107,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -18282,8 +18118,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -18312,8 +18147,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -18468,7 +18302,6 @@
 /obj/machinery/requests_console{
 	department = "Hydroponics";
 	departmentType = 2;
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18728,8 +18561,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -19144,7 +18976,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -19189,8 +19020,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -19370,8 +19200,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/computer/shuttle/mining,
 /turf/open/floor/plasteel/blue/side{
@@ -19622,8 +19451,7 @@
 /obj/structure/grille,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -19790,8 +19618,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 4
@@ -19840,8 +19667,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/blue/side{
 	dir = 4
@@ -19989,8 +19815,7 @@
 /area/crew_quarters/locker)
 "aSW" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
@@ -20001,8 +19826,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -20022,7 +19846,6 @@
 	department = "Bar";
 	departmentType = 2;
 	pixel_x = 30;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /obj/machinery/camera{
@@ -20105,7 +19928,6 @@
 /obj/machinery/vending/cola/random,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/escape{
@@ -20126,7 +19948,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
@@ -20149,8 +19970,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -20173,8 +19993,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -20355,8 +20174,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -20372,8 +20190,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/blue/corner{
 	dir = 4
@@ -20696,8 +20513,7 @@
 /obj/structure/closet/wardrobe/grey,
 /obj/machinery/requests_console{
 	department = "Locker Room";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -20758,8 +20574,7 @@
 /area/hallway/primary/central)
 "aVc" = (
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -20852,8 +20667,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -20869,8 +20683,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -20897,8 +20710,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20976,8 +20788,7 @@
 /area/bridge)
 "aVt" = (
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -21049,16 +20860,14 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aVD" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/weapon/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
@@ -21243,8 +21052,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -21319,8 +21127,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -21338,8 +21145,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
@@ -21414,7 +21220,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Art Storage";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21427,8 +21232,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/storage/art)
@@ -21437,8 +21241,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -21464,8 +21267,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/port)
@@ -21497,7 +21299,6 @@
 "aWE" = (
 /obj/machinery/computer/med_data,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/segment{
@@ -21565,8 +21366,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -21751,8 +21551,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -21907,8 +21706,7 @@
 /obj/machinery/requests_console{
 	department = "Kitchen";
 	departmentType = 2;
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -22202,8 +22000,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -22216,8 +22013,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22276,8 +22072,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -22301,7 +22096,6 @@
 /obj/machinery/button/door{
 	id = "kanyewest";
 	name = "Privacy Shutters";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/grimy,
@@ -22461,8 +22255,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22572,8 +22365,7 @@
 	pixel_y = 1
 	},
 /obj/item/clothing/under/suit_jacket/really_black{
-	pixel_x = -2;
-	pixel_y = 0
+	pixel_x = -2
 	},
 /obj/structure/window{
 	icon_state = "window";
@@ -22733,8 +22525,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -22760,7 +22551,6 @@
 /obj/machinery/button/door{
 	id = "heads_meeting";
 	name = "Security Shutters";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/wood,
@@ -22846,8 +22636,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -22865,8 +22654,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22989,7 +22777,6 @@
 /area/hallway/primary/central)
 "aZZ" = (
 /obj/machinery/vending/cigarette{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/bar,
@@ -23047,7 +22834,6 @@
 /area/crew_quarters/bar)
 "bah" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/bar,
@@ -23106,11 +22892,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -23136,8 +22920,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -23183,8 +22966,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -23231,8 +23013,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -23268,8 +23049,7 @@
 /area/hallway/secondary/entry)
 "baG" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -23314,8 +23094,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -23403,7 +23182,6 @@
 "baZ" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -23580,7 +23358,6 @@
 /area/crew_quarters/heads/captain)
 "bbv" = (
 /obj/machinery/status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable{
@@ -23675,8 +23452,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Vacant Office A APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -23689,8 +23465,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -24012,8 +23787,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24077,8 +23851,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
@@ -24103,8 +23876,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
@@ -24187,8 +23959,7 @@
 /obj/item/device/radio/intercom{
 	dir = 8;
 	freerange = 1;
-	name = "Station Intercom (Command)";
-	pixel_x = 0
+	name = "Station Intercom (Command)"
 	},
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
@@ -24206,7 +23977,6 @@
 /area/hallway/primary/starboard)
 "bdc" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/light,
@@ -24233,8 +24003,7 @@
 "bdf" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -24288,8 +24057,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -24303,8 +24071,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
@@ -24425,8 +24192,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24437,8 +24203,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -24462,8 +24227,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24577,8 +24341,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Disposal APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -24622,8 +24385,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -24681,7 +24443,6 @@
 /obj/machinery/computer/upload/ai,
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -21
 	},
 /turf/open/floor/circuit,
@@ -24805,7 +24566,6 @@
 /area/hallway/primary/central)
 "ber" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
@@ -24895,8 +24655,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -25114,7 +24873,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/landmark/event_spawn,
@@ -25127,7 +24885,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Locker Room APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -25158,8 +24915,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -25256,8 +25012,7 @@
 "bfr" = (
 /obj/structure/noticeboard{
 	dir = 8;
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
@@ -25463,7 +25218,6 @@
 /area/hallway/primary/starboard)
 "bfZ" = (
 /obj/structure/sign/securearea{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/purple/side{
@@ -25580,8 +25334,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Mech Bay APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -25711,8 +25464,7 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light{
 	dir = 8
@@ -25728,8 +25480,7 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -25737,8 +25488,7 @@
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -25772,7 +25522,6 @@
 /area/bridge/meeting_room)
 "bgL" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/wood,
@@ -25820,8 +25569,7 @@
 	department = "Captain's Desk";
 	departmentType = 5;
 	name = "Captain RC";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/structure/filingcabinet,
 /turf/open/floor/wood,
@@ -25925,7 +25673,6 @@
 "bhf" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/white,
@@ -25970,7 +25717,6 @@
 	id = "MedbayFoyer";
 	name = "Medbay Doors Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 26;
 	req_access_txt = "5"
 	},
@@ -25982,8 +25728,7 @@
 "bhl" = (
 /obj/structure/filingcabinet,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
@@ -26236,8 +25981,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -26268,8 +26012,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26394,8 +26137,7 @@
 /area/quartermaster/storage)
 "bid" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/central)
@@ -26478,7 +26220,6 @@
 	department = "Chemistry";
 	departmentType = 2;
 	pixel_x = -30;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /obj/machinery/light{
@@ -26622,8 +26363,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -26642,8 +26382,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -26651,8 +26390,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -26661,8 +26399,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whitered/corner{
@@ -26739,8 +26476,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -26922,8 +26658,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -26941,7 +26676,6 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
@@ -26995,8 +26729,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -27028,8 +26761,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -27051,9 +26783,7 @@
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -27098,11 +26828,9 @@
 /area/bridge/meeting_room)
 "bjF" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -27122,8 +26850,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -27175,8 +26902,7 @@
 /area/security/checkpoint/medical)
 "bjN" = (
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -27295,9 +27021,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -27375,8 +27099,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -27390,8 +27113,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -27423,8 +27145,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -27454,8 +27175,7 @@
 	dir = 8
 	},
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -27468,7 +27188,6 @@
 	departmentType = 2;
 	name = "Science Requests Console";
 	pixel_x = -30;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -27559,8 +27278,7 @@
 "bkC" = (
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -27572,8 +27290,7 @@
 "bkE" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/port)
@@ -27588,8 +27305,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -27644,8 +27360,7 @@
 /area/quartermaster/office)
 "bkO" = (
 /obj/machinery/light_switch{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/item/weapon/screwdriver{
 	pixel_y = 10
@@ -27680,8 +27395,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -27694,8 +27408,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -27720,8 +27433,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -27737,8 +27449,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -27766,8 +27477,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -27775,8 +27485,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Conference Room APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -27811,8 +27520,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -27878,8 +27586,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -27935,9 +27642,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/white,
@@ -27949,8 +27654,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -28059,14 +27763,12 @@
 	dir = 10
 	},
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -28075,8 +27777,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -28154,8 +27855,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	on = 1;
@@ -28223,7 +27923,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/weapon/cigbutt,
@@ -28378,8 +28077,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -28419,8 +28117,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
@@ -28433,8 +28130,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/brown/corner{
 	dir = 8
@@ -28477,8 +28173,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 8
@@ -28545,8 +28240,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -28593,8 +28287,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -28611,7 +28304,6 @@
 	frequency = 1485;
 	listening = 0;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/light,
@@ -28668,8 +28360,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -28884,8 +28575,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Research Lab APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -29012,8 +28702,7 @@
 "bnB" = (
 /obj/structure/closet/wardrobe/chemistry_white,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -29049,7 +28738,6 @@
 /area/quartermaster/office)
 "bnF" = (
 /obj/structure/sign/nosmoking_2{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/disposalpipe/segment{
@@ -29108,8 +28796,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -29120,7 +28807,6 @@
 /area/hallway/primary/central)
 "bnO" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/filingcabinet/chestdrawer,
@@ -29172,7 +28858,6 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
 	network = list("Prison");
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/disposal/bin,
@@ -29195,8 +28880,7 @@
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -29237,8 +28921,7 @@
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -29360,7 +29043,6 @@
 	departmentType = 1;
 	name = "Medbay RC";
 	pixel_x = 30;
-	pixel_y = 0;
 	pixel_z = 0
 	},
 /obj/machinery/light,
@@ -29474,8 +29156,7 @@
 /obj/item/weapon/stock_parts/cell/high/plus,
 /obj/item/weapon/crowbar,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -29588,8 +29269,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -29677,8 +29357,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29735,7 +29414,6 @@
 	},
 /obj/machinery/flasher{
 	id = "hopflash";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -29881,8 +29559,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -29899,7 +29576,6 @@
 /area/science/lab)
 "bpq" = (
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -23
 	},
 /turf/open/floor/plasteel/white,
@@ -29935,12 +29611,10 @@
 	id = "MedbayFoyer";
 	name = "Medbay Exit Button";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -30053,7 +29727,6 @@
 	department = "Genetics";
 	departmentType = 0;
 	name = "Genetics Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/item/weapon/storage/pill_bottle/mutadone,
@@ -30212,11 +29885,9 @@
 /obj/item/weapon/folder/white,
 /obj/structure/table,
 /obj/item/weapon/disk/tech_disk{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/item/weapon/disk/tech_disk{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/item/weapon/disk/design_disk,
@@ -30364,8 +30035,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
@@ -30373,8 +30043,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
@@ -30514,8 +30183,7 @@
 	req_access_txt = "17"
 	},
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -30573,7 +30241,6 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/structure/sign/nosmoking_2{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30587,8 +30254,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -30602,8 +30268,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/whiteyellow/side{
@@ -30614,8 +30279,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/noticeboard{
 	pixel_y = 32
@@ -30634,8 +30298,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -30659,8 +30322,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -30671,8 +30333,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -30717,8 +30378,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -30731,8 +30391,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -30777,8 +30436,7 @@
 /area/medical/genetics)
 "brl" = (
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30962,7 +30620,6 @@
 "brA" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -31079,8 +30736,7 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/item/device/multitool,
 /obj/machinery/camera{
@@ -31183,8 +30839,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/vending/cart,
 /turf/open/floor/plasteel,
@@ -31192,7 +30847,6 @@
 "brX" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/masks{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/item/weapon/storage/box/gloves{
@@ -31374,7 +31028,6 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/light,
@@ -31408,14 +31061,12 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay East";
 	dir = 8;
 	network = list("SS13");
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/white,
@@ -31450,8 +31101,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -31459,8 +31109,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31471,8 +31120,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
@@ -31548,8 +31196,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Experimentation Lab APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -31732,7 +31379,6 @@
 	departmentType = 1;
 	name = "Medbay RC";
 	pixel_x = -30;
-	pixel_y = 0;
 	pixel_z = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31982,8 +31628,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32005,8 +31650,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/bluespace_beacon,
 /turf/open/floor/plasteel,
@@ -32016,8 +31660,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -32025,8 +31668,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -32039,8 +31681,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -32048,8 +31689,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -32146,7 +31786,6 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = 0;
 	pixel_y = -30;
 	receive_ore_updates = 1
 	},
@@ -32310,8 +31949,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32336,8 +31974,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32381,8 +32018,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32476,8 +32112,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32499,8 +32134,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32537,8 +32171,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32548,8 +32181,7 @@
 /area/medical/genetics)
 "buM" = (
 /obj/machinery/keycard_auth{
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/computer/cargo,
 /turf/open/floor/plasteel/blue/side{
@@ -32621,8 +32253,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32638,8 +32269,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/preopen{
@@ -32686,8 +32316,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/blue/side{
@@ -32701,8 +32330,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -32721,8 +32349,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32743,8 +32370,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -32894,8 +32520,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Research";
 	dir = 1;
-	network = list("SS13","RD");
-	pixel_x = 0
+	network = list("SS13","RD")
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -32933,7 +32558,6 @@
 	c_tag = "Genetics Access";
 	dir = 8;
 	network = list("SS13");
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -32978,8 +32602,7 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/item/weapon/coin/silver,
 /turf/open/floor/plasteel/brown{
@@ -33028,8 +32651,7 @@
 /area/security/checkpoint/supply)
 "bvM" = (
 /obj/machinery/light_switch{
-	pixel_x = -20;
-	pixel_y = 0
+	pixel_x = -20
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -33276,8 +32898,7 @@
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -33294,8 +32915,7 @@
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -33434,24 +33054,19 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Cryogenics";
 	dir = 2;
-	network = list("SS13");
-	pixel_x = 0;
+	network = list("SS13")
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
 	pixel_y = 0
 	},
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bwK" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -33547,8 +33162,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -33568,8 +33182,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33583,8 +33196,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33600,8 +33212,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33620,8 +33231,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -33697,8 +33307,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -33712,8 +33321,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -33728,8 +33336,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -33753,7 +33360,6 @@
 	id = "smindicate";
 	name = "external door control";
 	pixel_x = -26;
-	pixel_y = 0;
 	req_access_txt = "150"
 	},
 /obj/docking_port/mobile{
@@ -33800,7 +33406,6 @@
 	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
 	name = "Research Monitor";
 	network = list("RD","MiniSat");
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/structure/table,
@@ -33866,7 +33471,6 @@
 	id = "telelab";
 	name = "Test Chamber Blast Doors";
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "47"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -33975,8 +33579,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34097,7 +33700,6 @@
 "bxU" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
-	pixel_x = 0;
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
@@ -34113,8 +33715,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34201,7 +33802,6 @@
 /obj/structure/table,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/stamp/qm{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -34640,7 +34240,6 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
-	pixel_x = 0;
 	pixel_y = 30;
 	pixel_z = 0
 	},
@@ -34810,7 +34409,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Server Room APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -34821,8 +34419,7 @@
 /area/science/server)
 "bzz" = (
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/airalarm{
 	pixel_y = 25
@@ -34864,7 +34461,6 @@
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	name = "Research Monitor";
 	network = list("RD");
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -34967,8 +34563,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -34993,8 +34588,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -35055,8 +34649,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35161,8 +34754,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -35176,8 +34768,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -35264,8 +34855,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -35282,8 +34872,7 @@
 "bAz" = (
 /obj/machinery/airalarm/server{
 	dir = 4;
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -35366,8 +34955,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -35386,8 +34974,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -35472,7 +35059,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	pixel_x = -32;
-	pixel_y = 0;
 	supply_display = 1
 	},
 /turf/open/floor/plasteel/brown{
@@ -35574,11 +35160,9 @@
 "bBf" = (
 /obj/structure/filingcabinet,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/camera{
@@ -35593,8 +35177,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -35618,8 +35201,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -35632,8 +35214,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -35642,8 +35223,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway South-West";
@@ -35787,8 +35367,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35844,8 +35423,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -35934,7 +35512,6 @@
 	department = "Chief Medical Officer's Desk";
 	departmentType = 5;
 	name = "Chief Medical Officer RC";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/barber,
@@ -36109,7 +35686,6 @@
 /area/crew_quarters/heads/hor)
 "bCh" = (
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/light,
@@ -36199,8 +35775,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -36422,15 +35997,12 @@
 "bCT" = (
 /obj/structure/table,
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/clothing/neck/stethoscope,
@@ -36446,8 +36018,7 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay South";
@@ -36492,8 +36063,7 @@
 /area/crew_quarters/heads/cmo)
 "bDa" = (
 /obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/barber,
@@ -36565,8 +36135,7 @@
 /obj/machinery/requests_console{
 	department = "Mining";
 	departmentType = 0;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light{
 	dir = 8
@@ -36590,8 +36159,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -36656,8 +36224,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -36677,8 +36244,7 @@
 /obj/item/device/assembly/flash/handheld,
 /obj/item/device/assembly/flash/handheld,
 /obj/machinery/ai_status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -36727,8 +36293,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Treatment Center APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -36764,8 +36329,7 @@
 /area/medical/sleeper)
 "bDE" = (
 /obj/machinery/vending/wallmed{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
@@ -36916,8 +36480,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /mob/living/simple_animal/mouse,
 /turf/open/floor/plasteel/floorgrime,
@@ -36926,8 +36489,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/floorgrime,
@@ -36949,8 +36511,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -36962,8 +36523,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/science/storage)
@@ -36991,8 +36551,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -37005,8 +36564,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
@@ -37053,7 +36611,6 @@
 	c_tag = "Chief Medical Office";
 	dir = 8;
 	network = list("SS13");
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/barber,
@@ -37065,8 +36622,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
 	dir = 2;
-	network = list("Xeno","RD");
-	pixel_x = 0
+	network = list("Xeno","RD")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -37083,7 +36639,6 @@
 "bEp" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/structure/sign/nosmoking_2{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/delivery,
@@ -37135,7 +36690,6 @@
 "bEv" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37165,8 +36719,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Lab West";
 	dir = 2;
-	network = list("SS13","RD");
-	pixel_y = 0
+	network = list("SS13","RD")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -37279,8 +36832,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -37351,8 +36903,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
@@ -37370,8 +36921,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -37461,8 +37011,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37485,8 +37034,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -37528,8 +37076,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /turf/open/floor/plasteel/caution/corner{
@@ -37682,8 +37229,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -37732,8 +37278,7 @@
 "bFH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light_switch{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/heads/cmo)
@@ -37950,7 +37495,6 @@
 	pixel_y = -2
 	},
 /obj/item/device/assembly/prox_sensor{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -38126,8 +37670,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
@@ -38184,8 +37727,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -38215,8 +37757,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -38262,8 +37803,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -38380,8 +37920,7 @@
 /area/crew_quarters/heads/cmo)
 "bHc" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -38501,8 +38040,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
@@ -38562,8 +38100,7 @@
 	layer = 4;
 	name = "Test Chamber Telescreen";
 	network = list("Toxins");
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -38666,8 +38203,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -38679,8 +38215,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -38688,8 +38223,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -38725,7 +38259,6 @@
 "bHN" = (
 /obj/machinery/requests_console{
 	department = "Tech storage";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -38830,8 +38363,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -38889,8 +38421,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/caution/corner{
@@ -38908,7 +38439,6 @@
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Button";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "39"
 	},
 /obj/machinery/door/firedoor,
@@ -38957,8 +38487,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -38994,7 +38523,6 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
-	pixel_x = 0;
 	pixel_y = -30;
 	pixel_z = 0
 	},
@@ -39017,7 +38545,6 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/item/weapon/storage/firstaid/toxin{
@@ -39107,8 +38634,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -39122,8 +38648,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -39142,8 +38667,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -39335,8 +38859,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39588,8 +39111,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -39818,8 +39340,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
@@ -39915,7 +39436,6 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = 0;
 	pixel_y = -30;
 	receive_ore_updates = 1
 	},
@@ -39924,7 +39444,6 @@
 /area/science/mixing)
 "bJX" = (
 /obj/item/device/assembly/signaler{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /obj/item/device/assembly/signaler{
@@ -39960,7 +39479,6 @@
 	pixel_y = -4
 	},
 /obj/item/device/assembly/timer{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/structure/table/reinforced,
@@ -39970,8 +39488,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Toxins Lab APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -40061,8 +39578,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/closed/wall,
 /area/quartermaster/miningdock)
@@ -40229,11 +39745,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/sign/securearea{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40248,8 +39762,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -40265,8 +39778,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40281,8 +39793,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -40298,8 +39809,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Medbay APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -40317,8 +39827,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -40445,7 +39954,6 @@
 /obj/machinery/button/door{
 	id = "misclab";
 	name = "Test Chamber Blast Doors";
-	pixel_x = 0;
 	pixel_y = -2;
 	req_access_txt = "55"
 	},
@@ -40453,8 +39961,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40468,7 +39975,6 @@
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Moniter";
 	network = list("Xeno");
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -40584,7 +40090,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -40842,8 +40347,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -40912,8 +40416,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -40931,8 +40434,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -40946,8 +40448,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -41009,8 +40510,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -41027,8 +40527,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -41063,7 +40562,6 @@
 "bMp" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/white,
@@ -41088,7 +40586,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/engine/vacuum,
@@ -41155,7 +40652,6 @@
 	id_tag = "tox_airlock_control";
 	interior_door_tag = "tox_airlock_interior";
 	pixel_x = -24;
-	pixel_y = 0;
 	sanitize_external = 1;
 	sensor_tag = "tox_airlock_sensor"
 	},
@@ -41475,8 +40971,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -41584,8 +41079,7 @@
 /area/science/mixing)
 "bNz" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins Lab East";
@@ -41915,7 +41409,6 @@
 	dir = 8;
 	freerange = 1;
 	name = "Station Intercom (Telecoms)";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
@@ -41967,8 +41460,7 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
@@ -42240,8 +41732,7 @@
 	department = "Atmospherics";
 	departmentType = 4;
 	name = "Atmos RC";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42404,8 +41895,7 @@
 	dir = 4
 	},
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42473,7 +41963,6 @@
 "bPx" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/deathsposal{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/disposalpipe/trunk{
@@ -42523,8 +42012,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -42576,7 +42064,6 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = 0;
 	pixel_y = -30;
 	receive_ore_updates = 1
 	},
@@ -42731,8 +42218,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/device/radio/off,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -42982,8 +42468,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -43016,8 +42501,7 @@
 "bQO" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/light_switch{
-	pixel_x = -20;
-	pixel_y = 0
+	pixel_x = -20
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
@@ -43056,7 +42540,6 @@
 	departmentType = 2;
 	dir = 2;
 	name = "Science Requests Console";
-	pixel_x = 0;
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
@@ -43201,8 +42684,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -43223,8 +42705,7 @@
 	layer = 4;
 	name = "Engine Monitor";
 	network = list("Engine");
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -43419,8 +42900,7 @@
 "bRM" = (
 /obj/structure/table,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/white,
@@ -43527,8 +43007,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -43538,13 +43017,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/button/door{
 	id = "xenobio8";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -43557,8 +43034,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -43765,20 +43241,16 @@
 	},
 /obj/structure/table,
 /obj/item/weapon/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/item/weapon/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -43795,7 +43267,6 @@
 /area/engine/atmos)
 "bSD" = (
 /obj/structure/sign/atmosplaque{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/table,
@@ -43987,8 +43458,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 25
@@ -44011,7 +43481,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Virology APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -44053,8 +43522,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
@@ -44067,8 +43535,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -44089,8 +43556,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -44110,7 +43576,6 @@
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Moniter";
 	network = list("Test");
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -44336,8 +43801,7 @@
 	},
 /obj/item/weapon/pen,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -44505,8 +43969,7 @@
 	department = "Telecoms Admin";
 	departmentType = 5;
 	name = "Telecoms RC";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -44516,7 +43979,6 @@
 /obj/machinery/button/door{
 	id = "xenobio3";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -44526,8 +43988,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -44558,8 +44019,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -44611,7 +44071,6 @@
 "bUk" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
-	pixel_x = 0;
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
@@ -44670,8 +44129,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -44706,8 +44164,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -44719,8 +44176,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -44735,8 +44191,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -45039,8 +44494,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45098,8 +44552,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -45271,8 +44724,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45514,13 +44966,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/button/door{
 	id = "xenobio7";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -45654,7 +45104,6 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Telecoms Server APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -45778,8 +45227,7 @@
 /area/engine/atmos)
 "bWS" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics West";
@@ -45800,8 +45248,7 @@
 /area/engine/atmos)
 "bWT" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 0;
@@ -45917,8 +45364,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
@@ -45930,8 +45376,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -45998,7 +45443,6 @@
 "bXl" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46051,8 +45495,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -46227,8 +45670,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46292,8 +45734,7 @@
 /area/security/checkpoint/engineering)
 "bXQ" = (
 /obj/structure/fireaxecabinet{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -46385,7 +45826,6 @@
 /area/medical/virology)
 "bYb" = (
 /obj/machinery/vending/cigarette{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
@@ -46393,7 +45833,6 @@
 "bYc" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/deathsposal{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/disposalpipe/trunk{
@@ -46419,7 +45858,6 @@
 /obj/machinery/button/door{
 	id = "xenobio2";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -46429,8 +45867,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -46533,8 +45970,7 @@
 /area/science/misc_lab)
 "bYp" = (
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 10
@@ -46568,8 +46004,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -46821,8 +46256,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -46892,8 +46326,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/circuit{
 	name = "Mainframe Base";
@@ -46969,8 +46402,7 @@
 /area/tcommsat/computer)
 "bZw" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -46992,8 +46424,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/light{
 	dir = 8
@@ -47031,8 +46462,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
@@ -47220,15 +46650,13 @@
 /obj/machinery/button/door{
 	id = "xenobio6";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -47273,8 +46701,7 @@
 /area/science/misc_lab)
 "cab" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/corner{
@@ -47364,8 +46791,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -47408,8 +46834,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -47481,8 +46906,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47552,8 +46976,7 @@
 	department = "Atmospherics";
 	departmentType = 4;
 	name = "Atmos RC";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/light{
@@ -47746,8 +47169,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -47765,8 +47187,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
@@ -47778,8 +47199,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -47839,8 +47259,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Testing Lab APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -47930,8 +47349,7 @@
 "cbn" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
-	name = "SERVER ROOM";
-	pixel_y = 0
+	name = "SERVER ROOM"
 	},
 /turf/closed/wall,
 /area/tcommsat/computer)
@@ -47953,14 +47371,12 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "CE Office APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -48013,7 +47429,6 @@
 	c_tag = "Aft Primary Hallway 1";
 	dir = 8;
 	network = list("SS13");
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -48043,8 +47458,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -48197,8 +47611,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -48215,7 +47628,6 @@
 /obj/machinery/button/door{
 	id = "xenobio1";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -48225,8 +47637,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line{
@@ -48274,8 +47685,7 @@
 /obj/machinery/camera{
 	c_tag = "Testing Chamber";
 	dir = 1;
-	network = list("Test","RD");
-	pixel_x = 0
+	network = list("Test","RD")
 	},
 /obj/machinery/light,
 /turf/open/floor/engine,
@@ -48605,7 +48015,6 @@
 /area/engine/atmos)
 "ccE" = (
 /obj/structure/sign/nosmoking_2{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plating,
@@ -48721,8 +48130,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -48864,8 +48272,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -48877,8 +48284,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -48896,8 +48302,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -49019,8 +48424,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -49060,8 +48464,6 @@
 	node1_concentration = 0.8;
 	node2_concentration = 0.2;
 	on = 1;
-	pixel_x = 0;
-	pixel_y = 0;
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel,
@@ -49192,8 +48594,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -49283,8 +48684,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -49402,8 +48802,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -49466,8 +48865,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
@@ -49532,8 +48930,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
@@ -49552,7 +48949,6 @@
 /area/maintenance/aft)
 "ceE" = (
 /obj/structure/sign/fire{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -49649,7 +49045,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -49736,19 +49131,16 @@
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -49905,8 +49297,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 1
@@ -49916,8 +49307,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -49952,8 +49342,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -49984,7 +49373,6 @@
 	dir = 1
 	},
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/neutral{
@@ -50102,8 +49490,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -50117,7 +49504,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Incinerator APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -50143,7 +49529,6 @@
 /area/maintenance/disposal/incinerator)
 "cfZ" = (
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50166,7 +49551,6 @@
 "cgb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/deathsposal{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/trunk,
@@ -50258,8 +49642,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -50278,8 +49661,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
@@ -50389,8 +49771,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -50430,8 +49811,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
@@ -50440,8 +49820,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -50500,8 +49879,7 @@
 	department = "Chief Engineer's Desk";
 	departmentType = 3;
 	name = "Chief Engineer RC";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/computer/apc_control,
 /turf/open/floor/plasteel/neutral{
@@ -50533,9 +49911,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering East";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /obj/structure/closet/wardrobe/engineering_yellow,
 /turf/open/floor/plasteel/yellow/corner{
@@ -50943,8 +50319,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -50959,8 +50334,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -51047,8 +50421,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -51098,16 +50471,14 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/tank/internals/emergency_oxygen/engi{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 5
 	},
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/glasses/meson/engine,
@@ -51134,8 +50505,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -51162,8 +50532,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -51177,7 +50546,6 @@
 	cell_type = 15000;
 	dir = 1;
 	name = "Engineering APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -51252,8 +50620,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -51293,7 +50660,6 @@
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "11"
 	},
 /obj/machinery/button/door{
@@ -51524,8 +50890,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -51884,8 +51249,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -51893,8 +51257,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
@@ -52199,8 +51562,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -52570,7 +51932,6 @@
 "clh" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -31
 	},
 /obj/machinery/computer/turbine_computer{
@@ -52737,7 +52098,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
@@ -53093,7 +52453,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -53247,8 +52606,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
@@ -53265,8 +52623,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -53279,8 +52636,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -53336,8 +52692,7 @@
 	dir = 8
 	},
 /obj/structure/sign/fire{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -53347,8 +52702,7 @@
 	on = 1
 	},
 /obj/structure/sign/fire{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/doorButtons/access_button{
 	idSelf = "incinerator_access_control";
@@ -53427,8 +52781,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
@@ -53441,8 +52794,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 2;
@@ -53517,9 +52869,7 @@
 /obj/machinery/camera{
 	c_tag = "SMES Room";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	on = 1;
@@ -53683,8 +53033,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -53721,8 +53070,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -53832,9 +53180,7 @@
 /obj/machinery/camera{
 	c_tag = "SMES Access";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13")
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -53858,8 +53204,7 @@
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -54079,7 +53424,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/engine/vacuum,
@@ -54305,8 +53649,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/highpressure/fulltile,
@@ -54332,8 +53675,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54429,8 +53771,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 30
@@ -54535,8 +53876,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -54620,8 +53960,7 @@
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -54656,8 +53995,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
@@ -54675,8 +54013,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -54693,8 +54030,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -54706,8 +54042,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -54749,8 +54084,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -54801,7 +54135,6 @@
 /area/shuttle/pod_4)
 "cpK" = (
 /obj/machinery/computer/shuttle/pod{
-	pixel_x = 0;
 	pixel_y = -32;
 	possible_destinations = "pod_lavaland2";
 	shuttleId = "pod2"
@@ -54812,7 +54145,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -54823,7 +54155,6 @@
 	pixel_y = -28
 	},
 /obj/item/device/radio/intercom{
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/chair{
@@ -55016,7 +54347,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/camera{
@@ -55044,7 +54374,6 @@
 /obj/machinery/button/door{
 	id = "engsm";
 	name = "Radiation Shutters Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "10"
 	},
@@ -55087,8 +54416,7 @@
 /area/maintenance/port/aft)
 "cqo" = (
 /obj/structure/sign/pods{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -55127,7 +54455,6 @@
 /area/hallway/secondary/entry)
 "cqs" = (
 /obj/structure/sign/fire{
-	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/closed/wall/r_wall,
@@ -55172,8 +54499,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -55410,7 +54736,6 @@
 	dir = 4;
 	locked = 0;
 	pixel_x = -23;
-	pixel_y = 0;
 	req_access = null;
 	req_one_access_txt = "24;10"
 	},
@@ -55644,8 +54969,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -55672,8 +54996,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -55924,7 +55247,6 @@
 	dir = 1;
 	name = "turbine vent monitor";
 	network = list("Turbine");
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -56012,8 +55334,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/engine/supermatter)
@@ -56043,9 +55364,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -56183,7 +55502,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
@@ -56209,8 +55527,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -56253,7 +55570,6 @@
 "cth" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /obj/machinery/light/small,
@@ -56272,8 +55588,6 @@
 	c_tag = "MiniSat Pod Access";
 	dir = 1;
 	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -56390,8 +55704,7 @@
 "ctw" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/computer/station_alert,
 /turf/open/floor/plasteel/vault{
@@ -56458,7 +55771,6 @@
 /obj/machinery/button/door{
 	id = "teledoor";
 	name = "MiniSat Teleport Shutters Control";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "17;65"
 	},
@@ -56479,8 +55791,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -56557,7 +55868,6 @@
 "ctQ" = (
 /obj/structure/table,
 /obj/machinery/microwave{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/machinery/firealarm{
@@ -56572,9 +55882,7 @@
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/closed/wall,
 /area/engine/engineering)
@@ -56586,8 +55894,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -56622,8 +55929,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "MiniSat Foyer APC";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/structure/chair,
 /turf/open/floor/plasteel/black,
@@ -56637,8 +55943,6 @@
 	c_tag = "MiniSat Teleporter";
 	dir = 1;
 	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -56664,7 +55968,6 @@
 "cub" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /obj/machinery/light/small,
@@ -56688,7 +55991,6 @@
 	enabled = 1;
 	icon_state = "control_standby";
 	name = "Antechamber Turret Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "65"
 	},
@@ -56933,14 +56235,11 @@
 	c_tag = "MiniSat Atmospherics";
 	dir = 4;
 	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/line{
@@ -56954,8 +56253,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
@@ -56980,8 +56278,6 @@
 	c_tag = "MiniSat Antechamber";
 	dir = 4;
 	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /obj/machinery/turretid{
@@ -56990,7 +56286,6 @@
 	icon_state = "control_standby";
 	name = "Atmospherics Turret Control";
 	pixel_x = -27;
-	pixel_y = 0;
 	req_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -57016,7 +56311,6 @@
 	icon_state = "control_standby";
 	name = "Service Bay Turret Control";
 	pixel_x = 27;
-	pixel_y = 0;
 	req_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
@@ -57043,8 +56337,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -57076,8 +56369,6 @@
 	c_tag = "MiniSat Service Bay";
 	dir = 8;
 	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /obj/machinery/airalarm{
@@ -57101,8 +56392,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -57113,8 +56403,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "MiniSat Atmospherics APC";
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -57130,8 +56419,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -57142,8 +56430,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -57155,8 +56442,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57167,8 +56453,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57184,8 +56469,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57220,8 +56504,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -57232,8 +56515,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57249,8 +56531,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/turret_protected/aisat/service)
@@ -57258,8 +56539,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -57275,8 +56555,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "MiniSat Service Bay APC";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -57313,8 +56592,7 @@
 /area/ai_monitored/turret_protected/ai)
 "cvc" = (
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -57335,8 +56613,7 @@
 	dir = 4
 	},
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -57479,7 +56756,6 @@
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/item/device/radio/intercom{
@@ -57496,7 +56772,6 @@
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /turf/open/floor/circuit,
@@ -57523,7 +56798,6 @@
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/item/device/radio/intercom{
@@ -57540,7 +56814,6 @@
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /turf/open/floor/circuit,
@@ -57573,8 +56846,6 @@
 	c_tag = "MiniSat External NorthWest";
 	dir = 8;
 	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /turf/open/space,
@@ -57630,16 +56901,13 @@
 	c_tag = "MiniSat External NorthEast";
 	dir = 4;
 	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /turf/open/space,
 /area/space)
 "cvL" = (
 /obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -57658,8 +56926,7 @@
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvN" = (
 /obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -57722,8 +56989,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
@@ -57755,8 +57021,7 @@
 "cvZ" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
@@ -57765,8 +57030,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "MiniSat Chamber Hallway APC";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
@@ -57912,8 +57176,7 @@
 "cwp" = (
 /obj/structure/chair/office/dark,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/turret_protected/ai)
@@ -57972,8 +57235,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58017,8 +57279,7 @@
 	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/turret_protected/ai)
@@ -58101,8 +57362,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -58149,7 +57409,6 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -58170,7 +57429,6 @@
 "cwR" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -58309,7 +57567,6 @@
 /area/security/warden)
 "cxl" = (
 /obj/machinery/computer/shuttle/pod{
-	pixel_x = 0;
 	pixel_y = -32;
 	possible_destinations = "pod_lavaland1";
 	shuttleId = "pod1"
@@ -58320,7 +57577,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -58342,8 +57598,7 @@
 /area/shuttle/escape)
 "cxp" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -58400,7 +57655,6 @@
 	pixel_y = -28
 	},
 /obj/item/device/radio/intercom{
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/chair{
@@ -58440,8 +57694,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/transport)
@@ -58515,7 +57768,6 @@
 /area/shuttle/escape)
 "cxL" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -58558,8 +57810,7 @@
 /area/shuttle/escape)
 "cxR" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
@@ -58579,8 +57830,7 @@
 	},
 /obj/item/weapon/crowbar,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -58895,8 +58145,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -58986,8 +58235,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 1;
@@ -59244,8 +58492,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -59275,7 +58522,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -59325,8 +58571,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -59362,8 +58607,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59374,8 +58618,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59400,8 +58643,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59506,8 +58748,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
@@ -59646,8 +58887,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -59724,8 +58964,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/power/apc{
 	dir = 2;
@@ -59784,8 +59023,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59844,7 +59082,6 @@
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_x = 0;
 	pixel_y = -31
 	},
 /obj/item/device/radio/intercom{
@@ -59881,8 +59118,6 @@
 	c_tag = "MiniSat External SouthWest";
 	dir = 8;
 	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /turf/open/space,
@@ -59932,8 +59167,6 @@
 	c_tag = "MiniSat External SouthEast";
 	dir = 4;
 	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /turf/open/space,
@@ -59942,8 +59175,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/ai)
@@ -60004,8 +59236,6 @@
 	c_tag = "MiniSat External South";
 	dir = 2;
 	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
 	start_active = 1
 	},
 /turf/open/space,
@@ -60212,8 +59442,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
@@ -60272,8 +59501,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60469,8 +59697,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -60481,8 +59708,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Detective's Office APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -60577,7 +59803,6 @@
 "cCB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
-	pixel_x = 0;
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -60782,8 +60007,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -60797,8 +60021,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -60813,8 +60036,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60888,8 +60110,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -60897,8 +60118,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -60912,8 +60132,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -60929,8 +60148,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -61274,9 +60492,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Starboard";
 	dir = 8;
-	network = list("SS13","Engine");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13","Engine")
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -61366,8 +60582,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/engine/supermatter)
@@ -61440,8 +60655,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/engine/supermatter)
@@ -61562,8 +60776,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/tank/internals/plasma,
 /turf/open/floor/plating,
@@ -61632,8 +60845,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/engine/supermatter)
@@ -61779,8 +60991,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/engine/supermatter)
@@ -62663,8 +61874,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62688,8 +61898,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62706,8 +61915,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62724,8 +61932,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -62747,8 +61954,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62765,8 +61971,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62785,8 +61990,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62814,8 +62018,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -63330,7 +62533,6 @@
 	id = "smindicate";
 	name = "external door control";
 	pixel_x = -26;
-	pixel_y = 0;
 	req_access_txt = "150"
 	},
 /obj/docking_port/mobile{
@@ -63591,8 +62793,7 @@
 /area/shuttle/syndicate)
 "cJR" = (
 /obj/item/weapon/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/item/weapon/reagent_containers/glass/bottle/charcoal{
 	pixel_x = -3
@@ -64054,8 +63255,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 30
@@ -64524,8 +63724,7 @@
 	layer = 4;
 	name = "Engine Monitor";
 	network = list("Engine");
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -65015,8 +64214,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -65028,8 +64226,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -65040,8 +64237,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -65059,8 +64255,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -65068,8 +64263,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Starboard Maintenace APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -65112,8 +64306,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -65633,8 +64826,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65648,8 +64840,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65663,8 +64854,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65678,8 +64868,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65693,8 +64882,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65708,8 +64896,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -66101,8 +65288,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black{
 	name = "Mainframe Floor";
@@ -66127,8 +65313,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -66155,8 +65340,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -26321,6 +26321,7 @@
 	dir = 2
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -27692,6 +27693,7 @@
 "blu" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -32380,7 +32380,6 @@
 /area/medical/medbay/central)
 "bvl" = (
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = "";
 	name = "Surgery Observation";
 	req_access_txt = "0"
 	},

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -1100,7 +1100,6 @@
 /area/security/prison)
 "acK" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -5978,7 +5977,6 @@
 /area/maintenance/port/fore)
 "amD" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -12741,7 +12739,6 @@
 /area/maintenance/starboard/fore)
 "aCm" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -13392,13 +13389,11 @@
 /area/crew_quarters/dorms)
 "aDL" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -14533,7 +14528,6 @@
 /area/ai_monitored/storage/eva)
 "aGk" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -15394,7 +15388,6 @@
 	on = 1
 	},
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -18313,7 +18306,6 @@
 /area/hallway/secondary/exit)
 "aOV" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -22496,7 +22488,6 @@
 "aZo" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -22834,7 +22825,6 @@
 /area/crew_quarters/kitchen)
 "bal" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -22935,7 +22925,6 @@
 "baw" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -23845,7 +23834,6 @@
 "bcO" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/freezer,
@@ -26442,7 +26430,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -27818,7 +27805,6 @@
 "blH" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -28203,7 +28189,6 @@
 "bmC" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -33599,7 +33584,6 @@
 /area/security/checkpoint/checkpoint2)
 "bxN" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -37173,7 +37157,6 @@
 "bFA" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/white,
@@ -38742,7 +38725,6 @@
 /area/medical/virology)
 "bIK" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -39975,7 +39957,6 @@
 /area/science/xenobiology)
 "bLd" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -43898,7 +43879,6 @@
 	pixel_x = -22
 	},
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -44493,7 +44473,6 @@
 "bVk" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/white,
@@ -46153,7 +46132,6 @@
 /area/medical/virology)
 "bZa" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
@@ -53705,7 +53683,6 @@
 "coV" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{
@@ -63183,7 +63160,6 @@
 "cLf" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11
 	},
 /obj/structure/mirror{

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -13746,7 +13746,6 @@
 /area/shuttle/arrival)
 "aEy" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
@@ -57574,7 +57573,6 @@
 /area/shuttle/pod_1)
 "cxy" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced,
@@ -57599,7 +57597,6 @@
 /area/shuttle/transport)
 "cxD" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -57892,7 +57889,6 @@
 /area/shuttle/abandoned)
 "cyo" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -59692,7 +59688,6 @@
 /area/shuttle/transport)
 "cCy" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced{

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -6527,9 +6527,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "anJ" = (
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "anK" = (
@@ -14317,9 +14315,7 @@
 	},
 /area/security/checkpoint/checkpoint2)
 "aFJ" = (
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -33699,7 +33695,7 @@
 /area/medical/sleeper)
 "bxU" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
@@ -34277,7 +34273,7 @@
 /area/medical/sleeper)
 "bzi" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
@@ -40829,7 +40825,7 @@
 /area/engine/atmos)
 "bMW" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41333,7 +41329,7 @@
 /area/engine/atmos)
 "bOe" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
+	dir = 8
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -41341,7 +41337,7 @@
 "bOf" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10;
+	dir = 10
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -42854,13 +42850,13 @@
 	on = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRH" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5;
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -43087,7 +43083,7 @@
 /area/science/misc_lab)
 "bSg" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
@@ -43394,7 +43390,7 @@
 "bSP" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -43880,7 +43876,7 @@
 /area/engine/atmos)
 "bTR" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -44070,7 +44066,7 @@
 /area/science/misc_lab)
 "bUk" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
@@ -44575,7 +44571,7 @@
 /area/engine/break_room)
 "bVn" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
@@ -44862,7 +44858,7 @@
 /area/engine/atmos)
 "bWa" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -46024,7 +46020,7 @@
 /area/maintenance/port/aft)
 "bYx" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/port/aft)
@@ -46159,7 +46155,7 @@
 /area/engine/atmos)
 "bYS" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -46518,7 +46514,7 @@
 /area/engine/atmos)
 "bZH" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/item/weapon/wrench,
 /turf/open/floor/plasteel,
@@ -49462,6 +49458,7 @@
 "cfS" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
+	
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -50776,7 +50773,7 @@
 /area/maintenance/disposal/incinerator)
 "ciz" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
@@ -55270,7 +55267,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
@@ -58464,7 +58461,7 @@
 /area/space/nearstation)
 "czE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -59802,7 +59799,7 @@
 /area/space)
 "cCB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10;
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -61332,7 +61329,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -61471,7 +61468,7 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -61480,7 +61477,7 @@
 /obj/structure/window/reinforced/highpressure/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -65324,7 +65321,7 @@
 "cSI" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
@@ -78558,9 +78555,9 @@ ase
 avq
 aum
 avq
-axJ
+avq
 cwH
-axJ
+avq
 aAj
 aBK
 aCL
@@ -79589,7 +79586,7 @@ bsU
 axf
 amC
 alU
-auT
+aAM
 aBI
 aDf
 aEK
@@ -81129,7 +81126,7 @@ avb
 aaH
 bOi
 atO
-asK
+aud
 azF
 aAT
 aBw
@@ -81386,7 +81383,7 @@ aaH
 bNb
 apQ
 atO
-asK
+aud
 azF
 aAS
 aFP
@@ -81643,7 +81640,7 @@ avU
 avb
 bOi
 atO
-asK
+aud
 azF
 aAU
 aBG
@@ -81900,7 +81897,7 @@ alU
 ali
 alU
 atO
-asK
+aud
 azF
 aAP
 aAP
@@ -82157,7 +82154,7 @@ amC
 amC
 amC
 axi
-asK
+aud
 azF
 azF
 azF
@@ -82425,7 +82422,7 @@ aHe
 aIN
 aKp
 aLE
-aNm
+aNn
 aOl
 aPA
 aQN
@@ -85010,7 +85007,7 @@ aYU
 bbr
 bcu
 bfe
-bgx
+aYb
 aZE
 bjm
 bjr
@@ -85267,7 +85264,7 @@ aPA
 aPA
 aPA
 aWv
-bgx
+aYb
 aZE
 bjp
 bjr
@@ -85569,7 +85566,7 @@ cdW
 ceW
 bCq
 cgD
-cgH
+bUs
 bHE
 cjI
 bCq
@@ -85822,11 +85819,11 @@ bYy
 bHE
 bTz
 bHE
-cdY
+bUs
 ceY
 bCq
 bHE
-cgH
+bUs
 bHE
 bLu
 bCq
@@ -86853,7 +86850,7 @@ bCq
 bCq
 bCq
 bLv
-cgH
+bUs
 bLv
 aaa
 bCq
@@ -87110,7 +87107,7 @@ aoV
 aoV
 aoV
 bLv
-cgH
+bUs
 bLv
 aaa
 bLv
@@ -87367,7 +87364,7 @@ aoV
 aoV
 apQ
 bLv
-cgH
+bUs
 bLv
 aaf
 cAj
@@ -87566,7 +87563,7 @@ ayE
 ayE
 aLl
 aMT
-aOu
+aOi
 aPL
 aPK
 aSm
@@ -87624,7 +87621,7 @@ aoV
 aoV
 aoV
 bLv
-cgH
+bUs
 bLv
 aaa
 cjJ
@@ -87881,7 +87878,7 @@ aoV
 aoV
 aoV
 bLv
-cgH
+bUs
 bLv
 aaa
 cjJ
@@ -88138,7 +88135,7 @@ apQ
 apQ
 apQ
 bLv
-cgH
+bUs
 bLv
 aaf
 cjJ
@@ -88395,7 +88392,7 @@ aoV
 aoV
 aoV
 bLv
-cgH
+bUs
 bLv
 aaa
 cjJ
@@ -88652,7 +88649,7 @@ aoV
 aoV
 aoV
 bLv
-cgH
+bUs
 bLv
 aaa
 cjJ
@@ -88909,7 +88906,7 @@ aoV
 apQ
 apQ
 bLv
-cgH
+bUs
 bLv
 aaf
 cjJ
@@ -89166,7 +89163,7 @@ aoV
 aoV
 aoV
 bCq
-cgH
+bUs
 bCq
 aaa
 aaf
@@ -89423,7 +89420,7 @@ bES
 bES
 bES
 car
-cgH
+bUs
 bCq
 bCq
 bCq
@@ -89668,17 +89665,17 @@ bLv
 bLv
 bTA
 bUu
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
-bVH
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
 caq
 cbw
 ccu
@@ -90120,8 +90117,8 @@ apS
 aqT
 apS
 apS
-atX
-atX
+apS
+apS
 awe
 axw
 ayI
@@ -90158,12 +90155,12 @@ bmm
 bnM
 boV
 bnM
-brT
-brT
-brT
-brT
-brT
-brT
+bnM
+bnM
+bnM
+bnM
+bnM
+bnM
 bAe
 bBg
 bCq
@@ -90181,7 +90178,7 @@ bGp
 bGp
 bES
 bTC
-bUw
+bAx
 bVI
 bWB
 bWB
@@ -90438,7 +90435,7 @@ aaa
 aaa
 bCq
 bTF
-bUw
+bAx
 bVI
 bWD
 bXA
@@ -90695,7 +90692,7 @@ aaf
 aaf
 bCq
 bTE
-bUw
+bAx
 bVI
 bWC
 bXz
@@ -90952,7 +90949,7 @@ bKv
 bLB
 bES
 bMj
-bUw
+bAx
 bVI
 bWF
 bXC
@@ -91667,7 +91664,7 @@ cCi
 awg
 axy
 ayv
-azE
+azP
 aBn
 aCb
 aDD
@@ -91924,7 +91921,7 @@ cCi
 awg
 axy
 ayQ
-azE
+azP
 aBq
 aBr
 aDE
@@ -92181,7 +92178,7 @@ avh
 awh
 axz
 ayO
-azE
+azP
 aBp
 aCc
 aDF
@@ -92477,7 +92474,7 @@ bnS
 bwl
 bxG
 byR
-brT
+bnM
 bBl
 bCs
 bDz
@@ -93020,7 +93017,7 @@ bVb
 bWv
 cei
 bVJ
-caB
+cay
 ccw
 cif
 cgR
@@ -93277,7 +93274,7 @@ bUC
 bWu
 bVJ
 bVJ
-caB
+cay
 ccw
 cie
 cdT
@@ -94214,7 +94211,7 @@ cqG
 aeX
 ago
 agS
-ahw
+agQ
 ahR
 aiJ
 ajc
@@ -95083,7 +95080,7 @@ cgO
 ceo
 ceq
 cfa
-cmQ
+cje
 cgR
 ccw
 cDi
@@ -95340,7 +95337,7 @@ cdU
 ceo
 ceq
 clQ
-cmQ
+cje
 cgR
 cMm
 chX
@@ -95845,7 +95842,7 @@ bTg
 bUm
 bVp
 bXH
-bZf
+bUm
 bZC
 cbp
 cck
@@ -99445,7 +99442,7 @@ bTU
 cdz
 cez
 bUL
-cfS
+cfP
 bOd
 bMQ
 apQ
@@ -99878,7 +99875,7 @@ aif
 aif
 aif
 alK
-alM
+aif
 bkV
 anc
 anD
@@ -101952,7 +101949,7 @@ aro
 aCv
 aaf
 alP
-aGJ
+aGK
 aIe
 aJE
 aKQ
@@ -102766,14 +102763,14 @@ bDR
 bIn
 bJC
 bKL
-bLT
-bLT
-bLT
-bLT
-bLT
-bLT
-bLT
-bLT
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
 bUY
 bWe
 bWe
@@ -103031,7 +103028,7 @@ bNc
 bNc
 bNc
 bTY
-bUX
+bKH
 bzs
 bWV
 bzs
@@ -103039,7 +103036,7 @@ bzs
 bZM
 cbJ
 ceC
-cfV
+ceC
 cfW
 cfX
 chk
@@ -103288,7 +103285,7 @@ bQE
 bRM
 bOr
 bTZ
-bUX
+bKH
 bzs
 bAw
 bBR
@@ -103545,7 +103542,7 @@ bQD
 bLY
 bMa
 bTZ
-bUX
+bKH
 bzs
 bAw
 bXZ
@@ -104322,7 +104319,7 @@ bWX
 bOP
 bNd
 bTZ
-bUX
+bKH
 bzs
 bzs
 bzs
@@ -104779,7 +104776,7 @@ aBE
 alP
 aDX
 alP
-aGR
+aGK
 avI
 aJL
 aKX
@@ -105095,7 +105092,7 @@ bNd
 bNd
 bzs
 bzs
-ccH
+bMb
 cdK
 ceH
 cfn
@@ -106123,7 +106120,7 @@ bNd
 bzs
 bzs
 bzs
-ccH
+bMb
 bFr
 ceK
 ceJ
@@ -106557,7 +106554,7 @@ adU
 adU
 adU
 alg
-alN
+acx
 amv
 ane
 cxN
@@ -107139,16 +107136,16 @@ bMe
 bIg
 bIM
 bPv
-bLT
-bLT
-bLT
-bLT
-bLT
-bLT
-bLT
-bLT
-bLT
-bLT
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
+bPv
 caT
 cbP
 ccO
@@ -107862,7 +107859,7 @@ anf
 anf
 alP
 aCG
-aFt
+aDZ
 aFu
 aFu
 aFu

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -2576,7 +2576,6 @@
 /area/security/transfer)
 "afv" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
@@ -2619,7 +2618,6 @@
 	pressure_checks = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
@@ -6393,7 +6391,6 @@
 /area/maintenance/port/fore)
 "anl" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -6602,7 +6599,6 @@
 /area/maintenance/solars/port/fore)
 "anJ" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6831,7 +6827,6 @@
 /area/maintenance/port/fore)
 "aok" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -7873,14 +7868,12 @@
 /area/maintenance/port/fore)
 "aqL" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqM" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/machinery/meter,
@@ -8218,14 +8211,12 @@
 /area/construction/mining/aux_base)
 "arF" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "arG" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/closed/wall,
@@ -8237,7 +8228,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -8249,7 +8239,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -8266,14 +8255,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arK" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating{
@@ -8287,7 +8274,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -14479,7 +14465,6 @@
 /area/security/checkpoint/checkpoint2)
 "aFJ" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	icon_state = "intact";
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
@@ -44264,7 +44249,6 @@
 /area/maintenance/port/aft)
 "bTt" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/wood{
@@ -44280,7 +44264,6 @@
 /area/maintenance/port/aft)
 "bTv" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -44290,7 +44273,6 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -44307,7 +44289,6 @@
 /obj/structure/grille,
 /obj/structure/window/fulltile,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -44697,7 +44678,6 @@
 "bUr" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/space,
@@ -45257,7 +45237,6 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -47646,7 +47625,6 @@
 "caJ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/space,
@@ -48195,7 +48173,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -49649,7 +49626,6 @@
 /area/maintenance/starboard/aft)
 "ceN" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -55608,7 +55584,6 @@
 /area/engine/engineering)
 "crs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
@@ -56591,7 +56566,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "ctN" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/lattice,
@@ -56600,7 +56574,6 @@
 "ctO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/space,
@@ -59274,7 +59247,6 @@
 /area/space/nearstation)
 "czE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -60906,7 +60878,6 @@
 "cDk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/grille,
@@ -62105,7 +62076,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/engine,
@@ -62187,7 +62157,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -62327,7 +62296,6 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -62337,7 +62305,6 @@
 /obj/structure/window/reinforced/highpressure/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -66208,7 +66175,6 @@
 "cSI" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -34099,7 +34099,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
 	pixel_x = 0;
-	initialize_directions = 10
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
@@ -34681,7 +34680,6 @@
 "bzi" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
@@ -35959,7 +35957,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -41119,7 +41116,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
 	external_pressure_bound = 0;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -41339,7 +41335,6 @@
 "bMW" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41846,7 +41841,6 @@
 "bOe" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -41855,7 +41849,6 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	initialize_directions = 10
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -42380,7 +42373,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "mix_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -43383,14 +43375,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
-	initialize_directions = 12
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRH" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5;
-	initialize_directions = 12
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -43623,7 +43613,6 @@
 "bSg" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
@@ -43936,7 +43925,6 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -44430,7 +44418,6 @@
 "bTR" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -44474,7 +44461,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2o_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -44627,7 +44613,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
 	pixel_x = 0;
-	initialize_directions = 10
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
@@ -45139,7 +45124,6 @@
 "bVn" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
@@ -45428,7 +45412,6 @@
 "bWa" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -46376,7 +46359,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "tox_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -46609,7 +46591,6 @@
 "bYx" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/port/aft)
@@ -46745,7 +46726,6 @@
 "bYS" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
@@ -47110,7 +47090,6 @@
 "bZH" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/item/weapon/wrench,
 /turf/open/floor/plasteel,
@@ -48158,7 +48137,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "co2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -50097,7 +50075,6 @@
 "cfS" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4;
-	initialize_directions = 12
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -50268,7 +50245,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
 	external_pressure_bound = 120;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -51436,7 +51412,6 @@
 "ciz" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
@@ -52492,7 +52467,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "n2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -52521,7 +52495,6 @@
 	external_pressure_bound = 0;
 	frequency = 1441;
 	id_tag = "o2_out";
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
 	pressure_checks = 2;
@@ -54098,7 +54071,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 0;
-	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 0;
 	pressure_checks = 2;
@@ -55979,7 +55951,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
-	initialize_directions = 11
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
@@ -60609,7 +60580,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
 	pixel_x = 0;
-	initialize_directions = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)

--- a/_maps/map_files/generic/Centcomm.dmm
+++ b/_maps/map_files/generic/Centcomm.dmm
@@ -4790,7 +4790,6 @@
 "mD" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 11;
 	pixel_y = 0
 	},
@@ -11495,7 +11494,6 @@
 "Cq" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{
@@ -11564,7 +11562,6 @@
 "CA" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{
@@ -11704,7 +11701,6 @@
 "CO" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{
@@ -11737,7 +11733,6 @@
 "CR" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /turf/open/floor/plasteel/bar,
@@ -11774,7 +11769,6 @@
 "CW" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{

--- a/_maps/map_files/generic/Centcomm.dmm
+++ b/_maps/map_files/generic/Centcomm.dmm
@@ -98,8 +98,7 @@
 "ap" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green{
-	layer = 3.3;
-	pixel_y = 0
+	layer = 3.3
 	},
 /turf/open/floor/holofloor{
 	icon_state = "wood";
@@ -147,12 +146,10 @@
 /obj/effect/holodeck_effect/mobspawner/penguin,
 /obj/effect/holodeck_effect/mobspawner/penguin,
 /obj/item/toy/snowball{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/toy/snowball{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 5
 	},
 /obj/item/toy/snowball{
 	pixel_x = -4
@@ -3064,7 +3061,6 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/ears/earmuffs,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -3152,8 +3148,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	name = "cargo display";
-	pixel_x = 0;
-	pixel_y = 0;
 	supply_display = 1
 	},
 /turf/closed/indestructible/riveted,
@@ -3251,8 +3245,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/open/floor/plating,
 /area/centcom/supply)
@@ -3313,8 +3306,7 @@
 "jk" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3472,8 +3464,7 @@
 "jA" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3493,7 +3484,6 @@
 	dir = 8;
 	icon_state = "nboard00";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-nboard00 (WEST)"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3913,8 +3903,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -4004,7 +3993,6 @@
 "kK" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/brown,
@@ -4250,7 +4238,6 @@
 	dir = 8;
 	icon_state = "nboard00";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-nboard00 (WEST)"
 	},
 /turf/open/floor/plasteel/vault,
@@ -4346,8 +4333,6 @@
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
 	name = "WARNING: BLAST DOORS";
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "icon-doors"
 	},
 /turf/open/floor/plating,
@@ -4359,7 +4344,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/vault{
@@ -4475,7 +4459,6 @@
 	dir = 8;
 	icon_state = "nboard00";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-nboard00 (WEST)"
 	},
 /turf/open/floor/plasteel/brown{
@@ -4782,8 +4765,7 @@
 "mD" = (
 /obj/structure/sink{
 	dir = 4;
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror/magic/badmin{
 	pixel_x = 28
@@ -4844,7 +4826,6 @@
 "mJ" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/closet/crate/bin,
@@ -4858,7 +4839,6 @@
 "mK" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/brown{
@@ -4995,8 +4975,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -5067,7 +5046,6 @@
 /area/centcom/ferry)
 "nk" = (
 /obj/machinery/status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -5088,7 +5066,6 @@
 	department = "Captain's Desk";
 	departmentType = 5;
 	name = "Captain RC";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -5108,7 +5085,6 @@
 /obj/item/weapon/pen/fourcolor,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = 32;
 	req_access_txt = "0";
 	use_power = 0
@@ -5517,7 +5493,6 @@
 	dir = 8;
 	icon_state = "nboard00";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-nboard00 (WEST)"
 	},
 /turf/open/floor/plasteel/vault{
@@ -5597,8 +5572,7 @@
 /obj/item/clothing/glasses/eyepatch,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
@@ -5635,8 +5609,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen/red,
@@ -5776,7 +5749,6 @@
 /obj/item/weapon/lighter,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/vault{
@@ -5886,7 +5858,6 @@
 "oY" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/vault{
@@ -6090,8 +6061,7 @@
 	name = "memo"
 	},
 /obj/structure/noticeboard{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/bar{
 	dir = 2
@@ -6269,7 +6239,6 @@
 	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
 	name = "Research Monitor";
 	network = list("RD","Sat");
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/grimy,
@@ -6295,8 +6264,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Commander's Office APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal{
@@ -6564,7 +6532,6 @@
 	dir = 8;
 	icon_state = "nboard00";
 	pixel_x = 32;
-	pixel_y = 0;
 	tag = "icon-nboard00 (WEST)"
 	},
 /turf/open/floor/plasteel/green/side{
@@ -7118,7 +7085,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -7139,7 +7105,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -7337,7 +7302,6 @@
 /obj/machinery/button/door{
 	id = "XCCFerry";
 	name = "Hanger Bay Shutters";
-	pixel_x = 0;
 	pixel_y = -38;
 	req_access_txt = "0"
 	},
@@ -7372,7 +7336,6 @@
 "sk" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/closet/crate/bin,
@@ -7415,7 +7378,6 @@
 "sp" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/vault{
@@ -7480,8 +7442,6 @@
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
 	name = "WARNING: BLAST DOORS";
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "icon-doors"
 	},
 /turf/open/floor/plating,
@@ -7522,7 +7482,6 @@
 	id = "nukeop_ready";
 	name = "mission launch control";
 	pixel_x = -26;
-	pixel_y = 0;
 	req_access_txt = "151"
 	},
 /turf/open/floor/plasteel/bar{
@@ -7809,7 +7768,6 @@
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	tag = "icon-doors"
 	},
 /turf/open/floor/plating,
@@ -8152,7 +8110,6 @@
 /obj/machinery/button/door{
 	id = "XCCFerry";
 	name = "Hanger Bay Shutters";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "2"
 	},
@@ -8384,8 +8341,6 @@
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
 	name = "WARNING: BLAST DOORS";
-	pixel_x = 0;
-	pixel_y = 0;
 	tag = "icon-doors"
 	},
 /turf/open/floor/plating,
@@ -9350,8 +9305,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Briefing Area APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -9514,8 +9468,7 @@
 /area/centcom/control)
 "xJ" = (
 /obj/item/weapon/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/item/weapon/reagent_containers/glass/bottle/charcoal{
 	pixel_x = -3
@@ -9857,7 +9810,6 @@
 /obj/structure/closet/secure_closet/ertMed,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = -32;
 	req_access_txt = "0";
 	use_power = 0
@@ -9962,8 +9914,7 @@
 /obj/structure/filingcabinet/medical,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -9991,8 +9942,7 @@
 "yD" = (
 /obj/machinery/computer/security,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -10111,8 +10061,7 @@
 /obj/machinery/door/firedoor,
 /obj/item/weapon/storage/fancy/donut_box,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -11612,8 +11561,7 @@
 "CH" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/bar,
 /area/tdome/tdomeobserve)
@@ -11801,9 +11749,7 @@
 	},
 /area/tdome/tdomeobserve)
 "Dc" = (
-/obj/machinery/computer/security/telescreen{
-	pixel_y = 0
-	},
+/obj/machinery/computer/security/telescreen,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 1
@@ -11921,9 +11867,7 @@
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
 "Dp" = (
-/obj/machinery/computer/security/telescreen{
-	pixel_y = 0
-	},
+/obj/machinery/computer/security/telescreen,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -12543,9 +12487,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tdome/tdomeadmin)
 "EW" = (
-/obj/machinery/computer/security/telescreen{
-	pixel_y = 0
-	},
+/obj/machinery/computer/security/telescreen,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -12560,9 +12502,7 @@
 /area/tdome/tdomeadmin)
 "EY" = (
 /obj/machinery/button/flasher{
-	id = "tdomeflash";
-	pixel_x = 0;
-	pixel_y = 0
+	id = "tdomeflash"
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault{
@@ -12595,8 +12535,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -12742,7 +12681,6 @@
 /obj/machinery/button/door{
 	id = "thunderdomehea";
 	name = "Heavy Supply Control";
-	pixel_y = 0;
 	req_access_txt = "102"
 	},
 /obj/structure/table/reinforced,
@@ -12754,7 +12692,6 @@
 /obj/machinery/button/door{
 	id = "thunderdome";
 	name = "Main Blast Doors Control";
-	pixel_y = 0;
 	req_access_txt = "102"
 	},
 /obj/structure/table/reinforced,
@@ -12767,7 +12704,6 @@
 /obj/machinery/button/door{
 	id = "thunderdomegen";
 	name = "General Supply Control";
-	pixel_y = 0;
 	req_access_txt = "102"
 	},
 /obj/structure/table/reinforced,
@@ -12949,8 +12885,7 @@
 "FY" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /obj/item/weapon/storage/firstaid/regular{
 	pixel_x = -2;

--- a/_maps/map_files/generic/Centcomm.dmm
+++ b/_maps/map_files/generic/Centcomm.dmm
@@ -3290,7 +3290,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3321,8 +3320,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
@@ -3481,7 +3479,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3503,8 +3500,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
@@ -3655,7 +3651,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3687,8 +3682,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
@@ -4650,7 +4644,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -4711,8 +4704,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/green/side{
 	dir = 4
@@ -7248,7 +7240,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7968,7 +7959,6 @@
 /area/centcom/control)
 "tB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/green/corner{
@@ -7991,7 +7981,6 @@
 /obj/item/weapon/paper/pamphlet/ccaInfo,
 /obj/item/weapon/paper/pamphlet/ccaInfo,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/green/side{
@@ -8013,8 +8002,7 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/green/side{
 	dir = 5
@@ -8733,7 +8721,6 @@
 /area/centcom/control)
 "vC" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/green/corner,
@@ -9057,7 +9044,6 @@
 /area/centcom/ferry)
 "wr" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -10059,7 +10045,6 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -10278,7 +10263,6 @@
 /area/centcom/control)
 "zf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -10654,7 +10638,6 @@
 /area/tdome/tdomeobserve)
 "Ai" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/green/side{
@@ -11900,7 +11883,6 @@
 "Dk" = (
 /obj/machinery/vending/boozeomat,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -13865,7 +13847,6 @@
 /area/syndicate_mothership)
 "JG" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -13880,7 +13861,6 @@
 /area/syndicate_mothership/control)
 "JI" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/bar{
@@ -13931,7 +13911,6 @@
 /area/centcom/evac)
 "JQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -13944,7 +13923,6 @@
 /area/centcom/evac)
 "JS" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/yellow,
@@ -13952,7 +13930,6 @@
 "JT" = (
 /obj/structure/bed,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -13961,7 +13938,6 @@
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -13979,7 +13955,6 @@
 	dir = 9
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13989,8 +13964,7 @@
 	dir = 5
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
@@ -14006,8 +13980,7 @@
 /area/centcom/supply)
 "JZ" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 4
@@ -14015,8 +13988,7 @@
 /area/centcom/supply)
 "Ka" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 4
@@ -14027,7 +13999,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14037,8 +14008,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
@@ -14048,7 +14018,6 @@
 /area/centcom/supply)
 "Ke" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -14057,8 +14026,7 @@
 /area/centcom/control)
 "Kf" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 4
@@ -14074,7 +14042,6 @@
 /area/syndicate_mothership)
 "Kh" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -14083,8 +14050,7 @@
 /area/centcom/control)
 "Ki" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -14103,7 +14069,6 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
@@ -14143,7 +14108,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/pointybush,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/grass,
@@ -14167,8 +14131,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/genericbush,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/grass,
 /area/centcom/control)
@@ -14188,8 +14151,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fernybush,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	name = "plating";
@@ -14203,22 +14165,19 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/genericbush,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/grass,
 /area/centcom/control)
 "Kv" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "Kw" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
@@ -14331,7 +14290,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14374,7 +14332,6 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14435,7 +14392,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/pointybush,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/grass,
@@ -14463,8 +14419,7 @@
 /area/wizard_station)
 "Lc" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -14514,8 +14469,7 @@
 "Lj" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -14537,7 +14491,6 @@
 /area/tdome/tdomeobserve)
 "Lm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
@@ -14546,8 +14499,7 @@
 /area/tdome/tdomeobserve)
 "Ln" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/green/side{
 	dir = 8
@@ -14560,7 +14512,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/palebush,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid,
@@ -14570,8 +14521,7 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/fernybush,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	dir = 6;
@@ -14586,7 +14536,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/palebush,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid,
@@ -14596,8 +14545,7 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/fernybush,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	dir = 6;
@@ -14607,8 +14555,7 @@
 /area/tdome/tdomeadmin)
 "Ls" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -14616,7 +14563,6 @@
 /area/tdome/tdomeadmin)
 "Lt" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -14877,14 +14823,12 @@
 /area/shuttle/escape)
 "Me" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Mf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,

--- a/_maps/map_files/generic/Centcomm.dmm
+++ b/_maps/map_files/generic/Centcomm.dmm
@@ -5556,7 +5556,6 @@
 "oo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -6673,7 +6672,6 @@
 "qI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/machinery/meter,
@@ -6696,7 +6694,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -6719,7 +6716,6 @@
 "qK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /obj/machinery/meter,
@@ -12919,7 +12915,6 @@
 "FO" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 1
 	},
 /turf/open/floor/plating/airless,


### PR DESCRIPTION
Fixes #28587
Fixes #28625
Fixes numerous graphical pipe glitches due to var-edited colors instead of using proper subtypes
Fixes a number of wires that didn't actually have their directions set despite visually looking like they were connected.
Cleans up the 3~4 instances of the same pipe or wire per color in the editor
Cleans up a ton of dirty edits in general (ie supply pipes having req_access_txt for no reason in random locations)