### PR TITLE
ERT Security Officer Ion Carbine

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
@@ -32,6 +32,7 @@
 	new /obj/item/weapon/storage/box/flashes(src)
 	new /obj/item/weapon/storage/box/handcuffs(src)
 	new /obj/item/weapon/shield/riot/tele(src)
+	new /obj/item/weapon/gun/energy/ionrifle/carbine/pin(src)
 
 /obj/structure/closet/secure_closet/ertMed
 	name = "medical closet"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -27,6 +27,9 @@
 	flight_x_offset = 18
 	flight_y_offset = 11
 
+/obj/item/weapon/gun/energy/ionrifle/carbine/pin
+	pin = /obj/item/device/firing_pin
+
 /obj/item/weapon/gun/energy/decloner
 	name = "biological demolecularisor"
 	desc = "A gun that discharges high amounts of controlled radiation to slowly break a target into component elements."


### PR DESCRIPTION
Two Ion Carbines now spawn in the ERT armoury, inside the Sec Lockers.

The idea is to give the Sec ERT a better way to deal with mechs and rogue cyborgs if they need to, thus granting them more versatility in the field. 

These Carbines use the standard firing pin.

:cl: Steelpoint
add: NanoTrasen has begun issuing Security ERT Officers Ion Carbines to assist in dealing with mechanized and cybernetic threats towards NanoTrasen assets. 
/:cl:
