### PR TITLE
 	Changes symptom timers and values to account for the fact that ssdisease fires once every two seconds, not one

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -294,6 +294,8 @@
 		var/list/L = list()
 		for(var/datum/symptom/S in symptoms)
 			L += S.id
+			if(S.neutered)
+				L += "N"
 		L = sortList(L) // Sort the list so it doesn't matter which order the symptoms are in.
 		var/result = jointext(L, ":")
 		id = result
@@ -324,7 +326,6 @@
 	if(!S.neutered)
 		S.neutered = TRUE
 		S.name += " (neutered)"
-		S.id += "N" //new disease is unique
 
 /*
 

--- a/code/datums/diseases/advance/symptoms/beard.dm
+++ b/code/datums/diseases/advance/symptoms/beard.dm
@@ -23,8 +23,8 @@ BONUS
 	transmittable = -1
 	level = 4
 	severity = 1
-	symptom_delay_min = 18
-	symptom_delay_max = 36
+	symptom_delay_min = 12
+	symptom_delay_max = 24
 
 /datum/symptom/beard/Activate(datum/disease/advance/A)
 	if(!..())

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -25,8 +25,8 @@ Bonus
 	level = 3
 	severity = 3
 	base_message_chance = 15
-	symptom_delay_min = 10
-	symptom_delay_max = 30
+	symptom_delay_min = 6
+	symptom_delay_max = 18
 
 /datum/symptom/choking/Start(datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -25,8 +25,8 @@ Bonus
 	level = 4
 	severity = 2
 	base_message_chance = 25
-	symptom_delay_min = 10
-	symptom_delay_max = 30
+	symptom_delay_min = 6
+	symptom_delay_max = 18
 	var/brain_damage = FALSE
 
 /datum/symptom/confusion/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -25,8 +25,8 @@ BONUS
 	level = 1
 	severity = 1
 	base_message_chance = 15
-	symptom_delay_min = 2
-	symptom_delay_max = 15
+	symptom_delay_min = 1
+	symptom_delay_max = 8
 	var/infective = FALSE
 
 /datum/symptom/cough/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -25,8 +25,8 @@ Bonus
 	level = 4
 	severity = 3
 	base_message_chance = 100
-	symptom_delay_min = 25
-	symptom_delay_max = 80
+	symptom_delay_min = 13
+	symptom_delay_max = 48
 
 /datum/symptom/deafness/Start(datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -25,8 +25,8 @@ Bonus
 	level = 4
 	severity = 2
 	base_message_chance = 50
-	symptom_delay_min = 15
-	symptom_delay_max = 40
+	symptom_delay_min = 9
+	symptom_delay_max = 28
 
 /datum/symptom/dizzy/Start(datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/fever.dm
+++ b/code/datums/diseases/advance/symptoms/fever.dm
@@ -25,8 +25,8 @@ Bonus
 	level = 2
 	severity = 2
 	base_message_chance = 20
-	symptom_delay_min = 10
-	symptom_delay_max = 30
+	symptom_delay_min = 6
+	symptom_delay_max = 18
 	var/unsafe = FALSE //over the heat threshold
 
 /datum/symptom/fever/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -25,8 +25,8 @@ Bonus
 	level = 6
 	severity = 5
 	base_message_chance = 20
-	symptom_delay_min = 20
-	symptom_delay_max = 75
+	symptom_delay_min = 12
+	symptom_delay_max = 42
 	var/infective = FALSE
 
 /datum/symptom/fire/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -25,8 +25,8 @@ Bonus
 	level = 6
 	severity = 5
 	base_message_chance = 50
-	symptom_delay_min = 15
-	symptom_delay_max = 60
+	symptom_delay_min = 8
+	symptom_delay_max = 36
 	var/bleed = FALSE
 	var/pain = FALSE
 

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -27,8 +27,8 @@ Bonus
 	var/list/possible_mutations
 	var/archived_dna = null
 	base_message_chance = 50
-	symptom_delay_min = 60
-	symptom_delay_max = 120
+	symptom_delay_min = 36
+	symptom_delay_max = 80
 	var/no_reset = FALSE
 
 /datum/symptom/genetic_mutation/Activate(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -25,8 +25,8 @@ Bonus
 	level = 5
 	severity = 3
 	base_message_chance = 25
-	symptom_delay_min = 25
-	symptom_delay_max = 90
+	symptom_delay_min = 15
+	symptom_delay_max = 30
 	var/fake_healthy = FALSE
 
 /datum/symptom/hallucigen/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -26,8 +26,8 @@ BONUS
 	level = 1
 	severity = 1
 	base_message_chance = 100
-	symptom_delay_min = 15
-	symptom_delay_max = 30
+	symptom_delay_min = 8
+	symptom_delay_max = 24
 
 /datum/symptom/headache/Start(datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -58,7 +58,7 @@ Bonus
 	level = 6
 
 /datum/symptom/heal/toxin/Heal(mob/living/M, datum/disease/advance/A)
-	var/heal_amt = 0.5 * power
+	var/heal_amt = 1 * power
 	if(M.toxloss > 0 && prob(base_message_chance) && !hide_healing)
 		new /obj/effect/temp_visual/heal(get_turf(M), "#66FF99")
 	M.adjustToxLoss(-heal_amt)
@@ -89,7 +89,7 @@ Bonus
 	level = 8
 
 /datum/symptom/heal/toxin/plus/Heal(mob/living/M, datum/disease/advance/A)
-	var/heal_amt = 1 * power
+	var/heal_amt = 2 * power
 	if(M.toxloss > 0 && prob(base_message_chance) && !hide_healing)
 		new /obj/effect/temp_visual/heal(get_turf(M), "#00FF00")
 	M.adjustToxLoss(-heal_amt)
@@ -122,7 +122,7 @@ Bonus
 	level = 6
 
 /datum/symptom/heal/brute/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 1 * power
+	var/heal_amt = 2 * power
 
 	var/list/parts = M.get_damaged_bodyparts(1,1) //1,1 because it needs inputs.
 
@@ -165,7 +165,7 @@ Bonus
 	level = 8
 
 /datum/symptom/heal/brute/plus/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 2 * power
+	var/heal_amt = 4 * power
 
 	var/list/parts = M.get_damaged_bodyparts(1,1) //1,1 because it needs inputs.
 
@@ -214,7 +214,7 @@ Bonus
 	level = 6
 
 /datum/symptom/heal/burn/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 1 * power
+	var/heal_amt = 2 * power
 
 	var/list/parts = M.get_damaged_bodyparts(1,1) //1,1 because it needs inputs.
 
@@ -256,7 +256,7 @@ Bonus
 	level = 8
 
 /datum/symptom/heal/burn/plus/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 2 * power
+	var/heal_amt = 4 * power
 
 	var/list/parts = M.get_damaged_bodyparts(1,1) //1,1 because it needs inputs.
 
@@ -306,7 +306,7 @@ Bonus
 	symptom_delay_max = 8
 
 /datum/symptom/heal/dna/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/amt_healed = 1 * power
+	var/amt_healed = 2 * power
 	M.adjustBrainLoss(-amt_healed)
 	//Non-power mutations, excluding race, so the virus does not force monkey -> human transformations.
 	var/list/unclean_mutations = (GLOB.not_good_mutations|GLOB.bad_mutations) - GLOB.mutations_list[RACEMUT]

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -19,8 +19,8 @@ Bonus
 	stage_speed = -3
 	transmittable = -4
 	level = 6
-	symptom_delay_min = 15
-	symptom_delay_max = 80
+	symptom_delay_min = 8
+	symptom_delay_max = 48
 	severity = 5
 	var/sleep_level = 0
 	var/sleepy_ticks = 0

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -39,10 +39,10 @@ Bonus
 	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(4, 5)
-			M.adjustOxyLoss(-3, 0)
-			M.losebreath = max(0, M.losebreath - 2)
+			M.adjustOxyLoss(-7, 0)
+			M.losebreath = max(0, M.losebreath - 4)
 			if(regenerate_blood && M.blood_volume < BLOOD_VOLUME_NORMAL)
-				M.blood_volume += 1
+				M.blood_volume += 2
 		else
 			if(prob(base_message_chance))
 				to_chat(M, "<span class='notice'>[pick("Your lungs feel great.", "You realize you haven't been breathing.", "You don't feel the need to breathe.")]</span>")

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -23,8 +23,8 @@ Bonus
 	transmittable = -3
 	level = 5
 	severity = 0
-	symptom_delay_min = 5
-	symptom_delay_max = 10
+	symptom_delay_min = 3
+	symptom_delay_max = 7
 	var/purge_alcohol = FALSE
 	var/brain_heal = FALSE
 

--- a/code/datums/diseases/advance/symptoms/shedding.dm
+++ b/code/datums/diseases/advance/symptoms/shedding.dm
@@ -24,8 +24,8 @@ BONUS
 	level = 4
 	severity = 1
 	base_message_chance = 50
-	symptom_delay_min = 45
-	symptom_delay_max = 90
+	symptom_delay_min = 25
+	symptom_delay_max = 50
 
 /datum/symptom/shedding/Activate(datum/disease/advance/A)
 	if(!..())

--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -24,8 +24,8 @@ Bonus
 	transmittable = 2
 	level = 2
 	severity = 2
-	symptom_delay_min = 10
-	symptom_delay_max = 30
+	symptom_delay_min = 6
+	symptom_delay_max = 18
 	var/unsafe = FALSE //over the cold threshold
 
 /datum/symptom/fever/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -23,8 +23,8 @@ BONUS
 	transmittable = -2
 	level = 5
 	severity = 1
-	symptom_delay_min = 25
-	symptom_delay_max = 75
+	symptom_delay_min = 14
+	symptom_delay_max = 45
 
 /datum/symptom/vitiligo/Activate(datum/disease/advance/A)
 	if(!..())

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -24,8 +24,8 @@ Bonus
 	transmittable = 4
 	level = 1
 	severity = 1
-	symptom_delay_min = 5
-	symptom_delay_max = 35
+	symptom_delay_min = 3
+	symptom_delay_max = 22
 
 /datum/symptom/sneeze/Start(datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -25,8 +25,8 @@ Bonus
 	level = 5
 	severity = 4
 	base_message_chance = 50
-	symptom_delay_min = 25
-	symptom_delay_max = 80
+	symptom_delay_min = 14
+	symptom_delay_max = 48
 	var/remove_eyes = FALSE
 
 /datum/symptom/visionloss/Start(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/voice_change.dm
+++ b/code/datums/diseases/advance/symptoms/voice_change.dm
@@ -25,8 +25,8 @@ Bonus
 	level = 6
 	severity = 2
 	base_message_chance = 100
-	symptom_delay_min = 60
-	symptom_delay_max = 120
+	symptom_delay_min = 25
+	symptom_delay_max = 80
 	var/scramble_language = FALSE
 	var/datum/language/current_language
 	var/datum/language_holder/original_language

--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -29,8 +29,8 @@ Bonus
 	level = 3
 	severity = 4
 	base_message_chance = 100
-	symptom_delay_min = 25
-	symptom_delay_max = 80
+	symptom_delay_min = 15
+	symptom_delay_max = 50
 	var/vomit_blood = FALSE
 	var/proj_vomit = 0
 

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -25,8 +25,8 @@ Bonus
 	level = 4
 	severity = 1
 	base_message_chance = 100
-	symptom_delay_min = 15
-	symptom_delay_max = 45
+	symptom_delay_min = 8
+	symptom_delay_max = 25
 
 /datum/symptom/weight_gain/Start(datum/disease/advance/A)
 	..()
@@ -73,8 +73,8 @@ Bonus
 	level = 3
 	severity = 1
 	base_message_chance = 100
-	symptom_delay_min = 15
-	symptom_delay_max = 45
+	symptom_delay_min = 8
+	symptom_delay_max = 25
 
 /datum/symptom/weight_loss/Start(datum/disease/advance/A)
 	..()
@@ -121,8 +121,8 @@ Bonus
 	stage_speed = -2
 	transmittable = -2
 	level = 4
-	symptom_delay_min = 5
-	symptom_delay_max = 5
+	symptom_delay_min = 3
+	symptom_delay_max = 3
 
 /datum/symptom/weight_even/Activate(datum/disease/advance/A)
 	if(!..())

--- a/code/datums/diseases/advance/symptoms/youth.dm
+++ b/code/datums/diseases/advance/symptoms/youth.dm
@@ -24,8 +24,8 @@ BONUS
 	transmittable = -4
 	level = 5
 	base_message_chance = 100
-	symptom_delay_min = 25
-	symptom_delay_max = 50
+	symptom_delay_min = 14
+	symptom_delay_max = 30
 
 /datum/symptom/youth/Activate(datum/disease/advance/A)
 	if(!..())

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -46,10 +46,11 @@
 		var/list/this = list()
 		this["name"] = D.name
 		if(istype(D, /datum/disease/advance))
-			var/datum/disease/advance/A = SSdisease.archive_diseases[D.GetDiseaseID()]
-			if(A.name == "Unknown")
+			var/datum/disease/advance/A = D
+			var/datum/disease/advance/archived = SSdisease.archive_diseases[D.GetDiseaseID()]
+			if(archived.name == "Unknown")
 				this["can_rename"] = TRUE
-			this["name"] = A.name
+			this["name"] = archived.name
 			this["is_adv"] = TRUE
 			this["resistance"] = A.totalResistance()
 			this["stealth"] = A.totalStealth()


### PR DESCRIPTION
The time between activations in general has been set to about 60% of the previous value.

I've heard reports of healing symptoms being weaker than normal post-rework. This was largely caused by self-respiration healing at half the speed, no longer negating oxygen damage from asphyxiation. I also corrected the other values as the intention was to heal one point of damage per second, not every two.