### PR TITLE
Removes clickcatcher regeneration every view range change

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -655,7 +655,6 @@ GLOBAL_LIST(external_rsc_urls)
 		CRASH("change_view called without argument.")
 
 	view = new_size
-	apply_clickcatcher()
 
 /client/proc/generate_clickcatcher()
 	if(!void)


### PR DESCRIPTION
Should fix the view range thing, but this is not the proper solution, just for test merging for now.