### PR TITLE
Clock powerdrain now works on any device with a powercell

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_helpers/clock_powerdrain.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/clock_powerdrain.dm
@@ -1,5 +1,8 @@
 //horrifying power drain proc made for clockcult's power drain in lieu of six istypes or six for(x in view) loops
 /atom/movable/proc/power_drain(clockcult_user)
+	var/obj/item/weapon/stock_pars/cell/cell = get_cell()
+	if(cell)
+		return cell.power_drain(clockcult_user)
 	return 0
 
 /obj/machinery/power/apc/power_drain(clockcult_user)

--- a/code/game/gamemodes/clock_cult/clock_helpers/clock_powerdrain.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/clock_powerdrain.dm
@@ -1,6 +1,6 @@
 //horrifying power drain proc made for clockcult's power drain in lieu of six istypes or six for(x in view) loops
 /atom/movable/proc/power_drain(clockcult_user)
-	var/obj/item/weapon/stock_pars/cell/cell = get_cell()
+	var/obj/item/weapon/stock_parts/cell/cell = get_cell()
 	if(cell)
 		return cell.power_drain(clockcult_user)
 	return 0

--- a/code/game/gamemodes/clock_cult/clock_helpers/clock_powerdrain.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/clock_powerdrain.dm
@@ -5,6 +5,9 @@
 		return cell.power_drain(clockcult_user)
 	return 0
 
+/obj/item/weapon/melee/baton/power_drain(clockcult_user)	//balance memes
+	return 0
+
 /obj/item/weapon/gun/power_drain(clockcult_user)	//balance memes
 	return 0
 

--- a/code/game/gamemodes/clock_cult/clock_helpers/clock_powerdrain.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/clock_powerdrain.dm
@@ -5,6 +5,9 @@
 		return cell.power_drain(clockcult_user)
 	return 0
 
+/obj/item/weapon/gun/power_drain(clockcult_user)	//balance memes
+	return 0
+
 /obj/machinery/power/apc/power_drain(clockcult_user)
 	if(cell && cell.charge)
 		playsound(src, "sparks", 50, 1)


### PR DESCRIPTION
Small oversight from the get_cell refactor methinks