### PR TITLE
Fixes AI <-> Shell mind transfer issues

### DIFF
--- a/code/datums/antagonists/datum_traitor.dm
+++ b/code/datums/antagonists/datum_traitor.dm
@@ -38,7 +38,7 @@
 
 
 /datum/antagonist/traitor/on_body_transfer(mob/living/old_body, mob/living/new_body)
-	if(isAI(new_body)==isAI(old_body))
+	if(issilicon(new_body) && issilicon(old_body))
 		..()
 	else
 		silent = TRUE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1085,7 +1085,8 @@
 		camera.c_tag = real_name	//update the camera name too
 	diag_hud_set_aishell()
 	mainframe.diag_hud_set_deployed()
-	mainframe.show_laws() //Always remind the AI when switching
+	if(mainframe.laws)
+		mainframe.laws.show_laws(mainframe) //Always remind the AI when switching
 	mainframe = null
 
 /mob/living/silicon/robot/attack_ai(mob/user)


### PR DESCRIPTION
- Fixed Traitor/Malf AIs resetting their antagonist status and points
upon transfering to a shell and back.

- Fixes connected borgs being shown their laws when the AI returns to
its shell.

Fixes https://github.com/tgstation/tgstation/issues/28845
Fixes https://github.com/tgstation/tgstation/issues/28422