### PR TITLE
Disables tgui build in travis

### DIFF
--- a/tools/travis/build_tools.sh
+++ b/tools/travis/build_tools.sh
@@ -6,6 +6,6 @@ set -e
 if [ "$BUILD_TOOLS" = true ];
 then
     md5sum -c - <<< "49bc6b1b9ed56c83cceb6674bd97cb34 *html/changelogs/example.yml";
-    cd tgui && source ~/.nvm/nvm.sh && gulp && cd ..;
+    #cd tgui && source ~/.nvm/nvm.sh && gulp && cd ..;
     python tools/ss13_genchangelog.py html/changelog.html html/changelogs;
 fi;


### PR DESCRIPTION
Some random dependency is failing: https://travis-ci.org/tgstation/tgstation/jobs/263093429

After this is merged we can revert it when we figure out why it's not working.

In the meantime, it's preventing us from doing the mergeful