### PR TITLE
Fixes portals not autosetting their overridden target turf on Initialize - "It actually was my fault"

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -58,7 +58,7 @@
 	if(Adjacent(user))
 		teleport(user)
 
-/obj/effect/portal/Initialize(mapload, _creator, _lifespan = 0, obj/effect/portal/_linked, automatic_link = FALSE, hard_target_override, atmos_link_override)
+/obj/effect/portal/Initialize(mapload, _creator, _lifespan = 0, obj/effect/portal/_linked, automatic_link = FALSE, turf/hard_target_override, atmos_link_override)
 	. = ..()
 	GLOB.portals += src
 	if(!istype(_linked) && automatic_link)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -71,6 +71,8 @@
 	link_portal(_linked)
 	hardlinked = automatic_link
 	creator = _creator
+	if(isturf(hard_target_override))
+		hard_target = hard_target_override
 
 /obj/effect/portal/proc/link_portal(obj/effect/portal/newlink)
 	linked = newlink


### PR DESCRIPTION
⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ ⌛️ 
(that's 150)