### PR TITLE
Replaces useless teleporter consoles on bridge

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -19783,7 +19783,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUb" = (
-/obj/machinery/computer/aifixer,
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/brown{
 	dir = 10
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -19783,7 +19783,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUb" = (
-/obj/machinery/computer/teleporter,
+/obj/machinery/computer/aifixer,
 /turf/open/floor/plasteel/brown{
 	dir = 10
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -38774,7 +38774,7 @@
 	},
 /area/bridge)
 "bxN" = (
-/obj/machinery/computer/aifixer,
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/darkpurple/side{
 	icon_state = "darkpurple";
 	dir = 1

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32967,7 +32967,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
-/obj/machinery/computer/teleporter,
+/obj/machinery/computer/aifixer,
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32967,7 +32967,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
-/obj/machinery/computer/aifixer,
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6802,7 +6802,7 @@
 	},
 /area/bridge)
 "aoQ" = (
-/obj/machinery/computer/teleporter,
+/obj/machinery/computer/aifixer,
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6802,7 +6802,7 @@
 	},
 /area/bridge)
 "aoQ" = (
-/obj/machinery/computer/aifixer,
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},


### PR DESCRIPTION
closes #28818

:cl: shizcalev
balance: Nanotrasen has upgraded the obsolete teleporter consoles on most NT branded stations with newer ones preloaded with the newest Supermatter monitoring application!
/:cl: