### PR TITLE
Some fixes for the anomalous crystal

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -357,6 +357,7 @@
 		updatehealth() //then we check if the mob should wake up.
 		update_canmove()
 		update_sight()
+		clear_alert("oxy")
 		reload_fullscreen()
 		. = 1
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -542,8 +542,7 @@ Difficulty: Very Hard
 
 /obj/machinery/anomalous_crystal/emitter/Initialize()
 	. = ..()
-	generated_projectile = pick(/obj/item/projectile/magic/aoe/fireball/infernal,/obj/item/projectile/magic/aoe/lightning,/obj/item/projectile/magic/spellblade,
-								 /obj/item/projectile/bullet/meteorshot, /obj/item/projectile/beam/xray, /obj/item/projectile/colossus)
+	generated_projectile = pick(/obj/item/projectile/colossus)
 
 	var/proj_name = initial(generated_projectile.name)
 	observer_desc = "This crystal generates \a [proj_name] when activated."
@@ -582,6 +581,8 @@ Difficulty: Very Hard
 				var/mob/living/carbon/human/H = i
 				if(H.stat == DEAD)
 					H.set_species(/datum/species/shadow, 1)
+					H.regenerate_limbs()
+					H.regenerate_organs()
 					H.revive(1,0)
 					H.disabilities |= NOCLONE //Free revives, but significantly limits your options for reviving except via the crystal
 					H.grab_ghost(force = TRUE)
@@ -734,7 +735,7 @@ Difficulty: Very Hard
 
 /obj/structure/closet/stasis/process()
 	if(holder_animal)
-		if(holder_animal.stat == DEAD && !QDELETED(holder_animal))
+		if(holder_animal.stat == DEAD)
 			dump_contents()
 			holder_animal.gib()
 			return
@@ -762,7 +763,7 @@ Difficulty: Very Hard
 		L.disabilities &= ~MUTE
 		L.status_flags &= ~GODMODE
 		L.notransform = 0
-		if(holder_animal && !QDELETED(holder_animal))
+		if(holder_animal)
 			holder_animal.mind.transfer_to(L)
 			L.mind.RemoveSpell(/obj/effect/proc_holder/spell/targeted/exit_possession)
 		if(kill || !isanimal(loc))


### PR DESCRIPTION
Just some fixes for the Anomalous crystal
* Dark Reprise crystal properly regenerates organs and limbs for revivees - And now also clears off that stupid O2 warning
* Removed all the projectiles from the emitter crystal except the colossus one because they were either completely broken (magic was completely fucked) or boring. Now it just spits out a death bolt every time, a bit more predictable and generally more all around useful
* Fixed an issue where players getting killed while possessing mobs that qdel on death weren't able to get back in their bodies

:cl:
fix: Fixed a few anomalous crystal effects
/:cl: