### PR TITLE
[Deltastation] Fixes some access issues

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3384,7 +3384,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock{
 	name = "Auxiliary Storage Closet";
-	req_access_txt = ""
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3384,7 +3384,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock{
 	name = "Auxiliary Storage Closet";
-	req_access_txt = "32"
+	req_access_txt = ""
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3383,7 +3383,7 @@
 "aht" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock{
-	name = "Auxiliary Storage Closet";
+	name = "Auxiliary Storage Closet"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -9033,7 +9033,7 @@
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Cargo Maintenance";
-	req_access_txt = "48;50"
+	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,


### PR DESCRIPTION
:cl: BeeSting12
tweak: Deltastation's auxiliary storage in arrivals can be accessed by anyone now.
fix: Deltastation's cargo bay maintenance can now be accessed by cargo techs.
/:cl:

Why: The door couldn't be accessed by anyone with maintenance access by default which is inconsistent with the maint door just south of it leading into the same room. I decided to make it all access so anyone can get in because it resembles the emergency storages on meta/box and I believe that is the intended purpose. 
Picture for visual people- The topmost door is the one being editted:
![](https://file.house/DGV7.png)
