### PR TITLE
[s] Holodeck exploit fix

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -171,6 +171,8 @@
 			load_program(area)
 	else if("safety" in href_list)
 		var/safe = text2num(href_list["safety"])
+		if(!issilicon(usr))
+			return
 		emagged = !safe
 		if(!program)
 			return


### PR DESCRIPTION
The emag button in the holodeck console now checks that the user is a silicon.
[s] tag because it is an exploit.
Fixes https://github.com/tgstation/tgstation/issues/28915