### PR TITLE
Possibly fix player_list sometimes having a null

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -317,7 +317,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Re-enter Corpse"
 	if(!client)
 		return
-	if(!(mind && QDELETED(mind.current)))
+	if(!mind || QDELETED(mind.current))
 		to_chat(src, "<span class='warning'>You have no body.</span>")
 		return
 	if(!can_reenter_corpse)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -317,7 +317,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Re-enter Corpse"
 	if(!client)
 		return
-	if(!(mind && mind.current))
+	if(!(mind && QDELETED(mind.current)))
 		to_chat(src, "<span class='warning'>You have no body.</span>")
 		return
 	if(!can_reenter_corpse)


### PR DESCRIPTION
Fixes #27438
I am 99% this will fix the issue for good.
What is happening, from my understanding anyway is:
1) A mob gets destroyed(an easy example is dying in CTF, you get dusted)
2) The person is ghosted, logout is called on the destroyed mob, removing it from `player_list`
3) The person instantly clicks re-enter, mob has not yet been deleted, which then calls `Login()`, readding to the `player_list`
4) Mob gets deleted, their reference in `player_list` is left as null.

This might not be the case and I end up wrong, but it doesn't hurt to have this check here.
