### PR TITLE
Mapmerge dictionary pruning tweak [DNM]

### DIFF
--- a/tools/mapmerge/map_helpers.py
+++ b/tools/mapmerge/map_helpers.py
@@ -108,7 +108,7 @@ def merge_map(newfile, backupfile, tgm):
 
     header = False
     #step two: clean the dictionary if it has too many unused keys
-    if len(unused_keys) > min(1600, (len(old_dict) * 0.5)):
+    if len(unused_keys) > 0:
         print("NOTICE: Trimming the dictionary.")
         trimmed_dict_map = trim_dictionary({"dictionary": old_dict, "grid": merged_grid})
         old_dict = trimmed_dict_map["dictionary"]


### PR DESCRIPTION
Makes mapmerge always prune unused keys.

Fixes fatal mapmerge errors causing map corruption on small maps with tiny dictionaries such as golemship.

Also fixes fastDMM compatibility.

Sister PR to #29204