### PR TITLE
Reduces number of changelings per round to 2

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_players = 15
 	required_enemies = 1
-	recommended_enemies = 4
+	recommended_enemies = 1
 	reroll_friendly = 1
 
 	announce_span = "green"

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_players = 15
 	required_enemies = 1
-	recommended_enemies = 1
+	recommended_enemies = 2
 	reroll_friendly = 1
 
 	announce_span = "green"


### PR DESCRIPTION
:cl:
tweak: Reduces number of changelings per round to 2
/:cl:

[why]: # Coderbus agrees that changelings are overpowered, reducing their numbers per round will stop them from dominating rounds untill a proper overhaul comes.