### PR TITLE
fixes astar and windoors

### DIFF
--- a/code/__HELPERS/AStar.dm
+++ b/code/__HELPERS/AStar.dm
@@ -175,6 +175,9 @@ Actual Adjacent procs :
 	for(var/obj/structure/window/W in src)
 		if(!W.CanAStarPass(ID, adir))
 			return 1
+	for(var/obj/machinery/door/window/W in src)
+		if(!W.CanAStarPass(ID, adir))
+			return 1
 	for(var/obj/O in T)
 		if(!O.CanAStarPass(ID, rdir, caller))
 			return 1


### PR DESCRIPTION
Astar wasn't checking windoors on the from turf.

See, now, with interfaces, I could just do for (var/interface/borderblocker in src) and avoid having to do two loops. #wewantinterfaces

This bug would also exist with border firedoors, but they aren't in use, so i'll skip that.

fixes #22631 