### PR TITLE
Makes goonchat robust.

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -134,6 +134,89 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 	else
 		to_chat(src, "<span class='notice'>There are no admin notices at the moment.</span>")
 
+/client/verb/fix_chat()
+	set name "Fix chat"
+	set category = "OOC"
+	if (!chatOutput || !istype(chatOutput))
+		var/action = alert(src, "Invalid Chat Output data found!\nRecreate data?", "Wot?", "Recreate Chat Output data", "Cancel")
+		if (action != "Recreate Chat Output data")
+			return
+		chatOutput = new /datum/chatOutput(src)
+		chatOutput.start()
+		action = alert(src, "Goon chat reloading, wait a bit and tell me if it's fixed", "", "Fixed", "Nope")
+		if (action == "Fixed")
+			log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by re-creating the chatOutput datum")
+		else
+			chatOutput.load()
+			alert(src, "How about now? (give it a moment (it may also try to load twice))", "", "Yes", "No")
+			if (action == "Yes")
+				log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by re-creating the chatOutput datum and forcing a load()")
+			else
+				action = alert(src, "Welp, I'm all out of ideas. Try closing byond and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "", "Thanks anyways", "Switch to old chat")
+				if (action == "Switch to old chat")
+					winset(src, "output", list2params(list("on-show" = "", "is-disabled" = "false", "is-visible" = "true")))
+					winset(src, "browseroutput", "is-disabled=true;is-visible=false")
+				log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window after recreating the chatOutput and forcing a load()")
+	
+	else if (chatOutput.loaded)
+		var/action = alert(src, "ChatOutput seems to be loaded\nDo you want me to force a reload, wiping the chat log or just refresh the chat window because it broke/went away?", "Hmmm", "Force Reload", "Refresh", "Cancel")
+		switch (action)
+			if ("Force Reload")
+				chatOutput.loaded = FALSE
+				chatOutput.start() //this is likely to fail since it asks , but we should try it anyways so we know.
+				action = alert(src, "Goon chat reloading, wait a bit and tell me if it's fixed", "", "Fixed", "Nope")
+				if (action == "Fixed")
+					log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a start()")
+				else
+					chatOutput.load()
+					alert(src, "How about now? (give it a moment (it may also try to load twice))", "", "Yes", "No")
+					if (action == "Yes")
+						log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a load()")
+					else
+						action = alert(src, "Welp, I'm all out of ideas. Try closing byond and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "", "Thanks anyways", "Switch to old chat")
+						if (action == "Switch to old chat")
+							winset(src, "output", list2params(list("on-show" = "", "is-disabled" = "false", "is-visible" = "true")))
+							winset(src, "browseroutput", "is-disabled=true;is-visible=false")
+						log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window forcing a start() and forcing a load()")
+						
+			if ("Refresh")
+				chatOutput.showChat()
+				action = alert(src, "Goon chat refreshing, wait a bit and tell me if it's fixed", "", "Fixed", "Nope, force a reload")
+				if (action == "Fixed")
+					log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a show()")
+				else
+					chatOutput.loaded = FALSE
+					chatOutput.load()
+					alert(src, "How about now? (give it a moment)", "", "Yes", "No")
+					if (action == "Yes")
+						log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a load()")
+					else
+						action = alert(src, "Welp, I'm all out of ideas. Try closing byond and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "", "Thanks anyways", "Switch to old chat")
+						if (action == "Switch to old chat")
+							winset(src, "output", list2params(list("on-show" = "", "is-disabled" = "false", "is-visible" = "true")))
+							winset(src, "browseroutput", "is-disabled=true;is-visible=false")
+						log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window forcing a show() and forcing a load()")
+		return
+	
+	else
+		chatOutput.start()
+		var/action = alert(src, "Manually loading Chat, wait a bit and tell me if it's fixed", "", "Fixed", "Nope")
+		if (action == "Fixed")
+			log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by manually calling start()")
+		else
+			chatOutput.load()
+			alert(src, "How about now? (give it a moment (it may also try to load twice))", "", "Yes", "No")
+			if (action == "Yes")
+				log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by manually calling start() and forcing a load()")
+			else
+				action = alert(src, "Welp, I'm all out of ideas. Try closing byond and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "", "Thanks anyways", "Switch to old chat")
+				if (action == "Switch to old chat")
+					winset(src, "output", list2params(list("on-show" = "", "is-disabled" = "false", "is-visible" = "true")))
+					winset(src, "browseroutput", "is-disabled=true;is-visible=false")
+				log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window after manually calling start() and forcing a load()")
+	
+	
+
 /client/verb/motd()
 	set name = "MOTD"
 	set category = "OOC"

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -135,7 +135,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 		to_chat(src, "<span class='notice'>There are no admin notices at the moment.</span>")
 
 /client/verb/fix_chat()
-	set name "Fix chat"
+	set name = "Fix chat"
 	set category = "OOC"
 	if (!chatOutput || !istype(chatOutput))
 		var/action = alert(src, "Invalid Chat Output data found!\nRecreate data?", "Wot?", "Recreate Chat Output data", "Cancel")

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -154,8 +154,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 			else
 				action = alert(src, "Welp, I'm all out of ideas. Try closing byond and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "", "Thanks anyways", "Switch to old chat")
 				if (action == "Switch to old chat")
-					winset(src, "output", list2params(list("on-show" = "", "is-disabled" = "false", "is-visible" = "true")))
-					winset(src, "browseroutput", "is-disabled=true;is-visible=false")
+					winset(src, "output", "is-visible=true;is-disabled=false")
+					winset(src, "browseroutput", "is-visible=false")
 				log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window after recreating the chatOutput and forcing a load()")
 	
 	else if (chatOutput.loaded)
@@ -175,8 +175,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 					else
 						action = alert(src, "Welp, I'm all out of ideas. Try closing byond and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "", "Thanks anyways", "Switch to old chat")
 						if (action == "Switch to old chat")
-							winset(src, "output", list2params(list("on-show" = "", "is-disabled" = "false", "is-visible" = "true")))
-							winset(src, "browseroutput", "is-disabled=true;is-visible=false")
+							winset(src, "output", "is-visible=true;is-disabled=false")
+							winset(src, "browseroutput", "is-visible=false")
 						log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window forcing a start() and forcing a load()")
 						
 			if ("Refresh")
@@ -193,8 +193,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 					else
 						action = alert(src, "Welp, I'm all out of ideas. Try closing byond and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "", "Thanks anyways", "Switch to old chat")
 						if (action == "Switch to old chat")
-							winset(src, "output", list2params(list("on-show" = "", "is-disabled" = "false", "is-visible" = "true")))
-							winset(src, "browseroutput", "is-disabled=true;is-visible=false")
+							winset(src, "output", "is-visible=true;is-disabled=false")
+							winset(src, "browseroutput", "is-visible=false")
 						log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window forcing a show() and forcing a load()")
 		return
 	

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -148,7 +148,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 			log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by re-creating the chatOutput datum")
 		else
 			chatOutput.load()
-			alert(src, "How about now? (give it a moment (it may also try to load twice))", "", "Yes", "No")
+			action = alert(src, "How about now? (give it a moment (it may also try to load twice))", "", "Yes", "No")
 			if (action == "Yes")
 				log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by re-creating the chatOutput datum and forcing a load()")
 			else
@@ -169,7 +169,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 					log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a start()")
 				else
 					chatOutput.load()
-					alert(src, "How about now? (give it a moment (it may also try to load twice))", "", "Yes", "No")
+					action = alert(src, "How about now? (give it a moment (it may also try to load twice))", "", "Yes", "No")
 					if (action == "Yes")
 						log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a load()")
 					else
@@ -187,7 +187,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 				else
 					chatOutput.loaded = FALSE
 					chatOutput.load()
-					alert(src, "How about now? (give it a moment)", "", "Yes", "No")
+					action = alert(src, "How about now? (give it a moment)", "", "Yes", "No")
 					if (action == "Yes")
 						log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a load()")
 					else

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -241,24 +241,23 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	message = replacetext(message, "\n", "<br>")
 	message = replacetext(message, "\t", "[GLOB.TAB][GLOB.TAB]")
 	
-	//Also send it to their output window.
-	C << original_message
-	
 	for(var/I in targets)
 		//Grab us a client if possible
 		var/client/C = grab_client(I)
-
+		
 		if (!C)
 			continue
-
+		
+		//Send it to the old style output window.
+		C << original_message
+		
 		if(!C.chatOutput || C.chatOutput.broken) // A player who hasn't updated his skin file.
-			C << original_message
-			return TRUE
+			continue
 
 		if(!C.chatOutput.loaded)
-			//Client sucks at loading things, put their messages in a queue
+			//Client still loading, put their messages in a queue
 			C.chatOutput.messageQueue += message
-			return
+			continue
 
 		// url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.
 		C << output(url_encode(url_encode(message)), "browseroutput:output")

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -98,7 +98,10 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 
 	messageQueue = null
 	sendClientData()
-
+	
+	//do not convert to to_chat()
+	owner << {"<span class="userdanger">If you can see this, update byond.</span>"}
+	
 	pingLoop()
 
 /datum/chatOutput/proc/showChat()

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -90,8 +90,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 
 	testing("Chat loaded for [owner.ckey]")
 	loaded = TRUE
-	winset(owner, "output", "is-disabled=true;is-visible=false")
-	winset(owner, "browseroutput", "is-disabled=false;is-visible=true")
+	showChat()
 
 
 	for(var/message in messageQueue)
@@ -101,6 +100,10 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	sendClientData()
 
 	pingLoop()
+
+/datum/chatOutput/proc/showChat()
+	winset(owner, "output", "list2params(list("is-disabled" = "true", "is-visible" = "false", "on-show" = {".winset "output" "is-visible=false""})))
+	winset(owner, "browseroutput", "is-disabled=false;is-visible=true")
 
 /datum/chatOutput/proc/pingLoop()
 	set waitfor = FALSE
@@ -237,7 +240,10 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	message = replacetext(message, "\proper", "")
 	message = replacetext(message, "\n", "<br>")
 	message = replacetext(message, "\t", "[GLOB.TAB][GLOB.TAB]")
-
+	
+	//Also send it to their output window.
+	C << original_message
+	
 	for(var/I in targets)
 		//Grab us a client if possible
 		var/client/C = grab_client(I)
@@ -252,8 +258,6 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 		if(!C.chatOutput.loaded)
 			//Client sucks at loading things, put their messages in a queue
 			C.chatOutput.messageQueue += message
-			//But also send it to their output window since that shows until goonchat loads
-			C << original_message
 			return
 
 		// url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -102,7 +102,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	pingLoop()
 
 /datum/chatOutput/proc/showChat()
-	winset(owner, "output", list2params(list("is-disabled" = "true", "is-visible" = "false", "on-show" = {".winset "output" "is-visible=false""})))
+	winset(owner, "output", "is-visible=false")
 	winset(owner, "browseroutput", "is-disabled=false;is-visible=true")
 
 /datum/chatOutput/proc/pingLoop()

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -102,7 +102,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	pingLoop()
 
 /datum/chatOutput/proc/showChat()
-	winset(owner, "output", "list2params(list("is-disabled" = "true", "is-visible" = "false", "on-show" = {".winset "output" "is-visible=false""})))
+	winset(owner, "output", list2params(list("is-disabled" = "true", "is-visible" = "false", "on-show" = {".winset "output" "is-visible=false""})))
 	winset(owner, "browseroutput", "is-disabled=false;is-visible=true")
 
 /datum/chatOutput/proc/pingLoop()


### PR DESCRIPTION
The old chat is kept active, we still push to it, so it stays up to date should goonchat fail to load but seem load or go away.

Added a OOC verb to fix goonchat, this system logs what was needed to fix it, so we can narrow our focus better.

Workaround for #28717 until I can get home and figure out how to prevent it. (might also fix it)

I'm not at my computer right now, I coded this on my laptop in the web editor at a friends house, somebody download this and test how it works and then maybe test merge this.

I likely won't be back home until monday to properly look at #28717

I also had to fix a bug in to_chat that would keep group/mass messages from showing to all recipients if one of the recipients hadn't loaded the chat yet or had a broken chat.