### PR TITLE
Fixes global init linux bug by using proc typepath references, adds better error detection

### DIFF
--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -52,8 +52,16 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 /datum/controller/global_vars/Initialize()
 	gvars_datum_init_order = list()
 	gvars_datum_protected_varlist = list("gvars_datum_protected_varlist")
-	
-	for(var/I in typesof(/datum/controller/global_vars/proc))
+	var/list/global_procs = typesof(/datum/controller/global_vars/proc)
+	var/expected_len = vars.len - gvars_datum_in_built_vars.len
+	if(global_procs.len != expected_len)
+		warning("Unable to detect all global initialization procs! Expected [expected_len] got [global_procs.len]!")
+		if(global_procs.len)
+			var/list/expected_global_procs = vars - gvars_datum_in_built_vars
+			for(var/I in global_procs)
+				expected_global_procs -= replacetext("[I]", "InitGlobal", "")
+			log_world("Missing procs: [expected_global_procs.Join(", ")]")
+	for(var/I in global_procs)
 		var/start_tick = world.time
 		call(src, I)()
 		var/end_tick = world.time

--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -53,14 +53,9 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 	gvars_datum_init_order = list()
 	gvars_datum_protected_varlist = list("gvars_datum_protected_varlist")
 	
-	//See https://github.com/tgstation/tgstation/issues/26954
 	for(var/I in typesof(/datum/controller/global_vars/proc))
-		var/CLEANBOT_RETURNS = "[I]"
-		pass(CLEANBOT_RETURNS)
-	
-	for(var/I in vars - gvars_datum_in_built_vars)
 		var/start_tick = world.time
-		call(src, "InitGlobal[I]")()
+		call(src, I)()
 		var/end_tick = world.time
 		if(end_tick - start_tick)
-			warning("Global [I] slept during initialization!")
+			warning("Global [replacetext("[I]", "InitGlobal", "")] slept during initialization!")


### PR DESCRIPTION
Rather than build a proc name string, we use the full proc type path reference in the call()() global.

*Byond can't not find the proc if we give it a direct reference to the proc.*

Also adds some error detection and reporting to global init handling.

Ported from Baystation12/Baystation12#17874 (Thanks @PsiOmegaDelta)