### PR TITLE
Removes chat pings from href logs

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -73,7 +73,7 @@
 			return
 
 	//Logs all hrefs, except chat pings
-	if(href_list["proc"] != "ping")
+	if(!(href_list["_src_"] == "chat" && href_list["proc"] == "ping" && LAZYLEN(href_list) == 2))
 		WRITE_FILE(GLOB.world_href_log, "<small>[time_stamp(show_ds = TRUE)] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br>")
 
 	// Admin PM

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -72,8 +72,9 @@
 			to_chat(src, "<span class='danger'>Your previous action was ignored because you've done too many in a second</span>")
 			return
 
-	//Logs all hrefs
-	GLOB.world_href_log << "<small>[time_stamp(show_ds = TRUE)] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br>"
+	//Logs all hrefs, except chat pings
+	if(href_list["proc"] != "ping")
+		GLOB.world_href_log << "<small>[time_stamp(show_ds = TRUE)] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br>"
 
 	// Admin PM
 	if(href_list["priv_msg"])


### PR DESCRIPTION
Might not be the proper way to do this, but I'm a bit tired right now and couldn't think of anything else. 
Chat pings are useless and only clutters href logs, without any real benefit.