### PR TITLE
Prolonging Prisms have a higher cost to delay, but no longer increase in cost based off of CV

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -206,7 +206,7 @@
 	observer_message = "<span class='warning'>An onyx prism forms in midair and sprouts tendrils to support itself!</span>"
 	invokers_required = 2
 	multiple_invokers_used = TRUE
-	usage_tip = "The power cost to delay a shuttle increases based on CV and the number of times activated."
+	usage_tip = "The power cost to delay a shuttle increases based on the number of times activated."
 	tier = SCRIPTURE_APPLICATION
 	one_per_tile = TRUE
 	primary_component = VANGUARD_COGWHEEL

--- a/code/game/gamemodes/clock_cult/clock_structures/prolonging_prism.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/prolonging_prism.dm
@@ -15,8 +15,8 @@
 	/obj/item/clockwork/alloy_shards/large = 1, \
 	/obj/item/clockwork/component/vanguard_cogwheel/onyx_prism = 1)
 	var/static/list/component_refund = list(VANGUARD_COGWHEEL = 2, GEIS_CAPACITOR = 1, REPLICANT_ALLOY = 1)
-	var/static/delay_cost = 2500
-	var/static/delay_cost_increase = 750
+	var/static/delay_cost = 3000
+	var/static/delay_cost_increase = 1250
 	var/static/delay_remaining = 0
 
 /obj/structure/destructible/clockwork/powered/prolonging_prism/examine(mob/user)
@@ -27,7 +27,7 @@
 		else
 			var/efficiency = get_efficiency_mod(TRUE)
 			to_chat(user, "<span class='inathneq_small'>It requires at least <b>[get_delay_cost()]W</b> of power to attempt to delay the arrival of an emergency shuttle by <b>[2 * efficiency]</b> minutes.</span>")
-			to_chat(user, "<span class='inathneq_small'>This cost increases by <b>[delay_cost_increase * 0.1]W</b> for every <b>10 CV</b> and <b>[delay_cost_increase]W</b> for every previous activation.</span>")
+			to_chat(user, "<span class='inathneq_small'>This cost increases by <b>[delay_cost_increase]W</b> for every previous activation.</span>")
 
 /obj/structure/destructible/clockwork/powered/prolonging_prism/forced_disable(bad_effects)
 	if(active)
@@ -116,7 +116,7 @@
 		CHECK_TICK //we may be going over a hell of a lot of turfs
 
 /obj/structure/destructible/clockwork/powered/prolonging_prism/proc/get_delay_cost()
-	return Floor((GLOB.clockwork_construction_value * delay_cost_increase * 0.01) + delay_cost, MIN_CLOCKCULT_POWER)
+	return Floor(delay_cost, MIN_CLOCKCULT_POWER)
 
 /obj/structure/destructible/clockwork/powered/prolonging_prism/proc/seven_random_hexes(turf/T, efficiency)
 	var/static/list/hex_states = list("prismhex1", "prismhex2", "prismhex3", "prismhex4", "prismhex5", "prismhex6", "prismhex7")


### PR DESCRIPTION
:cl: Joan
balance: Prolonging Prisms have a higher cost to delay, but no longer increase in cost based off of CV.
balance: Base delay cost changed from 2500W to 3000W, cost increase per activation changed from 750W to 1250W, cost increase per 10 CV changed from 75W to 0W.
/:cl:

Why did I think this was a good idea? More CV shouldn't hinder shit all.
