### PR TITLE
Allows admins to set messages when they delay the round end

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -16,5 +16,3 @@ GLOBAL_VAR_INIT(CHARGELEVEL, 0.001) // Cap for how fast cells charge, as a perce
 GLOBAL_LIST_EMPTY(powernets)
 
 GLOBAL_VAR_INIT(bsa_unlock, FALSE)	//BSA unlocked by head ID swipes
-
-GLOBAL_VAR_INIT(admin_delay_notice, "")

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -16,3 +16,5 @@ GLOBAL_VAR_INIT(CHARGELEVEL, 0.001) // Cap for how fast cells charge, as a perce
 GLOBAL_LIST_EMPTY(powernets)
 
 GLOBAL_VAR_INIT(bsa_unlock, FALSE)	//BSA unlocked by head ID swipes
+
+GLOBAL_VAR_INIT(admin_delay_notice, "")

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -34,6 +34,8 @@ SUBSYSTEM_DEF(ticker)
 
 	var/delay_end = 0						//if set true, the round will not restart on it's own
 
+	var/admin_delay_notice = ""				//a message to display to anyone who tries to restart the world after a delay
+
 	var/triai = 0							//Global holder for Triumvirate
 	var/tipped = 0							//Did we broadcast the tip of the day yet?
 	var/selected_tip						// What will be the tip of the day?

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -425,7 +425,7 @@
 	var/list/options = list("Regular Restart", "Hard Restart (No Delay/Feeback Reason)", "Hardest Restart (No actions, just reboot)")
 	if(world.RunningService())
 		options += "Service Restart (Force restart DD)";
-	if(alert(usr, "This will end the round, are you SURE you want to do this? [GLOB.admin_delay_notice ? "An admin has already delayed the round end for the following reason: [GLOB.admin_delay_notice]" : ""]", "Confirmation", "Yes", "No") == "Yes")
+	if(alert(usr, "This will end the round, are you SURE you want to do this? [SSticker.admin_delay_notice ? "An admin has already delayed the round end for the following reason: [SSticker.admin_delay_notice]" : ""]", "Confirmation", "Yes", "No") == "Yes")
 		var result = input(usr, "Select reboot method", "World Reboot", options[1]) as null|anything in options
 		if(result)
 			SSblackbox.add_details("admin_verb","Reboot World") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -425,19 +425,20 @@
 	var/list/options = list("Regular Restart", "Hard Restart (No Delay/Feeback Reason)", "Hardest Restart (No actions, just reboot)")
 	if(world.RunningService())
 		options += "Service Restart (Force restart DD)";
-	var result = input(usr, "Select reboot method", "World Reboot", options[1]) as null|anything in options
-	if(result)
-		SSblackbox.add_details("admin_verb","Reboot World") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-		switch(result)
-			if("Regular Restart")
-				SSticker.Reboot("Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key].", "admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]", 10)
-			if("Hard Restart (No Delay, No Feeback Reason)")
-				world.Reboot()
-			if("Hardest Restart (No actions, just reboot)")
-				world.Reboot(fast_track = TRUE)
-			if("Service Restart (Force restart DD)")
-				GLOB.reboot_mode = REBOOT_MODE_HARD
-				world.ServiceReboot()
+	if(alert(usr, "This will end the round, are you SURE you want to do this? [GLOB.admin_delay_notice ? "An admin has already delayed the round end for the following reason: [GLOB.admin_delay_notice]" : ""]", "Confirmation", "Yes", "No") == "Yes")
+		var result = input(usr, "Select reboot method", "World Reboot", options[1]) as null|anything in options
+		if(result)
+			SSblackbox.add_details("admin_verb","Reboot World") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+			switch(result)
+				if("Regular Restart")
+					SSticker.Reboot("Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key].", "admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]", 10)
+				if("Hard Restart (No Delay, No Feeback Reason)")
+					world.Reboot()
+				if("Hardest Restart (No actions, just reboot)")
+					world.Reboot(fast_track = TRUE)
+				if("Service Restart (Force restart DD)")
+					GLOB.reboot_mode = REBOOT_MODE_HARD
+					world.ServiceReboot()
 
 /datum/admins/proc/end_round()
 	set category = "Server"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -425,7 +425,14 @@
 	var/list/options = list("Regular Restart", "Hard Restart (No Delay/Feeback Reason)", "Hardest Restart (No actions, just reboot)")
 	if(world.RunningService())
 		options += "Service Restart (Force restart DD)";
-	if(alert(usr, "This will end the round, are you SURE you want to do this? [SSticker.admin_delay_notice ? "An admin has already delayed the round end for the following reason: [SSticker.admin_delay_notice]" : ""]", "Confirmation", "Yes", "No") == "Yes")
+
+	var/rebootconfirm
+	if(SSticker.admin_delay_notice)
+		if(alert(usr, "Are you sure? An admin has already delayed the round end for the following reason: [SSticker.admin_delay_notice]", "Confirmation", "Yes", "No") == "Yes")
+			rebootconfirm = TRUE
+	else
+		rebootconfirm = TRUE
+	if(rebootconfirm)
 		var result = input(usr, "Select reboot method", "World Reboot", options[1]) as null|anything in options
 		if(result)
 			SSblackbox.add_details("admin_verb","Reboot World") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -354,8 +354,8 @@
 			if(SSticker.admin_delay_notice == null)
 				return
 		SSticker.delay_end = !SSticker.delay_end
-		log_admin("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")
-		message_admins("<span class='adminnotice'>[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].</span>")
+		log_admin("[key_name(usr)] [SSticker.delay_end ? "delayed the round end for reason: [SSticker.admin_delay_notice]" : "has made the round end normally"].")
+		message_admins("<span class='adminnotice'>[key_name(usr)] [SSticker.delay_end ? "delayed the round end for reason: [SSticker.admin_delay_notice]" : "has made the round end normally"].</span>")
 		href_list["secrets"] = "check_antagonist"
 
 	else if(href_list["end_round"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -350,8 +350,8 @@
 			return
 
 		if(!SSticker.delay_end)
-			GLOB.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
-			if(GLOB.admin_delay_notice == null)
+			SSticker.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
+			if(SSticker.admin_delay_notice == null)
 				return
 		SSticker.delay_end = !SSticker.delay_end
 		log_admin("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -349,9 +349,10 @@
 		if(!check_rights(R_SERVER))
 			return
 
-		GLOB.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason")
-		if(!GLOB.admin_delay_notice)
-			GLOB.admin_delay_notice = "An admin has already delayed the round end."
+		if(!SSticker.delay_end)
+			GLOB.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
+			if(GLOB.admin_delay_notice == null)
+				return
 		SSticker.delay_end = !SSticker.delay_end
 		log_admin("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")
 		message_admins("<span class='adminnotice'>[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].</span>")
@@ -362,7 +363,7 @@
 			return
 
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] is considering ending the round.</span>")
-		if(alert(usr, "This will end the round, are you SURE you want to do this? [GLOB.admin_delay_notice ? "An admin has already delayed the round end for the following reason: [GLOB.admin_delay_notice]" : ""]", "Confirmation", "Yes", "No") == "Yes")
+		if(alert(usr, "This will end the round, are you SURE you want to do this?", "Confirmation", "Yes", "No") == "Yes")
 			if(alert(usr, "Final Confirmation: End the round NOW?", "Confirmation", "Yes", "No") == "Yes")
 				message_admins("<span class='adminnotice'>[key_name_admin(usr)] has ended the round.</span>")
 				SSticker.force_ending = 1 //Yeah there we go APC destroyed mission accomplished

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -349,9 +349,9 @@
 		if(!check_rights(R_SERVER))
 			return
 
-		if(!SSticker.admin_delay_notice)
+		if(SSticker.delay_end)
 			SSticker.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
-			if(SSticker.admin_delay_notice == null)
+			if(!SSticker.admin_delay_notice)
 				return
 		SSticker.delay_end = !SSticker.delay_end
 		var/reason = SSticker.admin_delay_notice //laziness

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -349,7 +349,7 @@
 		if(!check_rights(R_SERVER))
 			return
 
-		if(!SSticker.delay_end)
+		if(!SSticker.admin_delay_notice)
 			SSticker.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
 			if(SSticker.admin_delay_notice == null)
 				return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -354,8 +354,10 @@
 			if(SSticker.admin_delay_notice == null)
 				return
 		SSticker.delay_end = !SSticker.delay_end
-		log_admin("[key_name(usr)] [SSticker.delay_end ? "delayed the round end for reason: [SSticker.admin_delay_notice]" : "has made the round end normally"].")
-		message_admins("<span class='adminnotice'>[key_name(usr)] [SSticker.delay_end ? "delayed the round end for reason: [SSticker.admin_delay_notice]" : "has made the round end normally"].</span>")
+		var/reason = SSticker.admin_delay_notice //laziness
+		var/msg = "[key_name(user)] delayed the round end.[reason ? " Reason: [reason]" : ""]"
+		log_admin(msg)
+		message_admins("<span class='adminnotice'>[msg]</span>")
 		href_list["secrets"] = "check_antagonist"
 
 	else if(href_list["end_round"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -349,6 +349,9 @@
 		if(!check_rights(R_SERVER))
 			return
 
+		GLOB.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason")
+		if(!GLOB.admin_delay_notice)
+			GLOB.admin_delay_notice = "An admin has already delayed the round end."
 		SSticker.delay_end = !SSticker.delay_end
 		log_admin("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")
 		message_admins("<span class='adminnotice'>[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].</span>")
@@ -359,7 +362,7 @@
 			return
 
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] is considering ending the round.</span>")
-		if(alert(usr, "This will end the round, are you SURE you want to do this?", "Confirmation", "Yes", "No") == "Yes")
+		if(alert(usr, "This will end the round, are you SURE you want to do this? [GLOB.admin_delay_notice ? "An admin has already delayed the round end for the following reason: [GLOB.admin_delay_notice]" : ""]", "Confirmation", "Yes", "No") == "Yes")
 			if(alert(usr, "Final Confirmation: End the round NOW?", "Confirmation", "Yes", "No") == "Yes")
 				message_admins("<span class='adminnotice'>[key_name_admin(usr)] has ended the round.</span>")
 				SSticker.force_ending = 1 //Yeah there we go APC destroyed mission accomplished

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -355,7 +355,7 @@
 				return
 		SSticker.delay_end = !SSticker.delay_end
 		var/reason = SSticker.admin_delay_notice //laziness
-		var/msg = "[key_name(user)] delayed the round end.[reason ? " Reason: [reason]" : ""]"
+		var/msg = "[key_name(usr)] delayed the round end.[reason ? " Reason: [reason]" : ""]"
 		log_admin(msg)
 		message_admins("<span class='adminnotice'>[msg]</span>")
 		href_list["secrets"] = "check_antagonist"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -355,9 +355,9 @@
 				return
 		SSticker.delay_end = !SSticker.delay_end
 		var/reason = SSticker.admin_delay_notice //laziness
-		var/msg = "[key_name(usr)] delayed the round end.[reason ? " Reason: [reason]" : ""]"
-		log_admin(msg)
-		message_admins("<span class='adminnotice'>[msg]</span>")
+		var/msg = "delayed the round end.[reason ? " Reason: [reason]" : ""]"
+		log_admin("[key_name(usr)] [msg]")
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] [msg]</span>")
 		href_list["secrets"] = "check_antagonist"
 
 	else if(href_list["end_round"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -357,7 +357,7 @@
 		var/reason = SSticker.admin_delay_notice //laziness
 		var/msg = "delayed the round end.[reason ? " Reason: [reason]" : ""]"
 		log_admin("[key_name(usr)] [msg]")
-		message_admins("<span class='adminnotice'>[key_name_admin(usr)] [msg]</span>")
+		message_admins("[key_name_admin(usr)] [msg]")
 		href_list["secrets"] = "check_antagonist"
 
 	else if(href_list["end_round"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -349,13 +349,13 @@
 		if(!check_rights(R_SERVER))
 			return
 
-		if(SSticker.delay_end)
+		if(!SSticker.delay_end)
 			SSticker.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
 			if(!SSticker.admin_delay_notice)
 				return
 		SSticker.delay_end = !SSticker.delay_end
-		var/reason = SSticker.admin_delay_notice //laziness
-		var/msg = "delayed the round end.[reason ? " Reason: [reason]" : ""]"
+		var/reason = SSticker.delay_end ? "for reason: [SSticker.admin_delay_notice]" : "."//laziness
+		var/msg = "[SSticker.delay_end ? "delayed" : "undelayed"] the round end [reason]"
 		log_admin("[key_name(usr)] [msg]")
 		message_admins("[key_name_admin(usr)] [msg]")
 		href_list["secrets"] = "check_antagonist"


### PR DESCRIPTION
requested by mso.

You can set a reason/warning for other admins not to end the round after you've delayed it.

:cl: Tacolizard
add: Admins can now set a message/warning when they delay the round end, to be shown to anyone who tries to reboot the world.
/:cl: