### PR TITLE
HoS Combat Knife

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -77,6 +77,7 @@
 	new /obj/item/device/megaphone/sec(src)
 	new /obj/item/weapon/holosign_creator/security(src)
 	new /obj/item/weapon/storage/lockbox/loyalty(src)
+	new /obj/item/weapon/kitchen/knife/combat(src)
 	new /obj/item/clothing/mask/gas/sechailer/swat(src)
 	new /obj/item/weapon/storage/box/flashbangs(src)
 	new /obj/item/weapon/shield/riot/tele(src)


### PR DESCRIPTION
Spawns a combat knife in the HoS's personal locker.

Sister PR of : https://github.com/tgstation/tgstation/pull/28720

:cl: Steelpoint
add: Head of Security's personal locker holds a combat knife.
/:cl: