### PR TITLE
Converted borgs will properly show the glowing eye message at distances of 1

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -34,7 +34,7 @@
 	if(cell && cell.charge <= 0)
 		msg += "<span class='warning'>Its battery indicator is blinking red!</span>\n"
 
-	if(is_servant_of_ratvar(src) && user.Adjacent(src) && !stat) //To counter pseudo-stealth by using headlamps
+	if(is_servant_of_ratvar(src) && get_dist(user, src) <= 1 && !stat) //To counter pseudo-stealth by using headlamps
 		msg += "<span class='warning'>Its eyes are glowing a blazing yellow!</span>\n"
 
 	switch(stat)


### PR DESCRIPTION
Instead of only when you could actually touch the borg.