### PR TITLE
Changed APC areastring to use paths, fixes rad squares in maint tunnels

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11785,7 +11785,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Primary Tool Storage APC";
-	areastring = "/turf/open/floor/plating";
+	areastring = "/area/storage/primary";
 	pixel_x = 1;
 	pixel_y = -24
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -3604,7 +3604,7 @@
 "ahO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
-/area/security/main)
+/area/maintenance/fore/secondary)
 "ahP" = (
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -5456,7 +5456,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/security/courtroom)
+/area/maintenance/fore/secondary)
 "alM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -6764,7 +6764,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/area/maintenance/fore/secondary)
 "aoJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -7347,7 +7347,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/dorms)
+/area/maintenance/fore/secondary)
 "aql" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -7635,7 +7635,7 @@
 	d2 = 2
 	},
 /turf/open/floor/plating,
-/area/security/processing)
+/area/maintenance/fore)
 "aqU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8191,7 +8191,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/lawoffice)
+/area/maintenance/fore)
 "asp" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -9298,7 +9298,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/plating,
-/area/security/vacantoffice/b)
+/area/maintenance/fore)
 "avi" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -11363,7 +11363,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
+/area/maintenance/fore)
 "azR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11516,7 +11516,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/security/checkpoint/checkpoint2)
+/area/maintenance/port/fore)
 "aAk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11660,7 +11660,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/maintenance/port/fore)
 "aAx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -11797,7 +11797,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/storage/primary)
+/area/maintenance/port/fore)
 "aAM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11984,7 +11984,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/gateway)
+/area/maintenance/fore)
 "aBj" = (
 /obj/structure/rack{
 	dir = 8;
@@ -12014,7 +12014,7 @@
 	req_access_txt = "1"
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/checkpoint2)
+/area/maintenance/port/fore)
 "aBm" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13227,7 +13227,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/theatre)
+/area/maintenance/starboard/fore)
 "aEc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -13291,7 +13291,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/chapel/main)
+/area/maintenance/starboard/fore)
 "aEh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14412,7 +14412,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/library)
+/area/maintenance/starboard/fore)
 "aGH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14497,7 +14497,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/chapel/office)
+/area/maintenance/starboard/fore)
 "aGN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -14997,7 +14997,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/crew_quarters/bar)
+/area/maintenance/starboard/fore)
 "aHT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -15074,7 +15074,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/theatre)
+/area/maintenance/starboard/fore)
 "aIc" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -15087,7 +15087,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/bar)
+/area/maintenance/starboard/fore)
 "aId" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -15140,7 +15140,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/kitchen)
+/area/maintenance/starboard/fore)
 "aIi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15223,7 +15223,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/hydroponics)
+/area/maintenance/starboard/fore)
 "aIo" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -15718,7 +15718,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/crew_quarters/kitchen)
+/area/maintenance/starboard/fore)
 "aJB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -15727,7 +15727,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/hydroponics)
+/area/maintenance/starboard/fore)
 "aJC" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -15993,7 +15993,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/construction/mining/aux_base)
+/area/maintenance/port/fore)
 "aKg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/blue,
@@ -18862,7 +18862,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/library)
+/area/maintenance/starboard/fore)
 "aRL" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Holding Area";
@@ -20678,7 +20678,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/storage/art)
+/area/maintenance/port)
 "aWx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -20714,7 +20714,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/storage/emergency/port)
+/area/maintenance/port)
 "aWA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22515,7 +22515,7 @@
 	d2 = 2
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/toilet/locker)
+/area/maintenance/port)
 "baN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -22860,7 +22860,7 @@
 	d2 = 4
 	},
 /turf/open/floor/plating,
-/area/security/vacantoffice)
+/area/maintenance/port)
 "bbJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -22939,7 +22939,7 @@
 	req_access_txt = "4"
 	},
 /turf/open/floor/plating,
-/area/security/detectives_office)
+/area/maintenance/port)
 "bbV" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -24263,7 +24263,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/locker)
+/area/maintenance/port)
 "bfd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -24335,7 +24335,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
-/area/quartermaster/storage)
+/area/maintenance/port)
 "bfl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -24704,7 +24704,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/science/robotics/mechbay)
+/area/maintenance/aft)
 "bgp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
@@ -26631,7 +26631,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/quartermaster/storage)
+/area/maintenance/port)
 "bkH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26805,7 +26805,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/bridge/meeting_room)
+/area/maintenance/central)
 "bkY" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable{
@@ -26905,7 +26905,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/medical/morgue)
+/area/maintenance/aft)
 "blh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -26983,7 +26983,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/storage/emergency/starboard)
+/area/maintenance/aft)
 "blp" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -29859,7 +29859,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/science/explab)
+/area/maintenance/starboard)
 "brz" = (
 /obj/structure/table,
 /obj/item/weapon/pen,
@@ -33898,7 +33898,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/area/maintenance/port/aft)
 "bAo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33923,7 +33923,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/supply)
+/area/maintenance/port/aft)
 "bAp" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/light{
@@ -34982,7 +34982,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/medical/sleeper)
+/area/maintenance/aft)
 "bCC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -35409,7 +35409,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/medical/sleeper)
+/area/maintenance/aft)
 "bDB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -36192,7 +36192,7 @@
 	d2 = 2
 	},
 /turf/open/floor/plating,
-/area/janitor)
+/area/maintenance/aft)
 "bFm" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -36244,7 +36244,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/janitor)
+/area/maintenance/aft)
 "bFt" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window,
@@ -37678,7 +37678,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/maintenance/aft)
 "bIt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38816,7 +38816,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/medical/medbay/central)
+/area/maintenance/aft)
 "bKL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -38907,7 +38907,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/heads/cmo)
+/area/maintenance/aft)
 "bKT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -39319,7 +39319,7 @@
 	req_access_txt = "24"
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/maintenance/aft)
 "bLP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -39429,7 +39429,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/medical/medbay/central)
+/area/maintenance/aft)
 "bMd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43111,7 +43111,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/construction)
+/area/maintenance/port/aft)
 "bUB" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -43127,7 +43127,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/tcommsat/computer)
+/area/maintenance/port/aft)
 "bUC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -46505,7 +46505,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/construction)
+/area/maintenance/port/aft)
 "ccf" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/plasteel/black/telecomms/mainframe,
@@ -47892,7 +47892,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/science/misc_lab)
+/area/maintenance/starboard/aft)
 "cfu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -47969,7 +47969,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/maintenance/port/aft)
 "cfE" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/neutral{
@@ -48131,7 +48131,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
+/area/maintenance/aft)
 "cfY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57477,7 +57477,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
+/area/maintenance/central)
 "cAH" = (
 /obj/machinery/processor,
 /turf/open/floor/plating,
@@ -57533,7 +57533,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/main)
+/area/maintenance/fore/secondary)
 "cAO" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -58204,7 +58204,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/detectives_office)
+/area/maintenance/port)
 "cCo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -96755,7 +96755,7 @@ aJv
 bzs
 bFp
 bGJ
-bHZ
+bHX
 bJA
 bKG
 bLK
@@ -98049,7 +98049,7 @@ bOc
 bPe
 bQu
 bRE
-bSL
+bSJ
 bPe
 bOd
 cCB
@@ -98306,7 +98306,7 @@ bOd
 bPg
 bQx
 bRH
-bSO
+bSM
 bTU
 bUS
 bUS
@@ -98322,7 +98322,7 @@ cez
 cez
 cfQ
 chd
-ciw
+bQy
 cpP
 ckc
 clb
@@ -98820,7 +98820,7 @@ bOg
 bPi
 bQz
 bRJ
-bSO
+bSM
 bTV
 bUT
 bWc
@@ -101910,7 +101910,7 @@ bKH
 bzs
 bAw
 bBR
-bHZ
+bHX
 bzs
 bzs
 bzs
@@ -102167,7 +102167,7 @@ bKH
 bzs
 bAw
 bXZ
-bHZ
+bHX
 bZN
 caK
 bzs

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -856,6 +856,7 @@
 /obj/machinery/power/apc{
 	cell_type = 5000;
 	dir = 4;
+	areastring = "/area/ai_monitored/security/armory";
 	name = "Armory APC";
 	pixel_x = 24
 	},
@@ -1580,6 +1581,7 @@
 "adN" = (
 /obj/machinery/power/apc{
 	dir = 8;
+	areastring = "/area/crew_quarters/heads/hos";
 	name = "Head of Security's Office APC";
 	pixel_x = -24
 	},
@@ -1909,6 +1911,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Prison Wing APC";
+	areastring = "/area/security/prison";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -2739,6 +2742,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Prisoner Transfer Centre";
+	areastring = "/area/security/transfer";
 	pixel_y = -27
 	},
 /turf/open/floor/plasteel/black,
@@ -3320,6 +3324,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Brig Control APC";
+	areastring = "/area/security/warden";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -3582,6 +3587,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Security Office APC";
+	areastring = "/area/security/main";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -4367,6 +4373,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Brig APC";
+	areastring = "/area/security/brig";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -5440,6 +5447,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Courtroom APC";
+	areastring = "/area/security/courtroom";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -6081,6 +6089,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Port Bow Solar APC";
+	areastring = "/area/maintenance/solars/port/fore";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -6746,6 +6755,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Fitness Room APC";
+	areastring = "/area/crew_quarters/fitness";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -6976,6 +6986,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Fore Maintenance APC";
+	areastring = "/area/maintenance/fore/secondary";
 	pixel_y = 24
 	},
 /obj/structure/disposalpipe/segment{
@@ -7086,6 +7097,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Bow Solar APC";
+	areastring = "/area/maintenance/solars/starboard/fore";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -7324,6 +7336,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Dormitory APC";
+	areastring = "/area/crew_quarters/dorms";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -7581,6 +7594,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Bow Maintenance APC";
+	areastring = "/area/maintenance/port/fore";
 	pixel_x = -1;
 	pixel_y = 26
 	},
@@ -7612,6 +7626,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Labor Shuttle Dock APC";
+	areastring = "/area/security/processing";
 	pixel_x = -24
 	},
 /obj/structure/cable,
@@ -7802,6 +7817,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Starboard Bow Maintenance APC";
+	areastring = "/area/maintenance/starboard/fore";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -9278,6 +9294,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Vacant Office B APC";
+	areastring = "/area/security/vacantoffice/b";
 	pixel_x = -24
 	},
 /turf/open/floor/plating,
@@ -9286,6 +9303,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Law Office APC";
+	areastring = "/area/lawoffice";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -9517,6 +9535,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Electrical Maintenance APC";
+	areastring = "/area/maintenance/department/electrical";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -9662,6 +9681,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Fore Maintenance APC";
+	areastring = "/area/maintenance/fore";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -10909,6 +10929,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "EVA Storage APC";
+	areastring = "/area/ai_monitored/storage/eva";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -11488,6 +11509,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Security Checkpoint APC";
+	areastring = "/area/security/checkpoint/checkpoint2";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -11629,6 +11651,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Garden APC";
+	areastring = "/area/hydroponics/garden";
 	pixel_x = 27;
 	pixel_y = 2
 	},
@@ -11762,6 +11785,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Primary Tool Storage APC";
+	areastring = "/turf/open/floor/plating";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -11948,6 +11972,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Gateway APC";
+	areastring = "/area/gateway";
 	pixel_x = -24;
 	pixel_y = -1
 	},
@@ -12238,6 +12263,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Vault APC";
+	areastring = "/area/ai_monitored/nuke_storage";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -13257,6 +13283,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Chapel APC";
+	areastring = "/area/chapel/main";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -13385,6 +13412,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Entry Hall APC";
+	areastring = "/area/hallway/secondary/entry";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -13706,6 +13734,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Dormitory Bathrooms APC";
+	areastring = "/area/crew_quarters/toilet";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13839,6 +13868,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Chapel Office APC";
+	areastring = "/area/chapel/office";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -15036,6 +15066,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Theatre APC";
+	areastring = "/area/crew_quarters/theatre";
 	pixel_x = -25
 	},
 /obj/structure/cable,
@@ -15048,6 +15079,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Bar APC";
+	areastring = "/area/crew_quarters/bar";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -15100,6 +15132,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Kitchen APC";
+	areastring = "/area/crew_quarters/kitchen";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -15179,6 +15212,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Hydroponics APC";
+	areastring = "/area/hydroponics";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -15947,6 +15981,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Auxillary Base Construction APC";
+	areastring = "/area/construction/mining/aux_base";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -16547,6 +16582,7 @@
 	},
 /obj/machinery/power/apc{
 	name = "Port Hall APC";
+	areastring = "/area/hallway/primary/port";
 	dir = 1;
 	pixel_y = 26
 	},
@@ -18820,6 +18856,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Library APC";
+	areastring = "/area/library";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -18892,6 +18929,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Auxiliary Tool Storage APC";
+	areastring = "/area/storage/tools";
 	pixel_y = 24
 	},
 /obj/machinery/firealarm{
@@ -20045,6 +20083,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Fore Primary Hallway APC";
+	areastring = "/area/hallway/primary/fore";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -20623,6 +20662,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Art Storage";
+	areastring = "/area/storage/art";
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20661,6 +20701,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Emergency Storage APC";
+	areastring = "/area/storage/emergency/port";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -20887,7 +20928,7 @@
 /area/bridge)
 "aWV" = (
 /obj/machinery/turretid{
-	control_area = "AI Upload Chamber";
+	control_area = "/area/ai_monitored/turret_protected/ai_upload";
 	name = "AI Upload turret control";
 	pixel_y = -25
 	},
@@ -20907,6 +20948,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Bridge APC";
+	areastring = "/area/bridge";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -21381,6 +21423,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Port Maintenance APC";
+	areastring = "/area/maintenance/port";
 	pixel_x = -27;
 	pixel_y = 2
 	},
@@ -21661,6 +21704,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Central Hall APC";
+	areastring = "/area/hallway/primary/central";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -22385,6 +22429,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Escape Hallway APC";
+	areastring = "/area/hallway/secondary/exit";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -22461,6 +22506,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Locker Restrooms APC";
+	areastring = "/area/crew_quarters/toilet/locker";
 	pixel_x = 27;
 	pixel_y = 2
 	},
@@ -22703,6 +22749,7 @@
 	cell_type = 2500;
 	dir = 1;
 	name = "Captain's Office APC";
+	areastring = "/area/crew_quarters/heads/captain";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -22805,6 +22852,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Vacant Office APC";
+	areastring = "/area/security/vacantoffice";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -23669,6 +23717,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Disposal APC";
+	areastring = "/area/maintenance/disposal";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -23758,6 +23807,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Upload APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -24202,6 +24252,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Locker Room APC";
+	areastring = "/area/crew_quarters/locker";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -24270,6 +24321,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Cargo Bay APC";
+	areastring = "/area/quartermaster/storage";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -24467,6 +24519,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Starboard Primary Hallway APC";
+	areastring = "/area/hallway/primary/starboard";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -24642,6 +24695,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Mech Bay APC";
+	areastring = "/area/science/robotics/mechbay";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -24927,6 +24981,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Chemistry APC";
+	areastring = "/area/medical/chemistry";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -25052,6 +25107,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Morgue APC";
+	areastring = "/area/medical/morgue";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -26084,6 +26140,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Bridge Maintenance APC";
+	areastring = "/area/maintenance/department/bridge";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -26740,6 +26797,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Conference Room APC";
+	areastring = "/area/bridge/meeting_room";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -26914,6 +26972,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Starboard Emergency Storage APC";
+	areastring = "/area/storage/emergency/starboard";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -26929,6 +26988,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medbay Security APC";
+	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -27816,6 +27876,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Research Lab APC";
+	areastring = "/area/science/lab";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -28342,6 +28403,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Robotics Lab APC";
+	areastring = "/area/science/robotics/lab";
 	pixel_x = -25
 	},
 /obj/structure/cable,
@@ -28923,6 +28985,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Genetics APC";
+	areastring = "/area/medical/genetics";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -29325,6 +29388,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Gravity Generator APC";
+	areastring = "/area/engine/gravity_generator";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -30373,6 +30437,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Experimentation Lab APC";
+	areastring = "/area/science/explab";
 	pixel_x = 26
 	},
 /obj/structure/cable,
@@ -30800,6 +30865,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Teleporter APC";
+	areastring = "/area/teleporter";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -30982,6 +31048,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Cargo Office APC";
+	areastring = "/area/quartermaster/office";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -33068,6 +33135,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Quartermaster APC";
+	areastring = "/area/quartermaster/qm";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -33107,6 +33175,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mining Dock APC";
+	areastring = "/area/quartermaster/miningdock";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -33485,6 +33554,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Server Room APC";
+	areastring = "/area/science/server";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -33841,6 +33911,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Cargo Security APC";
+	areastring = "/area/security/checkpoint/supply";
 	pixel_x = 1;
 	pixel_y = 24
 	},
@@ -34654,6 +34725,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Science Security APC";
+	areastring = "/area/security/checkpoint/science";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -34704,6 +34776,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "RD Office APC";
+	areastring = "/area/crew_quarters/heads/hor";
 	pixel_x = -25
 	},
 /obj/structure/cable,
@@ -35304,6 +35377,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Tech Storage APC";
+	areastring = "/area/storage/tech";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -35323,6 +35397,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Treatment Center APC";
+	areastring = "/area/medical/sleeper";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -35672,6 +35747,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Misc Research APC";
+	areastring = "/area/science/research";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -36108,6 +36184,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Custodial Closet APC";
+	areastring = "/area/janitor";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -36923,6 +37000,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Toxins Storage APC";
+	areastring = "/area/science/storage";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -37303,6 +37381,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Aft Maintenance APC";
+	areastring = "/area/maintenance/aft";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -38414,6 +38493,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Toxins Lab APC";
+	areastring = "/area/science/mixing";
 	pixel_x = 26
 	},
 /obj/structure/cable,
@@ -38731,6 +38811,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Medbay APC";
+	areastring = "/area/medical/medbay/central";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -38815,6 +38896,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "CM Office APC";
+	areastring = "/area/crew_quarters/heads/cmo";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -39175,6 +39257,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Delivery Office APC";
+	areastring = "/area/quartermaster/sorting";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -39398,6 +39481,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Xenobiology APC";
+	areastring = "/area/science/xenobiology";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -40502,6 +40586,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Engineering Security APC";
+	areastring = "/area/security/checkpoint/engineering";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -42280,6 +42365,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Virology APC";
+	areastring = "/area/medical/virology";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -42618,6 +42704,7 @@
 "bTJ" = (
 /obj/machinery/power/apc{
 	name = "Aft Hall APC";
+	areastring = "/area/hallway/primary/aft";
 	dir = 8;
 	pixel_x = -25;
 	pixel_y = 1
@@ -43013,6 +43100,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Construction Area APC";
+	areastring = "/area/construction";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -43028,6 +43116,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Telecomms Monitoring APC";
+	areastring = "/area/tcommsat/computer";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -43859,6 +43948,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Telecomms Server APC";
+	areastring = "/area/tcommsat/server";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -45175,6 +45265,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Atmospherics APC";
+	areastring = "/area/engine/atmos";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -45903,6 +45994,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Testing Lab APC";
+	areastring = "/area/science/misc_lab";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -46013,6 +46105,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "CE Office APC";
+	areastring = "/area/crew_quarters/heads/chief";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -46076,6 +46169,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Engineering Foyer APC";
+	areastring = "/area/engine/break_room";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -46960,6 +47054,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Quarter Maintenance APC";
+	areastring = "/area/maintenance/starboard/aft";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -47226,6 +47321,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Port Quarter Maintenance APC";
+	areastring = "/area/maintenance/port/aft";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -48029,6 +48125,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Incinerator APC";
+	areastring = "/area/maintenance/disposal/incinerator";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -49063,6 +49160,7 @@
 	cell_type = 15000;
 	dir = 1;
 	name = "Engineering APC";
+	areastring = "/area/engine/engineering";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -49100,6 +49198,7 @@
 	cell_type = 15000;
 	dir = 1;
 	name = "Engineering APC";
+	areastring = "/area/engine/engineering";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -49427,6 +49526,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Port Quarter Solar APC";
+	areastring = "/area/maintenance/solars/port/aft";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -50071,6 +50171,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Quarter Solar APC";
+	areastring = "/area/maintenance/solars/starboard/aft";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -52701,6 +52802,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "SMES room APC";
+	areastring = "/area/engine/engine_smes";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -54382,6 +54484,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "MiniSat Foyer APC";
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	pixel_x = 27
 	},
 /obj/structure/chair,
@@ -54847,6 +54950,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "MiniSat Atmospherics APC";
+	areastring = "/area/ai_monitored/turret_protected/aisat/atmos";
 	pixel_x = -27
 	},
 /obj/structure/cable{
@@ -54999,6 +55103,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "MiniSat Service Bay APC";
+	areastring = "/area/ai_monitored/turret_protected/aisat/service";
 	pixel_x = 27
 	},
 /obj/structure/cable{
@@ -55459,6 +55564,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "MiniSat Chamber Hallway APC";
+	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
 	pixel_x = 27
 	},
 /turf/open/floor/circuit,
@@ -55747,6 +55853,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "AI Chamber APC";
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = -24
 	},
 /obj/machinery/flasher{
@@ -57362,6 +57469,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Head of Personnel APC";
+	areastring = "/area/crew_quarters/heads/hop";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -58091,6 +58199,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Detective's Office APC";
+	areastring = "/area/security/detectives_office";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -62438,6 +62547,7 @@
 	cell_type = 2500;
 	dir = 1;
 	name = "Central Maintenance APC";
+	areastring = "/area/maintenance/central";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -62501,6 +62611,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Starboard Maintenance APC";
+	areastring = "/area/maintenance/starboard";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -63844,6 +63955,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Central Maintenance APC";
+	areastring = "/area/maintenance/central/secondary";
 	pixel_x = -24
 	},
 /obj/structure/cable{

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -54542,7 +54542,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cud" = (
 /obj/machinery/turretid{
-	control_area = null;
+	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
 	enabled = 1;
 	icon_state = "control_standby";
 	name = "Antechamber Turret Control";
@@ -54831,7 +54831,7 @@
 	start_active = 1
 	},
 /obj/machinery/turretid{
-	control_area = "AI Satellite Atmospherics";
+	control_area = "/area/ai_monitored/turret_protected/aisat/atmos";
 	enabled = 1;
 	icon_state = "control_standby";
 	name = "Atmospherics Turret Control";
@@ -54856,7 +54856,7 @@
 	dir = 4
 	},
 /obj/machinery/turretid{
-	control_area = "AI Satellite Service";
+	control_area = "/area/ai_monitored/turret_protected/aisat/service";
 	enabled = 1;
 	icon_state = "control_standby";
 	name = "Service Bay Turret Control";
@@ -55179,7 +55179,7 @@
 	dir = 4
 	},
 /obj/machinery/turretid{
-	control_area = "AI Satellite Hallway";
+	control_area = "/area/ai_monitored/turret_protected/aisat/hallway";
 	enabled = 1;
 	icon_state = "control_standby";
 	name = "Chamber Hallway Turret Control";

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -246,6 +246,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "AI Core APC";
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -697,6 +698,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Northern External Waste Belt APC";
+	areastring = "/area/maintenance/asteroid/disposal/north";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -1627,6 +1629,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Telecomms Server APC";
+	areastring = "/area/tcommsat/server";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -3872,6 +3875,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Telecomms Control Room APC";
+	areastring = "/area/tcommsat/computer";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -4415,6 +4419,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Prison Wing APC";
+	areastring = "/area/security/prison";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -6100,6 +6105,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "AI Asteroid Maintenance APC";
+	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -6439,6 +6445,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Captain's Private Quarters APC";
+	areastring = "/area/crew_quarters/heads/captain";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -6531,6 +6538,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Disposals APC";
+	areastring = "/area/quartermaster/sorting";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/asteroid/end,
@@ -7054,6 +7062,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Cargo APC";
+	areastring = "/area/quartermaster/office";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -7706,6 +7715,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Dorm APC";
+	areastring = "/area/crew_quarters/locker";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
@@ -9216,6 +9226,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Chief Engineer's Private Quarters APC";
+	areastring = "/area/crew_quarters/heads/chief/private";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -9636,6 +9647,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Female Sleeping Quarters APC";
+	areastring = "/area/crew_quarters/dorms/female";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -10355,6 +10367,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Cargo Warehouse APC";
+	areastring = "/area/quartermaster/storage";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -10585,6 +10598,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Security Equipment APC";
+	areastring = "/area/security/main";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -10775,6 +10789,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Male Sleeping Quarters APC";
+	areastring = "/area/crew_quarters/dorms/male";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -10808,6 +10823,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Chief Medical Officer's Private Quarters APC";
+	areastring = "/area/crew_quarters/heads/cmo/private";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -11668,6 +11684,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Vault APC";
+	areastring = "/area/security/courtroom";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -12042,6 +12059,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Fore Asteroid Maintenance APC";
+	areastring = "/area/maintenance/asteroid/fore/cargo_west";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -12456,6 +12474,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Fore Maintenance APC";
+	areastring = "/area/maintenance/asteroid/fore/com_north";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -12717,6 +12736,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Research Director's Private Quarters APC";
+	areastring = "/area/crew_quarters/heads/hor/private";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -13950,6 +13970,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mining Dock APC";
+	areastring = "/area/quartermaster/miningdock";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -14979,6 +15000,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Brig APC";
+	areastring = "/area/security/brig";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -15103,6 +15125,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Dorm Toilets APC";
+	areastring = "/area/crew_quarters/toilet";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -15198,6 +15221,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Head of Security's Personal Quarters APC";
+	areastring = "/area/crew_quarters/heads/hos/private";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -15220,6 +15244,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Bridge APC";
+	areastring = "/area/bridge";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -16164,6 +16189,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Head of Personnel's Office APC";
+	areastring = "/area/crew_quarters/heads/hop";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -16375,6 +16401,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Quartermaster's Private Quarters APC";
+	areastring = "/area/quartermaster/qm/private";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -16881,6 +16908,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Gravity Generator APC";
+	areastring = "/area/maintenance/asteroid/fore/cargo_west";
 	pixel_y = -24
 	},
 /turf/closed/mineral,
@@ -17549,6 +17577,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Cargo Security Checkpoint APC";
+	areastring = "/area/security/checkpoint/supply";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -17954,6 +17983,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Fore Asteroid Maintenance APC";
+	areastring = "/area/maintenance/asteroid/fore/com_east";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -18444,6 +18474,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Cargo Quantum Pad APC";
+	areastring = "/area/teleporter/quantum/cargo";
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/black{
@@ -19104,6 +19135,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Fore Maintenance West APC";
+	areastring = "/area/maintenance/asteroid/fore/com_west";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -19177,6 +19209,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Lawyer's Office APC";
+	areastring = "/area/lawoffice";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -19557,6 +19590,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Fore Asteroid Maintenance APC";
+	areastring = "/area/maintenance/asteroid/fore/cargo_south";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -20226,6 +20260,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Fore Asteroid Maintenance APC";
+	areastring = "/area/maintenance/asteroid/fore/com_west";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/end,
@@ -23357,6 +23392,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Command Asteroid Solars Maintenance APC";
+	areastring = "/area/maintenance/asteroid/fore/com_south";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -23866,6 +23902,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Security Quantum Pad APC";
+	areastring = "/area/teleporter/quantum/security";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -23910,6 +23947,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Custodial APC";
+	areastring = "/area/janitor";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -24165,6 +24203,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Vault APC";
+	areastring = "/area/ai_monitored/nuke_storage";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -24946,6 +24985,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Command Asteroid Solars APC";
+	areastring = "/area/maintenance/solars/asteroid/command";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -25415,6 +25455,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Fore Asteroid Solars APC";
+	areastring = "/area/maintenance/solars/asteroid/fore";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -27169,6 +27210,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Hallway APC";
+	areastring = "/area/hallway/primary/port";
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/cobweb,
@@ -27279,6 +27321,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Asteroid Maintenance APC";
+	areastring = "/area/maintenance/asteroid/port/neast";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -27475,6 +27518,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Bar APC";
+	areastring = "/area/crew_quarters/bar";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -27615,6 +27659,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Rehabilitation Dome APC";
+	areastring = "/area/crew_quarters/rehab_dome";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -27690,6 +27735,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Central Primary Hallway APC";
+	areastring = "/area/hallway/primary/central";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -27855,6 +27901,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Kitchen APC";
+	areastring = "/area/crew_quarters/kitchen";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -29525,6 +29572,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Hallway APC";
+	areastring = "/area/hallway/primary/starboard";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -30522,6 +30570,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "EVA APC";
+	areastring = "/area/ai_monitored/storage/eva";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -31231,6 +31280,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Surgery APC";
+	areastring = "/area/medical/surgery";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
@@ -33545,6 +33595,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Chief Medical Officer's Office APC";
+	areastring = "/area/crew_quarters/heads/cmo";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -35015,6 +35066,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Morgue APC";
+	areastring = "/area/medical/patients_rooms";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -37560,6 +37612,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medbay Security Checkpoint APC";
+	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -38629,6 +38682,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Primary Tool Storage APC";
+	areastring = "/area/storage/primary";
 	pixel_x = -24
 	},
 /obj/structure/cable/orange{
@@ -39128,6 +39182,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Central Asteroid Maintenance APC";
+	areastring = "/area/maintenance/asteroid/central";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -39431,6 +39486,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Virology APC";
+	areastring = "/area/medical/virology";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -40019,6 +40075,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medbay APC";
+	areastring = "/area/medical/medbay/central";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -40330,6 +40387,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Engineering Foyer APC";
+	areastring = "/area/engine/break_room";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -40528,6 +40586,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Engineering Foyer APC";
+	areastring = "/area/engine/break_room";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -41538,6 +41597,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Engineering Security Checkpoint APC";
+	areastring = "/area/security/checkpoint/engineering";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -41919,6 +41979,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Port Asteroid Maintenance APC";
+	areastring = "/area/maintenance/asteroid/port/east";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -43171,6 +43232,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Cloning Lab APC";
+	areastring = "/area/medical/genetics/cloning";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -43949,6 +44011,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Engineering APC";
+	areastring = "/area/engine/engineering";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -44469,6 +44532,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Atmospherics APC";
+	areastring = "/area/engine/atmos";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -45265,6 +45329,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Library APC";
+	areastring = "/area/library";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -47686,6 +47751,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Chemistry APC";
+	areastring = "/area/medical/chemistry";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -47948,6 +48014,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Fitness APC";
+	areastring = "/area/crew_quarters/fitness";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -48513,6 +48580,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Gravity Generator APC";
+	areastring = "/area/engine/gravity_generator";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -48982,6 +49050,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Lounge APC";
+	areastring = "/area/library/lounge";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -49290,6 +49359,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Genetics APC";
+	areastring = "/area/medical/genetics";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -49937,6 +50007,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Medbay Storage APC";
+	areastring = "/area/medical/medbay/zone2";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -50326,6 +50397,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Chief Engineer's Office APC";
+	areastring = "/area/crew_quarters/heads/chief";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -50441,6 +50513,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Engineering SMES Storage APC";
+	areastring = "/area/engine/engine_smes";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -52226,9 +52299,7 @@
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bTt" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -52237,17 +52308,13 @@
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bTu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bTv" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment,
@@ -52468,25 +52535,19 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bTU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bTV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bTW" = (
 /obj/structure/sink{
 	dir = 4;
@@ -52498,9 +52559,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bTX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -52819,9 +52878,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bUF" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -53083,6 +53140,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Fitness Bathroom APC";
+	areastring = "/area/crew_quarters/toilet/fitness";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -53097,9 +53155,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bVh" = (
 /obj/machinery/camera{
 	c_tag = "Fitness Bathrooms";
@@ -53115,9 +53171,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bVi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -53125,9 +53179,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bVj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating{
@@ -53386,9 +53438,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bVG" = (
 /obj/machinery/door/airlock{
 	id_tag = "fb1"
@@ -53397,9 +53447,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bVH" = (
 /obj/machinery/light/small,
 /obj/structure/toilet{
@@ -53415,9 +53463,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bVI" = (
 /turf/open/floor/engine{
 	baseturf = /turf/open/floor/plating/asteroid/airless;
@@ -53781,9 +53827,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bWC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -53792,9 +53836,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bWD" = (
 /obj/machinery/door/airlock{
 	id_tag = "fb2"
@@ -53805,9 +53847,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bWE" = (
 /obj/machinery/light/small,
 /obj/structure/toilet{
@@ -53822,9 +53862,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bWF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
@@ -53891,6 +53929,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Chapel APC";
+	areastring = "/area/chapel/main";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -54115,6 +54154,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Eastern External Waste Belt APC";
+	areastring = "/area/maintenance/asteroid/disposal/east";
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
@@ -54141,17 +54181,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bXm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bXn" = (
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Arena"
@@ -54327,17 +54363,13 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bXL" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bXM" = (
 /obj/machinery/shower{
 	dir = 8
@@ -54345,9 +54377,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bXN" = (
 /obj/machinery/computer/holodeck,
 /obj/effect/landmark/event_spawn,
@@ -54573,9 +54603,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bYo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -54583,9 +54611,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bYp" = (
 /obj/structure/table,
 /obj/item/weapon/paper/fluff/holodeck/disclaimer,
@@ -54736,18 +54762,14 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bYG" = (
 /obj/item/weapon/soap/nanotrasen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bYH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -54892,9 +54914,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bYX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -54902,9 +54922,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "bYY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -56014,6 +56032,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Gambler Den APC";
+	areastring = "/area/crew_quarters/abandoned_gambling_den";
 	pixel_y = -24
 	},
 /turf/open/floor/wood{
@@ -57554,6 +57573,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Aft Asteroid Solar APC";
+	areastring = "/area/maintenance/solars/asteroid/aft";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -58177,6 +58197,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Tech Storage APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -58217,6 +58238,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mining Storage APC";
+	areastring = "/area/quartermaster/miningdock/abandoned";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -58518,6 +58540,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Arrival Hallway Maintenance APC";
+	areastring = "/area/maintenance/asteroid/aft/arrivals";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -58904,6 +58927,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Auxillary Construction APC";
+	areastring = "/area/security/vacantoffice";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -59864,6 +59888,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Departures APC";
+	areastring = "/area/hallway/secondary/exit";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -60105,6 +60130,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Research Quantum Pad APC";
+	areastring = "/area/teleporter/quantum/research";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -60138,6 +60164,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Docking Quantum Pad APC";
+	areastring = "/area/teleporter/quantum/docking";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -60524,6 +60551,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Aux Construction APC";
+	areastring = "/area/construction/mining/aux_base";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -60599,6 +60627,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "AI Upload APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -60717,6 +60746,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Teleporter APC";
+	areastring = "/area/teleporter";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -62934,6 +62964,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Arrivals APC";
+	areastring = "/area/hallway/secondary/entry";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -63294,6 +63325,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Science-Docking Bridge APC";
+	areastring = "/area/hallway/secondary/bridges/sci_dock";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -64358,6 +64390,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Aft Asteroid Hallway APC";
+	areastring = "/area/hallway/primary/aft";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -64391,6 +64424,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Aft Asteroid Maintenance APC";
+	areastring = "/area/maintenance/asteroid/aft/science";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -65958,6 +65992,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Robotics APC";
+	areastring = "/area/science/robotics/lab";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -66084,6 +66119,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Research and Development APC";
+	areastring = "/area/science/lab";
 	pixel_x = -25
 	},
 /obj/structure/cable/orange,
@@ -67698,6 +67734,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Science APC";
+	areastring = "/area/science/research";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
@@ -68337,6 +68374,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Xenobiology APC";
+	areastring = "/area/science/xenobiology";
 	pixel_x = -25
 	},
 /obj/structure/cable/orange{
@@ -68439,6 +68477,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Toxins Lab APC";
+	areastring = "/area/science/mixing";
 	pixel_y = 25
 	},
 /obj/structure/cable/orange{
@@ -69351,6 +69390,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Science Security Checkpoint APC";
+	areastring = "/area/security/checkpoint/science";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -69842,6 +69882,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "RnD Server APC";
+	areastring = "/area/science/server";
 	pixel_y = 25
 	},
 /obj/structure/disposalpipe/segment{
@@ -70136,6 +70177,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Research Director's Office APC";
+	areastring = "/area/crew_quarters/heads/hor";
 	pixel_y = 25
 	},
 /obj/structure/cable/orange{
@@ -70965,6 +71007,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Testing Lab APC";
+	areastring = "/area/science/misc_lab";
 	pixel_y = 25
 	},
 /obj/structure/cable/orange{
@@ -71076,6 +71119,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "South-Eastern External Waste Belt APC";
+	areastring = "/area/maintenance/asteroid/disposal/southeast";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -71127,6 +71171,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "South-Western External Waste Belt APC";
+	areastring = "/area/maintenance/asteroid/disposal/southwest";
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
@@ -72405,6 +72450,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Chapel Office APC";
+	areastring = "/area/chapel/office";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -74410,6 +74456,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Arrival Security Checkpoint APC";
+	areastring = "/area/security/checkpoint/checkpoint2";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -74815,9 +74862,7 @@
 /turf/open/floor/plasteel/freezer{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet{
-	name = "Fitness Toilets"
-	})
+/area/crew_quarters/toilet/fitness)
 "cKo" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall{
@@ -75432,6 +75477,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Quartermaster's Office APC";
+	areastring = "/area/quartermaster/qm";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -75680,6 +75726,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Fore Asteroid Hallway APC";
+	areastring = "/area/hallway/primary/fore";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -75923,6 +75970,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Asteroid Maintenance APC";
+	areastring = "/area/maintenance/asteroid/port/west";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -76834,6 +76882,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Theatre APC";
+	areastring = "/area/crew_quarters/theatre";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -77356,6 +77405,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Morgue APC";
+	areastring = "/area/medical/morgue";
 	pixel_y = 24
 	},
 /obj/structure/table,
@@ -78580,6 +78630,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Toxins Storage APC";
+	areastring = "/area/science/storage";
 	pixel_y = 25
 	},
 /obj/structure/cable/orange{
@@ -79977,6 +80028,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Incinerator APC";
+	areastring = "/area/maintenance/disposal/incinerator";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -80579,6 +80631,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Security Transfer Range APC";
+	areastring = "/area/security/transfer";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -80859,6 +80912,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medical-Cargo Bridge APC";
+	areastring = "/area/hallway/secondary/bridges/med_cargo";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -80880,6 +80934,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Command-Service Bridge APC";
+	areastring = "/area/hallway/secondary/bridges/com_serv";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -81026,6 +81081,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Service-Engineering Bridge APC";
+	areastring = "/area/hallway/secondary/bridges/serv_engi";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -81099,6 +81155,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Engineering-Medical Bridge APC";
+	areastring = "/area/hallway/secondary/bridges/engi_med";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -81181,6 +81238,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Docking-Medical Bridge APC";
+	areastring = "/area/hallway/secondary/bridges/dock_med";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -81514,6 +81572,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Cargo-AI-Command Bridge APC";
+	areastring = "/area/hallway/secondary/bridges/cargo_ai";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -81619,6 +81678,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Command-Engineering Bridge APC";
+	areastring = "/area/hallway/secondary/bridges/com_engi";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -81689,6 +81749,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Service-Science Bridge APC";
+	areastring = "/area/hallway/secondary/bridges/serv_sci";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -81757,6 +81818,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Cargo Hallway APC";
+	areastring = "/area/hallway/primary/starboard/fore";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -81781,6 +81843,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Cargo Hallway APC";
+	areastring = "/area/maintenance/asteroid/fore/cargo_south";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -82313,6 +82376,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Quarter Primary Hallway APC";
+	areastring = "/area/hallway/primary/starboard/aft";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -83968,6 +84032,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Hydroponics APC";
+	areastring = "/area/hydroponics";
 	pixel_x = -23;
 	pixel_y = 2
 	},
@@ -84821,6 +84886,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Cell Block APC";
+	areastring = "/area/security/prison";
 	pixel_x = 23;
 	pixel_y = 2
 	},
@@ -86968,6 +87034,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Prisoner Transfer APC";
+	areastring = "/area/security/transfer";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -87358,6 +87425,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Labor Shuttle Dock APC";
+	areastring = "/area/security/processing";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -89802,6 +89870,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Armory APC";
+	areastring = "/area/security/armory";
 	pixel_x = 24
 	},
 /turf/open/floor/plating/astplate{
@@ -91866,6 +91935,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Warden's Office APC";
+	areastring = "/area/security/warden";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange{
@@ -91931,6 +92001,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Courtroom APC";
+	areastring = "/area/security/courtroom";
 	pixel_y = -24
 	},
 /obj/structure/cable/orange,
@@ -91975,6 +92046,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Head of Security's Office APC";
+	areastring = "/area/crew_quarters/heads/hos";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -92342,6 +92414,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Brig APC";
+	areastring = "/area/security/brig";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -93189,6 +93262,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Detective's Office APC";
+	areastring = "/area/security/detectives_office";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -94361,6 +94435,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Starboard Asteroid Maintenance APC";
+	areastring = "/area/maintenance/asteroid/starboard";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/stripes/end{

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -6170,7 +6170,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/quartermaster/sorting)
+/area/maintenance/asteroid/fore/cargo_west)
 "amK" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box,
@@ -6460,7 +6460,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/heads/captain)
+/area/maintenance/asteroid/fore/com_north)
 "anj" = (
 /obj/structure/table/wood,
 /obj/item/weapon/pinpointer,
@@ -6545,7 +6545,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/quartermaster/sorting)
+/area/maintenance/asteroid/fore/cargo_west)
 "ans" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating/asteroid,
@@ -7077,7 +7077,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/quartermaster/office)
+/area/maintenance/asteroid/fore/cargo_west)
 "aov" = (
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
@@ -7726,7 +7726,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/locker)
+/area/maintenance/asteroid/fore/com_north)
 "apL" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating/astplate{
@@ -9241,7 +9241,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/heads/chief/private)
+/area/maintenance/asteroid/fore/com_east)
 "asU" = (
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
@@ -10387,7 +10387,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/quartermaster/storage)
+/area/maintenance/asteroid/fore/cargo_west)
 "avf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -10842,7 +10842,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/heads/cmo/private)
+/area/maintenance/asteroid/fore/com_north)
 "avZ" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet{
@@ -12756,7 +12756,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/heads/hor/private)
+/area/maintenance/asteroid/fore/com_east)
 "azX" = (
 /obj/structure/chair{
 	dir = 1
@@ -13984,7 +13984,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/quartermaster/miningdock)
+/area/maintenance/asteroid/fore/cargo_south)
 "aCx" = (
 /obj/structure/closet/crate,
 /turf/open/floor/mineral/titanium/blue,
@@ -15135,7 +15135,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet)
+/area/maintenance/asteroid/fore/com_north)
 "aEr" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -15232,7 +15232,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/heads/hos/private)
+/area/bridge)
 "aEB" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -16199,7 +16199,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/heads/hop)
+/area/bridge)
 "aGd" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -16421,7 +16421,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/quartermaster/qm/private)
+/area/maintenance/asteroid/fore/com_east)
 "aGs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
@@ -17584,7 +17584,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/checkpoint/supply)
+/area/maintenance/asteroid/fore/cargo_south)
 "aIF" = (
 /obj/effect/landmark/secequipment,
 /turf/open/floor/plasteel/red/side{
@@ -30036,7 +30036,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/asteroid/starboard)
 "bfq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30806,7 +30806,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/asteroid/starboard)
 "bgE" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -39501,7 +39501,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/virology)
+/area/maintenance/asteroid/starboard)
 "bvO" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -43945,7 +43945,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/engine/atmos)
+/area/maintenance/asteroid/central)
 "bDU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -47735,7 +47735,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/asteroid/starboard)
 "bKY" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -47762,7 +47762,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/chemistry)
+/area/maintenance/asteroid/starboard)
 "bLa" = (
 /obj/structure/plasticflaps,
 /turf/open/floor/plating{
@@ -47955,7 +47955,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard)
+/area/maintenance/asteroid/starboard)
 "bLs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -48029,7 +48029,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/fitness)
+/area/maintenance/asteroid/port/west)
 "bLy" = (
 /obj/machinery/light{
 	dir = 8
@@ -48871,7 +48871,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/genetics)
+/area/maintenance/asteroid/starboard)
 "bMP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -49354,7 +49354,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/medbay/zone2)
+/area/maintenance/asteroid/starboard)
 "bNL" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -49370,7 +49370,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/genetics)
+/area/maintenance/asteroid/starboard)
 "bNM" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -50018,7 +50018,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/medbay/zone2)
+/area/maintenance/asteroid/starboard)
 "bOP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
@@ -53155,7 +53155,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/toilet/fitness)
+/area/maintenance/asteroid/port/west)
 "bVh" = (
 /obj/machinery/camera{
 	c_tag = "Fitness Bathrooms";
@@ -58946,7 +58946,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/vacantoffice)
+/area/maintenance/asteroid/aft/arrivals)
 "chd" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -59902,7 +59902,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/secondary/exit)
+/area/maintenance/asteroid/aft/arrivals)
 "ciY" = (
 /obj/structure/grille/broken,
 /obj/item/clothing/head/cone,
@@ -60765,7 +60765,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/teleporter)
+/area/maintenance/asteroid/aft/arrivals)
 "ckp" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -62974,7 +62974,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/secondary/entry)
+/area/maintenance/asteroid/aft/arrivals)
 "coq" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -64401,7 +64401,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/aft)
+/area/maintenance/asteroid/aft/science)
 "cqM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66130,7 +66130,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/science/lab)
+/area/maintenance/asteroid/aft/science)
 "ctR" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -66809,7 +66809,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/science/xenobiology)
+/area/maintenance/asteroid/aft/science)
 "cvi" = (
 /obj/machinery/light{
 	dir = 8
@@ -68388,7 +68388,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/science/xenobiology)
+/area/maintenance/asteroid/aft/science)
 "cxE" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -68488,7 +68488,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/science/mixing)
+/area/maintenance/asteroid/aft/science)
 "cxQ" = (
 /obj/machinery/r_n_d/server/core,
 /turf/open/floor/circuit{
@@ -69901,7 +69901,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/science/server)
+/area/maintenance/asteroid/aft/science)
 "cAp" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -70193,7 +70193,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/heads/hor)
+/area/maintenance/asteroid/aft/science)
 "cAQ" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -71026,7 +71026,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/science/misc_lab)
+/area/maintenance/asteroid/aft/science)
 "cCy" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -74475,7 +74475,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/checkpoint/checkpoint2)
+/area/maintenance/asteroid/aft/arrivals)
 "cJx" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable/orange{
@@ -74969,7 +74969,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/science/mixing)
+/area/maintenance/asteroid/aft/science)
 "cKA" = (
 /obj/item/clothing/head/sombrero/shamebrero,
 /turf/open/floor/plating/asteroid/airless,
@@ -75488,7 +75488,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/quartermaster/qm)
+/area/maintenance/asteroid/fore/cargo_west)
 "cLD" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -75740,7 +75740,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/fore)
+/area/maintenance/asteroid/fore/com_west)
 "cMc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -76569,7 +76569,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/theatre)
+/area/maintenance/asteroid/port/west)
 "cNE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/cafeteria{
@@ -76893,7 +76893,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/theatre)
+/area/maintenance/asteroid/port/west)
 "cOp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -77635,7 +77635,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/medical/morgue)
+/area/maintenance/asteroid/starboard)
 "cPR" = (
 /obj/machinery/light{
 	dir = 1
@@ -81833,7 +81833,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/hallway/primary/starboard/fore)
+/area/maintenance/asteroid/fore/cargo_south)
 "cYl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -89876,7 +89876,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/armory)
+/area/maintenance/asteroid/fore/com_west)
 "dqH" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall{
@@ -92012,7 +92012,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/courtroom)
+/area/maintenance/asteroid/fore/com_north)
 "duS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -92061,7 +92061,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/crew_quarters/heads/hos)
+/area/maintenance/asteroid/fore/com_west)
 "duX" = (
 /obj/machinery/keycard_auth{
 	pixel_x = -24
@@ -99545,9 +99545,9 @@ aaa
 aaa
 aXK
 aXK
-caf
-caf
-caf
+bRR
+bRR
+bRR
 aXK
 aXK
 aaa
@@ -132593,8 +132593,8 @@ aaa
 abC
 aaa
 deF
-dfH
-dfH
+deH
+deH
 deF
 abW
 abW

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -61252,7 +61252,7 @@
 "cln" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/turretid{
-	control_area = "AI Upload Chamber";
+	control_area = "/area/ai_monitored/turret_protected/ai_upload";
 	name = "AI Upload turret control";
 	pixel_y = 25
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -48253,7 +48253,7 @@
 "bPo" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/turretid{
-	control_area = "AI Satellite Antechamber";
+	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
 	enabled = 1;
 	icon_state = "control_standby";
 	name = "Antechamber Turret Control";

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2333,7 +2333,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
+/area/maintenance/starboard/fore)
 "aeT" = (
 /obj/structure/chair{
 	dir = 4;
@@ -6410,7 +6410,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
+/area/maintenance/port/fore)
 "aoo" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -6430,7 +6430,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/checkpoint2)
+/area/maintenance/starboard/fore)
 "aop" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -8989,7 +8989,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/area/maintenance/starboard/fore)
 "asY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -9032,7 +9032,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/maintenance/starboard/fore)
 "ate" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -12505,7 +12505,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/maintenance/port/fore)
 "aAx" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -19518,7 +19518,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
+/area/maintenance/port/fore)
 "aOe" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -24291,7 +24291,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/maintenance/port/fore)
 "aWE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -38399,7 +38399,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/maintenance/port/fore)
 "bxt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/plasticflaps{
@@ -43854,7 +43854,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/maintenance/starboard)
 "bGP" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26;
@@ -57891,7 +57891,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/lawoffice)
+/area/maintenance/starboard)
 "cgR" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -58342,7 +58342,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/library)
+/area/maintenance/port)
 "chN" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -58858,7 +58858,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/security/range)
+/area/maintenance/starboard)
 "ciI" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -60291,7 +60291,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/maintenance/starboard)
 "clx" = (
 /turf/closed/wall,
 /area/crew_quarters/locker)
@@ -62541,7 +62541,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/maintenance/starboard)
 "cpW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -63941,7 +63941,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
+/area/maintenance/starboard)
 "csO" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -67570,7 +67570,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/library)
+/area/maintenance/port)
 "czM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -69529,7 +69529,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/maintenance/port)
 "cDB" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -69822,7 +69822,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/toilet/restrooms)
+/area/maintenance/starboard/aft)
 "cEh" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -72743,7 +72743,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/xenobiology)
+/area/maintenance/port)
 "cJD" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -72841,7 +72841,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/science/research)
+/area/maintenance/port)
 "cJO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -73167,7 +73167,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/medical/storage)
+/area/maintenance/starboard/aft)
 "cKC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -74817,7 +74817,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/medical/medbay/central)
+/area/maintenance/starboard/aft)
 "cNR" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -78310,7 +78310,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
+/area/maintenance/starboard/aft)
 "cUM" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -78449,7 +78449,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
+/area/maintenance/port)
 "cVb" = (
 /obj/structure/cable/white,
 /obj/effect/spawner/structure/window/reinforced,
@@ -85133,7 +85133,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/explab)
+/area/maintenance/port)
 "diZ" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -88781,7 +88781,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/medical/surgery)
+/area/maintenance/starboard/aft)
 "dqk" = (
 /obj/structure/cable/white{
 	d1 = 2;
@@ -93686,7 +93686,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/maintenance/port)
 "dzM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -96030,7 +96030,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/maintenance/port/aft)
 "dEk" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -96231,7 +96231,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/maintenance/port/aft)
 "dEE" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -96430,7 +96430,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/maintenance/aft)
 "dEW" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -97128,7 +97128,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/maintenance/port/aft)
 "dGp" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -97382,7 +97382,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/medical/medbay/central)
+/area/maintenance/aft)
 "dGO" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -97471,7 +97471,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/medical/medbay/central)
+/area/maintenance/starboard/aft)
 "dGS" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -99289,7 +99289,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/science/research)
+/area/maintenance/port/aft)
 "dKJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -100395,7 +100395,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/chapel/office)
+/area/maintenance/port/aft)
 "dMG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -100486,7 +100486,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/area/maintenance/port/aft)
 "dMQ" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
@@ -148465,7 +148465,7 @@ dJN
 cJM
 dLH
 dML
-dNJ
+dED
 dOy
 dPo
 dQd

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -52094,7 +52094,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVK" = (
 /obj/machinery/turretid{
-	control_area = "AI Upload Chamber";
+	control_area = "/area/ai_monitored/turret_protected/ai_upload";
 	icon_state = "control_stun";
 	name = "AI Upload turret control";
 	pixel_y = -32

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -870,6 +870,7 @@
 	cell_type = 10000;
 	dir = 2;
 	name = "Starboard Bow Solar APC";
+	areastring = "/area/maintenance/solars/starboard/fore";
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -1632,6 +1633,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Auxiliary Construction APC";
+	areastring = "/area/construction/mining/aux_base";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -2926,6 +2928,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Arrivals Hallway APC";
+	areastring = "/area/hallway/secondary/entry";
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4156,6 +4159,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Customs Desk APC";
+	areastring = "/area/security/checkpoint/customs";
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -4314,6 +4318,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Security Checkpoint APC";
+	areastring = "/area/security/checkpoint/checkpoint2";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -4721,6 +4726,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Starboard Bow Maintenance APC";
+	areastring = "/area/maintenance/starboard/fore";
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -5938,6 +5944,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Auxiliary Office APC";
+	areastring = "/area/security/vacantoffice";
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6341,6 +6348,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Electronics Marketing APC";
+	areastring = "/area/crew_quarters/electronic_marketing_den";
 	pixel_y = -26
 	},
 /turf/open/floor/wood,
@@ -8468,6 +8476,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Disposal APC";
+	areastring = "/area/maintenance/disposal";
 	pixel_y = -24
 	},
 /obj/structure/disposalpipe/segment{
@@ -8781,6 +8790,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Custodial Closet APC";
+	areastring = "/area/janitor";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -9916,6 +9926,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Auxiliary Restrooms APC";
+	areastring = "/area/crew_quarters/toilet/auxiliary";
 	pixel_y = -26
 	},
 /turf/open/floor/plating,
@@ -10319,6 +10330,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Port Bow Maintenance APC";
+	areastring = "/area/maintenance/port/fore";
 	pixel_y = -26
 	},
 /obj/structure/cable/white,
@@ -12192,6 +12204,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Cargo Warehouse APC";
+	areastring = "/area/quartermaster/warehouse";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/brown{
@@ -12899,6 +12912,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Atmospherics Engine APC";
+	areastring = "/area/engine/atmospherics_engine";
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
@@ -13036,6 +13050,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Bar APC";
+	areastring = "/area/crew_quarters/bar";
 	pixel_y = 24
 	},
 /obj/machinery/light/small{
@@ -13169,6 +13184,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Port Primary Hallway APC";
+	areastring = "/area/hallway/primary/fore";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -13458,6 +13474,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Abandoned Garden APC";
+	areastring = "/area/hydroponics/garden/abandoned";
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/bot,
@@ -15082,6 +15099,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Turbine Generator APC";
+	areastring = "/area/maintenance/disposal/incinerator";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -15639,6 +15657,7 @@
 	cell_type = 10000;
 	dir = 2;
 	name = "Port Bow Solar APC";
+	areastring = "/area/maintenance/solars/port/fore";
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16695,6 +16714,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Post - Cargo APC";
+	areastring = "/area/security/checkpoint/supply";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/red/side{
@@ -17201,6 +17221,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Abandoned Gambling Den APC";
+	areastring = "/area/crew_quarters/abandoned_gambling_den";
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -17264,6 +17285,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Atrium APC";
+	areastring = "/area/crew_quarters/bar/atrium";
 	pixel_y = 24
 	},
 /obj/machinery/camera{
@@ -17882,6 +17904,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Theatre Backstage APC";
+	areastring = "/area/crew_quarters/theatre";
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/redblue,
@@ -17986,6 +18009,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Delivery Office APC";
+	areastring = "/area/quartermaster/sorting";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -19833,6 +19857,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Cargo Bay APC";
+	areastring = "/area/quartermaster/storage";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -19922,6 +19947,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Quartermaster's Office APC";
+	areastring = "/area/quartermaster/qm";
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -20794,6 +20820,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Cargo Office APC";
+	areastring = "/area/quartermaster/office";
 	pixel_y = 28
 	},
 /obj/structure/cable/white{
@@ -22155,6 +22182,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Education Chamber APC";
+	areastring = "/area/prison/execution_room";
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -22412,6 +22440,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Service Hall APC";
+	areastring = "/area/hallway/secondary/service";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -24690,6 +24719,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Prison Wing APC";
+	areastring = "/area/security/prison";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -26502,6 +26532,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Hydroponics APC";
+	areastring = "/area/hydroponics";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/greenblue/side,
@@ -26587,6 +26618,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Kitchen APC";
+	areastring = "/area/crew_quarters/kitchen";
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/bot,
@@ -27559,6 +27591,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Atmospherics APC";
+	areastring = "/area/engine/atmos";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -29990,6 +30023,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Mining Dock APC";
+	areastring = "/area/quartermaster/miningoffice";
 	pixel_x = 26
 	},
 /obj/machinery/camera{
@@ -30895,6 +30929,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Office APC";
+	areastring = "/area/security/main";
 	pixel_x = -26
 	},
 /obj/structure/cable/white{
@@ -31471,6 +31506,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Central Primary Hallway APC";
+	areastring = "/area/hallway/primary/central";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -34737,6 +34773,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Head of Security's Office APC";
+	areastring = "/area/crew_quarters/heads/hos";
 	pixel_y = -26
 	},
 /obj/structure/cable/white,
@@ -35289,6 +35326,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Security Transferring APC";
+	areastring = "/area/security/transfer";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/red/side,
@@ -36643,6 +36681,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Vault APC";
+	areastring = "/area/security/nuke_storage";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/vault{
@@ -38004,6 +38043,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Gravity Generator APC";
+	areastring = "/area/engine/gravity_generator";
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39144,6 +39184,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Engineering Foyer APC";
+	areastring = "/area/engine/break_room";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -40641,6 +40682,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Primary Tool Storage APC";
+	areastring = "/area/storage/primary";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -41704,6 +41746,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Bridge APC";
+	areastring = "/area/bridge";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/darkblue/side,
@@ -42438,6 +42481,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Technology Storage APC";
+	areastring = "/area/storage/tech";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -42902,6 +42946,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Detective's Office APC";
+	areastring = "/area/security/detectives_office";
 	pixel_y = 24
 	},
 /obj/item/device/taperecorder,
@@ -43175,6 +43220,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "AI Chamber APC";
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/vault{
@@ -43612,6 +43658,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Council Chambers APC";
+	areastring = "/area/bridge/meeting_room/council";
 	pixel_y = 26
 	},
 /turf/open/floor/wood,
@@ -44187,6 +44234,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Transit Tube Access APC";
+	areastring = "/area/engine/transit_tube";
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -44700,6 +44748,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Telecomms Monitoring APC";
+	areastring = "/area/tcommsat/computer";
 	pixel_y = 28
 	},
 /obj/item/weapon/twohanded/required/kirbyplants/random,
@@ -44862,6 +44911,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Auxiliary Tool Storage APC";
+	areastring = "/area/storage/tools";
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -46798,6 +46848,7 @@
 	cell_type = 10000;
 	dir = 2;
 	name = "Captain's Office APC";
+	areastring = "/area/crew_quarters/heads/captain";
 	pixel_y = -24
 	},
 /obj/structure/cable/white,
@@ -47996,6 +48047,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Warden's Office APC";
+	areastring = "/area/security/warden";
 	pixel_x = 26
 	},
 /obj/machinery/camera{
@@ -48653,6 +48705,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Security Post - Engineering APC";
+	areastring = "/area/security/checkpoint/engineering";
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51062,6 +51115,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "AI Satellite Exterior APC";
+	areastring = "/area/aisat";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/vault{
@@ -51164,6 +51218,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Chief Engineer's APC";
+	areastring = "/area/crew_quarters/heads/chief";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/vault{
@@ -52017,6 +52072,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "MiniSat APC";
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	pixel_y = -27
 	},
 /obj/structure/cable/white,
@@ -52789,6 +52845,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Armoury APC";
+	areastring = "/area/ai_monitored/security/armory";
 	pixel_y = -26
 	},
 /obj/machinery/camera{
@@ -53156,6 +53213,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Port Maintenance APC";
+	areastring = "/area/maintenance/port";
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
@@ -54193,6 +54251,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "HoP Office APC";
+	areastring = "/area/crew_quarters/heads/hop";
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
@@ -54214,6 +54273,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Telecomms Server Room APC";
+	areastring = "/area/tcommsat/server";
 	pixel_x = -26
 	},
 /obj/structure/cable/white,
@@ -54791,6 +54851,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Brig APC";
+	areastring = "/area/security/brig";
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55376,6 +55437,7 @@
 	cell_type = 10000;
 	dir = 2;
 	name = "Captain's Quarters APC";
+	areastring = "/area/crew_quarters/heads/captain/private";
 	pixel_y = -24
 	},
 /obj/structure/cable/white,
@@ -56411,6 +56473,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Law Office APC";
+	areastring = "/area/lawoffice";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -57513,6 +57576,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Engine Room APC";
+	areastring = "/area/engine/engineering";
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/bot,
@@ -58432,6 +58496,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Teleporter APC";
+	areastring = "/area/teleporter";
 	pixel_y = 28
 	},
 /obj/structure/cable/white{
@@ -58939,6 +59004,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "AI Upload Access APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_y = -27
 	},
 /turf/open/floor/plasteel/vault{
@@ -59610,6 +59676,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Shooting Range APC";
+	areastring = "/area/security/range";
 	pixel_x = -26
 	},
 /obj/structure/cable/white{
@@ -59896,6 +59963,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Library APC";
+	areastring = "/area/library";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -60196,6 +60264,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Courtroom APC";
+	areastring = "/area/security/courtroom";
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
@@ -61308,6 +61377,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Command Hall APC";
+	areastring = "/area/hallway/secondary/command";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -62507,6 +62577,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Starboard Maintenance APC";
+	areastring = "/area/maintenance/starboard";
 	pixel_y = -26
 	},
 /obj/structure/cable/white,
@@ -63456,6 +63527,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "E.V.A. Storage APC";
+	areastring = "/area/ai_monitored/storage/eva";
 	pixel_y = 26
 	},
 /obj/structure/cable/white{
@@ -63622,6 +63694,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Gateway APC";
+	areastring = "/area/gateway";
 	pixel_y = 28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -66030,6 +66103,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Primary Restroom APC";
+	areastring = "/area/crew_quarters/toilet/restrooms";
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -66210,6 +66284,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Lockerroom APC";
+	areastring = "/area/crew_quarters/locker";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -66676,6 +66751,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Corporate Lounge APC";
+	areastring = "/area/bridge/showroom/corporate";
 	pixel_x = -26
 	},
 /obj/structure/cable/white{
@@ -67321,6 +67397,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Engineering Storage APC";
+	areastring = "/area/engine/storage";
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
@@ -71719,6 +71796,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Dormitories APC";
+	areastring = "/area/crew_quarters/dorms";
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73002,6 +73080,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medbay Storage APC";
+	areastring = "/area/medical/storage";
 	pixel_x = -26
 	},
 /obj/machinery/camera{
@@ -73469,6 +73548,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Auxiliary Power APC";
+	areastring = "/area/maintenance/department/electrical";
 	pixel_x = 26
 	},
 /turf/open/floor/plating,
@@ -76487,6 +76567,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Recreation Area APC";
+	areastring = "/area/crew_quarters/fitness/recreation";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -76890,6 +76971,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Post - Science APC";
+	areastring = "/area/security/checkpoint/science/research";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -77922,6 +78004,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Post - Medical APC";
+	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -78791,6 +78874,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Chemistry Lab APC";
+	areastring = "/area/medical/chemistry";
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
@@ -79140,6 +79224,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Maintenance APC";
+	areastring = "/area/maintenance/port";
 	pixel_y = 28
 	},
 /obj/structure/cable/white{
@@ -79484,6 +79569,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Xenobiology Lab APC";
+	areastring = "/area/science/xenobiology";
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -80795,6 +80881,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Research and Development Lab APC";
+	areastring = "/area/science/lab";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -81199,6 +81286,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Abandoned Gambling Den APC";
+	areastring = "/area/crew_quarters/abandoned_gambling_den";
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
@@ -82789,6 +82877,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Experimentation Lab APC";
+	areastring = "/area/science/explab";
 	pixel_y = 24
 	},
 /obj/machinery/camera{
@@ -83320,6 +83409,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Abandoned Medical Lab APC";
+	areastring = "/area/medical/abandoned";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -84275,6 +84365,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Firing Range APC";
+	areastring = "/area/science/misc_lab/range";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -84475,6 +84566,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Mech Bay APC";
+	areastring = "/area/science/robotics/mechbay";
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -84517,6 +84609,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Medical Maintenance APC";
+	areastring = "/area/maintenance/department/medical";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -84609,6 +84702,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Cloning Lab APC";
+	areastring = "/area/medical/genetics/cloning";
 	pixel_y = 24
 	},
 /obj/item/weapon/folder/white,
@@ -86691,6 +86785,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Abandoned Research Lab APC";
+	areastring = "/area/science/research/abandoned";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -86854,6 +86949,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Research Director's Office APC";
+	areastring = "/area/crew_quarters/heads/hor";
 	pixel_x = -26
 	},
 /obj/structure/cable/white,
@@ -87618,6 +87714,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medbay APC";
+	areastring = "/area/medical/medbay/central";
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -89218,6 +89315,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Genetics Lab APC";
+	areastring = "/area/medical/genetics";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -90293,6 +90391,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Surgery APC";
+	areastring = "/area/medical/surgery";
 	pixel_y = -26
 	},
 /obj/machinery/camera{
@@ -90337,6 +90436,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Auxiliary Construction Zone APC";
+	areastring = "/area/hallway/secondary/construction";
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
@@ -90942,6 +91042,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Chief Medical Officer's Office APC";
+	areastring = "/area/crew_quarters/heads/cmo";
 	pixel_x = 26
 	},
 /obj/machinery/camera{
@@ -91121,6 +91222,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Toxins Lab APC";
+	areastring = "/area/science/mixing";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -92384,6 +92486,7 @@
 	cell_type = 10000;
 	dir = 2;
 	name = "Starboard Quarter Solar APC";
+	areastring = "/area/maintenance/solars/starboard/aft";
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -93392,6 +93495,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Abandoned Theatre APC";
+	areastring = "/area/crew_quarters/theatre/abandoned";
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
@@ -93703,6 +93807,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Research Division Server Room APC";
+	areastring = "/area/science/server";
 	pixel_x = -26
 	},
 /obj/machinery/light_switch{
@@ -93809,6 +93914,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Robotics Lab APC";
+	areastring = "/area/science/robotics/lab";
 	pixel_x = -26
 	},
 /obj/structure/disposalpipe/trunk{
@@ -94830,6 +94936,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Private Investigator's Office APC";
+	areastring = "/area/security/detectives_office/private_investigators_office";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -95250,6 +95357,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Research Division APC";
+	areastring = "/area/science/research";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -95349,6 +95457,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Morgue APC";
+	areastring = "/area/medical/morgue";
 	pixel_y = -26
 	},
 /turf/open/floor/plating,
@@ -95859,6 +95968,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Toxins Storage APC";
+	areastring = "/area/science/storage";
 	pixel_x = 26
 	},
 /obj/structure/cable/white,
@@ -97141,6 +97251,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Aft Maintenance APC";
+	areastring = "/area/maintenance/aft";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -98698,6 +98809,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Quarter Maintenance APC";
+	areastring = "/area/maintenance/port/aft";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -98796,6 +98908,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Departures Customs APC";
+	areastring = "/area/security/checkpoint/customs";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -100640,6 +100753,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Abandoned Library APC";
+	areastring = "/area/library/abandoned";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -101322,6 +101436,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Virology Satellite APC";
+	areastring = "/area/medical/virology";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -103720,6 +103835,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Chapel APC";
+	areastring = "/area/chapel/main";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -104898,6 +105014,7 @@
 	cell_type = 10000;
 	dir = 2;
 	name = "Port Quarter Solar APC";
+	areastring = "/area/maintenance/solars/port/aft";
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -106093,6 +106210,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Departures Checkpoint APC";
+	areastring = "/area/security/checkpoint/checkpoint2";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -106416,6 +106534,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Chapel Quarters APC";
+	areastring = "/area/chapel/office";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -109158,6 +109277,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Departure Lounge APC";
+	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	pixel_y = 28
 	},
 /obj/machinery/camera{
@@ -109908,6 +110028,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Port Primary Hallway APC";
+	areastring = "/area/hallway/primary/port";
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
@@ -109928,6 +110049,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Starboard Primary Hallway APC";
+	areastring = "/area/hallway/primary/starboard";
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
@@ -109961,6 +110083,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Starboard Quarter Maintenance APC";
+	areastring = "/area/hallway/primary/aft";
 	pixel_x = 26
 	},
 /turf/open/floor/plating,
@@ -109979,6 +110102,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Aft Primary Hallway APC";
+	areastring = "/area/hallway/primary/aft";
 	pixel_x = 26
 	},
 /obj/structure/cable/white{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24148,7 +24148,7 @@
 "aUy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/turretid{
-	control_area = "AI Upload Chamber";
+	control_area = "/area/ai_monitored/turret_protected/ai_upload";
 	icon_state = "control_stun";
 	name = "AI Upload turret control";
 	pixel_y = 28

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55512,7 +55512,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/medical/storage)
+/area/maintenance/port/aft)
 "cbJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -72018,7 +72018,7 @@
 	req_access_txt = "6"
 	},
 /turf/open/floor/plating,
-/area/medical/morgue)
+/area/maintenance/aft)
 "cGU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
@@ -111567,7 +111567,7 @@ cia
 cia
 cuj
 cbx
-dDx
+dDw
 bXE
 cxU
 cxU
@@ -113328,7 +113328,7 @@ bok
 bqz
 bsL
 buk
-dCQ
+dCH
 bdP
 baG
 baG
@@ -113337,7 +113337,7 @@ bEB
 baG
 bHW
 baG
-dDd
+dCH
 baG
 bdP
 baG
@@ -113822,7 +113822,7 @@ aJN
 dhI
 aME
 aNW
-dCu
+dCt
 aQx
 aMB
 aTe
@@ -113858,7 +113858,7 @@ bGy
 bGy
 bGy
 bTG
-dDj
+dCE
 bWk
 bXK
 bYV
@@ -116656,7 +116656,7 @@ aJS
 aUx
 aUx
 aXI
-dCF
+dCE
 baQ
 bci
 aaf
@@ -118211,7 +118211,7 @@ bov
 bqN
 bsX
 buA
-dCR
+dCK
 byg
 bzW
 bBJ
@@ -118976,7 +118976,7 @@ aaf
 bfw
 bhp
 bjb
-dCL
+dCK
 bmE
 boy
 bqP
@@ -120540,7 +120540,7 @@ bQr
 bRJ
 bGM
 bTW
-dDk
+dCE
 bWA
 bXV
 bZk
@@ -120768,7 +120768,7 @@ aTp
 aIT
 aTk
 aXS
-dCG
+dCE
 baV
 bcj
 bdH
@@ -120997,7 +120997,7 @@ ajF
 akP
 ami
 anx
-dCd
+dCb
 apU
 arp
 asF
@@ -121598,7 +121598,7 @@ cAu
 cBo
 crL
 cwN
-dDD
+dDy
 cFl
 cGh
 cHb
@@ -123107,7 +123107,7 @@ aWf
 aWf
 aWf
 aWf
-dDh
+dCT
 aWf
 aWf
 bVo
@@ -123590,7 +123590,7 @@ aMY
 aOu
 aOv
 aQR
-dCy
+dCv
 aTw
 aUM
 aWs
@@ -124655,7 +124655,7 @@ bUh
 bVs
 bWN
 bWR
-dDn
+dDl
 caM
 ccu
 bST
@@ -126699,7 +126699,7 @@ dCU
 byC
 bwX
 bHe
-dDc
+dCU
 bKm
 bKe
 bNE
@@ -130517,7 +130517,7 @@ axQ
 ayR
 axY
 aBG
-dCm
+dCk
 aEk
 aFs
 aGT

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -34408,7 +34408,7 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bny" = (
 /obj/machinery/turretid{
-	control_area = "AI Satellite Antechamber";
+	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
 	enabled = 1;
 	icon_state = "control_standby";
 	name = "Antechamber Turret Control";

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1464,6 +1464,7 @@
 	cell_type = 2500;
 	dir = 1;
 	name = "Prisoner Education Chamber APC";
+	areastring = "/area/prison/execution_room";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -2557,6 +2558,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Prison Wing APC";
+	areastring = "/area/security/prison";
 	pixel_x = 1;
 	pixel_y = 24
 	},
@@ -3409,6 +3411,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Recreation Area APC";
+	areastring = "/area/crew_quarters/fitness/recreation";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -3935,6 +3938,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Armory APC";
+	areastring = "/area/ai_monitored/security/armory";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -4260,6 +4264,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Port Bow Solar APC";
+	areastring = "/area/maintenance/solars/port/fore";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -6332,6 +6337,7 @@
 	cell_type = 5000;
 	dir = 8;
 	name = "Brig Control APC";
+	areastring = "/area/security/warden";
 	pixel_x = -26
 	},
 /obj/structure/cable/yellow,
@@ -6496,6 +6502,7 @@
 	cell_type = 2500;
 	dir = 4;
 	name = "Shooting Range APC";
+	areastring = "/area/security/range";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -6997,6 +7004,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Security Office APC";
+	areastring = "/area/security/main";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow,
@@ -7638,6 +7646,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Disposal APC";
+	areastring = "/area/maintenance/disposal";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
@@ -8431,6 +8440,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Gravity Generator APC";
+	areastring = "/area/engine/gravity_generator";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -9145,6 +9155,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Bow Solar APC";
+	areastring = "/area/maintenance/solars/starboard/fore";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -10896,6 +10907,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Head of Security's Office APC";
+	areastring = "/area/crew_quarters/heads/hos";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -12209,6 +12221,7 @@
 	cell_type = 10000;
 	dir = 2;
 	name = "Brig APC";
+	areastring = "/area/security/brig";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -12757,6 +12770,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Vault APC";
+	areastring = "/area/security/nuke_storage";
 	pixel_y = 25
 	},
 /obj/structure/cable/yellow{
@@ -13214,6 +13228,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mining APC";
+	areastring = "/area/quartermaster/miningoffice";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -13626,6 +13641,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Fore Maintenance APC";
+	areastring = "/area/maintenance/fore";
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
@@ -14446,6 +14462,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Dormitories APC";
+	areastring = "/area/crew_quarters/dorms";
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14953,6 +14970,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Detective APC";
+	areastring = "/area/security/detectives_office";
 	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
@@ -16101,6 +16119,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Warehouse APC";
+	areastring = "/area/quartermaster/warehouse";
 	pixel_x = 27
 	},
 /obj/structure/cable/yellow{
@@ -16406,6 +16425,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Restrooms APC";
+	areastring = "/area/crew_quarters/toilet/restrooms";
 	pixel_y = -26
 	},
 /obj/structure/cable/yellow{
@@ -17020,6 +17040,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Fore Primary Hallway APC";
+	areastring = "/area/hallway/primary/fore";
 	pixel_y = -27
 	},
 /obj/structure/cable/yellow,
@@ -18250,6 +18271,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Storage Wing APC";
+	areastring = "/area/construction/storage/wing";
 	pixel_y = -27
 	},
 /obj/structure/cable/yellow{
@@ -18623,6 +18645,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Law Office APC";
+	areastring = "/area/lawoffice";
 	pixel_y = 24
 	},
 /obj/item/weapon/twohanded/required/kirbyplants{
@@ -20680,6 +20703,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Quartermaster's Office APC";
+	areastring = "/area/quartermaster/qm";
 	pixel_y = 30
 	},
 /obj/structure/cable/yellow{
@@ -21176,6 +21200,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Garden APC";
+	areastring = "/area/hydroponics/garden";
 	pixel_x = 27;
 	pixel_y = 2
 	},
@@ -21201,6 +21226,7 @@
 	cell_type = 10000;
 	dir = 8;
 	name = "Engine Room APC";
+	areastring = "/area/engine/engineering";
 	pixel_x = -26
 	},
 /obj/structure/cable/yellow{
@@ -22110,6 +22136,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Upload APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow{
@@ -23237,6 +23264,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Auxillary Base Construction APC";
+	areastring = "/area/construction/mining/aux_base";
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/yellow/side,
@@ -23616,6 +23644,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Locker Room APC";
+	areastring = "/area/crew_quarters/locker";
 	pixel_x = -1;
 	pixel_y = -26
 	},
@@ -24027,6 +24056,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Security Post - Cargo Bay APC";
+	areastring = "/area/security/checkpoint/supply";
 	pixel_x = 1;
 	pixel_y = 24
 	},
@@ -24168,6 +24198,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "AI Upload Access APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload_foyer";
 	pixel_y = -27
 	},
 /obj/machinery/light/small{
@@ -24299,6 +24330,7 @@
 	cell_type = 2500;
 	dir = 2;
 	name = "Courtroom APC";
+	areastring = "/area/security/courtroom";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -26185,6 +26217,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "CE Office APC";
+	areastring = "/area/crew_quarters/heads/chief";
 	pixel_x = 28
 	},
 /obj/structure/cable/yellow,
@@ -26774,6 +26807,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Tech Storage APC";
+	areastring = "/area/storage/tech";
 	pixel_x = -27
 	},
 /obj/structure/cable/yellow{
@@ -27332,6 +27366,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Cargo Bay APC";
+	areastring = "/area/quartermaster/storage";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -27775,6 +27810,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Auxiliary Tool Storage APC";
+	areastring = "/area/storage/tools";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -28215,6 +28251,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Cargo Office APC";
+	areastring = "/area/quartermaster/office";
 	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
@@ -28632,6 +28669,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Engineering Security APC";
+	areastring = "/area/security/checkpoint/engineering";
 	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
@@ -28742,6 +28780,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Customs APC";
+	areastring = "/area/security/checkpoint/customs";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -29525,6 +29564,7 @@
 	aidisabled = 0;
 	dir = 1;
 	name = "AI Chamber APC";
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -30879,6 +30919,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Custodial Closet APC";
+	areastring = "/area/janitor";
 	pixel_x = -24
 	},
 /obj/structure/table,
@@ -30938,6 +30979,7 @@
 	cell_type = 2500;
 	dir = 4;
 	name = "Central Maintenance APC";
+	areastring = "/area/maintenance/central";
 	pixel_x = 26
 	},
 /obj/structure/cable/yellow,
@@ -31316,6 +31358,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Starboard Hallway APC";
+	areastring = "/area/hallway/primary/starboard";
 	pixel_y = 26
 	},
 /obj/structure/cable/yellow{
@@ -32649,6 +32692,7 @@
 	cell_type = 2500;
 	dir = 4;
 	name = "Delivery Office APC";
+	areastring = "/area/quartermaster/sorting";
 	pixel_x = 26
 	},
 /obj/structure/cable/yellow{
@@ -34476,6 +34520,7 @@
 	cell_type = 2500;
 	dir = 4;
 	name = "MiniSat Antechamber APC";
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	pixel_x = 29
 	},
 /obj/structure/cable/yellow{
@@ -34730,6 +34775,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Hallway APC";
+	areastring = "/area/hallway/primary/port";
 	pixel_x = -1;
 	pixel_y = 26
 	},
@@ -34886,6 +34932,7 @@
 	cell_type = 10000;
 	dir = 8;
 	name = "Bridge APC";
+	areastring = "/area/bridge";
 	pixel_x = -27
 	},
 /obj/structure/cable/yellow,
@@ -35802,6 +35849,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Arrivals APC";
+	areastring = "/area/hallway/secondary/entry";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -36309,6 +36357,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Captain's Quarters APC";
+	areastring = "/area/crew_quarters/heads/captain/private";
 	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
@@ -36391,6 +36440,7 @@
 	cell_type = 2500;
 	dir = 8;
 	name = "Art Storage APC";
+	areastring = "/area/storage/art";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -36718,6 +36768,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Engineering Foyer APC";
+	areastring = "/area/engine/break_room";
 	pixel_x = -1;
 	pixel_y = -26
 	},
@@ -36875,6 +36926,7 @@
 	aidisabled = 0;
 	dir = 2;
 	name = "MiniSat Exterior APC";
+	areastring = "/area/aisat";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow{
@@ -36986,6 +37038,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "MiniSat Foyer APC";
+	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
 	pixel_y = -29
 	},
 /obj/structure/cable/yellow,
@@ -37910,6 +37963,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Head of Personnel APC";
+	areastring = "/area/crew_quarters/heads/hop";
 	pixel_y = 24
 	},
 /turf/open/floor/carpet,
@@ -39534,6 +39588,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Bar APC";
+	areastring = "/area/crew_quarters/bar";
 	pixel_y = 25
 	},
 /obj/structure/cable/yellow{
@@ -40070,6 +40125,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Port Maintenance APC";
+	areastring = "/area/maintenance/port";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow{
@@ -40459,6 +40515,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Theatre APC";
+	areastring = "/area/crew_quarters/theatre";
 	pixel_y = 25
 	},
 /obj/structure/cable/yellow{
@@ -40497,6 +40554,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "MiniSat Maint APC";
+	areastring = "/area/ai_monitored/storage/satellite";
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40630,6 +40688,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Atmospherics APC";
+	areastring = "/area/engine/atmos";
 	pixel_y = 28
 	},
 /obj/structure/cable/yellow{
@@ -40868,6 +40927,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Telecomms Control Room APC";
+	areastring = "/area/tcommsat/computer";
 	pixel_x = 26
 	},
 /obj/machinery/computer/telecomms/server{
@@ -42499,6 +42559,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Auxiliary Restrooms APC";
+	areastring = "/area/crew_quarters/toilet/auxiliary";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
@@ -42754,6 +42815,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Command Hallway APC";
+	areastring = "/area/hallway/secondary/command";
 	pixel_y = 25
 	},
 /obj/structure/cable/yellow{
@@ -45291,6 +45353,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Teleporter APC";
+	areastring = "/area/teleporter";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45418,6 +45481,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Gateway APC";
+	areastring = "/area/gateway";
 	pixel_x = 28
 	},
 /obj/structure/cable/yellow{
@@ -46676,6 +46740,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Vacant Office APC";
+	areastring = "/area/security/vacantoffice";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -46799,6 +46864,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "E.V.A. Storage APC";
+	areastring = "/area/ai_monitored/storage/eva";
 	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
@@ -47370,6 +47436,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Telecomms Server Room APC";
+	areastring = "/area/tcommsat/server";
 	pixel_x = 25
 	},
 /obj/machinery/light/small{
@@ -47544,6 +47611,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Library APC";
+	areastring = "/area/library";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -48129,6 +48197,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Telecomms Storage APC";
+	areastring = "/area/storage/tcom";
 	pixel_x = -28
 	},
 /obj/structure/cable/yellow{
@@ -48583,6 +48652,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Nanotrasen Corporate Showroom APC";
+	areastring = "/area/bridge/showroom/corporate";
 	pixel_x = 28
 	},
 /obj/structure/cable/yellow{
@@ -50164,6 +50234,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Kitchen APC";
+	areastring = "/area/crew_quarters/kitchen";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
@@ -50873,6 +50944,7 @@
 	cell_type = 2500;
 	dir = 1;
 	name = "Starboard Maintenance APC";
+	areastring = "/area/maintenance/starboard";
 	pixel_x = -1;
 	pixel_y = 26
 	},
@@ -51323,6 +51395,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Central Primary Hallway APC";
+	areastring = "/area/hallway/primary/central";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -51781,6 +51854,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Port Quarter Solar APC";
+	areastring = "/area/maintenance/solars/port/aft";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -53906,6 +53980,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medical Security Checkpoint APC";
+	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -24
 	},
 /obj/machinery/airalarm{
@@ -55785,6 +55860,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Hydroponics APC";
+	areastring = "/area/hydroponics";
 	pixel_y = -28
 	},
 /obj/structure/cable/yellow,
@@ -57480,6 +57556,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Sleeper Room APC";
+	areastring = "/area/medical/sleeper";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -57518,6 +57595,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Medbay Storage APC";
+	areastring = "/area/medical/storage";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow{
@@ -57772,6 +57850,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Post - Research Division APC";
+	areastring = "/area/security/checkpoint/science/research";
 	pixel_x = -24
 	},
 /obj/structure/cable/yellow,
@@ -57847,6 +57926,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Incinerator APC";
+	areastring = "/area/maintenance/disposal/incinerator";
 	pixel_x = -24
 	},
 /obj/structure/cable/yellow{
@@ -58809,6 +58889,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Medbay Central APC";
+	areastring = "/area/medical/medbay/central";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -59060,6 +59141,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Research Division APC";
+	areastring = "/area/science/research";
 	pixel_y = 25
 	},
 /obj/structure/cable/yellow{
@@ -61287,6 +61369,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Cryogenics APC";
+	areastring = "/area/medical/cryo";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -61914,6 +61997,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Surgery APC";
+	areastring = "/area/medical/surgery";
 	pixel_x = 26
 	},
 /obj/structure/cable/yellow{
@@ -62067,6 +62151,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "CMO's Office APC";
+	areastring = "/area/crew_quarters/heads/cmo";
 	pixel_x = 26
 	},
 /obj/structure/cable/yellow{
@@ -62994,6 +63079,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Chemistry APC";
+	areastring = "/area/medical/chemistry";
 	pixel_x = -24
 	},
 /obj/structure/closet/secure_closet/chemical{
@@ -63075,6 +63161,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Research Lab APC";
+	areastring = "/area/science/lab";
 	pixel_y = -26
 	},
 /obj/structure/cable/yellow,
@@ -63309,6 +63396,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Experimentation Lab APC";
+	areastring = "/area/science/explab";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
@@ -63705,6 +63793,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Aft Hallway APC";
+	areastring = "/area/hallway/primary/aft";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -64596,6 +64685,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Toxins Storage APC";
+	areastring = "/area/science/storage";
 	pixel_y = 25
 	},
 /obj/structure/cable/yellow{
@@ -65093,6 +65183,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Quarter Maintenance APC";
+	areastring = "/area/maintenance/port/aft";
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
@@ -65110,6 +65201,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Patient Room A APC";
+	areastring = "/area/medical/patients_rooms/room_a";
 	pixel_x = -26
 	},
 /obj/structure/cable/yellow{
@@ -65245,6 +65337,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Genetics Lab APC";
+	areastring = "/area/medical/genetics";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -66183,6 +66276,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Patient Room B APC";
+	areastring = "/area/medical/patients_rooms/room_b";
 	pixel_x = -26
 	},
 /obj/structure/cable/yellow{
@@ -66476,6 +66570,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "RD Office APC";
+	areastring = "/area/crew_quarters/heads/hor";
 	pixel_y = -27
 	},
 /obj/structure/cable/yellow,
@@ -67586,6 +67681,7 @@
 	dir = 4;
 	locked = 0;
 	name = "Cloning Lab APC";
+	areastring = "/area/medical/genetics/cloning";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow,
@@ -68093,6 +68189,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Medbay Aft APC";
+	areastring = "/area/medical/medbay/aft";
 	pixel_x = 26
 	},
 /obj/structure/cable/yellow{
@@ -68308,6 +68405,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Mech Bay APC";
+	areastring = "/area/science/robotics/mechbay";
 	pixel_x = 28
 	},
 /obj/structure/cable/yellow{
@@ -68815,6 +68913,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Research Firing Range APC";
+	areastring = "/area/science/misc_lab/range";
 	pixel_y = -28
 	},
 /obj/structure/table,
@@ -69467,6 +69566,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Toxins Lab APC";
+	areastring = "/area/science/mixing";
 	pixel_x = 26
 	},
 /obj/structure/cable/yellow{
@@ -69759,6 +69859,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Robotics Lab APC";
+	areastring = "/area/science/robotics/lab";
 	pixel_y = 25
 	},
 /obj/structure/cable/yellow{
@@ -69975,6 +70076,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Virology APC";
+	areastring = "/area/medical/virology";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -70288,6 +70390,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Morgue APC";
+	areastring = "/area/medical/morgue";
 	pixel_x = 26
 	},
 /obj/structure/cable/yellow{
@@ -72611,6 +72714,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Research Division Server Room APC";
+	areastring = "/area/science/server";
 	pixel_y = 25
 	},
 /obj/structure/cable/yellow{
@@ -73898,6 +74002,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Departure Lounge APC";
+	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -74662,6 +74767,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Starboard Quarter Solar APC";
+	areastring = "/area/maintenance/solars/starboard/aft";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -74886,6 +74992,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Aft Maintenance APC";
+	areastring = "/area/maintenance/aft";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
@@ -75899,6 +76006,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Chapel APC";
+	areastring = "/area/chapel/main";
 	pixel_x = -25
 	},
 /turf/open/floor/carpet,
@@ -76150,6 +76258,7 @@
 	dir = 2;
 	lighting = 3;
 	name = "Chapel Office APC";
+	areastring = "/area/chapel/office";
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -82721,6 +82830,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Xenobiology APC";
+	areastring = "/area/science/xenobiology";
 	pixel_y = 27
 	},
 /obj/structure/cable/yellow{
@@ -83558,6 +83668,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Test Chamber Maintenance APC";
+	areastring = "/area/maintenance/department/science/xenobiology";
 	pixel_x = 26
 	},
 /turf/open/floor/plating,
@@ -85095,6 +85206,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Tool Storage APC";
+	areastring = "/area/storage/primary";
 	pixel_y = -27
 	},
 /obj/structure/cable/yellow,
@@ -86980,6 +87092,7 @@
 	cell_type = 2500;
 	dir = 4;
 	name = "Port Bow Maintenance APC";
+	areastring = "/area/maintenance/port/fore";
 	pixel_x = 26
 	},
 /turf/open/floor/plating{
@@ -88217,6 +88330,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Starboard Bow Maintenance APC";
+	areastring = "/area/maintenance/starboard/fore";
 	pixel_y = -28
 	},
 /obj/structure/cable/yellow{
@@ -89503,6 +89617,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Starboard Quarter Maintenance APC";
+	areastring = "/area/maintenance/starboard/aft";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -12012,7 +12012,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
+/area/maintenance/port/central)
 "ath" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -13952,7 +13952,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
+/area/maintenance/starboard/central)
 "awx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -18750,7 +18750,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
+/area/maintenance/starboard/central)
 "aFg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -20476,7 +20476,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/maintenance/port/central)
 "aHP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -20940,7 +20940,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/janitor)
+/area/maintenance/port/central)
 "aID" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -26087,9 +26087,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central{
-	name = "Primary Hallway"
-	})
+/area/maintenance/starboard)
 "aRy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29234,7 +29232,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/library)
+/area/maintenance/port)
 "aXO" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/toxin{
@@ -32924,7 +32922,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/medical/medbay/zone3)
+/area/maintenance/port)
 "beG" = (
 /obj/structure/sign/bluecross_2,
 /turf/closed/wall,
@@ -33042,7 +33040,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/maintenance/starboard)
 "beQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -33534,7 +33532,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/chapel/main)
+/area/maintenance/port)
 "bfA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -33560,7 +33558,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/chapel/main)
+/area/maintenance/port)
 "bfC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall,
@@ -34281,7 +34279,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/maintenance/port)
 "bgP" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
@@ -78915,7 +78913,7 @@ alg
 apJ
 apJ
 apI
-ata
+aHF
 atU
 apI
 apI
@@ -81758,7 +81756,7 @@ asg
 awT
 aAR
 avi
-bxO
+bxL
 asg
 aLf
 aMt

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -565,6 +565,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Bridge APC";
+	areastring = "/area/bridge";
 	pixel_y = -26
 	},
 /obj/structure/cable/white,
@@ -2794,6 +2795,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Head of Personnel Quarter's APC";
+	areastring = "/area/crew_quarters/heads/hop";
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel/vault{
@@ -2979,6 +2981,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Detective's Office APC";
+	areastring = "/area/security/detectives_office";
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
@@ -3631,6 +3634,7 @@
 	aidisabled = 0;
 	dir = 1;
 	name = "AI Chamber APC";
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = 24
 	},
 /turf/open/floor/circuit/green,
@@ -3962,6 +3966,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Captain's Quarters APC";
+	areastring = "/area/crew_quarters/heads/captain/private";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -6805,6 +6810,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Office APC";
+	areastring = "/area/security/brig";
 	pixel_x = -26
 	},
 /obj/structure/cable/white{
@@ -7199,6 +7205,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Cargo Bay APC";
+	areastring = "/area/quartermaster/storage";
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
@@ -8234,6 +8241,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Mining Dock APC";
+	areastring = "/area/quartermaster/miningdock";
 	pixel_x = 26
 	},
 /obj/structure/extinguisher_cabinet{
@@ -9798,6 +9806,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Teleporter APC";
+	areastring = "/area/teleporter";
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
@@ -10037,6 +10046,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "E.V.A. Storage APC";
+	areastring = "/area/ai_monitored/storage/eva";
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
@@ -10481,6 +10491,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Primary Tool Storage APC";
+	areastring = "/area/storage/primary";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -12269,6 +12280,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Atmospherics Engine APC";
+	areastring = "/area/engine/atmos";
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
@@ -15215,6 +15227,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Central Starboard Maintenance APC";
+	areastring = "/area/maintenance/starboard/central";
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -15260,6 +15273,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Departure Lounge APC";
+	areastring = "/area/hallway/secondary/exit";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -16219,6 +16233,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Atrium APC";
+	areastring = "/area/crew_quarters/bar";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -16865,6 +16880,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Dormitories APC";
+	areastring = "/area/crew_quarters/dorms";
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
@@ -16925,6 +16941,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Theatre Backstage APC";
+	areastring = "/area/crew_quarters/theatre";
 	pixel_y = 25
 	},
 /obj/structure/extinguisher_cabinet{
@@ -19596,6 +19613,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Central Port Maintenance APC";
+	areastring = "/area/maintenance/port/central";
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -21304,6 +21322,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Gravity Generator APC";
+	areastring = "/area/engine/gravity_generator";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -21597,6 +21616,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Custodial Closet APC";
+	areastring = "/area/janitor";
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
@@ -21769,6 +21789,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Kitchen APC";
+	areastring = "/area/crew_quarters/kitchen";
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -23615,6 +23636,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Hydroponics APC";
+	areastring = "/area/hydroponics";
 	pixel_y = -26
 	},
 /obj/structure/cable/white,
@@ -24069,6 +24091,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Engine Room APC";
+	areastring = "/area/engine/engineering";
 	pixel_x = 26
 	},
 /obj/structure/cable/white,
@@ -24648,6 +24671,7 @@
 	aidisabled = 0;
 	dir = 1;
 	name = "Primary Hall APC";
+	areastring = "/area/hallway/primary/central";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -26462,6 +26486,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Chemistry Lab APC";
+	areastring = "/area/medical/chemistry";
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
@@ -27376,6 +27401,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Library APC";
+	areastring = "/area/library";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -27645,6 +27671,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Research Division APC";
+	areastring = "/area/science/research";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -27991,6 +28018,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Research and Development Lab APC";
+	areastring = "/area/science/lab";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -28608,6 +28636,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Morgue APC";
+	areastring = "/area/medical/morgue";
 	pixel_y = -26
 	},
 /obj/structure/cable/white{
@@ -30398,6 +30427,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Mech Bay APC";
+	areastring = "/area/science/robotics/mechbay";
 	pixel_y = 28
 	},
 /obj/structure/cable/white{
@@ -30667,6 +30697,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medbay APC";
+	areastring = "/area/medical/medbay/zone3";
 	pixel_x = -26
 	},
 /obj/structure/cable/white,
@@ -31306,6 +31337,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Security Checkpoint APC";
+	areastring = "/area/hallway/primary/central";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -31945,6 +31977,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Port Maintenance APC";
+	areastring = "/area/maintenance/port";
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -32230,6 +32263,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Robotics Lab APC";
+	areastring = "/area/science/robotics/lab";
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -33463,6 +33497,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Starboard Maintenance APC";
+	areastring = "/area/maintenance/starboard";
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -33692,6 +33727,7 @@
 	aidisabled = 0;
 	dir = 1;
 	name = "Central Hall APC";
+	areastring = "/area/hallway/primary/central";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
@@ -33851,6 +33887,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Chapel APC";
+	areastring = "/area/chapel/main";
 	pixel_y = 25
 	},
 /obj/effect/landmark/start/assistant,
@@ -34691,6 +34728,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Arrivals APC";
+	areastring = "/area/hallway/secondary/entry";
 	pixel_y = 25
 	},
 /obj/structure/cable/white{
@@ -35932,6 +35970,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Xenobiology Lab APC";
+	areastring = "/area/science/xenobiology";
 	pixel_x = 26
 	},
 /obj/machinery/light_switch{
@@ -39457,6 +39496,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Telecomms Server Room APC";
+	areastring = "/area/tcommsat/server";
 	pixel_x = -26
 	},
 /obj/structure/cable{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -972,6 +972,7 @@
 	aidisabled = 0;
 	dir = 1;
 	name = "AI Chamber APC";
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = 24
 	},
 /obj/effect/landmark/tripai,
@@ -1424,6 +1425,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "MiniSat Antechamber APC";
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	pixel_x = -24
 	},
 /obj/machinery/recharger,
@@ -2095,6 +2097,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "MiniSat Port Maintenance APC";
+	areastring = "/area/ai_monitored/turret_protected/AIsatextAP";
 	pixel_x = -24
 	},
 /turf/open/floor/plating,
@@ -2290,6 +2293,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "MiniSat Starboard Maintenance APC";
+	areastring = "/area/ai_monitored/turret_protected/AIsatextAS";
 	pixel_x = 24
 	},
 /turf/open/floor/plating,
@@ -3326,6 +3330,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Prison Wing APC";
+	areastring = "/area/security/prison";
 	pixel_x = 1;
 	pixel_y = 24
 	},
@@ -3815,6 +3820,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Armory APC";
+	areastring = "/area/security/armory";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -3914,6 +3920,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Prisoner Transfer Centre";
+	areastring = "/area/security/transfer";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -4355,6 +4362,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Office APC";
+	areastring = "/area/security/main";
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -4683,6 +4691,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Crematorium APC";
+	areastring = "/area/security/processing/cremation";
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -5396,6 +5405,7 @@
 	cell_type = 10000;
 	dir = 4;
 	name = "Brig APC";
+	areastring = "/area/security/brig";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -5816,6 +5826,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Brig Control APC";
+	areastring = "/area/security/warden";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -6293,6 +6304,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Head of Security's Office APC";
+	areastring = "/area/crew_quarters/heads/hos";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -6864,6 +6876,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Fore Maintenance APC";
+	areastring = "/area/maintenance/fore";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -7562,6 +7575,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Vault APC";
+	areastring = "/area/ai_monitored/nuke_storage";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -7584,6 +7598,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Gateway APC";
+	areastring = "/area/teleporter";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -7645,6 +7660,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Dormitory APC";
+	areastring = "/area/crew_quarters/dorms";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -8705,6 +8721,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Dormitory Maintenance APC";
+	areastring = "/area/maintenance/department/crew_quarters/dorms";
 	pixel_x = -24
 	},
 /obj/structure/cable,
@@ -10267,6 +10284,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Fitness Room APC";
+	areastring = "/area/crew_quarters/fitness/recreation";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -10836,6 +10854,7 @@
 	cell_type = 2500;
 	dir = 1;
 	name = "Captain's Office APC";
+	areastring = "/area/crew_quarters/heads/captain";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -11152,6 +11171,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Port Solar APC";
+	areastring = "/area/maintenance/solars/port";
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
@@ -11521,6 +11541,7 @@
 	cell_type = 10000;
 	dir = 4;
 	name = "Bridge APC";
+	areastring = "/area/bridge";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -11870,6 +11891,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Fore Primary Hallway APC";
+	areastring = "/area/hallway/primary/fore";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -12420,6 +12442,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Upload APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -12526,6 +12549,7 @@
 	cell_type = 5000;
 	dir = 8;
 	name = "Central Hall APC";
+	areastring = "/area/hallway/primary/central";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -13395,6 +13419,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Tool Storage APC";
+	areastring = "/area/storage/primary";
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -13715,6 +13740,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Head of Personnel APC";
+	areastring = "/area/crew_quarters/heads/hop";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -13855,6 +13881,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Detective's Office APC";
+	areastring = "/area/security/detectives_office";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -14413,6 +14440,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Emergency Storage APC";
+	areastring = "/area/storage/emergency/starboard";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -15562,6 +15590,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Dormitory Bathrooms APC";
+	areastring = "/area/crew_quarters/toilet/restrooms";
 	pixel_x = 26
 	},
 /obj/structure/cable,
@@ -17202,6 +17231,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Teleporter APC";
+	areastring = "/area/teleporter";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -17645,6 +17675,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Departure Lounge APC";
+	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -17751,6 +17782,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Art Storage APC";
+	areastring = "/area/storage/art";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -17785,6 +17817,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Cafeteria APC";
+	areastring = "/area/crew_quarters/cafeteria/lunchroom";
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -17819,6 +17852,7 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Auxiliary Restrooms APC";
+	areastring = "/area/crew_quarters/toilet/auxiliary";
 	pixel_y = -24
 	},
 /obj/item/weapon/soap/nanotrasen,
@@ -18942,6 +18976,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Bar Maintenance APC";
+	areastring = "/area/maintenance/department/crew_quarters/bar";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -19052,6 +19087,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Security Post - Cargo APC";
+	areastring = "/area/security/checkpoint/supply";
 	pixel_x = -24
 	},
 /obj/structure/closet/wardrobe/red,
@@ -19589,6 +19625,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "EVA Storage APC";
+	areastring = "/area/storage/eva";
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel,
@@ -20150,6 +20187,7 @@
 	cell_type = 2500;
 	dir = 4;
 	name = "Cargo Maintenance APC";
+	areastring = "/area/maintenance/department/cargo";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -20172,6 +20210,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Disposal APC";
+	areastring = "/area/maintenance/disposal";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -21444,6 +21483,7 @@
 "aUU" = (
 /obj/machinery/power/apc{
 	name = "Hydroponics APC";
+	areastring = "/area/hydroponics";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -21919,6 +21959,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Kitchen APC";
+	areastring = "/area/crew_quarters/kitchen";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -22036,6 +22077,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Bar APC";
+	areastring = "/area/crew_quarters/bar";
 	pixel_x = 27
 	},
 /obj/structure/cable{
@@ -22088,6 +22130,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Theatre APC";
+	areastring = "/area/crew_quarters/theatre";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -23684,6 +23727,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Custodial Closet APC";
+	areastring = "/area/janitor";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -23926,6 +23970,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Cargo Office APC";
+	areastring = "/area/quartermaster/office";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -23984,6 +24029,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Cargo Bay APC";
+	areastring = "/area/quartermaster/storage";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -24138,6 +24184,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Security Checkpoint APC";
+	areastring = "/area/security/checkpoint/customs";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -25311,6 +25358,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Quartermaster APC";
+	areastring = "/area/quartermaster/qm";
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -25415,6 +25463,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Starboard Solar APC";
+	areastring = "/area/maintenance/solars/starboard";
 	pixel_x = -24
 	},
 /turf/open/floor/plating,
@@ -26132,6 +26181,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Mech Bay APC";
+	areastring = "/area/science/robotics/mechbay";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -26720,6 +26770,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Mining Dock APC";
+	areastring = "/area/quartermaster/miningdock";
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/brown/corner{
@@ -27731,6 +27782,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Lounge APC";
+	areastring = "/area/crew_quarters/lounge";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -28139,6 +28191,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Morgue APC";
+	areastring = "/area/medical/morgue";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -28868,6 +28921,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Robotics Lab APC";
+	areastring = "/area/science/robotics/lab";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -28943,6 +28997,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Testing Lab APC";
+	areastring = "/area/science/explab";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -29087,6 +29142,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Lounge APC";
+	areastring = "/area/storage/emergency/port";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -29193,6 +29249,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medbay Security APC";
+	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -30831,6 +30888,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Server Room APC";
+	areastring = "/area/science/server";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -31175,6 +31233,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Arrivals APC";
+	areastring = "/area/hallway/secondary/entry";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -31322,6 +31381,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Medbay APC";
+	areastring = "/area/medical/medbay/zone3";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -31340,6 +31400,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Medbay APC";
+	areastring = "/area/medical/medbay/central";
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -32193,6 +32254,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Research Lab APC";
+	areastring = "/area/science/explab";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -33502,6 +33564,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Research Lobby APC";
+	areastring = "/area/science/research/lobby";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -33605,6 +33668,7 @@
 	cell_type = 10000;
 	dir = 1;
 	name = "Research Division APC";
+	areastring = "/area/science/research";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -33863,6 +33927,7 @@
 	cell_type = 5000;
 	dir = 8;
 	name = "Xenobiology APC";
+	areastring = "/area/science/xenobiology";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -35106,6 +35171,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Chemistry APC";
+	areastring = "/area/medical/chemistry";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -36517,6 +36583,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "RD Office APC";
+	areastring = "/area/crew_quarters/heads/hor";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -36754,6 +36821,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Toxins Lab APC";
+	areastring = "/area/science/mixing";
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -36871,6 +36939,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Genetics APC";
+	areastring = "/area/medical/genetics";
 	pixel_x = 27
 	},
 /obj/structure/cable{
@@ -36925,6 +36994,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Treatment Center APC";
+	areastring = "/area/medical/sleeper";
 	pixel_x = -24
 	},
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,
@@ -37484,6 +37554,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "CMO's Office APC";
+	areastring = "/area/crew_quarters/heads/cmo";
 	pixel_x = 26
 	},
 /obj/structure/cable,
@@ -38286,6 +38357,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Science Security APC";
+	areastring = "/area/security/checkpoint/science";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -38551,6 +38623,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Toxins Launch Room APC";
+	areastring = "/area/science/mineral_storeroom";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -38770,6 +38843,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Personal Examination Room APC";
+	areastring = "/area/medical/exam_room";
 	pixel_x = -25
 	},
 /obj/structure/cable,
@@ -39164,6 +39238,7 @@
 	cell_type = 5000;
 	dir = 1;
 	name = "Virology APC";
+	areastring = "/area/medical/virology";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -39985,6 +40060,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Toxins Storage APC";
+	areastring = "/area/science/storage";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -40637,6 +40713,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Monastery Docking Bay APC";
+	areastring = "/area/chapel/dock";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -40858,6 +40935,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Surgery APC";
+	areastring = "/area/medical/surgery";
 	pixel_x = 26
 	},
 /obj/structure/cable,
@@ -40947,6 +41025,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Atmospherics APC";
+	areastring = "/area/engine/atmos";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -43308,6 +43387,7 @@
 "bQB" = (
 /obj/machinery/power/apc{
 	name = "Aft Hall APC";
+	areastring = "/area/hallway/primary/aft";
 	dir = 8;
 	pixel_x = -25;
 	pixel_y = 1
@@ -44558,6 +44638,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Gravity Generator APC";
+	areastring = "/area/engine/gravity_generator";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -44695,6 +44776,7 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Tech Storage APC";
+	areastring = "/area/storage/tech";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -45772,6 +45854,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Engineering Security APC";
+	areastring = "/area/security/checkpoint/engineering";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -46007,6 +46090,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "CE Office APC";
+	areastring = "/area/crew_quarters/heads/chief";
 	pixel_x = 28
 	},
 /obj/structure/cable{
@@ -46463,6 +46547,7 @@
 	cell_type = 10000;
 	dir = 8;
 	name = "Engine Room APC";
+	areastring = "/area/engine/engine_smes";
 	pixel_x = -26
 	},
 /obj/structure/cable,
@@ -47015,6 +47100,7 @@
 	cell_type = 5000;
 	dir = 8;
 	name = "Engineering Maintenance APC";
+	areastring = "/area/maintenance/department/engine";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -47413,6 +47499,7 @@
 	cell_type = 15000;
 	dir = 4;
 	name = "Engineering APC";
+	areastring = "/area/engine/engineering";
 	pixel_x = 28
 	},
 /obj/structure/cable{
@@ -47435,6 +47522,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Incinerator APC";
+	areastring = "/area/maintenance/disposal/incinerator";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -49667,6 +49755,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Chapel Office APC";
+	areastring = "/area/chapel/office";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -49946,6 +50035,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Monastery APC";
+	areastring = "/area/chapel/main/monastery";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -50462,6 +50552,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Monastery External APC";
+	areastring = "/area/chapel/main/monastery";
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/asteroid{
@@ -50727,6 +50818,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Garden APC";
+	areastring = "/area/hydroponics/garden/monastery";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -52055,6 +52147,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Monastery Maintenance APC";
+	areastring = "/area/maintenance/department/chapel/monastery";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -52133,6 +52226,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Library APC";
+	areastring = "/area/library";
 	pixel_x = 24
 	},
 /obj/machinery/airalarm{
@@ -52986,6 +53080,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Telecomms Monitoring APC";
+	areastring = "/area/tcommsat/computer";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -53208,6 +53303,7 @@
 	dir = 1;
 	layer = 4;
 	name = "Telecomms Server APC";
+	areastring = "/area/tcommsat/server";
 	pixel_y = 24
 	},
 /obj/structure/cable,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1035,7 +1035,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/turretid{
-	control_area = "AI Chamber";
+	control_area = "/area/ai_monitored/turret_protected/ai";
 	name = "AI Chamber turret control";
 	pixel_x = 5;
 	pixel_y = -24
@@ -1054,7 +1054,7 @@
 /area/ai_monitored/turret_protected/ai)
 "acs" = (
 /obj/machinery/turretid{
-	control_area = "AI Satellite Antechamber";
+	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
 	name = "AI Satellite turret control";
 	pixel_x = -5;
 	pixel_y = -24
@@ -53475,7 +53475,7 @@
 /area/science/research/lobby)
 "cnC" = (
 /obj/machinery/turretid{
-	control_area = "AI Satellite Antechamber";
+	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
 	name = "AI Satellite turret control";
 	pixel_x = -5;
 	pixel_y = -24

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -5721,7 +5721,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/security/processing/cremation)
+/area/maintenance/department/security/brig)
 "amJ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 6
@@ -6066,7 +6066,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/maintenance/department/security/brig)
 "any" = (
 /obj/machinery/light{
 	dir = 8
@@ -9920,7 +9920,7 @@
 	req_access_txt = "20"
 	},
 /turf/open/floor/plating,
-/area/bridge)
+/area/maintenance/fore)
 "avN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/vault,
@@ -10512,7 +10512,7 @@
 	req_access_txt = "20"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/heads/captain)
+/area/maintenance/fore)
 "awU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -13328,7 +13328,7 @@
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
+/area/maintenance/department/cargo)
 "aDm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14956,7 +14956,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/security/detectives_office)
+/area/maintenance/department/security/brig)
 "aGU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16920,7 +16920,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/quartermaster/storage)
+/area/maintenance/department/cargo)
 "aLi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -17711,7 +17711,7 @@
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
+/area/maintenance/department/security/brig)
 "aMR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -19959,7 +19959,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/hydroponics)
+/area/maintenance/department/crew_quarters/bar)
 "aRN" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
@@ -20043,7 +20043,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/bar)
+/area/maintenance/department/crew_quarters/bar)
 "aRV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -20082,7 +20082,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/storage/eva)
+/area/maintenance/department/crew_quarters/bar)
 "aRY" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -21106,7 +21106,7 @@
 	req_one_access_txt = "12;46"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/theatre)
+/area/maintenance/department/crew_quarters/bar)
 "aUh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Theatre Maintenance";
@@ -21115,7 +21115,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/crew_quarters/theatre)
+/area/maintenance/department/crew_quarters/bar)
 "aUi" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway Cargo";
@@ -24472,7 +24472,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/maintenance/department/cargo)
 "bbB" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular{
@@ -27135,7 +27135,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/quartermaster/miningdock)
+/area/maintenance/department/cargo)
 "bhs" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -29130,7 +29130,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/storage/emergency/port)
+/area/maintenance/department/engine)
 "bmh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -32690,7 +32690,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/maintenance/department/engine)
 "btP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -36558,7 +36558,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/medical/chemistry)
+/area/maintenance/department/engine)
 "bBm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/yellow/corner{
@@ -38653,7 +38653,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/science/mineral_storeroom)
+/area/maintenance/department/cargo)
 "bFB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -47142,7 +47142,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/maintenance/department/engine)
 "bYJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -86040,7 +86040,7 @@ adw
 adL
 adV
 adV
-cnF
+cnD
 adV
 adV
 aeN
@@ -87582,7 +87582,7 @@ adC
 adO
 adZ
 adZ
-cnI
+cnG
 adZ
 adZ
 aeR
@@ -90774,7 +90774,7 @@ bKX
 bVZ
 bWO
 bXA
-bYr
+bQO
 bZe
 bZM
 caF
@@ -91288,7 +91288,7 @@ bVi
 bMe
 bWP
 bXy
-bYr
+bQO
 bZe
 bZN
 caH
@@ -95592,7 +95592,7 @@ atn
 aFM
 aGJ
 aGJ
-aIn
+aDl
 aEk
 aEk
 aLj

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -795,7 +795,7 @@
 /area/space)
 "abO" = (
 /turf/closed/wall/r_wall,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "abP" = (
 /obj/item/weapon/cautery,
 /obj/item/weapon/scalpel,
@@ -840,20 +840,20 @@
 "abV" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "abW" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "abX" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "abY" = (
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "abZ" = (
 /obj/structure/shuttle/engine/propulsion/left,
 /obj/effect/turf_decal/stripes/line,
@@ -874,16 +874,16 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acd" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "ace" = (
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acf" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber North";
@@ -896,19 +896,19 @@
 	pixel_y = -24
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "ach" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "aci" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -916,7 +916,7 @@
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
 	},
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acj" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -937,7 +937,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "ack" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -962,7 +962,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acl" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -984,7 +984,7 @@
 	pixel_x = 27
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acm" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat External Port";
@@ -1006,7 +1006,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "aco" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -1014,7 +1014,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acp" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -1027,7 +1027,7 @@
 	req_access_txt = "65"
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -1041,7 +1041,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acr" = (
 /obj/machinery/ai_slipper{
 	uses = 8
@@ -1051,7 +1051,7 @@
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acs" = (
 /obj/machinery/turretid{
 	control_area = "AI Satellite Antechamber";
@@ -1060,7 +1060,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "act" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/glass_command{
@@ -1068,7 +1068,7 @@
 	req_access_txt = "65"
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acu" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -1082,7 +1082,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acv" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat External Starboard";
@@ -1096,7 +1096,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acx" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -1104,7 +1104,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acy" = (
 /obj/effect/landmark/start/ai,
 /obj/item/device/radio/intercom{
@@ -1142,7 +1142,7 @@
 	pixel_y = -28
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -1150,7 +1150,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acA" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -1158,17 +1158,17 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acB" = (
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acC" = (
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acD" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
@@ -1186,7 +1186,7 @@
 	pixel_y = 37
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acE" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
@@ -1196,7 +1196,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/circuit,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acF" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/plating/airless,
@@ -1211,7 +1211,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -1222,7 +1222,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acI" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -1240,7 +1240,7 @@
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
 	},
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acJ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -1249,7 +1249,7 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acK" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -1257,7 +1257,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acL" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -1268,11 +1268,11 @@
 	uses = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acM" = (
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/white,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acN" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -1296,7 +1296,7 @@
 "acR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/black,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acS" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -1304,11 +1304,11 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/black,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "acU" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -1335,14 +1335,14 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "ada" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "adb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -1357,21 +1357,21 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "adc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "add" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/wreck/ai)
+/area/ai_monitored/turret_protected/ai)
 "ade" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/metal,
@@ -11446,7 +11446,7 @@
 /area/bridge)
 "azk" = (
 /obj/machinery/turretid{
-	control_area = "AI Upload Chamber";
+	control_area = "/area/ai_monitored/turret_protected/ai_upload";
 	name = "AI Upload turret control";
 	pixel_y = -25
 	},

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -531,6 +531,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/crew_quarters/toilet/locker
 	name = "Locker Toilets"
 	icon_state = "toilet"
+
+/area/crew_quarters/toilet/fitness
+	name = "Fitness Toilets"
+	icon_state = "toilet"
 	
 /area/crew_quarters/toilet/female
 	name = "Female Toilets"

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -672,11 +672,14 @@
 	..()
 	if(!mapload)
 		return
-	
-	if(!control_area)
-		control_area = get_area(src)
-	else
+
+	if(control_area)
 		control_area = locate(text2path(control_area)) in GLOB.sortedAreas
+		if(control_area == null)
+			control_area = get_area(src)
+			stack_trace("Bad control_area path for [src], [src.control_area]")
+	else if(!control_area)
+		control_area = get_area(src)
 
 	for(var/obj/machinery/porta_turret/T in control_area)
 		turrets |= T

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -676,7 +676,7 @@
 	if(!control_area)
 		control_area = get_area(src)
 	else
-		control_area = locate(text2path(control_area))
+		control_area = locate(text2path(control_area)) in GLOB.sortedAreas
 
 	for(var/obj/machinery/porta_turret/T in control_area)
 		turrets |= T

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -672,15 +672,11 @@
 	..()
 	if(!mapload)
 		return
-	if(control_area && istext(control_area))
-		for(var/V in GLOB.sortedAreas)
-			var/area/A = V
-			if(A.name == control_area)
-				control_area = A
-				break
-
+	
 	if(!control_area)
 		control_area = get_area(src)
+	else
+		control_area = locate(text2path(control_area))
 
 	for(var/obj/machinery/porta_turret/T in control_area)
 		turrets |= T

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -180,7 +180,7 @@
 	if(isarea(A) && src.areastring == null)
 		src.area = A
 	else
-		src.area = get_area_by_name(areastring)
+		src.area = locate(text2path(areastring))
 	update_icon()
 
 	make_terminal()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -177,10 +177,13 @@
 	var/area/A = src.loc.loc
 
 	//if area isn't specified use current
-	if(isarea(A) && src.areastring == null)
-		src.area = A
-	else
+	if(areastring)
 		src.area = locate(text2path(areastring)) in GLOB.sortedAreas
+		if(!src.area)
+			src.area = A
+			stack_trace("Bad areastring path for [src], [src.areastring]")
+	else if(isarea(A) && src.areastring == null)
+		src.area = A
 	update_icon()
 
 	make_terminal()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -180,7 +180,7 @@
 	if(isarea(A) && src.areastring == null)
 		src.area = A
 	else
-		src.area = locate(text2path(areastring))
+		src.area = locate(text2path(areastring)) in GLOB.sortedAreas
 	update_icon()
 
 	make_terminal()


### PR DESCRIPTION
Fixes #27482
Closes #29271

Changed control_area for turrets and areastring for APC's to both use proper paths instead of area names, which was no bueno.

Cleaned up the old areas that were placed in maintenace for those APCs

Made the maintenance door areas leading out of departments consistent between all the maps (ergo they are on the tunnel's powernet, providing emergency egress.)