### PR TITLE
Fixed delta and meta using prison station areas, nested both execution room types under one parent

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -334,22 +334,22 @@
 	dir = 6
 	},
 /turf/closed/wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "abc" = (
 /turf/closed/wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "abd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/closed/wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "abe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "abf" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/plasteel/floorgrime,
@@ -359,7 +359,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "abh" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/floorgrime,
@@ -444,14 +444,14 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "abu" = (
 /obj/machinery/door/poddoor{
 	id = "executionspaceblast";
 	name = "blast door"
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "abv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -460,7 +460,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "abw" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -473,7 +473,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "abx" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/floorgrime,
@@ -481,7 +481,7 @@
 "aby" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "abz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -762,7 +762,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "acb" = (
 /obj/machinery/sparker{
 	dir = 2;
@@ -773,12 +773,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "acc" = (
 /obj/structure/bed,
 /obj/effect/landmark/revenantspawn,
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "acd" = (
 /turf/closed/wall,
 /area/security/prison)
@@ -946,7 +946,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "acA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2
@@ -955,13 +955,13 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "acB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "acC" = (
 /obj/structure/bed,
 /obj/machinery/camera{
@@ -1046,7 +1046,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "acJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1181,7 +1181,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "acY" = (
 /obj/structure/table,
 /obj/item/weapon/paper,
@@ -1198,7 +1198,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ada" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/flasher{
@@ -1490,7 +1490,7 @@
 /obj/item/weapon/surgical_drapes,
 /obj/item/weapon/razor,
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "adD" = (
 /obj/machinery/button/flasher{
 	id = "executionflash";
@@ -1506,7 +1506,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "adE" = (
 /obj/structure/table,
 /obj/item/weapon/folder/red{
@@ -1518,7 +1518,7 @@
 /obj/item/device/assembly/flash/handheld,
 /obj/item/weapon/reagent_containers/spray/pepper,
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "adF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -1716,13 +1716,13 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aeb" = (
 /obj/structure/table,
 /obj/item/device/flashlight/lamp,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aec" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1733,7 +1733,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aed" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -1752,13 +1752,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aee" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aef" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1771,7 +1771,7 @@
 "aeg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aeh" = (
 /obj/machinery/button/door{
 	id = "permacell3";
@@ -2040,7 +2040,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aeI" = (
 /obj/structure/rack,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2060,7 +2060,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "aeJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2069,7 +2069,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aeK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2081,13 +2081,13 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aeL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aeM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
@@ -2118,7 +2118,7 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aeO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2457,17 +2457,17 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afv" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -2482,7 +2482,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afx" = (
 /obj/machinery/light_switch{
 	pixel_x = 25
@@ -2496,7 +2496,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -2505,7 +2505,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afz" = (
 /obj/structure/table,
 /obj/item/weapon/restraints/handcuffs,
@@ -2515,7 +2515,7 @@
 /area/security/prison)
 "afA" = (
 /turf/closed/wall/r_wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afB" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -2735,18 +2735,18 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agg" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Prisoner Transfer Centre";
-	areastring = "/area/security/transfer";
+	areastring = "/area/security/execution/transfer";
 	pixel_y = -27
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agh" = (
 /obj/structure/table,
 /obj/item/device/electropack,
@@ -2760,7 +2760,7 @@
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -1224,7 +1224,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "acO" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/black{
@@ -1599,7 +1599,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "adD" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit{
@@ -1734,7 +1734,7 @@
 "adS" = (
 /obj/item/weapon/ore/glass,
 /turf/open/floor/plating/asteroid,
-/area/security/transfer)
+/area/security/execution/transfer)
 "adT" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/energy/ionrifle,
@@ -1775,7 +1775,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "adW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2922,15 +2922,15 @@
 /area/ai_monitored/security/armory)
 "agk" = (
 /turf/closed/mineral,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agl" = (
 /turf/closed/wall{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "agm" = (
 /turf/open/floor/plating/asteroid,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agn" = (
 /obj/machinery/door/airlock/glass_external{
 	cyclelinkeddir = 1
@@ -3748,7 +3748,7 @@
 /turf/closed/wall/rust{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4116,7 +4116,7 @@
 /obj/structure/rack,
 /obj/item/weapon/pickaxe/mini,
 /turf/open/floor/plating/asteroid,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aiA" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -4501,7 +4501,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "ajq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -4514,7 +4514,7 @@
 /obj/structure/rack,
 /obj/item/weapon/shovel,
 /turf/open/floor/plating/asteroid,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ajs" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -4913,7 +4913,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "akj" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating{
@@ -4922,7 +4922,7 @@
 	icon_state = "asteroid_dug";
 	name = "ditch"
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "akk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -5465,7 +5465,7 @@
 	icon_state = "asteroid_dug";
 	name = "ditch"
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "alr" = (
 /turf/open/floor/plating/asteroid,
 /area/security/prison)
@@ -80392,7 +80392,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid,
-/area/security/transfer)
+/area/security/execution/transfer)
 "cVx" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -80631,7 +80631,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Security Transfer Range APC";
-	areastring = "/area/security/transfer";
+	areastring = "/area/security/execution/transfer";
 	pixel_y = 24
 	},
 /obj/structure/cable/orange{
@@ -80641,7 +80641,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "cVR" = (
 /obj/structure/table,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -80680,7 +80680,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "cVU" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -80726,7 +80726,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "cVX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80781,7 +80781,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "cWa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -86974,7 +86974,7 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkI" = (
 /obj/structure/rack,
 /obj/item/weapon/pickaxe,
@@ -86982,7 +86982,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkJ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/orange{
@@ -86995,7 +86995,7 @@
 "dkK" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/asteroid,
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkL" = (
 /obj/structure/sign/poster/contraband/fun_police{
 	pixel_y = 32
@@ -87003,22 +87003,22 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkM" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkN" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkO" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkP" = (
 /obj/item/weapon/ore/glass,
 /obj/structure/cable/orange{
@@ -87029,12 +87029,12 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkQ" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Prisoner Transfer APC";
-	areastring = "/area/security/transfer";
+	areastring = "/area/security/execution/transfer";
 	pixel_x = 24
 	},
 /obj/structure/cable/orange{
@@ -87044,7 +87044,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/orange{
@@ -87059,24 +87059,24 @@
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkT" = (
 /obj/structure/mineral_door/iron,
 /turf/open/floor/plating/astplate{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkU" = (
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkV" = (
 /obj/item/weapon/ore/glass,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkW" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -87086,7 +87086,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -87094,7 +87094,7 @@
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "dkY" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/orange{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -16311,7 +16311,7 @@
 /area/security/prison)
 "aHy" = (
 /turf/closed/wall/r_wall,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aHz" = (
 /obj/machinery/door/poddoor{
 	id = "justiceblast";
@@ -16324,7 +16324,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aHA" = (
 /obj/structure/lattice/catwalk,
 /obj/item/weapon/wrench,
@@ -16990,12 +16990,12 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aIL" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aIM" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -17009,7 +17009,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aIN" = (
 /obj/structure/sign/fire,
 /turf/closed/wall/r_wall,
@@ -17553,14 +17553,14 @@
 /turf/open/floor/plasteel/darkred/corner{
 	dir = 1
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aKd" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aKe" = (
 /obj/machinery/flasher{
 	id = "justiceflash";
@@ -17571,7 +17571,7 @@
 /turf/open/floor/plasteel/darkred/corner{
 	dir = 4
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aKf" = (
 /obj/machinery/door/poddoor{
 	id = "turbinevent";
@@ -18301,11 +18301,11 @@
 "aLK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aLL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/plasteel/vault,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aLN" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
@@ -19201,7 +19201,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aNA" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "justicechamber";
@@ -19226,7 +19226,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aNB" = (
 /obj/structure/cable/white{
 	d2 = 2;
@@ -19242,7 +19242,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aNC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposaloutlet{
@@ -20135,7 +20135,7 @@
 	icon_state = "darkred";
 	dir = 9
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aOZ" = (
 /obj/structure/cable/white{
 	d1 = 2;
@@ -20180,7 +20180,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aPa" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -20199,7 +20199,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aPb" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -20213,7 +20213,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aPc" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -20232,7 +20232,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 5
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aPd" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/structure/window/reinforced{
@@ -20242,14 +20242,14 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aPe" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aPf" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -21203,7 +21203,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aQS" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -21217,7 +21217,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aQT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -21225,7 +21225,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aQU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -21234,7 +21234,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aQV" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -21244,7 +21244,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aQW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -21254,7 +21254,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aQX" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -21279,7 +21279,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aQY" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 2;
@@ -22145,7 +22145,7 @@
 	icon_state = "darkred";
 	dir = 10
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aSA" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -22156,7 +22156,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkred/side,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aSB" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -22167,7 +22167,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkred/side,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aSC" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
@@ -22176,13 +22176,13 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/darkred/side,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aSD" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Education Chamber APC";
-	areastring = "/area/prison/execution_room";
+	areastring = "/area/security/execution/education";
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -22192,7 +22192,7 @@
 	icon_state = "darkred";
 	dir = 6
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aSE" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -22203,7 +22203,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aSF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -22212,7 +22212,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aSG" = (
 /obj/structure/sign/securearea{
 	pixel_x = 32
@@ -22892,7 +22892,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aUe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -30855,7 +30855,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bjO" = (
 /obj/structure/cable/white{
 	d2 = 4;
@@ -30867,7 +30867,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bjP" = (
 /obj/structure/cable/white{
 	d2 = 8;
@@ -30879,10 +30879,10 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bjQ" = (
 /turf/closed/wall/r_wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bjR" = (
 /obj/machinery/light{
 	dir = 8
@@ -31590,14 +31590,14 @@
 /obj/structure/cable/white,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bll" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "blm" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/cable/white{
@@ -31608,7 +31608,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bln" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/machinery/status_display{
@@ -31617,7 +31617,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "blo" = (
 /obj/machinery/computer/security{
 	name = "Labor Camp Monitoring";
@@ -31628,7 +31628,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/red,
-/area/security/transfer)
+/area/security/execution/transfer)
 "blp" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/ai_status_display{
@@ -31642,7 +31642,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "blq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -31652,7 +31652,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "blr" = (
 /obj/structure/cable/white{
 	d2 = 2;
@@ -31660,7 +31660,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bls" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -32715,7 +32715,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bnh" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -32725,25 +32725,25 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bni" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bnj" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bnk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bnl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -32751,7 +32751,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bnm" = (
 /obj/structure/cable/white,
 /obj/structure/cable/white{
@@ -32763,7 +32763,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bnn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -33709,7 +33709,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bpe" = (
 /obj/structure/cable/white{
 	d2 = 4;
@@ -33723,7 +33723,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/vacuum,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bpf" = (
 /obj/structure/cable/white{
 	d2 = 4;
@@ -33736,7 +33736,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bpg" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -33747,7 +33747,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bph" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -33766,7 +33766,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bpi" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/red,
@@ -33778,7 +33778,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bpj" = (
 /obj/machinery/gulag_teleporter,
 /obj/structure/disposalpipe/segment{
@@ -33787,7 +33787,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bpk" = (
 /obj/machinery/computer/gulag_teleporter_computer,
 /obj/structure/disposalpipe/segment{
@@ -33796,7 +33796,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bpl" = (
 /obj/structure/cable/white{
 	d1 = 2;
@@ -33809,7 +33809,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bpm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
@@ -33835,7 +33835,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bpn" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -34572,11 +34572,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bqD" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bqE" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 8;
@@ -34590,13 +34590,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bqF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bqG" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -34612,7 +34612,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bqH" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -34626,7 +34626,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bqI" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -34645,7 +34645,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bqJ" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -34664,7 +34664,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bqK" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -34677,7 +34677,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bqL" = (
 /obj/structure/cable/white{
 	d2 = 2;
@@ -34689,7 +34689,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bqM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -35300,7 +35300,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bsa" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -35316,20 +35316,20 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bsb" = (
 /turf/open/floor/plasteel/red/side,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bsc" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Security Transferring APC";
-	areastring = "/area/security/transfer";
+	areastring = "/area/security/execution/transfer";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/red/side,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bsd" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -35337,7 +35337,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bse" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/firealarm{
@@ -35350,7 +35350,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bsf" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/red/side{
@@ -36053,7 +36053,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/red,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bto" = (
 /obj/structure/cable/white{
 	d2 = 8;
@@ -36061,7 +36061,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "btp" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -36727,7 +36727,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "buD" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -36743,7 +36743,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "buE" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/briefcase{
@@ -36754,7 +36754,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "buF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -36765,7 +36765,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "buG" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin,
@@ -36773,7 +36773,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "buH" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/machinery/firealarm{
@@ -36783,7 +36783,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "buI" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -37694,12 +37694,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bwe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bwf" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 8;
@@ -37713,7 +37713,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bwg" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -37727,13 +37727,13 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bwh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bwi" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37741,7 +37741,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bwj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -37749,7 +37749,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bwk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -37760,7 +37760,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bwl" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/red/side{
@@ -38712,16 +38712,16 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bxY" = (
 /turf/open/floor/plasteel/neutral,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bxZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bya" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
@@ -38733,13 +38733,13 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "byb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "byc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -39990,7 +39990,7 @@
 /area/shuttle/labor)
 "bzS" = (
 /turf/closed/wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bzT" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/firealarm{
@@ -40014,7 +40014,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bzU" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -40030,7 +40030,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bzV" = (
 /obj/structure/chair{
 	dir = 1
@@ -40040,7 +40040,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/red/side,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bzX" = (
 /obj/structure/chair{
 	dir = 1
@@ -40050,7 +40050,7 @@
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/red/side,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bzY" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
@@ -40062,7 +40062,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bzZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -41065,7 +41065,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bBB" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -41085,7 +41085,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "bBC" = (
 /obj/structure/cable/white{
 	d2 = 8;
@@ -41094,7 +41094,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "bBD" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -108412,7 +108412,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault,
-/area/prison/execution_room)
+/area/security/execution/education)
 "eff" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -108674,7 +108674,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/red/side,
-/area/security/transfer)
+/area/security/execution/transfer)
 "efG" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -113063,7 +113063,7 @@
 "era" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral,
-/area/security/transfer)
+/area/security/execution/transfer)
 "erb" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -418,7 +418,7 @@
 /area/solar/starboard/fore)
 "aaZ" = (
 /turf/closed/wall/r_wall,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aba" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -472,7 +472,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/prison/execution_room)
+/area/security/execution/education)
 "abh" = (
 /obj/item/weapon/soap/nanotrasen,
 /obj/item/weapon/bikehorn/rubberducky,
@@ -639,7 +639,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aby" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -648,7 +648,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "abz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -657,7 +657,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "abA" = (
 /obj/machinery/shower{
 	dir = 4
@@ -864,7 +864,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "abW" = (
 /obj/structure/bed,
 /obj/item/clothing/suit/straight_jacket,
@@ -874,7 +874,7 @@
 /obj/effect/landmark/revenantspawn,
 /obj/item/device/electropack,
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "abX" = (
 /obj/machinery/flasher{
 	id = "justiceflash";
@@ -885,7 +885,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "abY" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restroom";
@@ -996,7 +996,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "acn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -1005,7 +1005,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aco" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
@@ -1015,7 +1015,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "acp" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1135,7 +1135,7 @@
 /turf/open/floor/plasteel/darkred{
 	dir = 4
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "acB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -1150,7 +1150,7 @@
 /turf/open/floor/plasteel/darkred{
 	dir = 4
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "acC" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
@@ -1181,7 +1181,7 @@
 /turf/open/floor/plasteel/darkred{
 	dir = 4
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "acD" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -1417,7 +1417,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "acW" = (
 /obj/structure/table,
 /obj/item/weapon/folder/red{
@@ -1436,7 +1436,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "acX" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1445,7 +1445,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "acY" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -1458,13 +1458,13 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "acZ" = (
 /obj/machinery/power/apc{
 	cell_type = 2500;
 	dir = 1;
 	name = "Prisoner Education Chamber APC";
-	areastring = "/area/prison/execution_room";
+	areastring = "/area/security/execution/education";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -1481,7 +1481,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "ada" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -1601,7 +1601,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "adn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/chair/office/dark{
@@ -1611,15 +1611,15 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "ado" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "adp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "adq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -1634,11 +1634,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "adr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/prison/execution_room)
+/area/security/execution/education)
 "ads" = (
 /obj/structure/bed,
 /obj/machinery/camera{
@@ -1821,7 +1821,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 2
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "adK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -1829,7 +1829,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 2
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "adL" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1838,7 +1838,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 2
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "adM" = (
 /obj/machinery/button/door{
 	id = "prisonereducation";
@@ -1854,7 +1854,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 2
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "adN" = (
 /obj/machinery/light_switch{
 	pixel_x = 26
@@ -1870,7 +1870,7 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 2
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "adO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/flasher{
@@ -2047,7 +2047,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aeh" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -2061,7 +2061,7 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aei" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -2075,7 +2075,7 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/black,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aej" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -2094,7 +2094,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/prison/execution_room)
+/area/security/execution/education)
 "aek" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -2283,7 +2283,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/vault,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aeI" = (
 /obj/item/weapon/tank/internals/oxygen/red{
 	pixel_x = -4;
@@ -2306,14 +2306,14 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/item/weapon/wrench,
 /turf/open/floor/plasteel/vault,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aeJ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/vault,
-/area/prison/execution_room)
+/area/security/execution/education)
 "aeK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -12800,7 +12800,7 @@
 /area/shuttle/labor)
 "ayv" = (
 /turf/closed/wall,
-/area/prison/execution_room)
+/area/security/execution/education)
 "ayw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2520,31 +2520,31 @@
 /area/ai_monitored/turret_protected/AIsatextAS)
 "afU" = (
 /turf/closed/wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
 /turf/closed/wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/closed/wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "afZ" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/plasteel/black,
@@ -2607,7 +2607,7 @@
 	name = "blast door"
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -2616,7 +2616,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2629,7 +2629,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -2638,11 +2638,11 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agn" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel/black,
@@ -2696,12 +2696,12 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agw" = (
 /obj/structure/bed,
 /obj/effect/landmark/revenantspawn,
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agx" = (
 /obj/machinery/sparker{
 	dir = 2;
@@ -2712,7 +2712,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agy" = (
 /turf/closed/wall,
 /area/security/prison)
@@ -2786,13 +2786,13 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agH" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2
@@ -2801,7 +2801,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agI" = (
 /obj/structure/bed,
 /obj/machinery/camera{
@@ -2933,7 +2933,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -2943,7 +2943,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "agV" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -2960,7 +2960,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "agW" = (
 /obj/machinery/flasher{
 	id = "PCell 2";
@@ -3062,7 +3062,7 @@
 /obj/item/device/mmi,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahk" = (
 /obj/structure/table,
 /obj/item/weapon/folder/red{
@@ -3072,7 +3072,7 @@
 	pixel_x = -3
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahl" = (
 /obj/machinery/button/flasher{
 	id = "executionflash";
@@ -3088,7 +3088,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahm" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Long-Term Cell 2";
@@ -3151,7 +3151,7 @@
 	d2 = 2
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahv" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -3159,7 +3159,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahw" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3170,19 +3170,19 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahx" = (
 /obj/structure/table,
 /obj/item/device/flashlight/lamp,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahy" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -3201,11 +3201,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3399,7 +3399,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahT" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -3417,7 +3417,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahU" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3432,7 +3432,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahV" = (
 /obj/structure/rack,
 /obj/item/weapon/tank/internals/anesthetic{
@@ -3453,7 +3453,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahW" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -3469,7 +3469,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahX" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable{
@@ -3481,7 +3481,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3501,7 +3501,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ahZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3666,7 +3666,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aiw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -3681,13 +3681,13 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aix" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aiy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -3701,7 +3701,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aiz" = (
 /obj/machinery/light_switch{
 	pixel_x = 25
@@ -3710,10 +3710,10 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aiA" = (
 /turf/closed/wall/r_wall,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aiB" = (
 /turf/open/floor/plasteel/red,
 /area/security/prison)
@@ -3901,7 +3901,7 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "aja" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3914,13 +3914,13 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ajb" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Prisoner Transfer Centre";
-	areastring = "/area/security/transfer";
+	areastring = "/area/security/execution/transfer";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -3928,7 +3928,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/security/transfer)
+/area/security/execution/transfer)
 "ajc" = (
 /obj/structure/closet/secure_closet/brig,
 /turf/open/floor/plasteel/black,

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1011,9 +1011,14 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Firing Range"
 	icon_state = "firingrange"
 
-/area/security/transfer
-	name = "Transfer Centre"
+/area/security/execution
 	icon_state = "execution_room"
+
+/area/security/execution/transfer
+	name = "Transfer Centre"
+	
+/area/security/execution/education
+	name = "Prisoner Education Chamber"
 
 /area/security/nuke_storage
 	name = "Vault"


### PR DESCRIPTION
Delta and Meta were using areas meant for Prison Station (old space gulag) for their execution rooms, which caused them to be excluded in valid area checks for Prison Break & Egalitarian Station events.