### PR TITLE
Cere's emergency shuttle no longer flies in reverse

### DIFF
--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -59265,7 +59265,7 @@
 	height = 20;
 	name = "Cere emergency shuttle";
 	port_angle = 90;
-	preferred_direction = 2;
+	preferred_direction = 1;
 	width = 42
 	},
 /obj/docking_port/stationary{


### PR DESCRIPTION
fixes #27949

:cl: shizcalev
fix: Cerestation's emergency shuttle autopilot will no longer fly you in reverse back to Centcom!
/:cl: