### PR TITLE
Fixes IV Drips

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -117,13 +117,13 @@
 	if(beaker)
 		// Give blood
 		if(mode)
-			if(beaker.volume > 0)
+			if(beaker.reagents.total_volume)
 				var/transfer_amount = 5
 				if(istype(beaker, /obj/item/weapon/reagent_containers/blood))
 					// speed up transfer on blood packs
 					transfer_amount = 10
-				var/fraction = min(transfer_amount/beaker.volume, 1) //the fraction that is transfered of the total volume
-				beaker.reagents.reaction(attached, INJECT, fraction,0) //make reagents reacts, but don't spam messages
+				var/fraction = min(transfer_amount/beaker.reagents.total_volume, 1) //the fraction that is transfered of the total volume
+				beaker.reagents.reaction(attached, INJECT, fraction, 0) //make reagents reacts, but don't spam messages
 				beaker.reagents.trans_to(attached, transfer_amount)
 				update_icon()
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -198,23 +198,22 @@
 	to_chat(usr, "The IV drip is now [mode ? "injecting" : "taking blood"].")
 	update_icon()
 
-/obj/machinery/iv_drip/examine()
-	set src in view()
+/obj/machinery/iv_drip/examine(mob/user)
 	..()
-	if(!(usr in view(2)) && usr != loc)
+	if(get_dist(user, src) > 2)
 		return
 
-	to_chat(usr, "The IV drip is [mode ? "injecting" : "taking blood"].")
+	to_chat(user, "The IV drip is [mode ? "injecting" : "taking blood"].")
 
 	if(beaker)
 		if(beaker.reagents && beaker.reagents.reagent_list.len)
-			to_chat(usr, "<span class='notice'>Attached is \a [beaker] with [beaker.reagents.total_volume] units of liquid.</span>")
+			to_chat(user, "<span class='notice'>Attached is \a [beaker] with [beaker.reagents.total_volume] units of liquid.</span>")
 		else
-			to_chat(usr, "<span class='notice'>Attached is an empty [beaker.name].</span>")
+			to_chat(user, "<span class='notice'>Attached is an empty [beaker.name].</span>")
 	else
-		to_chat(usr, "<span class='notice'>No chemicals are attached.</span>")
+		to_chat(user, "<span class='notice'>No chemicals are attached.</span>")
 
-	to_chat(usr, "<span class='notice'>[attached ? attached : "No one"] is attached.</span>")
+	to_chat(user, "<span class='notice'>[attached ? attached : "No one"] is attached.</span>")
 
 #undef IV_TAKING
 #undef IV_INJECTING

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -1,20 +1,28 @@
+#define IV_TAKING 0
+#define IV_INJECTING 1
+
 /obj/machinery/iv_drip
 	name = "\improper IV drip"
 	icon = 'icons/obj/iv_drip.dmi'
 	icon_state = "iv_drip"
-	anchored = 0
+	anchored = FALSE
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	var/mob/living/carbon/attached = null
-	var/mode = 1 // 1 is injecting, 0 is taking blood.
+	var/mode = IV_INJECTING
 	var/obj/item/weapon/reagent_containers/beaker = null
 	var/list/drip_containers = list(/obj/item/weapon/reagent_containers/blood,
-											/obj/item/weapon/reagent_containers/food,
-											/obj/item/weapon/reagent_containers/glass)
+									/obj/item/weapon/reagent_containers/food,
+									/obj/item/weapon/reagent_containers/glass)
 
 /obj/machinery/iv_drip/Initialize()
 	..()
 	update_icon()
 	drip_containers = typecacheof(drip_containers)
+
+/obj/machinery/iv_drip/Destroy()
+	attached = null
+	QDEL_NULL(beaker)
+	return ..()
 
 /obj/machinery/iv_drip/update_icon()
 	if(attached)
@@ -59,11 +67,11 @@
 			add_overlay(filling_overlay)
 
 /obj/machinery/iv_drip/MouseDrop(mob/living/target)
-	if(!ishuman(usr) || !usr.canUseTopic(src,BE_CLOSE) || !isliving(target))
+	if(!ishuman(usr) || !usr.canUseTopic(src, BE_CLOSE) || !isliving(target))
 		return
 
 	if(attached)
-		visible_message("<span class='warning'>[attached] is detached from \the [src].</span>")
+		visible_message("<span class='warning'>[attached] is detached from [src].</span>")
 		attached = null
 		update_icon()
 		return
@@ -74,7 +82,7 @@
 
 	if(Adjacent(target) && usr.Adjacent(target))
 		if(beaker)
-			usr.visible_message("<span class='warning'>[usr] attaches \the [src] to \the [target].</span>", "<span class='notice'>You attach \the [src] to \the [target].</span>")
+			usr.visible_message("<span class='warning'>[usr] attaches [src] to [target].</span>", "<span class='notice'>You attach [src] to [target].</span>")
 			attached = target
 			START_PROCESSING(SSmachines, src)
 			update_icon()
@@ -83,16 +91,16 @@
 
 
 /obj/machinery/iv_drip/attackby(obj/item/weapon/W, mob/user, params)
-	if (is_type_in_typecache(W, drip_containers))
-		if(!isnull(beaker))
+	if(is_type_in_typecache(W, drip_containers))
+		if(beaker)
 			to_chat(user, "<span class='warning'>There is already a reagent container loaded!</span>")
 			return
 		if(!user.drop_item())
 			return
 
-		W.loc = src
+		W.forceMove(src)
 		beaker = W
-		to_chat(user, "<span class='notice'>You attach \the [W] to \the [src].</span>")
+		to_chat(user, "<span class='notice'>You attach [W] to [src].</span>")
 		update_icon()
 		return
 	else
@@ -123,7 +131,7 @@
 					// speed up transfer on blood packs
 					transfer_amount = 10
 				var/fraction = min(transfer_amount/beaker.reagents.total_volume, 1) //the fraction that is transfered of the total volume
-				beaker.reagents.reaction(attached, INJECT, fraction, 0) //make reagents reacts, but don't spam messages
+				beaker.reagents.reaction(attached, INJECT, fraction, FALSE) //make reagents reacts, but don't spam messages
 				beaker.reagents.trans_to(attached, transfer_amount)
 				update_icon()
 
@@ -132,13 +140,14 @@
 			var/amount = beaker.reagents.maximum_volume - beaker.reagents.total_volume
 			amount = min(amount, 4)
 			// If the beaker is full, ping
-			if(amount == 0)
-				if(prob(5)) visible_message("\The [src] pings.")
+			if(!amount)
+				if(prob(5))
+					visible_message("[src] pings.")
 				return
 
 			// If the human is losing too much blood, beep.
 			if(attached.blood_volume < BLOOD_VOLUME_SAFE && prob(5))
-				visible_message("\The [src] beeps loudly.")
+				visible_message("[src] beeps loudly.")
 				playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)
 			attached.transfer_blood_to(beaker, amount)
 			update_icon()
@@ -147,7 +156,7 @@
 	if(!ishuman(user))
 		return
 	if(attached)
-		visible_message("[attached] is detached from \the [src]")
+		visible_message("[attached] is detached from [src]")
 		attached = null
 		update_icon()
 		return
@@ -165,11 +174,11 @@
 		to_chat(usr, "<span class='warning'>You can't do that!</span>")
 		return
 
-	if(usr.stat)
+	if(usr.incapacitated())
 		return
 
 	if(beaker)
-		beaker.loc = get_turf(src)
+		beaker.forceMove(get_turf(src))
 		beaker = null
 		update_icon()
 
@@ -182,7 +191,7 @@
 		to_chat(usr, "<span class='warning'>You can't do that!</span>")
 		return
 
-	if(usr.stat)
+	if(usr.incapacitated())
 		return
 
 	mode = !mode
@@ -192,7 +201,8 @@
 /obj/machinery/iv_drip/examine()
 	set src in view()
 	..()
-	if (!(usr in view(2)) && usr!=loc) return
+	if(!(usr in view(2)) && usr != loc)
+		return
 
 	to_chat(usr, "The IV drip is [mode ? "injecting" : "taking blood"].")
 
@@ -205,3 +215,6 @@
 		to_chat(usr, "<span class='notice'>No chemicals are attached.</span>")
 
 	to_chat(usr, "<span class='notice'>[attached ? attached : "No one"] is attached.</span>")
+
+#undef IV_TAKING
+#undef IV_INJECTING


### PR DESCRIPTION
So, apparently someone didn't understand reagents very well.

This checked for a reagent containers volume...which is always above 0. If it was 0, it wouldn't be a reagent container.

Secondly, when doing the fractionalizing, it would also go by the reagent containers volume, as opposed to the reagent's volume.

This means that a blood transfer would transfer 10 units on the first process, then it would do 9.5 on the second....then 9 on the third. You quickly run into diminishing returns...and the end result is that a 200 unit blood pack barely restores 100 units of blood.

Either case, this fixes that by ensuring the code doesn't run if there aren't any reagents in the reagent container attached to the, and it ensure the proper ratio for injecting is always maintained.

:cl: Fox McCloud
fix: Fixes IV drips not properly injecting the right amount of blood
/:cl:
