### PR TITLE
Fixes oversight with APCs using areastring

### DIFF
--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -33,7 +33,7 @@
 
 	for(var/obj/machinery/power/apc/C in GLOB.apcs_list)
 		if(C.cell && C.z == ZLEVEL_STATION)
-			var/area/A = get_area(C)
+			var/area/A = C.area
 
 			var/skip = 0
 			for(var/area_type in skipped_areas)

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -133,8 +133,8 @@
 			active_apc.locked = TRUE
 			active_apc.update_icon()
 			active_apc = null
-		to_chat(usr, "<span class='robot notice'>[bicon(src)] Connected to APC in [get_area(APC)]. Interface request sent.</span>")
-		log_activity("remotely accessed APC in [get_area(APC)]")
+		to_chat(usr, "<span class='robot notice'>[bicon(src)] Connected to APC in [APC.area]. Interface request sent.</span>")
+		log_activity("remotely accessed APC in [APC.area]")
 		APC.interact(usr, GLOB.not_incapacitated_state)
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 		message_admins("[key_name_admin(usr)] remotely accessed [APC] from [src] at [get_area(src)].")

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -513,7 +513,7 @@ GLOBAL_PROTECT(AdminProcCallCount)
 			areas_all.Add(A.type)
 
 	for(var/obj/machinery/power/apc/APC in GLOB.apcs_list)
-		var/area/A = get_area(APC)
+		var/area/A = APC.area
 		if(!(A.type in areas_with_APC))
 			areas_with_APC.Add(A.type)
 


### PR DESCRIPTION
Didn't think to check for things not looking for an APC's area var (which reports it's assigned area) as opposed to it's physical area.

I guess this was never caught before since nobody ever bothered to use the areastring var, despite it being added 5 years ago.