### PR TITLE
Adds recipes for botany chemicals/ports /VG/ #15432

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1244,7 +1244,7 @@
 	..()
 
 /datum/reagent/plantnutriment/eznutriment
-	name = "E-Z-Nutrient"
+	name = "E-Z-Nutriment"
 	id = "eznutriment"
 	description = "Cheap and extremely common type of plant nutriment."
 	color = "#376400" // RBG: 50, 100, 0

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -650,3 +650,23 @@
 	var/location = get_turf(holder.my_atom)
 	for(var/i in 1 to 10)
 		new /obj/item/stack/sheet/plastic(location)
+
+//Botany chemicals, ported from /VG/ #15432
+
+/datum/chemical_reaction/eznutrmient
+	name = "E-Z-Nutriment"
+	id = "eznutriment"
+	results = list("eznutriment" = 3)
+	required_reagents = list("nitrogen" = 1, "phosphorus" = 1, "potassium" = 1)
+
+/datum/chemical_reaction/robustharvest
+	name = "Robust Harvest"
+	id = "robustharvestnutriment"
+	results = list("eznutriment" = 1)
+	required_reagents = list("eznutriment" = 1, "sacid" = 1)
+
+/datum/chemical_reaction/left4zed
+	name = "Left 4 Zed"
+	id = "left4zednutriment"
+	results = list("left4zednutriment" = 1)
+	required_reagents = list("eznutriment" = 1, "radium" = 1)


### PR DESCRIPTION
:cl: Tacolizard
add: Ported /VG/ #15432; Robust Harvest, E-Z-Nutriment, and Left4Zed now have chemical recipes.
tweak: Renamed E-Z-Nutrient to E-Z-Nutriment to match its name with its chemical ID
/:cl:

