### PR TITLE
Removes spaces to underline from add_details

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -259,7 +259,6 @@ SUBSYSTEM_DEF(blackbox)
 
 /datum/feedback_variable/proc/add_details(text)
 	if (istext(text))
-		text = replacetext(text, " ", "_")
 		if (!details)
 			details = text
 		else


### PR DESCRIPTION
It's unclear why this line exists; I did a quick check around the usages of this proc and nothing indicated to me a reason.

Meanwhile this causes feedback like https://atlantaned.space/newSS13tools/round.php?stat=shuttle_reason&round=74062
https://atlantaned.space/newSS13tools/stats/monthlyStats.php?year=2017&month=06&stat=admin_verb
https://atlantaned.space/newSS13tools/stats/monthlyStats.php?year=2017&month=06&stat=preferences_verb

@nfreader