### PR TITLE
B.O.S.S.: Bluespace Object Support System

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -64469,6 +64469,12 @@
 "cTC" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/mining)
+"cTD" = (
+/obj/machinery/boss_sender/sci,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 1
+	},
+/area/science/lab)
 
 (1,1,1) = {"
 aaa
@@ -111375,7 +111381,7 @@ aXq
 aYV
 bfX
 bhC
-biU
+cTD
 bks
 blI
 bnn

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -60693,7 +60693,7 @@
 	},
 /area/science/lab)
 "clB" = (
-/obj/structure/chair/stool,
+/obj/machinery/boss_sender/sci,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "clC" = (

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -6115,6 +6115,13 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"nh" = (
+/obj/machinery/boss_receiver/sci,
+/turf/open/floor/plasteel/purple/corner{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1
+	},
+/area/mine/production)
 
 (1,1,1) = {"
 aa
@@ -20986,7 +20993,7 @@ bq
 br
 bO
 ck
-cD
+nh
 br
 bq
 bq
@@ -37991,8 +37998,8 @@ aa
 mS
 mV
 mq
-na
-nd
+mV
+nc
 aa
 aa
 fV
@@ -38500,9 +38507,9 @@ aj
 "}
 (127,1,1) = {"
 mQ
-mR
+mQ
 fW
-mT
+mQ
 mW
 hg
 ac
@@ -39016,7 +39023,7 @@ aj
 aa
 aa
 aa
-mU
+mS
 mY
 ms
 hJ

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -16,3 +16,5 @@ GLOBAL_VAR_INIT(CHARGELEVEL, 0.001) // Cap for how fast cells charge, as a perce
 GLOBAL_LIST_EMPTY(powernets)
 
 GLOBAL_VAR_INIT(bsa_unlock, FALSE)	//BSA unlocked by head ID swipes
+
+GLOBAL_LIST_EMPTY(boss_receivers)

--- a/code/game/machinery/boss.dm
+++ b/code/game/machinery/boss.dm
@@ -1,0 +1,30 @@
+//B.O.S.S.: Bluespace Object Support System
+
+
+
+
+//BOSS machine//
+/obj/machinery/boss
+	name = "B.O.S.S."
+	desc = "The Bluespace Object Support System, or 'B.O.S.S.' is used to teleport items to far away places to aid explorers."
+	icon_state = "autolathe"
+
+	density = TRUE
+	anchored = TRUE
+
+	obj_integrity = 250
+	max_integrity = 250
+
+	var/list/stored_items
+
+/obj/machinery/boss/attackby(obj/item/O, mob/user, params)
+	if(user.a_intent == INTENT_HARM) //so we can hit the machine
+		return ..()
+
+	if(O.origin_tech)
+		O.forceMove(get_turf(src))
+
+
+//BOSS beacon//
+
+

--- a/code/game/machinery/boss.dm
+++ b/code/game/machinery/boss.dm
@@ -4,6 +4,8 @@
 //the main BOSS sender and variants
 //the BOSS receiver
 
+//TODO clean up lists when receivers are destroyed
+
 //BOSS sender//
 /obj/machinery/boss_sender
 	name = "B.O.S.S."
@@ -18,14 +20,36 @@
 
 	var/checkTech = FALSE
 
+	var/multiple_receivers = TRUE
+
+	var/obj/machinery/boss_receiver/linked
+
 /obj/machinery/boss_sender/sci
-	desc = "The Bluespace Object Support System, or 'B.O.S.S.' is used to teleport equipment made in R&D to lavaland, to aid the miners."
+	desc = "The Bluespace Object Support System, or 'B.O.S.S.' is used to teleport equipment made in R&D to lavaland, to aid the miners. Interact with an open hand to send or remove items."
 	checkTech = TRUE
+	multiple_receivers = FALSE
+
+/obj/machinery/boss_sender/sci/Initialize()
+	..()
+	for(var/obj/machinery/boss_receiver/B in GLOB.boss_receivers)
+		if(B.is_mining_receiver)
+			linked = B
+			return
 
 /obj/machinery/boss_sender/attack_hand(mob/user)
 	switch(alert(user,,"[src.name] panel","Send items","Remove an item"))
-		if("Send items")
-			return //todo
+		if("Send all items")
+			if(multiple_receivers)
+				var/input = input("Select a B.O.S.S. receiver unit.", "[src.name] panel", null, null) as null|anything in GLOB.boss_receivers
+				if(input)
+					var/obj/machinery/boss_receiver/B = input
+					if(istype(B))
+						linked = B
+
+			if(linked)
+				for(var/obj/item/I in src.contents)
+					I.forceMove(linked)
+				to_chat(user, "Items sent to receiver.")
 		if("Remove an item")
 			var/input = input("Select an item to remove.", "[src.name] panel", null, null) as null|anything in src.contents
 			if(input)
@@ -37,19 +61,17 @@
 	if(user.a_intent == INTENT_HARM) //so we can hit the machine
 		return ..()
 
-	var/accept_item = TRUE
 
-	if(checkTech)
-		if(!O.origin_tech)
-			accept_item = FALSE
+	if(checkTech && !O.origin_tech)
+		to_chat(user, "<span class='warning'>This doesn't seem to have a tech origin!</span>")
+		return
 
 	if(!user.drop_item())
 		to_chat(user, "<span class='warning'>\The [O] is stuck to your hand, you cannot put it in the [src.name]!</span>")
 		return
 
-	if(accept_item)
-		O.forceMove(src)
-		return
+	O.forceMove(src)
+	return
 
 
 //BOSS receiver//
@@ -57,5 +79,11 @@
 	name = "B.O.S.S. receiver"
 	desc = "This machine receives items sent through bluespace from a B.O.S.S. sender unit."
 	icon_state = "autolathe"
+	var/is_mining_receiver = FALSE
 
+/obj/machinery/boss_receiver/sci
+	is_mining_receiver = TRUE
 
+/obj/machinery/boss_receiver/sci/Initialize()
+	..()
+	GLOB.boss_receivers += src

--- a/code/game/machinery/boss.dm
+++ b/code/game/machinery/boss.dm
@@ -23,13 +23,15 @@
 	checkTech = TRUE
 
 /obj/machinery/boss_sender/attack_hand(mob/user)
-	switch(alert(user,"","[src.name] panel","Send items","Remove an item"))
+	switch(alert(user,,"[src.name] panel","Send items","Remove an item"))
 		if("Send items")
 			return //todo
 		if("Remove an item")
 			var/input = input("Select an item to remove.", "[src.name] panel", null, null) as null|anything in src.contents
 			if(input)
-				input.forceMove(get_turf(src))
+				var/obj/item/I = input
+				if(istype(I))
+					I.forceMove(get_turf(src))
 
 /obj/machinery/boss_sender/attackby(obj/item/O, mob/user, params)
 	if(user.a_intent == INTENT_HARM) //so we can hit the machine

--- a/code/game/machinery/boss.dm
+++ b/code/game/machinery/boss.dm
@@ -109,7 +109,7 @@
 
 /obj/machinery/boss_receiver/examine(mob/user)
 	..()
-	if(contents)
+	if(contents.len > 0)
 		to_chat(user,"<span class='notice'>A light indicates the [src.name] is storing items.</span>")
 
 /obj/machinery/boss_receiver/attack_hand(mob/user)

--- a/code/game/machinery/boss.dm
+++ b/code/game/machinery/boss.dm
@@ -1,11 +1,11 @@
 //B.O.S.S.: Bluespace Object Support System
 
 //contains:
-//the main BOSS machine and variants
+//the main BOSS sender and variants
 //the BOSS receiver
 
-//BOSS machine//
-/obj/machinery/boss
+//BOSS sender//
+/obj/machinery/boss_sender
 	name = "B.O.S.S."
 	desc = "The Bluespace Object Support System, or 'B.O.S.S.' is used to teleport items to far away places to aid others."
 	icon_state = "autolathe"
@@ -16,14 +16,22 @@
 	obj_integrity = 250
 	max_integrity = 250
 
-	var/list/stored_items
 	var/checkTech = FALSE
 
-/obj/machinery/boss/sci
+/obj/machinery/boss_sender/sci
 	desc = "The Bluespace Object Support System, or 'B.O.S.S.' is used to teleport equipment made in R&D to lavaland, to aid the miners."
 	checkTech = TRUE
 
-/obj/machinery/boss/attackby(obj/item/O, mob/user, params)
+/obj/machinery/boss_sender/attack_hand(mob/user)
+	switch(alert(user,"","[src.name] panel","Send items","Remove an item"))
+		if("Send items")
+			return //todo
+		if("Remove an item")
+			var/input = input("Select an item to remove.", "[src.name] panel", null, null) as null|anything in src.contents
+			if(input)
+				input.forceMove(get_turf(src))
+
+/obj/machinery/boss_sender/attackby(obj/item/O, mob/user, params)
 	if(user.a_intent == INTENT_HARM) //so we can hit the machine
 		return ..()
 
@@ -38,11 +46,14 @@
 		return
 
 	if(accept_item)
-		O.forceMove(get_turf(src))
-		stored_items += O
+		O.forceMove(src)
 		return
 
 
 //BOSS receiver//
+/obj/machinery/boss_receiver
+	name = "B.O.S.S. receiver"
+	desc = "This machine receives items sent through bluespace from a B.O.S.S. sender unit."
+	icon_state = "autolathe"
 
 

--- a/code/game/machinery/boss.dm
+++ b/code/game/machinery/boss.dm
@@ -1,7 +1,8 @@
 //B.O.S.S.: Bluespace Object Support System
 
-
-
+//contains:
+//the main BOSS machine and variants
+//the BOSS receiver
 
 //BOSS machine//
 /obj/machinery/boss
@@ -26,10 +27,22 @@
 	if(user.a_intent == INTENT_HARM) //so we can hit the machine
 		return ..()
 
-	if(checkTech && O.origin_tech)
+	var/accept_item = TRUE
+
+	if(checkTech)
+		if(!O.origin_tech)
+			accept_item = FALSE
+
+	if(!user.drop_item())
+		to_chat(user, "<span class='warning'>\The [O] is stuck to your hand, you cannot put it in the [src.name]!</span>")
+		return
+
+	if(accept_item)
 		O.forceMove(get_turf(src))
+		stored_items += O
+		return
 
 
-//BOSS beacon//
+//BOSS receiver//
 
 

--- a/code/game/machinery/boss.dm
+++ b/code/game/machinery/boss.dm
@@ -30,15 +30,15 @@
 	multiple_receivers = FALSE
 
 /obj/machinery/boss_sender/sci/Initialize()
-	..()
 	for(var/obj/machinery/boss_receiver/B in GLOB.boss_receivers)
 		if(B.is_mining_receiver)
 			linked = B
 			return
 
 /obj/machinery/boss_sender/attack_hand(mob/user)
-	switch(alert(user,,"[src.name] panel","Send items","Remove an item"))
+	switch(alert(user,,"[src.name] panel","Send all items","Remove an item"))
 		if("Send all items")
+
 			if(multiple_receivers)
 				var/input = input("Select a B.O.S.S. receiver unit.", "[src.name] panel", null, null) as null|anything in GLOB.boss_receivers
 				if(input)
@@ -48,7 +48,7 @@
 
 			if(linked)
 				for(var/obj/item/I in src.contents)
-					I.forceMove(linked)
+					I.forceMove(linked) //might have to use Exit() here
 				to_chat(user, "Items sent to receiver.")
 		if("Remove an item")
 			var/input = input("Select an item to remove.", "[src.name] panel", null, null) as null|anything in src.contents
@@ -85,5 +85,4 @@
 	is_mining_receiver = TRUE
 
 /obj/machinery/boss_receiver/sci/Initialize()
-	..()
 	GLOB.boss_receivers += src

--- a/code/game/machinery/boss.dm
+++ b/code/game/machinery/boss.dm
@@ -4,11 +4,14 @@
 //the main BOSS sender and variants
 //the BOSS receiver
 
-//TODO clean up lists when receivers are destroyed
+//TODO
+//clean up lists when receivers are destroyed?
+//make them require power
+//make them drop held items when destroyed
 
 //BOSS sender//
 /obj/machinery/boss_sender
-	name = "B.O.S.S."
+	name = "\improper B.O.S.S. sender"
 	desc = "The Bluespace Object Support System, or 'B.O.S.S.' is used to teleport items to far away places to aid others."
 	icon_state = "autolathe"
 
@@ -38,26 +41,29 @@
 
 /obj/machinery/boss_sender/attack_hand(mob/user)
 	..()
-	switch(alert(user,"Select an option.","[src.name] panel","Send all items","Manage [src.name] inventory"))
-		if("Send all items")
+	if(powered())
+		switch(alert(user,"Select an option.","[src.name] panel","Send all items","Manage inventory"))
+			if("Send all items")
 
-			if(multiple_receivers)
-				var/input = input("Select a B.O.S.S. receiver unit.", "[src.name] panel", null, null) as null|anything in GLOB.boss_receivers
+				if(multiple_receivers)
+					var/input = input("Select a B.O.S.S. receiver unit.", "[src.name] panel", null, null) as null|anything in GLOB.boss_receivers
+					if(input)
+						var/obj/machinery/boss_receiver/B = input
+						if(istype(B))
+							linked = B
+
+				if(linked)
+					for(var/obj/item/I in src.contents)
+						I.forceMove(linked)
+						linked.announce_item(I)
+					to_chat(user, "Item[contents.len > 1 ? "s" : ""] sent to receiver.")
+
+			if("Manage inventory")
+				var/input = input("Select an item to remove.", "[src.name] panel", null, null) as null|anything in src.contents
 				if(input)
-					var/obj/machinery/boss_receiver/B = input
-					if(istype(B))
-						linked = B
-
-			if(linked)
-				for(var/obj/item/I in src.contents)
-					I.forceMove(linked) //might have to use Exit() here
-				to_chat(user, "Items sent to receiver.")
-		if("Remove an item")
-			var/input = input("Select an item to remove.", "[src.name] panel", null, null) as null|anything in src.contents
-			if(input)
-				var/obj/item/I = input
-				if(istype(I))
-					user.put_in_active_hand(I)
+					var/obj/item/I = input
+					if(istype(I))
+						user.put_in_active_hand(I)
 
 /obj/machinery/boss_sender/attackby(obj/item/O, mob/user, params)
 	if(user.a_intent == INTENT_HARM) //so we can hit the machine
@@ -72,13 +78,14 @@
 		to_chat(user, "<span class='warning'>\The [O] is stuck to your hand, you cannot put it in the [src.name]!</span>")
 		return
 
-	O.forceMove(src)
+	if(powered())
+		O.forceMove(src)
 	return
 
 
 //BOSS receiver//
 /obj/machinery/boss_receiver
-	name = "B.O.S.S. receiver"
+	name = "\improper B.O.S.S. receiver"
 	desc = "This machine receives items sent through bluespace from a B.O.S.S. sender unit."
 	icon_state = "autolathe"
 	var/is_mining_receiver = FALSE
@@ -89,19 +96,35 @@
 	obj_integrity = 250
 	max_integrity = 250
 
+	verb_say = "beeps"
+	verb_ask = "beeps"
+	verb_exclaim = "beeps"
+
 /obj/machinery/boss_receiver/sci
 	is_mining_receiver = TRUE
 
 /obj/machinery/boss_receiver/sci/Initialize()
+	..()
 	GLOB.boss_receivers += src
 
+/obj/machinery/boss_receiver/examine(mob/user)
+	..()
+	if(contents)
+		to_chat(user,"<span class='notice'>A light indicates the [src.name] is storing items.</span>")
+
 /obj/machinery/boss_receiver/attack_hand(mob/user)
-	switch(alert(user, "Select an option", "[src.name] panel", "Manage inventory", "Cancel"))
-		if("Cancel")
-			return
-		if("Manage inventory")
-			var/input = input("Select an item to remove.", "[src.name] panel", null, null) as null|anything in src.contents
-			if(input)
-				var/obj/item/I = input
-				if(istype(I))
-					user.put_in_active_hand(I)
+	..()
+	if(powered())
+		switch(alert(user, "Select an option", "[src.name] panel", "Manage inventory", "Cancel"))
+			if("Cancel")
+				return
+			if("Manage inventory")
+				var/input = input("Select an item to remove.", "[src.name] panel", null, null) as null|anything in src.contents
+				if(input)
+					var/obj/item/I = input
+					if(istype(I))
+						user.put_in_active_hand(I)
+
+/obj/machinery/boss_receiver/proc/announce_item(var/obj/item/I)
+	if(powered())
+		say("Item received: [I.name]")

--- a/code/game/machinery/boss.dm
+++ b/code/game/machinery/boss.dm
@@ -6,7 +6,7 @@
 //BOSS machine//
 /obj/machinery/boss
 	name = "B.O.S.S."
-	desc = "The Bluespace Object Support System, or 'B.O.S.S.' is used to teleport items to far away places to aid explorers."
+	desc = "The Bluespace Object Support System, or 'B.O.S.S.' is used to teleport items to far away places to aid others."
 	icon_state = "autolathe"
 
 	density = TRUE
@@ -16,12 +16,17 @@
 	max_integrity = 250
 
 	var/list/stored_items
+	var/checkTech = FALSE
+
+/obj/machinery/boss/sci
+	desc = "The Bluespace Object Support System, or 'B.O.S.S.' is used to teleport equipment made in R&D to lavaland, to aid the miners."
+	checkTech = TRUE
 
 /obj/machinery/boss/attackby(obj/item/O, mob/user, params)
 	if(user.a_intent == INTENT_HARM) //so we can hit the machine
 		return ..()
 
-	if(O.origin_tech)
+	if(checkTech && O.origin_tech)
 		O.forceMove(get_turf(src))
 
 

--- a/code/game/machinery/boss.dm
+++ b/code/game/machinery/boss.dm
@@ -30,13 +30,15 @@
 	multiple_receivers = FALSE
 
 /obj/machinery/boss_sender/sci/Initialize()
+	..()
 	for(var/obj/machinery/boss_receiver/B in GLOB.boss_receivers)
 		if(B.is_mining_receiver)
 			linked = B
 			return
 
 /obj/machinery/boss_sender/attack_hand(mob/user)
-	switch(alert(user,,"[src.name] panel","Send all items","Remove an item"))
+	..()
+	switch(alert(user,"Select an option.","[src.name] panel","Send all items","Manage [src.name] inventory"))
 		if("Send all items")
 
 			if(multiple_receivers)
@@ -55,7 +57,7 @@
 			if(input)
 				var/obj/item/I = input
 				if(istype(I))
-					I.forceMove(get_turf(src))
+					user.put_in_active_hand(I)
 
 /obj/machinery/boss_sender/attackby(obj/item/O, mob/user, params)
 	if(user.a_intent == INTENT_HARM) //so we can hit the machine
@@ -81,8 +83,25 @@
 	icon_state = "autolathe"
 	var/is_mining_receiver = FALSE
 
+	density = TRUE
+	anchored = TRUE
+
+	obj_integrity = 250
+	max_integrity = 250
+
 /obj/machinery/boss_receiver/sci
 	is_mining_receiver = TRUE
 
 /obj/machinery/boss_receiver/sci/Initialize()
 	GLOB.boss_receivers += src
+
+/obj/machinery/boss_receiver/attack_hand(mob/user)
+	switch(alert(user, "Select an option", "[src.name] panel", "Manage inventory", "Cancel"))
+		if("Cancel")
+			return
+		if("Manage inventory")
+			var/input = input("Select an item to remove.", "[src.name] panel", null, null) as null|anything in src.contents
+			if(input)
+				var/obj/item/I = input
+				if(istype(I))
+					user.put_in_active_hand(I)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -517,6 +517,7 @@
 #include "code\game\machinery\autolathe.dm"
 #include "code\game\machinery\bank_machine.dm"
 #include "code\game\machinery\Beacon.dm"
+#include "code\game\machinery\boss.dm"
 #include "code\game\machinery\buttons.dm"
 #include "code\game\machinery\cell_charger.dm"
 #include "code\game\machinery\cloning.dm"


### PR DESCRIPTION
:cl: Tacolizard: Bluespace Boogaloo
add: Added B.O.S.S., a new way for RnD to easily aid miners on lavaland by sending them gear. 
add: A B.O.S.S. sender unit has been added to science in Boxstation and Metastation. Insert any item with a tech origin and press 'Send all items' to instantly teleport them.
add: A B.O.S.S. receiver unit has been placed in the mining base. It receives items teleported to it from the sender located on-station.
/:cl:

before you ask, yes, bombs have a tech origin.


This PR is designed to facilitate a better relationship between miners and RnD by allowing scientists to instantaneously transport items to mining without even leaving their department. 


~~semi-wip, but pretty much conceptually complete. Just needs bugtesting and the like.~~
actually this is pretty much bug free yay!


**Sprites needed:**
B.O.S.S. sender
B.O.S.S. receiver
