### PR TITLE
oh well if it's a 1/8 chance it can stay

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -76,7 +76,7 @@
 			stored_obj.forceMove(T)
 			playsound(T,'sound/effects/explosion2.ogg', 200, 1)
 			new /obj/effect/temp_visual/explosion(T)
-			user.ex_act(2)
+			user.ex_act(3)
 			qdel(src)
 		else
 			to_chat(user, "<span class='holoparasite'>[src] glows with a strange <font color=\"[spawner.namedatum.colour]\">light</font>, and you don't touch it.</span>")


### PR DESCRIPTION
Remember when we said airlock charges were unfun?
Now make that once per every 20 seconds, and instead of a 1/2 chance of instakill, a 100% chance of an instakill due to ex_act(2) instacritting with the exception of someone in full bomb armor. 

SS13's meta should not be "Examine everything you EVER touch or be at risk of instakill"