### PR TITLE
Fix ruin ripley's spawn equipment

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -104,7 +104,7 @@
 			D.attach(src)
 
 	else //Add plasma cutter if no drill
-		var /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma/P = new
+		var/obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma/P = new
 		P.attach(src)
 
 	//Add ore box to cargo

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -103,9 +103,9 @@
 			var/obj/item/mecha_parts/mecha_equipment/drill/D = new
 			D.attach(src)
 
-	else //Add possible plasma cutter if no drill
-		var/obj/item/mecha_parts/mecha_equipment/M = new
-		M.attach(src)
+	else //Add plasma cutter if no drill
+		var /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma/P = new
+		P.attach(src)
 
 	//Add ore box to cargo
 	cargo.Add(new /obj/structure/ore_box(src))


### PR DESCRIPTION
The lavaland-ruin ripley had a 30% chance of spawning with a `/obj/item/mecha_parts/mecha_equipment/` equipped instead of a drill since merge of #28600 on June 20 .

Fixes #29465 