### PR TITLE
Allows [s] to be used anywhere in the title

### DIFF
--- a/tools/github_webhook_processor.php
+++ b/tools/github_webhook_processor.php
@@ -212,7 +212,7 @@ function handle_pr($payload) {
 			return;
 	} 
 	
-	if (strtolower(substr($payload['pull_request']['title'], 0, 3)) == '[s]') {
+	if (strpos(strtolower($payload['pull_request']['title']), '[s]') !== false) {
 		echo "PR Announcement Halted; Secret tag detected.\n";
 		return;
 	}


### PR DESCRIPTION
Any servers using the Hippie PR mirrorer and /tg/ PR webhook won't be getting silent notifications