### PR TITLE
Enables goonchat restart notification

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -40,9 +40,15 @@ SUBSYSTEM_DEF(server_maint)
 
 /datum/controller/subsystem/server_maint/Shutdown()
 	kick_clients_in_lobby("<span class='boldannounce'>The round came to an end with you in the lobby.</span>", TRUE) //second parameter ensures only afk clients are kicked
+	var/server = config.server
 	for(var/thing in GLOB.clients)
+		if(!thing)
+			continue
 		var/client/C = thing
-		if(C && config.server)	//if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
-			C << link("byond://[config.server]")
+		var/datum/chatOutput/co = C.chatOutput
+		if(co)
+			co.ehjax_send(data = "roundrestart")
+		if(server)	//if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
+			C << link("byond://[server]")
 
 #undef PING_BUFFER_TIME


### PR DESCRIPTION
Seems we missed this in the original port: https://github.com/tgstation/tgstation/blob/master/code/modules/goonchat/browserassets/js/browserOutput.js#L389