### PR TITLE
Box Viro Wants Plasma v2

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -41535,6 +41535,12 @@
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	layer = 2.9
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bQF" = (


### PR DESCRIPTION
:cl:
tweak: 2 plasma sheets have been added to viro break room on box
/:cl:

[why]: Viro's on box want plasma in viro so they dont have to go raid it from other departments
