### PR TITLE
Fix RCL loading

### DIFF
--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -23,17 +23,20 @@
 /obj/item/weapon/twohanded/rcl/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = W
-		if(user.transferItemToLoc(W, src))
-			loaded = W
-			loaded.max_amount = max_amount //We store a lot.
-		else
-			to_chat(user, "<span class='warning'>[src] is stuck to your hand!</span>")
-			return
+		
+		if(!loaded)
+			if(!user.transferItemToLoc(W, src))
+				to_chat(user, "<span class='warning'>[src] is stuck to your hand!</span>")
+				return
+			else
+				loaded = W //W.loc is src at this point.
+				loaded.max_amount = max_amount //We store a lot.
+				return
 
 		if(loaded.amount < max_amount)
-			var/amount = min(loaded.amount + C.amount, max_amount)
-			C.use(amount - loaded.amount)
-			loaded.amount = amount
+			var/transfer_amount = min(max_amount - loaded_amount, C.amount)
+			C.use(transfer_amount)
+			loaded.amount += transfer_amount
 		else
 			return
 		update_icon()

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -34,7 +34,7 @@
 				return
 
 		if(loaded.amount < max_amount)
-			var/transfer_amount = min(max_amount - loaded_amount, C.amount)
+			var/transfer_amount = min(max_amount - loaded.amount, C.amount)
 			C.use(transfer_amount)
 			loaded.amount += transfer_amount
 		else


### PR DESCRIPTION
Rapid cable layer will now add coils you use on it to its total instead of setting its quantity to twice the size of what you last used on it.

Fixes #29763
Also a previously unnoticed coil-duplication bug.