### PR TITLE
Removes the gulag sink and water bottles from the sustenance vendor.

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
@@ -10012,7 +10012,7 @@ aE
 az
 az
 az
-aV
+az
 az
 aQ
 bk

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -768,8 +768,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	icon_state = "sustenance"
 	products = list(/obj/item/weapon/reagent_containers/food/snacks/tofu = 24,
 					/obj/item/weapon/reagent_containers/food/drinks/ice = 12,
-					/obj/item/weapon/reagent_containers/food/snacks/candy_corn = 6,
-					/obj/item/weapon/reagent_containers/glass/beaker/waterbottle = 10)
+					/obj/item/weapon/reagent_containers/food/snacks/candy_corn = 6)
 	contraband = list(/obj/item/weapon/kitchen/knife = 6,
 					/obj/item/weapon/reagent_containers/food/drinks/coffee = 12,
 					/obj/item/weapon/tank/internals/emergency_oxygen = 6,


### PR DESCRIPTION
:cl: BeeSting12
del: Water bottles from the sustenance vendor are gone. Wait for the ice in the ice cups melt, criminal scum.
del: There is no longer a sink in gulag. Hygiene is for the moral members of society.
/:cl:
This is a partial revert of two PRs, here's both of them.
#26290 - Adds the sink
#26709 -  Adds the water bottle

WHY:
Both of these items make gulag easy to escape. Escaping should be challenging, not easy like this. Currently actually mining to reach your point goal is seen as the worse option compared to escaping, which currently takes zero preparation, just vend a bottle and walk across lava to escape. Why anyone thought this was a good idea, I have no clue. I did leave the shower so that accidentally walking into lava doesn't completely screw you over if you can get back to the shower in time.

