### PR TITLE
Freon now simply uses a color matrix rather than blending an icon

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -968,13 +968,17 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 /image/proc/setDir(newdir)
 	dir = newdir
 
+#define FROZEN_RED_COLOR "#2E5E69"
+#define FROZEN_GREEN_COLOR "#60A2A8"
+#define FROZEN_BLUE_COLOR "#A1AFB1"
+
 /obj/proc/make_frozen_visual()
 	// Used to make the frozen item visuals for Freon.
 	if(resistance_flags & FREEZE_PROOF)
 		return
 	if(!HAS_SECONDARY_FLAG(src, FROZEN))
 		name = "frozen [name]"
-		add_atom_colour(list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0,0,0)), TEMPORARY_COLOUR_PRIORITY)
+		add_atom_colour(list(FROZEN_RED_COLOR, FROZEN_GREEN_COLOR, FROZEN_BLUE_COLOR, rgb(0,0,0)), TEMPORARY_COLOUR_PRIORITY)
 		alpha -= 25
 		SET_SECONDARY_FLAG(src, FROZEN)
 
@@ -982,6 +986,10 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 /obj/proc/make_unfrozen()
 	if(HAS_SECONDARY_FLAG(src, FROZEN))
 		name = replacetext(name, "frozen ", "")
-		remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0,0,0)))
+		remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, list(FROZEN_RED_COLOR, FROZEN_GREEN_COLOR, FROZEN_BLUE_COLOR, rgb(0,0,0)))
 		alpha += 25
 		CLEAR_SECONDARY_FLAG(src, FROZEN)
+
+#undef FROZEN_RED_COLOR
+#undef FROZEN_GREEN_COLOR
+#undef FROZEN_BLUE_COLOR

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -968,32 +968,20 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 /image/proc/setDir(newdir)
 	dir = newdir
 
-/atom/proc/freeze_icon_index()
-	return "\ref[initial(icon)]-[initial(icon_state)]"
-
 /obj/proc/make_frozen_visual()
 	// Used to make the frozen item visuals for Freon.
-	var/static/list/freeze_item_icons = list()
 	if(resistance_flags & FREEZE_PROOF)
 		return
-	if(!HAS_SECONDARY_FLAG(src, FROZEN) && (initial(icon) && initial(icon_state)))
-		var/index = freeze_icon_index()
-		var/icon/IC
-		var/icon/P = freeze_item_icons[index]
-		if(!P)
-			P = new /icon
-			for(var/iconstate in icon_states(icon))
-				var/icon/O = new('icons/effects/freeze.dmi', "ice_cube")
-				IC = new(icon, iconstate)
-				O.Blend(IC, ICON_ADD)
-				P.Insert(O, iconstate)
-			freeze_item_icons[index] = P
-		icon = P
+	if(!HAS_SECONDARY_FLAG(src, FROZEN))
 		name = "frozen [name]"
+		add_atom_colour(list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0,0,0)), TEMPORARY_COLOUR_PRIORITY)
+		alpha -= 25
 		SET_SECONDARY_FLAG(src, FROZEN)
 
 //Assumes already frozed
 /obj/proc/make_unfrozen()
-	icon = initial(icon)
-	name = replacetext(name, "frozen ", "")
-	CLEAR_SECONDARY_FLAG(src, FROZEN)
+	if(HAS_SECONDARY_FLAG(src, FROZEN))
+		name = replacetext(name, "frozen ", "")
+		remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0,0,0)))
+		alpha += 25
+		CLEAR_SECONDARY_FLAG(src, FROZEN)


### PR DESCRIPTION
![](http://puu.sh/x2kBw/c88ae2a37d.png)
This absolutely fixes: things animating weirdly/too fast while frozen, things showing up as other things while frozen, large objects like cyro pods being much smaller while frozen, things with overlays not appearing frozen properly.
Fixes #20245
Fixes #20314
Fixes #25874
Fixes #24744
This might fix: the server crashing at the same time freon is released, even though it's _definitely not_ freon that's doing it.