### PR TITLE
[Boxstation] Armoury Toolbox Holds Industrial Welder

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -4528,10 +4528,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajC" = (
-/obj/item/weapon/storage/toolbox/drone,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/weapon/storage/toolbox/sec,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "ajD" = (
@@ -89643,7 +89643,7 @@ aJq
 aLY
 aJq
 aJq
-bcW
+aRh
 bbV
 bfo
 bkS

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -128,6 +128,21 @@
 	new /obj/item/weapon/wirecutters(src)
 	new /obj/item/device/multitool(src)
 
+/obj/item/weapon/storage/toolbox/sec
+	name = "mechanical toolbox"
+	icon_state = "blue"
+	item_state = "toolbox_blue"
+
+/obj/item/weapon/storage/toolbox/sec/PopulateContents()
+	var/pickedcolor = pick("red","yellow","green","blue","pink","orange","cyan","white")
+	new /obj/item/weapon/screwdriver(src)
+	new /obj/item/weapon/wrench(src)
+	new /obj/item/weapon/weldingtool/largetank(src)
+	new /obj/item/weapon/crowbar(src)
+	new /obj/item/stack/cable_coil(src,30,pickedcolor)
+	new /obj/item/weapon/wirecutters(src)
+	new /obj/item/device/multitool(src)
+
 /obj/item/weapon/storage/toolbox/brass
 	name = "brass box"
 	desc = "A huge brass box with several indentations in its surface."


### PR DESCRIPTION
The toolbox in boxstation's armoury now contains a industrial welder instead of a standard welder. 

While spare fuel is never too far away, however I believe that a upgraded welding tool for the armoury would not go astray, in terms of helping with construction projects,, as well as fitting the preset theme of the armoury toolbox having better gear in it than 99% of other toolboxes. 

:cl: Steelpoint
tweak: The Warden of NTSS Boxstation was able to successfully acquisition a surplus Industrial Welder for the armouries toolbox.
/:cl: