### PR TITLE
Deathsquads no longer get shielded hardsuits

### DIFF
--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -338,7 +338,7 @@
 	name = "Death Commando"
 
 	uniform = /obj/item/clothing/under/color/green
-	suit = /obj/item/clothing/suit/space/hardsuit/shielded/swat
+	suit = /obj/item/clothing/suit/space/hardsuit/deathsquad
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/combat
 	mask = /obj/item/clothing/mask/gas/sechailer/swat


### PR DESCRIPTION
:cl: Joan
balance: Deathsquads no longer get shielded hardsuits.
/:cl:

https://github.com/tgstation/tgstation/pull/20057#issuecomment-241629059