### PR TITLE
Fixes ninjas not getting their katana

### DIFF
--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -67,6 +67,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 50
+	slot_flags = SLOT_BELT
 	sharpness = IS_SHARP
 	obj_integrity = 200
 	max_integrity = 200


### PR DESCRIPTION
New dash weapon was missing the belt slot flag, so it deleted itself when trying to equip to the ninja

Fixes https://github.com/tgstation/tgstation/issues/28880