### PR TITLE
makes astar a million times faster (not really)

### DIFF
--- a/code/__HELPERS/AStar.dm
+++ b/code/__HELPERS/AStar.dm
@@ -154,7 +154,7 @@ Actual Adjacent procs :
 /turf/proc/reachableAdjacentTurfs(caller, ID, simulated_only)
 	var/list/L = new()
 	var/turf/T
-	var/static/space_type_cache = typecacheof(list(/turfs/space))
+	var/static/space_type_cache = typecacheof(list(/turf/space))
 
 	for(var/dir in GLOB.cardinals)
 		T = get_step(src,dir)

--- a/code/__HELPERS/AStar.dm
+++ b/code/__HELPERS/AStar.dm
@@ -154,10 +154,11 @@ Actual Adjacent procs :
 /turf/proc/reachableAdjacentTurfs(caller, ID, simulated_only)
 	var/list/L = new()
 	var/turf/T
+	var/static/space_type_cache = typecacheof(list(/turfs/spacespace))
 
 	for(var/dir in GLOB.cardinals)
 		T = get_step(src,dir)
-		if(simulated_only && !istype(T))
+		if(!T || (simulated_only && space_type_cache[T.type]))
 			continue
 		if(!T.density && !LinkBlockedWithAccess(T,caller, ID))
 			L.Add(T)

--- a/code/__HELPERS/AStar.dm
+++ b/code/__HELPERS/AStar.dm
@@ -154,7 +154,7 @@ Actual Adjacent procs :
 /turf/proc/reachableAdjacentTurfs(caller, ID, simulated_only)
 	var/list/L = new()
 	var/turf/T
-	var/static/space_type_cache = typecacheof(list(/turfs/spacespace))
+	var/static/space_type_cache = typecacheof(list(/turfs/space))
 
 	for(var/dir in GLOB.cardinals)
 		T = get_step(src,dir)

--- a/code/__HELPERS/AStar.dm
+++ b/code/__HELPERS/AStar.dm
@@ -154,7 +154,7 @@ Actual Adjacent procs :
 /turf/proc/reachableAdjacentTurfs(caller, ID, simulated_only)
 	var/list/L = new()
 	var/turf/T
-	var/static/space_type_cache = typecacheof(list(/turf/space))
+	var/static/space_type_cache = typecacheof(list(/turf/open/space))
 
 	for(var/dir in GLOB.cardinals)
 		T = get_step(src,dir)


### PR DESCRIPTION
I should add this to my astar pr, but putting it here makes this funny bug more visible.

I don't want to re-name or change this var name, so i'm giving about the same effect as before the open/closed change, and making it exempt space turfs.

also fixed a bug that could cause a runtime if astar attempted to path the edge the zlevel

:cl: 
tweak: fixed both pathing attempting to path thru space even if asked not to.
/:cl:
@Fox-McCloud 