### PR TITLE
Virology fixes

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -294,6 +294,8 @@
 		var/list/L = list()
 		for(var/datum/symptom/S in symptoms)
 			L += S.id
+			if(S.neutered)
+				L += "N"
 		L = sortList(L) // Sort the list so it doesn't matter which order the symptoms are in.
 		var/result = jointext(L, ":")
 		id = result
@@ -324,7 +326,6 @@
 	if(!S.neutered)
 		S.neutered = TRUE
 		S.name += " (neutered)"
-		S.id += "N" //new disease is unique
 
 /*
 

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -46,10 +46,11 @@
 		var/list/this = list()
 		this["name"] = D.name
 		if(istype(D, /datum/disease/advance))
-			var/datum/disease/advance/A = SSdisease.archive_diseases[D.GetDiseaseID()]
-			if(A.name == "Unknown")
+			var/datum/disease/advance/A = D
+			var/datum/disease/advance/archived = SSdisease.archive_diseases[D.GetDiseaseID()]
+			if(archived.name == "Unknown")
 				this["can_rename"] = TRUE
-			this["name"] = A.name
+			this["name"] = archived.name
 			this["is_adv"] = TRUE
 			this["resistance"] = A.totalResistance()
 			this["stealth"] = A.totalStealth()


### PR DESCRIPTION
Fixes #29426 
Fixes an issue where copying a virus retained the unneutered id, effectively making vaccines for neutered viruses impossible to make.