### PR TITLE
Fixes cartridges not linking with their host PDAs on creation

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -48,7 +48,7 @@
 	var/mob/living/simple_animal/bot/active_bot
 	var/list/botlist = list()
 
-/obj/item/weapon/cartridge/Initialize(var/obj/item/device/pda/pda)
+/obj/item/weapon/cartridge/New(var/obj/item/device/pda/pda)
 	..()
 	if(pda)
 		host_pda = pda
@@ -130,7 +130,7 @@
 	icon_state = "cart-tox"
 	access = CART_REAGENT_SCANNER | CART_ATMOS
 
-/obj/item/weapon/cartridge/signal/Initialize()
+/obj/item/weapon/cartridge/signal/New()
 	..()
 	radio = new /obj/item/radio/integrated/signal(src)
 
@@ -179,7 +179,7 @@
 	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_REAGENT_SCANNER | CART_ATMOS | CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT | CLEAN_BOT | MED_BOT
 
-/obj/item/weapon/cartridge/rd/Initialize()
+/obj/item/weapon/cartridge/rd/New()
 	..()
 	radio = new /obj/item/radio/integrated/signal(src)
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -48,9 +48,10 @@
 	var/mob/living/simple_animal/bot/active_bot
 	var/list/botlist = list()
 
-/obj/item/weapon/cartridge/New(var/obj/item/device/pda/pda)
-	..()
-	if(pda)
+/obj/item/weapon/cartridge/Initialize()
+	. = ..()
+	var/obj/item/device/pda/pda = loc
+	if(istype(pda, /obj/item/device/pda))
 		host_pda = pda
 
 /obj/item/weapon/cartridge/engineering
@@ -130,7 +131,7 @@
 	icon_state = "cart-tox"
 	access = CART_REAGENT_SCANNER | CART_ATMOS
 
-/obj/item/weapon/cartridge/signal/New()
+/obj/item/weapon/cartridge/signal/Initialize()
 	..()
 	radio = new /obj/item/radio/integrated/signal(src)
 
@@ -179,7 +180,7 @@
 	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_REAGENT_SCANNER | CART_ATMOS | CART_DRONEPHONE
 	bot_access_flags = FLOOR_BOT | CLEAN_BOT | MED_BOT
 
-/obj/item/weapon/cartridge/rd/New()
+/obj/item/weapon/cartridge/rd/Initialize()
 	..()
 	radio = new /obj/item/radio/integrated/signal(src)
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -51,7 +51,7 @@
 /obj/item/weapon/cartridge/Initialize()
 	. = ..()
 	var/obj/item/device/pda/pda = loc
-	if(istype(pda, /obj/item/device/pda))
+	if(istype(pda))
 		host_pda = pda
 
 /obj/item/weapon/cartridge/engineering


### PR DESCRIPTION
:cl:
fix: Nanotrasen Electronics have fixed a bug where issued factory-fresh PDAs did not link to their cartridges, requiring manual reinsertion.
/:cl:

I don't know why Initialize doesn't work in this case where New does. And I'm not going to figure out why. In fact I think I'll stop bothering with Initialize memes.

Fixes https://github.com/tgstation/tgstation/issues/28985