### PR TITLE
Minor devil fixes.

### DIFF
--- a/code/datums/antagonists/devil.dm
+++ b/code/datums/antagonists/devil.dm
@@ -107,6 +107,7 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 		/obj/effect/proc_holder/spell/targeted/conjure_item/violin,
 		/obj/effect/proc_holder/spell/targeted/summon_dancefloor))
 	var/ascendable = FALSE
+	name = "Devil"
 
 
 /datum/antagonist/devil/New()
@@ -309,7 +310,7 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 /datum/antagonist/devil/proc/give_appropriate_spells()
 	remove_spells()
 	give_summon_contract()
-	if(SOULVALUE >= ARCH_THRESHOLD)
+	if(SOULVALUE >= ARCH_THRESHOLD && ascendable)
 		give_arch_spells()
 	else if(SOULVALUE >= TRUE_THRESHOLD)
 		give_true_spells()
@@ -403,7 +404,7 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 
 /datum/antagonist/devil/proc/hellish_resurrection(mob/living/body)
 	message_admins("[owner.name] (true name is: [truename]) is resurrecting using hellish energy.</a>")
-	if(SOULVALUE < ARCH_THRESHOLD && ascendable) // once ascended, arch devils do not go down in power by any means.
+	if(SOULVALUE < ARCH_THRESHOLD || !ascendable) // once ascended, arch devils do not go down in power by any means.
 		reviveNumber += LOSS_PER_DEATH
 		update_hud()
 	if(body)
@@ -450,8 +451,8 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 				A.faction |= "hell"
 				H.forceMove(A)
 				A.oldform = H
+				owner.transfer_to(A, TRUE)
 				A.set_name()
-				owner.transfer_to(A)
 				if(SOULVALUE >= ARCH_THRESHOLD && ascendable)
 					A.convert_to_archdevil()
 	else

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1641,6 +1641,7 @@
 			if(istype(S, type))
 				continue
 		S.charge_counter = delay
+		S.updateButtonIcon()
 		INVOKE_ASYNC(S, /obj/effect/proc_holder/spell.proc/start_recharge)
 
 /datum/mind/proc/get_ghost(even_if_they_cant_reenter)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -359,6 +359,10 @@
 		update_sight()
 		reload_fullscreen()
 		. = 1
+		if(mind)
+			for(var/S in mind.spell_list)
+				var/obj/effect/proc_holder/spell/spell = S
+				spell.updateButtonIcon()
 
 //proc used to completely heal a mob.
 /mob/living/proc/fully_heal(admin_revive = 0)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -449,6 +449,9 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 	perform(targets,user=user)
 
+/obj/effect/proc_holder/spell/proc/updateButtonIcon()
+	action.UpdateButtonIcon()
+
 /obj/effect/proc_holder/spell/proc/can_be_cast_by(mob/caster)
 	if((human_req || clothes_req) && !ishuman(caster))
 		return 0


### PR DESCRIPTION
Hello, this fixes a couple of devil related bugs.

Fixes devils not losing souls upon resurrection.
Fixes spells appearing deactivated upon resurrection.  Note: this applies to more than just devils, but it's the most common scenario for this to be a problem.
Fixes unascendable devils being able to get ascension grade spells.
Devils with salt and flash banes now have their spell icons greyed out properly upon being hit with their bane.

These are all pretty obscure, so there's no real need for a changelog.