### PR TITLE
Nerfs Perfluorodecalin.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -518,15 +518,17 @@
 /datum/reagent/medicine/perfluorodecalin
 	name = "Perfluorodecalin"
 	id = "perfluorodecalin"
-	description = "Extremely rapidly restores oxygen deprivation, but inhibits speech. May also heal small amounts of bruising and burns."
+	description = "Extremely rapidly restores serious oxygen deprivation, but may inhibit speech. May also heal small amounts of bruising and burns."
 	reagent_state = LIQUID
 	color = "#FF6464"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/perfluorodecalin/on_mob_life(mob/living/carbon/human/M)
-	M.adjustOxyLoss(-12*REM, 0)
-	M.silent = max(M.silent, 5)
-	if(prob(33))
+	if(M.getOxyLoss() < 50)
+		M.adjustOxyLoss(-6*REM, 0)
+	else
+		M.adjustOxyLoss(-12*REM, 0)
+		M.silent = max(M.silent, 5)
 		M.adjustBruteLoss(-0.5*REM, 0)
 		M.adjustFireLoss(-0.5*REM, 0)
 	..()


### PR DESCRIPTION
:cl: 
balance: Perfluorodecalin now only mutes at high level of Oxygen loss damage.
/:cl:

[why]: # Requesting a bypass to the freeze for Chemical nerfs.

Chemical nerfs are not fun and their abuse allows a mere single syringe to kill one person with no chance of retaliation.

With a shift in playerbase, people have rushed to use this to the maximum extent and the rounds aren't fun to deal with this anymore.