### PR TITLE
Fixes the kinetic crusher not emitting light

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -13,7 +13,8 @@
 	force_wielded = 20
 	throwforce = 5
 	throw_speed = 4
-	luminosity = 4
+	light_range = 5
+	light_power = 1
 	armour_penetration = 10
 	materials = list(MAT_METAL=1150, MAT_GLASS=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'


### PR DESCRIPTION
It lost lighting during the /vg/lighting port and now it has it back
The light is equivalent to a seclight, which miners start with