### PR TITLE
Applies a temporary fix over player_list having a null until the proper solution is found

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -225,8 +225,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	for(var/_M in GLOB.player_list)
 		var/mob/M = _M
 		if(!M)
+			stack_trace("Null detected in player_list. Type: [GLOB.player_list[M]]")
 			listclearnulls(GLOB.player_list)
-			stack_trace("Null detected in GLOB.player_list. List has been cleared from nulls.")
 			continue
 		if(M.stat != DEAD) //not dead, not important
 			continue

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -225,8 +225,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	for(var/_M in GLOB.player_list)
 		var/mob/M = _M
 		if(!M)
-			stack_trace("Null detected in player_list. Type: [GLOB.player_list[M]]")
 			listclearnulls(GLOB.player_list)
+			stack_trace("Null detected in GLOB.player_list. List has been cleared from nulls.")
 			continue
 		if(M.stat != DEAD) //not dead, not important
 			continue

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -224,6 +224,10 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/list/the_dead = list()
 	for(var/_M in GLOB.player_list)
 		var/mob/M = _M
+		if(!M)
+			listclearnulls(GLOB.player_list)
+			stack_trace("Null detected in GLOB.player_list. List has been cleared from nulls.")
+			continue
 		if(M.stat != DEAD) //not dead, not important
 			continue
 		if(!M.client || !client) //client is so that ghosts don't have to listen to mice

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -1,5 +1,5 @@
 /mob/Login()
-	GLOB.player_list |= src
+	GLOB.player_list[src] = type
 	lastKnownIP	= client.address
 	computer_id	= client.computer_id
 	log_access("Mob Login: [key_name(src)] was assigned to a [type]")

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -1,5 +1,5 @@
 /mob/Login()
-	GLOB.player_list[src] = type
+	GLOB.player_list |= src
 	lastKnownIP	= client.address
 	computer_id	= client.computer_id
 	log_access("Mob Login: [key_name(src)] was assigned to a [type]")


### PR DESCRIPTION
So basically something is not being removed from the `GLOB.player_list` properly. This doesn't seem to happen as often(I believe pAIs were causing it aswell) but they still do.

I'm well aware this is not the solution to the problem, but a temporary bandaid is better than ~~bleeding~~ runtiming to death.