### PR TITLE
Romerol zombies count as dead for assassinate and maroon objectives.

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -89,7 +89,7 @@
 
 /datum/objective/assassinate/check_completion()
 	if(target && target.current)
-		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > 6 || !target.current.ckey) //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
+		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > 6 || !target.current.ckey || target.current.dna.species.id == "memezombies") //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
 			return 1
 		return 0
 	return 1
@@ -152,7 +152,7 @@
 
 /datum/objective/maroon/check_completion()
 	if(target && target.current)
-		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > 6 || !target.current.ckey) //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
+		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > 6 || !target.current.ckey || target.current.dna.species.id == "memezombies") //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
 			return 1
 		if(target.current.onCentcom() || target.current.onSyndieBase())
 			return 0

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -89,7 +89,10 @@
 
 /datum/objective/assassinate/check_completion()
 	if(target && target.current)
-		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > 6 || !target.current.ckey || target.current.dna.species.id == "memezombies") //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
+		var/mob/living/carbon/human/H
+		if(ishuman(target.current))
+			H = target.current
+		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > 6 || !target.current.ckey || (H && H.dna.species.id == "memezombies")) //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
 			return 1
 		return 0
 	return 1
@@ -152,7 +155,10 @@
 
 /datum/objective/maroon/check_completion()
 	if(target && target.current)
-		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > 6 || !target.current.ckey || target.current.dna.species.id == "memezombies") //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
+		var/mob/living/carbon/human/H
+		if(ishuman(target.current))
+			H = target.current
+		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > 6 || !target.current.ckey || (H && H.dna.species.id == "memezombies")) //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
 			return 1
 		if(target.current.onCentcom() || target.current.onSyndieBase())
 			return 0


### PR DESCRIPTION
:cl: Y0SH1_M4S73R
fix: Romerol zombies count as dead for assassinate and maroon objectives.
/:cl:

Romerol causes enough fuckery with the round. Why should its fuckery extend to antags' objectives?
