### PR TITLE
Minor Projectile Reflection Refactor

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -49,7 +49,7 @@
 					return 0
 
 	if(!(P.original == src && P.firer == src)) //can't block or reflect when shooting yourself
-		if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
+		if(P.is_reflectable)
 			if(check_reflect(def_zone)) // Checks if you've passed a reflection% check
 				visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
 								"<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -40,6 +40,7 @@
 	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb
 	var/projectile_type = /obj/item/projectile
 	var/range = 50 //This will de-increment every step. When 0, it will delete the projectile.
+	var/is_reflectable = 0 // Can it be reflected or not?
 		//Effects
 	var/stun = 0
 	var/knockdown = 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -40,7 +40,7 @@
 	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb
 	var/projectile_type = /obj/item/projectile
 	var/range = 50 //This will de-increment every step. When 0, it will delete the projectile.
-	var/is_reflectable = 0 // Can it be reflected or not?
+	var/is_reflectable = FALSE // Can it be reflected or not?
 		//Effects
 	var/stun = 0
 	var/knockdown = 0

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -13,7 +13,7 @@
 	light_color = LIGHT_COLOR_RED
 	ricochets_max = 50	//Honk!
 	ricochet_chance = 80
-	is_reflectable = 1
+	is_reflectable = TRUE
 
 /obj/item/projectile/beam/laser
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -13,6 +13,7 @@
 	light_color = LIGHT_COLOR_RED
 	ricochets_max = 50	//Honk!
 	ricochet_chance = 80
+	is_reflectable = 1
 
 /obj/item/projectile/beam/laser
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -4,6 +4,7 @@
 	damage = 0
 	damage_type = BURN
 	flag = "energy"
+	is_reflectable = 1
 
 /obj/item/projectile/energy/chameleon
 	nodamage = TRUE

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -4,7 +4,7 @@
 	damage = 0
 	damage_type = BURN
 	flag = "energy"
-	is_reflectable = 1
+	is_reflectable = TRUE
 
 /obj/item/projectile/energy/chameleon
 	nodamage = TRUE


### PR DESCRIPTION
Very minor projectile reflection refactor. 

Removes the snowflake typecheck for projectile reflection; instead, it's a var (`is_reflectable`) on the projectile itself.

Nothing is changed, mechanically, from this (other than maybe saving a teensy about of CPU by avoiding the typechecks), but it allows for more customization of reflection in the future; maybe some bullets will be able to be reflected or perhaps a few energy/beam projectiles should ignore reflection entirely; either case, it's now possible to implement var more cleanly and without snowflake code.