### PR TITLE
Fixes virology timing in a better way

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -58,7 +58,7 @@ Bonus
 	level = 6
 
 /datum/symptom/heal/toxin/Heal(mob/living/M, datum/disease/advance/A)
-	var/heal_amt = 0.5 * power
+	var/heal_amt = 1 * power
 	if(M.toxloss > 0 && prob(base_message_chance) && !hide_healing)
 		new /obj/effect/temp_visual/heal(get_turf(M), "#66FF99")
 	M.adjustToxLoss(-heal_amt)
@@ -89,7 +89,7 @@ Bonus
 	level = 8
 
 /datum/symptom/heal/toxin/plus/Heal(mob/living/M, datum/disease/advance/A)
-	var/heal_amt = 1 * power
+	var/heal_amt = 2 * power
 	if(M.toxloss > 0 && prob(base_message_chance) && !hide_healing)
 		new /obj/effect/temp_visual/heal(get_turf(M), "#00FF00")
 	M.adjustToxLoss(-heal_amt)
@@ -122,7 +122,7 @@ Bonus
 	level = 6
 
 /datum/symptom/heal/brute/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 1 * power
+	var/heal_amt = 2 * power
 
 	var/list/parts = M.get_damaged_bodyparts(1,1) //1,1 because it needs inputs.
 
@@ -165,7 +165,7 @@ Bonus
 	level = 8
 
 /datum/symptom/heal/brute/plus/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 2 * power
+	var/heal_amt = 4 * power
 
 	var/list/parts = M.get_damaged_bodyparts(1,1) //1,1 because it needs inputs.
 
@@ -214,7 +214,7 @@ Bonus
 	level = 6
 
 /datum/symptom/heal/burn/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 1 * power
+	var/heal_amt = 2 * power
 
 	var/list/parts = M.get_damaged_bodyparts(1,1) //1,1 because it needs inputs.
 
@@ -256,7 +256,7 @@ Bonus
 	level = 8
 
 /datum/symptom/heal/burn/plus/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 2 * power
+	var/heal_amt = 4 * power
 
 	var/list/parts = M.get_damaged_bodyparts(1,1) //1,1 because it needs inputs.
 
@@ -306,7 +306,7 @@ Bonus
 	symptom_delay_max = 8
 
 /datum/symptom/heal/dna/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/amt_healed = 1 * power
+	var/amt_healed = 2 * power
 	M.adjustBrainLoss(-amt_healed)
 	//Non-power mutations, excluding race, so the virus does not force monkey -> human transformations.
 	var/list/unclean_mutations = (GLOB.not_good_mutations|GLOB.bad_mutations) - GLOB.mutations_list[RACEMUT]

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -39,8 +39,8 @@ Bonus
 	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(4, 5)
-			M.adjustOxyLoss(-3, 0)
-			M.losebreath = max(0, M.losebreath - 2)
+			M.adjustOxyLoss(-7, 0)
+			M.losebreath = max(0, M.losebreath - 4)
 			if(regenerate_blood && M.blood_volume < BLOOD_VOLUME_NORMAL)
 				M.blood_volume += 1
 		else

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -18,7 +18,7 @@
 	//If the early warnings are suppressed or not
 	var/suppress_warning = FALSE
 	//Ticks between each activation
-	var/symptom_counter = 0
+	var/next_activation = 0
 	var/symptom_delay_min = 1
 	var/symptom_delay_max = 1
 	//Can be used to multiply virus effects
@@ -36,7 +36,7 @@
 
 // Called when processing of the advance disease, which holds this symptom, starts.
 /datum/symptom/proc/Start(datum/disease/advance/A)
-	symptom_counter = rand(symptom_delay_min, symptom_delay_max)
+	next_activation = world.time + rand(symptom_delay_min * 10, symptom_delay_max * 10) //so it doesn't instantly activate on infection
 	return
 
 // Called when the advance disease is going to be deleted or when the advance disease stops processing.
@@ -46,11 +46,10 @@
 /datum/symptom/proc/Activate(datum/disease/advance/A)
 	if(neutered)
 		return FALSE
-	if(symptom_counter)
-		symptom_counter--
+	if(world.time < next_activation)
 		return FALSE
 	else
-		symptom_counter = rand(symptom_delay_min, symptom_delay_max)
+		next_activation = world.time + rand(symptom_delay_min * 10, symptom_delay_max * 10)
 		return TRUE
 
 /datum/symptom/proc/Copy()


### PR DESCRIPTION
Closes #29448

This changes the delay between symptom activation to be based on world.time instead of a counter every process. Some symptoms that activate every tick have still been buffed since the minimum wait time will still be two seconds.

Thanks to @MrStonedOne for the better idea.