### PR TITLE
places a dresser in pubbystation's dorms

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -10011,8 +10011,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "avQ" = (
-/obj/structure/table/wood,
-/obj/item/weapon/storage/book/bible,
+/obj/structure/dresser,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "avR" = (
@@ -86720,7 +86719,7 @@ cnC
 cjZ
 cjZ
 cjZ
-cnD
+cnC
 cks
 cka
 aaa


### PR DESCRIPTION
Somewhat self explanatory. Pubbystation lacks a public-access dresser, seems to be an oversight, so I'm giving the map one. It's in the middle dorm room, replaces a table and a bible which are in the other two dormrooms.

:cl: BeeSting12
add: Pubbystation's dorms now has a dresser.
/:cl: