### PR TITLE
Chasms, asteroid turfs, basalt, and lava can no longer be made wet

### DIFF
--- a/code/game/turfs/simulated/chasm.dm
+++ b/code/game/turfs/simulated/chasm.dm
@@ -14,6 +14,12 @@
 	var/drop_y = 1
 	var/drop_z = 1
 
+/turf/open/chasm/MakeSlippery(wet_setting = TURF_WET_WATER, min_wet_time = 0, wet_time_to_add = 0)
+	return
+
+/turf/open/chasm/MakeDry(wet_setting = TURF_WET_WATER)
+	return
+
 /turf/open/chasm/Entered(atom/movable/AM)
 	START_PROCESSING(SSobj, src)
 	drop_stuff(AM)

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -25,6 +25,12 @@
 /turf/open/floor/plating/asteroid/burn_tile()
 	return
 
+/turf/open/floor/plating/asteroid/MakeSlippery(wet_setting = TURF_WET_WATER, min_wet_time = 0, wet_time_to_add = 0)
+	return
+
+/turf/open/floor/plating/asteroid/MakeDry(wet_setting = TURF_WET_WATER)
+	return
+
 /turf/open/floor/plating/asteroid/ex_act(severity, target)
 	contents_explosion(severity, target)
 	switch(severity)

--- a/code/game/turfs/simulated/floor/plating/lava.dm
+++ b/code/game/turfs/simulated/floor/plating/lava.dm
@@ -11,7 +11,13 @@
 	light_power = 0.75
 	light_color = LIGHT_COLOR_LAVA
 
-/turf/open/floor/plating/lava/ex_act()
+/turf/open/floor/plating/lava/ex_act(severity, target)
+	contents_explosion(severity, target)
+
+/turf/open/floor/plating/lava/MakeSlippery(wet_setting = TURF_WET_WATER, min_wet_time = 0, wet_time_to_add = 0)
+	return
+
+/turf/open/floor/plating/lava/MakeDry(wet_setting = TURF_WET_WATER)
 	return
 
 /turf/open/floor/plating/lava/airless


### PR DESCRIPTION
:cl: Joan
balance: Chasms, asteroid turfs, basalt, and lava can no longer be made wet.
/:cl:

There's not enough water in the WORLD to make lavaland turfs wet and frankly lava and chasms cannot be justified.
[Also, apparently a balance issue?](https://github.com/tgstation/tgstation/pull/28886#issuecomment-311715864)

Also fixes lava not exploding things on it when exploded. Hey.