### PR TITLE
[s]Fixes panic bunker

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -87,9 +87,8 @@
 
 	var/check_randomizer = 0
 
-	var/allow_panic_bunker_bounce = 0 //Send new players somewhere else
-	var/panic_server_name = "somewhere else"
-	var/panic_address = "byond://" //Reconnect a player this linked server if this server isn't accepting new players
+	var/panic_server_name
+	var/panic_address //Reconnect a player this linked server if this server isn't accepting new players
 
 	//IP Intel vars
 	var/ipintel_email
@@ -455,11 +454,12 @@
 				if("cross_comms_name")
 					cross_name = value
 				if("panic_server_name")
-					panic_server_name = value
+					if (value != "\[Put the name here\]")
+						panic_server_name = value
 				if("panic_server_address")
-					panic_address = value
-					if(value != "byond:\\address:port")
-						allow_panic_bunker_bounce = 1
+					if(value != "byond://address:port")
+						panic_address = value
+
 				if("medal_hub_address")
 					global.medal_hub = value
 				if("medal_hub_password")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -423,10 +423,11 @@ GLOBAL_LIST(external_rsc_urls)
 			log_access("Failed Login: [key] - New account attempting to connect during panic bunker")
 			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
 			to_chat(src, "Sorry but the server is currently not accepting connections from never before seen players.")
-			if(config.allow_panic_bunker_bounce && tdata != "redirect")
+			var/list/connectiontopic_a = params2list(connectiontopic)
+			if(config.allow_panic_bunker_bounce && !connectiontopic_a["redirect"])
 				to_chat(src, "<span class='notice'>Sending you to [config.panic_server_name].</span>")
 				winset(src, null, "command=.options")
-				src << link("[config.panic_address]?redirect")
+				src << link("[config.panic_address]?redirect=1")
 			qdel(src)
 			return
 		

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -424,13 +424,13 @@ GLOBAL_LIST(external_rsc_urls)
 			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
 			to_chat(src, "Sorry but the server is currently not accepting connections from never before seen players.")
 			var/list/connectiontopic_a = params2list(connectiontopic)
-			if(config.allow_panic_bunker_bounce && !connectiontopic_a["redirect"])
-				to_chat(src, "<span class='notice'>Sending you to [config.panic_server_name].</span>")
+			if(config.panic_address && !connectiontopic_a["redirect"])
+				to_chat(src, "<span class='notice'>Sending you to [config.panic_server_name ? config.panic_server_name : config.panic_address].</span>")
 				winset(src, null, "command=.options")
 				src << link("[config.panic_address]?redirect=1")
 			qdel(src)
 			return
-		
+
 		new_player = 1
 		account_join_date = sanitizeSQL(findJoinDate())
 		var/datum/DBQuery/query_add_player = SSdbcore.NewQuery("INSERT INTO [format_table_name("player")] (`ckey`, `firstseen`, `lastseen`, `ip`, `computerid`, `lastadminrank`, `accountjoindate`) VALUES ('[sql_ckey]', Now(), Now(), INET_ATON('[sql_ip]'), '[sql_computerid]', '[sql_admin_rank]', [account_join_date ? "'[account_join_date]'" : "NULL"])")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -282,17 +282,6 @@ GLOBAL_LIST(external_rsc_urls)
 	if (isnum(cached_player_age) && cached_player_age == -1) //first connection
 		player_age = 0
 	if (isnum(cached_player_age) && cached_player_age == -1) //first connection
-		if (config.panic_bunker && !holder && !(ckey in GLOB.deadmins))
-			log_access("Failed Login: [key] - New account attempting to connect during panic bunker")
-			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
-			to_chat(src, "Sorry but the server is currently not accepting connections from never before seen players.")
-			if(config.allow_panic_bunker_bounce && tdata != "redirect")
-				to_chat(src, "<span class='notice'>Sending you to [config.panic_server_name].</span>")
-				winset(src, null, "command=.options")
-				src << link("[config.panic_address]?redirect")
-			qdel(src)
-			return 0
-
 		if (config.notify_new_player_age >= 0)
 			message_admins("New user: [key_name_admin(src)] is connecting here for the first time.")
 			if (config.irc_first_connection_alert)
@@ -430,6 +419,17 @@ GLOBAL_LIST(external_rsc_urls)
 	if(!query_client_in_db.Execute())
 		return
 	if(!query_client_in_db.NextRow())
+		if (config.panic_bunker && !holder && !(ckey in GLOB.deadmins))
+			log_access("Failed Login: [key] - New account attempting to connect during panic bunker")
+			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
+			to_chat(src, "Sorry but the server is currently not accepting connections from never before seen players.")
+			if(config.allow_panic_bunker_bounce && tdata != "redirect")
+				to_chat(src, "<span class='notice'>Sending you to [config.panic_server_name].</span>")
+				winset(src, null, "command=.options")
+				src << link("[config.panic_address]?redirect")
+			qdel(src)
+			return
+		
 		new_player = 1
 		account_join_date = sanitizeSQL(findJoinDate())
 		var/datum/DBQuery/query_add_player = SSdbcore.NewQuery("INSERT INTO [format_table_name("player")] (`ckey`, `firstseen`, `lastseen`, `ip`, `computerid`, `lastadminrank`, `accountjoindate`) VALUES ('[sql_ckey]', Now(), Now(), INET_ATON('[sql_ip]'), '[sql_computerid]', '[sql_admin_rank]', [account_join_date ? "'[account_join_date]'" : "NULL"])")

--- a/config/config.txt
+++ b/config/config.txt
@@ -265,10 +265,10 @@ NOTIFY_NEW_PLAYER_ACCOUNT_AGE 1
 
 ## If panic bunker is on and a player is rejected (see above), attempt to send them to this connected server (see below) instead.
 ##	You probably want this to be the same as CROSS_SERVER_ADDRESS
-PANIC_SERVER_ADDRESS byond://address:port
+#PANIC_SERVER_ADDRESS byond://address:port
 
 ##Name of the place to send people rejected by the bunker
-PANIC_SERVER_NAME [Put the name here]
+#PANIC_SERVER_NAME [Put the name here]
 
 ## Uncomment to have the changelog file automatically open when a user connects and hasn't seen the latest changelog
 #AGGRESSIVE_CHANGELOG


### PR DESCRIPTION
fixes #29279

When @Jordie0608 (i think) merged the two database procs into one, being able to stop the creation of the player in the player db on rejection stopped being possible.

Rather than try to re-jigger it back into two procs, I just opted to drop it inside the db proc.