### PR TITLE
Makes pulsing the AI wire of a borg offer the user the option to change it and properly notifies the AI when it is cut.

### DIFF
--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -40,3 +40,4 @@
 #define		NEW_MODULE   2
 #define		RENAME       3
 #define		AI_SHELL     4
+#define		DISCONNECT   5

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -26,12 +26,16 @@
 	status += "The reset module hardware light is [R.has_module() ? "on" : "off"]."
 	return status
 
-/datum/wires/robot/on_pulse(wire)
+/datum/wires/robot/on_pulse(wire, user)
 	var/mob/living/silicon/robot/R = holder
 	switch(wire)
 		if(WIRE_AI) // Pulse to pick a new AI.
 			if(!R.emagged)
-				var/new_ai = select_active_ai(R)
+				var/new_ai
+				if(user)
+					new_ai = select_active_ai(user)
+				else
+					new_ai = select_active_ai(R)
 				if(new_ai && (new_ai != R.connected_ai))
 					R.connected_ai = new_ai
 					if(R.shell)
@@ -59,8 +63,12 @@
 	switch(wire)
 		if(WIRE_AI) // Cut the AI wire to reset AI control.
 			if(!mend)
+				if(R.shell)
+					R.undeploy()
+					R.notify_ai(AI_SHELL)
+				else
+					R.notify_ai(TRUE)
 				R.connected_ai = null
-				R.undeploy() //Forced disconnect of an AI should this body be a shell.
 		if(WIRE_LAWSYNC) // Cut the law wire, and the borg will no longer receive law updates from its AI. Repair and it will re-sync.
 			if(mend)
 				if(!R.emagged)

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -36,6 +36,7 @@
 					new_ai = select_active_ai(user)
 				else
 					new_ai = select_active_ai(R)
+				R.notify_ai(DISCONNECT)
 				if(new_ai && (new_ai != R.connected_ai))
 					R.connected_ai = new_ai
 					if(R.shell)
@@ -63,11 +64,9 @@
 	switch(wire)
 		if(WIRE_AI) // Cut the AI wire to reset AI control.
 			if(!mend)
+				R.notify_ai(DISCONNECT)
 				if(R.shell)
 					R.undeploy()
-					R.notify_ai(AI_SHELL)
-				else
-					R.notify_ai(TRUE)
 				R.connected_ai = null
 		if(WIRE_LAWSYNC) // Cut the law wire, and the borg will no longer receive law updates from its AI. Repair and it will re-sync.
 			if(mend)

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -127,13 +127,13 @@
 	for(var/wire in wires)
 		cut(wire)
 
-/datum/wires/proc/pulse(wire)
+/datum/wires/proc/pulse(wire, user)
 	if(is_cut(wire))
 		return
-	on_pulse(wire)
+	on_pulse(wire, user)
 
-/datum/wires/proc/pulse_color(color)
-	pulse(get_wire(color))
+/datum/wires/proc/pulse_color(color, mob/living/user)
+	pulse(get_wire(color), user)
 
 /datum/wires/proc/pulse_assembly(obj/item/device/assembly/S)
 	for(var/color in assemblies)
@@ -177,7 +177,7 @@
 /datum/wires/proc/on_cut(wire, mend = FALSE)
 	return
 
-/datum/wires/proc/on_pulse(wire)
+/datum/wires/proc/on_pulse(wire, user)
 	return
 // End Overridable Procs
 
@@ -236,7 +236,7 @@
 		if("pulse")
 			if(istype(I, /obj/item/device/multitool) || IsAdminGhost(usr))
 				playsound(holder, 'sound/weapons/empty.ogg', 20, 1)
-				pulse_color(target_wire)
+				pulse_color(target_wire, L)
 				. = TRUE
 			else
 				to_chat(L, "<span class='warning'>You need a multitool!</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -848,6 +848,8 @@
 			to_chat(connected_ai, "<br><br><span class='notice'>NOTICE - Cyborg reclassification detected: [oldname] is now designated as [newname].</span><br>")
 		if(AI_SHELL) //New Shell
 			to_chat(connected_ai, "<br><br><span class='notice'>NOTICE - New cyborg shell detected: <a href='?src=\ref[connected_ai];track=[html_encode(name)]'>[name]</a></span><br>")
+		if(DISCONNECT) //New Shell
+			to_chat(connected_ai, "<br><br><span class='notice'>NOTICE - Remote telemetry lost with [name].</span><br>")
 
 /mob/living/silicon/robot/canUseTopic(atom/movable/M, be_close = 0)
 	if(stat || lockcharge || low_power_mode)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -848,7 +848,7 @@
 			to_chat(connected_ai, "<br><br><span class='notice'>NOTICE - Cyborg reclassification detected: [oldname] is now designated as [newname].</span><br>")
 		if(AI_SHELL) //New Shell
 			to_chat(connected_ai, "<br><br><span class='notice'>NOTICE - New cyborg shell detected: <a href='?src=\ref[connected_ai];track=[html_encode(name)]'>[name]</a></span><br>")
-		if(DISCONNECT) //New Shell
+		if(DISCONNECT) //Tampering with the wires
 			to_chat(connected_ai, "<br><br><span class='notice'>NOTICE - Remote telemetry lost with [name].</span><br>")
 
 /mob/living/silicon/robot/canUseTopic(atom/movable/M, be_close = 0)


### PR DESCRIPTION
:cl:
balance: The AI swap menu is now given to the person with the multi-tool rather than the Borg. Old behavior remains for all non multi-tool sources
fix: Borgs and shells now notify when un-linked due to the wire being cut.
/:cl:

Fixes: #28852

The change to the robotics behavior was because it makes more sense for the dude reprogramming you to be able to PICK.