### PR TITLE
Revert "Fixes being able to "stomp out" sigils with TK"

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -19,9 +19,6 @@
 		return 1
 	return ..()
 
-/obj/effect/clockwork/sigil/attack_tk(mob/user)
-	return //you can't tk stomp sigils, but you can hit them with something
-
 /obj/effect/clockwork/sigil/attack_hand(mob/user)
 	if(iscarbon(user) && !user.stat && !is_servant_of_ratvar(user))
 		user.visible_message("<span class='warning'>[user] stamps out [src]!</span>", "<span class='danger'>You stomp on [src], scattering it into thousands of particles.</span>")


### PR DESCRIPTION
This reverts https://github.com/tgstation/tgstation/pull/29735.

I don't agree that this is a "fix" at all, it appears to be a balance change and should not have been allowed during the freeze.