### PR TITLE
Robotic legs are not weak to glass shards

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -197,6 +197,8 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 			var/obj/item/bodypart/O = H.get_bodypart(picked_def_zone)
 			if(!istype(O))
 				return
+			if(O.status == BODYPART_ROBOTIC)
+				return
 			var/feetCover = (H.wear_suit && H.wear_suit.body_parts_covered & FEET) || (H.w_uniform && H.w_uniform.body_parts_covered & FEET)
 			if(H.shoes || feetCover || H.movement_type & FLYING || H.buckled)
 				return


### PR DESCRIPTION
:cl: Kor
add: Glass shards will no longer hurt people with robotic legs.
/:cl:

Why: As with the last PR, I want people to be able to show off their fancy new aug sprites

Shoes are plentiful and everyone starts with them so I think this is negligible as a balance change