### PR TITLE
Fix the attackby of the supermatter containment core

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -181,10 +181,8 @@
 
 /obj/item/nuke_core_container/supermatter/attackby(obj/item/weapon/hemostat/supermatter/tongs, mob/user)
 	if(istype(tongs))
-		if(!user.temporarilyRemoveItemFromInventory(tongs))
-			to_chat(user, "<span class='warning'>\The [tongs] is stuck to your hand!</span>")
-		else
-			load(sliver, user)
+		//try to load shard into core
+		load(tongs, user)
 	else
 		return ..()
 


### PR DESCRIPTION
It was eating your tongs for no apparent reason and also not passing the
tongs into the load proc instead passing in it's own sliver

Fixes #29203