### PR TITLE
Fixes resin stacking & allows lasers to pass through resin

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -278,7 +278,7 @@
 
 /obj/structure/foamedmetal/resin/CanPass(atom/movable/mover, turf/target, height)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
-		return 1
+		return TRUE
 	. = ..()
 
 #undef ALUMINUM_FOAM

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -276,6 +276,10 @@
 		for(var/obj/item/Item in O)
 			Item.extinguish()
 
+/obj/structure/foamedmetal/resin/CanPass(atom/movable/mover, turf/target, height)
+	if(istype(mover) && mover.checkpass(PASSGLASS))
+		return 1
+	. = ..()
 
 #undef ALUMINUM_FOAM
 #undef IRON_FOAM

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -295,14 +295,10 @@
 	if(nozzle_mode == RESIN_FOAM)
 		if(!Adj|| !isturf(target))
 			return
-		var/existing_resin_check = FALSE
 		for(var/S in target)
 			if(istype(S, /obj/effect/particle_effect/foam/metal/resin) || istype(S, /obj/structure/foamedmetal/resin))
-				existing_resin_check = TRUE
-				break
-		if(existing_resin_check)
-			to_chat(user, "<span class='warning'>There's already resin here!</span>")
-			return
+				to_chat(user, "<span class='warning'>There's already resin here!</span>")
+				return
 		if(metal_synthesis_cooldown < 5)
 			var/obj/effect/particle_effect/foam/metal/resin/F = new (get_turf(target))
 			F.amount = 0

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -295,6 +295,14 @@
 	if(nozzle_mode == RESIN_FOAM)
 		if(!Adj|| !isturf(target))
 			return
+		var/existing_resin_check = FALSE
+		for(var/S in target)
+			if(istype(S, /obj/effect/particle_effect/foam/metal/resin) || istype(S, /obj/structure/foamedmetal/resin))
+				existing_resin_check = TRUE
+				break
+		if(existing_resin_check)
+			to_chat(user, "<span class='warning'>There's already resin here!</span>")
+			return
 		if(metal_synthesis_cooldown < 5)
 			var/obj/effect/particle_effect/foam/metal/resin/F = new (get_turf(target))
 			F.amount = 0


### PR DESCRIPTION
* Prevents the player from stacking resin in a single tile.
* Lasers now go through resin, just like glass.

:cl:
fix: Fixes stacking atmos resin objects in a single tile
tweak: Lasers now go through atmos resin objects
/:cl:

Fixes #28828
