### PR TITLE
[Cere] Removes all access from cell doors in brig

### DIFF
--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -4893,7 +4893,8 @@
 "akf" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	id = "Cell 8";
-	name = "Cell Door 8"
+	name = "Cell Door 8";
+	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -7656,7 +7657,8 @@
 "apD" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	id = "Cell 9";
-	name = "Cell Door 9"
+	name = "Cell Door 9";
+	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -88415,7 +88417,8 @@
 "dnc" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	id = "Cell 7";
-	name = "Cell Door 7"
+	name = "Cell Door 7";
+	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90914,7 +90917,8 @@
 "drV" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	id = "Cell 10";
-	name = "Cell Door 10"
+	name = "Cell Door 10";
+	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -2545,7 +2545,8 @@
 "afz" = (
 /obj/machinery/door/window/brigdoor/northleft{
 	id = "Cell 6";
-	name = "Cell Door 6"
+	name = "Cell Door 6";
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -87998,7 +87999,8 @@
 "dmi" = (
 /obj/machinery/door/window/brigdoor/northleft{
 	id = "Cell 5";
-	name = "Cell Door 5"
+	name = "Cell Door 5";
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -3369,7 +3369,7 @@
 /obj/machinery/door/window/brigdoor/westleft{
 	id = "Cell 4";
 	name = "Cell Door 4";
-	req_access_txt = "1"
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -4894,7 +4894,7 @@
 /obj/machinery/door/window/brigdoor/eastleft{
 	id = "Cell 8";
 	name = "Cell Door 8";
-	req_access_txt = "1"
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -7606,7 +7606,7 @@
 /obj/machinery/door/window/brigdoor/westleft{
 	id = "Cell 2";
 	name = "Cell Door 2";
-	req_access_txt = "1"
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -7658,7 +7658,7 @@
 /obj/machinery/door/window/brigdoor/eastleft{
 	id = "Cell 9";
 	name = "Cell Door 9";
-	req_access_txt = "1"
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -72146,7 +72146,7 @@
 /obj/machinery/door/window/brigdoor/westleft{
 	id = "Cell 3";
 	name = "Cell Door 3";
-	req_access_txt = "1"
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -88418,7 +88418,7 @@
 /obj/machinery/door/window/brigdoor/eastleft{
 	id = "Cell 7";
 	name = "Cell Door 7";
-	req_access_txt = "1"
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90898,7 +90898,7 @@
 /obj/machinery/door/window/brigdoor/westleft{
 	id = "Cell 1";
 	name = "Cell Door 1";
-	req_access_txt = "1"
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -90918,7 +90918,7 @@
 /obj/machinery/door/window/brigdoor/eastleft{
 	id = "Cell 10";
 	name = "Cell Door 10";
-	req_access_txt = "1"
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/red{
 	baseturf = /turf/open/floor/plating/asteroid/airless


### PR DESCRIPTION
:cl: Penguaro
fix: Nanotrasen Technical Support has resolved the security issue that affected some of the cell doors on Cere Station. They are now all locked as per security standard.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Fixes #29272
Fixes #29287 (Duplicate Issue)