### PR TITLE
Machine subsystem now checks qdel status

### DIFF
--- a/code/controllers/subsystem/machines.dm
+++ b/code/controllers/subsystem/machines.dm
@@ -39,12 +39,12 @@ SUBSYSTEM_DEF(machines)
 	while(currentrun.len)
 		var/obj/machinery/thing = currentrun[currentrun.len]
 		currentrun.len--
-		if(thing && thing.process(seconds) != PROCESS_KILL)
+		if(!QDELETED(thing) && thing.process(seconds) != PROCESS_KILL)
 			if(thing.use_power)
 				thing.auto_use_power() //add back the power state
 		else
 			processing -= thing
-			if (thing)
+			if (!QDELETED(thing))
 				thing.isprocessing = 0
 		if (MC_TICK_CHECK)
 			return


### PR DESCRIPTION
If an item is qdeleted, it is not queued for processing and removed
from the processing list (if it's not already gone)

This will prevent machines getting processed when qdeleted (due to being
cached in the subsystem current run list)