### PR TITLE
Jetpacks no longer have an action button for setting them as internals

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -5,7 +5,7 @@
 	item_state = "jetpack"
 	w_class = WEIGHT_CLASS_BULKY
 	distribute_pressure = ONE_ATMOSPHERE * O2STANDARD
-	actions_types = list(/datum/action/item_action/set_internals, /datum/action/item_action/toggle_jetpack, /datum/action/item_action/jetpack_stabilization)
+	actions_types = list(/datum/action/item_action/toggle_jetpack, /datum/action/item_action/jetpack_stabilization)
 	var/gas_type = "o2"
 	var/on = FALSE
 	var/stabilizers = FALSE
@@ -191,7 +191,7 @@
 
 //Return a jetpack that the mob can use
 //Back worn jetpacks, hardsuit internal packs, and so on.
-//Used in Process_Spacemove() and wherever you want to check for/get a jetpack	
+//Used in Process_Spacemove() and wherever you want to check for/get a jetpack
 
 /mob/proc/get_jetpack()
 	return


### PR DESCRIPTION
It's annoying to have 3 identical buttons at the top of the screen and two of them are related to flying and one of them kills you instead. 

And for those of you curious no it didn't kill me because I realized right after I clicked but I realized how mad it would have made me and how pointless having the button is