### PR TITLE
Makes oldchat show while goonchat loads, sends preload messages there.

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -556,8 +556,8 @@ GLOBAL_LIST(external_rsc_urls)
 	log_access("Failed Login: [key] [computer_id] [address] - CID randomizer check")
 	var/url = winget(src, null, "url")
 	//special javascript to make them reconnect under a new window.
-	src << browse("<a id='link' href='byond://[url]?token=[token]'>byond://[url]?token=[token]</a><script type='text/javascript'>document.getElementById(\"link\").click();window.location=\"byond://winset?command=.quit\"</script>", "border=0;titlebar=0;size=1x1")
-	src << browse("<a href='byond://[url]?token=[token]'>You will be automatically taken to the game, if not, click here to be taken manually</a>", "window=browseroutput")
+	src << browse({"<a id='link' href="byond://[url]?token=[token]">byond://[url]?token=[token]</a><script type="text/javascript">document.getElementById("link").click();window.location="byond://winset?command=.quit"</script>"}, "border=0;titlebar=0;size=1x1;window=redirect")
+	to_chat(src, {"<a href="byond://[url]?token=[token]">You will be automatically taken to the game, if not, click here to be taken manually</a>"})
 
 /client/proc/note_randomizer_user()
 	var/const/adminckey = "CID-Error"

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -32,7 +32,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 		alert(owner.mob, "Updated chat window does not exist. If you are using a custom skin file please allow the game to update.")
 		return
 
-	if(winget(owner, "browseroutput", "is-disabled") == "false") //Already setup
+	if(winget(owner, "browseroutput", "is-visible") == "true") //Already setup
 		doneLoading()
 
 	else //Not setup
@@ -90,7 +90,10 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 
 	testing("Chat loaded for [owner.ckey]")
 	loaded = TRUE
-	winset(owner, "browseroutput", "is-disabled=false")
+	winset(owner, "output", "is-disabled=true;is-visible=false")
+	winset(owner, "browseroutput", "is-disabled=false;is-visible=true")
+
+
 	for(var/message in messageQueue)
 		to_chat(owner, message)
 
@@ -228,7 +231,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 		targets = target 
 		if(!targets.len)
 			return
-
+	var/original_message = message
 	//Some macros remain in the string even after parsing and fuck up the eventual output
 	message = replacetext(message, "\improper", "")
 	message = replacetext(message, "\proper", "")
@@ -241,14 +244,16 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 
 		if (!C)
 			continue
-		
+
 		if(!C.chatOutput || C.chatOutput.broken) // A player who hasn't updated his skin file.
-			C << message
+			C << original_message
 			return TRUE
-			
+
 		if(!C.chatOutput.loaded)
 			//Client sucks at loading things, put their messages in a queue
 			C.chatOutput.messageQueue += message
+			//But also send it to their output window since that shows until goonchat loads
+			C << original_message
 			return
 
 		// url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1593,7 +1593,7 @@ window "outputwindow"
 		font-style = ""
 		text-color = #000000
 		background-color = #ffffff
-		is-visible = true
+		is-visible = false
 		is-disabled = true
 		is-transparent = false
 		is-default = false
@@ -1608,6 +1608,32 @@ window "outputwindow"
 		use-title = false
 		on_show = ""
 		on_hide = ""
+	elem "output"
+		type = OUTPUT
+		pos = 0,0
+		size = 640x480
+		anchor1 = 0,0
+		anchor2 = 100,100
+		font-family = ""
+		font-size = 0
+		font-style = ""
+		text-color = #000000
+		background-color = #ffffff
+		is-visible = true
+		is-disabled = false
+		is-transparent = false
+		is-default = true
+		border = none
+		drop-zone = false
+		right-click = false
+		saved-params = ""
+		on-size = ""
+		show-history = false
+		show-url = false
+		auto-format = false
+		use-title = false
+		on_show = ""
+		on_hide = ""		
 
 window "statwindow"
 	elem "statwindow"


### PR DESCRIPTION
:cl:
tweak: Makes old chat show while goonchat loads. Should goonchat fail to load, the old chat will still be operational.
/:cl:

Fixes issues in cid randomizer detector conflicting with goonchat loading and failing to show users a message

@N3X15 @somepotato
fixes #28346 (technically, by making it a non-issue)