### PR TITLE
Unprotects the deadmin list

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -1,8 +1,8 @@
 GLOBAL_LIST_EMPTY(clients)							//all clients
 GLOBAL_LIST_EMPTY(admins)							//all clients whom are admins
 GLOBAL_PROTECT(admins)
-GLOBAL_LIST_EMPTY(deadmins)							//all clients who have used the de-admin verb.
-GLOBAL_PROTECT(deadmins)
+GLOBAL_LIST_EMPTY(deadmins)							//all ckeys who have used the de-admin verb.
+
 GLOBAL_LIST_EMPTY(directory)							//all ckeys with associated client
 GLOBAL_LIST_EMPTY(stealthminID)						//reference list with IDs that store ckeys, for stealthmins
 


### PR DESCRIPTION
The only thing being in this list does is give you a re-admin verb that still verifies you are really suppose to be an admin by checking the .txt, and make you exempt for bans and a few other on connection things.

An admin adding or removing somebody to/from this list with vv is not a credible enough of a security threat to justify locking it, and I needed to edit this list to test something, and i couldn't, and that made me sad.