### PR TITLE
Makes bIcon scale to 16x16 like byond chat output did

### DIFF
--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -180,11 +180,11 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 /proc/bicon(thing)
 	if (!thing)
 		return
-
+	var/static/list/bicon_cache = list()
 	if (isicon(thing))
 		var/icon/I = thing
 		var/icon_md5 = md5(I)
-		if (!bicon_cache[I]) // Doesn't exist yet, make it.
+		if (!bicon_cache[icon_md5]) // Doesn't exist yet, make it.
 			I = icon(I) //copy it
 			I.Scale(16,16) //scale it
 			bicon_cache[icon_md5] = icon2base64(thing) //base64 it
@@ -194,7 +194,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	var/atom/A = thing
 	var/key = "[istype(A.icon, /icon) ? "\ref[A.icon]" : A.icon]:[A.icon_state]"
 
-	var/static/list/bicon_cache = list()
+
 	if (!bicon_cache[key]) // Doesn't exist, make it.
 		var/icon/I = icon(A.icon, A.icon_state, SOUTH, 1)
 		I.Scale(16,16)

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -182,11 +182,13 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 		return
 
 	if (isicon(thing))
-		//Icons get pooled constantly, references are no good here.
-		/*if (!bicon_cache["\ref[obj]"]) // Doesn't exist yet, make it.
-			bicon_cache["\ref[obj]"] = icon2base64(obj)
-		return "<img class='icon misc' src='data:image/png;base64,[bicon_cache["\ref[obj]"]]'>"*/
-		return "<img class='icon misc' src='data:image/png;base64,[icon2base64(thing)]'>"
+		var/icon/I = thing
+		var/icon_md5 = md5(I)
+		if (!bicon_cache[I]) // Doesn't exist yet, make it.
+			I = icon(I) //copy it
+			I.Scale(16,16) //scale it
+			bicon_cache[icon_md5] = icon2base64(thing) //base64 it
+		return "<img class='icon misc' src='data:image/png;base64,[bicon_cache[icon_md5]]'>"
 
 	// Either an atom or somebody fucked up and is gonna get a runtime, which I'm fine with.
 	var/atom/A = thing
@@ -195,6 +197,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	var/static/list/bicon_cache = list()
 	if (!bicon_cache[key]) // Doesn't exist, make it.
 		var/icon/I = icon(A.icon, A.icon_state, SOUTH, 1)
+		I.Scale(16,16)
 		if (ishuman(thing)) // Shitty workaround for a BYOND issue.
 			var/icon/temp = I
 			I = icon()


### PR DESCRIPTION
There was lag and ddos issues because to_chat does certain find replace operations on the resulting string, so putting base64 encoded data of large images in these strings would be insanely and excessively costly.

This is basically banking on the assumption that md5 on a 480x480 image is less costly than 4 find/replaces and 2 html_encodes on the base64 of that 480x480 image.

If this doesn't work or we need larger icon support for some reason, I'll just move bIcon over to the asset cache system.
