### PR TITLE
Projectile target check hit code now uses a proc for resharing

### DIFF
--- a/code/modules/projectiles/guns/beam_rifle.dm
+++ b/code/modules/projectiles/guns/beam_rifle.dm
@@ -681,11 +681,9 @@
 			animate(src, pixel_x = pixel_x_offset, pixel_y = pixel_y_offset, time = max(1, (delay <= 3 ? delay - 1 : delay)), flags = ANIMATION_END_NOW)
 		old_pixel_x = pixel_x_offset
 		old_pixel_y = pixel_y_offset
-		if(original && (original.layer>=2.75) || ismob(original))
-			if(loc == get_turf(original))
-				if(!(original in permutated))
-					Collide(original)
-	    c2 = loc
+		if(can_hit_target(original, permutated))
+			Collide(original)
+		c2 = loc
 		Range()
 		if(check_for_turf_edge(loc))
 			spawn_tracer(constant_tracer)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -264,11 +264,8 @@
 				animate(src, pixel_x = pixel_x_offset, pixel_y = pixel_y_offset, time = max(1, (delay <= 3 ? delay - 1 : delay)), flags = ANIMATION_END_NOW)
 			old_pixel_x = pixel_x_offset
 			old_pixel_y = pixel_y_offset
-
-			if(original && (original.layer >= PROJECTILE_HIT_THRESHHOLD_LAYER) || ismob(original))
-				if(loc == get_turf(original))
-					if(!(original in permutated))
-						Collide(original)
+			if(can_hit_target(original, permutated))
+				Collide(original)
 			Range()
 			if (delay > 0)
 				sleep(delay)
@@ -280,12 +277,18 @@
 				if((!( current ) || loc == current))
 					current = locate(Clamp(x+xo,1,world.maxx),Clamp(y+yo,1,world.maxy),z)
 				step_towards(src, current)
-				if(original && (original.layer >= PROJECTILE_HIT_THRESHHOLD_LAYER) || ismob(original))
-					if(loc == get_turf(original))
-						if(!(original in permutated))
-							Collide(original)
+				if(can_hit_target(original, permutated))
+					Collide(original)
 				Range()
 			sleep(config.run_speed * 0.9)
+
+//Returns true if the target atom is on our current turf and above the right layer
+/obj/item/projectile/proc/can_hit_target(atom/target, var/list/passthrough)
+	if(target && (target.layer >= PROJECTILE_HIT_THRESHHOLD_LAYER) || ismob(target))
+		if(loc == get_turf(target))
+			if(!(target in passthrough))
+				return TRUE
+	return FALSE
 
 /obj/item/projectile/proc/preparePixelProjectile(atom/target, var/turf/targloc, mob/living/user, params, spread)
 	var/turf/curloc = get_turf(user)


### PR DESCRIPTION
This also fixes the fact that the beam rifle didn't use a define which could have caused some annoying bugs if anyone ever changed the layer define