### PR TITLE
Fix fireaxe cabinets spawned with broken icons

### DIFF
--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -12,8 +12,8 @@
 	max_integrity = 150
 	integrity_failure = 50
 
-/obj/structure/fireaxecabinet/New()
-	..()
+/obj/structure/fireaxecabinet/Initialize()
+	. = ..()
 	update_icon()
 
 /obj/structure/fireaxecabinet/Destroy()


### PR DESCRIPTION
Closes #29251

Bad mix of `New` and `Initialize`
