### PR TITLE
Removes most tiny fans from Deltastation, replaced with airlock cycle system

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -388,6 +388,7 @@
 /area/hallway/secondary/entry)
 "aaU" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
@@ -439,7 +440,6 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aaY" = (
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -486,6 +486,7 @@
 /area/hallway/secondary/entry)
 "abe" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
@@ -696,6 +697,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "External Solar Access";
 	req_access_txt = "10; 13"
 	},
@@ -714,7 +716,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/starboard/fore)
@@ -12322,6 +12323,7 @@
 "azU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Supply Dock Airlock";
 	req_access_txt = "31"
 	},
@@ -12348,6 +12350,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
 	name = "Supply Dock Airlock";
 	req_access_txt = "31"
 	},
@@ -13316,6 +13319,7 @@
 /area/quartermaster/storage)
 "aBS" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Supply Dock Airlock";
 	req_access_txt = "31"
 	},
@@ -14963,6 +14967,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "External Solar Access";
 	req_access_txt = "10";
 	req_one_access = null;
@@ -14983,7 +14988,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/fans/tiny,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -22303,7 +22307,6 @@
 	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -27497,6 +27500,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "Mining Dock Airlock";
 	req_access = null;
 	req_access_txt = "48"
@@ -27527,6 +27531,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
 	name = "Mining Dock Airlock";
 	req_access = null;
 	req_access_txt = "48"
@@ -34719,7 +34724,6 @@
 /turf/open/floor/plasteel,
 /area/security/transfer)
 "bqD" = (
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/security/transfer)
@@ -36388,6 +36392,7 @@
 "btE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
@@ -36756,6 +36761,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/vault{
+	cyclelinkeddir = 4;
 	locked = 1;
 	name = "Vault Door";
 	req_access_txt = "53"
@@ -36782,6 +36788,7 @@
 /area/security/nuke_storage)
 "buu" = (
 /obj/machinery/door/airlock/vault{
+	cyclelinkeddir = 8;
 	locked = 1;
 	name = "Vault Door";
 	req_access_txt = "53"
@@ -37174,7 +37181,6 @@
 /area/engine/gravity_generator)
 "bve" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -37870,7 +37876,6 @@
 /area/security/transfer)
 "bwe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/security/transfer)
@@ -38277,6 +38282,7 @@
 "bwP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
@@ -39750,7 +39756,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
-	cyclelinkeddir = 0;
+	cyclelinkeddir = 4;
 	name = "Bridge Access";
 	req_access_txt = "19"
 	},
@@ -39819,7 +39825,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
-	cyclelinkeddir = 0;
+	cyclelinkeddir = 8;
 	name = "Bridge Access";
 	req_access_txt = "19"
 	},
@@ -40069,7 +40075,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
-	cyclelinkeddir = 0;
+	cyclelinkeddir = 4;
 	name = "Bridge Access";
 	req_access_txt = "19"
 	},
@@ -40110,7 +40116,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
-	cyclelinkeddir = 0;
+	cyclelinkeddir = 8;
 	name = "Bridge Access";
 	req_access_txt = "19"
 	},
@@ -40953,7 +40959,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
-	cyclelinkeddir = 0;
+	cyclelinkeddir = 4;
 	name = "Bridge Access";
 	req_access_txt = "19"
 	},
@@ -40998,7 +41004,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_command{
-	cyclelinkeddir = 0;
+	cyclelinkeddir = 8;
 	name = "Bridge Access";
 	req_access_txt = "19"
 	},
@@ -45568,6 +45574,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/hatch{
+	cyclelinkeddir = 4;
 	name = "MiniSat Exterior Access";
 	req_one_access_txt = "32;19"
 	},
@@ -50861,6 +50868,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 4;
 	name = "Brig";
 	req_access_txt = "63"
 	},
@@ -52954,6 +52962,7 @@
 "bWY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 4;
 	name = "Brig";
 	req_access_txt = "63"
 	},
@@ -54136,6 +54145,7 @@
 /area/engine/engineering)
 "bZk" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "External Containment Access";
 	req_access_txt = "10; 13"
 	},
@@ -68625,6 +68635,7 @@
 /area/engine/engineering)
 "cAZ" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "External Containment Access";
 	req_access_txt = "10; 13"
 	},
@@ -70566,6 +70577,7 @@
 /area/crew_quarters/fitness/recreation)
 "cEM" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
@@ -78191,6 +78203,7 @@
 "cTR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
+	cyclelinkeddir = 2;
 	name = "Research Division Access";
 	req_access_txt = "47"
 	},
@@ -78211,6 +78224,7 @@
 "cTT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
+	cyclelinkeddir = 2;
 	name = "Research Division Access";
 	req_access_txt = "47"
 	},
@@ -98428,6 +98442,7 @@
 /area/science/test_area)
 "dHX" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
@@ -98446,6 +98461,7 @@
 /area/maintenance/port/aft)
 "dHZ" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
@@ -102769,6 +102785,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dRe" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "External Docking Port"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -105050,6 +105067,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "External Solar Access";
 	req_access_txt = "10; 13"
 	},
@@ -105068,7 +105086,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/aft)
@@ -106362,6 +106379,7 @@
 /area/security/checkpoint/checkpoint2)
 "dXR" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "External Docking Port";
 	req_access_txt = "63"
 	},
@@ -106374,7 +106392,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/checkpoint2)
 "dXS" = (
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/checkpoint2)
@@ -106598,6 +106615,7 @@
 "dYr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
@@ -107034,7 +107052,6 @@
 /turf/open/floor/carpet,
 /area/chapel/office)
 "dZg" = (
-/obj/structure/fans/tiny,
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
@@ -107365,6 +107382,7 @@
 /area/chapel/office)
 "dZQ" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
@@ -110392,6 +110410,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	name = "External Solar Access";
 	req_access_txt = "10; 13"
 	},
@@ -110410,7 +110429,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/starboard/aft)
@@ -112563,6 +112581,7 @@
 /area/hallway/secondary/entry)
 "epc" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 2;
 	name = "External Docking Port"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -112815,6 +112834,319 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"epB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Solar Access";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/solars/starboard/fore)
+"epC" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 1;
+	name = "External Docking Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"epD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Solar Access";
+	req_access_txt = "10";
+	req_one_access = null;
+	req_one_access_txt = "13; 24"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/solars/port/fore)
+"epE" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass_command{
+	cyclelinkeddir = 8;
+	name = "Bridge Access";
+	req_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/bridge)
+"epF" = (
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/hatch{
+	cyclelinkeddir = 8;
+	name = "MiniSat Exterior Access";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/engine/transit_tube)
+"epG" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 8;
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"epH" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 8;
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"epI" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Containment Access";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"epJ" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Containment Access";
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"epK" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port)
+"epL" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	cyclelinkeddir = 1;
+	name = "Research Division Access";
+	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
+"epM" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	cyclelinkeddir = 1;
+	name = "Research Division Access";
+	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
+"epN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Solar Access";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/solars/starboard/aft)
+"epO" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Docking Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"epP" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Docking Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"epQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Solar Access";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/solars/port/aft)
+"epR" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Docking Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"epS" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	name = "External Docking Port";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/checkpoint2)
 
 (1,1,1) = {"
 aaa
@@ -132499,7 +132831,7 @@ aaf
 bVT
 bVT
 bVT
-cEM
+epK
 bWg
 bWg
 chF
@@ -132949,7 +133281,7 @@ aaf
 aaf
 aBX
 aBX
-aEN
+epD
 aBX
 aBZ
 aBZ
@@ -133755,7 +134087,7 @@ bBV
 bDJ
 btD
 bHx
-bJy
+epF
 bLz
 bHv
 bPy
@@ -136590,7 +136922,7 @@ bRV
 bDM
 bVT
 bXw
-bZk
+epI
 bVT
 ccU
 ceE
@@ -136608,7 +136940,7 @@ cuM
 cht
 ccU
 bVT
-cAZ
+epJ
 bXw
 bVT
 cEV
@@ -140521,7 +140853,7 @@ aaa
 aaf
 dUl
 dUl
-dVx
+epQ
 dUl
 dUl
 aaf
@@ -144475,14 +144807,14 @@ aaf
 aaf
 aaf
 aax
-epb
+egV
 aax
 aaf
 aaa
 aaa
 aaf
 aax
-epb
+egV
 aax
 aaf
 aaf
@@ -144732,14 +145064,14 @@ aaa
 aaf
 aaa
 aax
-aci
+ack
 aax
 aax
 aax
 aax
 aax
 aax
-aci
+ack
 aax
 aaa
 aaf
@@ -144989,14 +145321,14 @@ aax
 aaD
 abT
 aax
-epc
+egU
 aax
 acC
 acT
 ack
 adq
 aax
-epb
+egW
 aax
 abR
 aaD
@@ -147315,8 +147647,8 @@ edp
 edp
 een
 epc
-aci
-epc
+ack
+epC
 agl
 agN
 ahu
@@ -148189,7 +148521,7 @@ cTR
 cVw
 cXn
 cYN
-cTR
+epL
 dbv
 dcR
 deC
@@ -148330,14 +148662,14 @@ aaf
 aaf
 aaf
 aax
-epb
+egV
 aax
 aaf
 aaf
 aaf
 aaf
 aax
-epc
+egT
 aax
 aaf
 aaf
@@ -148587,14 +148919,14 @@ aaa
 aaf
 aaa
 aax
-aci
+ack
 aax
 aax
 aax
 aax
 aax
 aax
-aci
+ack
 aax
 aaa
 aaf
@@ -148703,7 +149035,7 @@ cTT
 cVy
 cXp
 cYP
-cTT
+epM
 dbx
 dcS
 deE
@@ -148844,14 +149176,14 @@ aax
 aaD
 abR
 aax
-epc
+egU
 aax
 acE
 acV
 adg
 adr
 aax
-epb
+egW
 aax
 abT
 aaD
@@ -150129,14 +150461,14 @@ aaa
 aaf
 aaa
 aax
-aci
+ack
 aax
 aax
 aax
 aax
 aax
 aax
-aci
+ack
 aax
 aaa
 aaf
@@ -153109,15 +153441,15 @@ aaf
 aaa
 aaa
 dMY
-dRf
+dPA
 dMY
-dRf
+dPA
 dMY
 aaf
 aaf
 aaf
 dMY
-dRf
+dPA
 dXk
 dXS
 dXk
@@ -153213,14 +153545,14 @@ aaa
 aaf
 aaa
 aax
-aci
+ack
 aax
 aax
 aax
 aax
 aax
 aax
-aci
+ack
 aax
 aaa
 aaf
@@ -153366,17 +153698,17 @@ aaa
 aaa
 aaa
 dMY
-dRe
+epO
 dMY
-dRe
+epP
 dMY
 aaa
 aaa
 aaa
 dMY
-dRe
+epR
 dXk
-dXR
+epS
 dXk
 aaa
 aaa
@@ -155852,7 +156184,7 @@ brK
 bsV
 bxw
 bzN
-bBc
+epE
 bCL
 bEL
 bEL
@@ -156131,16 +156463,16 @@ cim
 brN
 brN
 bqq
-coe
+bkT
 cpL
-cqZ
+brH
 csr
-cub
+bmI
 cvE
 cwY
-cqZ
-cqZ
-cqZ
+brH
+brH
+brH
 brH
 bkT
 cFG
@@ -156166,10 +156498,10 @@ djZ
 dlM
 dnc
 doh
-dpQ
+dnc
 drt
 dsT
-dpQ
+dnc
 ego
 dwO
 dyc
@@ -157064,7 +157396,7 @@ aaa
 aaa
 aaa
 abg
-aby
+epB
 abg
 aaf
 aaf
@@ -163571,9 +163903,9 @@ bDq
 bNb
 bOP
 bIZ
-bTh
+epG
 bVq
-bWY
+epH
 bIZ
 beF
 cct
@@ -167221,7 +167553,7 @@ agg
 agg
 aaf
 eik
-eis
+epN
 eik
 aaf
 aaf


### PR DESCRIPTION
Tiny fans were always considered bad map design, and only used when absolutely needed.
Mso's lazy airlock cycling is a much better system.

A few were left in in places like the telecomms server room, the toxins launcher, and the old containment area since it seemed okayish to leave them. Those airlocks still got cycling though.

:cl:
del: The majority of the tiny fans on Deltastation have been removed.
tweak: Airlocks going to space, and secure areas like the bridge and sec on Delta have been given the cycling system.
/:cl: