### PR TITLE
Fixes the server taking for fucking ever to initialize for local test

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1210,6 +1210,9 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 #define DELTA_CALC max(((max(world.tick_usage, world.cpu) / 100) * max(Master.sleep_delta,1)), 1)
 
 /proc/stoplag()
+	if (!Master || !(Master.current_runlevel & RUNLEVELS_DEFAULT))
+		sleep(world.tick_lag)
+		return 1
 	. = 0
 	var/i = 1
 	do


### PR DESCRIPTION
Initializations complete within 334 seconds!
vs
Initializations complete within 177.1 seconds!

(on my slow ass laptop)

Stupid edge case, stop_lag sleeps for extra time if world.cpu is over 100, but default config doesn't call stop_lag until 500% of the way into the tick during mc init, meaning world.cpu would be creeping up to 500%. Basically this was all being silly and stupid and sleeping for long periods of time to try to make up for the server being overworked, and it only makes sense to do this during the round, not during pre-game.