### PR TITLE
Fixes a lot of eye damage procs

### DIFF
--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -101,7 +101,7 @@ Bonus
 	if(!..())
 		return
 	var/mob/living/M = A.affected_mob
-	var/obj/item/organ/eyes/eyes = M.getorganslot("eyes_sight")
+	var/obj/item/organ/eyes/eyes = M.getorganslot("eye_sight")
 	if (!eyes)
 		return
 	switch(A.stage)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -502,7 +502,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	M.adjust_blurriness(3)
 	M.adjust_eye_damage(rand(2,4))
-	var/obj/item/organ/eyes/eyes = M.getorganslot("eyes_sight")
+	var/obj/item/organ/eyes/eyes = M.getorganslot("eye_sight")
 	if (!eyes)
 		return
 	if(eyes.eye_damage >= 10)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -262,7 +262,7 @@
 
 	var/damage = intensity - get_eye_protection()
 	if(.) // we've been flashed
-		var/obj/item/organ/eyes/eyes = getorganslot("eyes_sight")
+		var/obj/item/organ/eyes/eyes = getorganslot("eye_sight")
 		if (!eyes)
 			return
 		if(visual)

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -3,9 +3,9 @@
 // eye damage, eye_blind, eye_blurry, druggy, BLIND disability, NEARSIGHT disability, and HUSK disability.
 
 /mob/living/carbon/damage_eyes(amount)
-	var/obj/item/organ/eyes/eyes = getorganslot("eyes_sight")
+	var/obj/item/organ/eyes/eyes = getorganslot("eye_sight")
 	if (!eyes)
-		return 
+		return
 	if(amount>0)
 		eyes.eye_damage = amount
 		if(eyes.eye_damage > 20)
@@ -15,9 +15,9 @@
 				overlay_fullscreen("eye_damage", /obj/screen/fullscreen/impaired, 1)
 
 /mob/living/carbon/set_eye_damage(amount)
-	var/obj/item/organ/eyes/eyes = getorganslot("eyes_sight")
+	var/obj/item/organ/eyes/eyes = getorganslot("eye_sight")
 	if (!eyes)
-		return 
+		return
 	eyes.eye_damage = max(amount,0)
 	if(eyes.eye_damage > 20)
 		if(eyes.eye_damage > 30)
@@ -28,7 +28,7 @@
 		clear_fullscreen("eye_damage")
 
 /mob/living/carbon/adjust_eye_damage(amount)
-	var/obj/item/organ/eyes/eyes = getorganslot("eyes_sight")
+	var/obj/item/organ/eyes/eyes = getorganslot("eye_sight")
 	if (!eyes)
 		return
 	eyes.eye_damage = max(eyes.eye_damage+amount, 0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -686,7 +686,7 @@
 	taste_description = "dull toxin"
 
 /datum/reagent/medicine/oculine/on_mob_life(mob/living/M)
-	var/obj/item/organ/eyes/eyes = M.getorganslot("eyes_sight")
+	var/obj/item/organ/eyes/eyes = M.getorganslot("eye_sight")
 	if (!eyes)
 		return
 	if(M.disabilities & BLIND)


### PR DESCRIPTION
:cl: XDTM
fix: Eyes can now be properly damaged.
/:cl:

IT'S EYE SIGHT NOT EYES SIGHT

WHY WASN'T IT NAMED EYES ANYWAY

HOW DID NOBODY NOTICE THAT EYES WERE IMMUNE TO DAMAGE

Fixes #29554
