### PR TITLE
Fixes goonchat on ie8

### DIFF
--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -133,7 +133,8 @@ function highlightTerms(el) {
 							newWord = words[w].replace("<", "&lt;").replace(new RegExp(opts.highlightTerms[i], 'gi'), addHighlightMarkup);
 							break;
 						}
-						console.log(newWord)
+						if (window.console)
+							console.log(newWord)
 					}
 					newText += newWord || words[w].replace("<", "&lt;");
 					newText += w >= words.length ? '' : ' ';


### PR DESCRIPTION
ie8 doesn't define the console unless dev tools are open, this error would break parsing the load command, so it would never load.