### PR TITLE
Give c4 correct plastic_overlay

### DIFF
--- a/code/game/objects/items/weapons/grenades/plastic.dm
+++ b/code/game/objects/items/weapons/grenades/plastic.dm
@@ -170,8 +170,8 @@
 
 /obj/item/weapon/grenade/plastic/c4/New()
 	wires = new /datum/wires/explosive/c4(src)
-	plastic_overlay = mutable_appearance(icon, "plastic-explosive2")
 	..()
+	plastic_overlay = mutable_appearance(icon, "plastic-explosive2")
 
 /obj/item/weapon/grenade/plastic/c4/Destroy()
 	qdel(wires)


### PR DESCRIPTION
Fixes #19270

c4 was not using a visible `plastic_overlay`: its `New()` created the correct `mutable_appearance`, but the parent, `plastic/New()` set it back to something incorrect.

Fixing `/plastic`'s defect in generality might be better, but I'm throwing this out there first.