### PR TITLE
PDA Refactor Part 1: Phantom Blood Menace

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -41,7 +41,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/note = "Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant!" //Current note in the notepad function
 	var/notehtml = ""
 	var/notescanned = 0 // True if what is in the notekeeper was from a paper.
-	var/cart = "" //A place to stick cartridge menu information
 	var/detonatable = TRUE // Can the PDA be blown up?
 	var/hidden = 0 // Is the PDA hidden from the PDA list?
 	var/emped = 0
@@ -286,7 +285,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 					dat += "Temperature: [round(environment.temperature-T0C)]&deg;C<br>"
 				dat += "<br>"
 			else//Else it links to the cart menu proc. Although, it really uses menu hub 4--menu 4 doesn't really exist as it simply redirects to hub.
-				dat += cart
+				dat += cartridge.generate_menu()
 
 	dat += "</body></html>"
 	user << browse(dat, "window=pda;size=400x450;border=1;can_resize=1;can_minimize=0")
@@ -313,9 +312,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 					mode = round(mode/10)
 					if(mode==4 || mode == 5)//Fix for cartridges. Redirects to hub.
 						mode = 0
-					else if(mode >= 40 && mode <= 59)//Fix for cartridges. Redirects to refresh the menu.
-						cartridge.mode = mode
-						cartridge.unlock()
 			if ("Authenticate")//Checks for ID
 				id_check(U)
 			if("UpdateInfo")
@@ -328,8 +324,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 					U.put_in_hands(cartridge)
 					to_chat(U, "<span class='notice'>You remove [cartridge] from [src].</span>")
 					scanmode = 0
-					if (cartridge.radio)
-						cartridge.radio.hostpda = null
+					cartridge.host_pda = null
 					cartridge = null
 					update_icon()
 
@@ -470,9 +465,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 			else//Cartridge menu linking
 				mode = text2num(href_list["choice"])
-				if(cartridge)
-					cartridge.mode = mode
-					cartridge.unlock()
+
 	else//If not in range, can't interact or not using the pda.
 		U.unset_machine()
 		U << browse(null, "window=pda")
@@ -480,7 +473,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 //EXTRA FUNCTIONS===================================
 
-	if (mode == 2||mode == 21)//To clear message overlays.
+	if (mode == 2 || mode == 21)//To clear message overlays.
 		update_icon()
 
 	if ((honkamt > 0) && (prob(60)))//For clown virus.
@@ -705,9 +698,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 		if(!user.transferItemToLoc(C, src))
 			return
 		cartridge = C
+		cartridge.host_pda = src
 		to_chat(user, "<span class='notice'>You insert [cartridge] into [src].</span>")
-		if(cartridge.radio)
-			cartridge.radio.hostpda = src
 		update_icon()
 
 	else if(istype(C, /obj/item/weapon/card/id))

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -621,6 +621,7 @@ Code:
 				if (chan.channel_name == current_channel)
 					current = chan
 			if(current.locked && current.author != host_pda_owner_name)
+				host_pda.mode = 99
 				host_pda.Topic(null,list("choice"="Refresh"))
 				return
 			GLOB.news_network.SubmitArticle(message,host_pda.owner,current_channel)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -34,7 +34,6 @@
 	var/spam_enabled = 0 //Enables "Send to All" Option
 
 	var/obj/item/device/pda/host_pda = null
-	var/mode = null
 	var/menu
 	var/datum/data/record/active1 = null //General
 	var/datum/data/record/active2 = null //Medical

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -33,6 +33,7 @@
 	var/bot_access_flags = 0 //Bit flags. Selection: SEC_BOT | MULE_BOT | FLOOR_BOT | CLEAN_BOT | MED_BOT
 	var/spam_enabled = 0 //Enables "Send to All" Option
 
+	var/obj/item/device/pda/host_pda = null
 	var/mode = null
 	var/menu
 	var/datum/data/record/active1 = null //General
@@ -190,23 +191,11 @@
 	..()
 	radio = new /obj/item/radio/integrated/signal(src)
 
-/obj/item/weapon/cartridge/proc/unlock()
-	if (!istype(loc, /obj/item/device/pda))
+/obj/item/weapon/cartridge/proc/print_to_host(text, mob/user)
+	if(!host_pda || !user)
 		return
-
-	generate_menu()
-	print_to_host(menu)
-	return
-
-/obj/item/weapon/cartridge/proc/print_to_host(text)
-	if (!istype(loc, /obj/item/device/pda))
-		return
-	var/obj/item/device/pda/P = loc
-	P.cart = text
-
-	for (var/mob/M in viewers(1, loc.loc))
-		if (M.client && M.machine == loc)
-			P.attack_self(M)
+	host_pda.cart = text
+	host_pda.attack_self(user)
 
 	return
 
@@ -232,7 +221,9 @@
 
 
 /obj/item/weapon/cartridge/proc/generate_menu(mob/user)
-	switch(mode)
+	if(!host_pda)
+		return
+	switch(host_pda.mode)
 		if(40) //signaller
 			var/obj/item/radio/integrated/signal/S = radio
 			menu = "<h4><img src=pda_signaler.png> Remote Signaling System</h4>"
@@ -557,6 +548,7 @@ Code:
 		if (54) // Beepsky, Medibot, Floorbot, and Cleanbot access
 			menu = "<h4><img src=pda_medbot.png> Bots Interlink</h4>"
 			bot_control()
+	return menu
 
 /obj/item/weapon/cartridge/Topic(href, href_list)
 	..()
@@ -566,15 +558,14 @@ Code:
 		usr << browse(null, "window=pda")
 		return
 
-	var/obj/item/device/pda/pda = loc
-
+	var/obj/item/device/pda/pda = host_pda
+ 
 	switch(href_list["choice"])
 		if("Medical Records")
 			active1 = find_record("id", href_list["target"], GLOB.data_core.general)
 			if(active1)
 				active2 = find_record("id", href_list["target"], GLOB.data_core.medical)
-			pda.mode = 441
-			mode = 441
+			host_pda.mode = 441
 			if(!active2)
 				active1 = null
 
@@ -582,8 +573,7 @@ Code:
 			active1 = find_record("id", href_list["target"], GLOB.data_core.general)
 			if(active1)
 				active3 = find_record("id", href_list["target"], GLOB.data_core.security)
-			pda.mode = 451
-			mode = 451
+			host_pda.mode = 451
 			if(!active3)
 				active1 = null
 
@@ -622,34 +612,32 @@ Code:
 		if("Power Select")
 			var/pnum = text2num(href_list["target"])
 			powmonitor = powermonitors[pnum]
-			pda.mode = 433
-			mode = 433
+			host_pda.mode = 433
 
 		if("Supply Orders")
-			pda.mode =47
-			mode = 47
+			host_pda.mode =47
 
 		if("Newscaster Access")
-			mode = 53
+			host_pda.mode = 53
 
 		if("Newscaster Message")
-			var/pda_owner_name = pda.id ? "[pda.id.registered_name] ([pda.id.assignment])" : "Unknown"
-			var/message = pda.msg_input()
+			var/pda_owner_name = host_pda.id ? "[host_pda.id.registered_name] ([host_pda.id.assignment])" : "Unknown"
+			var/message = host_pda.msg_input()
 			var/datum/newscaster/feed_channel/current
 			for(var/datum/newscaster/feed_channel/chan in GLOB.news_network.network_channels)
 				if (chan.channel_name == current_channel)
 					current = chan
-			if(current.locked && current.author != pda_owner_name)
-				pda.cart += "<h5> ERROR : NOT AUTHORIZED [pda.id ? "" : "- ID SLOT EMPTY"] </h5>"
-				pda.Topic(null,list("choice"="Refresh"))
+			if(current.locked && current.author != host_pda_owner_name)
+				host_pda.cart += "<h5> ERROR : NOT AUTHORIZED [host_pda.id ? "" : "- ID SLOT EMPTY"] </h5>"
+				host_pda.Topic(null,list("choice"="Refresh"))
 				return
-			GLOB.news_network.SubmitArticle(message,pda.owner,current_channel)
-			pda.Topic(null,list("choice"=num2text(mode)))
+			GLOB.news_network.SubmitArticle(message,host_pda.owner,current_channel)
+			host_pda.Topic(null,list("choice"=num2text(host_pda.mode)))
 			return
 
 		if("Newscaster Switch Channel")
-			current_channel = pda.msg_input()
-			pda.Topic(null,list("choice"=num2text(mode)))
+			current_channel = host_pda.msg_input()
+			host_pda.Topic(null,list("choice"=num2text(host_pda.mode)))
 			return
 
 	//Bot control section! Viciously ripped from radios for being laggy and terrible.
@@ -662,7 +650,7 @@ Code:
 			if("botlist")
 				active_bot = null
 			if("summon") //Args are in the correct order, they are stated here just as an easy reminder.
-				active_bot.bot_control(command= "summon", user_turf= get_turf(usr), user_access= pda.GetAccess())
+				active_bot.bot_control(command= "summon", user_turf= get_turf(usr), user_access= host_pda.GetAccess())
 			else //Forward all other bot commands to the bot itself!
 				active_bot.bot_control(command= href_list["op"], user= usr)
 
@@ -671,7 +659,7 @@ Code:
 		active_bot.bot_control(command= href_list["mule"], user= usr, pda= 1)
 
 	generate_menu(usr)
-	print_to_host(menu)
+	print_to_host(menu, usr)
 
 
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -540,6 +540,9 @@ Code:
 		if (54) // Beepsky, Medibot, Floorbot, and Cleanbot access
 			menu = "<h4><img src=pda_medbot.png> Bots Interlink</h4>"
 			bot_control()
+		if (99) //Newscaster message permission error
+			menu = "<h5> ERROR : NOT AUTHORIZED [host_pda.id ? "" : "- ID SLOT EMPTY"] </h5>"
+
 	return menu
 
 /obj/item/weapon/cartridge/Topic(href, href_list)
@@ -611,14 +614,13 @@ Code:
 			host_pda.mode = 53
 
 		if("Newscaster Message")
-			var/pda_owner_name = host_pda.id ? "[host_pda.id.registered_name] ([host_pda.id.assignment])" : "Unknown"
+			var/host_pda_owner_name = host_pda.id ? "[host_pda.id.registered_name] ([host_pda.id.assignment])" : "Unknown"
 			var/message = host_pda.msg_input()
 			var/datum/newscaster/feed_channel/current
 			for(var/datum/newscaster/feed_channel/chan in GLOB.news_network.network_channels)
 				if (chan.channel_name == current_channel)
 					current = chan
 			if(current.locked && current.author != host_pda_owner_name)
-				host_pda.cart += "<h5> ERROR : NOT AUTHORIZED [host_pda.id ? "" : "- ID SLOT EMPTY"] </h5>"
 				host_pda.Topic(null,list("choice"="Refresh"))
 				return
 			GLOB.news_network.SubmitArticle(message,host_pda.owner,current_channel)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -49,7 +49,7 @@
 	var/mob/living/simple_animal/bot/active_bot
 	var/list/botlist = list()
 
-/obj/item/weapon/cartridge/New(var/obj/item/device/pda/pda)
+/obj/item/weapon/cartridge/Initialize(var/obj/item/device/pda/pda)
 	..()
 	if(pda)
 		host_pda = pda
@@ -131,7 +131,7 @@
 	icon_state = "cart-tox"
 	access = CART_REAGENT_SCANNER | CART_ATMOS
 
-/obj/item/weapon/cartridge/signal/New()
+/obj/item/weapon/cartridge/signal/Initialize()
 	..()
 	radio = new /obj/item/radio/integrated/signal(src)
 
@@ -180,7 +180,7 @@
 	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_REAGENT_SCANNER | CART_ATMOS | CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT | CLEAN_BOT | MED_BOT
 
-/obj/item/weapon/cartridge/rd/New()
+/obj/item/weapon/cartridge/rd/Initialize()
 	..()
 	radio = new /obj/item/radio/integrated/signal(src)
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -49,7 +49,7 @@
 	var/mob/living/simple_animal/bot/active_bot
 	var/list/botlist = list()
 
-/obj/item/weapon/cartridge/New(/obj/item/device/pda/pda)
+/obj/item/weapon/cartridge/New(var/obj/item/device/pda/pda)
 	..()
 	if(pda)
 		host_pda = pda

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -191,14 +191,6 @@
 	..()
 	radio = new /obj/item/radio/integrated/signal(src)
 
-/obj/item/weapon/cartridge/proc/print_to_host(text, mob/user)
-	if(!host_pda || !user)
-		return
-	host_pda.cart = text
-	host_pda.attack_self(user)
-
-	return
-
 /obj/item/weapon/cartridge/proc/post_status(command, data1, data2)
 
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(1435)
@@ -558,8 +550,6 @@ Code:
 		usr << browse(null, "window=pda")
 		return
 
-	var/obj/item/device/pda/pda = host_pda
- 
 	switch(href_list["choice"])
 		if("Medical Records")
 			active1 = find_record("id", href_list["target"], GLOB.data_core.general)
@@ -658,9 +648,9 @@ Code:
 
 		active_bot.bot_control(command= href_list["mule"], user= usr, pda= 1)
 
-	generate_menu(usr)
-	print_to_host(menu, usr)
-
+	if(!host_pda)
+		return
+	host_pda.attack_self(usr)
 
 
 /obj/item/weapon/cartridge/proc/bot_control()

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -49,6 +49,11 @@
 	var/mob/living/simple_animal/bot/active_bot
 	var/list/botlist = list()
 
+/obj/item/weapon/cartridge/New(/obj/item/device/pda/pda)
+	..()
+	if(pda)
+		host_pda = pda
+
 /obj/item/weapon/cartridge/engineering
 	name = "\improper Power-ON cartridge"
 	icon_state = "cart-e"

--- a/code/game/objects/items/devices/PDA/radio.dm
+++ b/code/game/objects/items/devices/PDA/radio.dm
@@ -3,18 +3,14 @@
 	desc = "An electronic radio system of nanotrasen origin."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "power_mod"
-	var/obj/item/device/pda/hostpda = null
 
 	var/on = 0 //Are we currently active??
 	var/menu_message = ""
 
 /obj/item/radio/integrated/Initialize()
 	. = ..()
-	if (istype(loc.loc, /obj/item/device/pda))
-		hostpda = loc.loc
 
 /obj/item/radio/integrated/Destroy()
-	hostpda = null
 	return ..()
 
 /*


### PR DESCRIPTION
1st part of a multi-part story
Links the host PDA to the cartridge object the cartridge is in and removing the bullshit snowflake procs that were literally looping through the location to find PDA.

Newscaster Access was extra snowflakey and doesn't work in this refactor but it doesn't work in the base game either https://github.com/tgstation/tgstation/issues/28680