### PR TITLE
Refactors threat assessment for security bots

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -134,3 +134,11 @@
 #define INCORPOREAL_MOVE_BASIC 1
 #define INCORPOREAL_MOVE_SHADOW 2 // leaves a trail of shadows
 #define INCORPOREAL_MOVE_JAUNT 3 // is blocked by holy water/salt
+
+//Secbot and ED209 judgement criteria bitflag values
+#define JUDGE_EMAGGED 1
+#define JUDGE_IDCHECK 2
+#define JUDGE_WEAPONCHECK 4
+#define JUDGE_RECORDCHECK 8
+//ED209's ignore monkeys
+#define JUDGE_IGNOREMONKEYS 16

--- a/code/game/gamemodes/devil/true_devil/_true_devil.dm
+++ b/code/game/gamemodes/devil/true_devil/_true_devil.dm
@@ -101,7 +101,7 @@
 		return 0
 	return 1
 
-/mob/living/carbon/true_devil/assess_threat()
+/mob/living/carbon/true_devil/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null)
 	return 666
 
 /mob/living/carbon/true_devil/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0)

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -50,7 +50,7 @@
 	internal_organs += new /obj/item/organ/ears
 	..()
 
-/mob/living/carbon/alien/assess_threat() // beepsky won't hunt aliums
+/mob/living/carbon/alien/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) // beepsky won't hunt aliums
 	return -10
 
 /mob/living/carbon/alien/handle_environment(datum/gas_mixture/environment)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -549,8 +549,8 @@
 	else
 		return null
 
-/mob/living/carbon/human/assess_threat(mob/living/simple_animal/bot/secbot/judgebot, lasercolor)
-	if(judgebot.emagged == 2)
+/mob/living/carbon/human/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null)
+	if(judgement_criteria & JUDGE_EMAGGED)
 		return 10 //Everyone is a criminal!
 
 	var/threatcount = 0
@@ -577,20 +577,20 @@
 
 	//Check for ID
 	var/obj/item/weapon/card/id/idcard = get_idcard()
-	if(judgebot.idcheck && !idcard && name=="Unknown")
+	if( (judgement_criteria & JUDGE_IDCHECK) && !idcard && name=="Unknown")
 		threatcount += 4
 
 	//Check for weapons
-	if(judgebot.weaponscheck)
+	if( (judgement_criteria & JUDGE_WEAPONCHECK) && weaponcheck)
 		if(!idcard || !(GLOB.access_weapons in idcard.access))
 			for(var/obj/item/I in held_items)
-				if(judgebot.check_for_weapons(I))
+				if(weaponcheck.Invoke(I))
 					threatcount += 4
-			if(judgebot.check_for_weapons(belt))
+			if(weaponcheck.Invoke(belt))
 				threatcount += 2
 
 	//Check for arrest warrant
-	if(judgebot.check_records)
+	if(judgement_criteria & JUDGE_RECORDCHECK)
 		var/perpname = get_face_name(get_id_name())
 		var/datum/data/record/R = find_record("name", perpname, GLOB.data_core.security)
 		if(R && R.fields["criminal"])

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -90,13 +90,14 @@
 /mob/living/carbon/monkey/canBeHandcuffed()
 	return 1
 
-/mob/living/carbon/monkey/assess_threat(mob/living/simple_animal/bot/secbot/judgebot, lasercolor)
-	if(judgebot.emagged == 2)
+/mob/living/carbon/monkey/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null)
+	if(judgement_criteria & JUDGE_EMAGGED)
 		return 10 //Everyone is a criminal!
+
 	var/threatcount = 0
 
 	//Securitrons can't identify monkeys
-	if(!lasercolor && judgebot.idcheck )
+	if( !(judgement_criteria & JUDGE_IGNOREMONKEYS) && (judgement_criteria & JUDGE_IDCHECK) )
 		threatcount += 4
 
 	//Lasertag bullshit
@@ -112,9 +113,9 @@
 		return threatcount
 
 	//Check for weapons
-	if(judgebot.weaponscheck)
+	if( (judgement_criteria & JUDGE_WEAPONCHECK) && weaponcheck )
 		for(var/obj/item/I in held_items)
-			if(judgebot.check_for_weapons(I))
+			if(weaponcheck.Invoke(I))
 				threatcount += 4
 
 	//mindshield implants imply trustworthyness

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -321,7 +321,7 @@
 	return 0
 
 
-/mob/living/silicon/assess_threat() //Secbots won't hunt silicon units
+/mob/living/silicon/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) //Secbots won't hunt silicon units
 	return -10
 
 /mob/living/silicon/proc/remove_med_sec_hud()

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -152,8 +152,23 @@ Auto Patrol[]"},
 			declare_arrests = !declare_arrests
 			update_controls()
 
+/mob/living/simple_animal/bot/ed209/proc/judgement_criteria()
+	var/final = FALSE 
+	if(idcheck)
+		final = final|JUDGE_IDCHECK
+	if(check_records)
+		final = final|JUDGE_RECORDCHECK
+	if(weaponscheck)
+		final = final|JUDGE_WEAPONCHECK
+	if(emagged)
+		final = final|JUDGE_EMAGGED
+	//ED209's ignore monkeys
+	final = final|JUDGE_IGNOREMONKEYS
+	return final
+
 /mob/living/simple_animal/bot/ed209/proc/retaliate(mob/living/carbon/human/H)
-	threatlevel = H.assess_threat(src)
+	var/judgement_criteria = judgement_criteria()
+	threatlevel = H.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
 	threatlevel += 6
 	if(threatlevel >= 4)
 		target = H
@@ -199,12 +214,13 @@ Auto Patrol[]"},
 	if(disabled)
 		return
 
+	var/judgement_criteria = judgement_criteria()
 	var/list/targets = list()
 	for(var/mob/living/carbon/C in view(7,src)) //Let's find us a target
 		var/threatlevel = 0
 		if((C.stat) || (C.lying))
 			continue
-		threatlevel = C.assess_threat(src, lasercolor)
+		threatlevel = C.assess_threat(judgement_criteria, lasercolor, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
 		//speak(C.real_name + text(": threat: []", threatlevel))
 		if(threatlevel < 4 )
 			continue
@@ -321,6 +337,7 @@ Auto Patrol[]"},
 		return
 	anchored = 0
 	threatlevel = 0
+	var/judgement_criteria = judgement_criteria()
 	for (var/mob/living/carbon/C in view(7,src)) //Let's find us a criminal
 		if((C.stat) || (C.handcuffed))
 			continue
@@ -328,7 +345,7 @@ Auto Patrol[]"},
 		if((C.name == oldtarget_name) && (world.time < last_found + 100))
 			continue
 
-		threatlevel = C.assess_threat(src, lasercolor)
+		threatlevel = C.assess_threat(judgement_criteria, lasercolor, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
 
 		if(!threatlevel)
 			continue
@@ -526,7 +543,8 @@ Auto Patrol[]"},
 	C.stuttering = 5
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
-		threat = H.assess_threat(src)
+		var/judgement_criteria = judgement_criteria()
+		threat = H.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
 	add_logs(src,C,"stunned")
 	if(declare_arrests)
 		var/area/location = get_area(src)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -148,11 +148,24 @@ Auto Patrol: []"},
 			update_controls()
 
 /mob/living/simple_animal/bot/secbot/proc/retaliate(mob/living/carbon/human/H)
-	threatlevel = H.assess_threat(src)
+	var/judgement_criteria = judgement_criteria()
+	threatlevel = H.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
 	threatlevel += 6
 	if(threatlevel >= 4)
 		target = H
 		mode = BOT_HUNT
+
+/mob/living/simple_animal/bot/secbot/proc/judgement_criteria()
+    var/final = FALSE 
+    if(idcheck)
+        final = final|JUDGE_IDCHECK
+    if(check_records)
+        final = final|JUDGE_RECORDCHECK
+    if(weaponscheck)
+        final = final|JUDGE_WEAPONCHECK
+    if(emagged)
+        final = final|JUDGE_EMAGGED
+    return final
 
 /mob/living/simple_animal/bot/secbot/attack_hand(mob/living/carbon/human/H)
 	if((H.a_intent == INTENT_HARM) || (H.a_intent == INTENT_DISARM))
@@ -222,6 +235,7 @@ Auto Patrol: []"},
 			back_to_idle()
 
 /mob/living/simple_animal/bot/secbot/proc/stun_attack(mob/living/carbon/C)
+	var/judgement_criteria = judgement_criteria()
 	playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)
 	icon_state = "secbot-c"
 	spawn(2)
@@ -231,11 +245,12 @@ Auto Patrol: []"},
 		C.stuttering = 5
 		C.Knockdown(100)
 		var/mob/living/carbon/human/H = C
-		threat = H.assess_threat(src)
+		threat = H.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
 	else
 		C.Knockdown(100)
 		C.stuttering = 5
-		threat = C.assess_threat()
+		threat = C.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
+
 	add_logs(src,C,"stunned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
@@ -350,6 +365,7 @@ Auto Patrol: []"},
 
 /mob/living/simple_animal/bot/secbot/proc/look_for_perp()
 	anchored = 0
+	var/judgement_criteria = judgement_criteria()
 	for (var/mob/living/carbon/C in view(7,src)) //Let's find us a criminal
 		if((C.stat) || (C.handcuffed))
 			continue
@@ -357,7 +373,7 @@ Auto Patrol: []"},
 		if((C.name == oldtarget_name) && (world.time < last_found + 100))
 			continue
 
-		threatlevel = C.assess_threat(src)
+		threatlevel = C.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
 
 		if(!threatlevel)
 			continue

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -219,7 +219,7 @@
 	to_chat(user, msg)
 
 
-/mob/living/simple_animal/drone/assess_threat() //Secbots won't hunt maintenance drones.
+/mob/living/simple_animal/drone/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) //Secbots won't hunt maintenance drones.
 	return -10
 
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -750,8 +750,8 @@
 /mob/proc/activate_hand(selhand)
 	return
 
-/mob/proc/assess_threat() //For sec bot threat assessment
-	return
+/mob/proc/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) //For sec bot threat assessment
+	return 0
 
 /mob/proc/get_ghost(even_if_they_cant_reenter = 0)
 	if(mind)


### PR DESCRIPTION
    Refactors threat assessment for security bots
    
    They don't share a common ancestor type so they were relying on the
    secbot having identical vars to the ed209, this is brittle and ugly, so
    instead a bitflag of criteria is passed through the mob assess_threat
    proc so it can choose how to react to each criteria
    
    As well as that, the weaponscheck proc used by the bots is now passed
    through as a callback, more things can now implement their own
    weapons checking for threat assessment if they need
    
    This means more things can now utilise the assess_threat proc if they so
    wanted to, as they no longer need to map 1 -> 1 to the ed209's vars
    
    Also fixed a runtime where the secbot didn't pass through itself to the
    assess_threat proc (what I originally wanted to fix)

