### PR TITLE
BYPASSES THE DEEP FREEZE

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -89,5 +89,6 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define UNACIDABLE 16 //acid can't even appear on it, let alone melt it.
 #define ACID_PROOF 32 //acid stuck on it doesn't melt it.
 #define INDESTRUCTIBLE 64 //doesn't take damage
+#define FREEZE_PROOF 128 //can't be frozen
 
 // language secondary flags for atoms

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -974,6 +974,8 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 /obj/proc/make_frozen_visual()
 	// Used to make the frozen item visuals for Freon.
 	var/static/list/freeze_item_icons = list()
+	if(resistance_flags & FREEZE_PROOF)
+		return
 	if(!HAS_SECONDARY_FLAG(src, FROZEN) && (initial(icon) && initial(icon_state)))
 		var/index = freeze_icon_index()
 		var/icon/IC

--- a/code/game/gamemodes/clock_cult/clock_structure.dm
+++ b/code/game/gamemodes/clock_cult/clock_structure.dm
@@ -133,7 +133,7 @@
 	desc = "A very large construction."
 	layer = MASSIVE_OBJ_LAYER
 	density = FALSE
-	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF | FREEZE_PROOF
 
 /obj/structure/destructible/clockwork/massive/Initialize()
 	. = ..()

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -9,7 +9,7 @@
 	icon_state = "nothing"
 	density = FALSE
 	invisibility = INVISIBILITY_MAXIMUM
-	resistance_flags = FIRE_PROOF | ACID_PROOF | INDESTRUCTIBLE
+	resistance_flags = FIRE_PROOF | ACID_PROOF | INDESTRUCTIBLE | FREEZE_PROOF
 	can_be_repaired = FALSE
 	immune_to_servant_attacks = TRUE
 	var/progress_in_seconds = 0 //Once this reaches GATEWAY_RATVAR_ARRIVAL, it's game over

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -3,7 +3,7 @@
 //Effects are mostly temporary visual effects like sparks, smoke, as well as decals, etc...
 /obj/effect
 	icon = 'icons/effects/effects.dmi'
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
 /obj/effect/attackby(obj/item/I, mob/living/user, params)
 	return

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -42,9 +42,6 @@
 	if(user && Adjacent(user))
 		teleport(user)
 
-/obj/effect/portal/make_frozen_visual()
-	return
-
 /obj/effect/portal/Crossed(atom/movable/AM, oldloc)
 	if(get_turf(oldloc) == get_turf(linked))
 		return ..()

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -122,6 +122,8 @@
 
 /turf/open/proc/freon_gas_act()
 	for(var/obj/I in contents)
+		if(I.resistance_flags & FREEZE_PROOF)
+			return
 		if(!HAS_SECONDARY_FLAG(I, FROZEN)) //let it go
 			I.make_frozen_visual()
 	for(var/mob/living/L in contents)

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -64,9 +64,6 @@
 	setDir(pick(GLOB.cardinals))
 	air_update_turf()
 
-/obj/effect/hotspot/make_frozen_visual()
-	return	//you take my fun i take yours
-
 /obj/effect/hotspot/proc/perform_exposure()
 	var/turf/open/location = loc
 	if(!istype(location) || !(location.air))

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -167,6 +167,7 @@
 	icon_state = "coffee"
 	list_reagents = list("coffee" = 30)
 	spillable = 1
+	resistance_flags = FREEZE_PROOF
 
 /obj/item/weapon/reagent_containers/food/drinks/ice
 	name = "Ice Cup"
@@ -197,6 +198,7 @@
 	name = "Dutch Hot Coco"
 	desc = "Made in Space South America."
 	list_reagents = list("hot_coco" = 30, "sugar" = 5)
+	resistance_flags = FREEZE_PROOF
 
 /obj/item/weapon/reagent_containers/food/drinks/dry_ramen
 	name = "Cup Ramen"

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -63,7 +63,7 @@
 	density = TRUE
 	anchored = FALSE
 	light_range = 4
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 
 	critical_machine = TRUE
 
@@ -131,8 +131,6 @@
 	var/produces_gas = TRUE
 	var/obj/effect/countdown/supermatter/countdown
 
-/obj/machinery/power/supermatter_shard/make_frozen_visual()
-	return
 
 /obj/machinery/power/supermatter_shard/Initialize()
 	. = ..()


### PR DESCRIPTION
By adding a FREEZE_PROOF resistance flag, which prevents freon from freezing an item; cleaning up a number of copypasta make_frozen_visual returns


Closes #29531
Fixes #29528
Fixes #26349
Also fixes it for hot coco.

https://youtu.be/SRH-Ywpz1_I

🆑 ShizCalev
fix: Robust coffee is now even more robust! No longer will you be drinking frozen hot coffee!
fix: Clockwork covenants and Ratvar will no longer go invisible by releasing a canister of freon!
fix: Ratvar's summoning portal will no longer be permanently broken by freon.
/🆑