### PR TITLE
Removes now-unnecessary obj_integrity definitions

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blank_blob"
 	desc = "A huge, pulsating yellow mass."
-	obj_integrity = 400
 	max_integrity = 400
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 75, acid = 90)
 	explosion_block = 6

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_factory"
 	desc = "A thick spire of tendrils."
-	obj_integrity = 200
 	max_integrity = 200
 	health_regen = 1
 	point_return = 25

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blank_blob"
 	desc = "A large, pulsating yellow mass."
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 65, acid = 90)
 	health_regen = 3

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_resource"
 	desc = "A thin spire of slightly swaying tendrils."
-	obj_integrity = 60
 	max_integrity = 60
 	point_return = 15
 	var/resource_delay = 0

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_shield"
 	desc = "A solid wall of slightly twitching tendrils."
-	obj_integrity = 150
 	max_integrity = 150
 	brute_resist = 0.25
 	explosion_block = 3

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -9,7 +9,6 @@
 	anchored = 1
 	layer = BELOW_MOB_LAYER
 	var/point_return = 0 //How many points the blob gets back when it removes a blob of that type. If less than 0, blob cannot be removed.
-	obj_integrity = 30
 	max_integrity = 30
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 80, acid = 70)
 	var/health_regen = 2 //how much health this blob regens when pulsed
@@ -326,7 +325,7 @@
 	name = "normal blob"
 	icon_state = "blob"
 	light_range = 0
-	obj_integrity = 21
+	obj_integrity = 21 //doesn't start at full health
 	max_integrity = 25
 	health_regen = 1
 	brute_resist = 0.25

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -3,7 +3,6 @@
 	name = "ark of the Clockwork Justicar"
 	desc = "A massive, thrumming rip in spacetime."
 	clockwork_desc = "A portal to the Celestial Derelict. Massive and intimidating, it is the only thing that can both transport Ratvar and withstand the massive amount of energy he emits."
-	obj_integrity = 500
 	max_integrity = 500
 	mouse_opacity = 2
 	icon = 'icons/effects/clockwork_effects.dmi'

--- a/code/game/gamemodes/clock_cult/clock_structures/clockwork_obelisk.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/clockwork_obelisk.dm
@@ -9,7 +9,6 @@
 	unanchored_icon = "obelisk_unwrenched"
 	construction_value = 20
 	max_integrity = 150
-	obj_integrity = 150
 	break_message = "<span class='warning'>The obelisk falls to the ground, undamaged!</span>"
 	debris = list(/obj/item/clockwork/alloy_shards/small = 4, \
 	/obj/item/clockwork/alloy_shards/medium = 2, \

--- a/code/game/gamemodes/clock_cult/clock_structures/geis_binding.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/geis_binding.dm
@@ -4,7 +4,6 @@
 	desc = "A flickering, glowing purple ring around a target."
 	clockwork_desc = "A binding ring around a target, preventing them from taking action while they're being converted."
 	max_integrity = 25
-	obj_integrity = 25
 	light_range = 2
 	light_power = 0.5
 	light_color = "#AF0AAF"

--- a/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/mania_motor.dm
@@ -10,7 +10,6 @@
 	construction_value = 20
 	break_message = "<span class='warning'>The antenna break off, leaving a pile of shards!</span>"
 	max_integrity = 100
-	obj_integrity = 100
 	light_color = "#AF0AAF"
 	debris = list(/obj/item/clockwork/alloy_shards/large = 2, \
 	/obj/item/clockwork/alloy_shards/small = 2, \

--- a/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
@@ -5,7 +5,6 @@
 	clockwork_desc = "A fragile turret which will automatically attack nearby unrestrained non-Servants that can see it."
 	icon_state = "ocular_warden"
 	unanchored_icon = "ocular_warden_unwrenched"
-	obj_integrity = 25
 	max_integrity = 25
 	construction_value = 15
 	layer = WALL_OBJ_LAYER

--- a/code/game/gamemodes/clock_cult/clock_structures/prolonging_prism.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/prolonging_prism.dm
@@ -9,7 +9,6 @@
 	unanchored_icon = "prolonging_prism_unwrenched"
 	construction_value = 20
 	max_integrity = 125
-	obj_integrity = 125
 	break_message = "<span class='warning'>The prism falls to the ground with a heavy thud!</span>"
 	debris = list(/obj/item/clockwork/alloy_shards/small = 3, \
 	/obj/item/clockwork/alloy_shards/medium = 1, \

--- a/code/game/gamemodes/clock_cult/clock_structures/taunting_trail.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/taunting_trail.dm
@@ -5,7 +5,6 @@
 	clockwork_desc = "A cloud of purple smoke that confuses and knocks down non-Servants that enter it."
 	gender = PLURAL
 	max_integrity = 5
-	obj_integrity = 5
 	density = 1
 	color = list("#AF0AAF", "#AF0AAF", "#AF0AAF", rgb(0,0,0))
 	icon = 'icons/effects/effects.dmi'

--- a/code/game/gamemodes/clock_cult/clock_structures/tinkerers_cache.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/tinkerers_cache.dm
@@ -9,7 +9,6 @@
 	construction_value = 10
 	break_message = "<span class='warning'>The cache's fire winks out before it falls in on itself!</span>"
 	max_integrity = 80
-	obj_integrity = 80
 	light_color = "#C2852F"
 	var/wall_generation_cooldown
 	var/turf/closed/wall/clockwork/linkedwall //if we've got a linked wall and are producing

--- a/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/tinkerers_daemon.dm
@@ -8,7 +8,6 @@
 	inactive_icon = "tinkerers_daemon"
 	unanchored_icon = "tinkerers_daemon_unwrenched"
 	max_integrity = 100
-	obj_integrity = 100
 	construction_value = 20
 	break_message = "<span class='warning'>The daemon shatters into millions of pieces, leaving only a disc of metal!</span>"
 	debris = list(/obj/item/clockwork/alloy_shards/medium = 1, \

--- a/code/game/gamemodes/clock_cult/clock_structures/wall_gear.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/wall_gear.dm
@@ -5,7 +5,6 @@
 	unanchored_icon = "wall_gear"
 	climbable = TRUE
 	max_integrity = 100
-	obj_integrity = 100
 	layer = BELOW_OBJ_LAYER
 	construction_value = 3
 	desc = "A massive brass gear. You could probably secure or unsecure it with a wrench, or just climb over it."

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -11,7 +11,6 @@
 	anchored = 1
 	layer = HIGH_OBJ_LAYER
 	max_integrity = 300
-	obj_integrity = 300
 	integrity_failure = 100
 	armor = list(melee = 20, bullet = 50, laser = 50, energy = 50, bomb = 10, bio = 100, rad = 100, fire = 10, acid = 70)
 	var/datum/gang/gang

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -527,7 +527,6 @@
 	layer = MOB_LAYER
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	light_color = LIGHT_COLOR_CYAN
-	obj_integrity = 30
 	max_integrity = 30
 	anchored = TRUE
 	var/lon_range = 1
@@ -550,7 +549,6 @@
 	name = "swarmer trap"
 	desc = "A quickly assembled trap that electrifies living beings and overwhelms machine sensors. Will not retain its form if damaged enough."
 	icon_state = "trap"
-	obj_integrity = 10
 	max_integrity = 10
 	density = 0
 
@@ -594,7 +592,6 @@
 	desc = "A quickly assembled energy blockade. Will not retain its form if damaged enough, but disabler beams and swarmers pass right through."
 	icon_state = "barricade"
 	light_range = 1
-	obj_integrity = 50
 	max_integrity = 50
 
 /obj/structure/swarmer/blockade/CanPass(atom/movable/O)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -495,7 +495,6 @@ This is here to make the tiles around the station mininuke change when it's arme
 	desc = "Better keep this safe."
 	icon_state = "nucleardisk"
 	persistence_replacement = /obj/item/weapon/disk/fakenucleardisk
-	obj_integrity = 250
 	max_integrity = 250
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 30, bio = 0, rad = 0, fire = 100, acid = 100)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -455,7 +455,6 @@
 	var/obj/item/link = null
 	var/cooldown_time = 30 //3s
 	var/cooldown = 0
-	obj_integrity = 10
 	max_integrity = 10
 	resistance_flags = FLAMMABLE
 

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -7,7 +7,6 @@
 	anchored = 1
 	var/obj/item/device/pda/storedpda = null
 	var/list/colorlist = list()
-	obj_integrity = 200
 	max_integrity = 200
 
 

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -5,7 +5,6 @@
 	icon_state = "ai-slipper0"
 	layer = PROJECTILE_HIT_THRESHHOLD_LAYER
 	anchored = TRUE
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 30)
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -15,7 +15,6 @@
 	resistance_flags = FIRE_PROOF
 
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, bio = 0, rad = 0, fire = 90, acid = 50)
-	obj_integrity = 100
 	max_integrity = 100
 	integrity_failure = 50
 	var/list/network = list("SS13")

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -12,7 +12,6 @@
 	desc = "The basic construction for Nanotrasen-Always-Watching-You cameras."
 	icon = 'icons/obj/monitors.dmi'
 	icon_state = "camera1"
-	obj_integrity = 150
 	max_integrity = 150
 	//	Motion, EMP-Proof, X-Ray
 	var/static/list/possible_upgrades = typecacheof(list(/obj/item/device/assembly/prox_sensor, /obj/item/stack/sheet/mineral/plasma, /obj/item/device/analyzer))

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -7,7 +7,6 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 300
 	active_power_usage = 300
-	obj_integrity = 200
 	max_integrity = 200
 	integrity_failure = 100
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 40, acid = 20)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "box_0"
 	density = 1
-	obj_integrity = 250
 	max_integrity = 250
 	var/obj/item/weapon/circuitboard/circuit = null
 	var/state = 1

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -13,7 +13,6 @@
 	desc = "Looks like this would make good cover."
 	anchored = 1
 	density = 1
-	obj_integrity = 100
 	max_integrity = 100
 	var/proj_pass_rate = 50 //How many projectiles will pass the cover. Lower means stronger cover
 	var/material = METAL
@@ -75,7 +74,6 @@
 	desc = "Bags of sand. Self explanatory."
 	icon = 'icons/obj/smooth_structures/sandbags.dmi'
 	icon_state = "sandbags"
-	obj_integrity = 280
 	max_integrity = 280
 	proj_pass_rate = 20
 	pass_flags = LETPASSTHROW
@@ -92,7 +90,6 @@
 	icon_state = "barrier0"
 	density = 0
 	anchored = 0
-	obj_integrity = 180
 	max_integrity = 180
 	proj_pass_rate = 20
 	armor = list(melee = 10, bullet = 50, laser = 50, energy = 50, bomb = 10, bio = 100, rad = 100, fire = 10, acid = 0)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -46,7 +46,6 @@
 	name = "airlock"
 	icon = 'icons/obj/doors/airlocks/station/public.dmi'
 	icon_state = "closed"
-	obj_integrity = 300
 	max_integrity = 300
 	var/normal_integrity = AIRLOCK_INTEGRITY_N
 	integrity_failure = 70

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -8,7 +8,6 @@
 	density = 1
 	layer = OPEN_DOOR_LAYER
 	power_channel = ENVIRON
-	obj_integrity = 350
 	max_integrity = 350
 	armor = list(melee = 30, bullet = 30, laser = 20, energy = 20, bomb = 10, bio = 100, rad = 100, fire = 80, acid = 70)
 	CanAtmosPass = ATMOS_PASS_DENSITY

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -11,7 +11,6 @@
 	icon_state = "door_open"
 	opacity = 0
 	density = 0
-	obj_integrity = 300
 	max_integrity = 300
 	resistance_flags = FIRE_PROOF
 	heat_proof = 1
@@ -241,7 +240,6 @@
 	glass = 0
 	explosion_block = 2
 	assemblytype = /obj/structure/firelock_frame/heavy
-	obj_integrity = 550
 	max_integrity = 550
 
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -8,7 +8,6 @@
 	explosion_block = 3
 	heat_proof = 1
 	safe = 0
-	obj_integrity = 600
 	max_integrity = 600
 	armor = list(melee = 50, bullet = 100, laser = 100, energy = 100, bomb = 50, bio = 100, rad = 100, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -7,8 +7,7 @@
 	closingLayer = ABOVE_WINDOW_LAYER
 	resistance_flags = ACID_PROOF
 	var/base_state = "left"
-	obj_integrity = 150 //If you change this, consider changing ../door/window/brigdoor/ health at the bottom of this .dm file
-	max_integrity = 150
+	max_integrity = 150 //If you change this, consider changing ../door/window/brigdoor/ max_integrity at the bottom of this .dm file
 	integrity_failure = 0
 	armor = list(melee = 20, bullet = 50, laser = 50, energy = 50, bomb = 10, bio = 100, rad = 100, fire = 70, acid = 100)
 	visible = 0
@@ -305,8 +304,7 @@
 	icon_state = "leftsecure"
 	base_state = "leftsecure"
 	var/id = null
-	obj_integrity = 300 //Stronger doors for prison (regular window door health is 200)
-	max_integrity = 300
+	max_integrity = 300 //Stronger doors for prison (regular window door health is 200)
 	reinf = 1
 	explosion_block = 1
 

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -13,7 +13,6 @@
 	anchored = 1
 	density = 1
 
-	obj_integrity = 250
 	max_integrity = 250
 	integrity_failure = 80
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -15,7 +15,6 @@
 	icon = 'icons/obj/monitors.dmi'
 	icon_state = "fire0"
 	anchored = 1
-	obj_integrity = 250
 	max_integrity = 250
 	integrity_failure = 100
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 100, rad = 100, fire = 90, acid = 30)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -11,7 +11,6 @@
 	var/last_flash = 0 //Don't want it getting spammed like regular flashes
 	var/strength = 100 //How knocked down targets are when flashed.
 	var/base_state = "mflash"
-	obj_integrity = 250
 	max_integrity = 250
 	integrity_failure = 100
 	anchored = 1

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -38,7 +38,6 @@ Possible to do for anyone motivated enough:
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
 	active_power_usage = 100
-	obj_integrity = 300
 	max_integrity = 300
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 0)
 	var/list/masters = list()//List of living mobs that use the holopad

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -9,7 +9,6 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 4
-	obj_integrity = 300
 	max_integrity = 300
 	armor = list(melee = 50, bullet = 30, laser = 70, energy = 50, bomb = 20, bio = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -217,7 +217,6 @@
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	resistance_flags = FLAMMABLE
-	obj_integrity = 150
 	max_integrity = 150
 	var/obj/machinery/launchpad/briefcase/pad
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -99,7 +99,6 @@ Class Procs:
 	verb_say = "beeps"
 	verb_yell = "blares"
 	pressure_resistance = 15
-	obj_integrity = 200
 	max_integrity = 200
 
 	var/stat = 0

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -10,7 +10,6 @@
 	level = 1		// underfloor
 	layer = LOW_OBJ_LAYER
 	anchored = 1
-	obj_integrity = 500
 	max_integrity = 500
 	armor = list(melee = 70, bullet = 70, laser = 70, energy = 70, bomb = 0, bio = 0, rad = 0, fire = 80, acid = 80)
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -176,7 +176,6 @@ GLOBAL_LIST_EMPTY(allCasters)
 	verb_ask = "beeps"
 	verb_exclaim = "beeps"
 	armor = list(melee = 50, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 30)
-	obj_integrity = 200
 	max_integrity = 200
 	integrity_failure = 50
 	var/screen = 0

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -28,8 +28,7 @@
 	var/raised = 0			//if the turret cover is "open" and the turret is raised
 	var/raising= 0			//if the turret is currently opening or closing its cover
 
-	obj_integrity = 160			//the turret's health
-	max_integrity = 160
+	max_integrity = 160		//the turret's health
 	integrity_failure = 80
 	armor = list(melee = 50, bullet = 30, laser = 30, energy = 30, bomb = 30, bio = 0, rad = 0, fire = 90, acid = 90)
 
@@ -578,9 +577,8 @@
 	return 10 //Syndicate turrets shoot everything not in their faction
 
 /obj/machinery/porta_turret/syndicate/pod
-	max_integrity = 40
 	integrity_failure = 20
-	obj_integrity = 40
+	max_integrity = 40
 	stun_projectile = /obj/item/projectile/bullet/weakbullet3
 	lethal_projectile = /obj/item/projectile/bullet/weakbullet3
 
@@ -615,7 +613,6 @@
 
 /obj/machinery/porta_turret/centcomm_shuttle
 	installation = null
-	obj_integrity = 260
 	max_integrity = 260
 	always_up = 1
 	use_power = NO_POWER_USE

--- a/code/game/machinery/porta_turret/portable_turret_cover.dm
+++ b/code/game/machinery/porta_turret/portable_turret_cover.dm
@@ -10,7 +10,6 @@
 	anchored = 1
 	layer = HIGH_OBJ_LAYER
 	density = 0
-	obj_integrity = 80
 	max_integrity = 80
 	var/obj/machinery/porta_turret/parent_turret = null
 

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -57,7 +57,6 @@ GLOBAL_LIST_EMPTY(allConsoles)
 	var/obj/item/device/radio/Radio
 	var/emergency //If an emergency has been called by this device. Acts as both a cooldown and lets the responder know where it the emergency was triggered from
 	var/receive_ore_updates = FALSE //If ore redemption machines will send an update when it receives new ores.
-	obj_integrity = 300
 	max_integrity = 300
 	armor = list(melee = 70, bullet = 30, laser = 30, energy = 30, bomb = 0, bio = 0, rad = 0, fire = 90, acid = 90)
 

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -7,8 +7,7 @@
 	opacity = 0
 	anchored = 1
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	max_integrity = 200
-	obj_integrity = 200 //The shield can only take so much beating (prevents perma-prisons)
+	max_integrity = 200 //The shield can only take so much beating (prevents perma-prisons)
 	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/structure/emergency_shield/New()
@@ -55,7 +54,6 @@
 	name = "sanguine barrier"
 	desc = "A potent shield summoned by cultists to defend their rites."
 	icon_state = "shield-red"
-	obj_integrity = 60
 	max_integrity = 60
 
 /obj/structure/emergency_shield/sanguine/emp_act(severity)
@@ -65,7 +63,6 @@
 	name = "Invoker's Shield"
 	desc = "A weak shield summoned by cultists to protect them while they carry out delicate rituals"
 	color = "#FF0000"
-	obj_integrity = 20
 	max_integrity = 20
 	mouse_opacity = 0
 
@@ -83,7 +80,6 @@
 	pressure_resistance = 2*ONE_ATMOSPHERE
 	req_access = list(GLOB.access_engine)
 	max_integrity = 100
-	obj_integrity = 100
 	var/active = FALSE
 	var/list/deployed_shields
 	var/locked = 0
@@ -223,7 +219,6 @@
 	req_access = list(GLOB.access_teleporter)
 	flags = CONDUCT
 	use_power = NO_POWER_USE
-	obj_integrity = 300
 	max_integrity = 300
 	var/active = FALSE
 	var/power = 0

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -10,7 +10,6 @@
 	icon_state = "sheater-off"
 	name = "space heater"
 	desc = "Made by Space Amish using traditional space techniques, this heater/cooler is guaranteed not to set the station on fire."
-	obj_integrity = 250
 	max_integrity = 250
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 100, rad = 100, fire = 80, acid = 10)
 	var/obj/item/weapon/stock_parts/cell/cell

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -6,7 +6,6 @@
 	icon_state = "close"
 	anchored = 1
 	density = 1
-	obj_integrity = 250
 	max_integrity = 250
 
 	var/obj/item/clothing/suit/space/suit = null

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -21,7 +21,6 @@
 	verb_say = "beeps"
 	verb_ask = "beeps"
 	verb_exclaim = "beeps"
-	obj_integrity = 300
 	max_integrity = 300
 	integrity_failure = 100
 	armor = list(melee = 20, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70)

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -4,7 +4,6 @@
 	icon_state = "durand"
 	step_in = 4
 	dir_in = 1 //Facing North.
-	obj_integrity = 400
 	max_integrity = 400
 	deflect_chance = 20
 	armor = list(melee = 40, bullet = 35, laser = 15, energy = 10, bomb = 20, bio = 0, rad = 0, fire = 100, acid = 100)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -4,6 +4,7 @@
 	icon_state = "gygax"
 	step_in = 3
 	dir_in = 1 //Facing North.
+	max_integrity = 250
 	deflect_chance = 5
 	armor = list(melee = 25, bullet = 20, laser = 30, energy = 15, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 100)
 	max_temperature = 25000

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -4,7 +4,6 @@
 	icon_state = "gygax"
 	step_in = 3
 	dir_in = 1 //Facing North.
-	obj_integrity = 250
 	deflect_chance = 5
 	armor = list(melee = 25, bullet = 20, laser = 30, energy = 15, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 100)
 	max_temperature = 25000
@@ -18,7 +17,7 @@
 	desc = "A lightweight exosuit, painted in a dark scheme. This model appears to have some modifications."
 	name = "\improper Dark Gygax"
 	icon_state = "darkgygax"
-	obj_integrity = 300
+	max_integrity = 300
 	deflect_chance = 15
 	armor = list(melee = 40, bullet = 40, laser = 50, energy = 35, bomb = 20, bio = 0, rad = 0, fire = 100, acid = 100)
 	max_temperature = 35000

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -3,7 +3,6 @@
 	name = "\improper H.O.N.K"
 	icon_state = "honker"
 	step_in = 3
-	obj_integrity = 140
 	max_integrity = 140
 	deflect_chance = 60
 	internal_damage_threshold = 60

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -3,7 +3,6 @@
 	name = "\improper Marauder"
 	icon_state = "marauder"
 	step_in = 5
-	obj_integrity = 500
 	max_integrity = 500
 	deflect_chance = 25
 	armor = list(melee = 50, bullet = 55, laser = 40, energy = 30, bomb = 30, bio = 0, rad = 0, fire = 100, acid = 100)
@@ -47,7 +46,7 @@
 	icon_state = "seraph"
 	operation_req_access = list(GLOB.access_cent_specops)
 	step_in = 3
-	obj_integrity = 550
+	max_integrity = 550
 	wreckage = /obj/structure/mecha_wreckage/seraph
 	internal_damage_threshold = 20
 	force = 55

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -5,7 +5,6 @@
 	step_in = 2
 	dir_in = 2 //Facing South.
 	step_energy_drain = 3
-	obj_integrity = 200
 	max_integrity = 200
 	deflect_chance = 30
 	armor = list(melee = 30, bullet = 30, laser = 30, energy = 30, bomb = 30, bio = 0, rad = 0, fire = 100, acid = 100)

--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -4,7 +4,6 @@
 	icon_state = "reticence"
 	step_in = 2
 	dir_in = 1 //Facing North.
-	obj_integrity = 100
 	max_integrity = 100
 	deflect_chance = 3
 	armor = list(melee = 25, bullet = 20, laser = 30, energy = 15, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 100)

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -7,7 +7,6 @@
 	icon_state = "mecha_equip"
 	force = 5
 	origin_tech = "materials=2;engineering=2"
-	obj_integrity = 300
 	max_integrity = 300
 	var/equip_cooldown = 0 // cooldown after use
 	var/equip_ready = 1 //whether the equipment is ready for use. (or deactivated/activated for static stuff)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -30,8 +30,7 @@
 	var/dir_in = 2//What direction will the mech face when entered/powered on? Defaults to South.
 	var/step_energy_drain = 10
 	var/melee_energy_drain = 15
-	obj_integrity = 300 //obj_integrity is health
-	max_integrity = 300
+	max_integrity = 300 //max_integrity is base health
 	var/deflect_chance = 10 //chance to deflect the incoming projectiles, hits, or lesser the effect of ex_act.
 	armor = list(melee = 20, bullet = 10, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 100)
 	var/list/facing_modifiers = list(FRONT_ARMOUR = 1.5, SIDE_ARMOUR = 1, BACK_ARMOUR = 0.5)

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -4,7 +4,6 @@
 	icon_state = "odysseus"
 	step_in = 3
 	max_temperature = 15000
-	obj_integrity = 120
 	max_integrity = 120
 	wreckage = /obj/structure/mecha_wreckage/odysseus
 	internal_damage_threshold = 35

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -6,7 +6,6 @@
 	var/fast_pressure_step_in = 2 //step_in while in normal pressure conditions
 	var/slow_pressure_step_in = 4 //step_in while in better pressure conditions
 	max_temperature = 20000
-	obj_integrity = 200
 	max_integrity = 200
 	lights_power = 7
 	deflect_chance = 15
@@ -63,7 +62,6 @@
 	name = "\improper APLU \"Firefighter\""
 	icon_state = "firefighter"
 	max_temperature = 65000
-	obj_integrity = 250
 	max_integrity = 250
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	lights_power = 7

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -201,7 +201,6 @@
 	name = "foamed metal"
 	desc = "A lightweight foamed metal wall."
 	gender = PLURAL
-	obj_integrity = 20
 	max_integrity = 20
 	CanAtmosPass = ATMOS_PASS_DENSITY
 
@@ -236,7 +235,6 @@
 	return !density
 
 /obj/structure/foamedmetal/iron
-	obj_integrity = 50
 	max_integrity = 50
 	icon_state = "ironfoam"
 
@@ -247,7 +245,6 @@
 	opacity = FALSE
 	icon_state = "atmos_resin"
 	alpha = 120
-	obj_integrity = 10
 	max_integrity = 10
 	layer = EDGED_TURF_LAYER
 

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -9,7 +9,6 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "glowshroom" //replaced in New
 	layer = ABOVE_NORMAL_TURF_LAYER
-	obj_integrity = 30
 	max_integrity = 30
 	var/delay = 1200
 	var/floor = 0

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -5,7 +5,7 @@
 	desc = "it's stringy and sticky"
 	anchored = 1
 	density = 0
-	obj_integrity = 15
+	max_integrity = 15
 
 
 
@@ -82,7 +82,7 @@
 	icon_state = "spiderling"
 	anchored = 0
 	layer = PROJECTILE_HIT_THRESHHOLD_LAYER
-	obj_integrity = 3
+	max_integrity = 3
 	var/amount_grown = 0
 	var/grow_as = null
 	var/obj/machinery/atmospherics/components/unary/vent_pump/entry_vent
@@ -188,7 +188,7 @@
 	name = "cocoon"
 	desc = "Something wrapped in silky spider web"
 	icon_state = "cocoon1"
-	obj_integrity = 60
+	max_integrity = 60
 
 /obj/structure/spider/cocoon/Initialize()
 	icon_state = pick("cocoon1","cocoon2","cocoon3")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -24,9 +24,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/icon/alternate_worn_icon = null//If this is set, update_icons() will find on mob (WORN, NOT INHANDS) states in this file instead, primary use: badminnery/events
 	var/alternate_worn_layer = null//If this is set, update_icons() will force the on mob state (WORN, NOT INHANDS) onto this layer, instead of it's default
 
-	obj_integrity = 200
 	max_integrity = 200
-
 
 	var/hitsound = null
 	var/usesound = null

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -76,14 +76,14 @@
 	anchored = TRUE
 	density = TRUE
 	mouse_opacity = 2
-	max_integrity = INFINITY
+	resistance_flags = INDESTRUCTIBLE
 	CanAtmosPass = ATMOS_PASS_DENSITY
 	armor = list(melee = 0, bullet = 25, laser = 50, energy = 50, bomb = 25, bio = 100, rad = 100, fire = 100, acid = 100)
 	var/obj/item/device/forcefield/generator
 
 /obj/structure/projected_forcefield/Initialize(mapload, obj/item/device/forcefield/origin)
+	. = ..()
 	generator = origin
-	..()
 
 /obj/structure/projected_forcefield/Destroy()
 	visible_message("<span class='warning'>[src] flickers and disappears!</span>")

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -76,7 +76,6 @@
 	anchored = TRUE
 	density = TRUE
 	mouse_opacity = 2
-	obj_integrity = INFINITY
 	max_integrity = INFINITY
 	CanAtmosPass = ATMOS_PASS_DENSITY
 	armor = list(melee = 0, bullet = 25, laser = 50, energy = 50, bomb = 25, bio = 100, rad = 100, fire = 100, acid = 100)

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -2,7 +2,6 @@
 /obj/item/device/instrument
 	name = "generic instrument"
 	resistance_flags = FLAMMABLE
-	obj_integrity = 100
 	max_integrity = 100
 	var/datum/song/handheld/song
 	var/instrumentId = "generic"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -9,7 +9,6 @@
 	throw_speed = 3
 	throw_range = 7
 	resistance_flags = FLAMMABLE
-	obj_integrity = 40
 	max_integrity = 40
 	novariants = FALSE
 	var/heal_brute = 0

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -35,7 +35,7 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 /obj/item/stack/sheet/glass/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.glass_recipes
 	return ..()
-	
+
 /obj/item/stack/sheet/glass/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
 	if(istype(W, /obj/item/stack/cable_coil))
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(pglass_recipes, list ( \
 /obj/item/stack/sheet/plasmaglass/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.pglass_recipes
 	return ..()
-	
+
 /obj/item/stack/sheet/plasmaglass/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
 
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 /obj/item/stack/sheet/rglass/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.reinforced_glass_recipes
 	return ..()
-	
+
 GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	new/datum/stack_recipe("directional reinforced window", /obj/structure/window/plasma/reinforced/unanchored, time = 0, on_floor = TRUE, window_checks = TRUE), \
 	new/datum/stack_recipe("fulltile reinforced window", /obj/structure/window/plasma/reinforced/fulltile/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE) \
@@ -192,7 +192,6 @@ GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	resistance_flags = ACID_PROOF
 	armor = list("melee" = 100, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 100)
-	obj_integrity = 40
 	max_integrity = 40
 	var/cooldown = 0
 	sharpness = IS_SHARP

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -152,7 +152,6 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 	origin_tech = "plasmatech=2;materials=2"
 	sheettype = "plasma"
 	resistance_flags = FLAMMABLE
-	obj_integrity = 100
 	max_integrity = 100
 	materials = list(MAT_PLASMA=MINERAL_MATERIAL_AMOUNT)
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -584,7 +584,6 @@
 
 /obj/item/toy/cards
 	resistance_flags = FLAMMABLE
-	obj_integrity = 50
 	max_integrity = 50
 	var/parentdeck = null
 	var/deckstyle = "nanotrasen"

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -10,7 +10,6 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	resistance_flags = FLAMMABLE
-	obj_integrity = 40
 	max_integrity = 40
 	var/active = 0
 	var/det_time = 50

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -9,7 +9,6 @@
 	sharpness = IS_SHARP
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	heat = 3500
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 30)
 	resistance_flags = FIRE_PROOF

--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -11,7 +11,6 @@
 	item_state = "paintcan"
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FLAMMABLE
-	obj_integrity = 100
 	max_integrity = 100
 	var/paintleft = 10
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -20,7 +20,6 @@
 	max_combined_w_class = 21
 	storage_slots = 21
 	resistance_flags = 0
-	obj_integrity = 300
 	max_integrity = 300
 
 /*

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -6,7 +6,6 @@
 	item_state = "utility"
 	slot_flags = SLOT_BELT
 	attack_verb = list("whipped", "lashed", "disciplined")
-	obj_integrity = 300
 	max_integrity = 300
 
 /obj/item/weapon/storage/belt/update_icon()

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -12,7 +12,6 @@
 	max_combined_w_class = 21
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	resistance_flags = FLAMMABLE
-	obj_integrity = 150
 	max_integrity = 150
 	var/folder_path = /obj/item/weapon/folder //this is the path of the folder that gets spawned in New()
 
@@ -43,7 +42,6 @@
 	max_combined_w_class = 21
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	resistance_flags = FLAMMABLE
-	obj_integrity = 150
 	max_integrity = 150
 
 /obj/item/weapon/storage/briefcase/sniperbundle/PopulateContents()

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -9,7 +9,6 @@
 	slot_flags = SLOT_BACK
 	slowdown = 1
 	actions_types = list(/datum/action/item_action/toggle_mister)
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 30)
 	resistance_flags = FIRE_PROOF

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -209,7 +209,6 @@
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = IS_SHARP
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 30)
 	resistance_flags = FIRE_PROOF
@@ -258,7 +257,6 @@
 	light_color = "#00ff00"//green
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 75
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
@@ -418,7 +416,6 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
 	sharpness = IS_SHARP
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 30)
 	var/obj/item/weapon/grenade/explosive = null
@@ -568,7 +565,6 @@
 	attack_verb = list("attacked", "impaled", "pierced")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = IS_SHARP
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 30)
 	resistance_flags = FIRE_PROOF

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -11,7 +11,6 @@
 	throw_speed = 3
 	throw_range = 7
 	attack_verb = list("banned")
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
@@ -56,7 +55,6 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 50
 	sharpness = IS_SHARP
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 50)
 	resistance_flags = FIRE_PROOF
@@ -201,7 +199,6 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 50
 	sharpness = IS_SHARP
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 50)
 	resistance_flags = FIRE_PROOF

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -4,7 +4,6 @@
 	name = "\improper AI core"
 	icon = 'icons/mob/ai.dmi'
 	icon_state = "0"
-	obj_integrity = 500
 	max_integrity = 500
 	var/state = 0
 	var/datum/ai_laws/laws = new()

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -9,7 +9,6 @@
 
 /obj/structure/alien
 	icon = 'icons/mob/alien.dmi'
-	obj_integrity = 100
 	max_integrity = 100
 
 /obj/structure/alien/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
@@ -59,7 +58,6 @@
 	opacity = 1
 	anchored = 1
 	canSmoothWith = list(/obj/structure/alien/resin)
-	obj_integrity = 200
 	max_integrity = 200
 	smooth = SMOOTH_TRUE
 	var/resintype = null
@@ -92,7 +90,6 @@
 	icon = 'icons/obj/smooth_structures/alien/resin_membrane.dmi'
 	icon_state = "membrane0"
 	opacity = 0
-	obj_integrity = 160
 	max_integrity = 160
 	resintype = "membrane"
 	canSmoothWith = list(/obj/structure/alien/resin/wall, /obj/structure/alien/resin/membrane)
@@ -119,7 +116,6 @@
 	density = 0
 	layer = TURF_LAYER
 	icon_state = "weeds"
-	obj_integrity = 15
 	max_integrity = 15
 	canSmoothWith = list(/obj/structure/alien/weeds, /turf/closed/wall)
 	smooth = SMOOTH_MORE
@@ -220,7 +216,6 @@
 	icon_state = "egg_growing"
 	density = FALSE
 	anchored = TRUE
-	obj_integrity = 100
 	max_integrity = 100
 	integrity_failure = 5
 	var/status = GROWING	//can be GROWING, GROWN or BURST; all mutually exclusive

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -10,7 +10,6 @@
 	icon_state = "easel"
 	density = 1
 	resistance_flags = FLAMMABLE
-	obj_integrity = 60
 	max_integrity = 60
 	var/obj/item/weapon/canvas/painting = null
 

--- a/code/game/objects/structures/barsigns.dm
+++ b/code/game/objects/structures/barsigns.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/barsigns.dmi'
 	icon_state = "empty"
 	req_access = list(GLOB.access_bar)
-	obj_integrity = 500
 	max_integrity = 500
 	integrity_failure = 250
 	armor = list(melee = 20, bullet = 20, laser = 20, energy = 100, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 50)
@@ -16,12 +15,8 @@
 	var/prev_sign = ""
 	var/panel_open = 0
 
-
-
-
-/obj/structure/sign/barsign/New()
-	..()
-
+/obj/structure/sign/barsign/Initialize()
+	. = ..()
 
 //filling the barsigns list
 	for(var/bartype in subtypesof(/datum/barsign))
@@ -29,11 +24,8 @@
 		if(!signinfo.hidden)
 			barsigns += signinfo
 
-
 //randomly assigning a sign
 	set_sign(pick(barsigns))
-
-
 
 /obj/structure/sign/barsign/proc/set_sign(datum/barsign/sign)
 	if(!istype(sign))
@@ -44,8 +36,6 @@
 		desc = sign.desc
 	else
 		desc = "It displays \"[name]\"."
-
-
 
 /obj/structure/sign/barsign/obj_break(damage_flag)
 	if(!broken && !(flags & NODECONSTRUCT))

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -5,7 +5,6 @@
 	desc = "It's a gruesome pile of thick, sticky resin shaped like a nest."
 	icon = 'icons/obj/smooth_structures/alien/nest.dmi'
 	icon_state = "nest"
-	obj_integrity = 120
 	max_integrity = 120
 	smooth = SMOOTH_TRUE
 	can_be_unanchored = 0

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -16,7 +16,6 @@
 	can_buckle = 1
 	buckle_lying = 1
 	resistance_flags = FLAMMABLE
-	obj_integrity = 100
 	max_integrity = 100
 	integrity_failure = 30
 	var/buildstacktype = /obj/item/stack/sheet/metal

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -7,7 +7,6 @@
 	can_buckle = 1
 	buckle_lying = 0 //you sit in a chair, not lay
 	resistance_flags = 0
-	obj_integrity = 250
 	max_integrity = 250
 	integrity_failure = 25
 	var/buildstacktype = /obj/item/stack/sheet/metal
@@ -119,7 +118,6 @@
 	name = "wooden chair"
 	desc = "Old is never too old to not be in fashion."
 	resistance_flags = FLAMMABLE
-	obj_integrity = 70
 	max_integrity = 70
 	buildstacktype = /obj/item/stack/sheet/mineral/wood
 	buildstackamount = 3
@@ -141,7 +139,6 @@
 	icon_state = "comfychair"
 	color = rgb(255,255,255)
 	resistance_flags = FLAMMABLE
-	obj_integrity = 70
 	max_integrity = 70
 	buildstackamount = 2
 	var/mutable_appearance/armrest
@@ -314,7 +311,6 @@
 	icon_state = "wooden_chair_toppled"
 	item_state = "woodenchair"
 	resistance_flags = FLAMMABLE
-	obj_integrity = 70
 	max_integrity = 70
 	hitsound = 'sound/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/wood

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -242,7 +242,6 @@ LINEN BINS
 	icon_state = "linenbin-full"
 	anchored = 1
 	resistance_flags = FLAMMABLE
-	obj_integrity = 70
 	max_integrity = 70
 	var/amount = 10
 	var/list/sheets = list()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -12,7 +12,6 @@
 	var/locked = FALSE
 	var/large = TRUE
 	var/wall_mounted = 0 //never solid (You can always pass over it)
-	obj_integrity = 200
 	max_integrity = 200
 	integrity_failure = 50
 	armor = list(melee = 20, bullet = 10, laser = 10, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 70, acid = 60)

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -5,7 +5,6 @@
 	icon_state = "cardboard"
 	mob_storage_capacity = 1
 	resistance_flags = FLAMMABLE
-	obj_integrity = 70
 	max_integrity = 70
 	integrity_failure = 0
 	can_weld_shut = 0
@@ -61,7 +60,7 @@
 	name = "large metal box"
 	desc = "THE COWARDS! THE FOOLS!"
 	icon_state = "metalbox"
-	obj_integrity = 500
+	max_integrity = 500
 	mob_storage_capacity = 5
 	resistance_flags = 0
 	move_speed_multiplier = 2

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -3,7 +3,6 @@
 	desc = "Old will forever be in fashion."
 	icon_state = "cabinet"
 	resistance_flags = FLAMMABLE
-	obj_integrity = 70
 	max_integrity = 70
 
 /obj/structure/closet/acloset

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -126,7 +126,6 @@
 	desc = "It's a burial receptacle for the dearly departed."
 	icon_state = "coffin"
 	resistance_flags = FLAMMABLE
-	obj_integrity = 70
 	max_integrity = 70
 	horizontal = TRUE
 	delivery_icon = "deliverycrate"

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -3,7 +3,6 @@
 	req_access = list(GLOB.access_bar)
 	icon_state = "cabinet"
 	resistance_flags = FLAMMABLE
-	obj_integrity = 70
 	max_integrity = 70
 
 /obj/structure/closet/secure_closet/bar/PopulateContents()

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -24,7 +24,6 @@
 /obj/structure/closet/secure_closet/personal/cabinet
 	icon_state = "cabinet"
 	resistance_flags = FLAMMABLE
-	obj_integrity = 70
 	max_integrity = 70
 
 /obj/structure/closet/secure_closet/personal/cabinet/PopulateContents()

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -3,7 +3,6 @@
 	desc = "It's a card-locked storage unit."
 	locked = 1
 	icon_state = "secure"
-	obj_integrity = 250
 	max_integrity = 250
 	armor = list(melee = 30, bullet = 50, laser = 50, energy = 100, bomb = 0, bio = 0, rad = 0, fire = 80, acid = 80)
 	secure = 1

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -162,7 +162,6 @@
 	req_access = list(GLOB.access_forensics_lockers)
 	icon_state = "cabinet"
 	resistance_flags = FLAMMABLE
-	obj_integrity = 70
 	max_integrity = 70
 
 /obj/structure/closet/secure_closet/detective/PopulateContents()

--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -4,7 +4,6 @@
 	icon_state = "securecrate"
 	secure = 1
 	locked = 1
-	obj_integrity = 500
 	max_integrity = 500
 	armor = list(melee = 30, bullet = 50, laser = 50, energy = 100, bomb = 0, bio = 0, rad = 0, fire = 80, acid = 80)
 	var/tamperproof = 0

--- a/code/game/objects/structures/destructible_structures.dm
+++ b/code/game/objects/structures/destructible_structures.dm
@@ -1,6 +1,5 @@
 /obj/structure/destructible //a base for destructible structures
 	max_integrity = 100
-	obj_integrity = 100
 	var/break_message = "<span class='warning'>The strange, admin-y structure breaks!</span>" //The message shown when a structure breaks
 	var/break_sound = 'sound/magic/clockwork/invoke_general.ogg' //The sound played when a structure breaks
 	var/list/debris = null //Parts left behind when a structure breaks, takes the form of list(path = amount_to_spawn)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -7,7 +7,6 @@
 	anchored = 1
 	resistance_flags = ACID_PROOF
 	armor = list(melee = 30, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 70, acid = 100)
-	obj_integrity = 200
 	max_integrity = 200
 	integrity_failure = 50
 	var/obj/item/showpiece = null

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -5,7 +5,6 @@
 	var/overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 	anchored = 0
 	density = 1
-	obj_integrity = 200
 	max_integrity = 200
 	var/state = 0
 	var/mineral = null

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -5,7 +5,6 @@
 	icon_state = "extinguisher_closed"
 	anchored = 1
 	density = 0
-	obj_integrity = 200
 	max_integrity = 200
 	integrity_failure = 50
 	var/obj/item/weapon/extinguisher/stored_extinguisher

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -14,7 +14,6 @@
 	var/opening = 0
 	density = 1
 	opacity = 1
-	obj_integrity = 100
 	max_integrity = 100
 
 	canSmoothWith = list(
@@ -220,7 +219,6 @@
 	mineral = /obj/item/stack/sheet/mineral/diamond
 	walltype = /turf/closed/wall/mineral/diamond
 	canSmoothWith = list(/obj/structure/falsewall/diamond, /turf/closed/wall/mineral/diamond)
-	obj_integrity = 800
 	max_integrity = 800
 
 /obj/structure/falsewall/plasma

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -9,7 +9,6 @@
 	armor = list(melee = 50, bullet = 20, laser = 0, energy = 100, bomb = 10, bio = 100, rad = 100, fire = 90, acid = 50)
 	var/locked = 1
 	var/open = 0
-	obj_integrity = 150
 	max_integrity = 150
 	integrity_failure = 50
 

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -1,6 +1,5 @@
 /obj/structure/flora
 	resistance_flags = FLAMMABLE
-	obj_integrity = 150
 	max_integrity = 150
 	anchored = 1
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -7,7 +7,6 @@
 	var/state = GIRDER_NORMAL
 	var/girderpasschance = 20 // percentage chance that a projectile passes through the girder.
 	var/can_displace = TRUE //If the girder can be moved around by wrenching it
-	obj_integrity = 200
 	max_integrity = 200
 
 /obj/structure/girder/examine(mob/user)
@@ -306,7 +305,6 @@
 	anchored = 0
 	state = GIRDER_DISPLACED
 	girderpasschance = 25
-	obj_integrity = 120
 	max_integrity = 120
 
 /obj/structure/girder/reinforced
@@ -314,7 +312,6 @@
 	icon_state = "reinforced"
 	state = GIRDER_REINF
 	girderpasschance = 0
-	obj_integrity = 350
 	max_integrity = 350
 
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -9,7 +9,6 @@
 	pressure_resistance = 5*ONE_ATMOSPHERE
 	layer = BELOW_OBJ_LAYER
 	armor = list(melee = 50, bullet = 70, laser = 70, energy = 100, bomb = 10, bio = 100, rad = 100, fire = 0, acid = 0)
-	obj_integrity = 50
 	max_integrity = 50
 	integrity_failure = 20
 	var/rods_type = /obj/item/stack/rods

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -5,7 +5,6 @@
 	name = "holo sign"
 	icon = 'icons/effects/effects.dmi'
 	anchored = 1
-	obj_integrity = 1
 	max_integrity = 1
 	armor = list(melee = 0, bullet = 50, laser = 50, energy = 50, bomb = 0, bio = 0, rad = 0, fire = 20, acid = 20)
 	var/obj/item/weapon/holosign_creator/projector
@@ -46,7 +45,6 @@
 	icon_state = "holosign_sec"
 	pass_flags = LETPASSTHROW
 	density = 1
-	obj_integrity = 20
 	max_integrity = 20
 	var/allow_walk = 1 //can we pass through it on walk intent
 
@@ -89,7 +87,6 @@
 	name = "Energy Field"
 	desc = "A fragile energy field that blocks movement. Excels at blocking lethal projectiles."
 	density = 1
-	obj_integrity = 10
 	max_integrity = 10
 	allow_walk = 0
 
@@ -103,7 +100,6 @@
 /obj/structure/holosign/barrier/cyborg/hacked
 	name = "Charged Energy Field"
 	desc = "A powerful energy field that blocks movement. Energy arcs off it"
-	obj_integrity = 20
 	max_integrity = 20
 	var/shockcd = 0
 

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -8,7 +8,6 @@
 	desc = "The frame of a meat spike."
 	density = 1
 	anchored = 0
-	obj_integrity = 200
 	max_integrity = 200
 
 /obj/structure/kitchenspike_frame/attackby(obj/item/I, mob/user, params)
@@ -51,7 +50,6 @@
 	anchored = 1
 	buckle_lying = 0
 	can_buckle = 1
-	obj_integrity = 250
 	max_integrity = 250
 
 

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -6,7 +6,6 @@
 	density = 0
 	anchored = 1
 	armor = list(melee = 50, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 80, acid = 50)
-	obj_integrity = 50
 	max_integrity = 50
 	layer = LATTICE_LAYER //under pipes
 	var/number_of_rods = 1

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -8,7 +8,6 @@
 	can_buckle = TRUE
 	density = TRUE
 	max_integrity = 100
-	obj_integrity = 100
 	buckle_lying = FALSE
 	layer = ABOVE_MOB_LAYER
 	var/view_range = 10

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -14,7 +14,6 @@
 	var/state = 0 //closed, 1 == open
 	var/isSwitchingStates = 0
 	var/close_delay = -1 //-1 if does not auto close.
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 100, bomb = 10, bio = 100, rad = 100, fire = 50, acid = 50)
 	var/sheetType = /obj/item/stack/sheet/metal
@@ -144,14 +143,12 @@
 
 /obj/structure/mineral_door/iron
 	name = "iron door"
-	obj_integrity = 300
 	max_integrity = 300
 
 /obj/structure/mineral_door/silver
 	name = "silver door"
 	icon_state = "silver"
 	sheetType = /obj/item/stack/sheet/mineral/silver
-	obj_integrity = 300
 	max_integrity = 300
 
 /obj/structure/mineral_door/gold
@@ -163,7 +160,6 @@
 	name = "uranium door"
 	icon_state = "uranium"
 	sheetType = /obj/item/stack/sheet/mineral/uranium
-	obj_integrity = 300
 	max_integrity = 300
 	light_range = 2
 
@@ -171,7 +167,6 @@
 	name = "sandstone door"
 	icon_state = "sandstone"
 	sheetType = /obj/item/stack/sheet/mineral/sandstone
-	obj_integrity = 100
 	max_integrity = 100
 
 /obj/structure/mineral_door/transparent
@@ -207,7 +202,6 @@
 	name = "diamond door"
 	icon_state = "diamond"
 	sheetType = /obj/item/stack/sheet/mineral/diamond
-	obj_integrity = 1000
 	max_integrity = 1000
 
 /obj/structure/mineral_door/wood
@@ -217,7 +211,6 @@
 	closeSound = 'sound/effects/doorcreaky.ogg'
 	sheetType = /obj/item/stack/sheet/mineral/wood
 	resistance_flags = FLAMMABLE
-	obj_integrity = 200
 	max_integrity = 200
 
 /obj/structure/mineral_door/paperframe
@@ -228,7 +221,6 @@
 	sheetType = /obj/item/stack/sheet/paperframes
 	sheetAmount = 3
 	resistance_flags = FLAMMABLE
-	obj_integrity = 20
 	max_integrity = 20
 
 /obj/structure/mineral_door/paperframe/Initialize()

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -6,7 +6,6 @@
 	icon_state = "mirror"
 	density = 0
 	anchored = 1
-	obj_integrity = 200
 	max_integrity = 200
 	integrity_failure = 100
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -18,7 +18,6 @@
 	icon_state = "morgue1"
 	density = 1
 	anchored = 1
-	obj_integrity = 400
 	max_integrity = 400
 
 	var/obj/structure/tray/connected = null
@@ -251,7 +250,6 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	var/obj/structure/bodycontainer/connected = null
 	anchored = 1
 	pass_flags = LETPASSTHROW
-	obj_integrity = 350
 	max_integrity = 350
 
 /obj/structure/tray/Destroy()

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -5,7 +5,6 @@
 	icon_state = "nboard00"
 	density = 0
 	anchored = 1
-	obj_integrity = 150
 	max_integrity = 150
 	var/notices = 0
 

--- a/code/game/objects/structures/petrified_statue.dm
+++ b/code/game/objects/structures/petrified_statue.dm
@@ -4,7 +4,6 @@
 	icon_state = "human_male"
 	density = 1
 	anchored = 1
-	obj_integrity = 200
 	max_integrity = 200
 	var/timer = 240 //eventually the person will be freed
 	var/mob/living/petrified_mob

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -4,7 +4,6 @@
 	opacity = 0
 	density = 0
 	layer = SIGN_LAYER
-	obj_integrity = 100
 	max_integrity = 100
 	armor = list(melee = 50, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 50)
 	var/buildable_sign = 1 //unwrenchable and modifiable
@@ -113,7 +112,6 @@
 /obj/structure/sign/map
 	name = "station map"
 	desc = "A framed picture of the station."
-	obj_integrity = 500
 	max_integrity = 500
 
 /obj/structure/sign/map/left

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -8,7 +8,6 @@
 	icon_state = ""
 	density = 1
 	anchored = 0
-	obj_integrity = 100
 	max_integrity = 100
 	var/oreAmount = 5
 	var/material_drop_type = /obj/item/stack/sheet/metal
@@ -96,7 +95,7 @@
 ////////////////////////uranium///////////////////////////////////
 
 /obj/structure/statue/uranium
-	obj_integrity = 300
+	max_integrity = 300
 	light_range = 2
 	material_drop_type = /obj/item/stack/sheet/mineral/uranium
 	var/last_event = 0
@@ -141,7 +140,7 @@
 ////////////////////////////plasma///////////////////////////////////////////////////////////////////////
 
 /obj/structure/statue/plasma
-	obj_integrity = 200
+	max_integrity = 200
 	material_drop_type = /obj/item/stack/sheet/mineral/plasma
 	desc = "This statue is suitably made from plasma."
 
@@ -192,7 +191,7 @@
 //////////////////////gold///////////////////////////////////////
 
 /obj/structure/statue/gold
-	obj_integrity = 300
+	max_integrity = 300
 	material_drop_type = /obj/item/stack/sheet/mineral/gold
 	desc = "This is a highly valuable statue made from gold."
 
@@ -219,7 +218,7 @@
 //////////////////////////silver///////////////////////////////////////
 
 /obj/structure/statue/silver
-	obj_integrity = 300
+	max_integrity = 300
 	material_drop_type = /obj/item/stack/sheet/mineral/silver
 	desc = "This is a valuable statue made from silver."
 
@@ -246,7 +245,7 @@
 /////////////////////////diamond/////////////////////////////////////////
 
 /obj/structure/statue/diamond
-	obj_integrity = 1000
+	max_integrity = 1000
 	material_drop_type = /obj/item/stack/sheet/mineral/diamond
 	desc = "This is a very expensive diamond statue"
 
@@ -265,7 +264,7 @@
 ////////////////////////bananium///////////////////////////////////////
 
 /obj/structure/statue/bananium
-	obj_integrity = 300
+	max_integrity = 300
 	material_drop_type = /obj/item/stack/sheet/mineral/bananium
 	desc = "A bananium statue with a small engraving:'HOOOOOOONK'."
 	var/spam_flag = 0
@@ -300,7 +299,7 @@
 /////////////////////sandstone/////////////////////////////////////////
 
 /obj/structure/statue/sandstone
-	obj_integrity = 50
+	max_integrity = 50
 	material_drop_type = /obj/item/stack/sheet/mineral/sandstone
 
 /obj/structure/statue/sandstone/assistant
@@ -318,7 +317,7 @@
 /////////////////////snow/////////////////////////////////////////
 
 /obj/structure/statue/snow
-	obj_integrity = 50
+	max_integrity = 50
 	material_drop_type = /obj/item/stack/sheet/mineral/snow
 
 /obj/structure/statue/snow/snowman

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -17,7 +17,6 @@
 	density = 0
 	anchored = 0
 	layer = PROJECTILE_HIT_THRESHHOLD_LAYER
-	obj_integrity = 100
 	max_integrity = 100
 	var/framestack = /obj/item/stack/rods
 	var/framestackamount = 2

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -29,7 +29,6 @@
 	var/buildstackamount = 1
 	var/framestackamount = 2
 	var/deconstruction_ready = 1
-	obj_integrity = 100
 	max_integrity = 100
 	integrity_failure = 30
 	smooth = SMOOTH_TRUE
@@ -162,7 +161,6 @@
 	icon_state = "glass_table"
 	buildstack = /obj/item/stack/sheet/glass
 	canSmoothWith = null
-	obj_integrity = 70
 	max_integrity = 70
 	resistance_flags = ACID_PROOF
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 80, acid = 100)
@@ -244,7 +242,6 @@
 	framestack = /obj/item/stack/sheet/mineral/wood
 	buildstack = /obj/item/stack/sheet/mineral/wood
 	resistance_flags = FLAMMABLE
-	obj_integrity = 70
 	max_integrity = 70
 	canSmoothWith = list(/obj/structure/table/wood,
 		/obj/structure/table/wood/poker,
@@ -296,7 +293,6 @@
 	deconstruction_ready = 0
 	buildstack = /obj/item/stack/sheet/plasteel
 	canSmoothWith = list(/obj/structure/table/reinforced, /obj/structure/table)
-	obj_integrity = 200
 	max_integrity = 200
 	integrity_failure = 50
 	armor = list(melee = 10, bullet = 30, laser = 30, energy = 100, bomb = 20, bio = 0, rad = 0, fire = 80, acid = 70)
@@ -409,7 +405,6 @@
 	density = 1
 	anchored = 1
 	pass_flags = LETPASSTHROW //You can throw objects over this, despite it's density.
-	obj_integrity = 20
 	max_integrity = 20
 
 /obj/structure/rack/CanPass(atom/movable/mover, turf/target, height=0)

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -7,7 +7,6 @@
 	icon_state = "dispenser"
 	density = 1
 	anchored = 1
-	obj_integrity = 300
 	max_integrity = 300
 	var/oxygentanks = TANK_DISPENSER_CAPACITY
 	var/plasmatanks = TANK_DISPENSER_CAPACITY
@@ -25,7 +24,7 @@
 	for(var/i in 1 to plasmatanks)
 		new /obj/item/weapon/tank/internals/plasma(src)
 	update_icon()
-	
+
 /obj/structure/tank_dispenser/update_icon()
 	cut_overlays()
 	switch(oxygentanks)

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -7,7 +7,6 @@
 	name = "shuttle"
 	icon = 'icons/turf/shuttle.dmi'
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	obj_integrity = 500
 	max_integrity = 500
 	armor = list(melee = 100, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70) //default + ignores melee
 

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -55,7 +55,6 @@
 	active_power_usage = 8
 	power_channel = ENVIRON
 	req_access = list(GLOB.access_atmospherics)
-	obj_integrity = 250
 	max_integrity = 250
 	integrity_failure = 80
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 0, bio = 100, rad = 100, fire = 90, acid = 30)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -20,7 +20,6 @@ Pipelines + Other Objects -> Pipe network
 	on_blueprints = TRUE
 	layer = GAS_PIPE_HIDDEN_LAYER //under wires
 	resistance_flags = FIRE_PROOF
-	obj_integrity = 200
 	max_integrity = 200
 	var/nodealert = 0
 	var/can_unwrench = 0

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -6,7 +6,6 @@
 	icon_state = "pod-off"
 	density = 1
 	anchored = 1
-	obj_integrity = 350
 	max_integrity = 350
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 0, bio = 100, rad = 100, fire = 30, acid = 30)
 	layer = ABOVE_WINDOW_LAYER

--- a/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
@@ -4,7 +4,6 @@
 	icon_state = "generic"
 	name = "pressure tank"
 	desc = "A large vessel containing pressurized gas."
-	obj_integrity = 800
 	max_integrity = 800
 	var/volume = 10000 //in liters, 1 meters by 1 meters by 2 meters
 	density = 1

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -7,11 +7,10 @@
 	var/icon_state_open = "cold_off"
 	density = TRUE
 	anchored = TRUE
-	obj_integrity = 300
 	max_integrity = 300
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 0, bio = 100, rad = 100, fire = 80, acid = 30)
 	layer = OBJ_LAYER
-	
+
 	var/on = FALSE
 	var/min_temperature = 0
 	var/max_temperature = 0

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -11,7 +11,6 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 4
-	obj_integrity = 150
 	max_integrity = 150
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 0, bio = 100, rad = 100, fire = 40, acid = 0)
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -18,7 +18,6 @@
 	var/can_min_release_pressure = (ONE_ATMOSPHERE / 10)
 
 	armor = list(melee = 50, bullet = 50, laser = 50, energy = 100, bomb = 10, bio = 100, rad = 100, fire = 80, acid = 50)
-	obj_integrity = 250
 	max_integrity = 250
 	integrity_failure = 100
 	pressure_resistance = 7 * ONE_ATMOSPHERE
@@ -138,7 +137,6 @@
 	icon_state = "proto"
 	icon_state = "proto"
 	volume = 5000
-	obj_integrity = 300
 	max_integrity = 300
 	temperature_resistance = 2000 + T0C
 	can_max_release_pressure = (ONE_ATMOSPHERE * 30)

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -2,7 +2,6 @@
 	name = "portable_atmospherics"
 	icon = 'icons/obj/atmos.dmi'
 	use_power = NO_POWER_USE
-	obj_integrity = 250
 	max_integrity = 250
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 0, bio = 100, rad = 100, fire = 60, acid = 30)
 

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -28,7 +28,6 @@
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "forge"
 	anchored = 1
-	obj_integrity = 200
 	max_integrity = 200
 	var/mob/living/current_wizard = null
 	var/next_check = 0

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1,7 +1,6 @@
 /obj/item/clothing
 	name = "clothing"
 	resistance_flags = FLAMMABLE
-	obj_integrity = 200
 	max_integrity = 200
 	integrity_failure = 80
 	var/damaged_clothes = 0 //similar to machine's BROKEN stat and structure's broken var

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -170,7 +170,6 @@
 	icon_state = "tiki_eyebrow"
 	item_state = "tiki_eyebrow"
 	resistance_flags = FLAMMABLE
-	obj_integrity = 100
 	max_integrity = 100
 	actions_types = list(/datum/action/item_action/adjust)
 	dog_fashion = null

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -4,7 +4,6 @@
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has radiation shielding."
 	icon_state = "hardsuit0-engineering"
 	item_state = "eng_helm"
-	obj_integrity = 300
 	max_integrity = 300
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75, fire = 50, acid = 75)
 	var/basestate = "hardsuit"
@@ -64,7 +63,6 @@
 	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding."
 	icon_state = "hardsuit-engineering"
 	item_state = "eng_hardsuit"
-	obj_integrity = 300
 	max_integrity = 300
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75, fire = 50, acid = 75)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals,/obj/item/device/t_scanner, /obj/item/weapon/construction/rcd, /obj/item/weapon/pipe_dispenser)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -7,7 +7,6 @@
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
 	strip_delay = 60
 	equip_delay_other = 40
-	obj_integrity = 250
 	max_integrity = 250
 	resistance_flags = 0
 	armor = list(melee = 30, bullet = 30, laser = 30, energy = 10, bomb = 25, bio = 0, rad = 0, fire = 50, acid = 50)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -316,7 +316,6 @@
 	layer = SPACEVINE_LAYER
 	mouse_opacity = 2 //Clicking anywhere on the turf is good enough
 	pass_flags = PASSTABLE | PASSGRILLE
-	obj_integrity = 50
 	max_integrity = 50
 	var/energy = 0
 	var/datum/spacevine_controller/master = null

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -552,7 +552,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	var/collapse
 	var/image/down
 
-	obj_integrity = 100
+	max_integrity = 100
 
 /obj/effect/fake_attacker/attackby(obj/item/weapon/P, mob/living/user, params)
 	step_away(src,my_target,2)

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -7,7 +7,6 @@
 	amount_per_transfer_from_this = 10
 	volume = 50
 	materials = list(MAT_GLASS=500)
-	obj_integrity = 20
 	max_integrity = 20
 	spillable = 1
 	resistance_flags = ACID_PROOF

--- a/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
@@ -18,7 +18,6 @@
 	var/dispense_flavour = ICECREAM_VANILLA
 	var/flavour_name = "vanilla"
 	container_type = OPENCONTAINER
-	obj_integrity = 300
 	max_integrity = 300
 
 /obj/machinery/icecream_vat/proc/get_ingredient_list(type)

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -130,7 +130,6 @@
 	seed = /obj/item/seeds/cherry/bomb
 	bitesize_mod = 2
 	volume = 125 //Gives enough room for the black powder at max potency
-	obj_integrity = 40
 	max_integrity = 40
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cherry_bomb/attack_self(mob/living/user)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -18,7 +18,6 @@
 	density = 1
 	opacity = 0
 	resistance_flags = FLAMMABLE
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 0)
 	var/state = 0

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -114,7 +114,6 @@
 	layer = HIGH_OBJ_LAYER
 	density = FALSE
 	anchored = TRUE
-	obj_integrity = 30
 	max_integrity = 30
 	layer = LATTICE_LAYER
 

--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -76,7 +76,6 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 	icon_state = "marker"
 	layer = BELOW_OPEN_DOOR_LAYER
 	armor = list(melee = 50, bullet = 75, laser = 75, energy = 75, bomb = 25, bio = 100, rad = 100, fire = 25, acid = 0)
-	obj_integrity = 50
 	max_integrity = 50
 	anchored = TRUE
 	light_range = 2

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -158,7 +158,6 @@
 	list_reagents = list("sugar" = 3, "ethanol" = 2, "stabilizing_agent" = 3, "minttoxin" = 2)
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
-	obj_integrity = 100
 	max_integrity = 100
 	seed = /obj/item/seeds/lavaland/polypore
 
@@ -209,7 +208,6 @@
 	icon_state = "mushroom_bowl"
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE
-	obj_integrity = 200
 	max_integrity = 200
 
 //what you can craft with these things

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -6,7 +6,6 @@
 	force = 10
 	throwforce = 0
 	resistance_flags = FLAMMABLE
-	obj_integrity = 100
 	max_integrity = 100
 	w_class = WEIGHT_CLASS_BULKY
 	max_w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -20,7 +20,6 @@
 	tint = 3
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 	layer = MOB_LAYER
-	obj_integrity = 100
 	max_integrity = 100
 
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -626,7 +626,6 @@
 /obj/structure/cloth_pile
 	name = "pile of bandages"
 	desc = "It emits a strange aura, as if there was still life within it..."
-	obj_integrity = 50
 	max_integrity = 50
 	armor = list(melee = 90, bullet = 90, laser = 25, energy = 80, bomb = 50, bio = 100, fire = -50, acid = -50)
 	icon = 'icons/obj/items.dmi'

--- a/code/modules/mob/living/simple_animal/hostile/jungle_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle_mobs.dm
@@ -170,7 +170,6 @@
 	desc = "A floating bubble containing leaper venom, the contents are under a surprising amount of pressure."
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "leaper"
-	obj_integrity = 10
 	max_integrity = 10
 	density = FALSE
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -730,7 +730,7 @@ Difficulty: Very Hard
 	icon_state = null //This shouldn't even be visible, so if it DOES show up, at least nobody will notice
 	density = 1
 	anchored = 1
-	obj_integrity = 999
+	resistance_flags = FIRE_PROOF | ACID_PROOF | INDESTRUCTIBLE
 	var/mob/living/simple_animal/holder_animal
 
 /obj/structure/closet/stasis/process()
@@ -740,8 +740,8 @@ Difficulty: Very Hard
 			holder_animal.gib()
 			return
 
-/obj/structure/closet/stasis/New()
-	..()
+/obj/structure/closet/stasis/Initialize(mapload)
+	. = ..()
 	if(isanimal(loc))
 		holder_animal = loc
 	START_PROCESSING(SSobj, src)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -30,7 +30,6 @@
 	var/max_hardware_size = 0								// Maximal hardware w_class. Tablets/PDAs have 1, laptops 2, consoles 4.
 	var/steel_sheet_cost = 5								// Amount of steel sheets refunded when disassembling an empty frame of this computer.
 
-	obj_integrity = 100
 	integrity_failure = 50
 	max_integrity = 100
 	armor = list(melee = 0, bullet = 20, laser = 20, energy = 100, bomb = 0, bio = 100, rad = 100, fire = 0, acid = 0)

--- a/code/modules/modular_computers/computers/machinery/modular_console.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_console.dm
@@ -16,7 +16,6 @@
 	max_hardware_size = 4
 	steel_sheet_cost = 10
 	light_strength = 2
-	obj_integrity = 300
 	max_integrity = 300
 	integrity_failure = 150
 

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -69,7 +69,6 @@
 	block_chance = 50
 	slot_flags = SLOT_BELT
 	sharpness = IS_SHARP
-	obj_integrity = 200
 	max_integrity = 200
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	bypass_density = TRUE

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -14,8 +14,7 @@ It is possible to destroy the net by the occupant or someone else.
 	mouse_opacity = 1//So you can hit it with stuff.
 	anchored = 1//Can't drag/grab the trapped mob.
 	layer = ABOVE_ALL_MOB_LAYER
-	obj_integrity = 25//How much health it has.
-	max_integrity = 25
+	max_integrity = 25 //How much health it has.
 	var/mob/living/affecting = null//Who it is currently affecting, if anyone.
 	var/mob/living/master = null//Who shot web. Will let this person know if the net was successful or failed.
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -19,7 +19,6 @@
 	slot_flags = SLOT_HEAD
 	body_parts_covered = HEAD
 	resistance_flags = FLAMMABLE
-	obj_integrity = 50
 	max_integrity = 50
 	dog_fashion = /datum/dog_fashion/head
 

--- a/code/modules/paperwork/paper_cutter.dm
+++ b/code/modules/paperwork/paper_cutter.dm
@@ -110,7 +110,6 @@
 	icon_state = "paperslip"
 	icon = 'icons/obj/bureaucracy.dmi'
 	resistance_flags = FLAMMABLE
-	obj_integrity = 50
 	max_integrity = 50
 
 /obj/item/weapon/paperslip/New()

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -8,7 +8,6 @@
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
-	obj_integrity = 50
 	max_integrity = 50
 
 	var/obj/item/weapon/paper/internalPaper

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -18,7 +18,6 @@
 	idle_power_usage = 30
 	active_power_usage = 200
 	power_channel = EQUIP
-	obj_integrity = 300
 	max_integrity = 300
 	integrity_failure = 100
 	var/obj/item/weapon/paper/copy = null	//what's in the copier!

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -30,7 +30,6 @@
 	item_state = "paper"
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
-	obj_integrity = 50
 	max_integrity = 50
 	var/icon/img		//Big photo image
 	var/scribble		//Scribble on the back.

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -46,7 +46,6 @@
 	anchored = 1
 	use_power = NO_POWER_USE
 	req_access = null
-	obj_integrity = 200
 	max_integrity = 200
 	integrity_failure = 50
 	resistance_flags = FIRE_PROOF

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -3,7 +3,6 @@
 	name = "floodlight frame"
 	desc = "A bare metal frame looking vaguely like a floodlight. Requires wrenching down."
 	max_integrity = 100
-	obj_integrity = 100
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "floodlight_c1"
 	density = TRUE

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -42,7 +42,6 @@
 	icon_state = "tube-construct-stage1"
 	anchored = 1
 	layer = WALL_OBJ_LAYER
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 50, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 80, acid = 50)
 
@@ -156,7 +155,6 @@
 	desc = "A lighting fixture."
 	anchored = 1
 	layer = WALL_OBJ_LAYER
-	obj_integrity = 100
 	max_integrity = 100
 	use_power = ACTIVE_POWER_USE
 	idle_power_usage = 2

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -10,7 +10,6 @@ GLOBAL_LIST_EMPTY(rad_collectors)
 	density = 1
 	req_access = list(GLOB.access_engine_equip)
 //	use_power = NO_POWER_USE
-	obj_integrity = 350
 	max_integrity = 350
 	integrity_failure = 80
 	var/obj/item/weapon/tank/internals/plasma/loaded_tank = null

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -26,7 +26,6 @@ field_generator power level display
 	anchored = 0
 	density = 1
 	use_power = NO_POWER_USE
-	obj_integrity = 500
 	max_integrity = 500
 	//100% immune to lasers and energy projectiles since it absorbs their energy.
 	armor = list(melee = 25, bullet = 10, laser = 100, energy = 100, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 70)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -26,7 +26,6 @@
 	icon_state = "none"
 	anchored = 0
 	density = 1
-	obj_integrity = 500
 	max_integrity = 500
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 90, acid = 80)
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -265,6 +265,7 @@
 	density = 1
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 250
+	max_integrity = 200
 	integrity_failure = 100
 	var/icon_screen = "solar"
 	var/icon_keyboard = "power_key"

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -12,7 +12,6 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 	var/id = 0
-	obj_integrity = 150
 	max_integrity = 150
 	integrity_failure = 50
 	var/obscured = 0
@@ -22,8 +21,8 @@
 	var/turn_angle = 0
 	var/obj/machinery/power/solar_control/control = null
 
-/obj/machinery/power/solar/New(var/turf/loc, var/obj/item/solar_assembly/S)
-	..(loc)
+/obj/machinery/power/solar/Initialize(mapload, obj/item/solar_assembly/S)
+	. = ..()
 	Make(S)
 	connect_to_network()
 
@@ -50,7 +49,8 @@
 		S = new /obj/item/solar_assembly(src)
 		S.glass_type = /obj/item/stack/sheet/glass
 		S.anchored = 1
-	S.loc = src
+	else
+		S.forceMove(src)
 	if(S.glass_type == /obj/item/stack/sheet/rglass) //if the panel is in reinforced glass
 		max_integrity *= 2 								 //this need to be placed here, because panels already on the map don't have an assembly linked to
 		obj_integrity = max_integrity
@@ -265,8 +265,6 @@
 	density = 1
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 250
-	obj_integrity = 200
-	max_integrity = 200
 	integrity_failure = 100
 	var/icon_screen = "solar"
 	var/icon_keyboard = "power_key"

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -11,7 +11,6 @@
 	anchored = 1
 	density = 1
 	use_power = NO_POWER_USE
-	obj_integrity = 250
 	max_integrity = 250
 	integrity_failure = 50
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -7,7 +7,6 @@
 	anchored = 0
 	container_type = DRAWABLE
 	pressure_resistance = 2*ONE_ATMOSPHERE
-	obj_integrity = 300
 	max_integrity = 300
 	var/tank_volume = 1000 //In units, how much the dispenser can hold
 	var/reagent_id = "water" //The ID of the reagent that the dispenser uses

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -11,7 +11,6 @@
 	density = 0
 	pressure_resistance = 5*ONE_ATMOSPHERE
 	level = 2
-	obj_integrity = 200
 	max_integrity = 200
 	var/ptype = 0
 

--- a/code/modules/recycling/disposal-structures.dm
+++ b/code/modules/recycling/disposal-structures.dm
@@ -139,7 +139,6 @@
 	level = 1			// underfloor only
 	var/dpdir = 0		// bitmask of pipe directions
 	dir = 0// dir will contain dominant direction for junction pipes
-	obj_integrity = 200
 	max_integrity = 200
 	armor = list(melee = 25, bullet = 10, laser = 10, energy = 100, bomb = 0, bio = 100, rad = 100, fire = 90, acid = 30)
 	layer = DISPOSAL_PIPE_LAYER			// slightly lower than wires and other pipes

--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -9,7 +9,6 @@
 	density = 1
 	on_blueprints = TRUE
 	armor = list(melee = 25, bullet = 10, laser = 10, energy = 100, bomb = 0, bio = 100, rad = 100, fire = 90, acid = 30)
-	obj_integrity = 200
 	max_integrity = 200
 	resistance_flags = FIRE_PROOF
 	interact_open = TRUE

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -55,9 +55,7 @@
 
 /obj/structure/table/abductor/wabbajack
 	name = "wabbajack altar"
-	desc = "Whether you're sleeping or waking, it's going to be \
-		quite chaotic."
-	obj_integrity = 1000
+	desc = "Whether you're sleeping or waking, it's going to be quite chaotic."
 	max_integrity = 1000
 	verb_say = "chants"
 	var/obj/machinery/power/emitter/energycannon/magical/our_statue
@@ -183,7 +181,6 @@
 /obj/structure/table/wood/bar
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	flags = NODECONSTRUCT
-	obj_integrity = 1000
 	max_integrity = 1000
 	var/boot_dir = 1
 

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -8,7 +8,6 @@
 	anchored = 0
 	can_buckle = 1
 	buckle_lying = 0
-	obj_integrity = 300
 	max_integrity = 300
 	armor = list(melee = 30, bullet = 30, laser = 30, energy = 0, bomb = 30, bio = 0, rad = 0, fire = 60, acid = 60)
 	var/auto_door_open = TRUE


### PR DESCRIPTION
We don't need these unless something is starting at lower-than-normal max_integrity, which few things do.