### PR TITLE
[s] Fixes for charter autoaccept

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -154,7 +154,7 @@ GLOBAL_LIST_INIT(numbers_as_words, list("One", "Two", "Three", "Four",
 	"Eighteen", "Nineteen"))
 
 /proc/generate_number_strings()
-	var/list/L
+	var/list/L[198]
 	for(var/i in 1 to 99)
 		L += "[i]"
 		L += "\Roman[i]"

--- a/code/game/objects/items/weapons/charter.dm
+++ b/code/game/objects/items/weapons/charter.dm
@@ -23,7 +23,7 @@
 		var/names = jointext(GLOB.station_names, "|")
 		var/suffixes = jointext(GLOB.station_suffixes, "|")
 		var/numerals = jointext(GLOB.station_numerals, "|")
-		var/regexstr = "(([prefixes]) )?(([names]) ?)([suffixes]) ([numerals])"
+		var/regexstr = "^(([prefixes]) )?(([names]) ?)([suffixes]) ([numerals])$"
 		standard_station_regex = new(regexstr)
 
 /obj/item/weapon/station_charter/attack_self(mob/living/user)


### PR DESCRIPTION
Actually fixes "http://www.pornhub.com Station 13", a replacement fix PR for https://github.com/tgstation/tgstation/pull/29016

Also fixes arabic and roman numerals being concatenated in a giant string instead of as separate list items.

closes #29016