### PR TITLE
Fixes noncultists being able to out literally everyone from bloodcult with a single item

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -388,7 +388,10 @@
 /obj/item/device/flashlight/flare/culttorch/afterattack(atom/movable/A, mob/user, proximity)
 	if(!proximity)
 		return
-
+	if(!iscultist(user))
+		to_chat(user, "That doesn't seem to do anything useful.")
+		return
+		
 	if(istype(A, /obj/item))
 
 		var/list/cultists = list()


### PR DESCRIPTION
I'm considering this a game-breaking exploit hence why I'm pring it against the mighty winter storm!

A device meant to aid cultists should not also be a way to out every single cultist that exists without them ever really knowing, including the ones who haven't actually culted the entire round. 

Fixes #29594