### PR TITLE
[s] Fixes Malf AI exploit

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -1,5 +1,21 @@
 #define DEFAULT_DOOMSDAY_TIMER 4500
 
+GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
+		/obj/machinery/field/containment,
+		/obj/machinery/power/supermatter_shard,
+		/obj/machinery/dominator,
+		/obj/machinery/doomsday_device,
+		/obj/machinery/nuclearbomb,
+		/obj/machinery/nuclearbomb/selfdestruct,
+		/obj/machinery/nuclearbomb/syndicate,
+		/obj/machinery/syndicatebomb,
+		/obj/machinery/syndicatebomb/badmin,
+		/obj/machinery/syndicatebomb/badmin/clown,
+		/obj/machinery/syndicatebomb/empty,
+		/obj/machinery/syndicatebomb/self_destruct,
+		/obj/machinery/syndicatebomb/training
+	)))
+
 //The malf AI action subtype. All malf actions are subtypes of this.
 /datum/action/innate/ai
 	name = "AI Action"
@@ -562,6 +578,9 @@
 	if(!istype(target))
 		to_chat(ranged_ability_user, "<span class='warning'>You can only overload machines!</span>")
 		return
+	if(is_type_in_typecache(target, GLOB.blacklisted_malf_machines))
+		to_chat(ranged_ability_user, "<span class='warning'>You cannot overload that device!</span>")
+		return
 	ranged_ability_user.playsound_local(ranged_ability_user, "sparks", 50, 0)
 	attached_action.adjust_uses(-1)
 	target.audible_message("<span class='userdanger'>You hear a loud electrical buzzing sound coming from [target]!</span>")
@@ -606,7 +625,7 @@
 	if(!istype(target))
 		to_chat(ranged_ability_user, "<span class='warning'>You can only animate machines!</span>")
 		return
-	if(!target.can_be_overridden())
+	if(!target.can_be_overridden() || is_type_in_typecache(target, GLOB.blacklisted_malf_machines))
 		to_chat(ranged_ability_user, "<span class='warning'>That machine can't be overriden!</span>")
 		return
 	ranged_ability_user.playsound_local(ranged_ability_user, 'sound/misc/interference.ogg', 50, 0)

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -3,7 +3,6 @@
 GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		/obj/machinery/field/containment,
 		/obj/machinery/power/supermatter_shard,
-		/obj/machinery/dominator,
 		/obj/machinery/doomsday_device,
 		/obj/machinery/nuclearbomb,
 		/obj/machinery/nuclearbomb/selfdestruct,


### PR DESCRIPTION
Fixes Malf AIs being able to forcibly detonate / animate potentially round-ending machinery, the SM, and syndiebombs (which it can't normally interact with.)