### PR TITLE
Adds emergency toolbox to escape pod supplies

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -525,6 +525,7 @@
 	new /obj/item/weapon/pickaxe/emergency(src)
 	new /obj/item/weapon/pickaxe/emergency(src)
 	new /obj/item/weapon/survivalcapsule(src)
+	new /obj/item/weapon/storage/toolbox/emergency(src)
 
 /obj/item/weapon/storage/pod/attackby(obj/item/weapon/W, mob/user, params)
 	return


### PR DESCRIPTION
Closes  #19247

the safe in an escape pod now includes an emergency toolbox, suitable for opening exits through the pod's walls if needed.