### PR TITLE
Fixes Hijack Objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -240,7 +240,7 @@
 		return 0
 	if(issilicon(owner.current))
 		return 0
-	if(!(SSshuttle.emergency.shuttle_areas[get_area(owner.current)]))
+	if(!SSshuttle.emergency.shuttle_areas[get_area(owner.current)])
 		return 0
 	return SSshuttle.emergency.is_hijacked()
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -240,9 +240,8 @@
 		return 0
 	if(issilicon(owner.current))
 		return 0
-	if(SSshuttle.emergency.shuttle_areas[get_area(owner.current)])
+	if(!(SSshuttle.emergency.shuttle_areas[get_area(owner.current)]))
 		return 0
-
 	return SSshuttle.emergency.is_hijacked()
 
 


### PR DESCRIPTION
[Feature Freeze!]: # We are currently not considering any balance or antagonist oriented pull requests. Full details, as well as ways to bypass this freeze, are available here https://github.com/tgstation/tgstation/pull/28223

[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

:cl: ktccd
fix: Hijacking should now be possible again!
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Hijacking currently checks if you are in the shuttle and then promptly redtexts you if you are.
This is pretty whack, so I changed it to redtext you if you're NOT in the shuttle instead.
I honestly do not understand how this bug could've passed even rudimentary testing...