### PR TITLE
Cyborgs grabbing ore works consistently

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -30,48 +30,39 @@
 			show_message = FALSE
 			break
 	var/obj/item/weapon/storage/bag/ore/OB
-	if(istype(loc, /turf/open/floor/plating/asteroid))
-		if(ishuman(AM))
-			var/mob/living/carbon/human/H = AM
-			for(var/thing in H.get_storage_slots())
-				if(istype(thing, /obj/item/weapon/storage/bag/ore))
-					OB = thing
-					break
-			for(var/thing in H.held_items)
-				if(istype(thing, /obj/item/weapon/storage/bag/ore))
-					OB = thing
-					break
-		else if(iscyborg(AM))
-			var/mob/living/silicon/robot/R = AM
-			for(var/thing in R.module_active)
-				if(istype(thing, /obj/item/weapon/storage/bag/ore))
-					OB = thing
-					break
-		if(OB)
-			var/obj/structure/ore_box/box
-			if(!OB.can_be_inserted(src, TRUE, AM))
-				if(!OB.spam_protection)
-					to_chat(AM, "<span class='warning'>Your [OB.name] is full and can't hold any more ore!</span>")
-					OB.spam_protection = TRUE
-					sleep(1)
-					OB.spam_protection = FALSE
+	if(ishuman(AM))
+		var/mob/living/carbon/human/H = AM
+		OB = locate(/obj/item/weapon/storage/bag/ore) in H.get_storage_slots()
+		if(!OB)
+			OB = locate(/obj/item/weapon/storage/bag/ore) in H.held_items
+	else if(iscyborg(AM))
+		var/mob/living/silicon/robot/R = AM
+		OB = locate(/obj/item/weapon/storage/bag/ore) in R.held_items
+	if(OB)
+		var/obj/structure/ore_box/box
+		if(!OB.can_be_inserted(src, TRUE, AM))
+			if(!OB.spam_protection)
+				to_chat(AM, "<span class='warning'>Your [OB.name] is full and can't hold any more ore!</span>")
+				OB.spam_protection = TRUE
+				sleep(1)
+				OB.spam_protection = FALSE
+		else
+			OB.handle_item_insertion(src, TRUE, AM)
+		// Then, if the user is dragging an ore box, empty the satchel
+		// into the box.
+		var/mob/living/L = AM
+		if(istype(L.pulling, /obj/structure/ore_box))
+			box = L.pulling
+			for(var/obj/item/weapon/ore/O in OB)
+				OB.remove_from_storage(src, box)
+		if(show_message)
+			playsound(L, "rustle", 50, TRUE)
+			if(box)
+				L.visible_message("<span class='notice'>[L] offloads the ores into [box].</span>", \
+				"<span class='notice'>You offload the ores beneath you into your [box.name].</span>")
 			else
-				OB.handle_item_insertion(src, TRUE, AM)
-			// Then, if the user is dragging an ore box, empty the satchel
-			// into the box.
-			var/mob/living/L = AM
-			if(istype(L.pulling, /obj/structure/ore_box))
-				box = L.pulling
-				for(var/obj/item/weapon/ore/O in OB)
-					OB.remove_from_storage(src, box)
-			if(show_message)
-				playsound(L, "rustle", 50, TRUE)
-				if(box)
-					L.visible_message("<span class='notice'>[L] offloads the ores into [box].</span>", \
-					"<span class='notice'>You offload the ores beneath you into your [box.name].</span>")
-				else
-					L.visible_message("<span class='notice'>[L] scoops up the ores beneath them.</span>", \
-					"<span class='notice'>You scoop up the ores beneath you with your [OB.name].</span>")
+				L.visible_message("<span class='notice'>[L] scoops up the ores beneath them.</span>", \
+				"<span class='notice'>You scoop up the ores beneath you with your [OB.name].</span>")
 	return ..()
 
 /obj/item/weapon/ore/uranium

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -615,29 +615,6 @@
 		add_overlay(head_overlay)
 	update_fire()
 
-#define BORG_CAMERA_BUFFER 30
-
-/mob/living/silicon/robot/proc/do_camera_update(oldLoc)
-	if(oldLoc != src.loc)
-		GLOB.cameranet.updatePortableCamera(src.camera)
-	updating = 0
-
-/mob/living/silicon/robot/Move(a, b, flag)
-	var/oldLoc = src.loc
-	. = ..()
-	if(.)
-		if(src.camera)
-			if(!updating)
-				updating = 1
-				addtimer(CALLBACK(src, .proc/do_camera_update, oldLoc), BORG_CAMERA_BUFFER)
-	if(module)
-		if(istype(module, /obj/item/weapon/robot_module/miner))
-			if(istype(loc, /turf/open/floor/plating/asteroid))
-				for(var/obj/item/I in held_items)
-					if(istype(I, /obj/item/weapon/storage/bag/ore))
-						loc.attackby(I, src)
-#undef BORG_CAMERA_BUFFER
-
 /mob/living/silicon/robot/proc/self_destruct()
 	if(emagged)
 		if(mmi)

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -4,7 +4,7 @@
 
 /mob/living/silicon/robot/forceMove(atom/destination)
 	. = ..()
-	update_camera_location(oldLoc)
+	update_camera_location(destination)
 
 /mob/living/silicon/robot/proc/do_camera_update(oldLoc)
 	if(!QDELETED(camera) && oldLoc != get_turf(src))

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -1,3 +1,24 @@
+/mob/living/silicon/robot/Moved(oldLoc, dir)
+	. = ..()
+	update_camera_location(oldLoc)
+
+/mob/living/silicon/robot/forceMove(atom/destination)
+	. = ..()
+	update_camera_location(oldLoc)
+
+/mob/living/silicon/robot/proc/do_camera_update(oldLoc)
+	if(!QDELETED(camera) && oldLoc != get_turf(src))
+		GLOB.cameranet.updatePortableCamera(camera)
+	updating = FALSE
+
+#define BORG_CAMERA_BUFFER 30
+/mob/living/silicon/robot/proc/update_camera_location(oldLoc)
+	oldLoc = get_turf(oldLoc)
+	if(!QDELETED(camera) && !updating && oldLoc != get_turf(src))
+		updating = TRUE
+		addtimer(CALLBACK(src, .proc/do_camera_update, oldLoc), BORG_CAMERA_BUFFER)
+#undef BORG_CAMERA_BUFFER
+
 /mob/living/silicon/robot/Process_Spacemove(movement_dir = 0)
 	if(ionpulse())
 		return 1


### PR DESCRIPTION
The bit in `robot/Move()` where they tried to grab ore is Gone, since it's covered by normal ore crossing.
Also, crossing ore always tries to pick it up, even if not on an asteroid turf, because that isn't actually a reliable check for if you want to pick up ore.
Also also, I replaced the for loops that had breaks in `ore/Crossed()` with locates, since they should be either the same speed or faster.
Also, also also, borg camera updates on moving happen even if the move was a teleport.

~~TODO when I get up in the morning: try to make the stuff in `ore/Crossed()` only trigger on the first ore crossed since stacks of ore can be pretty, um, huge.~~