### PR TITLE
ClickCross now uses CanPass instead of density directly.

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -25,7 +25,7 @@
 	* If you are diagonally adjacent, ensure you can pass through at least one of the mutually adjacent square.
 		* Passing through in this case ignores anything with the LETPASSTHROW pass flag, such as tables, racks, and morgue trays.
 */
-/turf/Adjacent(var/atom/neighbor, var/atom/target = null)
+/turf/Adjacent(atom/neighbor, atom/target = null, atom/movable/mover = null)
 	var/turf/T0 = get_turf(neighbor)
 
 	if(T0 == src) //same turf
@@ -37,7 +37,7 @@
 	// Non diagonal case
 	if(T0.x == x || T0.y == y)
 		// Check for border blockages
-		return T0.ClickCross(get_dir(T0,src), border_only = 1, target_atom = target) && src.ClickCross(get_dir(src,T0), border_only = 1, target_atom = target)
+		return T0.ClickCross(get_dir(T0,src), border_only = 1, target_atom = target, mover = mover) && src.ClickCross(get_dir(src,T0), border_only = 1, target_atom = target, mover = mover)
 
 	// Diagonal case
 	var/in_dir = get_dir(T0,src) // eg. northwest (1+8) = 9 (00001001)
@@ -45,14 +45,16 @@
 	var/d2 = in_dir&12			 // eg. west	  (1+8)&12 (0000 1100) = 8 (0000 1000)
 
 	for(var/d in list(d1,d2))
-		if(!T0.ClickCross(d, border_only = 1, target_atom = target))
+		if(!T0.ClickCross(d, border_only = 1, target_atom = target, mover = mover))
 			continue // could not leave T0 in that direction
 
 		var/turf/T1 = get_step(T0,d)
-		if(!T1 || T1.density || !T1.ClickCross(get_dir(T1,T0) | get_dir(T1,src), border_only = 0, target_atom = target)) //let's check both directions at once
+		if(!T1 || T1.density)
+			continue
+		if(!T1.ClickCross(get_dir(T1,src), border_only = 0, target_atom = target, mover = mover) || !T1.ClickCross(get_dir(T1,T0), border_only = 0, target_atom = target, mover = mover))
 			continue // couldn't enter or couldn't leave T1
 
-		if(!src.ClickCross(get_dir(src,T1), border_only = 1, target_atom = target))
+		if(!src.ClickCross(get_dir(src,T1), border_only = 1, target_atom = target, mover = mover))
 			continue // could not enter src
 
 		return 1 // we don't care about our own density
@@ -68,7 +70,7 @@
 		return TRUE
 	if(!isturf(loc))
 		return FALSE
-	if(loc.Adjacent(neighbor,target = neighbor))
+	if(loc.Adjacent(neighbor,target = neighbor, mover = src))
 		return TRUE
 	return FALSE
 
@@ -86,9 +88,11 @@
 	This is defined as any dense ON_BORDER object, or any dense object without LETPASSTHROW.
 	The border_only flag allows you to not objects (for source and destination squares)
 */
-/turf/proc/ClickCross(target_dir, border_only, target_atom = null)
+/turf/proc/ClickCross(target_dir, border_only, target_atom = null, atom/movable/mover = null)
 	for(var/obj/O in src)
-		if( !O.density || O == target_atom || (O.pass_flags & LETPASSTHROW)) //check if there's a dense object present on the turf
+		if(mover && O.CanPass(mover,get_step(src,target_dir)) || !mover && !O.density)
+			continue
+		if(O == target_atom || (O.pass_flags & LETPASSTHROW)) //check if there's a dense object present on the turf
 			continue // LETPASSTHROW is used for anything you can click through (or the firedoor special case, see above)
 
 		if( O.flags&ON_BORDER) // windows are on border, check them first

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -90,7 +90,7 @@
 */
 /turf/proc/ClickCross(target_dir, border_only, target_atom = null, atom/movable/mover = null)
 	for(var/obj/O in src)
-		if(mover && O.CanPass(mover,get_step(src,target_dir)) || !mover && !O.density)
+		if((mover && O.CanPass(mover,get_step(src,target_dir))) || (!mover && !O.density))
 			continue
 		if(O == target_atom || (O.pass_flags & LETPASSTHROW)) //check if there's a dense object present on the turf
 			continue // LETPASSTHROW is used for anything you can click through (or the firedoor special case, see above)


### PR DESCRIPTION
Fixes #28722
Closes #28837 - This is just more generic alternative.

This might cause non-obvious issues. Extended testmerge recommended.