### PR TITLE
You can no longer regenerate preference icons many times

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -105,6 +105,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/uplink_spawn_loc = UPLINK_PDA
 
 	var/list/menuoptions
+	var/is_updating = FALSE
 
 /datum/preferences/New(client/C)
 	parent = C
@@ -766,6 +767,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				text += ". The ban is for [duration] minutes and expires on [expiration_time] (server time)"
 			text += ".</span>"
 			to_chat(user, text)
+		return
+
+	//Anything that updates the preference icon lives below this line
+	if(is_updating)
+		to_chat(user, "<span class='redtext'>Your preference icon is still updating, please wait.</span>")
 		return
 
 	if(href_list["preference"] == "job")

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -21,6 +21,9 @@
 	age = rand(AGE_MIN,AGE_MAX)
 
 /datum/preferences/proc/update_preview_icon()
+	if(is_updating)
+		return
+	is_updating=TRUE
 	// Silicons only need a very basic preview since there is no customization for them.
 	if(job_engsec_high)
 		switch(job_engsec_high)
@@ -83,3 +86,4 @@
 	preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
 	CHECK_TICK
 	qdel(mannequin)
+	is_updating=FALSE


### PR DESCRIPTION
You must complete the existing regenerate first, the only thing the
topic will allow is jobban looksup, since they do not require a
preference change

The topic processor will not run until the preference icons are updated,
so spam clicking will not work

Fixes #29359 in an unsophisticated way