### PR TITLE
The Ark of the Clockwork Justicar is now much cheaper to summon

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -80,8 +80,6 @@ GLOBAL_LIST_EMPTY(all_scripture) //a list containing scripture instances; not us
 
 #define ARK_SUMMON_COST 5 //how many of each component an Ark costs to summon
 
-#define ARK_CONSUME_COST 15 //how many of each component an Ark needs to consume to activate
-
 //Objective text define
 #define CLOCKCULT_OBJECTIVE "Construct the Ark of the Clockwork Justicar and free Ratvar."
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -490,14 +490,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		for(var/obj/structure/destructible/clockwork/massive/celestial_gateway/G in GLOB.all_clockwork_objects)
 			var/area/gate_area = get_area(G)
 			textlist += "Ark Location: <b>[uppertext(gate_area.map_name)]</b><br>"
-			if(G.still_needs_components())
-				textlist += "Ark Components required:<br>"
-				for(var/i in G.required_components)
-					if(G.required_components[i])
-						textlist += "[get_component_icon(i)] <b><font color=[get_component_color_bright(i)]>[G.required_components[i]]</font></b> "
-				textlist += "<br>"
-			else
-				textlist += "Seconds until Ratvar's arrival: <b>[G.get_arrival_text(TRUE)]</b><br>"
+			textlist += "Seconds until Ratvar's arrival: <b>[G.get_arrival_text(TRUE)]</b><br>"
 			break
 		if(unconverted_ais_exist)
 			if(unconverted_ais_exist > 1)

--- a/code/game/gamemodes/clock_cult/clock_helpers/component_helpers.dm
+++ b/code/game/gamemodes/clock_cult/clock_helpers/component_helpers.dm
@@ -22,12 +22,6 @@
 	else
 		for(var/i in GLOB.clockwork_component_cache)
 			.[i] = max(MAX_COMPONENTS_BEFORE_RAND - LOWER_PROB_PER_COMPONENT*GLOB.clockwork_component_cache[i], 1)
-	for(var/obj/structure/destructible/clockwork/massive/celestial_gateway/G in GLOB.all_clockwork_objects)
-		if(G.still_needs_components())
-			for(var/i in G.required_components)
-				if(!G.required_components[i])
-					. -= i
-		break
 	. = pickweight(.)
 
 //returns a component name from a component id

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_judgement.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_judgement.dm
@@ -6,14 +6,13 @@
 /datum/clockwork_scripture/create_object/ark_of_the_clockwork_justiciar
 	descname = "Structure, Win Condition"
 	name = "Ark of the Clockwork Justiciar"
-	desc = "Tears apart a rift in spacetime to Reebe, the Celestial Derelict, using a massive amount of components.\n\
-	This gateway will, after some time, call forth Ratvar from his exile and massively empower all scriptures and tools."
+	desc = "Tears apart a rift in spacetime to Reebe, the Celestial Derelict. This gateway will, after some time, call forth Ratvar from his exile and massively empower all scriptures and tools."
 	invocations = list("ARMORER! FRIGHT! AMPERAGE! VANGUARD! I CALL UPON YOU!!", \
 	"THE TIME HAS COME FOR OUR MASTER TO BREAK THE CHAINS OF EXILE!!", \
 	"LEND US YOUR AID! ENGINE COMES!!")
 	channel_time = 150
 	consumed_components = list(BELLIGERENT_EYE = ARK_SUMMON_COST, VANGUARD_COGWHEEL = ARK_SUMMON_COST, GEIS_CAPACITOR = ARK_SUMMON_COST, REPLICANT_ALLOY = ARK_SUMMON_COST, HIEROPHANT_ANSIBLE = ARK_SUMMON_COST)
-	invokers_required = 6
+	invokers_required = 3
 	multiple_invokers_used = TRUE
 	object_path = /obj/structure/destructible/clockwork/massive/celestial_gateway
 	creator_message = null

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -17,10 +17,8 @@
 	var/first_sound_played = FALSE
 	var/second_sound_played = FALSE
 	var/third_sound_played = FALSE
-	var/fourth_sound_played = FALSE
 	var/obj/effect/clockwork/overlay/gateway_glow/glow
 	var/obj/effect/countdown/clockworkgate/countdown
-	var/list/required_components = list(BELLIGERENT_EYE = ARK_CONSUME_COST, VANGUARD_COGWHEEL = ARK_CONSUME_COST, GEIS_CAPACITOR = ARK_CONSUME_COST, REPLICANT_ALLOY = ARK_CONSUME_COST, HIEROPHANT_ANSIBLE = ARK_CONSUME_COST)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/Initialize()
 	. = ..()
@@ -50,8 +48,10 @@
 		if(!is_blocked_turf(OT, TRUE))
 			open_turfs |= OT
 	if(open_turfs.len)
-		for(var/mob/living/L in T)
-			L.forceMove(pick(open_turfs))
+		for(var/a in T)
+			var/atom/movable/A = a
+			if(!A.anchored || isliving(A))
+				A.forceMove(pick(open_turfs))
 	resistance_flags &= ~INDESTRUCTIBLE
 	density = TRUE
 	invisibility = 0
@@ -104,45 +104,6 @@
 	var/damage = max((obj_integrity * 0.70) / severity, 100) //requires multiple bombs to take down
 	take_damage(damage, BRUTE, "bomb", 0)
 
-/obj/structure/destructible/clockwork/massive/celestial_gateway/attackby(obj/item/I, mob/living/user, params) //add components directly to the ark
-	if(!is_servant_of_ratvar(user) || !still_needs_components())
-		return ..()
-	if(istype(I, /obj/item/clockwork/component))
-		var/obj/item/clockwork/component/C = I
-		if(required_components[C.component_id])
-			required_components[C.component_id]--
-			to_chat(user, "<span class='notice'>You add [C] to [src].</span>")
-			user.drop_item()
-			qdel(C)
-		else
-			to_chat(user, "<span class='notice'>[src] has enough [get_component_name(C.component_id)][C.component_id != REPLICANT_ALLOY ? "s":""].</span>")
-		return 1
-	else if(istype(I, /obj/item/clockwork/slab))
-		var/obj/item/clockwork/slab/S = I
-		var/used_components = FALSE
-		var/used_all = TRUE
-		for(var/i in S.stored_components)
-			if(required_components[i])
-				var/to_use = min(S.stored_components[i], required_components[i])
-				required_components[i] -= to_use
-				S.stored_components[i] -= to_use
-				if(to_use)
-					used_components = TRUE
-				if(S.stored_components[i])
-					used_all = FALSE
-		if(used_components)
-			update_slab_info(S)
-			user.visible_message("<span class='notice'>[user][used_all ? "":" partially"] empties [S] into [src].</span>", \
-			"<span class='notice'>You offload [used_all ? "all":"some"] of your slab's components into [src].</span>")
-		return 1
-	else
-		return ..()
-
-/obj/structure/destructible/clockwork/massive/celestial_gateway/proc/still_needs_components()
-	for(var/i in required_components)
-		if(required_components[i])
-			return TRUE
-
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/get_arrival_text(s_on_time)
 	. = "IMMINENT"
 	if(!obj_integrity)
@@ -155,21 +116,14 @@
 	..()
 	icon_state = initial(icon_state)
 	if(is_servant_of_ratvar(user) || isobserver(user))
-		if(still_needs_components())
-			to_chat(user, "<span class='big'><b>Components required until activation:</b></span>")
-			for(var/i in required_components)
-				if(required_components[i])
-					to_chat(user, "[get_component_icon(i)] <span class='[get_component_span(i)]'>[get_component_name(i)][i != REPLICANT_ALLOY ? "s":""]:</span> \
-					<span class='[get_component_span(i)]_large'>[required_components[i]]</span>")
-		else
-			to_chat(user, "<span class='big'><b>Seconds until Ratvar's arrival:</b> [get_arrival_text(TRUE)]</span>")
-			switch(progress_in_seconds)
-				if(-INFINITY to GATEWAY_REEBE_FOUND)
-					to_chat(user, "<span class='heavy_brass'>It's still opening.</span>")
-				if(GATEWAY_REEBE_FOUND to GATEWAY_RATVAR_COMING)
-					to_chat(user, "<span class='heavy_brass'>It's reached the Celestial Derelict and is drawing power from it.</span>")
-				if(GATEWAY_RATVAR_COMING to INFINITY)
-					to_chat(user, "<span class='heavy_brass'>Ratvar is coming through the gateway!</span>")
+		to_chat(user, "<span class='big'><b>Seconds until Ratvar's arrival:</b> [get_arrival_text(TRUE)]</span>")
+		switch(progress_in_seconds)
+			if(-INFINITY to GATEWAY_REEBE_FOUND)
+				to_chat(user, "<span class='heavy_brass'>It's still opening.</span>")
+			if(GATEWAY_REEBE_FOUND to GATEWAY_RATVAR_COMING)
+				to_chat(user, "<span class='heavy_brass'>It's reached the Celestial Derelict and is drawing power from it.</span>")
+			if(GATEWAY_RATVAR_COMING to INFINITY)
+				to_chat(user, "<span class='heavy_brass'>Ratvar is coming through the gateway!</span>")
 	else
 		switch(progress_in_seconds)
 			if(-INFINITY to GATEWAY_REEBE_FOUND)
@@ -180,12 +134,12 @@
 				to_chat(user, "<span class='boldwarning'>Something is coming through!</span>")
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/process()
+	if(!obj_integrity)
+		return
 	if(!first_sound_played || prob(7))
 		for(var/M in GLOB.player_list)
 			if(M && !isnewplayer(M))
 				to_chat(M, "<span class='warning'><b>You hear otherworldly sounds from the [dir2text(get_dir(get_turf(M), get_turf(src)))]...</span>")
-	if(!obj_integrity)
-		return 0
 	var/convert_dist = 1 + (round(Floor(progress_in_seconds, 15) * 0.067))
 	for(var/t in RANGE_TURFS(convert_dist, loc))
 		var/turf/T = t
@@ -205,45 +159,26 @@
 			if(!step_away(O, src, 2) || get_dist(O, src) < 2)
 				O.take_damage(50, BURN, "bomb")
 			O.update_icon()
-	if(still_needs_components())
-		if(!first_sound_played)
-			priority_announce("Massive energy anomaly detected on short-range scanners. Attempting to triangulate location...", "Anomaly Alert")
-			send_to_playing_players(sound('sound/effects/clockcult_gateway_charging.ogg', 1, channel = CHANNEL_JUSTICAR_ARK, volume = 10))
-			first_sound_played = TRUE
-		make_glow()
-		glow.icon_state = "clockwork_gateway_components"
-		var/used_components = FALSE
-		for(var/i in required_components)
-			if(required_components[i])
-				var/to_use = min(GLOB.clockwork_component_cache[i], required_components[i])
-				required_components[i] -= to_use
-				GLOB.clockwork_component_cache[i] -= to_use
-				if(to_use)
-					used_components = TRUE
-		if(used_components)
-			update_slab_info()
-		if(still_needs_components())
-			return
 	progress_in_seconds += GATEWAY_SUMMON_RATE
 	switch(progress_in_seconds)
 		if(-INFINITY to GATEWAY_REEBE_FOUND)
-			if(!second_sound_played)
+			if(!first_sound_played)
 				send_to_playing_players(sound('sound/effects/clockcult_gateway_charging.ogg', 1, channel = CHANNEL_JUSTICAR_ARK, volume = 30))
-				second_sound_played = TRUE
+				first_sound_played = TRUE
 			make_glow()
 			glow.icon_state = "clockwork_gateway_charging"
 		if(GATEWAY_REEBE_FOUND to GATEWAY_RATVAR_COMING)
-			if(!third_sound_played)
+			if(!second_sound_played)
 				var/area/gate_area = get_area(src)
 				priority_announce("Location of massive energy anomaly has been triangulated. Location: [gate_area.map_name].", "Anomaly Alert")
 				send_to_playing_players(sound('sound/effects/clockcult_gateway_active.ogg', 1, channel = CHANNEL_JUSTICAR_ARK, volume = 35))
-				third_sound_played = TRUE
+				second_sound_played = TRUE
 			make_glow()
 			glow.icon_state = "clockwork_gateway_active"
 		if(GATEWAY_RATVAR_COMING to GATEWAY_RATVAR_ARRIVAL)
-			if(!fourth_sound_played)
+			if(!third_sound_played)
 				send_to_playing_players(sound('sound/effects/clockcult_gateway_closing.ogg', 1, channel = CHANNEL_JUSTICAR_ARK, volume = 40))
-				fourth_sound_played = TRUE
+				third_sound_played = TRUE
 			make_glow()
 			glow.icon_state = "clockwork_gateway_closing"
 		if(GATEWAY_RATVAR_ARRIVAL to INFINITY)


### PR DESCRIPTION
:cl: Joan
balance: The Ark of the Clockwork Justicar no longer needs to consume 15 of each component after being summoned to properly activate. Changed invokers required to summon the Ark from 6 to 3.
/:cl:

A Robustin:tm: sponsored idea.
More chances to try to summon, more chances to fuck it up, less completely donging over the cult if you mess it up.
