### PR TITLE
Fix modular consoles

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -49,14 +49,15 @@
 	var/comp_light_color			//The color of that light
 
 
-
+/obj/item/device/modular_computer/New()
+	all_components = list()
+	
 /obj/item/device/modular_computer/Initialize()
 	. = ..()
 	START_PROCESSING(SSobj, src)
 	if(!physical)
 		physical = src
 	comp_light_color = "#FFFFFF"
-	all_components = list()
 	idle_threads = list()
 	update_icon()
 

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -39,7 +39,7 @@
 
 	// Optional hardware (improves functionality, but is not critical for computer to work)
 
-	var/list/all_components							// List of "connection ports" in this computer and the components with which they are plugged
+	var/list/all_components = list()						// List of "connection ports" in this computer and the components with which they are plugged
 
 	var/list/idle_threads							// Idle programs on background. They still receive process calls but can't be interacted with.
 	var/obj/physical = null									// Object that represents our computer. It's used for Adjacent() and UI visibility checks.
@@ -49,9 +49,6 @@
 	var/comp_light_color			//The color of that light
 
 
-/obj/item/device/modular_computer/New()
-	all_components = list()
-	
 /obj/item/device/modular_computer/Initialize()
 	. = ..()
 	START_PROCESSING(SSobj, src)


### PR DESCRIPTION
processors try to add components to the list on Initialize()
list probably ~~doesnt exist yet due to vOv~~ got populated then paved over in the base Initialize()

Fixes #28745


:cl: drline
fix: Nanotrasen finally sent out IT personnel to plug your modular consoles back in. You're welcome.
/:cl:
