### PR TITLE
Rename Bump to Collide

### DIFF
--- a/code/datums/forced_movement.dm
+++ b/code/datums/forced_movement.dm
@@ -82,7 +82,7 @@
 
 	. = . && (vic.loc != tar.loc)
 
-/mob/Bump(atom/A)
+/mob/Collide(atom/A)
 	. = ..()
 	if(force_moving && force_moving.allow_climbing && istype(A,/obj/structure))
 		var/obj/structure/S = A

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -217,8 +217,12 @@
 /atom/movable/Crossed(atom/movable/AM, oldloc)
 	return
 
-/atom/movable/Bump(atom/A, yes) //the "yes" arg is to differentiate our Bump proc from byond's, without it every Bump() call would become a double Bump().
-	if((A && yes))
+
+//This is tg's equivalent to the byond bump, it used to be called bump with a second arg
+//to differentiate it, naturally everyone forgot about this immediately and so some things
+//would bump twice, so now it's called Collide
+/atom/movable/proc/Collide(atom/A)	
+	if((A))
 		if(throwing)
 			throwing.hit_atom(A)
 			. = 1

--- a/code/game/gamemodes/clock_cult/clock_mobs/anima_fragment.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs/anima_fragment.dm
@@ -49,7 +49,7 @@
 /mob/living/simple_animal/hostile/clockwork/fragment/Process_Spacemove(movement_dir = 0)
 	return 1
 
-/mob/living/simple_animal/hostile/clockwork/fragment/Bump(atom/movable/AM)
+/mob/living/simple_animal/hostile/clockwork/fragment/Collide(atom/movable/AM)
 	. = ..()
 	if(movement_delay_time <= world.time && next_move <= world.time && isliving(AM) && !is_servant_of_ratvar(AM))
 		var/mob/living/L = AM

--- a/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ratvar_the_clockwork_justicar.dm
@@ -46,7 +46,7 @@
 	R.visible_message("<span class='heavy_brass'>[R] forms, and its eyes blink open, glowing bright red!</span>")
 	R.key = O.key
 
-/obj/structure/destructible/clockwork/massive/ratvar/Bump(atom/A)
+/obj/structure/destructible/clockwork/massive/ratvar/Collide(atom/A)
 	var/turf/T = get_turf(A)
 	if(T == loc)
 		T = get_step(T, dir) //please don't run into a window like a bird, ratvar

--- a/code/game/gamemodes/clock_cult/clock_structures/taunting_trail.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/taunting_trail.dm
@@ -47,7 +47,7 @@
 	affect_mob(AM)
 	return ..()
 
-/obj/structure/destructible/clockwork/taunting_trail/Bump(atom/movable/AM)
+/obj/structure/destructible/clockwork/taunting_trail/Collide(atom/movable/AM)
 	affect_mob(AM)
 	return ..()
 

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -130,7 +130,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	SpinAnimation()
 	QDEL_IN(src, lifetime)
 
-/obj/effect/meteor/Bump(atom/A)
+/obj/effect/meteor/Collide(atom/A)
 	if(A)
 		ram_turf(get_turf(A))
 		playsound(src.loc, meteorsound, 40, 1)
@@ -295,7 +295,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	if(!isspaceturf(T))
 		new /obj/effect/decal/cleanable/blood(T)
 
-/obj/effect/meteor/meaty/Bump(atom/A)
+/obj/effect/meteor/meaty/Collide(atom/A)
 	A.ex_act(hitpwr)
 	get_hit()
 
@@ -334,7 +334,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	..()
 	explosion(src.loc, 5, 10, 15, 20, 0)
 
-/obj/effect/meteor/tunguska/Bump()
+/obj/effect/meteor/tunguska/Collide()
 	..()
 	if(prob(20))
 		explosion(src.loc,2,4,6,8)

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -88,13 +88,6 @@
 		is_powered = FALSE
 	icon_state = icon_name + "[is_powered]" + "[(blood ? "bld" : "")]" // add the blood tag at the end
 
-// This is purely for admin possession !FUN!.
-/obj/machinery/recycler/Bump(atom/movable/AM)
-	..()
-	if(AM)
-		Bumped(AM)
-
-
 /obj/machinery/recycler/Bumped(atom/movable/AM)
 
 	if(stat & (BROKEN|NOPOWER))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -539,7 +539,7 @@
 		playsound(src,stepsound,40,1)
 	return result
 
-/obj/mecha/Bump(var/atom/obstacle, yes)
+/obj/mecha/Collide(var/atom/obstacle)
 	if(phasing && get_charge() >= phasing_energy_drain && !throwing)
 		spawn()
 			if(can_move)
@@ -551,23 +551,22 @@
 				sleep(step_in*3)
 				can_move = 1
 	else
-		if(yes)
-			if(..()) //mech was thrown
-				return
-			if(bumpsmash && occupant) //Need a pilot to push the PUNCH button.
-				if(nextsmash < world.time)
-					obstacle.mech_melee_attack(src)
-					if(!obstacle || !obstacle.density)
-						step(src,dir)
-					nextsmash = world.time + smashcooldown
-			if(isobj(obstacle))
-				var/obj/O = obstacle
-				if(!O.anchored)
-					step(obstacle, dir)
-			else if(ismob(obstacle))
-				var/mob/M = obstacle
-				if(!M.anchored)
-					step(obstacle, dir)
+		if(..()) //mech was thrown
+			return
+		if(bumpsmash && occupant) //Need a pilot to push the PUNCH button.
+			if(nextsmash < world.time)
+				obstacle.mech_melee_attack(src)
+				if(!obstacle || !obstacle.density)
+					step(src,dir)
+				nextsmash = world.time + smashcooldown
+		if(isobj(obstacle))
+			var/obj/O = obstacle
+			if(!O.anchored)
+				step(obstacle, dir)
+		else if(ismob(obstacle))
+			var/mob/M = obstacle
+			if(!M.anchored)
+				step(obstacle, dir)
 
 
 

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -107,7 +107,7 @@
 /obj/effect/anomaly/grav/Crossed(mob/A)
 	gravShock(A)
 
-/obj/effect/anomaly/grav/Bump(mob/A)
+/obj/effect/anomaly/grav/Collide(mob/A)
 	gravShock(A)
 
 /obj/effect/anomaly/grav/Bumped(mob/A)
@@ -143,7 +143,7 @@
 /obj/effect/anomaly/flux/Crossed(mob/living/M)
 	mobShock(M)
 
-/obj/effect/anomaly/flux/Bump(mob/living/M)
+/obj/effect/anomaly/flux/Collide(mob/living/M)
 	mobShock(M)
 
 /obj/effect/anomaly/flux/Bumped(mob/living/M)

--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -19,7 +19,7 @@
 		return 0
 	.=..()
 
-/obj/effect/particle_effect/water/Bump(atom/A)
+/obj/effect/particle_effect/water/Collide(atom/A)
 	if(reagents)
 		reagents.reaction(A)
 	return ..()

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -104,7 +104,7 @@
 /obj/structure/spider/spiderling/nurse
 	grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/nurse
 
-/obj/structure/spider/spiderling/Bump(atom/user)
+/obj/structure/spider/spiderling/Collide(atom/user)
 	if(istype(user, /obj/structure/table))
 		src.loc = user.loc
 	else

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -116,7 +116,7 @@
 		if(istype(M.selected,/obj/item/mecha_parts/mecha_equipment/drill))
 			src.attackby(M.selected,M)
 			return*/
-//Aparantly mechs are just TOO COOL to call Bump(), so fuck em (for now)
+//Aparantly mechs are just TOO COOL to call Collide())
 	else
 		return
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -123,7 +123,7 @@
 		// Nothing but border objects stop you from leaving a tile, only one loop is needed
 		for(var/obj/obstacle in mover.loc)
 			if(!obstacle.CheckExit(mover, src) && obstacle != mover && obstacle != forget)
-				mover.Bump(obstacle, 1)
+				mover.Collide(obstacle)
 				return FALSE
 
 	var/list/large_dense = list()
@@ -131,14 +131,14 @@
 	for(var/atom/movable/border_obstacle in src)
 		if(border_obstacle.flags & ON_BORDER)
 			if(!border_obstacle.CanPass(mover, mover.loc, 1) && (forget != border_obstacle))
-				mover.Bump(border_obstacle, 1)
+				mover.Collide(border_obstacle)
 				return FALSE
 		else
 			large_dense += border_obstacle
 
 	//Then, check the turf itself
 	if (!src.CanPass(mover, src))
-		mover.Bump(src, 1)
+		mover.Collide(src)
 		return FALSE
 
 	//Finally, check objects/mobs to block entry that are not on the border
@@ -150,7 +150,7 @@
 				tompost_bump = obstacle
 				top_layer = obstacle.layer
 	if(tompost_bump)
-		mover.Bump(tompost_bump,1)
+		mover.Collide(tompost_bump)
 		return FALSE
 
 	return TRUE //Nothing found to block so return success!

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -210,7 +210,7 @@
 			master.last = I
 			I.process()
 
-/obj/effect/beam/i_beam/Bump()
+/obj/effect/beam/i_beam/Collide()
 	qdel(src)
 	return
 

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -585,7 +585,7 @@
 /obj/effect/ctf/ammo/Crossed(atom/movable/AM)
 	reload(AM)
 
-/obj/effect/ctf/ammo/Bump(atom/movable/AM)
+/obj/effect/ctf/ammo/Collide(atom/movable/AM)
 	reload(AM)
 
 /obj/effect/ctf/ammo/Bumped(atom/movable/AM)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -69,7 +69,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/ex_act(severity, target)
 	return 0
 
-/obj/effect/immovablerod/Bump(atom/clong)
+/obj/effect/immovablerod/Collide(atom/clong)
 	if(prob(10))
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
 		audible_message("<span class='danger'>You hear a CLANG!</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -894,7 +894,7 @@
 		return 1
 	..()
 
-/mob/living/carbon/human/Bump(atom/A)
+/mob/living/carbon/human/Collide(atom/A)
 	..()
 	var/crashdir = get_dir(src, A)
 	var/obj/item/device/flightpack/FP = get_flightpack()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -80,19 +80,19 @@
 	staticOverlays["animal"] = staticOverlay
 
 
-//Generic Bump(). Override MobBump() and ObjBump() instead of this.
-/mob/living/Bump(atom/A, yes)
+//Generic Collide(). Override MobCollide() and ObjCollide() instead of this.
+/mob/living/Collide(atom/A)
 	if(..()) //we are thrown onto something
 		return
-	if (buckled || !yes || now_pushing)
+	if (buckled || now_pushing)
 		return
 	if(ismob(A))
 		var/mob/M = A
-		if(MobBump(M))
+		if(MobCollide(M))
 			return
 	if(isobj(A))
 		var/obj/O = A
-		if(ObjBump(O))
+		if(ObjCollide(O))
 			return
 	if(ismovableatom(A))
 		var/atom/movable/AM = A
@@ -104,7 +104,7 @@
 	last_bumped = world.time
 
 //Called when we bump onto a mob
-/mob/living/proc/MobBump(mob/M)
+/mob/living/proc/MobCollide(mob/M)
 	//Even if we don't push/swap places, we "touched" them, so spread fire
 	spreadFire(M)
 
@@ -174,7 +174,7 @@
 				return 1
 
 //Called when we bump onto an obj
-/mob/living/proc/ObjBump(obj/O)
+/mob/living/proc/ObjCollide(obj/O)
 	return
 
 //Called when we want to push an atom/movable
@@ -893,7 +893,7 @@
 		ExtinguishMob()
 
 //Share fire evenly between the two mobs
-//Called in MobBump() and Crossed()
+//Called in MobCollide() and Crossed()
 /mob/living/proc/spreadFire(mob/living/L)
 	if(!istype(L))
 		return

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -29,7 +29,7 @@
 
 	var/list/surgeries = list()	//a list of surgery datums. generally empty, they're added when the player wants them.
 
-	var/now_pushing = null //used by living/Bump() and living/PushAM() to prevent potential infinite loop.
+	var/now_pushing = null //used by living/Collide() and living/PushAM() to prevent potential infinite loop.
 
 	var/cameraFollow = null
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -719,7 +719,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	else	// no path, so calculate new one
 		calc_summon_path()
 
-/mob/living/simple_animal/bot/Bump(M as mob|obj) //Leave no door unopened!
+/mob/living/simple_animal/bot/Collide(M as mob|obj) //Leave no door unopened!
 	. = ..()
 	if((istype(M, /obj/machinery/door/airlock) ||  istype(M, /obj/machinery/door/window)) && (!isnull(access_card)))
 		var/obj/machinery/door/D = M

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -632,7 +632,7 @@
 	return
 
 // called when bot bumps into anything
-/mob/living/simple_animal/bot/mulebot/Bump(atom/obs)
+/mob/living/simple_animal/bot/mulebot/Collide(atom/obs)
 	if(wires.is_cut(WIRE_AVOIDANCE))	// usually just bumps, but if avoidance disabled knock over mobs
 		if(isliving(obs))
 			var/mob/living/L = obs

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -304,7 +304,7 @@
 	can_repair_constructs = TRUE
 
 
-/mob/living/simple_animal/hostile/construct/harvester/Bump(atom/AM)
+/mob/living/simple_animal/hostile/construct/harvester/Collide(atom/AM)
 	. = ..()
 	if(istype(AM, /turf/closed/wall/mineral/cult) && AM != loc) //we can go through cult walls
 		var/atom/movable/stored_pulling = pulling

--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -81,7 +81,7 @@
 		else
 			to_chat(user, "<span class='holoparasite'>[src] glows with a strange <font color=\"[spawner.namedatum.colour]\">light</font>, and you don't touch it.</span>")
 
-/obj/guardian_bomb/Bump(atom/A)
+/obj/guardian_bomb/Collide(atom/A)
 	detonate(A)
 	..()
 

--- a/code/modules/mob/living/simple_animal/guardian/types/fire.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/fire.dm
@@ -31,7 +31,7 @@
 	..()
 	collision_ignite(AM)
 
-/mob/living/simple_animal/hostile/guardian/fire/Bump(AM as mob|obj)
+/mob/living/simple_animal/hostile/guardian/fire/Collide(AM as mob|obj)
 	..()
 	collision_ignite(AM)
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -173,7 +173,7 @@ Difficulty: Hard
 			SetRecoveryTime(MEGAFAUNA_DEFAULT_RECOVERY_TIME)
 
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/Bump(atom/A)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/Collide(atom/A)
 	if(charging)
 		if(isturf(A) || isobj(A) && A.density)
 			A.ex_act(2)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -148,7 +148,7 @@
 
 	. += config.slime_delay
 
-/mob/living/simple_animal/slime/ObjBump(obj/O)
+/mob/living/simple_animal/slime/ObjCollide(obj/O)
 	if(!client && powerlevel > 0)
 		var/probab = 10
 		switch(powerlevel)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -114,7 +114,7 @@
 	return clashing
 
 
-/obj/singularity/narsie/Bump(atom/A)
+/obj/singularity/narsie/Collide(atom/A)
 	var/turf/T = get_turf(A)
 	if(T == loc)
 		T = get_step(A, A.dir) //please don't slam into a window like a bird, nar-sie

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -28,7 +28,7 @@
 	addtimer(CALLBACK(src, .proc/move), 1)
 
 
-/obj/effect/accelerated_particle/Bump(atom/A)
+/obj/effect/accelerated_particle/Collide(atom/A)
 	if(A)
 		if(isliving(A))
 			toxmob(A)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -102,7 +102,7 @@
 	return 0 //Will there be an impact? Who knows.  Will we see it? No.
 
 
-/obj/singularity/Bump(atom/A)
+/obj/singularity/Collide(atom/A)
 	consume(A)
 	return
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(blacklisted_tesla_types, typecacheof(list(/obj/machinery/atmosp
 	EB.orbit(src, orbitsize, pick(FALSE, TRUE), rand(10, 25), pick(3, 4, 5, 6, 36))
 
 
-/obj/singularity/energy_ball/Bump(atom/A)
+/obj/singularity/energy_ball/Collide(atom/A)
 	dust_mobs(A)
 
 /obj/singularity/energy_ball/Bumped(atom/A)

--- a/code/modules/projectiles/guns/beam_rifle.dm
+++ b/code/modules/projectiles/guns/beam_rifle.dm
@@ -395,7 +395,7 @@
 	if(!QDELETED(target))
 		handle_impact(target)
 
-/obj/item/projectile/beam/beam_rifle/Bump(atom/target, yes)
+/obj/item/projectile/beam/beam_rifle/Collide(atom/target)
 	if(check_pierce(target))
 		permutated += target
 		return FALSE
@@ -472,7 +472,7 @@
 		if(original && (original.layer>=2.75) || ismob(original))
 			if(loc == get_turf(original))
 				if(!(original in permutated))
-					Bump(original, 1)
+					Collide(original)
 		Range()
 
 /obj/item/projectile/beam/beam_rifle/hitscan/Range()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -137,9 +137,7 @@
 	else
 		return 50 //if the projectile doesn't do damage, play its hitsound at 50% volume
 
-/obj/item/projectile/Bump(atom/A, yes)
-	if(!yes) //prevents double bumps.
-		return
+/obj/item/projectile/Collide(atom/A)
 	if(check_ricochet() && check_ricochet_flag(A) && ricochets < ricochets_max)
 		ricochets++
 		if(A.handle_ricochet(src))
@@ -270,7 +268,7 @@
 			if(original && (original.layer >= PROJECTILE_HIT_THRESHHOLD_LAYER) || ismob(original))
 				if(loc == get_turf(original))
 					if(!(original in permutated))
-						Bump(original, 1)
+						Collide(original)
 			Range()
 			if (delay > 0)
 				sleep(delay)
@@ -285,7 +283,7 @@
 				if(original && (original.layer >= PROJECTILE_HIT_THRESHHOLD_LAYER) || ismob(original))
 					if(loc == get_turf(original))
 						if(!(original in permutated))
-							Bump(original, 1)
+							Collide(original)
 				Range()
 			sleep(config.run_speed * 0.9)
 
@@ -340,7 +338,7 @@
 /obj/item/projectile/Crossed(atom/movable/AM) //A mob moving on a tile with a projectile is hit by it.
 	..()
 	if(isliving(AM) && AM.density && !checkpass(PASSMOB))
-		Bump(AM, 1)
+		Collide(AM)
 
 /obj/item/projectile/Destroy()
 	return ..()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -355,7 +355,7 @@
 	if(proxdet)
 		for(var/mob/living/L in range(1, get_turf(src)))
 			if(L.stat != DEAD && L != firer)
-				return Bump(L, TRUE)
+				return Collide(L)
 	..()
 
 /obj/item/projectile/magic/aoe/lightning

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -108,9 +108,7 @@
 	nodamage = 1
 	flag = "bullet"
 
-/obj/item/projectile/meteor/Bump(atom/A, yes)
-	if(!yes) //prevents multi bumps.
-		return
+/obj/item/projectile/meteor/Collide(atom/A)
 	if(A == firer)
 		loc = A.loc
 		return

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -48,7 +48,7 @@
 		density = FALSE
 	..()
 
-/obj/vehicle/scooter/skateboard/Bump(atom/A)
+/obj/vehicle/scooter/skateboard/Collide(atom/A)
 	..()
 	if(A.density && has_buckled_mobs())
 		var/mob/living/carbon/H = buckled_mobs[1]

--- a/code/modules/vehicles/speedbike.dm
+++ b/code/modules/vehicles/speedbike.dm
@@ -38,7 +38,7 @@
 	pixel_y = -48 //to fix the offset when Initialized()
 	pixel_x = -48
 
-/obj/vehicle/space/speedbike/speedwagon/Bump(atom/movable/A)
+/obj/vehicle/space/speedbike/speedwagon/Collide(atom/movable/A)
 	. = ..()
 	if(A.density && has_buckled_mobs())
 		var/atom/throw_target = get_edge_target_turf(A, src.dir)
@@ -65,4 +65,4 @@
 	if(src.has_buckled_mobs())
 		for(var/atom/A in range(2, src))
 			if(!(A in src.buckled_mobs))
-				Bump(A)
+				Collide(A)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -63,7 +63,7 @@
 		riding_datum.handle_vehicle_offsets()
 
 
-/obj/vehicle/Bump(atom/movable/M)
+/obj/vehicle/Collide(atom/movable/M)
 	. = ..()
 	if(auto_door_open)
 		if(istype(M, /obj/machinery/door) && has_buckled_mobs())


### PR DESCRIPTION
This reduces confusion arising from the fact byond already has a built
in byond proc also named Bump.

We used an argument called yes to distinguish our Bump from byond's
builtin bump, but then we failed to make sure everyone of our bumps
properly override it, so a bunch of things have been double bumping

This resolves that issue permanently

I've also removed the second argument as it no longer has a purpose