### PR TITLE
removes griefProtection() from RND code

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -88,29 +88,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				D.linked_console = src
 	first_use = 0
 
-//Have it automatically push research to the centcom server so wild griffins can't fuck up R&D's work --NEO
-/obj/machinery/computer/rdconsole/proc/griefProtection()
-	for(var/obj/machinery/r_n_d/server/centcom/C in GLOB.machines)
-		for(var/v in files.known_tech)
-			var/datum/tech/T = files.known_tech[v]
-			C.files.AddTech2Known(T)
-		for(var/v in files.known_designs)
-			var/datum/design/D = files.known_designs[v]
-			C.files.AddDesign2Known(D)
-		C.files.RefreshResearch()
-
-
 /obj/machinery/computer/rdconsole/Initialize()
 	. = ..()
 	files = new /datum/research(src) //Setup the research data holder.
 	matching_designs = list()
 	if(!id)
 		fix_noid_research_servers()
-
-/*	Instead of calling this every tick, it is only being called when needed
-/obj/machinery/computer/rdconsole/process()
-	griefProtection()
-*/
 
 /obj/machinery/computer/rdconsole/attackby(obj/item/weapon/D, mob/user, params)
 
@@ -190,7 +173,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				else
 					files.AddTech2Known(t_disk.tech_stored[n])
 				updateUsrDialog()
-				griefProtection() //Update centcom too
 
 	else if(href_list["clear_tech"]) //Erase data on the technology disk.
 		if(t_disk)
@@ -233,7 +215,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				else
 					files.AddDesign2Known(d_disk.blueprints[n])
 				updateUsrDialog()
-				griefProtection() //Update centcom too
 
 	else if(href_list["clear_design"]) //Erases data on the design disk.
 		if(d_disk)
@@ -347,7 +328,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		if(!sync)
 			to_chat(usr, "<span class='danger'>You must connect to the network first!</span>")
 		else
-			griefProtection() //Putting this here because I dont trust the sync process
 			spawn(30)
 				if(src)
 					for(var/obj/machinery/r_n_d/server/S in GLOB.machines)
@@ -568,7 +548,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				linked_imprinter = null
 
 	else if(href_list["reset"]) //Reset the R&D console's database.
-		griefProtection()
 		var/choice = alert("R&D Console Database Reset", "Are you sure you want to reset the R&D console's database? Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue" && usr.canUseTopic(src))
 			message_admins("[key_name_admin(usr)] reset \the [src.name]'s database")

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -27,10 +27,6 @@
 							/obj/item/stack/cable_coil = 2,
 							/obj/item/weapon/stock_parts/scanning_module = 1)
 
-/obj/machinery/r_n_d/server/Destroy()
-	griefProtection()
-	return ..()
-
 /obj/machinery/r_n_d/server/RefreshParts()
 	var/tot_rating = 0
 	for(var/obj/item/weapon/stock_parts/SP in src)
@@ -62,8 +58,6 @@
 		if((T20C + 20) to (T0C + 70))
 			heat_health = max(0, heat_health - 1)
 	if(heat_health <= 0)
-		/*griefProtection() This seems to get called twice before running any code that deletes/damages the server or it's files anwyay.
-							refreshParts and the hasReq procs that get called by this are laggy and do not need to be called by every server on the map every tick */
 		var/updateRD = 0
 		files.known_designs = list()
 		for(var/v in files.known_tech)
@@ -78,26 +72,6 @@
 	else
 		produce_heat(heat_gen)
 		delay = initial(delay)
-
-
-/obj/machinery/r_n_d/server/emp_act(severity)
-	griefProtection()
-	..()
-
-/obj/machinery/r_n_d/server/ex_act(severity, target)
-	griefProtection()
-	..()
-
-//Backup files to centcom to help admins recover data after greifer attacks
-/obj/machinery/r_n_d/server/proc/griefProtection()
-	for(var/obj/machinery/r_n_d/server/centcom/C in GLOB.machines)
-		for(var/v in files.known_tech)
-			var/datum/tech/T = files.known_tech[v]
-			C.files.AddTech2Known(T)
-		for(var/v in files.known_designs)
-			var/datum/design/D = files.known_designs[v]
-			C.files.AddDesign2Known(D)
-		C.files.RefreshResearch()
 
 /obj/machinery/r_n_d/server/proc/produce_heat(heat_amt)
 	if(!(stat & (NOPOWER|BROKEN))) //Blatently stolen from space heater.
@@ -119,11 +93,6 @@
 
 				env.merge(removed)
 				air_update_turf()
-
-//called when the server is deconstructed.
-/obj/machinery/r_n_d/server/on_deconstruction()
-	griefProtection()
-	..()
 
 /obj/machinery/r_n_d/server/attack_hand(mob/user as mob) // I guess only exists to stop ninjas or hell does it even work I dunno.  See also ninja gloves.
 	if (disabled)


### PR DESCRIPTION
I've never seen a case in 3 months where admins had to rely on this to recover broken levels, and they can varedit /datum/research's /datum/levels anyways.
also if we care about "what level they had prior to being wiped" well just look at the level of parts on the station and the items, this seems needless.