### PR TITLE
Calling the base on_mob_life is mandatory

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -283,13 +283,18 @@
 			. = 1
 	..()
 
-/datum/reagent/toxin/chloralhydrate/delayed
+/datum/reagent/toxin/chloralhydratedelayed
+	name = "Chloral Hydrate"
 	id = "chloralhydrate2"
+	description = "A powerful sedative that induces confusion and drowsiness before putting its target to sleep."
+	reagent_state = SOLID
+	color = "#000067" // rgb: 0, 0, 103
+	toxpwr = 0
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 
-/datum/reagent/toxin/chloralhydrate/delayed/on_mob_life(mob/living/M)
+/datum/reagent/toxin/chloralhydratedelayed/on_mob_life(mob/living/M)
 	switch(current_cycle)
 		if(1 to 10)
-			return
 		if(10 to 20)
 			M.confused += 1
 			M.drowsyness += 1

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -294,7 +294,6 @@
 
 /datum/reagent/toxin/chloralhydratedelayed/on_mob_life(mob/living/M)
 	switch(current_cycle)
-		if(1 to 10)
 		if(10 to 20)
 			M.confused += 1
 			M.drowsyness += 1


### PR DESCRIPTION
:cl:
fix: delayed chloral hydrate actually works now.
/:cl:

fixes #29354
fixes #27983

on_mob_life should never return always use ..() beforhand or set it up so that its an if-else tree instead of a series of ifchecks with hard returns.

so the thing that ticks current cycle is the base of on_mob_life. additionally fixes a second coding error where this would have also acted like normal CH because inheritance. Chems with custom life effects like this can't be inherited from by chems with a different one.

thankfully the chem id system means that the path of chems mean nothing.

TLDR: don't put in returns and don't have parents for IRL logic instead of code reasons.