### PR TITLE
SM squawk tweaks

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -67,13 +67,14 @@
 
 	var/damage = 0
 	var/damage_archived = 0
-	var/safe_alert = "Crystalline hyperstructure returning to safe operating levels."
+	var/safe_alert = "Crystalline hyperstructure stability returning to safe operating parameters."
 	var/warning_point = 50
-	var/warning_alert = "Danger! Crystal hyperstructure instability!"
+	var/warning_alert = "Danger! Crystal hyperstructure stability faltering!"
 	var/damage_penalty_point = 550
 	var/emergency_point = 700
 	var/emergency_alert = "CRYSTAL DELAMINATION IMMINENT."
 	var/explosion_point = 900
+	var/stability = 100
 
 	var/emergency_issued = FALSE
 
@@ -337,24 +338,25 @@
 			supermatter_anomaly_gen(src, PYRO_ANOMALY, rand(5, 10))
 
 
+	if(damage > 1) // stability updates for squawks. > 1 to minimize number of changes during normal operation, takes roughly 40s of no cooling to trigger
+		stability = num2text(round(100 - ((damage / explosion_point) * 100), 0.05))
 
 	if(damage > warning_point) // while the core is still damaged and it's still worth noting its status
 		if((REALTIMEOFDAY - lastwarning) / 10 >= WARNING_DELAY)
-			var/stability = num2text(round((damage / explosion_point) * 100))
 
 			if(damage > emergency_point)
-				radio.talk_into(src, "[emergency_alert] Instability: [stability]%", common_channel, get_spans(), get_default_language())
+				radio.talk_into(src, "[emergency_alert] Stability: [stability]%", common_channel, get_spans(), get_default_language())
 				lastwarning = REALTIMEOFDAY
 				if(!has_reached_emergency)
 					investigate_log("has reached the emergency point for the first time.", INVESTIGATE_SUPERMATTER)
 					message_admins("[src] has reached the emergency point [ADMIN_JMP(src)].")
 					has_reached_emergency = 1
 			else if(damage >= damage_archived) // The damage is still going up
-				radio.talk_into(src, "[warning_alert] Instability: [stability]%", engineering_channel, get_spans(), get_default_language())
+				radio.talk_into(src, "[warning_alert] Stability: [stability]%", engineering_channel, get_spans(), get_default_language())
 				lastwarning = REALTIMEOFDAY - (WARNING_DELAY * 5)
 
 			else                                                 // Phew, we're safe
-				radio.talk_into(src, "[safe_alert] Instability: [stability]%", engineering_channel, get_spans(), get_default_language())
+				radio.talk_into(src, "[safe_alert] Stability: [stability]%", engineering_channel, get_spans(), get_default_language())
 				lastwarning = REALTIMEOFDAY
 
 			if(power > POWER_PENALTY_THRESHOLD)
@@ -440,10 +442,10 @@
 	if(Adjacent(user))
 		return attack_hand(user)
 	else
-		to_chat(user, "<span class='warning'>You attempt to interface with the control circuits but find they are not connected to your network. Maybe in a future firmware update.</span>")
+		to_chat(user, "<span class='warning'>Crystal hyperstructure stability is currently at: [stability]%</span>")
 
 /obj/machinery/power/supermatter_shard/attack_ai(mob/user)
-	to_chat(user, "<span class='warning'>You attempt to interface with the control circuits but find they are not connected to your network. Maybe in a future firmware update.</span>")
+	to_chat(user, "<span class='warning'>Crystal hyperstructure stability is currently at: [stability]%</span>")
 
 /obj/machinery/power/supermatter_shard/attack_hand(mob/living/user)
 	if(!istype(user))


### PR DESCRIPTION
Changes squawk (warnings) to count down from 100%
(ie Crystal Stability is at 97% opposed to Instability at 3%.)

Changed click message for silicons from saying 'nothing here right now, check again later', to actually giving the current stability