### PR TITLE
Fixes the fruity pebbles in the code

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -59,7 +59,7 @@
 	if(config.sql_enabled)
 		if(SSdbcore.Connect())
 			log_world("Database connection established.")
-			var/datum/DBQuery/query_db_version = SSdbcore.NewQuery("SELECT major, minor FROM [format_table_name("schema_version")] ORDER BY date DESC LIMIT 1")
+			var/datum/DBQuery/query_db_version = SSdbcore.NewQuery("SELECT major, minor FROM [format_table_name("schema_revision")] ORDER BY date DESC LIMIT 1")
 			query_db_version.Execute()
 			if(query_db_version.NextRow())
 				var/db_major = query_db_version.item[1]


### PR DESCRIPTION
@optimumtact named the versioning table `schema_revision` but was trying to access `schema_version`

This changes the query to use `schema_revision` instead of `schema_version`