### PR TITLE
Fixes cleave conditions for the cleaving saw

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -635,7 +635,7 @@
 		B.add_bleed(B.bleed_buildup)
 
 /obj/item/weapon/melee/transforming/cleaving_saw/attack(mob/living/target, mob/living/carbon/human/user)
-	if(!active || swiping)
+	if(!active || swiping || !target.density || get_turf(target) == get_turf(user))
 		..()
 	else
 		var/turf/user_turf = get_turf(user)


### PR DESCRIPTION
You can't cleave non-dense targets, since the cleave doesn't hit them.
You can't cleave someone on your own turf, because it can't handle that.