### PR TITLE
Adds log parsing sql email alert script

### DIFF
--- a/tools/SQLAlertEmail/email_config.ps1
+++ b/tools/SQLAlertEmail/email_config.ps1
@@ -1,0 +1,11 @@
+﻿$Path = '..\..\data\logs\' #Server directory up to the year folder, this can be a relative or absolute path; remember the trailing \
+$StringToMatch = 'SQL:'
+$From = 'admin@server.com'
+[string[]]$To = 'email@address.com', 'a_different@address.org' #Email will be sent to each address listed here, you can have as many as you want
+$Subject = 'SS13 server SQL error'
+$Body = 'A SQL error was found in the following files:' #This parameter is optional, set it as '' if you want it gone
+#SMTP server details; If you don't have one you can use the defaults provided here for Gmail's, provided you have a Google account
+$SMTPServer = 'smtp.gmail.com'
+$SMTPPort = '587'
+$Account = "username" #SMTP server account name, excluding the domain address (this part: @domain.com)
+$Password = 'password' #SMTP server password, if you're using Gmail's and have 2-factor authentication you'll have to use an App Password (Google for how)

--- a/tools/SQLAlertEmail/email_script.ps1
+++ b/tools/SQLAlertEmail/email_script.ps1
@@ -1,0 +1,23 @@
+﻿<#
+This is a script designed to parse through your server logs and locate any SQL errors reported.
+If found an email is sent to addresses specified in the configuration file: email_config.ps1.
+A SMTP server is required, if you don't have one the defaults for Gmail's can be used.
+
+Suggested use is to schedule this task to be executed daily at server-time midnight so all the day's logs are checked.
+You will likely find it helpful to set the configuration file to be untracked by git.
+#>
+. .\email_config.ps1
+$Date = Get-Date -format "yyyy\\MM\\dd"
+$Matches = Get-ChildItem "$Path$Date" -recurse -include *.log | Select-String "$StringToMatch" -List | Select Path, Line
+
+$email = New-Object System.Net.Mail.MailMessage
+$email.From = $From
+foreach($i in $To) {$email.To.Add($i)}
+$email.Subject = $Subject
+$MatchList = foreach($m in $Matches) {"`t$m`n"}
+$email.Body = $Body+"`n"+$MatchList
+
+$smtp = New-Object System.Net.Mail.SmtpClient($SMTPServer, $SMTPPort);
+$smtp.Credentials = New-Object System.Net.NetworkCredential($Account, $Password);
+$smtp.EnableSSL = $true
+$smtp.Send($email);


### PR DESCRIPTION
Powershell script which reads through `.log` files from the current date to search for the SQL error keyword `SQL:`. If found an email is sent to user defined addresses. This requires a SMTP server but Gmail's can be used for that (although it replaces the from address with the gmail account).

This was basically entirely designed for our servers so I can't guarantee functionality if another server's directory structure is different for whatever reason. However the script is pretty configurable so that shouldn't be a problem.

Obviously not natively supported on Linux; it's possible to install a powershell package if you want to run this, but I figure if you're hosting off Linux you're probably competent enough to recreate the script yourself anyway. Plus I don't know shell.

@MrStonedOne 