### PR TITLE
Tweaked SM overlay

### DIFF
--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -128,13 +128,13 @@
 /obj/effect/countdown/supermatter
 	name = "supermatter damage"
 	text_size = 1
-	color = "#ED84F4"
+	color = "#00ff80"
 
 /obj/effect/countdown/supermatter/get_value()
 	var/obj/machinery/power/supermatter_shard/S = attached_to
 	if(!istype(S))
 		return
-	return "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'>[round((S.damage / S.explosion_point) * 100)]</div>"
+	return "<div align='center' valign='middle' style='position:relative; top:0px; left:0px'>[round(S.get_integrity(), 1)]%</div>"
 
 /obj/effect/countdown/transformer
 	name = "transformer countdown"


### PR DESCRIPTION
Made the font a color that you can actually read over a plasma fire.

Also switched it to report the current integrity value as opposed to current failure percentage.

![image](https://user-images.githubusercontent.com/6209658/28893759-a0f8ea70-77a0-11e7-8ee6-79ba661e9eb3.png)

