### PR TITLE
Station Engineers Spawn With Industrial Welder 

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -62,6 +62,15 @@
 	new /obj/item/device/multitool(src)
 	new /obj/item/stack/cable_coil(src,30,pick("red","yellow","orange"))
 
+/obj/item/weapon/storage/belt/utility/full/engi/PopulateContents()
+	new /obj/item/weapon/screwdriver(src)
+	new /obj/item/weapon/wrench(src)
+	new /obj/item/weapon/weldingtool/largetank(src)
+	new /obj/item/weapon/crowbar(src)
+	new /obj/item/weapon/wirecutters(src)
+	new /obj/item/device/multitool(src)
+	new /obj/item/stack/cable_coil(src,30,pick("red","yellow","orange"))
+
 
 /obj/item/weapon/storage/belt/utility/atmostech/PopulateContents()
 	new /obj/item/weapon/screwdriver(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -58,7 +58,7 @@
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/head/welding(src)
 	for(var/i in 1 to 3)
-		new /obj/item/weapon/weldingtool/largetank(src)
+		new /obj/item/weapon/weldingtool(src)
 
 /obj/structure/closet/secure_closet/engineering_personal
 	name = "engineer's locker"

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -84,7 +84,7 @@ Station Engineer
 	name = "Station Engineer"
 	jobtype = /datum/job/engineer
 
-	belt = /obj/item/weapon/storage/belt/utility/full
+	belt = /obj/item/weapon/storage/belt/utility/full/engi
 	l_pocket = /obj/item/device/pda/engineering
 	ears = /obj/item/device/radio/headset/headset_eng
 	uniform = /obj/item/clothing/under/rank/engineer


### PR DESCRIPTION
This PR makes it that Station Engineers spawn with a Industrial Welder (40 Units) in their toolbelt, instead of the standard Welder tool. 

Personally I'm a bit conflicted on this proposal but I wanted to propose it anyway. On the one hand I very often never see Engineers either grab a Industrial Welder, or use the secret poly technique to get the Expanded Industrial Welder, hence I think this would be a good change to further help make Engineers just that little better than Assistants.

But on the other hand it would discourage Engineers to check engineering for better tools and it blurs the line between more experienced Engineers and newer ones. 

I'd like to hear your thoughts.

:cl: Steelpoint
add: Station Engineers spawn with a Industrial Welder in their toolbelt. 
tweak: Engineering Welder Locker now only holds three standard Welders.
/:cl: