### PR TITLE
Fixes unintended corgi equips.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -483,6 +483,7 @@ BLIND     // can't see anything
 	equip_delay_other = 50
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	resistance_flags = 0
+	dog_fashion = null
 
 /obj/item/clothing/suit/space
 	name = "space suit"


### PR DESCRIPTION
:cl: Galactic Corgi Breeding Mills, LLC
fix: Fixed corgis being able to wear spacesuit helmets despite lacking the proper code and sprites for them.
/:cl:

It seems someone forgot to set the dog_fashion for spacesuit helmets to null, so Ian could be equipped with any kind of spacesuit helmet, but it would simply not show up on his sprite and apply the normal security helmet wearing corgi naming scheme as opposed to an actual spacesuit helmet wearing corgi naming scheme. So now #29296 is fixed, and everything is better forever.