### PR TITLE
minor_announce now only works in areas that'd logically have working speakers

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -52,7 +52,7 @@
 
 	for(var/mob/M in GLOB.player_list)
 		var/turf/T = get_turf(M)
-		if(!isnewplayer(M) && M.can_hear() && (M.client.holder || istype(M, /mob/dead/observer) || (T && T.CanMinorAnnounce()))
+		if(M.client.holder || istype(M, /mob/dead/observer) || (T && M.can_hear() && T.CanMinorAnnounce()))
 			to_chat(M, "<b><font size = 3><font color = red>[title]</font color><BR>[message]</font size></b><BR>")
 			if(M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
 				if(alert)

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -51,10 +51,22 @@
 		return
 
 	for(var/mob/M in GLOB.player_list)
-		if(!isnewplayer(M) && M.can_hear())
+		var/turf/T = get_turf(M)
+		if(!isnewplayer(M) && M.can_hear() && (M.client.holder || istype(M, /mob/dead/observer) || (T && T.CanMinorAnnounce()))
 			to_chat(M, "<b><font size = 3><font color = red>[title]</font color><BR>[message]</font size></b><BR>")
 			if(M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
 				if(alert)
 					M << sound('sound/misc/notice1.ogg')
 				else
 					M << sound('sound/misc/notice2.ogg')
+
+/turf/proc/CanMinorAnnounce()
+	if(onCentcom())
+		return TRUE
+	
+	var/area/A = loc
+	var/static/list/minor_announce_offstation_areas = typecacheof(subtypesof(/area/mine) - list(/area/mine/unexplored, /area/mine/explored))
+	if(z != ZLEVEL_STATION && !is_type_in_typecache(A, minor_announce_offstation_areas))
+		return FALSE
+	
+	return A.powered(ENVIRON)


### PR DESCRIPTION
This doesn't affect priority_announce. Why: To increase immulsions, minor things shouldn't be able to be heard in areas they logically couldn't be.

:cl:
tweak: Minor station announcements can now only be heard in powered station areas
/:cl: