### PR TITLE
Fixes Ripley's pressure related move speed

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -3,8 +3,8 @@
 	name = "\improper APLU \"Ripley\""
 	icon_state = "ripley"
 	step_in = 4 //Move speed, lower is faster.
-	var/fast_pressure_step_in = 4 //step_in while in normal pressure conditions
-	var/slow_pressure_step_in = 2 //step_in while in better pressure conditions
+	var/fast_pressure_step_in = 2 //step_in while in normal pressure conditions
+	var/slow_pressure_step_in = 4 //step_in while in better pressure conditions
 	max_temperature = 20000
 	obj_integrity = 200
 	max_integrity = 200


### PR DESCRIPTION
The slow/fast speeds were accidentally reversed, so the Ripley was going fast in high pressure, and slow in low pressure.
Fixes https://github.com/tgstation/tgstation/issues/29026