### PR TITLE
Prevents the anomalous crystal from making fantasy into reality

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -699,7 +699,7 @@ Difficulty: Very Hard
 		for(var/i in T)
 			if(isitem(i) && !is_type_in_typecache(i, banned_items_typecache))
 				var/obj/item/W = i
-				if(!W.admin_spawned)
+				if(!W.admin_spawned && !HAS_SECONDARY_FLAG(W, HOLOGRAM))
 					L += W
 		if(L.len)
 			var/obj/item/CHOSEN = pick(L)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -699,7 +699,7 @@ Difficulty: Very Hard
 		for(var/i in T)
 			if(isitem(i) && !is_type_in_typecache(i, banned_items_typecache))
 				var/obj/item/W = i
-				if(!W.admin_spawned && !HAS_SECONDARY_FLAG(W, HOLOGRAM))
+				if(!W.admin_spawned && !HAS_SECONDARY_FLAG(W, HOLOGRAM) && !(W.flags & ABSTRACT))
 					L += W
 		if(L.len)
 			var/obj/item/CHOSEN = pick(L)


### PR DESCRIPTION
There was never a check to make sure holographic items weren't recreated with the refresher crystal, which delinked them from the holodeck system. Discovered this while fucking around after killing a colossus.

I almost don't want to fix this because it's fairly hilarious but on the other hand making infinite stamina e-swords and disablers is a little ehhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh

:cl:
fix: Fixed the refresher variant of the anomalous crystal making holodeck items real
/:cl: